### PR TITLE
Update using-dotnet-cli.md

### DIFF
--- a/docs/workflow/testing/using-your-build.md
+++ b/docs/workflow/testing/using-your-build.md
@@ -1,7 +1,7 @@
 
 # Using your .NET Runtime Build
 
-We assume that you have successfully built CoreCLR repository and thus have files of the form
+We assume that you have successfully built the repository and thus have files of the form
 ```
     ~/runtime/artifacts/bin/coreclr/<OS>.<arch>.<flavor>/
 ```
@@ -11,7 +11,7 @@ a 'host' program that will load the Runtime as well as all the other .NET librar
 code that your application needs. The easiest way to get all this other stuff is to simply use the
 standard 'dotnet' host that installs with .NET SDK.
 
-The released version of 'dotnet' tool may not be compatible with the live CoreCLR repository. The following steps
+The released version of 'dotnet' tool may not be compatible with the live repository. The following steps
 assume use of a dogfood build of the .NET SDK.
 
 ## Acquire the latest nightly .NET SDK
@@ -157,7 +157,7 @@ Assert failure(PID 13452 [0x0000348c], Thread: 10784 [0x2a20]): Consistency chec
 ## Using .NET SDK to run your .NET Application
 
 If you don't like the idea of copying files manually you can follow [these instructions](../using-dotnet-cli.md) to use dotnet cli to do this for you.
-However the steps described here are the simplest and most commonly used by CoreCLR developers for ad-hoc testing.
+However the steps described here are the simplest and most commonly used by runtime developers for ad-hoc testing.
 
 ## Using CoreRun to run your .NET Application
 

--- a/docs/workflow/using-dotnet-cli.md
+++ b/docs/workflow/using-dotnet-cli.md
@@ -17,7 +17,7 @@ For other walkthroughs see:
     artifacts\packages\<configuration>\Shipping\
 ```
 
-2. Acquired the latest nightly .NET SDK from [here](https://github.com/dotnet/installer) and added it's root folder to your [path](requirements/windows-requirements.md#adding-to-the-default-path-variable)
+2. Acquired the latest nightly .NET SDK from [here](https://github.com/dotnet/installer) and added its root folder to your [path](requirements/windows-requirements.md#adding-to-the-default-path-variable)
 
 ## First Run
 

--- a/docs/workflow/using-dotnet-cli.md
+++ b/docs/workflow/using-dotnet-cli.md
@@ -14,10 +14,10 @@ For other walkthroughs see:
 1. Successfully built CoreCLR repository and thus have files of the form shown below. From now on we call this folder NuGet package folder.
 
 ```
-    artifacts\bin\coreclr\<OS>.<arch>.<flavor>\.nuget\pkg\runtime.<OS>-<arch>.Microsoft.NETCore.Runtime.CoreCLR.<version>.nupkg
+    artifacts\packages\<configuration>\Shipping\
 ```
 
-2. Acquired the latest nightly .NET SDK from [here](https://github.com/dotnet/cli/blob/master/README.md#installers-and-binaries) and added it's root folder to your [path](requirements/windows-requirements.md#adding-to-the-default-path-variable)
+2. Acquired the latest nightly .NET SDK from [here](https://github.com/dotnet/installer) and added it's root folder to your [path](requirements/windows-requirements.md#adding-to-the-default-path-variable)
 
 ## First Run
 
@@ -29,13 +29,12 @@ From now on all instructions relate to this folder as "app folder".
 
 ### 2. Create NuGet.Config file
 
-The build script creates NuGet packages and puts them to `artifacts\bin\coreclr\<OS>.<arch>.<flavor>\.nuget\pkg\`. .NET SDK has no idea about its existence and we need to tell it where to search for the packages.
+The build script creates NuGet packages and puts them to `artifacts\packages\<configuration>\Shipping\`. .NET SDK has no idea about its existence and we need to tell it where to search for the packages.
 
 Please run `dotnet new nugetconfig` in the app folder and update the created `NuGet.Config` file:
 
 * **set path to local CoreCLR NuGet folder!!**
 * add address to dotnet core tools NuGet feed
-
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -44,11 +43,10 @@ Please run `dotnet new nugetconfig` in the app folder and update the created `Nu
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
 
