### PR TITLE
System.Diagnostics.Activity Perf Improvement Part 2

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -76,20 +76,11 @@ namespace System.Diagnostics
 
         private byte _w3CIdFlags;
 
-        /*
-         * Note:
-         *  DynamicDependency is used here to prevent the linker from removing the struct GetEnumerator on the internal types.
-         *  Some customers use this GetEnumerator dynamically to avoid allocations.
-         *  See: https://github.com/dotnet/runtime/pull/40362
-         */
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(TagsLinkedList))]
-        private TagsLinkedList? _tags;
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(LinkedList<ActivityLink>))]
-        private LinkedList<ActivityLink>? _links;
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(LinkedList<ActivityEvent>))]
-        private LinkedList<ActivityEvent>? _events;
 
+        private TagsLinkedList? _tags;
         private LinkedList<KeyValuePair<string, string?>>? _baggage;
+        private LinkedList<ActivityLink>? _links;
+        private LinkedList<ActivityEvent>? _events;
         private ConcurrentDictionary<string, object>? _customProperties;
         private string? _displayName;
 
@@ -1280,8 +1271,8 @@ namespace System.Diagnostics
             }
 
             public Enumerator<T> GetEnumerator() => new Enumerator<T>(_first);
-            IEnumerator<T> IEnumerable<T>.GetEnumerator() => new Enumerator<T>(_first);
-            IEnumerator IEnumerable.GetEnumerator() => new Enumerator<T>(_first);
+            IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 
         private class TagsLinkedList : IEnumerable<KeyValuePair<string, object?>>
@@ -1387,8 +1378,8 @@ namespace System.Diagnostics
             }
 
             public Enumerator<KeyValuePair<string, object?>> GetEnumerator() => new Enumerator<KeyValuePair<string, object?>>(_first);
-            IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => new Enumerator<KeyValuePair<string, object?>>(_first);
-            IEnumerator IEnumerable.GetEnumerator() => new Enumerator<KeyValuePair<string, object?>>(_first);
+            IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
             public IEnumerable<KeyValuePair<string, string?>> EnumerateStringValues()
             {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1401,13 +1401,12 @@ namespace System.Diagnostics
         // Note: Some customers use this Enumerator dynamically to avoid allocations.
         private struct Enumerator<T> : IEnumerator<T>
         {
-            private readonly LinkedListNode<T>? _head;
             private LinkedListNode<T>? _nextNode;
             [AllowNull, MaybeNull] private T _currentItem;
 
             public Enumerator(LinkedListNode<T>? head)
             {
-                _nextNode = _head = head;
+                _nextNode = head;
                 _currentItem = default;
             }
 
@@ -1428,7 +1427,7 @@ namespace System.Diagnostics
                 return true;
             }
 
-            public void Reset() => _nextNode = _head;
+            public void Reset() => throw new NotSupportedException();
 
             public void Dispose()
             {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1398,11 +1398,7 @@ namespace System.Diagnostics
             }
         }
 
-        /*
-         * Note:
-         *  Some customers use this Enumerator dynamically to avoid allocations.
-         *  See: https://github.com/dotnet/runtime/pull/40362
-         */
+        // Note: Some customers use this Enumerator dynamically to avoid allocations.
         private struct Enumerator<T> : IEnumerator<T>
         {
             private readonly LinkedListNode<T>? _head;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -76,10 +76,20 @@ namespace System.Diagnostics
 
         private byte _w3CIdFlags;
 
+        /*
+         * Note:
+         *  DynamicDependency is used here to prevent the linker from removing the struct GetEnumerator on the internal types.
+         *  Some customers use this GetEnumerator dynamically to avoid allocations.
+         *  See: https://github.com/dotnet/runtime/pull/40362
+         */
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(TagsLinkedList))]
         private TagsLinkedList? _tags;
-        private LinkedList<KeyValuePair<string, string?>>? _baggage;
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(LinkedList<ActivityLink>))]
         private LinkedList<ActivityLink>? _links;
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(LinkedList<ActivityEvent>))]
         private LinkedList<ActivityEvent>? _events;
+
+        private LinkedList<KeyValuePair<string, string?>>? _baggage;
         private ConcurrentDictionary<string, object>? _customProperties;
         private string? _displayName;
 
@@ -255,9 +265,6 @@ namespace System.Diagnostics
         /// </summary>
         public IEnumerable<KeyValuePair<string, object?>> TagObjects
         {
-#if ALLOW_PARTIALLY_TRUSTED_CALLERS
-        [System.Security.SecuritySafeCriticalAttribute]
-#endif
             get => _tags ?? s_emptyTagObjects;
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -76,7 +76,6 @@ namespace System.Diagnostics
 
         private byte _w3CIdFlags;
 
-
         private TagsLinkedList? _tags;
         private LinkedList<KeyValuePair<string, string?>>? _baggage;
         private LinkedList<ActivityLink>? _links;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1269,6 +1269,7 @@ namespace System.Diagnostics
                 }
             }
 
+            // Note: Some customers use this GetEnumerator dynamically to avoid allocations.
             public Enumerator<T> GetEnumerator() => new Enumerator<T>(_first);
             IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -1376,6 +1377,7 @@ namespace System.Diagnostics
                 }
             }
 
