### PR TITLE
Add code to preserve public fields of input types to JsonSerializer

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -10,7 +10,8 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         // Members accessed by the serializer when deserializing.
-        private const DynamicallyAccessedMemberTypes MembersAccessedOnRead = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties;
+        private const DynamicallyAccessedMemberTypes MembersAccessedOnRead =
+            DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields;
 
         [return: MaybeNull]
         private static TValue ReadCore<TValue>(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         // Members accessed by the serializer when serializing.
-        private const DynamicallyAccessedMemberTypes MembersAccessedOnWrite = DynamicallyAccessedMemberTypes.PublicProperties;
+        private const DynamicallyAccessedMemberTypes MembersAccessedOnWrite = DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields;
 
         private static void WriteCore<TValue>(
             Utf8JsonWriter writer,

--- a/src/libraries/System.Text.Json/tests/TrimmingTests/Helper.cs
+++ b/src/libraries/System.Text.Json/tests/TrimmingTests/Helper.cs
@@ -90,16 +90,18 @@ namespace SerializerTrimmingTest
         }
     }
 
-    internal class MyClass
+    public class MyClass
     {
         public int X { get; set; }
-        public int Y { get; set; }
+        [JsonInclude]
+        public int Y;
     }
 
     internal struct MyStruct
     {
         public int X { get; }
-        public int Y { get; }
+        [JsonInclude]
+        public int Y;
 
         [JsonConstructor]
         public MyStruct(int x, int y) => (X, Y) = (x, y);
@@ -108,7 +110,8 @@ namespace SerializerTrimmingTest
     internal class MyClassWithParameterizedCtor
     {
         public int X { get; set; }
-        public int Y { get; set; }
+        [JsonInclude]
+        public int Y;
 
         public MyClassWithParameterizedCtor(int x, int y) => (X, Y) = (x, y);
     }
@@ -116,11 +119,14 @@ namespace SerializerTrimmingTest
     internal class MyBigClass
     {
         public string A { get; }
-        public string B { get; }
+        [JsonInclude]
+        public string B;
         public string C { get; }
-        public int One { get; }
+        [JsonInclude]
+        public int One;
         public int Two { get; }
-        public int Three { get; }
+        [JsonInclude]
+        public int Three;
 
         public MyBigClass(string a, string b, string c, int one, int two, int three)
         {


### PR DESCRIPTION
Making this change now that field support has been added to `JsonSerializer` - https://github.com/dotnet/runtime/pull/36986.