-    <add key="local CoreCLR" value="C:\runtime\artifacts\bin\coreclr\Windows_NT.x64.Debug\.nuget\pkg" /> <!-- CHANGE THIS PATH to your local output path -->
+    <add key="local CoreCLR" value="C:\runtime\artifacts\artifacts\packages\Release\Shipping\" /> <!-- CHANGE THIS PATH to your local output path -->
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> <!-- link to corefx NuGet feed -->
   </packageSources>
 </configuration>
-
 ```
 
 ### 3. Create and update the Project file
@@ -60,15 +58,10 @@ Please run `dotnet new console` in the app folder and update the created `.cspro
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <RuntimeFrameworkVersion>3.0.0-preview1-26210-0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>5.0.0-dev</RuntimeFrameworkVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview1-26210-0" />
-    <PackageReference Include="runtime.win-x64.Microsoft.NETCore.Jit" Version="3.0.0-preview1-26210-0" />
-  </ItemGroup>
 
 </Project>
 ```
@@ -76,11 +69,11 @@ Please run `dotnet new console` in the app folder and update the created `.cspro
 **You have to set the correct values for `RuntimeIdentifier` (RI), `RuntimeFrameworkVersion` and versions of both packages.**
 
 You can generally figure that out by looking at the packages you found in your output.
-In our example you will see there is a package with the name `runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR.3.0.0-preview1-26210-0.nupkg`
+In our example you will see there is a package with the name `Microsoft.NETCore.App.Runtime.win-x64.5.0.0-dev.nupkg`
 
 ```
-runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR.3.0.0-preview1-26210-0.nupkg
-       ^--RI---^                                 ^--------version-------^
+Microsoft.NETCore.App.Runtime.win-x64.5.0.0-dev.nupkg
+                              ^-RI--^ ^version^
 ```
 
 ### 4. Change Program.cs
@@ -91,7 +84,7 @@ To make sure that you run against your local coreclr build please change your `M
 static void Main(string[] args)
 {
 	var coreAssemblyInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(object).Assembly.Location);
-	Console.WriteLine($"Hello World from Core {coreAssemblyInfo.ProductVersion}");
+	Console.WriteLine($"Hello World from .NET {coreAssemblyInfo.ProductVersion}");
 	Console.WriteLine($"The location is {typeof(object).Assembly.Location}");
 }
 ```
@@ -108,32 +101,48 @@ dotnet publish
 Make sure that restoring done by `dotnet publish` installed the explicit version of the Runtime that you have specified:
 
 ```
-PS C:\coreclr\helloWorld> dotnet publish
-  Restoring packages for C:\coreclr\helloWorld\helloWorld.csproj...
-  Installing runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR 3.0.0-preview1-26210-
+C:\coreclr\helloworld>dotnet publish
+Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+  Determining projects to restore...
+  Restored C:\coreclr\helloworld\helloworld.csproj (in 114 ms).
+  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
+  helloworld -> C:\coreclr\helloworld\bin\Debug\net5.0\win-x64\helloworld.dll
+  helloworld -> C:\coreclr\helloworld\bin\Debug\net5.0\win-x64\publish\
 ```
 
 If you see something like the message below it means that it has failed to restore your local runtime packages. In such case double check your `NuGet.config` file and paths used in it.
 
 ```
-C:\coreclr\helloWorld\helloWorld.csproj : warning NU1603: helloWorld depends on runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR (>= 3.0.0-preview1-26210-0) but runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR 3.0.0-preview1-26210-0 was not found. An approximate best match of runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR 3.0.0-preview2-25501-02 was resolved.
+C:\coreclr\helloworld>dotnet publish
+Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+  Determining projects to restore...
+C:\coreclr\helloworld\helloworld.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Runtime.win-x64 with version (= 5.0.0-does-not-exist)
+C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 25 version(s) in nuget [ Nearest version: 5.0.0-preview.1.20120.5 ]
+C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 1 version(s) in local CoreCLR [ Nearest version: 5.0.0-dev ]
+C:\coreclr\helloworld\helloworld.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Host.win-x64 with version (= 5.0.0-does-not-exist)
+C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 27 version(s) in nuget [ Nearest version: 5.0.0-preview.1.20120.5 ]
+C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 1 version(s) in local CoreCLR [ Nearest version: 5.0.0-dev ]
+  Failed to restore C:\coreclr\helloworld\helloworld.csproj (in 519 ms).
 ```
 
 ### 6. Run the app
 