+            // Note: Some customers use this GetEnumerator dynamically to avoid allocations.
             public Enumerator<KeyValuePair<string, object?>> GetEnumerator() => new Enumerator<KeyValuePair<string, object?>>(_first);
             IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => GetEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -1396,6 +1398,11 @@ namespace System.Diagnostics
             }
         }
 
+        /*
+         * Note:
+         *  Some customers use this Enumerator dynamically to avoid allocations.
+         *  See: https://github.com/dotnet/runtime/pull/40362
+         */
         private struct Enumerator<T> : IEnumerator<T>
         {
             private readonly LinkedListNode<T>? _head;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -1518,17 +1518,11 @@ namespace System.Diagnostics.Tests
 
             IEnumerable<KeyValuePair<string, object>> enumerable = a.TagObjects;
 
-            bool foundGetEnumerator = false;
-            foreach (MethodInfo method in enumerable.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic))
-            {
-                if(method.Name == "GetEnumerator" && !method.ReturnType.IsInterface && method.ReturnType.IsValueType)
-                {
-                    foundGetEnumerator = true;
-                    break;
-                }
-            }
+            MethodInfo method = enumerable.GetType().GetMethod("GetEnumerator", BindingFlags.Instance | BindingFlags.Public);
 
-            Assert.True(foundGetEnumerator);
+            Assert.NotNull(method);
+            Assert.False(method.ReturnType.IsInterface);
+            Assert.True(method.ReturnType.IsValueType);
         }
 
         [Fact]
@@ -1541,17 +1535,11 @@ namespace System.Diagnostics.Tests
 
             IEnumerable<ActivityEvent> enumerable = a.Events;
 
-            bool foundGetEnumerator = false;
-            foreach (MethodInfo method in enumerable.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic))
-            {
-                if (method.Name == "GetEnumerator" && !method.ReturnType.IsInterface && method.ReturnType.IsValueType)
-                {
-                    foundGetEnumerator = true;
-                    break;
-                }
-            }
+            MethodInfo method = enumerable.GetType().GetMethod("GetEnumerator", BindingFlags.Instance | BindingFlags.Public);
 
-            Assert.True(foundGetEnumerator);
+            Assert.NotNull(method);
+            Assert.False(method.ReturnType.IsInterface);
+            Assert.True(method.ReturnType.IsValueType);
         }
 
         public void Dispose()

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -1508,6 +1508,54 @@ namespace System.Diagnostics.Tests
             Assert.Equal(resultCount, a.TagObjects.Count());
         }
 
+        [Fact]
+        public void StructEnumerator_TagsLinkedList()
+        {
+            /*
+             * This test verifies the presence of the struct Enumerator on TagsLinkedList used by customers dynamically to avoid allocations.
+             */
+            Activity a = new Activity("TestActivity");
+            a.AddTag("Tag1", true);
+
+            IEnumerable<KeyValuePair<string, object>> enumerable = a.TagObjects;
+
+            bool foundGetEnumerator = false;
+            foreach (MethodInfo method in enumerable.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic))
+            {
+                if(method.Name == "GetEnumerator" && !method.ReturnType.IsInterface && method.ReturnType.IsValueType)
+                {
+                    foundGetEnumerator = true;
+                    break;
+                }
+            }
+
+            Assert.True(foundGetEnumerator);
+        }
+
+        [Fact]
+        public void StructEnumerator_GenericLinkedList()
+        {
+            /*
+             * This test verifies the presence of the struct Enumerator on LinkedList<T> used by customers dynamically to avoid allocations.
+             */
+            Activity a = new Activity("TestActivity");
+            a.AddEvent(new ActivityEvent());
+
+            IEnumerable<ActivityEvent> enumerable = a.Events;
+
+            bool foundGetEnumerator = false;
+            foreach (MethodInfo method in enumerable.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic))
+            {
+                if (method.Name == "GetEnumerator" && !method.ReturnType.IsInterface && method.ReturnType.IsValueType)
+                {
+                    foundGetEnumerator = true;
+                    break;
+                }
+            }
+
+            Assert.True(foundGetEnumerator);
+        }
+
         public void Dispose()
         {
             Activity.Current = null;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -1511,9 +1511,8 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void StructEnumerator_TagsLinkedList()
         {
-            /*
-             * This test verifies the presence of the struct Enumerator on TagsLinkedList used by customers dynamically to avoid allocations.
-             */
+            // Note: This test verifies the presence of the struct Enumerator on TagsLinkedList used by customers dynamically to avoid allocations.
+
             Activity a = new Activity("TestActivity");
             a.AddTag("Tag1", true);
 
@@ -1535,9 +1534,8 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void StructEnumerator_GenericLinkedList()
         {
-            /*
-             * This test verifies the presence of the struct Enumerator on LinkedList<T> used by customers dynamically to avoid allocations.
-             */
+            // Note: This test verifies the presence of the struct Enumerator on LinkedList<T> used by customers dynamically to avoid allocations.
+
             Activity a = new Activity("TestActivity");
             a.AddEvent(new ActivityEvent());
 


### PR DESCRIPTION
Updated the public code to use the internal `struct GetEnumerator` method to prevent the linker from removing it.

See #40362 

/cc @tarekgh @noahfalk @cijothomas @eerhardt 