### PR TITLE
Increase method resolution test coverage for generics

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/SampleMetadata/SampleMetadata.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/SampleMetadata/SampleMetadata.cs
@@ -450,6 +450,8 @@ namespace SampleMetadata
         public MarkAttribute(int mark) { }
     }
 
+    public class MyGenericClass<T> { }
+
     public class MethodHolderBase<T>
     {
         [Mark(10)]
@@ -467,6 +469,17 @@ namespace SampleMetadata
         [Mark(30)]
         private void Poo(int x, int y) { }
 
+        [Mark(40)]
+        public virtual void Foo<K>(MyGenericClass<K> x, int y) { }
+
+        [Mark(50)]
+        public virtual void Foo<K>(MyGenericClass<T> x, int y) { }
+
+        [Mark(60)]
+        public virtual void Foo(MyGenericClass<T> x, string y) { }
+
+        [Mark(70)]
+        public virtual void Foo(int x, int y) { }
     }
 
     public class MethodHolderDerived<T> : MethodHolderBase<T>
@@ -476,6 +489,18 @@ namespace SampleMetadata
 
         [Mark(10020)]
         public override void Voo(int x, int y) { }
+
+        [Mark(10040)]
+        public override void Foo<K>(MyGenericClass<K> x, int y) { }
+
+        [Mark(10050)]
+        public virtual void Foo<K>(MyGenericClass<int> x, int y) { }
+
+        [Mark(10060)]
+        public override void Foo(MyGenericClass<T> x, string y) { }
+
+        [Mark(10070)]
+        public override void Foo(int x, int y) { }
     }
 
     public class PropertyHolder1<T>

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
@@ -468,6 +468,29 @@ namespace System.Reflection.Tests
                 MethodInfo m = gi.GetMethod("Hoo", bf, binder, types, null);
                 Assert.Equal(11, m.GetMark());
             }
+
+            {
+                Type mgc = typeof(MyGenericClass<>).Project();
+                Type mgcClosed = mgc.MakeGenericType(typeof(int).Project());
+                Assert.Equal(mgc, mgcClosed.GetGenericTypeDefinition());
+
+                Type gi = t.MakeGenericType(typeof(int).Project());
+                Type[] types = { mgcClosed, typeof(string).Project() };
+                MethodInfo m = gi.GetMethod("Foo", bf, binder, types, null);
+                Assert.Equal(10060, m.GetMark());
+            }
+
+            {
+                Type[] types = { typeof(int).Project(), typeof(short).Project() };
+                MethodInfo m = typeof(MethodHolderDerived<>).Project().GetMethod("Foo", bf, binder, types, null);
+                Assert.Equal(10070, m.GetMark());
+            }
+
+            {
+                Type[] types = { typeof(int).Project(), typeof(int).Project() };
+                MethodInfo m = typeof(MethodHolderDerived<>).Project().GetMethod("Foo", bf, binder, types, null);
+                Assert.Equal(10070, m.GetMark());
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/TypeInfoFromProjectN/TypeInfo_GenericTypeParametersTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/TypeInfoFromProjectN/TypeInfo_GenericTypeParametersTests.cs
@@ -115,8 +115,6 @@ namespace System.Reflection.Tests
             VerifyGenericTypeParameters(typeof(Test_SIG21<int, string>).Project(), new string[] { }, new string[] { });
         }
 
-
-
         // Verify Generic Arguments
         [Fact]
         public static void TestGenericParameters16()
@@ -154,7 +152,6 @@ namespace System.Reflection.Tests
         {
             VerifyGenericTypeParameters(typeof(Test_C1).Project(), new string[] { }, null);
         }
-
 
         // Verify Generic Arguments
         [Fact]
@@ -197,7 +194,6 @@ namespace System.Reflection.Tests
         {
             VerifyGenericTypeParameters(typeof(Test_CIG1<>).Project(), new string[] { "T" }, new string[] { });
         }
-
 
         // Verify Generic Arguments
         [Fact]
@@ -263,12 +259,10 @@ namespace System.Reflection.Tests
 
             Assert.Equal(expectedGTP.Length, retGenericTypeParameters.Length);
 
-
             for (int i = 0; i < retGenericTypeParameters.Length; i++)
             {
                 Assert.Equal(expectedGTP[i], retGenericTypeParameters[i].Name);
             }
-
 
             Type baseType = typeInfo.BaseType;
             if (baseType == null)
@@ -282,19 +276,16 @@ namespace System.Reflection.Tests
                 baseType = interfaces[0];
             }
 
-
             TypeInfo typeInfoBase = baseType.GetTypeInfo();
             retGenericTypeParameters = typeInfoBase.GenericTypeParameters;
 
             Assert.Equal(expectedBaseGTP.Length, retGenericTypeParameters.Length);
-
 
             for (int i = 0; i < retGenericTypeParameters.Length; i++)
             {
                 Assert.Equal(expectedBaseGTP[i], retGenericTypeParameters[i].Name);
             }
         }
-
 
         private static Type[] getInterfaces(TypeInfo ti)
         {


### PR DESCRIPTION
Covers the branch mentioned in https://github.com/dotnet/runtime/issues/28046 (`System.Reflection.Runtime.BindingFlagSupport.MemberPolicies<>.GenericMethodAwareAreParameterTypesEqual`) which was not previously covered by tests.

The intent of these new tests was to trigger the reported exception for `t2.GetGenericTypeDefinition()` on this line:
```cs
if (!(t1.GetGenericTypeDefinition().Equals(t2.GetGenericTypeDefinition())))
```
however a repro was not found (although we still increase coverage to this area).

