### PR TITLE
Disable formatting for outerloop.

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -164,4 +164,5 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
     platforms:
     - Linux_x64
-    - Windows_NT_x64
+    # Isssue: https://github.com/dotnet/runtime/issues/40034
+    #- Windows_NT_x64


### PR DESCRIPTION
Repeat #40035 for outerloop job, right now it is all (for 10 days) red because of #40034

https://dev.azure.com/dnceng/public/_build?definitionId=655&_a=summary

PTAL @jashook @dotnet/jit-contrib 