### PR TITLE
Disable EOL Target Frameworks check in newer SDKs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -101,6 +101,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <!-- Determine what architecture we are building on. -->
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
+    
+    <!-- Turn off end of life target framework check as we still build for nca2.0 and nca3.0 some OOB libraries -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />


### PR DESCRIPTION
With recent SDKs (rc1) EOL checks were enabled for nca3.0 and nca2.0... we still build for those tfms in some libraries that support those frameworks via NuGet packages. Disable that check to unblock developers that get that SDK globally installed via latest VS Internal Preview.

cc: @dotnet/runtime-infrastructure 