### PR TITLE
Improve perf of hash one-shots on Win10

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
@@ -34,7 +34,7 @@ namespace Internal.Cryptography
                 dwFlags |= BCryptOpenAlgorithmProviderFlags.BCRYPT_ALG_HANDLE_HMAC_FLAG;
             }
 
-            _hAlgorithm = Interop.BCrypt.BCryptAlgorithmCache.GetCachedBCryptAlgorithmHandle(hashAlgId, dwFlags);
+            _hAlgorithm = Interop.BCrypt.BCryptAlgorithmCache.GetCachedBCryptAlgorithmHandle(hashAlgId, dwFlags, out _hashSize);
 
             // Win7 won't set hHash, Win8+ will; and both will set _hHash.
             // So keep hHash trapped in this scope to prevent (mis-)use of it.
@@ -56,17 +56,6 @@ namespace Internal.Cryptography
                     _hHash = hHash;
                     _reusable = true;
                 }
-            }
-
-            unsafe
-            {
-                int cbSizeOfHashSize;
-                int hashSize;
-                Debug.Assert(_hHash != null);
-                NTSTATUS ntStatus = Interop.BCrypt.BCryptGetProperty(_hHash, Interop.BCrypt.BCryptPropertyStrings.BCRYPT_HASH_LENGTH, &hashSize, sizeof(int), out cbSizeOfHashSize, 0);
-                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-                    throw Interop.BCrypt.CreateCryptographicException(ntStatus);
-                _hashSize = hashSize;
             }
         }
 

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHash.cs
@@ -4,13 +4,22 @@
 using System;
 using System.Runtime.InteropServices;
 
