### PR TITLE
[Test] Improve flakiness of test in Microsoft.Win32

### DIFF
--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Win32.SystemEventsTests
         public void TimerElapsedIsRoughlyEquivalentToInterval(int interval)
         {
             const double permittedProportionUnder = -0.1;
-            const double permittedProportionOver = 0.5;
+            const double permittedProportionOver = 5.0;
             var elapsed = new AutoResetEvent(false);
             IntPtr timer = IntPtr.Zero;
             var stopwatch = new Stopwatch();


### PR DESCRIPTION
failed test: Microsoft.Win32.SystemEventsTests.CreateTimerTests.TimerElapsedIsRoughlyEquivalentToInterval(interval: 500)

Error Message:
```
Timer should fire less than -10% before and less than 50% after expected interval 500, actual: 2345, difference: 369%
Expected: True
Actual:   False


Stack trace
   at Microsoft.Win32.SystemEventsTests.CreateTimerTests.TimerElapsedIsRoughlyEquivalentToInterval(Int32 interval) in /_/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs:line 164
```

https://github.com/dotnet/runtime/issues/34888