### PR TITLE
fix error mapping in HttpWebRequest to handle NetworkException

### DIFF
--- a/src/libraries/Common/src/System/Net/NetworkErrorHelper.cs
+++ b/src/libraries/Common/src/System/Net/NetworkErrorHelper.cs
@@ -13,6 +13,7 @@ namespace System.Net
             {
                 SocketError.AddressAlreadyInUse => NetworkError.EndPointInUse,
                 SocketError.HostNotFound => NetworkError.HostNotFound,
+                SocketError.NoData => NetworkError.HostNotFound,
                 SocketError.ConnectionRefused => NetworkError.ConnectionRefused,
                 SocketError.OperationAborted => NetworkError.OperationAborted,
                 SocketError.ConnectionAborted => NetworkError.ConnectionAborted,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -61,6 +61,15 @@ namespace System.Net.Http
                     socket.Connect(new DnsEndPoint(host, port));
                 }
             }
+            catch (SocketException se)
+            {
+                socket.Dispose();
+
+                // SocketConnectionFactory wraps SocketException in NetworkException. Do the same here.
+                NetworkException ne = NetworkErrorHelper.MapSocketException(se);
+
+                throw CreateWrappedException(ne, host, port, cancellationToken);
+            }
             catch (Exception e)
             {
                 socket.Dispose();

--- a/src/libraries/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/WebException.cs
@@ -96,18 +96,17 @@ namespace System.Net
 
         private static WebExceptionStatus GetStatusFromExceptionHelper(HttpRequestException ex)
         {
-            SocketException? socketEx = ex.InnerException as SocketException;
+            NetworkException? networkException = ex.InnerException as NetworkException;
 
-            if (socketEx is null)
+            if (networkException is null)
             {
                 return WebExceptionStatus.UnknownError;
             }
 
             WebExceptionStatus status;
-            switch (socketEx.SocketErrorCode)
+            switch (networkException.NetworkError)
             {
-                case SocketError.NoData:
-                case SocketError.HostNotFound:
+                case NetworkError.HostNotFound:
                     status = WebExceptionStatus.NameResolutionFailure;
                     break;
                 default:


### PR DESCRIPTION
Fixes #40606 

HttpWebRequest was specifically looking for a SocketException to detect and map HostNotFound. Change this to look for NetworkException.

Additionally, fix the sync Connect path in HttpClient to also throw NetworkException instead of SocketException.