-After you publish you will find all the binaries needed to run your application under `bin\Debug\netcoreapp3.0\win-x64\publish\`.
+After you publish you will find all the binaries needed to run your application under `bin\Debug\net5.0\win-x64\publish\`.
 To run the application simply run the EXE that is in this publish directory (it is the name of the app, or specified in the project file).
 
 ```
-.\bin\Debug\netcoreapp3.0\win-x64\publish\HelloWorld.exe
+.\bin\Debug\net5.0\win-x64\publish\HelloWorld.exe
 ```
 
-Running the app should tell you the version and which user and machine build the assembly as well as the commit hash of the code
-at the time of building:
+Running the app should tell you the version and where the location of System.Private.CoreLib in the publish directory:
 
 ```
-Hello World from Core 4.6.26210.0 @BuiltBy: adsitnik-MININT-O513E3V @SrcCode: https://github.com/dotnet/runtime/tree/3d6da797d1f7dc47d5934189787a4e8006ab3a04
-The location is C:\coreclr\helloWorld\bin\Debug\netcoreapp3.0\win-x64\publish\System.Private.CoreLib.dll
+Hello World from .NET 5.0.0-dev
+The location is C:\coreclr\helloworld\bin\Debug\net5.0\win-x64\publish\System.Private.CoreLib.dll
 ```
 
 **Congratulations! You have just run your first app against local CoreCLR build!**

--- a/docs/workflow/using-dotnet-cli.md
+++ b/docs/workflow/using-dotnet-cli.md
@@ -1,17 +1,17 @@
 
 # Using your .NET Runtime build with .NET SDK
 
-This walkthrough explains how to run against your local CoreCLR build using .NET SDK only.
+This walkthrough explains how to run your own app against your local build using only the .NET SDK.
 
 For other walkthroughs see:
 
-- [Using Your Build - Update CoreCLR from raw binary output](./testing/using-your-build.md)
+- [Using Your Build - Update from raw build output](./testing/using-your-build.md)
 - [Using CoreRun To Run .NET Application](./testing/using-corerun.md)
 - [Dogfooding .NET SDK](https://github.com/dotnet/runtime/blob/master/docs/project/dogfooding.md).
 
 ## Prerequisites
 
-1. Successfully built CoreCLR repository and thus have files of the form shown below. From now on we call this folder NuGet package folder.
+1. Successfully built this repository and thus have files of the form shown below. From now on we call this folder NuGet package folder.
 
 ```
     artifacts\packages\<configuration>\Shipping\
@@ -33,8 +33,7 @@ The build script creates NuGet packages and puts them to `artifacts\packages\<co
 
 Please run `dotnet new nugetconfig` in the app folder and update the created `NuGet.Config` file:
 
-* **set path to local CoreCLR NuGet folder!!**
-* add address to dotnet core tools NuGet feed
+* ** adjust path below to point to your in-repo NuGet folder**
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -43,8 +42,7 @@ Please run `dotnet new nugetconfig` in the app folder and update the created `Nu
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
 
-    <add key="local CoreCLR" value="C:\runtime\artifacts\artifacts\packages\Release\Shipping\" /> <!-- CHANGE THIS PATH to your local output path -->
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> <!-- link to corefx NuGet feed -->
+    <add key="local runtime" value="C:\runtime\artifacts\artifacts\packages\Release\Shipping\" /> <!-- CHANGE THIS PATH to your local output path -->
   </packageSources>
 </configuration>
 ```
@@ -78,14 +76,14 @@ Microsoft.NETCore.App.Runtime.win-x64.5.0.0-dev.nupkg
 
 ### 4. Change Program.cs
 
-To make sure that you run against your local coreclr build please change your `Main` method in `Program.cs` file to:
+To make sure that you run against your local build of this repo please change your `Main` method in `Program.cs` file to:
 
 ```cs
 static void Main(string[] args)
 {
-	var coreAssemblyInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(object).Assembly.Location);
-	Console.WriteLine($"Hello World from .NET {coreAssemblyInfo.ProductVersion}");
-	Console.WriteLine($"The location is {typeof(object).Assembly.Location}");
+    var coreAssemblyInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(object).Assembly.Location);
+    Console.WriteLine($"Hello World from .NET {coreAssemblyInfo.ProductVersion}");
+    Console.WriteLine($"The location is {typeof(object).Assembly.Location}");
 }
 ```
 
@@ -101,32 +99,32 @@ dotnet publish
 Make sure that restoring done by `dotnet publish` installed the explicit version of the Runtime that you have specified:
 
 ```
