### PR TITLE
Add GetProcessEnvironment command to diagnostics server

### DIFF
--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -68,7 +68,7 @@ uint16_t ProcessInfoPayload::GetSize()
         S_UINT16(GetStringLength(Arch) * sizeof(WCHAR)) :
         S_UINT16(0);
 
-    EnsureEnv();
+    PopulateEnvironment();
 
     size += sizeof(uint32_t);
     size += S_UINT16(_nEnvEntries * sizeof(uint32_t));
@@ -137,7 +137,7 @@ bool ProcessInfoPayload::Flatten(BYTE * &lpBuffer, uint16_t &cbSize)
     return fSuccess;
 }
 
-void ProcessInfoPayload::EnsureEnv()
+void ProcessInfoPayload::PopulateEnvironment()
 {
     if (Environment != nullptr)
         return;
@@ -211,7 +211,7 @@ void ProcessDiagnosticsProtocolHelper::GetProcessInfo(DiagnosticsIpc::IpcMessage
     payload.RuntimeCookie = DiagnosticsIpc::GetAdvertiseCookie_V1();
 
     // Get the environment block
-    payload.EnsureEnv();
+    payload.PopulateEnvironment();
 
     DiagnosticsIpc::IpcMessage ProcessInfoResponse;
     const bool fSuccess = ProcessInfoResponse.Initialize(DiagnosticsIpc::GenericSuccessHeader, payload) ?

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -242,10 +242,10 @@ void ProcessDiagnosticsProtocolHelper::GetProcessEnvironment(DiagnosticsIpc::Ipc
     struct EnvironmentHelper helper = {};
     helper.PopulateEnvironment();
 
-    uint32_t nBytes = helper.GetEnvironmentBlockSize();
+    struct EnvironmentHelper::InitialPayload payload = { helper.GetEnvironmentBlockSize(), 0 };
 
     DiagnosticsIpc::IpcMessage ProcessEnvironmentResponse;
-    const bool fSuccess = ProcessEnvironmentResponse.Initialize(DiagnosticsIpc::GenericSuccessHeader, nBytes) ?
+    const bool fSuccess = ProcessEnvironmentResponse.Initialize(DiagnosticsIpc::GenericSuccessHeader, payload) ?
         ProcessEnvironmentResponse.Send(pStream) :
         DiagnosticsIpc::IpcMessage::SendErrorMessage(pStream, E_FAIL);
 

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -173,26 +173,14 @@ void EnvironmentHelper::PopulateEnvironment()
         LPWSTR tmpEnv = new (nothrow) WCHAR[nWchars + 1];
         if (tmpEnv != nullptr)
         {
-            envCursor = envBlock;
-            LPWSTR payloadCursor = tmpEnv;
-
-            while(*envCursor != 0) 
-            {
-                // len characters
-                uint32_t len = static_cast<uint32_t>(wcslen(envCursor) + 1);
-                wcscpy(payloadCursor, envCursor);
-                envCursor += len;
-                payloadCursor += len;
-            }
-            *payloadCursor = W('\0');
+            memcpy(tmpEnv, envBlock, (nWchars + 1) * sizeof(WCHAR));
             Environment = tmpEnv;
         }
+        _nEnvEntries = nEntries;
+        _nWchars = nWchars;
     }
 
     FreeEnvironmentStringsW(envBlock);
-
-    _nEnvEntries = nEntries;
-    _nWchars = nWchars;
 
     return;
 }

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -126,7 +126,7 @@ bool ProcessInfoPayload::Flatten(BYTE * &lpBuffer, uint16_t &cbSize)
         if (!fSuccess)
             break;
 
-        uint32_t len = wcslen(cursor) + 1;
+        uint32_t len = static_cast<uint32_t>(wcslen(cursor) + 1);
         fSuccess &= TryWriteString(lpBuffer, cbSize, cursor);
         cursor += len;
     }
