### PR TITLE
Inline underlying array into ImmutableArray<T>.IsEmpty

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -156,7 +156,7 @@ namespace System.Collections.Immutable
         public bool IsEmpty
         {
             [NonVersionable]
-            get { return this.Length == 0; }
+            get { return this.array!.Length == 0; }
         }
 
         /// <summary>


### PR DESCRIPTION
As per @jkotas in https://github.com/dotnet/runtime/pull/39890#discussion_r460312491

> Take a look at: https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACAZQAtsoAHAGW2ADoASgFcAdhgCW+GAG4aNYgGYGuDFCFgMDALIBPAJL58QjLwA2MAIJQo2HQB4AKgD4aAbxoNPDBwG0AugzsNjqy1F4MHl6KDOJiDFwwIgDmGCwMALxOgda2fAnJqaHh0cAQEKYMergAovgcGDoZWfkpaenpDHRFUUql5ZU1dQ2kTdnBeYmtGR1dNAC+ctQ+AFLiGADiiTBQ4mAAFA0cMBAAZnvE5HQAlFd+8koXSAxkDADCjlnuYT3P5E+xmgcMBUFj2ugMRhMwHMVmCH0CVwYX3CKOIAHYGHtsBMCm0ZoiAPydBggBhwcjdTwLaiRTzRR4xOJAlQAITB+kMxjMlhy9mcCKRtJRzwx2KqtXqjSJjFJ5MpDGpQvpf0ZgOBGFe7IhXOhPLh/OwiORwrpor44qGOhG0pJZIpQupcyAA
> 
> TestA shows the code that people will get today.
> TestB shows the significantly slower code that people will get with this change.
> TestC shows how you need to change IsEmpty property to fix this regression