### PR TITLE
Update using-dotnet-cli.md

### DIFF
--- a/docs/workflow/using-dotnet-cli.md
+++ b/docs/workflow/using-dotnet-cli.md
@@ -58,13 +58,16 @@ Please run `dotnet new console` in the app folder and update the created `.cspro
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <RuntimeFrameworkVersion>5.0.0-dev</RuntimeFrameworkVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="5.0.0-dev" />
+  </ItemGroup>
 
 </Project>
 ```
 
-**You have to set the correct values for `RuntimeIdentifier` (RI), `RuntimeFrameworkVersion` and versions of both packages.**
+**You have to set the correct values for `RuntimeIdentifier` (RI) and `RuntimeFrameworkVersion`.**
 
 You can generally figure that out by looking at the packages you found in your output.
 In our example you will see there is a package with the name `Microsoft.NETCore.App.Runtime.win-x64.5.0.0-dev.nupkg`


### PR DESCRIPTION
Fixes "error NU1102: Unable to find package Microsoft.WindowsDesktop.App.Runtime.win-x64 with version (= 5.0.0-dev)"

This is based on https://github.com/dotnet/sdk/issues/10393#issuecomment-515188279 .