@@ -151,7 +151,7 @@ void ProcessInfoPayload::EnsureEnv()
     uint32_t nEntries = 0;
     while(*envCursor != 0) 
     {
-        uint32_t len = wcslen(envCursor) + 1;
+        uint32_t len = static_cast<uint32_t>(wcslen(envCursor) + 1);
         nEntries++;
         nWchars += len;
         envCursor += len;
@@ -164,7 +164,7 @@ void ProcessInfoPayload::EnsureEnv()
     while(*envCursor != 0) 
     {
         // len characters
-        uint32_t len = wcslen(envCursor) + 1;
+        uint32_t len = static_cast<uint32_t>(wcslen(envCursor) + 1);
         wcscpy(payloadCursor, envCursor);
         envCursor += len;
         payloadCursor += len;

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -126,7 +126,7 @@ bool ProcessInfoPayload::Flatten(BYTE * &lpBuffer, uint16_t &cbSize)
         if (!fSuccess)
             break;
 
-        int len = wcslen(cursor) + 1;
+        uint32_t len = wcslen(cursor) + 1;
         fSuccess &= TryWriteString(lpBuffer, cbSize, cursor);
         cursor += len;
     }
@@ -151,7 +151,7 @@ void ProcessInfoPayload::EnsureEnv()
     uint32_t nEntries = 0;
     while(*envCursor != 0) 
     {
-        int len = wcslen(envCursor) + 1;
+        uint32_t len = wcslen(envCursor) + 1;
         nEntries++;
         nWchars += len;
         envCursor += len;
@@ -164,7 +164,7 @@ void ProcessInfoPayload::EnsureEnv()
     while(*envCursor != 0) 
     {
         // len characters
-        int len = wcslen(envCursor) + 1;
+        uint32_t len = wcslen(envCursor) + 1;
         wcscpy(payloadCursor, envCursor);
         envCursor += len;
         payloadCursor += len;

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
@@ -51,6 +51,12 @@ struct EnvironmentHelper
     // It is encoded in the typical length-prefixed array format as defined in
     // the Diagnostics IPC Spec: https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
 
+    struct InitialPayload
+    {
+        uint32_t continuationSizeInBytes;
+        uint16_t future;
+    };
+
     // sent as: Array<Array<WCHAR>>
     NewArrayHolder<const WCHAR> Environment = nullptr;
 

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
@@ -41,8 +41,13 @@ struct ProcessInfoPayload
     LPCWSTR OS;
     LPCWSTR Arch;
     GUID RuntimeCookie;
+    NewArrayHolder<const WCHAR> Environment = nullptr;
+    void EnsureEnv();
     uint16_t GetSize();
     bool Flatten(BYTE * &lpBuffer, uint16_t& cbSize);
+private:
+    uint32_t _nEnvEntries = 0;
+    uint32_t _nWchars = 0;
 };
 
 class ProcessDiagnosticsProtocolHelper

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
@@ -42,7 +42,7 @@ struct ProcessInfoPayload
     LPCWSTR Arch;
     GUID RuntimeCookie;
     NewArrayHolder<const WCHAR> Environment = nullptr;
-    void EnsureEnv();
+    void PopulateEnvironment();
     uint16_t GetSize();
     bool Flatten(BYTE * &lpBuffer, uint16_t& cbSize);
 private:

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.h
@@ -18,8 +18,9 @@ class IpcStream;
 // see diagnosticsipc.h and diagnosticserver.h for more details
 enum class ProcessCommandId : uint8_t
 {
-    GetProcessInfo = 0x00,
-    ResumeRuntime  = 0x01,
+    GetProcessInfo        = 0x00,
+    ResumeRuntime         = 0x01,
+    GetProcessEnvironment = 0x02
     // future
 };
 
@@ -33,7 +34,6 @@ struct ProcessInfoPayload
     // GUID = 16 little endian bytes
     // wchar = 2 little endian bytes, UTF16 encoding
     // array<T> = uint length, length # of Ts
-    // string = (array<char> where the last char must = 0) or (length = 0)
 
     // ProcessInfo = long pid, string cmdline, string OS, string arch, GUID runtimeCookie
     uint64_t ProcessId;
@@ -41,10 +41,30 @@ struct ProcessInfoPayload
     LPCWSTR OS;
     LPCWSTR Arch;
     GUID RuntimeCookie;
-    NewArrayHolder<const WCHAR> Environment = nullptr;
-    void PopulateEnvironment();
     uint16_t GetSize();
     bool Flatten(BYTE * &lpBuffer, uint16_t& cbSize);
+};
+
+struct EnvironmentHelper
+{
+    // The environemnt is sent back as an optional continuation stream of data.
+    // It is encoded in the typical length-prefixed array format as defined in
+    // the Diagnostics IPC Spec: https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+
+    // sent as: Array<Array<WCHAR>>
+    NewArrayHolder<const WCHAR> Environment = nullptr;
+
+    void PopulateEnvironment();
+    uint32_t GetNumberOfElements() { PopulateEnvironment(); return _nEnvEntries; }
+
+    // Write the environment block to the stream
+    bool WriteToStream(IpcStream *pStream);
+
+    // The size in bytes of the Diagnostic IPC Protocol encoded Environment Block
+    // It is encoded as Array<Array<WCHAR>> so this will return at least sizeof(uint32_t)
+    // if the env block is empty or failed to be snapshotted since the stream will
+    // just contain 0 for the array length.
+    uint32_t GetEnvironmentBlockSize();
 private:
     uint32_t _nEnvEntries = 0;
     uint32_t _nWchars = 0;
@@ -56,6 +76,7 @@ public:
     // IPC event handlers.
     static void HandleIpcMessage(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream);
     static void GetProcessInfo(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream);
+    static void GetProcessEnvironment(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream);
     static void ResumeRuntimeStartup(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream);
 };
 

--- a/src/tests/tracing/eventpipe/processenvironment/processenvironment.cs
+++ b/src/tests/tracing/eventpipe/processenvironment/processenvironment.cs
@@ -46,8 +46,10 @@ namespace Tracing.Tests.ProcessEnvironmentValidation
             Utils.Assert(response.Header.CommandSet == 0xFF, $"Response must have Server command set. Expected: 0xFF, Received: 0x{response.Header.CommandSet:X2}"); // server
             Utils.Assert(response.Header.CommandId == 0x00, $"Response must have OK command id. Expected: 0x00, Received: 0x{response.Header.CommandId:X2}"); // OK
 
-            UInt32 continuationSizeInBytes = BitConverter.ToUInt32(response.Payload);
+            UInt32 continuationSizeInBytes = BitConverter.ToUInt32(response.Payload[0..4]);
             Logger.logger.Log($"continuation size: {continuationSizeInBytes} bytes");
+            UInt16 future = BitConverter.ToUInt16(response.Payload[4..]);
+            Logger.logger.Log($"future value: {future}");
 
             using var memoryStream = new MemoryStream();
             Logger.logger.Log($"Starting to copy continuation");

--- a/src/tests/tracing/eventpipe/processenvironment/processenvironment.cs
+++ b/src/tests/tracing/eventpipe/processenvironment/processenvironment.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using Microsoft.Diagnostics.Tracing;
+using Tracing.Tests.Common;
+
+namespace Tracing.Tests.ProcessEnvironmentValidation
+{
+    public class ProcessEnvironmentValidation
+    {
+        public static int Main(string[] args)
+        {
+
+            Process currentProcess = Process.GetCurrentProcess();
+            int pid = currentProcess.Id;
+            Logger.logger.Log($"Test PID: {pid}");
+            var testEnvPairs = new Dictionary<string, string>
+            {
+                { "TESTKEY1", "TESTVAL1" },
+                { "TESTKEY2", "TESTVAL2" },
+                { "TESTKEY3", "__TEST__VAL=;--3" }
+            };
+
+            foreach (var (key, val) in testEnvPairs)
+                System.Environment.SetEnvironmentVariable(key, val);
+
+            Stream stream = ConnectionHelper.GetStandardTransport(pid);
+
+            // 0x04 = ProcessCommandSet, 0x02 = ProcessInfo
+            var processInfoMessage = new IpcMessage(0x04, 0x02);
+            Logger.logger.Log($"Wrote: {processInfoMessage}");
+            Stream continuationStream = IpcClient.SendMessage(stream, processInfoMessage, out IpcMessage response);
+            Logger.logger.Log($"Received: {response}");
+
+            Utils.Assert(response.Header.CommandSet == 0xFF, $"Response must have Server command set. Expected: 0xFF, Received: 0x{response.Header.CommandSet:X2}"); // server
+            Utils.Assert(response.Header.CommandId == 0x00, $"Response must have OK command id. Expected: 0x00, Received: 0x{response.Header.CommandId:X2}"); // OK
+
+            UInt32 continuationSizeInBytes = BitConverter.ToUInt32(response.Payload);
+            Logger.logger.Log($"continuation size: {continuationSizeInBytes} bytes");
+
+            using var memoryStream = new MemoryStream();
+            Logger.logger.Log($"Starting to copy continuation");
+            continuationStream.CopyTo(memoryStream);
+            Logger.logger.Log($"Finished copying continuation");
+            byte[] envBlock = memoryStream.ToArray();
+            Logger.logger.Log($"Total bytes in continuation: {envBlock.Length}");
+
+            Utils.Assert(envBlock.Length == continuationSizeInBytes, $"Continuation size must equal the reported size in the payload response.  Expected: {continuationSizeInBytes} bytes, Received: {envBlock.Length} bytes");
+
+            // VALIDATE ENV
+            // env block is sent as Array<LPCWSTR> (length-prefixed array of length-prefixed wchar strings)
+            int start = 0;
+            int end = start + 4 /* sizeof(uint32_t) */;
+            UInt32 envCount = BitConverter.ToUInt32(envBlock[start..end]);
+            Logger.logger.Log($"envCount: {envCount}");
+
+            var env = new Dictionary<string,string>();
+            for (int i = 0; i < envCount; i++)
+            {
+                start = end;
+                end = start + 4 /* sizeof(uint32_t) */;
+                UInt32 pairLength = BitConverter.ToUInt32(envBlock[start..end]);
+
+                start = end;
+                end = start + ((int)pairLength * sizeof(char));
+                Utils.Assert(end <= envBlock.Length, $"String end can't exceed payload size. Expected: <{envBlock.Length}, Received: {end} (decoded length: {pairLength})");
+                string envPair = System.Text.Encoding.Unicode.GetString(envBlock[start..end]).TrimEnd('\0');
+                int equalsIndex = envPair.IndexOf('=');
+                env[envPair[0..equalsIndex]] = envPair[(equalsIndex+1)..];
+            }
+            Logger.logger.Log($"finished parsing env");
+
+
+            foreach (var (key, val) in testEnvPairs)
+                Utils.Assert(env.ContainsKey(key) && env[key].Equals(val), $"Did not find test environment pair in the environment block: '{key}' = '{val}'");
+            Logger.logger.Log($"Saw test values in env");
+
+            Utils.Assert(end == envBlock.Length, $"Full payload should have been read. Expected: {envBlock.Length}, Received: {end}");
+
+            return 100;
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/processenvironment/processenvironment.csproj
+++ b/src/tests/tracing/eventpipe/processenvironment/processenvironment.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -215,7 +215,8 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Utils.Assert(end <= totalSize, $"String end can't exceed payload size. Expected: <{totalSize}, Received: {end} (decoded length: {pairLength})");
                 string envPair = System.Text.Encoding.Unicode.GetString(response.Payload[start..end]).TrimEnd('\0');
                 string[] parts = envPair.Split('=');
-                Utils.Assert(parts.Count() == 2, $"Malformed environment entry when splitting element on '='.  Expected: 2 parts, Received: {parts.Count()} parts {envPair}");
+                // second part is allowed to be empty
+                Utils.Assert(parts.Count() == 2, $"Malformed environment entry when splitting element on '='.  Expected: 2 parts, Received: {parts.Count()}");
                 env[parts[0]] = parts[1];
             }
             Logger.logger.Log($"finished parsing env");

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -78,7 +78,6 @@ namespace Tracing.Tests.ProcessInfoValidation
             string envKey = "TESTKEY";
             string envVal = "TESTVAL";
             System.Environment.SetEnvironmentVariable(envKey, envVal);
-            System.Environment.SetEnvironmentVariable("foo", "");
 
             Stream stream = ConnectionHelper.GetStandardTransport(pid);
 

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -215,9 +215,8 @@ namespace Tracing.Tests.ProcessInfoValidation
                 Utils.Assert(end <= totalSize, $"String end can't exceed payload size. Expected: <{totalSize}, Received: {end} (decoded length: {pairLength})");
                 string envPair = System.Text.Encoding.Unicode.GetString(response.Payload[start..end]).TrimEnd('\0');
                 string[] parts = envPair.Split('=');
-                // second part is allowed to be empty
-                Utils.Assert(parts.Count() == 2, $"Malformed environment entry when splitting element on '='.  Expected: 2 parts, Received: {parts.Count()}");
-                env[parts[0]] = parts[1];
+                string value = string.Join('=', parts[1..]);
+                env[parts[0]] = value;
             }
             Logger.logger.Log($"finished parsing env");
 

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -78,6 +78,7 @@ namespace Tracing.Tests.ProcessInfoValidation
             string envKey = "TESTKEY";
             string envVal = "TESTVAL";
             System.Environment.SetEnvironmentVariable(envKey, envVal);
+            System.Environment.SetEnvironmentVariable("foo", "");
 
             Stream stream = ConnectionHelper.GetStandardTransport(pid);
 
@@ -214,9 +215,8 @@ namespace Tracing.Tests.ProcessInfoValidation
                 end = start + ((int)pairLength * sizeof(char));
                 Utils.Assert(end <= totalSize, $"String end can't exceed payload size. Expected: <{totalSize}, Received: {end} (decoded length: {pairLength})");
                 string envPair = System.Text.Encoding.Unicode.GetString(response.Payload[start..end]).TrimEnd('\0');
-                string[] parts = envPair.Split('=');
-                string value = string.Join('=', parts[1..]);
-                env[parts[0]] = value;
+                int equalsIndex = envPair.IndexOf('=');
+                env[envPair[0..equalsIndex]] = envPair[(equalsIndex+1)..];
             }
             Logger.logger.Log($"finished parsing env");
 


### PR DESCRIPTION
These changes send the Environment block via the GetProcessEnvironment command in the Diagnostics IPC Protocol.

The environment block is retrieved in the standard null delimited list of strings form, and is sent as an `Array<Array<WCHAR>>` in the IPC protocol.  In other words, it is retrieved as
```
key=val\0key=val\0\0
```
and sent as (the `|` are logical separators and not part of the data)
```
2|8|key=val\0|8|key=val\0
```

Note that the tests do not print the bytes of the payload since they include the environment where the tests are run.

closes #40572

CC @dotnet/dotnet-diag @jander-msft