### PR TITLE
add tests to increase enum serialization code coverage

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -119,35 +119,28 @@ namespace System.Text.Json.Serialization.Converters
                         return Unsafe.As<long, T>(ref int64);
                     }
                     break;
-
-                // When utf8reader/writer will support all primitive types we should remove custom bound checks
-                // https://github.com/dotnet/runtime/issues/29000
                 case TypeCode.SByte:
-                    if (reader.TryGetInt32(out int byte8) && JsonHelpers.IsInRangeInclusive(byte8, sbyte.MinValue, sbyte.MaxValue))
+                    if (reader.TryGetSByte(out sbyte byte8))
                     {
-                        sbyte byte8Value = (sbyte)byte8;
-                        return Unsafe.As<sbyte, T>(ref byte8Value);
+                        return Unsafe.As<sbyte, T>(ref byte8);
                     }
                     break;
                 case TypeCode.Byte:
-                    if (reader.TryGetUInt32(out uint ubyte8) && JsonHelpers.IsInRangeInclusive(ubyte8, byte.MinValue, byte.MaxValue))
+                    if (reader.TryGetByte(out byte ubyte8))
                     {
-                        byte ubyte8Value = (byte)ubyte8;
-                        return Unsafe.As<byte, T>(ref ubyte8Value);
+                        return Unsafe.As<byte, T>(ref ubyte8);
                     }
                     break;
                 case TypeCode.Int16:
-                    if (reader.TryGetInt32(out int int16) && JsonHelpers.IsInRangeInclusive(int16, short.MinValue, short.MaxValue))
+                    if (reader.TryGetInt16(out short int16))
                     {
-                        short shortValue = (short)int16;
-                        return Unsafe.As<short, T>(ref shortValue);
+                        return Unsafe.As<short, T>(ref int16);
                     }
                     break;
                 case TypeCode.UInt16:
-                    if (reader.TryGetUInt32(out uint uint16) && JsonHelpers.IsInRangeInclusive(uint16, ushort.MinValue, ushort.MaxValue))
+                    if (reader.TryGetUInt16(out ushort uint16))
                     {
-                        ushort ushortValue = (ushort)uint16;
-                        return Unsafe.As<ushort, T>(ref ushortValue);
+                        return Unsafe.As<ushort, T>(ref uint16);
                     }
                     break;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -119,28 +119,35 @@ namespace System.Text.Json.Serialization.Converters
                         return Unsafe.As<long, T>(ref int64);
                     }
                     break;
+
+                // When utf8reader/writer will support all primitive types we should remove custom bound checks
+                // https://github.com/dotnet/runtime/issues/29000
                 case TypeCode.SByte:
-                    if (reader.TryGetSByte(out sbyte byte8))
+                    if (reader.TryGetInt32(out int byte8) && JsonHelpers.IsInRangeInclusive(byte8, sbyte.MinValue, sbyte.MaxValue))
                     {
-                        return Unsafe.As<sbyte, T>(ref byte8);
+                        sbyte byte8Value = (sbyte)byte8;
+                        return Unsafe.As<sbyte, T>(ref byte8Value);
                     }
                     break;
                 case TypeCode.Byte:
-                    if (reader.TryGetByte(out byte ubyte8))
+                    if (reader.TryGetUInt32(out uint ubyte8) && JsonHelpers.IsInRangeInclusive(ubyte8, byte.MinValue, byte.MaxValue))
                     {
-                        return Unsafe.As<byte, T>(ref ubyte8);
+                        byte ubyte8Value = (byte)ubyte8;
+                        return Unsafe.As<byte, T>(ref ubyte8Value);
                     }
                     break;
                 case TypeCode.Int16:
