### PR TITLE
ICommand CanExecuteChanged should be nullable

### DIFF
--- a/src/libraries/System.ObjectModel/ref/System.ObjectModel.cs
+++ b/src/libraries/System.ObjectModel/ref/System.ObjectModel.cs
@@ -227,7 +227,7 @@ namespace System.Windows.Input
     [System.Windows.Markup.ValueSerializerAttribute("System.Windows.Input.CommandValueSerializer, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, Custom=null")]
     public partial interface ICommand
     {
-        event System.EventHandler CanExecuteChanged;
+        event System.EventHandler? CanExecuteChanged;
         bool CanExecute(object? parameter);
         void Execute(object? parameter);
     }

--- a/src/libraries/System.ObjectModel/src/System/Windows/Input/ICommand.cs
+++ b/src/libraries/System.ObjectModel/src/System/Windows/Input/ICommand.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Input
         /// <summary>
         /// Raised when the ability of the command to execute has changed.
         /// </summary>
-        event EventHandler CanExecuteChanged;
+        event EventHandler? CanExecuteChanged;
 
         /// <summary>
         /// Returns whether the command can be executed.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1237