### PR TITLE
Remove unused local in System.Configuration.ConfigurationManager

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
@@ -725,7 +725,6 @@ namespace System.Configuration
                     }
                 }
 
-                object temp = base[propertyName];
                 SettingsProperty setting = Properties[propertyName];
                 SettingsProvider provider = setting != null ? setting.Provider : null;
 


### PR DESCRIPTION
Remove unused local 'temp' in System.Configuration.ConfigurationManager

Fixes part of #30457