-                    if (reader.TryGetInt16(out short int16))
+                    if (reader.TryGetInt32(out int int16) && JsonHelpers.IsInRangeInclusive(int16, short.MinValue, short.MaxValue))
                     {
-                        return Unsafe.As<short, T>(ref int16);
+                        short shortValue = (short)int16;
+                        return Unsafe.As<short, T>(ref shortValue);
                     }
                     break;
                 case TypeCode.UInt16:
-                    if (reader.TryGetUInt16(out ushort uint16))
+                    if (reader.TryGetUInt32(out uint uint16) && JsonHelpers.IsInRangeInclusive(uint16, ushort.MinValue, ushort.MaxValue))
                     {
-                        return Unsafe.As<ushort, T>(ref uint16);
+                        ushort ushortValue = (ushort)uint16;
+                        return Unsafe.As<ushort, T>(ref ushortValue);
                     }
                     break;
             }

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit;
@@ -185,7 +186,7 @@ namespace System.Text.Json.Serialization.Tests
         private enum MyCustomEnum
         {
             First = 1,
-            Second =2
+            Second = 2
         }
 
         [Fact]
@@ -293,6 +294,223 @@ namespace System.Text.Json.Serialization.Tests
             T = 1 << 19,
             U = 1 << 20,
             V = 1 << 21,
+        }
+
+        [Fact, OuterLoop]
+        public static void VeryLargeAmountOfEnumDictionaryKeysToSerialize()
+        {
+            // Ensure we don't throw OutOfMemoryException.
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter() }
+            };
+
+            const int MaxValue = (int)MyEnum.V;
+
+            // Every value between 0 and MaxValue maps to a valid enum
+            // identifier, and is a candidate to go into the name cache.
+
+            // Write the first 45 values.
+            Dictionary<MyEnum, int> dictionary;
+            for (int i = 1; i < 46; i++)
+            {
+                dictionary = new Dictionary<MyEnum, int> { { (MyEnum)i, i } };
+                JsonSerializer.Serialize(dictionary, options);
+            }
+
+            // At this point, there are 60 values in the name cache;
+            // 22 cached at warm-up, the rest in the above loop.
+
+            // Ensure the approximate size limit for the name cache (a concurrent dictionary) is honored.
+            // Use multiple threads to perhaps go over the soft limit of 64, but not by more than a couple.
+            Parallel.For(
+                0,
+                8,
+                i =>
+                {
+                    dictionary = new Dictionary<MyEnum, int> { { (MyEnum)(46 + i), i } };
+                    JsonSerializer.Serialize(dictionary, options);
+                }
+            );
+
+            // Write the remaining enum values. The cache is capped to avoid
+            // OutOfMemoryException due to having too many cached items.
+            for (int i = 54; i <= MaxValue; i++)
+            {
+                dictionary = new Dictionary<MyEnum, int> { { (MyEnum)i, i } };
+                JsonSerializer.Serialize(dictionary, options);
+            }
+        }
+
+        public abstract class NumericEnumKeyDictionaryBase<T>
+        {
+            public abstract Dictionary<T, int> BuildDictionary(int i);
+
+            [Fact]
+            public void SerilizeDictionaryWhenCacheIsFull()
+            {
+                var options = new JsonSerializerOptions
+                {
+                    Converters = { new JsonStringEnumConverter() }
+                };
+
+                Dictionary<T, int> dictionary;
+                for (int i = 1; i <= 64; i++)
+                {
+                    dictionary = BuildDictionary(i);
+                    JsonSerializer.Serialize(dictionary, options);
+                }
+
+                dictionary = BuildDictionary(0);
+                string json = JsonSerializer.Serialize(dictionary, options);
+                Assert.Equal($"{{\"0\":0}}", json);
+            }
+        }
+
+        public class Int32EnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumInt32>
+        {
+            public override Dictionary<SampleEnumInt32, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumInt32, int> { { (SampleEnumInt32)i, i } };
+        }
+
+        public class UInt32EnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumUInt32>
+        {
+            public override Dictionary<SampleEnumUInt32, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumUInt32, int> { { (SampleEnumUInt32)i, i } };
+        }
+
+        public class UInt64EnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumUInt64>
+        {
+            public override Dictionary<SampleEnumUInt64, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumUInt64, int> { { (SampleEnumUInt64)i, i } };
+        }
+
+        public class Int64EnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumInt64>
+        {
+            public override Dictionary<SampleEnumInt64, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumInt64, int> { { (SampleEnumInt64)i, i } };
+        }
+
+        public class Int16EnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumInt16>
+        {
+            public override Dictionary<SampleEnumInt16, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumInt16, int> { { (SampleEnumInt16)i, i } };
+        }
+
+        public class UInt16EnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumUInt16>
+        {
+            public override Dictionary<SampleEnumUInt16, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumUInt16, int> { { (SampleEnumUInt16)i, i } };
+        }
+
+        public class ByteEnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumByte>
+        {
+            public override Dictionary<SampleEnumByte, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumByte, int> { { (SampleEnumByte)i, i } };
+        }
+
+        public class SByteEnumDictionary : NumericEnumKeyDictionaryBase<SampleEnumSByte>
+        {
+            public override Dictionary<SampleEnumSByte, int> BuildDictionary(int i) =>
+                new Dictionary<SampleEnumSByte, int> { { (SampleEnumSByte)i, i } };
+        }
+
+
+        [Flags]
+        public enum SampleEnumInt32
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+        }
+
+        [Flags]
+        public enum SampleEnumUInt32 : uint
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+        }
+
+        [Flags]
+        public enum SampleEnumUInt64 : ulong
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+        }
+
+        [Flags]
+        public enum SampleEnumInt64 : long
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+        }
+
+        [Flags]
+        public enum SampleEnumInt16 : short
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+        }
+
+        [Flags]
+        public enum SampleEnumUInt16 : ushort
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+        }
+
+        [Flags]
+        public enum SampleEnumByte : byte
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+        }
+
+        [Flags]
+        public enum SampleEnumSByte : sbyte
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json.Serialization.Tests
 
             // Try a unique naming policy
             options = new JsonSerializerOptions();
