### PR TITLE
Setting `WebProxy.BypassList` to null throws

### DIFF
--- a/src/libraries/System.Net.WebProxy/ref/System.Net.WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/ref/System.Net.WebProxy.cs
@@ -27,6 +27,7 @@ namespace System.Net
         public WebProxy(System.Uri? Address, bool BypassOnLocal, string[]? BypassList, System.Net.ICredentials? Credentials) { }
         public System.Uri? Address { get { throw null; } set { } }
         public System.Collections.ArrayList BypassArrayList { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string[] BypassList { get { throw null; } set { } }
         public bool BypassProxyOnLocal { get { throw null; } set { } }
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.NetworkInformation;
 using System.Runtime.Serialization;
@@ -63,6 +64,7 @@ namespace System.Net
 
         public bool BypassProxyOnLocal { get; set; }
 
+        [AllowNull]
         public string[] BypassList
         {
             get { return _bypassList != null ? (string[])_bypassList.ToArray(typeof(string)) : Array.Empty<string>(); }

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -68,7 +68,14 @@ namespace System.Net
             get { return _bypassList != null ? (string[])_bypassList.ToArray(typeof(string)) : Array.Empty<string>(); }
             set
             {
-                _bypassList = new ArrayList(value);
+                if (value == null)
+                {
+                    _bypassList = null;
+                }
+                else
+                {
+                    _bypassList = new ArrayList(value);
+                }
                 UpdateRegexList(true);
             }
         }

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -70,14 +70,7 @@ namespace System.Net
             get { return _bypassList != null ? (string[])_bypassList.ToArray(typeof(string)) : Array.Empty<string>(); }
             set
             {
-                if (value == null)
-                {
-                    _bypassList = null;
-                }
-                else
-                {
-                    _bypassList = new ArrayList(value);
-                }
+                _bypassList = value != null ? new ArrayList(value) : null;
                 UpdateRegexList(true);
             }
         }

--- a/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -111,7 +111,6 @@ namespace System.Net.Tests
             var p = new WebProxy();
             AssertExtensions.Throws<ArgumentNullException>("destination", () => p.GetProxy(null));
             AssertExtensions.Throws<ArgumentNullException>("host", () => p.IsBypassed(null));
-            AssertExtensions.Throws<ArgumentNullException>("c", () => p.BypassList = null);
             Assert.ThrowsAny<ArgumentException>(() => p.BypassList = new string[] { "*.com" });
         }
 

--- a/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -61,6 +61,11 @@ namespace System.Net.Tests
             p.BypassList = strings;
             Assert.Equal(strings, p.BypassList);
             Assert.Equal(strings, (string[])p.BypassArrayList.ToArray(typeof(string)));
+
+            strings = null;
+            p.BypassList = strings;
+            Assert.Equal(Array.Empty<string>(), p.BypassList);
+            Assert.Equal(Array.Empty<string>(), (string[])p.BypassArrayList.ToArray(typeof(string)));
         }
 
         [Fact]

--- a/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -64,8 +64,8 @@ namespace System.Net.Tests
 
             strings = null;
             p.BypassList = strings;
-            Assert.Equal(Array.Empty<string>(), p.BypassList);
-            Assert.Equal(Array.Empty<string>(), (string[])p.BypassArrayList.ToArray(typeof(string)));
+            Assert.Empty(p.BypassList);
+            Assert.Empty(p.BypassArrayList);
         }
 
         [Fact]


### PR DESCRIPTION
Delivers https://github.com/dotnet/runtime/issues/40655

Checked the value for null before passing it to `ArrayList` constructor.