### PR TITLE
Fix perf regression in System.Net.NetworkInformation.PhysicalAddress

### DIFF
--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -83,6 +83,7 @@ namespace System
             buffer[startingIndex] = (char)(packedResult >> 8);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void EncodeToUtf16(ReadOnlySpan<byte> bytes, Span<char> chars, Casing casing = Casing.Upper)
         {
             Debug.Assert(chars.Length >= bytes.Length * 2);

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
@@ -90,7 +90,7 @@ namespace System.Net.NetworkInformation
 
         public override string ToString()
         {
-            return Convert.ToHexString(_address.AsSpan());
+            return HexConverter.ToString(_address.AsSpan(), HexConverter.Casing.Upper);
         }
 
         public byte[] GetAddressBytes()


### PR DESCRIPTION
Closes #39720 by:
* Using the internal API directly to avoid input validation overhead
* Encourage inlining of a method that was in-line prior to #39702


|  Method |        Job | Toolchain |      Mean |    Error |   StdDev | Ratio | RatioSD |
|-------- |----------- |---------- |----------:|---------:|---------:|------:|--------:|
| PAShort | Job-CSJLAA |        PR |  11.90 ns | 0.215 ns | 0.191 ns |  0.84 |    0.02 |
| PAShort | Job-RPOJLS |    master |  14.17 ns | 0.302 ns | 0.335 ns |  1.00 |    0.00 |

/cc @danmosemsft @DrewScoggins 