-            options.Converters.Add(new JsonStringEnumConverter(new ToLower()));
+            options.Converters.Add(new JsonStringEnumConverter(new ToLowerNamingPolicy()));
 
             json = JsonSerializer.Serialize(DayOfWeek.Friday, options);
             Assert.Equal(@"""friday""", json);
@@ -49,7 +49,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Serialize((DayOfWeek)(-1), options));
         }
 
-        public class ToLower : JsonNamingPolicy
+        public class ToLowerNamingPolicy : JsonNamingPolicy
         {
             public override string ConvertName(string name) => name.ToLowerInvariant();
         }
@@ -93,7 +93,7 @@ namespace System.Text.Json.Serialization.Tests
 
             // Try a unique casing
             options = new JsonSerializerOptions();
-            options.Converters.Add(new JsonStringEnumConverter(new ToLower()));
+            options.Converters.Add(new JsonStringEnumConverter(new ToLowerNamingPolicy()));
 
             json = JsonSerializer.Serialize(FileAttributes.NoScrubData, options);
             Assert.Equal(@"""noscrubdata""", json);
@@ -145,7 +145,7 @@ namespace System.Text.Json.Serialization.Tests
             public LowerCaseEnumAttribute() { }
 
             public override JsonConverter CreateConverter(Type typeToConvert)
-                => new JsonStringEnumConverter(new ToLower());
+                => new JsonStringEnumConverter(new ToLowerNamingPolicy());
         }
 
         [Fact]
@@ -238,7 +238,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             var options = new JsonSerializerOptions
             {
-                Converters = { new JsonStringEnumConverter(new ToLower()) }
+                Converters = { new JsonStringEnumConverter(new ToLowerNamingPolicy()) }
             };
 
             for (int i = 0; i < 128; i++)