-using Microsoft.Win32.SafeHandles;
-
 internal partial class Interop
 {
     internal partial class BCrypt
     {
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static unsafe extern NTSTATUS BCryptHash(SafeBCryptAlgorithmHandle hAlgorithm, byte* pbSecret, int cbSecret, byte* pbInput, int cbInput, byte* pbOutput, int cbOutput);
+        internal static unsafe extern NTSTATUS BCryptHash(nuint hAlgorithm, byte* pbSecret, int cbSecret, byte* pbInput, int cbInput, byte* pbOutput, int cbOutput);
+
+        // Pseudo-handles, as defined in bcrypt.h
+        // TODO: This really should be backed by 'nuint' (see https://github.com/dotnet/roslyn/issues/44651)
+        public enum BCryptAlgPseudoHandle : uint
+        {
+            BCRYPT_MD5_ALG_HANDLE = 0x00000021,
+            BCRYPT_SHA1_ALG_HANDLE = 0x00000031,
+            BCRYPT_SHA256_ALG_HANDLE = 0x00000041,
+            BCRYPT_SHA384_ALG_HANDLE = 0x00000051,
+            BCRYPT_SHA512_ALG_HANDLE = 0x00000061,
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 using NTSTATUS = Interop.BCrypt.NTSTATUS;
@@ -33,12 +34,22 @@ namespace Internal.Cryptography
 
             public static unsafe int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
             {
-                // Shared handle, no using or dispose.
+                int hashSize; // in bytes
+
+                // Try using a pseudo-handle if available.
+                if (!s_useCompatOneShot)
+                {
+                    if (HashDataUsingPseudoHandle(hashAlgorithmId, source, destination, out hashSize))
+                    {
+                        return hashSize;
+                    }
+                }
+
+                // Pseudo-handle not available or a precondition check failed.
+                // Fall back to a shared handle with no using or dispose.
                 SafeBCryptAlgorithmHandle cachedAlgorithmHandle = BCryptAlgorithmCache.GetCachedBCryptAlgorithmHandle(
                     hashAlgorithmId,
                     BCryptOpenAlgorithmProviderFlags.None);
-
-                int hashSize;
 
                 NTSTATUS ntStatus = Interop.BCrypt.BCryptGetProperty(
                     cachedAlgorithmHandle,
@@ -58,33 +69,77 @@ namespace Internal.Cryptography
                     throw new CryptographicException();
                 }
 
-                if (!s_useCompatOneShot)
-                {
-                    try
-                    {
-                        fixed (byte* pSource = source)
-                        fixed (byte* pDestination = destination)
-                        {
-                            ntStatus = Interop.BCrypt.BCryptHash(cachedAlgorithmHandle, null, 0, pSource, source.Length, pDestination, hashSize);
-
-                            if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-                            {
-                                throw Interop.BCrypt.CreateCryptographicException(ntStatus);
-                            }
-                        }
-
-                        return hashSize;
-                    }
-                    catch (EntryPointNotFoundException)
-                    {
-                        s_useCompatOneShot = true;
-                    }
-                }
-
-                Debug.Assert(s_useCompatOneShot);
                 HashUpdateAndFinish(cachedAlgorithmHandle, hashSize, source, destination);
 
                 return hashSize;
+            }
+
+            private static unsafe bool HashDataUsingPseudoHandle(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination, out int hashSize)
+            {
+                hashSize = default;
+
+                Interop.BCrypt.BCryptAlgPseudoHandle algHandle;
+                int digestSizeInBytes;
+
+                if (hashAlgorithmId == HashAlgorithmNames.MD5)
+                {
+                    algHandle = Interop.BCrypt.BCryptAlgPseudoHandle.BCRYPT_MD5_ALG_HANDLE;
+                    digestSizeInBytes = 128 / 8;
+                }
+                else if (hashAlgorithmId == HashAlgorithmNames.SHA1)
+                {
+                    algHandle = Interop.BCrypt.BCryptAlgPseudoHandle.BCRYPT_SHA1_ALG_HANDLE;
+                    digestSizeInBytes = 160 / 8;
+                }
+                else if (hashAlgorithmId == HashAlgorithmNames.SHA256)
+                {
+                    algHandle = Interop.BCrypt.BCryptAlgPseudoHandle.BCRYPT_SHA256_ALG_HANDLE;
+                    digestSizeInBytes = 256 / 8;
+                }
+                else if (hashAlgorithmId == HashAlgorithmNames.SHA384)
+                {
+                    algHandle = Interop.BCrypt.BCryptAlgPseudoHandle.BCRYPT_SHA384_ALG_HANDLE;
+                    digestSizeInBytes = 384 / 8;
+                }
+                else if (hashAlgorithmId == HashAlgorithmNames.SHA512)
+                {
+                    algHandle = Interop.BCrypt.BCryptAlgPseudoHandle.BCRYPT_SHA512_ALG_HANDLE;
+                    digestSizeInBytes = 512 / 8;
+                }
+                else
+                {
+                    Debug.Fail("Unknown hash algorithm.");
+                    return false;
+                }
+
+                if (destination.Length < digestSizeInBytes)
+                {
+                    Debug.Fail("Caller should have checked length.");
+                    return false;
+                }
+
+                NTSTATUS ntStatus;
+                fixed (byte* pSrc = &MemoryMarshal.GetReference(source))
+                fixed (byte* pDest = &MemoryMarshal.GetReference(destination))
+                {
+                    try
+                    {
+                        ntStatus = Interop.BCrypt.BCryptHash((uint)algHandle, null /* pbSecret */, 0 /* cbSecret */, pSrc, source.Length, pDest, digestSizeInBytes);
+                    }
+                    catch (EntryPointNotFoundException)
+                    {
+                        s_useCompatOneShot = true; // this OS doesn't support BCryptHash with pseudohandles
+                        return false;
+                    }
+                }
+
+                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                {
+                    throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+                }
+
+                hashSize = digestSizeInBytes;
+                return true; // success!
             }
 
             private static void HashUpdateAndFinish(

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
@@ -49,20 +49,8 @@ namespace Internal.Cryptography
                 // Fall back to a shared handle with no using or dispose.
                 SafeBCryptAlgorithmHandle cachedAlgorithmHandle = BCryptAlgorithmCache.GetCachedBCryptAlgorithmHandle(
                     hashAlgorithmId,
-                    BCryptOpenAlgorithmProviderFlags.None);
-
-                NTSTATUS ntStatus = Interop.BCrypt.BCryptGetProperty(
-                    cachedAlgorithmHandle,
-                    Interop.BCrypt.BCryptPropertyStrings.BCRYPT_HASH_LENGTH,
-                    &hashSize,
-                    sizeof(int),
-                    out _,
-                    0);
-
-                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-                {
-                    throw Interop.BCrypt.CreateCryptographicException(ntStatus);
-                }
+                    BCryptOpenAlgorithmProviderFlags.None,
+                    out hashSize);
 
                 if (destination.Length < hashSize)
                 {
@@ -124,7 +112,7 @@ namespace Internal.Cryptography
                 {
                     try
                     {
-                        ntStatus = Interop.BCrypt.BCryptHash((uint)algHandle, null /* pbSecret */, 0 /* cbSecret */, pSrc, source.Length, pDest, digestSizeInBytes);
+                        ntStatus = Interop.BCrypt.BCryptHash((uint)algHandle, pbSecret: null, cbSecret: 0, pSrc, source.Length, pDest, digestSizeInBytes);
                     }
                     catch (EntryPointNotFoundException)
                     {


### PR DESCRIPTION
Uses bcrypt pseudo-handles (see https://docs.microsoft.com/windows/win32/seccng/cng-algorithm-pseudo-handles) with the `BCryptHash` routine to get a modest perf improvement in the one-shot hash algortihms when running on Windows 10. For downlevel Windows platforms, continues to use the existing "catch `EntryPointNotFound` and fall back to `BCryptHashData`" logic.

The Win10-specific routine also has a safety net such that if any of the invariants are violated (unknown algorithm or destination too short), it falls back to the downlevel code paths for additional error handling.

No change on other OSes.

|   Method | Toolchain | HashAlgorithm | SourceLengthInBytes |     Mean |   Error |  StdDev | Ratio |
|--------- |---------- |-------------- |-------------------- |---------:|--------:|--------:|------:|
| HashData |    master |          SHA1 |                   0 | 336.4 ns | 0.71 ns | 0.66 ns |  1.00 |
| HashData |     proto |          SHA1 |                   0 | 288.8 ns | 2.17 ns | 1.81 ns |  0.86 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |          SHA1 |                  64 | 420.8 ns | 2.22 ns | 1.85 ns |  1.00 |
| HashData |     proto |          SHA1 |                  64 | 374.6 ns | 1.35 ns | 1.27 ns |  0.89 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |          SHA1 |                 256 | 651.0 ns | 3.40 ns | 3.02 ns |  1.00 |
| HashData |     proto |          SHA1 |                 256 | 609.0 ns | 4.11 ns | 3.85 ns |  0.94 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |        SHA256 |                   0 | 274.7 ns | 1.33 ns | 1.24 ns |  1.00 |
| HashData |     proto |        SHA256 |                   0 | 226.2 ns | 1.13 ns | 0.94 ns |  0.82 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |        SHA256 |                  64 | 302.8 ns | 1.53 ns | 1.43 ns |  1.00 |
| HashData |     proto |        SHA256 |                  64 | 255.2 ns | 0.51 ns | 0.45 ns |  0.84 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |        SHA256 |                 256 | 390.4 ns | 1.10 ns | 0.92 ns |  1.00 |
| HashData |     proto |        SHA256 |                 256 | 348.5 ns | 1.90 ns | 1.78 ns |  0.89 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |        SHA512 |                   0 | 493.0 ns | 2.43 ns | 2.27 ns |  1.00 |
| HashData |     proto |        SHA512 |                   0 | 455.6 ns | 1.32 ns | 1.10 ns |  0.92 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |        SHA512 |                  64 | 498.4 ns | 1.02 ns | 0.91 ns |  1.00 |
| HashData |     proto |        SHA512 |                  64 | 468.5 ns | 2.48 ns | 2.07 ns |  0.94 |
|          |           |               |                     |          |         |         |       |
| HashData |    master |        SHA512 |                 256 | 947.0 ns | 4.13 ns | 3.86 ns |  1.00 |
| HashData |     proto |        SHA512 |                 256 | 907.9 ns | 4.28 ns | 4.01 ns |  0.96 |