### PR TITLE
HttpClient: add null check for requestUri argument

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -135,16 +136,16 @@ namespace System.Net.Http
 
         #region Simple Get Overloads
 
-        public Task<string> GetStringAsync(string? requestUri) =>
+        public Task<string> GetStringAsync(string requestUri) =>
             GetStringAsync(CreateUri(requestUri));
 
-        public Task<string> GetStringAsync(Uri? requestUri) =>
+        public Task<string> GetStringAsync(Uri requestUri) =>
             GetStringAsync(requestUri, CancellationToken.None);
 
-        public Task<string> GetStringAsync(string? requestUri, CancellationToken cancellationToken) =>
+        public Task<string> GetStringAsync(string requestUri, CancellationToken cancellationToken) =>
             GetStringAsync(CreateUri(requestUri), cancellationToken);
 
-        public Task<string> GetStringAsync(Uri? requestUri, CancellationToken cancellationToken) =>
+        public Task<string> GetStringAsync(Uri requestUri, CancellationToken cancellationToken) =>
             GetStringAsyncCore(GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken), cancellationToken);
 
         private async Task<string> GetStringAsyncCore(Task<HttpResponseMessage> getTask, CancellationToken cancellationToken)
@@ -192,16 +193,16 @@ namespace System.Net.Http
             }
         }
 
-        public Task<byte[]> GetByteArrayAsync(string? requestUri) =>
+        public Task<byte[]> GetByteArrayAsync(string requestUri) =>
             GetByteArrayAsync(CreateUri(requestUri));
 
-        public Task<byte[]> GetByteArrayAsync(Uri? requestUri) =>
+        public Task<byte[]> GetByteArrayAsync(Uri requestUri) =>
             GetByteArrayAsync(requestUri, CancellationToken.None);
 
-        public Task<byte[]> GetByteArrayAsync(string? requestUri, CancellationToken cancellationToken) =>
+        public Task<byte[]> GetByteArrayAsync(string requestUri, CancellationToken cancellationToken) =>
             GetByteArrayAsync(CreateUri(requestUri), cancellationToken);
 
-        public Task<byte[]> GetByteArrayAsync(Uri? requestUri, CancellationToken cancellationToken) =>
+        public Task<byte[]> GetByteArrayAsync(Uri requestUri, CancellationToken cancellationToken) =>
             GetByteArrayAsyncCore(GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken), cancellationToken);
 
         private async Task<byte[]> GetByteArrayAsyncCore(Task<HttpResponseMessage> getTask, CancellationToken cancellationToken)
@@ -280,16 +281,16 @@ namespace System.Net.Http
             }
         }
 
-        public Task<Stream> GetStreamAsync(string? requestUri) =>
+        public Task<Stream> GetStreamAsync(string requestUri) =>
             GetStreamAsync(CreateUri(requestUri));
 
-        public Task<Stream> GetStreamAsync(string? requestUri, CancellationToken cancellationToken) =>
+        public Task<Stream> GetStreamAsync(string requestUri, CancellationToken cancellationToken) =>
             GetStreamAsync(CreateUri(requestUri), cancellationToken);
 
-        public Task<Stream> GetStreamAsync(Uri? requestUri) =>
+        public Task<Stream> GetStreamAsync(Uri requestUri) =>
             GetStreamAsync(requestUri, CancellationToken.None);
 
-        public Task<Stream> GetStreamAsync(Uri? requestUri, CancellationToken cancellationToken) =>
+        public Task<Stream> GetStreamAsync(Uri requestUri, CancellationToken cancellationToken) =>
             FinishGetStreamAsync(GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken), cancellationToken);
 
         private async Task<Stream> FinishGetStreamAsync(Task<HttpResponseMessage> getTask, CancellationToken cancellationToken)
@@ -306,137 +307,147 @@ namespace System.Net.Http
 
         #region REST Send Overloads
 
