### PR TITLE
Disable test hanging in some configurations

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -2231,6 +2231,7 @@ namespace System.Text.Tests
             Assert.True(sb1.Equals(sb2));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40625")] // Hangs expanding the SB
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static unsafe void FailureOnLargeString()
         {


### PR DESCRIPTION
The test recently added to protect the fix for bounds checking Append to a huge StringBuilder is sometimes hanging on some configurations while doing the huge Append.
My assumption is that the machine is just overloaded copying 4GB, and the product fix is OK. Disabling this test for now.

Relates to https://github.com/dotnet/runtime/issues/40625