### PR TITLE
Change Linux fetch timeout behavior for chain building

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
@@ -30,7 +30,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
         public bool RespondEmpty { get; set; }
 
-        public TimeSpan RespondDelay { get; set; }
+        public TimeSpan ResponseDelay { get; set; }
         public DelayedActionsFlag DelayedActions { get; set; }
 
         private RevocationResponder(HttpListener listener, string uriPrefix)
@@ -165,8 +165,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             {
                 if (DelayedActions.HasFlag(DelayedActionsFlag.Aia))
                 {
-                    Trace($"Delaying response by {RespondDelay}.");
-                    Thread.Sleep(RespondDelay);
+                    Trace($"Delaying response by {ResponseDelay}.");
+                    Thread.Sleep(ResponseDelay);
                 }
 
                 byte[] certData = RespondEmpty ? Array.Empty<byte>() : authority.GetCertData();
@@ -183,8 +183,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             {
                 if (DelayedActions.HasFlag(DelayedActionsFlag.Crl))
                 {
-                    Trace($"Delaying response by {RespondDelay}.");
-                    Thread.Sleep(RespondDelay);
+                    Trace($"Delaying response by {ResponseDelay}.");
+                    Thread.Sleep(ResponseDelay);
                 }
 
                 byte[] crl = RespondEmpty ? Array.Empty<byte>() : authority.GetCrl();
@@ -228,8 +228,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
                         if (DelayedActions.HasFlag(DelayedActionsFlag.Ocsp))
                         {
-                            Trace($"Delaying response by {RespondDelay}.");
-                            Thread.Sleep(RespondDelay);
+                            Trace($"Delaying response by {ResponseDelay}.");
+                            Thread.Sleep(ResponseDelay);
                         }
 
                         responded = true;

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
@@ -30,6 +30,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
         public bool RespondEmpty { get; set; }
 
+        public TimeSpan RespondDelay { get; set; }
+        public DelayedActionsFlag DelayedActions { get; set; }
+
         private RevocationResponder(HttpListener listener, string uriPrefix)
         {
             _listener = listener;
@@ -160,6 +163,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
             if (_aiaPaths.TryGetValue(url, out authority))
             {
+                if (DelayedActions.HasFlag(DelayedActionsFlag.Aia))
+                {
+                    Trace($"Delaying response by {RespondDelay}.");
+                    Thread.Sleep(RespondDelay);
+                }
+
                 byte[] certData = RespondEmpty ? Array.Empty<byte>() : authority.GetCertData();
 
                 responded = true;
@@ -172,6 +181,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
             if (_crlPaths.TryGetValue(url, out authority))
             {
+                if (DelayedActions.HasFlag(DelayedActionsFlag.Crl))
+                {
+                    Trace($"Delaying response by {RespondDelay}.");
+                    Thread.Sleep(RespondDelay);
+                }
+
                 byte[] crl = RespondEmpty ? Array.Empty<byte>() : authority.GetCrl();
 
                 responded = true;
@@ -210,6 +225,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                         }
 
                         byte[] ocspResponse = RespondEmpty ? Array.Empty<byte>() : authority.BuildOcspResponse(certId, nonce);
+
+                        if (DelayedActions.HasFlag(DelayedActionsFlag.Ocsp))
+                        {
+                            Trace($"Delaying response by {RespondDelay}.");
+                            Thread.Sleep(RespondDelay);
+                        }
 
                         responded = true;
                         context.Response.StatusCode = 200;
@@ -351,6 +372,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             {
                 Console.WriteLine(trace);
             }
+        }
+
+        internal enum DelayedActionsFlag : byte
+        {
+            None = 0,
+            Ocsp = 0b1,
+            Crl = 0b10,
+            Aia = 0b100,
+            All = 0b11111111
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -102,7 +102,7 @@ namespace Internal.Cryptography.Pal
 
         private static byte[]? DownloadAsset(string uri, TimeSpan downloadTimeout)
         {
-            if (s_downloadBytes != null)
+            if (s_downloadBytes != null && downloadTimeout > TimeSpan.Zero)
             {
                 long totalMillis = (long)downloadTimeout.TotalMilliseconds;
                 CancellationTokenSource? cts = totalMillis > int.MaxValue ? null : new CancellationTokenSource((int)totalMillis);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -18,9 +18,9 @@ namespace Internal.Cryptography.Pal
     {
         private static readonly Func<string, CancellationToken, byte[]>? s_downloadBytes = CreateDownloadBytesFunc();
 
-        internal static X509Certificate2? DownloadCertificate(string uri, ref TimeSpan remainingDownloadTime)
+        internal static X509Certificate2? DownloadCertificate(string uri, TimeSpan downloadTimeout)
         {
-            byte[]? data = DownloadAsset(uri, ref remainingDownloadTime);
+            byte[]? data = DownloadAsset(uri, downloadTimeout);
 
             if (data == null || data.Length == 0)
             {
@@ -39,9 +39,9 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        internal static SafeX509CrlHandle? DownloadCrl(string uri, ref TimeSpan remainingDownloadTime)
+        internal static SafeX509CrlHandle? DownloadCrl(string uri, TimeSpan downloadTimeout)
         {
-            byte[]? data = DownloadAsset(uri, ref remainingDownloadTime);
+            byte[]? data = DownloadAsset(uri, downloadTimeout);
 
             if (data == null)
             {
@@ -77,9 +77,9 @@ namespace Internal.Cryptography.Pal
             return null;
         }
 
-        internal static SafeOcspResponseHandle? DownloadOcspGet(string uri, ref TimeSpan remainingDownloadTime)
+        internal static SafeOcspResponseHandle? DownloadOcspGet(string uri, TimeSpan downloadTimeout)
         {
-            byte[]? data = DownloadAsset(uri, ref remainingDownloadTime);
+            byte[]? data = DownloadAsset(uri, downloadTimeout);
 
             if (data == null)
             {
@@ -100,12 +100,11 @@ namespace Internal.Cryptography.Pal
             return resp;
         }
 
-        private static byte[]? DownloadAsset(string uri, ref TimeSpan remainingDownloadTime)
+        private static byte[]? DownloadAsset(string uri, TimeSpan downloadTimeout)
         {
-            if (s_downloadBytes != null && remainingDownloadTime > TimeSpan.Zero)
+            if (s_downloadBytes != null)
             {
-                long totalMillis = (long)remainingDownloadTime.TotalMilliseconds;
-                Stopwatch stopwatch = Stopwatch.StartNew();
+                long totalMillis = (long)downloadTimeout.TotalMilliseconds;
                 CancellationTokenSource? cts = totalMillis > int.MaxValue ? null : new CancellationTokenSource((int)totalMillis);
 
                 try
@@ -115,8 +114,6 @@ namespace Internal.Cryptography.Pal
                 catch { }
                 finally
                 {
-                    // TimeSpan.Zero isn't a worrisome value on the subtraction, it only means "no limit" on the original input.
-                    remainingDownloadTime -= stopwatch.Elapsed;
                     cts?.Dispose();
                 }
             }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -11,6 +11,8 @@ namespace Internal.Cryptography.Pal
 {
     internal sealed partial class ChainPal
     {
+        private static readonly TimeSpan s_maxUrlRetrievalTimeout = TimeSpan.FromMinutes(1);
+
         public static IChainPal FromHandle(IntPtr chainContext)
         {
             throw new PlatformNotSupportedException();
@@ -35,10 +37,17 @@ namespace Internal.Cryptography.Pal
             TimeSpan timeout,
             bool disableAia)
         {
-            // An input value of 0 on the timeout is treated as 15 seconds, to match Windows.
             if (timeout == TimeSpan.Zero)
             {
+                // An input value of 0 on the timeout is treated as 15 seconds, to match Windows.
                 timeout = TimeSpan.FromSeconds(15);
+            }
+            else if (timeout > s_maxUrlRetrievalTimeout || timeout < TimeSpan.Zero)
+            {
+                // Windows has a max timeout of 1 minute, so we'll match. Windows also treats
+                // the timeout as unsigned, so a negative value gets treated as a large positive
+                // value that is also clamped.
+                timeout = s_maxUrlRetrievalTimeout;
             }
 
             // Let Unspecified mean Local, so only convert if the source was UTC.

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -35,10 +35,10 @@ namespace Internal.Cryptography.Pal
             TimeSpan timeout,
             bool disableAia)
         {
-            // An input value of 0 on the timeout is "take all the time you need".
+            // An input value of 0 on the timeout is treated as 15 seconds, to match Windows.
             if (timeout == TimeSpan.Zero)
             {
-                timeout = TimeSpan.MaxValue;
+                timeout = TimeSpan.FromSeconds(15);
             }
 
             // Let Unspecified mean Local, so only convert if the source was UTC.
@@ -55,14 +55,14 @@ namespace Internal.Cryptography.Pal
             {
             }
 
-            TimeSpan remainingDownloadTime = timeout;
+            TimeSpan downloadTimeout = timeout;
 
             OpenSslX509ChainProcessor chainPal = OpenSslX509ChainProcessor.InitiateChain(
                 ((OpenSslX509CertificateReader)cert).SafeHandle,
                 customTrustStore,
                 trustMode,
                 verificationTime,
-                remainingDownloadTime);
+                downloadTimeout);
 
             Interop.Crypto.X509VerifyStatusCode status = chainPal.FindFirstChain(extraStore);
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -36,7 +36,7 @@ namespace Internal.Cryptography.Pal
             SafeX509StoreHandle store,
             X509RevocationMode revocationMode,
             DateTime verificationTime,
-            ref TimeSpan remainingDownloadTime)
+            TimeSpan downloadTimeout)
         {
             // In Offline mode, accept any cached CRL we have.
             // "CRL is Expired" is a better match for Offline than "Could not find CRL"
@@ -59,14 +59,13 @@ namespace Internal.Cryptography.Pal
                 return;
             }
 
-            // Don't do any work if we're over limit or prohibited from fetching new CRLs
-            if (remainingDownloadTime <= TimeSpan.Zero ||
-                revocationMode != X509RevocationMode.Online)
+            // Don't do any work if we're prohibited from fetching new CRLs
+            if (revocationMode != X509RevocationMode.Online)
             {
                 return;
             }
 
-            DownloadAndAddCrl(url, crlFileName, store, ref remainingDownloadTime);
+            DownloadAndAddCrl(url, crlFileName, store, downloadTimeout);
         }
 
         private static bool AddCachedCrl(string crlFileName, SafeX509StoreHandle store, DateTime verificationTime)
@@ -134,11 +133,11 @@ namespace Internal.Cryptography.Pal
             string url,
             string crlFileName,
             SafeX509StoreHandle store,
-            ref TimeSpan remainingDownloadTime)
+            TimeSpan downloadTimeout)
         {
             // X509_STORE_add_crl will increase the refcount on the CRL object, so we should still
             // dispose our copy.
-            using (SafeX509CrlHandle? crl = CertificateAssetDownloader.DownloadCrl(url, ref remainingDownloadTime))
+            using (SafeX509CrlHandle? crl = CertificateAssetDownloader.DownloadCrl(url, downloadTimeout))
             {
                 // null is a valid return (e.g. no remainingDownloadTime)
                 if (crl != null && !crl.IsInvalid)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -43,7 +43,7 @@ namespace Internal.Cryptography.Pal
         private readonly SafeX509StackHandle _untrustedLookup;
         private readonly SafeX509StoreCtxHandle _storeCtx;
         private readonly DateTime _verificationTime;
-        private TimeSpan _remainingDownloadTime;
+        private readonly TimeSpan _downloadTimeout;
         private WorkingChain? _workingChain;
 
         private OpenSslX509ChainProcessor(
@@ -52,14 +52,14 @@ namespace Internal.Cryptography.Pal
             SafeX509StackHandle untrusted,
             SafeX509StoreCtxHandle storeCtx,
             DateTime verificationTime,
-            TimeSpan remainingDownloadTime)
+            TimeSpan downloadTimeout)
         {
             _leafHandle = leafHandle;
             _store = store;
             _untrustedLookup = untrusted;
             _storeCtx = storeCtx;
             _verificationTime = verificationTime;
-            _remainingDownloadTime = remainingDownloadTime;
+            _downloadTimeout = downloadTimeout;
         }
 
         public void Dispose()
@@ -236,7 +236,7 @@ namespace Internal.Cryptography.Pal
 
                     X509Certificate2? downloaded = DownloadCertificate(
                         authorityInformationAccess,
-                        ref _remainingDownloadTime);
+                        _downloadTimeout);
 
                     // The AIA record is contained in a public structure, so no need to clear it.
                     CryptoPool.Return(authorityInformationAccess.Array!, clearSize: 0);
@@ -366,7 +366,7 @@ namespace Internal.Cryptography.Pal
                             _store,
                             revocationMode,
                             _verificationTime,
-                            ref _remainingDownloadTime);
+                            _downloadTimeout);
                     }
                 }
             }
@@ -655,7 +655,7 @@ namespace Internal.Cryptography.Pal
                 return status;
             }
 
-            if (revocationMode != X509RevocationMode.Online || _remainingDownloadTime <= TimeSpan.Zero)
+            if (revocationMode != X509RevocationMode.Online)
             {
                 return Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_UNABLE_TO_GET_CRL;
             }
@@ -690,7 +690,7 @@ namespace Internal.Cryptography.Pal
                 //
                 // So, for now, only try GET.
                 SafeOcspResponseHandle? resp =
-                    CertificateAssetDownloader.DownloadOcspGet(requestUrl, ref _remainingDownloadTime);
+                    CertificateAssetDownloader.DownloadOcspGet(requestUrl, _downloadTimeout);
 
                 using (resp)
                 {
@@ -1072,14 +1072,8 @@ namespace Internal.Cryptography.Pal
 
         private static X509Certificate2? DownloadCertificate(
             ReadOnlyMemory<byte> authorityInformationAccess,
-            ref TimeSpan remainingDownloadTime)
+            TimeSpan downloadTimeout)
         {
-            // Don't do any work if we're over limit.
-            if (remainingDownloadTime <= TimeSpan.Zero)
-            {
-                return null;
-            }
-
             string? uri = FindHttpAiaRecord(authorityInformationAccess, Oids.CertificateAuthorityIssuers);
 
             if (uri == null)
@@ -1087,7 +1081,7 @@ namespace Internal.Cryptography.Pal
                 return null;
             }
 
-            return CertificateAssetDownloader.DownloadCertificate(uri, ref remainingDownloadTime);
+            return CertificateAssetDownloader.DownloadCertificate(uri, downloadTimeout);
         }
 
         private static string? GetOcspEndpoint(SafeX509Handle cert)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -113,11 +113,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public static void AiaFetchDelayed()
         {
             CertificateAuthority.BuildPrivatePki(
-                PkiOptions.AllRevocation,
+                PkiOptions.OcspEverywhere,
                 out RevocationResponder responder,
                 out CertificateAuthority rootAuthority,
                 out CertificateAuthority intermediateAuthority,
@@ -132,7 +132,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             using (X509Certificate2 rootCert = rootAuthority.CloneIssuerCert())
             using (X509Certificate2 intermediateCert = intermediateAuthority.CloneIssuerCert())
             {
-                TimeSpan delay = TimeSpan.FromSeconds(3);
+                TimeSpan delay = TimeSpan.FromSeconds(1);
 
                 X509Chain chain = holder.Chain;
                 responder.ResponseDelay = delay;
@@ -144,7 +144,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 Stopwatch watch = Stopwatch.StartNew();
-                Assert.True(chain.Build(endEntityCert));
+                Assert.True(chain.Build(endEntityCert), GetFlags(chain, endEntityCert.Thumbprint).ToString());
                 watch.Stop();
 
                 Assert.True(watch.Elapsed >= delay);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 TimeSpan delay = TimeSpan.FromSeconds(3);
 
                 X509Chain chain = holder.Chain;
-                responder.RespondDelay = delay;
+                responder.ResponseDelay = delay;
                 responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
 
 
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 TimeSpan delay = TimeSpan.FromSeconds(3);
 
                 X509Chain chain = holder.Chain;
-                responder.RespondDelay = delay;
+                responder.ResponseDelay = delay;
                 responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
 
                 chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(1);
@@ -136,7 +136,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 TimeSpan delay = TimeSpan.FromSeconds(3);
 
                 X509Chain chain = holder.Chain;
-                responder.RespondDelay = delay;
+                responder.ResponseDelay = delay;
                 responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
 
                 chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(5);
@@ -175,7 +175,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 TimeSpan delay = TimeSpan.FromSeconds(3);
 
                 X509Chain chain = holder.Chain;
-                responder.RespondDelay = delay;
+                responder.ResponseDelay = delay;
                 responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
 
                 chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(2);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -39,7 +39,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 responder.ResponseDelay = delay;
                 responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
 
-
                 // This needs to be greater than delay, but less than 2x delay to ensure
                 // that the time is a timeout for individual fetches, not a running total.
                 chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(5);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -185,7 +185,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             using (X509Certificate2 intermediateCert = intermediateAuthority.CloneIssuerCert())
             {
                 // Delay is more than the 15 second default.
-                TimeSpan delay = TimeSpan.FromSeconds(30);
+                TimeSpan delay = TimeSpan.FromSeconds(25);
 
                 X509Chain chain = holder.Chain;
                 responder.ResponseDelay = delay;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -118,6 +118,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
         public static void RevocationCheckingMaximum(PkiOptions pkiOptions)
         {
+            // Windows 10 has a different maximum from previous versions of Windows.
+            // We are primarily testing that Linux behavior matches some behavior of
+            // Windows, so we won't test except on Windows 10.
+            if (PlatformDetection.WindowsVersion < 10)
+            {
+                return;
+            }
+
             CertificateAuthority.BuildPrivatePki(
                 pkiOptions,
                 out RevocationResponder responder,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -112,6 +112,98 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             }
         }
 
+        [Theory]
+        [InlineData(PkiOptions.OcspEverywhere)]
+        [InlineData(PkiOptions.CrlEverywhere)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        public static void RevocationCheckingMaximum(PkiOptions pkiOptions)
+        {
+            CertificateAuthority.BuildPrivatePki(
+                pkiOptions,
+                out RevocationResponder responder,
+                out CertificateAuthority rootAuthority,
+                out CertificateAuthority intermediateAuthority,
+                out X509Certificate2 endEntityCert,
+                nameof(RevocationCheckingMaximum));
+
+            using (responder)
+            using (rootAuthority)
+            using (intermediateAuthority)
+            using (endEntityCert)
+            using (ChainHolder holder = new ChainHolder())
+            using (X509Certificate2 rootCert = rootAuthority.CloneIssuerCert())
+            using (X509Certificate2 intermediateCert = intermediateAuthority.CloneIssuerCert())
+            {
+                TimeSpan delay = TimeSpan.FromMinutes(1.5);
+
+                X509Chain chain = holder.Chain;
+                responder.ResponseDelay = delay;
+                responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+
+                chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromMinutes(2);
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+                chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EndCertificateOnly;
+
+                chain.ChainPolicy.DisableCertificateDownloads = true;
+
+                // Even though UrlRetrievalTimeout is more than the delay, it should
+                // get clamped to 1 minute, and thus less than the actual delay.
+                Assert.False(chain.Build(endEntityCert));
+
+                const X509ChainStatusFlags ExpectedFlags =
+                    X509ChainStatusFlags.RevocationStatusUnknown |
+                    X509ChainStatusFlags.OfflineRevocation;
+
+                X509ChainStatusFlags eeFlags = GetFlags(chain, endEntityCert.Thumbprint);
+                Assert.Equal(ExpectedFlags, eeFlags);
+            }
+        }
+
+        [Theory]
+        [InlineData(PkiOptions.OcspEverywhere)]
+        [InlineData(PkiOptions.CrlEverywhere)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        public static void RevocationCheckingNegativeTimeout(PkiOptions pkiOptions)
+        {
+            CertificateAuthority.BuildPrivatePki(
+                pkiOptions,
+                out RevocationResponder responder,
+                out CertificateAuthority rootAuthority,
+                out CertificateAuthority intermediateAuthority,
+                out X509Certificate2 endEntityCert,
+                nameof(RevocationCheckingNegativeTimeout));
+
+            using (responder)
+            using (rootAuthority)
+            using (intermediateAuthority)
+            using (endEntityCert)
+            using (ChainHolder holder = new ChainHolder())
+            using (X509Certificate2 rootCert = rootAuthority.CloneIssuerCert())
+            using (X509Certificate2 intermediateCert = intermediateAuthority.CloneIssuerCert())
+            {
+                // Delay is more than the 15 second default.
+                TimeSpan delay = TimeSpan.FromSeconds(30);
+
+                X509Chain chain = holder.Chain;
+                responder.ResponseDelay = delay;
+                responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+
+                chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromMinutes(-1);
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+                chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EndCertificateOnly;
+
+                chain.ChainPolicy.DisableCertificateDownloads = true;
+
+                Assert.True(chain.Build(endEntityCert));
+            }
+        }
+
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]
         public static void AiaFetchDelayed()

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\CertificateAuthority.cs"
              Link="CommonTest\System\Security\Cryptography\509Certificates\CertificateAuthority.cs" />
     <Compile Include="RevocationTests\DynamicRevocationTests.cs" />
+    <Compile Include="RevocationTests\TimeoutTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\RevocationResponder.cs"
              Link="CommonTest\System\Security\Cryptography\509Certificates\RevocationResponder.cs" />
     <Compile Include="DSAOther.cs" />


### PR DESCRIPTION
This gets the ball rolling on what I guess is going to require some discussion to unify UrlRetreivalTimeout on Windows / Linux.

Change the UrlRetrievalTimeout behavior on Linux to match Windows' existing behavior of using a per-operation timeout rather than cumulative.

Add some tests for operations that time out.

Contributes to #38875
Closes #40578