### PR TITLE
Ensure that no exception is thrown when static properties on the Activity type are passed to EventListener

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -948,6 +948,12 @@ namespace System.Diagnostics
                                 Logger.Message($"Property {propertyName} not found on {type}");
                                 return new PropertyFetch(type);
                             }
+                            // Delegate creation below is incompatible with static properties.
+                            else if (propertyInfo.GetMethod?.IsStatic == true || propertyInfo.SetMethod?.IsStatic == true)
+                            {
+                                Logger.Message($"Property {propertyName} is static.");
+                                return new PropertyFetch(type);
+                            }
                             Type typedPropertyFetcher = typeInfo.IsValueType ?
                                 typeof(ValueTypedFetchProperty<,>) : typeof(RefTypedFetchProperty<,>);
                             Type instantiatedTypedPropertyFetcher = typedPropertyFetcher.GetTypeInfo().MakeGenericType(


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/38406.