-        public Task<HttpResponseMessage> GetAsync(string? requestUri)
+        public Task<HttpResponseMessage> GetAsync(string requestUri)
         {
             return GetAsync(CreateUri(requestUri));
         }
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri)
+        public Task<HttpResponseMessage> GetAsync(Uri requestUri)
         {
             return GetAsync(requestUri, defaultCompletionOption);
         }
 
-        public Task<HttpResponseMessage> GetAsync(string? requestUri, HttpCompletionOption completionOption)
+        public Task<HttpResponseMessage> GetAsync(string requestUri, HttpCompletionOption completionOption)
         {
             return GetAsync(CreateUri(requestUri), completionOption);
         }
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri, HttpCompletionOption completionOption)
+        public Task<HttpResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption)
         {
             return GetAsync(requestUri, completionOption, CancellationToken.None);
         }
 
-        public Task<HttpResponseMessage> GetAsync(string? requestUri, CancellationToken cancellationToken)
+        public Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken)
         {
             return GetAsync(CreateUri(requestUri), cancellationToken);
         }
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri, CancellationToken cancellationToken)
+        public Task<HttpResponseMessage> GetAsync(Uri requestUri, CancellationToken cancellationToken)
         {
             return GetAsync(requestUri, defaultCompletionOption, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> GetAsync(string? requestUri, HttpCompletionOption completionOption,
+        public Task<HttpResponseMessage> GetAsync(string requestUri, HttpCompletionOption completionOption,
             CancellationToken cancellationToken)
         {
             return GetAsync(CreateUri(requestUri), completionOption, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri, HttpCompletionOption completionOption,
+        public Task<HttpResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption,
             CancellationToken cancellationToken)
         {
+            if (requestUri is null) throw new ArgumentNullException(nameof(requestUri));
+
             return SendAsync(CreateRequestMessage(HttpMethod.Get, requestUri), completionOption, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> PostAsync(string? requestUri, HttpContent content)
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
         {
             return PostAsync(CreateUri(requestUri), content);
         }
 
-        public Task<HttpResponseMessage> PostAsync(Uri? requestUri, HttpContent content)
+        public Task<HttpResponseMessage> PostAsync(Uri requestUri, HttpContent content)
         {
             return PostAsync(requestUri, content, CancellationToken.None);
         }
 
-        public Task<HttpResponseMessage> PostAsync(string? requestUri, HttpContent content,
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content,
             CancellationToken cancellationToken)
         {
             return PostAsync(CreateUri(requestUri), content, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> PostAsync(Uri? requestUri, HttpContent content,
+        public Task<HttpResponseMessage> PostAsync(Uri requestUri, HttpContent content,
             CancellationToken cancellationToken)
         {
+            if (requestUri is null) throw new ArgumentNullException(nameof(requestUri));
+
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
             return SendAsync(request, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> PutAsync(string? requestUri, HttpContent content)
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content)
         {
             return PutAsync(CreateUri(requestUri), content);
         }
 
-        public Task<HttpResponseMessage> PutAsync(Uri? requestUri, HttpContent content)
+        public Task<HttpResponseMessage> PutAsync(Uri requestUri, HttpContent content)
         {
             return PutAsync(requestUri, content, CancellationToken.None);
         }
 
-        public Task<HttpResponseMessage> PutAsync(string? requestUri, HttpContent content,
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content,
             CancellationToken cancellationToken)
         {
             return PutAsync(CreateUri(requestUri), content, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> PutAsync(Uri? requestUri, HttpContent content,
+        public Task<HttpResponseMessage> PutAsync(Uri requestUri, HttpContent content,
             CancellationToken cancellationToken)
         {
+            if (requestUri is null) throw new ArgumentNullException(nameof(requestUri));
+
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Put, requestUri);
             request.Content = content;
             return SendAsync(request, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> PatchAsync(string? requestUri, HttpContent content)
+        public Task<HttpResponseMessage> PatchAsync(string requestUri, HttpContent content)
         {
             return PatchAsync(CreateUri(requestUri), content);
         }
 
-        public Task<HttpResponseMessage> PatchAsync(Uri? requestUri, HttpContent content)
+        public Task<HttpResponseMessage> PatchAsync(Uri requestUri, HttpContent content)
         {
             return PatchAsync(requestUri, content, CancellationToken.None);
         }
 
-        public Task<HttpResponseMessage> PatchAsync(string? requestUri, HttpContent content,
+        public Task<HttpResponseMessage> PatchAsync(string requestUri, HttpContent content,
             CancellationToken cancellationToken)
         {
             return PatchAsync(CreateUri(requestUri), content, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> PatchAsync(Uri? requestUri, HttpContent content,
+        public Task<HttpResponseMessage> PatchAsync(Uri requestUri, HttpContent content,
             CancellationToken cancellationToken)
         {
+            if (requestUri is null) throw new ArgumentNullException(nameof(requestUri));
+
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Patch, requestUri);
             request.Content = content;
             return SendAsync(request, cancellationToken);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(string? requestUri)
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri)
         {
             return DeleteAsync(CreateUri(requestUri));
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(Uri? requestUri)
+        public Task<HttpResponseMessage> DeleteAsync(Uri requestUri)
         {
             return DeleteAsync(requestUri, CancellationToken.None);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(string? requestUri, CancellationToken cancellationToken)
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken)
         {
             return DeleteAsync(CreateUri(requestUri), cancellationToken);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(Uri? requestUri, CancellationToken cancellationToken)
+        public Task<HttpResponseMessage> DeleteAsync(Uri requestUri, CancellationToken cancellationToken)
         {
+            if (requestUri is null) throw new ArgumentNullException(nameof(requestUri));
+
             return SendAsync(CreateRequestMessage(HttpMethod.Delete, requestUri), cancellationToken);
         }
 
@@ -799,6 +810,7 @@ namespace System.Net.Http
             }
         }
 
+        [return: NotNullIfNotNull("uri")]
         private Uri? CreateUri(string? uri) =>
             string.IsNullOrEmpty(uri) ? null : new Uri(uri, UriKind.RelativeOrAbsolute);
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -157,26 +157,22 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("/something.html")]
-        public void GetAsync_NoBaseAddress_InvalidUri_ThrowsException(string uri)
+        [Fact]
+        public void GetAsync_NoBaseAddress_InvalidUri_ThrowsException()
         {
             using (var client = new HttpClient(new CustomResponseHandler((r, c) => Task.FromResult(new HttpResponseMessage()))))
             {
-                Assert.Throws<InvalidOperationException>(() => { client.GetAsync(uri == null ? null : new Uri(uri, UriKind.RelativeOrAbsolute)); });
+                Assert.Throws<InvalidOperationException>(() => { client.GetAsync(new Uri("/something.html", UriKind.RelativeOrAbsolute)); });
             }
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("/")]
-        public async Task GetAsync_BaseAddress_ValidUri_Success(string uri)
+        [Fact]
+        public async Task GetAsync_BaseAddress_ValidUri_Success()
         {
             using (var client = new HttpClient(new CustomResponseHandler((r,c) => Task.FromResult(new HttpResponseMessage()))))
             {
                 client.BaseAddress = new Uri(CreateFakeUri());
-                using (HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead))
+                using (HttpResponseMessage response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 }
@@ -571,6 +567,49 @@ namespace System.Net.Http.Functional.Tests
             Assert.Throws<ObjectDisposedException>(() => { client.Timeout = TimeSpan.FromSeconds(1); });
         }
 
+        [Fact]
+        public void StartRequest_Throws_ArgumentNullException()
+        {
+            var client = new HttpClient();
+
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.DeleteAsync((string)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.DeleteAsync((Uri)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.DeleteAsync((string)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.DeleteAsync((Uri)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((string)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((Uri)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((string)null, (HttpCompletionOption)default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((Uri)null, (HttpCompletionOption)default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((string)null, (CancellationToken)default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((Uri)null, (CancellationToken)default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((string)null, default, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetAsync((Uri)null, default, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetByteArrayAsync((string)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetByteArrayAsync((Uri)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetByteArrayAsync((string)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetByteArrayAsync((Uri)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStreamAsync((string)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStreamAsync((Uri)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStreamAsync((string)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStreamAsync((Uri)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStringAsync((string)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStringAsync((Uri)null); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStringAsync((string)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.GetStringAsync((Uri)null, default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PostAsync((string)null, new ByteArrayContent(new byte[1])); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PostAsync((Uri)null, new ByteArrayContent(new byte[1])); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PostAsync((string)null, new ByteArrayContent(new byte[1]), default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PostAsync((Uri)null, new ByteArrayContent(new byte[1]), default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PutAsync((string)null, new ByteArrayContent(new byte[1])); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PutAsync((Uri)null, new ByteArrayContent(new byte[1])); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PutAsync((string)null, new ByteArrayContent(new byte[1]), default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PutAsync((Uri)null, new ByteArrayContent(new byte[1]), default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PatchAsync((string)null, new ByteArrayContent(new byte[1])); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PatchAsync((Uri)null, new ByteArrayContent(new byte[1])); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PatchAsync((string)null, new ByteArrayContent(new byte[1]), default); }).ParamName);
+            Assert.Equal("requestUri", Assert.Throws<ArgumentNullException>(() => { client.PatchAsync((Uri)null, new ByteArrayContent(new byte[1]), default); }).ParamName);
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -748,7 +787,7 @@ namespace System.Net.Http.Functional.Tests
         {
             int currentThreadId = Thread.CurrentThread.ManagedThreadId;
 
-            var client = new HttpClient(new CustomResponseHandler((r, c) => 
+            var client = new HttpClient(new CustomResponseHandler((r, c) =>
             {
                 Assert.Equal(currentThreadId, Thread.CurrentThread.ManagedThreadId);
                 return Task.FromResult(new HttpResponseMessage()
@@ -768,7 +807,7 @@ namespace System.Net.Http.Functional.Tests
                             Assert.Equal(currentThreadId, Thread.CurrentThread.ManagedThreadId);
                         })
                     }, completionOption);
-                    
+
                 Stream contentStream = response.Content.ReadAsStream();
                 Assert.Equal(currentThreadId, Thread.CurrentThread.ManagedThreadId);
             }
@@ -804,7 +843,7 @@ namespace System.Net.Http.Functional.Tests
                         }, completionOption);
 
                         Stream contentStream = response.Content.ReadAsStream();
-                        Assert.Equal(currentThreadId, Thread.CurrentThread.ManagedThreadId);                        
+                        Assert.Equal(currentThreadId, Thread.CurrentThread.ManagedThreadId);
                         using (StreamReader sr = new StreamReader(contentStream))
                         {
                             Assert.Equal(content, sr.ReadToEnd());
@@ -857,13 +896,13 @@ namespace System.Net.Http.Functional.Tests
                     Assert.IsNotType<TimeoutException>(ex.InnerException);
                 },
                 async server =>
-                { 
+                {
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         try
                         {
                             await connection.ReadRequestHeaderAsync();
-                            cts.Cancel();                        
+                            cts.Cancel();
                             await connection.ReadRequestBodyAsync();
                         }
                         catch { }
@@ -901,7 +940,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.IsType<TimeoutException>(ex.InnerException);
                 },
                 async server =>
-                { 
+                {
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         try
@@ -959,7 +998,7 @@ namespace System.Net.Http.Functional.Tests
                         }
                         catch { }
                     });
-                }); 
+                });
         }
 
         [Fact]
@@ -999,7 +1038,7 @@ namespace System.Net.Http.Functional.Tests
                         }
                         catch { }
                     });
-                }); 
+                });
         }
 
         [Fact]


### PR DESCRIPTION
1) For request which are called with null requestUri argument the correct ArgumentNullException is thrown according to the documentation
2) change nullability of requestUri argument to reflect the runtime behaviour

fixes: #40519