### PR TITLE
[mono] Fix configure to actually disable dllmap on non-mobile platforms

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -1418,7 +1418,7 @@ if test x$with_runtime_preset = xnetcore; then
    mono_feature_disable_perfcounters='yes'
    mono_feature_disable_attach='yes'
    mono_feature_disable_cfgdir_config='yes'
-   if test "x$enable_monodroid" = "x" -a "x$enable_monotouch" = "x"; then
+   if test "x$enable_monodroid" = "xno" -a "x$enable_monotouch" = "xno"; then
      mono_feature_disable_dllmap='yes' # FIXME: the mobile products use this
    fi
    disable_mono_native=yes


### PR DESCRIPTION
`$enable_monodroid` and `$enable_monotouch` are set to no by default, not an empty string.

Accidentally enabled globally here: https://github.com/dotnet/runtime/commit/a54d391d9daebf7b53e7f1efc1690c1c35177570#diff-294e5f7514d4059e724506770913e1d7R1386

Fixes https://github.com/dotnet/runtime/issues/40147