### PR TITLE
Fix runtime crash on Linux ARM64 running in WSL

### DIFF
--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -13,6 +13,134 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #include <asm/hwcap.h>
 #endif
 
+#if defined(HOST_ARM64) && defined(__linux__)
+typedef struct {
+    const char* name;
+    unsigned long hwCapFlag;
+} CpuCapability;
+
+static const CpuCapability CpuCapabilities[] = {
+    //{ "fp", HWCAP_FP },
+#ifdef HWCAP_ASIMD
+    { "asimd", HWCAP_ASIMD },
+#endif
+    //{ "evtstrm", HWCAP_EVTSTRM },
+#ifdef HWCAP_AES
+    { "aes", HWCAP_AES },
+#endif
+    //{ "pmull", HWCAP_PMULL },
+#ifdef HWCAP_SHA1
+    { "sha1", HWCAP_SHA1 },
+#endif
+#ifdef HWCAP_SHA2
+    { "sha2", HWCAP_SHA2 },
+#endif
+#ifdef HWCAP_CRC32
+    { "crc32", HWCAP_CRC32 },
+#endif
+#ifdef HWCAP_ATOMICS
+    { "atomics", HWCAP_ATOMICS },
+#endif
+    //{ "fphp", HWCAP_FPHP },
+    //{ "asimdhp", HWCAP_ASIMDHP },
+    //{ "cpuid", HWCAP_CPUID },
+#ifdef HWCAP_ASIMDRDM
+    { "asimdrdm", HWCAP_ASIMDRDM },
+#endif
+    //{ "jscvt", HWCAP_JSCVT },
+    //{ "fcma", HWCAP_FCMA },
+    //{ "lrcpc", HWCAP_LRCPC },
+    //{ "dcpop", HWCAP_DCPOP },
+    //{ "sha3", HWCAP_SHA3 },
+    //{ "sm3", HWCAP_SM3 },
+    //{ "sm4", HWCAP_SM4 },
+#ifdef HWCAP_ASIMDDP
+    { "asimddp", HWCAP_ASIMDDP },
+#endif
+    //{ "sha512", HWCAP_SHA512 },
+    //{ "sve", HWCAP_SVE },
+    //{ "asimdfhm", HWCAP_ASIMDFHM },
+    //{ "dit", HWCAP_DIT },
+    //{ "uscat", HWCAP_USCAT },
+    //{ "ilrcpc", HWCAP_ILRCPC },
+    //{ "flagm", HWCAP_FLAGM },
+    //{ "ssbs", HWCAP_SSBS },
+    //{ "sb", HWCAP_SB },
+    //{ "paca", HWCAP_PACA },
+    //{ "pacg", HWCAP_PACG },
+
+    // Ensure the array is never empty
+    { "", 0 }
+};
+
+// Returns the HWCAP_* flag corresponding to the given capability name.
+// If the capability name is not recognized or unused at present, zero is returned.
+static unsigned long LookupCpuCapabilityFlag(const char* start, size_t length)
+{
+    for (int i = 0; i < _countof(CpuCapabilities); i++)
+    {
+        const char* capabilityName = CpuCapabilities[i].name;
+        if ((length == strlen(capabilityName)) && (memcmp(start, capabilityName, length) == 0))
+        {
+            return CpuCapabilities[i].hwCapFlag;
+        }
+    }
+    return 0;
+}
+
+// Reads the first Features entry from /proc/cpuinfo (assuming other entries are essentially
+// identical) and translates it into a set of HWCAP_* flags.
+static unsigned long GetCpuCapabilityFlagsFromCpuInfo()
+{
+    unsigned long capabilityFlags = 0;
+    FILE* cpuInfoFile = fopen("/proc/cpuinfo", "r");
+
+    if (cpuInfoFile != NULL)
+    {
+        char* line = nullptr;
+        size_t lineLen = 0;
+
+        while (getline(&line, &lineLen, cpuInfoFile) != -1)
+        {
+            char* p = line;
+            while (isspace(*p)) p++;
+
+            if (memcmp(p, "Features", 8) != 0)
+                continue;
+
+            // Skip "Features" and look for ':'
+            p += 8;
+
+            while (isspace(*p)) p++;
+            if (*p != ':')
+                continue;
+
+            // Skip ':' and parse the list
+            p++;
+
+            while (true)
+            {
+                while (isspace(*p)) p++;
+                if (*p == 0)
+                    break;
+
+                char* start = p++;
+                while ((*p != 0) && !isspace(*p)) p++;
+
+                capabilityFlags |= LookupCpuCapabilityFlag(start, p - start);
+            }
+
+            break;
+        }
+
+        free(line);
+        fclose(cpuInfoFile);
+    }
+
+    return capabilityFlags;
+}
+#endif // defined(HOST_ARM64) && defined(__linux__)
+
 PALIMPORT
 VOID
 PALAPI
