### PR TITLE
Address additional feedback from #40172

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -276,9 +276,8 @@
     <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
          In this case, explicitly specify the path to the dotnet host. -->
     <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
-      <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
-      <_DotNetHostFileName>dotnet</_DotNetHostFileName>
-      <_DotNetHostFileName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</_DotNetHostFileName>
+      <_DotNetHostDirectory>$(DotNetRoot)</_DotNetHostDirectory>
+      <_DotNetHostFileName>$([System.IO.Path]::GetFileName('$(DotNetTool)'))</_DotNetHostFileName>
     </PropertyGroup>
 
     <ILLink AssemblyPaths="$(ILLinkTrimInputAssembly)"

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -69,9 +69,8 @@
     <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
       In this case, explicitly specify the path to the dotnet host. -->
     <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
-      <_DotNetHostDirectory>$(RepoRoot).dotnet</_DotNetHostDirectory>
-      <_DotNetHostFileName>dotnet</_DotNetHostFileName>
-      <_DotNetHostFileName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</_DotNetHostFileName>
+      <_DotNetHostDirectory>$(DotNetRoot)</_DotNetHostDirectory>
+      <_DotNetHostFileName>$([System.IO.Path]::GetFileName('$(DotNetTool)'))</_DotNetHostFileName>
     </PropertyGroup>
 
     <ILLink AssemblyPaths="$(_AssemblyPaths)"
@@ -82,5 +81,5 @@
         ToolPath="$(_DotNetHostDirectory)" />
   </Target>
 
-  <Import Project="$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir)', 'illink.targets'))" />
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" />
 </Project>


### PR DESCRIPTION
Follow up for https://github.com/dotnet/runtime/pull/40172 (Add step to run linker on entire runtime pack during libraries build).