### PR TITLE
Fix concurrent collections CA1836 rule violations

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="3.3.0-beta3.20407.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="3.3.0-beta3.20410.1" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -112,7 +112,7 @@
       <Rule Id="CA1833" Action="Warning" />          <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
       <Rule Id="CA1834" Action="Warning" />          <!-- Consider using 'StringBuilder.Append(char)' when applicable. -->
       <Rule Id="CA1835" Action="Warning" />          <!-- Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync' -->
-      <Rule Id="CA1836" Action="Info" />             <!-- Prefer IsEmpty over Count -->
+      <Rule Id="CA1836" Action="Warning" />          <!-- Prefer IsEmpty over Count -->
       <Rule Id="CA1837" Action="Warning" />          <!-- Use 'Environment.ProcessId' -->
       <Rule Id="CA1838" Action="Warning" />          <!-- Avoid 'StringBuilder' parameters for P/Invokes -->
       <Rule Id="CA2000" Action="None" />             <!-- Dispose objects before losing scope -->

--- a/src/libraries/Common/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/libraries/Common/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -105,7 +105,7 @@ namespace System.Data.ProviderBase
             ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>? oldPoolCollection = null;
             lock (this)
             {
-                if (_poolCollection.Count > 0)
+                if (!_poolCollection.IsEmpty)
                 {
                     oldPoolCollection = _poolCollection;
                     _poolCollection = new ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>();
@@ -232,7 +232,7 @@ namespace System.Data.ProviderBase
             //     to avoid conflict with DbConnectionFactory.CreateConnectionPoolGroup replacing pool entry
             lock (this)
             {
-                if (_poolCollection.Count > 0)
+                if (!_poolCollection.IsEmpty)
                 {
                     var newPoolCollection = new ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>();
 
@@ -267,7 +267,7 @@ namespace System.Data.ProviderBase
 
                 // must be pruning thread to change state and no connections
                 // otherwise pruning thread risks making entry disabled soon after user calls ClearPool
-                if (0 == _poolCollection.Count)
+                if (_poolCollection.IsEmpty)
                 {
                     if (PoolGroupStateActive == _state)
                     {

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Extensions.Http
             }
 
             // We didn't totally empty the cleanup queue, try again later.
-            if (_expiredHandlers.Count > 0)
+            if (!_expiredHandlers.IsEmpty)
             {
                 StartCleanupTimer();
             }

--- a/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -129,7 +129,7 @@ namespace System.Data.ProviderBase
             ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>? oldPoolCollection = null;
             lock (this)
             {
-                if (_poolCollection.Count > 0)
+                if (!_poolCollection.IsEmpty)
                 {
                     oldPoolCollection = _poolCollection;
                     _poolCollection = new ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>();
@@ -266,7 +266,7 @@ namespace System.Data.ProviderBase
             //     to avoid conflict with DbConnectionFactory.CreateConnectionPoolGroup replacing pool entry
             lock (this)
             {
-                if (_poolCollection.Count > 0)
+                if (!_poolCollection.IsEmpty)
                 {
                     var newPoolCollection = new ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>();
 
@@ -309,7 +309,7 @@ namespace System.Data.ProviderBase
 
                 // must be pruning thread to change state and no connections
                 // otherwise pruning thread risks making entry disabled soon after user calls ClearPool
-                if (0 == _poolCollection.Count)
+                if (_poolCollection.IsEmpty)
                 {
                     if (PoolGroupStateActive == _state)
                     {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
@@ -115,7 +115,7 @@ namespace System.Net.Security
         //
         internal static SafeFreeCredentials? TryCachedCredential(byte[]? thumbPrint, SslProtocols sslProtocols, bool isServer, EncryptionPolicy encryptionPolicy)
         {
-            if (s_cachedCreds.Count == 0)
+            if (s_cachedCreds.IsEmpty)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Not found, Current Cache Count = {s_cachedCreds.Count}");
                 return null;

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -318,7 +318,7 @@ namespace System.Threading.Tasks
                     }
 
                     // If we have encountered any exceptions, then throw.
-                    if ((exceptionQ != null) && (exceptionQ.Count > 0))
+                    if ((exceptionQ != null) && (!exceptionQ.IsEmpty))
                     {
                         ThrowSingleCancellationExceptionOrOtherException(exceptionQ, parallelOptions.CancellationToken,
                                                                          new AggregateException(exceptionQ));


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/roslyn-analyzers/pull/3978

Fix places where the rule detects an inefficient usage of `Count == 0` or similar condition after changing the rule to only diagnose allowed types (concurrent types for now).

Also updates rule severity to `Warning` in CodeAnalysis.ruleset file.

cc @mavasani @jeffhandley 