### PR TITLE
Intrinsicify SpanHelpers.IndexOfAny(char,char,char,char,char)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -897,7 +897,7 @@ namespace System
                     do
                     {
                         Vector256<ushort> search = LoadVector256(ref searchStart, offset);
-                        // We preform the Or at non-Vector level as we are using the maximum number of non-preserved registers (+ 1),
+                        // We perform the Or at non-Vector level as we are using the maximum number of non-preserved registers (+ 1),
                         // and more causes them first to be pushed to stack and then popped on exit to preseve their values.
                         int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
                         // Bitwise Or to combine the flagged matches for the second, third, fourth and fifth values to our match flags


### PR DESCRIPTION
Updated `Intrinsicify SpanHelpers.IndexOfAny(char,char,char,char,char)` https://github.com/dotnet/coreclr/pull/22880

Resolves: https://github.com/dotnet/runtime/issues/12097