@@ -25,6 +153,13 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 #if defined(HOST_ARM64)
 #if HAVE_AUXV_HWCAP_H
     unsigned long hwCap = getauxval(AT_HWCAP);
+
+#if defined(__linux__)
+    // getauxval(AT_HWCAP) returns zero on WSL1 (https://github.com/microsoft/WSL/issues/3682),
+    // fall back to reading capabilities from /proc/cpuinfo.
+    if (hwCap == 0)
+        hwCap = GetCpuCapabilityFlagsFromCpuInfo();
+#endif
 
 // HWCAP_* flags are introduced by ARM into the Linux kernel as new extensions are published.
 // For a given kernel, some of these flags may not be present yet.

--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -14,10 +14,11 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #endif
 
 #if defined(HOST_ARM64) && defined(__linux__)
-typedef struct {
+struct CpuCapability
+{
     const char* name;
     unsigned long hwCapFlag;
-} CpuCapability;
+};
 
 static const CpuCapability CpuCapabilities[] = {
     //{ "fp", HWCAP_FP },

--- a/src/coreclr/src/vm/eepolicy.cpp
+++ b/src/coreclr/src/vm/eepolicy.cpp
@@ -536,7 +536,9 @@ void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage
                 // Though we would like to remove the usage of ExecutionEngineException in any manner,
                 // we cannot. Its okay to use it in the case below since the process is terminating
                 // and this will serve as an exception object for debugger.
-                ohException = CLRException::GetPreallocatedExecutionEngineExceptionHandle();
+                // We avoid calling CLRException::GetPreallocatedExecutionEngineExceptionHandle to avoid
+                // an assertion in case the exception has not been allocated yet.
+                ohException = g_pPreallocatedExecutionEngineException;
             }
 
             // Preallocated exception handles can be null if FailFast is invoked before LoadBaseSystemClasses


### PR DESCRIPTION
After adding the `(hwCap & HWCAP_ASIMD) != 0` check in #38060, which was later replaced with the `CPUCompileFlags.IsSet(InstructionSet_AdvSimd)` check in #38425:
https://github.com/dotnet/runtime/blob/e13871cb275b9f53fa82285b2a81ada28a859b50/src/coreclr/src/vm/codeman.cpp#L1487-L1494
the runtime started to crash on startup on Linux ARM64 running in WSL 1 (I have no hardware to check WSL 2):
```
Fatal error. AdvSimd is not supported on the processor.

Assert failure(PID 438 [0x000001b6], Thread: 438 [0x01b6]): g_pPreallocatedExecutionEngineException != NULL
    File: /runtime/src/coreclr/src/vm/clrex.cpp Line: 511
    Image: /home/antonl/Core_Root/corerun

Aborted (core dumped)
```
The main issue is `getauxval(AT_HWCAP)` returning zero on ARM64 WSL 1 (see microsoft/WSL#3682).  Then we fail the assertion above trying to obtain the handle for the pre-allocated `ExecutionEngineException` before it is initialized.

The proposed fix is to fall back to reading CPU capabilities from `/proc/cpuinfo` file if `getauxval(AT_HWCAP)` returned zero (WSL 1 does not set `errno`).  We could limit the fix to WSL 1 by checking that `/proc/sys/kernel/osrelease` ends with `-Microsoft`, but that is fragile and probably not worth it.