-C:\coreclr\helloworld>dotnet publish
+c:\runtime\helloworld>dotnet publish
 Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
 Copyright (C) Microsoft Corporation. All rights reserved.
 
   Determining projects to restore...
-  Restored C:\coreclr\helloworld\helloworld.csproj (in 114 ms).
+  Restored c:\runtime\helloworld\helloworld.csproj (in 114 ms).
   You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
-  helloworld -> C:\coreclr\helloworld\bin\Debug\net5.0\win-x64\helloworld.dll
-  helloworld -> C:\coreclr\helloworld\bin\Debug\net5.0\win-x64\publish\
+  helloworld -> c:\runtime\helloworld\bin\Debug\net5.0\win-x64\helloworld.dll
+  helloworld -> c:\runtime\helloworld\bin\Debug\net5.0\win-x64\publish\
 ```
 
 If you see something like the message below it means that it has failed to restore your local runtime packages. In such case double check your `NuGet.config` file and paths used in it.
 
 ```
-C:\coreclr\helloworld>dotnet publish
+c:\runtime\helloworld>dotnet publish
 Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
 Copyright (C) Microsoft Corporation. All rights reserved.
 
   Determining projects to restore...
-C:\coreclr\helloworld\helloworld.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Runtime.win-x64 with version (= 5.0.0-does-not-exist)
-C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 25 version(s) in nuget [ Nearest version: 5.0.0-preview.1.20120.5 ]
-C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 1 version(s) in local CoreCLR [ Nearest version: 5.0.0-dev ]
-C:\coreclr\helloworld\helloworld.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Host.win-x64 with version (= 5.0.0-does-not-exist)
-C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 27 version(s) in nuget [ Nearest version: 5.0.0-preview.1.20120.5 ]
-C:\coreclr\helloworld\helloworld.csproj : error NU1102:   - Found 1 version(s) in local CoreCLR [ Nearest version: 5.0.0-dev ]
-  Failed to restore C:\coreclr\helloworld\helloworld.csproj (in 519 ms).
+c:\runtime\helloworld\helloworld.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Runtime.win-x64 with version (= 5.0.0-does-not-exist)
+c:\runtime\helloworld\helloworld.csproj : error NU1102:   - Found 25 version(s) in nuget [ Nearest version: 5.0.0-preview.1.20120.5 ]
+c:\runtime\helloworld\helloworld.csproj : error NU1102:   - Found 1 version(s) in local runtime [ Nearest version: 5.0.0-dev ]
+c:\runtime\helloworld\helloworld.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Host.win-x64 with version (= 5.0.0-does-not-exist)
+c:\runtime\helloworld\helloworld.csproj : error NU1102:   - Found 27 version(s) in nuget [ Nearest version: 5.0.0-preview.1.20120.5 ]
+c:\runtime\helloworld\helloworld.csproj : error NU1102:   - Found 1 version(s) in local runtime [ Nearest version: 5.0.0-dev ]
+  Failed to restore c:\runtime\helloworld\helloworld.csproj (in 519 ms).
 ```
 
 ### 6. Run the app
@@ -142,15 +140,15 @@ Running the app should tell you the version and where the location of System.Pri
 
 ```
 Hello World from .NET 5.0.0-dev
-The location is C:\coreclr\helloworld\bin\Debug\net5.0\win-x64\publish\System.Private.CoreLib.dll
+The location is c:\runtime\helloworld\bin\Debug\net5.0\win-x64\publish\System.Private.CoreLib.dll
 ```
 
-**Congratulations! You have just run your first app against local CoreCLR build!**
+**Congratulations! You have just run your first app against your local build of this repo**
 
-## Update CoreCLR using runtime nuget package
+## Update using runtime nuget package
 
-Updating CoreCLR from raw binary output is easier for quick one-off testing but using the nuget package is better
-for referencing your CoreCLR build in your actual application because of it does not require manual copying of files
+Updating the runtime from raw binary output is easier for quick one-off testing but using the nuget package is better
+for referencing your build in your actual application because of it does not require manual copying of files
 around each time the application is built and plugs into the rest of the tool chain. This set of instructions will cover
 the further steps needed to consume the runtime nuget package.
 


### PR DESCRIPTION
The current directions for trying out your own build of coreclr are a little outdated. These edits update the directories and files names to match the locations where I was able to find the build output. I did not update the second half of the document.