### PR TITLE
Suppress GS cookie checks in method epilogs

### DIFF
--- a/src/coreclr/src/vm/eetwain.cpp
+++ b/src/coreclr/src/vm/eetwain.cpp
@@ -5626,11 +5626,14 @@ void * EECodeManager::GetGSCookieAddr(PREGDISPLAY     pContext,
     INT32 spOffsetGSCookie = gcInfoDecoder.GetGSCookieStackSlot();
     if (spOffsetGSCookie != NO_GS_COOKIE)
     {
-        if(relOffset >= gcInfoDecoder.GetGSCookieValidRangeStart()
-            && relOffset < gcInfoDecoder.GetGSCookieValidRangeEnd())
+        if(relOffset >= gcInfoDecoder.GetGSCookieValidRangeStart())
         {
-            SIZE_T baseStackSlot = GetCallerSp(pContext);
-            return (LPVOID)( spOffsetGSCookie + baseStackSlot );
+            TADDR ptr = GetCallerSp(pContext) + spOffsetGSCookie;
+
+            // Detect the end of GS cookie scope by comparing its address with SP
+            // gcInfoDecoder.GetGSCookieValidRangeEnd() is not accurate. It does not
+            // account for GS cookie going out of scope inside epilog or multiple epilogs.
+            return (LPVOID) ((ptr >= pContext->SP) ? ptr : NULL);
         }
     }
     return NULL;


### PR DESCRIPTION
The information about end of GS cookie scope recorded in GC info is not accurate and it cannot even be made accurate without redesign that is not worth it. Detect end of GS cookie scope by comparing it with current SP instead.

Fixes #13041