### PR TITLE
Ensure FileStatus and FileSystemEntry Hidden and ReadOnly attributes are retrieved the same way

### DIFF
--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -140,7 +140,12 @@ namespace System.IO.Enumeration
         public DateTimeOffset LastAccessTimeUtc => _status.GetLastAccessTime(FullPath, continueOnError: true);
         public DateTimeOffset LastWriteTimeUtc => _status.GetLastWriteTime(FullPath, continueOnError: true);
         public bool IsDirectory => _status.InitiallyDirectory;
-        public bool IsHidden => _directoryEntry.Name[0] == '.' || (Attributes & FileAttributes.Hidden) != 0;
+        /// <summary>
+        /// Returns <see langword="true"/> if the file is hidden; <see langword="false" /> otherwise.
+        /// In Linux and OSX, a file can be marked hidden if the filename is prepended with a dot.
+        /// In Windows and OSX, a file can be hidden if the special hidden attribute is set. For example, via the <see cref="FileSystemInfo.Attributes" /> enum flag.
+        /// </summary>
+        public bool IsHidden => _directoryEntry.Name[0] == '.' || (_initialAttributes & FileAttributes.Hidden) != 0;
 
         public FileSystemInfo ToFileSystemInfo()
         {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -34,24 +34,32 @@ namespace System.IO
             status._fileStatusInitialized = -1;
         }
 
-        internal void Invalidate() => _fileStatusInitialized = -1;
 
-        internal bool IsReadOnly(ReadOnlySpan<char> path, bool continueOnError = false)
+        internal static bool IsDirectory(Interop.Sys.FileStatus fileStatus)
         {
-            EnsureStatInitialized(path, continueOnError);
+            return (fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+        }
+
+        internal static bool IsHidden(Interop.Sys.FileStatus fileStatus)
+        {
+            // If the filename starts with a period or has UF_HIDDEN flag set, it's hidden.
+            return (fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN;
+        }
+
+        internal static bool IsReadOnly(Interop.Sys.FileStatus fileStatus)
+        {
 #if TARGET_BROWSER
             const Interop.Sys.Permissions readBit = Interop.Sys.Permissions.S_IRUSR;
             const Interop.Sys.Permissions writeBit = Interop.Sys.Permissions.S_IWUSR;
 #else
             Interop.Sys.Permissions readBit, writeBit;
-
-            if (_fileStatus.Uid == Interop.Sys.GetEUid())
+            if (fileStatus.Uid == Interop.Sys.GetEUid())
             {
                 // User effectively owns the file
                 readBit = Interop.Sys.Permissions.S_IRUSR;
                 writeBit = Interop.Sys.Permissions.S_IWUSR;
             }
-            else if (_fileStatus.Gid == Interop.Sys.GetEGid())
+            else if (fileStatus.Gid == Interop.Sys.GetEGid())
             {
                 // User belongs to a group that effectively owns the file
                 readBit = Interop.Sys.Permissions.S_IRGRP;
@@ -65,8 +73,37 @@ namespace System.IO
             }
 #endif
 
-            return ((_fileStatus.Mode & (int)readBit) != 0 && // has read permission
-                (_fileStatus.Mode & (int)writeBit) == 0);     // but not write permission
+            return (fileStatus.Mode & (int)readBit) != 0 && // has read permission
+                (fileStatus.Mode & (int)writeBit) == 0;     // but not write permission
+        }
+
+        internal static bool IsSymLink(Interop.Sys.FileStatus fileStatus)
+        {
+            return (fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK;
+        }
+
+        internal static FileAttributes GetAttributes(bool isReadOnly, bool isSymlink, bool isDirectory, bool isHidden)
+        {
+            FileAttributes attributes = default;
+
+            if (isReadOnly)
+                attributes |= FileAttributes.ReadOnly;
+            if (isSymlink)
+                attributes |= FileAttributes.ReparsePoint;
+            if (isDirectory)
+                attributes |= FileAttributes.Directory;
+            if (isHidden)
+                attributes |= FileAttributes.Hidden;
+
+            return attributes != default ? attributes : FileAttributes.Normal;
+        }
+
+        internal void Invalidate() => _fileStatusInitialized = -1;
+
+        internal bool IsReadOnly(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            EnsureStatInitialized(path, continueOnError);
+            return IsReadOnly(_fileStatus);
         }
 
         public FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
@@ -78,22 +115,11 @@ namespace System.IO
             if (!_exists)
                 return (FileAttributes)(-1);
 
-            FileAttributes attributes = default;
-
-            if (IsReadOnly(path))
-                attributes |= FileAttributes.ReadOnly;
-
-            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK)
-                attributes |= FileAttributes.ReparsePoint;
-
-            if (_isDirectory)
-                attributes |= FileAttributes.Directory;
-
-            // If the filename starts with a period or has UF_HIDDEN flag set, it's hidden.
-            if (fileName.Length > 0 && (fileName[0] == '.' || (_fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN))
-                attributes |= FileAttributes.Hidden;
-
-            return attributes != default ? attributes : FileAttributes.Normal;
+            return GetAttributes(
+                IsReadOnly(path),
+                IsSymLink(_fileStatus),
+                _isDirectory,
+                (fileName.Length > 0 && fileName[0] == '.') || IsHidden(_fileStatus));
         }
 
         public void SetAttributes(string path, FileAttributes attributes)
@@ -300,13 +326,13 @@ namespace System.IO
             _exists = true;
 
             // IMPORTANT: Is directory logic must match the logic in FileSystemEntry
-            _isDirectory = (_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+            _isDirectory = IsDirectory(_fileStatus);
 
             // If we're a symlink, attempt to check the target to see if it is a directory
             if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK &&
                 Interop.Sys.Stat(path, out Interop.Sys.FileStatus targetStatus) >= 0)
             {
-                _isDirectory = (targetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+                _isDirectory = IsDirectory(targetStatus);
             }
 
             _fileStatusInitialized = 0;

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -113,18 +113,42 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
-        public void IsHiddenAttribute()
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        public void IsHiddenAttribute_Windows_OSX()
         {
-            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
-            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
-
             // Put a period in front to make it hidden on Unix
-            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, "." + GetTestFileName()));
+            IsHiddenAttributeInternal(useDotPrefix: false, useHiddenFlag: true);
+
+        }
+
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void IsHiddenAttribute_Unix()
+        {
+            // Windows and MacOS hide a file by setting the hidden attribute
+            IsHiddenAttributeInternal(useDotPrefix: true, useHiddenFlag: false);
+        }
+
+        private void IsHiddenAttributeInternal(bool useDotPrefix, bool useHiddenFlag)
+        {
+            string prefix = useDotPrefix ? "." : "";
+
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+
+            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, prefix + GetTestFileName()));
 
             fileOne.Create().Dispose();
             fileTwo.Create().Dispose();
