### PR TITLE
JS api for creating GC roots to store temporary object references in

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -181,7 +181,7 @@ var BindingSupportLib = {
 		},
 
 		unbox_mono_obj: function (mono_obj) {
-			if (mono_obj == 0)
+			if (mono_obj === 0)
 				return undefined;
 
 			var root = MONO.mono_wasm_new_root (mono_obj);
@@ -195,9 +195,7 @@ var BindingSupportLib = {
 		_unbox_mono_obj_rooted: function (root) {
 			var mono_obj = root.value;
 			if (mono_obj === 0)
-				console.log ("unbox_mono_obj_rooted got a null pointer");
-			else if (typeof (mono_obj) !== "number")
-				throw new Error ("invalid root object");
+				return undefined;
 			
 			var type = this.mono_get_obj_type (mono_obj);
 			//See MARSHAL_TYPE_ defines in driver.c

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -181,7 +181,7 @@ var BindingSupportLib = {
 		},
 
 		unbox_mono_obj: function (mono_obj) {
-			if (mono_obj === 0)
+			if (mono_obj == 0)
 				return undefined;
 
 			var root = MONO.mono_wasm_new_root (mono_obj);
@@ -194,6 +194,10 @@ var BindingSupportLib = {
 
 		_unbox_mono_obj_rooted: function (root) {
 			var mono_obj = root.value;
+			if (mono_obj === 0)
+				console.log ("unbox_mono_obj_rooted got a null pointer");
+			else if (typeof (mono_obj) !== "number")
+				throw new Error ("invalid root object");
 			
 			var type = this.mono_get_obj_type (mono_obj);
 			//See MARSHAL_TYPE_ defines in driver.c
@@ -288,7 +292,7 @@ var BindingSupportLib = {
 				}
 				return requiredObject;
 			default:
-				throw new Error ("no idea on how to unbox object kind " + type);
+				throw new Error ("no idea on how to unbox object kind " + type + " at offset " + mono_obj);
 			}
 		},
 
@@ -541,11 +545,10 @@ var BindingSupportLib = {
 				// Check enum contract
 				monoEnum = MONO.mono_wasm_new_root (this.call_method (this.object_to_enum, null, "iimm", [ method, parmIdx, monoObj.value ]))
 				// return the unboxed enum value.
-				var result = this.mono_unbox_enum (monoEnum);
+				return this.mono_unbox_enum (monoEnum.value);
 			} finally {
 				MONO.mono_wasm_release_roots (monoObj, monoEnum);
 			}
-			return result;
 		},
 		wasm_binding_obj_new: function (js_obj_id, ownsHandle, type)
 		{

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -143,32 +143,58 @@ var BindingSupportLib = {
 		mono_array_to_js_array: function (mono_array) {
 			if (mono_array == 0)
 				return null;
+			
+			var array_root = MONO.mono_wasm_new_root (mono_array), 
+				elem_root = MONO.mono_wasm_new_root ();
 
 			var res = [];
 			var len = this.mono_array_length (mono_array);
 			for (var i = 0; i < len; ++i)
 			{
-				var ele = this.mono_array_get (mono_array, i);
-				if (this.is_nested_array(ele))
-					res.push(this.mono_array_to_js_array(ele));
+				let ele = elem_root.value = this.mono_array_get (mono_array, i);
+				if (this.is_nested_array (ele))
+					res.push (this.mono_array_to_js_array(ele));
 				else
 					res.push (this.unbox_mono_obj (ele));
 			}
+
+			array_root.release();
+			elem_root.release();
 
 			return res;
 		},
 
 		js_array_to_mono_array: function (js_array) {
-			var mono_array = this.mono_obj_array_new (js_array.length);
+			var array_root = MONO.mono_wasm_new_root (this.mono_obj_array_new (js_array.length)),
+				elem_root = MONO.mono_wasm_new_root ();
+				
 			for (var i = 0; i < js_array.length; ++i) {
-				this.mono_obj_array_set (mono_array, i, this.js_to_mono_obj (js_array [i]));
+				elem_root.value = this.js_to_mono_obj (js_array [i]);
+				this.mono_obj_array_set (array_root.value, i, elem_root.value);
 			}
+
+			array_root.release();
+			elem_root.release();
+
 			return mono_array;
 		},
 
+		// Scratch root used for temporary storage in unbox_mono_obj.
+		// As long as this API is not re-entrant, this single slot is sufficient to ensure
+		//  that the object being unboxed is not collected until the unbox operation is done.
+		_unbox_mono_obj_root: null,
+
+		// FIXME: Is there a way to mechanically ensure that this function is not re-entrant,
+		//  other than the overhead of a try/finally block?
 		unbox_mono_obj: function (mono_obj) {
 			if (mono_obj == 0)
 				return undefined;
+
+			if (!MONO._unbox_mono_obj_root)
+				MONO._unbox_mono_obj_root = MONO.mono_wasm_new_root ();
+
+			MONO._unbox_mono_obj_root.value = mono_obj;
+			
 			var type = this.mono_get_obj_type (mono_obj);
 			//See MARSHAL_TYPE_ defines in driver.c
 			switch (type) {
@@ -183,6 +209,7 @@ var BindingSupportLib = {
 			case 5: { // delegate
 				var obj = this.extract_js_obj (mono_obj);
 				obj.__mono_delegate_alive__ = true;
+				// FIXME: Should we root the object as long as this function has not been GCd?
 				return function () {
 					return BINDING.invoke_delegate (obj, arguments);
 				};
@@ -250,6 +277,7 @@ var BindingSupportLib = {
 			case 23: // clr .NET SafeHandle
 				var addRef = true;
 				var js_handle = this.call_method(this.safehandle_get_handle, null, "mii", [ mono_obj, addRef ]);
+				// FIXME: Is this a GC object that needs to be rooted?
 				var requiredObject = BINDING.mono_wasm_require_handle (js_handle);
 				if (addRef)
 				{
@@ -322,6 +350,7 @@ var BindingSupportLib = {
 					var the_task = this.try_extract_mono_obj (js_obj);
 					if (the_task)
 						return the_task;
+					// FIXME: We need to root tcs for an appropriate timespan
 					var tcs = this.create_task_completion_source ();
 					js_obj.then (function (result) {
 						BINDING.set_task_result (tcs, result);
@@ -349,6 +378,8 @@ var BindingSupportLib = {
 					return this.extract_mono_obj (js_obj);
 			}
 		},
+
+		// FIXME: Audit all callers, this method returns an unrooted object
 		js_typed_array_to_array : function (js_obj) {
 
 			// JavaScript typed arrays are array-like objects and provide a mechanism for accessing 
@@ -504,11 +535,14 @@ var BindingSupportLib = {
 			if (js_obj === null || typeof js_obj === "undefined")
 				return 0;
 
-			var monoObj = this.js_to_mono_obj(js_obj);
+			var monoObj = MONO.mono_wasm_new_root (this.js_to_mono_obj (js_obj));
 			// Check enum contract
-			var monoEnum = this.call_method(this.object_to_enum, null, "iimm", [ method, parmIdx, monoObj ])
+			var monoEnum = MONO.mono_wasm_new_root (this.call_method (this.object_to_enum, null, "iimm", [ method, parmIdx, monoObj.value ]))
 			// return the unboxed enum value.
-			return this.mono_unbox_enum(monoEnum);
+			var result = this.mono_unbox_enum(monoEnum);
+			monoObj.release();
+			monoEnum.release();
+			return result;
 		},
 		wasm_binding_obj_new: function (js_obj_id, ownsHandle, type)
 		{

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -12,8 +12,9 @@
 #include <mono/metadata/tokentype.h>
 #include <mono/metadata/threads.h>
 #include <mono/metadata/image.h>
-#include <mono/metadata/gc-internals.h>
 #include <mono/metadata/mono-gc.h>
+// FIXME: unavailable in emscripten
+// #include <mono/metadata/gc-internals.h>
 #include <mono/utils/mono-logger.h>
 #include <mono/utils/mono-dl-fallback.h>
 #include <mono/jit/jit.h>
@@ -144,10 +145,11 @@ wasm_logger (const char *log_domain, const char *log_level, const char *message,
 	}, log_level, message, fatal, log_domain);
 }
 
-/*
+typedef uint32_t target_mword;
+typedef target_mword SgenDescriptor;
+typedef SgenDescriptor MonoGCDescriptor;
 MONO_API int   mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg);
 void  mono_gc_deregister_root (char* addr);
-*/
 
 EMSCRIPTEN_KEEPALIVE int
 mono_wasm_register_root (char *start, size_t size, const char *name) {

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -12,6 +12,8 @@
 #include <mono/metadata/tokentype.h>
 #include <mono/metadata/threads.h>
 #include <mono/metadata/image.h>
+#include <mono/metadata/gc-internals.h>
+#include <mono/metadata/mono-gc.h>
 #include <mono/utils/mono-logger.h>
 #include <mono/utils/mono-dl-fallback.h>
 #include <mono/jit/jit.h>
@@ -30,6 +32,9 @@ extern void* mono_wasm_invoke_js_marshalled (MonoString **exceptionMessage, void
 extern void* mono_wasm_invoke_js_unmarshalled (MonoString **exceptionMessage, MonoString *funcName, void* arg0, void* arg1, void* arg2);
 
 void mono_wasm_enable_debugging (int);
+
+int mono_wasm_register_root (char *start, size_t size, const char *name);
+void mono_wasm_deregister_root (char *addr);
 
 void mono_ee_interp_init (const char *opts);
 void mono_marshal_ilgen_init (void);
@@ -137,6 +142,21 @@ wasm_logger (const char *log_domain, const char *log_level, const char *message,
 				break;
 		}
 	}, log_level, message, fatal, log_domain);
+}
+
+/*
+MONO_API int   mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg);
+void  mono_gc_deregister_root (char* addr);
+*/
+
+EMSCRIPTEN_KEEPALIVE int
+mono_wasm_register_root (char *start, size_t size, const char *name) {
+	return mono_gc_register_root (start, size, NULL, MONO_ROOT_SOURCE_EXTERNAL, NULL, name ? name : "mono_wasm_register_root");
+}
+
+EMSCRIPTEN_KEEPALIVE void 
+mono_wasm_deregister_root (char *addr) {
+	mono_gc_deregister_root (addr);
 }
 
 #ifdef DRIVER_GEN

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -44,8 +44,9 @@ var MonoSupportLib = {
 			module ["mono_wasm_globalization_init"] = MONO.mono_wasm_globalization_init;
 			module ["mono_wasm_get_loaded_files"] = MONO.mono_wasm_get_loaded_files;
 			module ["mono_wasm_new_root_buffer"] = MONO.mono_wasm_new_root_buffer;
-			module ["mono_wasm_new_root_table"] = MONO.mono_wasm_new_root_table;
 			module ["mono_wasm_new_root"] = MONO.mono_wasm_new_root;
+			module ["mono_wasm_new_roots"] = MONO.mono_wasm_new_roots;
+			module ["mono_wasm_release_roots"] = MONO.mono_wasm_release_roots;
 		},
 
 		_mono_wasm_root_buffer_prototype: {

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -81,6 +81,9 @@ var MonoSupportLib = {
 				this.__buffer.set(this.__index, value);
 				return value;
 			},
+			valueOf: function () {
+				return this.get();
+			},
 			release: function () {
 				MONO._mono_wasm_release_scratch_index (this.__index);
 				this.__buffer = undefined;

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -185,9 +185,10 @@ var MonoSupportLib = {
 			}
 
 			var buffer = this.scratch_root_buffer;
-			var index = this.scratch_root_free_indices.pop ();
-			if (!index)
+			if (this.scratch_root_free_indices.length < 1)
 				throw new Error("Out of scratch root space");
+
+			var index = this.scratch_root_free_indices.pop ();
 				
 			var result = Object.create(MONO._mono_wasm_root_prototype);
 			result.__buffer = buffer.__buffer;

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -50,20 +50,24 @@ var MonoSupportLib = {
 
 		_mono_wasm_root_buffer_prototype: {
 			get: function (index) {
-				return this.__buffer[index];
+				return Module.HEAP32[this.__offset32 + index];
 			},
 			set: function (index, value) {
-				this.__buffer[index] = value;
+				var absoluteOffset = this.__offset32 + index;
+				console.log("writing", value, "to", absoluteOffset);
+				Module.HEAP32[absoluteOffset] = value;
 				return value;
 			},
 			release: function () {
-				if (this.__handle) {
+				console.log("releasing buffer at", this.__offset);
+
+				if (this.__offset) {
 					MONO.mono_wasm_deregister_root (this.__offset);
-					this.__buffer.fill (0);
+					MONO._fill_region(this.__offset, this.__count * 4, 0);
 					Module.free (this.__offset);
 				}
 
-				this.__buffer = this.__handle = this.__offset = undefined;
+				this.__handle = this.__offset = this.__count = this.__offset32 = undefined;
 			},
 		},
 
@@ -72,32 +76,39 @@ var MonoSupportLib = {
 
 		_mono_wasm_root_prototype: {
 			get: function () {
-				return this.__buffer[this.__index];
+				var result = this.__buffer.get(this.__index);
+				console.log ("value at", this.__index, "is", result);
+				return result;
 			},
 			set: function (value) {
-				this.__buffer[this.__index] = value;
+				this.__buffer.set(this.__index, value);
+				return value;
 			},
 			release: function () {
-				this.__index = MONO._mono_wasm_release_scratch_index (this.__index);
+				MONO._mono_wasm_release_scratch_index (this.__index);
+				this.__buffer = undefined;
+				this.__index = undefined;
 			}
 		},
 
 		_mono_wasm_release_scratch_index: function (index) {
-			if (index) {
-				this._scratch_root_buffer.__buffer[index] = 0;
-				this._scratch_root_free_indices.push (index);
-			}
+			if (index === undefined)
+				return;
 
-			return undefined;
+			console.log ("release", index, "with previous value", this._scratch_root_buffer.get(index));
+			this._scratch_root_buffer.set(index, 0);
+			this._scratch_root_free_indices.push (index);
 		},
 
 		_mono_wasm_claim_scratch_index: function () {
 			if (!this._scratch_root_buffer) {
 				const maxScratchRoots = 8192;
 				this._scratch_root_buffer = this.mono_wasm_new_root_buffer (maxScratchRoots, "js roots");
+
 				this._scratch_root_free_indices = new Array (maxScratchRoots);
 				for (var i = 0; i < maxScratchRoots; i++)
-					this._scratch_root_free_indices[i] = maxScratchRoots - i - 1;
+					this._scratch_root_free_indices[i] = i;
+				this._scratch_root_free_indices.reverse();
 
 				Object.defineProperty (MONO._mono_wasm_root_prototype, "value", {
 					get: MONO._mono_wasm_root_prototype.get,
@@ -109,7 +120,12 @@ var MonoSupportLib = {
 			if (this._scratch_root_free_indices.length < 1)
 				throw new Error("Out of scratch root space");
 
-			return this._scratch_root_free_indices.pop ();
+			var result = this._scratch_root_free_indices.pop ();
+			return result;
+		},
+
+		_zero_region: function (byteOffset, sizeBytes, value) {
+			(new Uint8Array (Module.HEAPU8.buffer, byteOffset, sizeBytes)).fill (0);
 		},
 
 		// Allocates a block of memory that can safely contain pointers into the managed heap.
@@ -125,14 +141,18 @@ var MonoSupportLib = {
 			if (capacity <= 0)
 				throw new Error("capacity >= 1");
 				
-			var offset = Module._malloc (capacity * 4);
-			var buffer = new Int32Array (Module.HEAPU8.buffer, offset, capacity);
-			buffer.fill (0);
+			var capacityBytes = capacity * 4;
+			var offset = Module._malloc (capacityBytes);
+			if ((offset % 4) !== 0)
+				throw new Error("Malloc returned an unaligned offset");
+
+			this._zero_region(offset, capacityBytes, 0);
 
 			var result = Object.create (MONO._mono_wasm_root_buffer_prototype);
-			result.__offset = offset;			
-			result.__handle = MONO.mono_wasm_register_root (offset, capacity, msg || 0);
-			result.__buffer = buffer;
+			result.__offset = offset;
+			result.__offset32 = offset / 4;
+			result.__count = capacity;	
+			result.__handle = MONO.mono_wasm_register_root (offset, capacityBytes, msg || 0);
 
 			return result;
 		},
@@ -147,13 +167,24 @@ var MonoSupportLib = {
 			var buffer = this._scratch_root_buffer;
 				
 			var result = Object.create (MONO._mono_wasm_root_prototype);
-			result.__buffer = buffer.__buffer;
+			result.__buffer = buffer;
 			result.__index = index;
 
-			if (value !== undefined)
-				result.value = value;
-			else
-				result.value = 0;
+			if (value !== undefined) {
+				console.log("initializing", index, "to", value);
+				result.set(value);
+
+				var tmp = result.value;
+				if (tmp != value)
+					throw new Error ("Store failed, result was" + tmp);
+			} else {
+				console.log("zero-initializing", index);
+				result.set(0);
+
+				var tmp = result.value;
+				if (tmp != 0)
+					throw new Error ("Zero init failed, result was" + tmp);
+			}
 
 			return result;
 		},
@@ -170,7 +201,7 @@ var MonoSupportLib = {
 				for (var i = 0; i < result.length; i++)
 					result[i] = this.mono_wasm_new_root (count_or_values[i]);
 			} else {
-				result = new Array (count);
+				result = new Array (count_or_values);
 				for (var i = 0; i < result.length; i++)
 					result[i] = this.mono_wasm_new_root ();
 			}

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -54,13 +54,10 @@ var MonoSupportLib = {
 			},
 			set: function (index, value) {
 				var absoluteOffset = this.__offset32 + index;
-				console.log("writing", value, "to", absoluteOffset);
 				Module.HEAP32[absoluteOffset] = value;
 				return value;
 			},
 			release: function () {
-				console.log("releasing buffer at", this.__offset);
-
 				if (this.__offset) {
 					MONO.mono_wasm_deregister_root (this.__offset);
 					MONO._fill_region(this.__offset, this.__count * 4, 0);
@@ -77,7 +74,6 @@ var MonoSupportLib = {
 		_mono_wasm_root_prototype: {
 			get: function () {
 				var result = this.__buffer.get(this.__index);
-				console.log ("value at", this.__index, "is", result);
 				return result;
 			},
 			set: function (value) {
@@ -95,7 +91,6 @@ var MonoSupportLib = {
 			if (index === undefined)
 				return;
 
-			console.log ("release", index, "with previous value", this._scratch_root_buffer.get(index));
 			this._scratch_root_buffer.set(index, 0);
 			this._scratch_root_free_indices.push (index);
 		},
@@ -171,19 +166,9 @@ var MonoSupportLib = {
 			result.__index = index;
 
 			if (value !== undefined) {
-				console.log("initializing", index, "to", value);
 				result.set(value);
-
-				var tmp = result.value;
-				if (tmp != value)
-					throw new Error ("Store failed, result was" + tmp);
 			} else {
-				console.log("zero-initializing", index);
 				result.set(0);
-
-				var tmp = result.value;
-				if (tmp != 0)
-					throw new Error ("Zero init failed, result was" + tmp);
 			}
 
 			return result;


### PR DESCRIPTION
Our current JS is not GC safe and as a result if a GC happens at the wrong time, objects being used by JS can get collected. This PR is a partial solution for the issue that introduces an API for allocating root buffers where you can store GC object references while JS code is manipulating them. Two convenience APIs are layered on top for creating single temporary roots. The PR updates some of the existing bindings APIs to make use of temporary roots when manipulating managed objects.