### PR TITLE
add macOS 11 with arm64 to RID graph

### DIFF
--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -3661,6 +3661,14 @@
     "any",
     "base"
   ],
+  "osx-arm64": [
+    "osx-arm64",
+    "osx",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "osx-x64": [
     "osx-x64",
     "osx",
@@ -3809,6 +3817,65 @@
     "osx.10.11",
     "osx.10.10-x64",
     "osx.10.10",
+    "osx-x64",
+    "osx",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "osx.11": [
+    "osx.11",
+    "osx",
+    "unix",
+    "any",
+    "base"
+  ],
+  "osx.11-arm64": [
+    "osx.11-arm64",
+    "osx.11",
+    "osx-arm64",
+    "osx",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "osx.11-x64": [
+    "osx.11-x64",
+    "osx.11",
+    "osx-x64",
+    "osx",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "osx.11.0": [
+    "osx.11.0",
+    "osx.11",
+    "osx",
+    "unix",
+    "any",
+    "base"
+  ],
+  "osx.11.0-arm64": [
+    "osx.11.0-arm64",
+    "osx.11.0",
+    "osx.11-arm64",
+    "osx.11",
+    "osx-arm64",
+    "osx",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "osx.11.0-x64": [
+    "osx.11.0-x64",
+    "osx.11.0",
+    "osx.11-x64",
+    "osx.11",
     "osx-x64",
     "osx",
     "unix-x64",

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1571,6 +1571,12 @@
         "unix"
       ]
     },
+    "osx-arm64": {
+      "#import": [
+        "osx",
+        "unix-arm64"
+      ]
+    },
     "osx-x64": {
       "#import": [
         "osx",
@@ -1641,6 +1647,40 @@
       "#import": [
         "osx.10.15",
         "osx.10.14-x64"
+      ]
+    },
+    "osx.11": {
+      "#import": [
+        "osx"
+      ]
+    },
+    "osx.11-arm64": {
+      "#import": [
+        "osx.11",
+        "osx-arm64"
+      ]
+    },
+    "osx.11-x64": {
+      "#import": [
+        "osx.11",
+        "osx-x64"
+      ]
+    },
+    "osx.11.0": {
+      "#import": [
+        "osx.11"
+      ]
+    },
+    "osx.11.0-arm64": {
+      "#import": [
+        "osx.11.0",
+        "osx.11-arm64"
+      ]
+    },
+    "osx.11.0-x64": {
+      "#import": [
+        "osx.11.0",
+        "osx.11-x64"
       ]
     },
     "rhel": {

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -124,6 +124,12 @@
       <Versions>10.10;10.11;10.12;10.13;10.14;10.15</Versions>
     </RuntimeGroup>
 
+    <RuntimeGroup Include="osx">
+      <Parent>unix</Parent>
+      <Architectures>x64;arm64</Architectures>
+      <Versions>11;11.0</Versions>
+    </RuntimeGroup>
+
     <RuntimeGroup Include="freebsd">
       <Parent>unix</Parent>
       <Architectures>x64</Architectures>


### PR DESCRIPTION
I added new node to fork for upcomming arm64.
I assume 3.1 and 2.1 will have same graph even if we probably will not make arm builds. 


fixes #40479