### PR TITLE
Updating ClaimsPrincipal.Current to default back to Thread.CurrentPrincipal, as was done on .NET Framework

### DIFF
--- a/src/libraries/System.Security.Claims/src/System.Security.Claims.csproj
+++ b/src/libraries/System.Security.Claims/src/System.Security.Claims.csproj
@@ -17,5 +17,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Security.Principal" />
+    <Reference Include="System.Threading.Thread" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Security.Principal;
+using System.Threading;
 
 namespace System.Security.Claims
 {
@@ -25,6 +26,11 @@ namespace System.Security.Claims
 
         private static Func<IEnumerable<ClaimsIdentity>, ClaimsIdentity?> s_identitySelector = SelectPrimaryIdentity;
         private static Func<ClaimsPrincipal> s_principalSelector = ClaimsPrincipalSelector;
+
+        private static ClaimsPrincipal SelectClaimsPrincipal()
+        {
+            return (Thread.CurrentPrincipal is ClaimsPrincipal claimsPrincipal) ? claimsPrincipal : new ClaimsPrincipal(Thread.CurrentPrincipal!);
+        }
 
         protected ClaimsPrincipal(SerializationInfo info, StreamingContext context)
         {
@@ -280,12 +286,7 @@ namespace System.Security.Claims
             // just accesses the current selected principal selector, doesn't set
             get
             {
-                if (s_principalSelector != null)
-                {
-                    return s_principalSelector();
-                }
-
-                return null;
+                return s_principalSelector is not null ? s_principalSelector() : SelectClaimsPrincipal();
             }
         }
 

--- a/src/libraries/System.Security.Claims/tests/ClaimsPrincipalTests.cs
+++ b/src/libraries/System.Security.Claims/tests/ClaimsPrincipalTests.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Principal;
+using System.Threading;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Security.Claims
@@ -198,6 +200,35 @@ namespace System.Security.Claims
             AssertExtensions.Throws<ArgumentNullException>("identity", () => new ClaimsPrincipal((IIdentity)null));
             AssertExtensions.Throws<ArgumentNullException>("principal", () => new ClaimsPrincipal((IPrincipal)null));
             AssertExtensions.Throws<ArgumentNullException>("reader", () => new ClaimsPrincipal((BinaryReader)null));
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void Current_FallsBackToThread()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                ClaimsPrincipal principal1 = new ClaimsPrincipal();
+                ClaimsPrincipal principal2 = new ClaimsPrincipal();
+
+                Thread.CurrentPrincipal = principal1;
+                Assert.Same(principal1, ClaimsPrincipal.Current);
+
+                Thread.CurrentPrincipal = principal2;
+                Assert.Same(principal2, ClaimsPrincipal.Current);
+
+                NonClaimsIdentity id = new NonClaimsIdentity() { Name = "NonClaimsIdentity_Name" };
+                NonClaimsPrincipal nonClaimsPrincipal = new NonClaimsPrincipal() { Identity = id };
+
+                Thread.CurrentPrincipal = nonClaimsPrincipal;
+
+                ClaimsPrincipal current = ClaimsPrincipal.Current;
+                Assert.NotNull(current);
+                Assert.Equal("NonClaimsIdentity_Name", current.Identity.Name);
+
+                // match .NET Framework behavior by throwing ArgumentNullException when Thread.CurrentPrincipal is null
+                Thread.CurrentPrincipal = null;
+                Assert.Throws<ArgumentNullException>(() => ClaimsPrincipal.Current);
+            }).Dispose();
         }
 
         private class NonClaimsPrincipal : IPrincipal

--- a/src/libraries/System.Security.Claims/tests/System.Security.Claims.Tests.csproj
+++ b/src/libraries/System.Security.Claims/tests/System.Security.Claims.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/36211