-            if (PlatformDetection.IsWindows)
-                fileTwo.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
+
+            if (useHiddenFlag)
+            {
+                fileTwo.Attributes |= FileAttributes.Hidden;
+            }
+
+            FileInfo fileCheck = new FileInfo(fileTwo.FullName);
+            Assert.Equal(fileTwo.Attributes, fileCheck.Attributes);
 
             IEnumerable<string> enumerable = new FileSystemEnumerable<string>(
                 testDirectory.FullName,
@@ -132,6 +156,30 @@ namespace System.IO.Tests.Enumeration
                 new EnumerationOptions() { AttributesToSkip = 0 })
             {
                 ShouldIncludePredicate = (ref FileSystemEntry entry) => entry.IsHidden
+            };
+
+            Assert.Equal(new string[] { fileTwo.FullName }, enumerable);
+        }
+
+        [Fact]
+        public void IsReadOnlyAttribute()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+
+            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
+
+            fileOne.Create().Dispose();
+            fileTwo.Create().Dispose();
+
+            fileTwo.Attributes |= FileAttributes.ReadOnly;
+
+            IEnumerable<string> enumerable = new FileSystemEnumerable<string>(
+                 testDirectory.FullName,
+                 (ref FileSystemEntry entry) => entry.ToFullPath(),
+                 new EnumerationOptions() { AttributesToSkip = 0 })
+            {
+                ShouldIncludePredicate = (ref FileSystemEntry entry) => (entry.Attributes & FileAttributes.ReadOnly) != 0
             };
 
             Assert.Equal(new string[] { fileTwo.FullName }, enumerable);

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/SkipAttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/SkipAttributeTests.cs
@@ -21,25 +21,42 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
-        public void SkippingHiddenFiles()
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        public void SkippingHiddenFiles_Windows_OSX()
+        {
+            SkippingHiddenFilesInternal(useDotPrefix: false, useHiddenFlag: true);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void SkippingHiddenFiles_Unix()
+        {
+            SkippingHiddenFilesInternal(useDotPrefix: true, useHiddenFlag: false);
+        }
+
+        private void SkippingHiddenFilesInternal(bool useDotPrefix, bool useHiddenFlag)
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
             DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Combine(testDirectory.FullName, GetTestFileName()));
-            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
 
-            // Put a period in front to make it hidden on Unix
-            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, "." + GetTestFileName()));
+            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
             FileInfo fileThree = new FileInfo(Path.Combine(testSubdirectory.FullName, GetTestFileName()));
-            FileInfo fileFour = new FileInfo(Path.Combine(testSubdirectory.FullName, "." + GetTestFileName()));
+
+            // Put a period in front of files two and four to make them hidden on Unix
+            string prefix = useDotPrefix ? "." : "";
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, prefix + GetTestFileName()));
+            FileInfo fileFour = new FileInfo(Path.Combine(testSubdirectory.FullName, prefix + GetTestFileName()));
 
             fileOne.Create().Dispose();
             fileTwo.Create().Dispose();
-            if (PlatformDetection.IsWindows)
-                fileTwo.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
             fileThree.Create().Dispose();
             fileFour.Create().Dispose();
-            if (PlatformDetection.IsWindows)
-                fileFour.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
+
+            if (useHiddenFlag)
+            {
+                fileTwo.Attributes |= FileAttributes.Hidden;
+                fileFour.Attributes |= FileAttributes.Hidden;
+            }
 
             // Default EnumerationOptions is to skip hidden
             string[] paths = GetPaths(testDirectory.FullName, new EnumerationOptions());


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37301

These two files do very similar tasks, but when it comes to collect the Hidden attribute, the first one is simpler than the second one:

https://github.com/dotnet/runtime/blob/bd6cbe3642f51d70839912a6a666e5de747ad581/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs#L59-L67

https://github.com/dotnet/runtime/blob/bd6cbe3642f51d70839912a6a666e5de747ad581/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs#L81-L82

This change ensures both collect the Hidden attribute the same way, and makes it more obvious that both methods are closely related.

Also, the ReadOnly attribute was not being collected in the first file, so I added code to do it, as well as a unit test.

I ran all the System.IO.FileSystem unit tests in Ubuntu and in MacOS and they passed. Pending yet to see the CI results.

This fix needs to go into 5.0, or later it could become a breaking change, as explained [here](https://github.com/dotnet/runtime/issues/37301#issuecomment-649209428).