### PR TITLE
[browser] Mark APIs as unsupported on browser

### DIFF
--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -29,12 +29,17 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Adds UnsupportedOSPlatform attribute for requested libraries -->
-  <ItemGroup Condition="'$(UnsupportedOSPlatform)' != '' and '$(IsTestProject)' != 'true'">
-    <AssemblyAttribute Include="System.Runtime.Versioning.UnsupportedOSPlatform">
-        <_Parameter1>$(UnsupportedOSPlatform)</_Parameter1>
-    </AssemblyAttribute>
+  <ItemGroup>
+    <_unsupportedOSPlatforms Include="$(UnsupportedOSPlatforms)" />
   </ItemGroup>
+
+  <Target Name="AddUnsupportedOSPlatformAttribute" BeforeTargets="GenerateAssemblyInfo" AfterTargets="PrepareForBuild">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.Versioning.UnsupportedOSPlatform" Condition="'@(_unsupportedOSPlatforms)' != ''">
+        <_Parameter1>%(_unsupportedOSPlatforms.Identity)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
 
   <Target Name="DecideIfWeNeedToIncludeDllSafeSearchPathAttribute"
           Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">

--- a/src/libraries/System.Data.Odbc/Directory.Build.props
+++ b/src/libraries/System.Data.Odbc/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
@@ -6,5 +6,7 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Drawing.Common/Directory.Build.props
+++ b/src/libraries/System.Drawing.Common/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.Ports/Directory.Build.props
+++ b/src/libraries/System.IO.Ports/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Csp/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Csp/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Encoding/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Encoding/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.OpenSsl/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/Directory.Build.props
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
-    <UnsupportedOSPlatform>windows</UnsupportedOSPlatform>
+    <UnsupportedOSPlatforms>windows;browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Pkcs/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Pkcs/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Primitives/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Primitives/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Xml/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Xml/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Even though the related [spec PR](https://github.com/dotnet/designs/pull/144) is a draft, we could start looking at how to use that new `UnsupportedOSPlatform` attribute.

APIs marked as unsupported at assembly level in this PR:
- System.Security.Cryptography.* besides S.S.C.Algorithms - it's mostly PNSE on browser except `RandomNumberGenerator` and `RandomNumberGeneratorImplementation` classes so we'll have to mark all the remaining types as unsupported
- System.Data.Odbc
- System.DirectoryServices.Protocols
- System.Drawing.Common
- System.IO.Ports

The example of the assembly info generated for S.S.C.OpenSsl which contains UnsupportedOSPlatform attributes for windows and browser platforms:
![image](https://user-images.githubusercontent.com/3258267/89784773-e7f1ab00-db21-11ea-8586-a2082695008c.png)

Part of https://github.com/dotnet/runtime/issues/41087