@@ -362,20 +362,20 @@ namespace System.Text.Json.Serialization.Tests
             [Fact]
             public void SerilizeDictionaryWhenCacheIsFull()
             {
-                var options = new JsonSerializerOptions
-                {
-                    Converters = { new JsonStringEnumConverter() }
-                };
+                // var options = new JsonSerializerOptions
+                // {
+                //     Converters = { new JsonStringEnumConverter() }
+                // };
 
                 Dictionary<T, int> dictionary;
                 for (int i = 1; i <= 64; i++)
                 {
                     dictionary = BuildDictionary(i);
-                    JsonSerializer.Serialize(dictionary, options);
+                    JsonSerializer.Serialize(dictionary);
                 }
 
                 dictionary = BuildDictionary(0);
-                string json = JsonSerializer.Serialize(dictionary, options);
+                string json = JsonSerializer.Serialize(dictionary);
                 Assert.Equal($"{{\"0\":0}}", json);
             }
         }

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -233,6 +233,23 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        [Fact]
+        public static void MoreThan64EnumValuesToSerializeWithNamingPolicy()
+        {
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter(new ToLower()) }
+            };
+
+            for (int i = 0; i < 128; i++)
+            {
+                MyEnum value = (MyEnum)i;
+                string asStr = value.ToString().ToLowerInvariant();
+                string expected = char.IsLetter(asStr[0]) ? $@"""{asStr}""" : asStr;
+                Assert.Equal(expected, JsonSerializer.Serialize(value, options));
+            }
+        }
+
         [Fact, OuterLoop]
         public static void VeryLargeAmountOfEnumsToSerialize()
         {
@@ -301,11 +318,6 @@ namespace System.Text.Json.Serialization.Tests
         {
             // Ensure we don't throw OutOfMemoryException.
 
-            var options = new JsonSerializerOptions
-            {
-                Converters = { new JsonStringEnumConverter() }
-            };
-
             const int MaxValue = (int)MyEnum.V;
 
             // Every value between 0 and MaxValue maps to a valid enum
@@ -316,7 +328,7 @@ namespace System.Text.Json.Serialization.Tests
             for (int i = 1; i < 46; i++)
             {
                 dictionary = new Dictionary<MyEnum, int> { { (MyEnum)i, i } };
-                JsonSerializer.Serialize(dictionary, options);
+                JsonSerializer.Serialize(dictionary);
             }
 
             // At this point, there are 60 values in the name cache;
@@ -330,7 +342,7 @@ namespace System.Text.Json.Serialization.Tests
                 i =>
                 {
                     dictionary = new Dictionary<MyEnum, int> { { (MyEnum)(46 + i), i } };
-                    JsonSerializer.Serialize(dictionary, options);
+                    JsonSerializer.Serialize(dictionary);
                 }
             );
 
@@ -339,7 +351,7 @@ namespace System.Text.Json.Serialization.Tests
             for (int i = 54; i <= MaxValue; i++)
             {
                 dictionary = new Dictionary<MyEnum, int> { { (MyEnum)i, i } };
-                JsonSerializer.Serialize(dictionary, options);
+                JsonSerializer.Serialize(dictionary);
             }
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -362,11 +362,6 @@ namespace System.Text.Json.Serialization.Tests
             [Fact]
             public void SerilizeDictionaryWhenCacheIsFull()
             {
-                // var options = new JsonSerializerOptions
-                // {
-                //     Converters = { new JsonStringEnumConverter() }
-                // };
-
                 Dictionary<T, int> dictionary;
                 for (int i = 1; i <= 64; i++)
                 {


### PR DESCRIPTION
Opening this PR because I messed up #39561, addressed feedback by @Jozkee 
Helps address #32341
Adds coverage to branch where WriteWithQuotes goes over the name cache soft limit. code
Adds coverage to branches where a Dictionary key is a numeric enum that is not in the cache and the value is not a valid identifier. code