### PR TITLE
Fix some createdump issues

### DIFF
--- a/docs/design/coreclr/botr/xplat-minidump-generation.md
+++ b/docs/design/coreclr/botr/xplat-minidump-generation.md
@@ -42,11 +42,11 @@ There will be some differences gathering the crash information but these platfor
 
 ### OS X ###
 
-As of .NET Core 5.0, createdump is supported on MacOS but instead of the MachO dump format, it generates the ELF coredumps. This is because of time constraints developing a MachO dump writer on the generation side and a MachO reader for the diagnostics tooling side (dotnet-dump and CLRMD). This means the native debuggers like gdb and lldb will not work with these dumps but the dotnet-dump tool will allow the managed state to be analyzed. Because of this behavior an additional environment variable will need to be set (COMPlus_DbgEnableElfDumpOnMacOS=1) along with the ones below in the Configuration/Policy section.
+As of .NET 5.0, createdump is supported on MacOS but instead of the MachO dump format, it generates the ELF coredumps. This is because of time constraints developing a MachO dump writer on the generation side and a MachO reader for the diagnostics tooling side (dotnet-dump and CLRMD). This means the native debuggers like gdb and lldb will not work with these dumps but the dotnet-dump tool will allow the managed state to be analyzed. Because of this behavior an additional environment variable will need to be set (COMPlus_DbgEnableElfDumpOnMacOS=1) along with the ones below in the Configuration/Policy section.
 
 ### Windows ###
 
-As of .NET Core 5.0, createdump and the below configuration environment variables are supported on Windows. It is implemented using the Windows MiniDumpWriteDump API. This allows consistent crash/unhandled exception dumps across all of our platforms. 
+As of .NET 5.0, createdump and the below configuration environment variables are supported on Windows. It is implemented using the Windows MiniDumpWriteDump API. This allows consistent crash/unhandled exception dumps across all of our platforms. 
 
 # Configuration/Policy #
 
@@ -79,13 +79,26 @@ The createdump utility can also be run from the command line on arbitrary .NET C
 
 `sudo createdump <pid>`
 
-    createdump [options] pid
-    -f, --name - dump path and file name. The pid can be placed in the name with %d. The default is "/tmp/coredump.%d"
-    -n, --normal - create minidump (default).
-    -h, --withheap - create minidump with heap.
+    -f, --name - dump path and file name. The %p, %e, %h %t format characters are supported. The default is '/tmp/coredump.%p'
+    -n, --normal - create minidump.
+    -h, --withheap - create minidump with heap (default).
     -t, --triage - create triage minidump.
     -u, --full - create full core dump.
     -d, --diag - enable diagnostic messages.
+
+
+**Dump name formatting**
+
+As of .NET 5.0, the following subset of the core pattern (see [core](https://man7.org/linux/man-pages/man5/core.5.html)) dump name formatting is supported:
+
+    %%  A single % character.
+    %d  PID of dumped process (for backwards createdump compatibility).
+    %p  PID of dumped process.
+    %P  PID of dumped process.
+    %e  The process executable filename.
+    %E  The process executable filename.
+    %h  Hostname return by gethostname().
+    %t  Time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
 
 # Testing #
 

--- a/docs/design/coreclr/botr/xplat-minidump-generation.md
+++ b/docs/design/coreclr/botr/xplat-minidump-generation.md
@@ -94,9 +94,7 @@ As of .NET 5.0, the following subset of the core pattern (see [core](https://man
     %%  A single % character.
     %d  PID of dumped process (for backwards createdump compatibility).
     %p  PID of dumped process.
-    %P  PID of dumped process.
     %e  The process executable filename.
-    %E  The process executable filename.
     %h  Hostname return by gethostname().
     %t  Time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
 

--- a/src/coreclr/src/debug/createdump/CMakeLists.txt
+++ b/src/coreclr/src/debug/createdump/CMakeLists.txt
@@ -14,6 +14,7 @@ if(CLR_CMAKE_HOST_WIN32)
 
     set(CREATEDUMP_SOURCES
         main.cpp
+        dumpname.cpp
         createdumpwindows.cpp
         createdump.rc
     )
@@ -28,6 +29,7 @@ if(CLR_CMAKE_HOST_WIN32)
         advapi32.lib
         version.lib
         dbghelp.lib
+        ws2_32.lib
     )
 
 else(CLR_CMAKE_HOST_WIN32)
@@ -49,6 +51,7 @@ else(CLR_CMAKE_HOST_WIN32)
 
     set(CREATEDUMP_SOURCES
         main.cpp
+        dumpname.cpp
         createdumpunix.cpp
         crashinfo.cpp
         threadinfo.cpp

--- a/src/coreclr/src/debug/createdump/createdump.h
+++ b/src/coreclr/src/debug/createdump/createdump.h
@@ -95,4 +95,6 @@ typedef int T_CONTEXT;
 #define MAX_LONGPATH   1024
 #endif
 
-bool CreateDump(const char* dumpPathTemplate, int pid, MINIDUMP_TYPE minidumpType);
+bool FormatDumpName(std::string& name, const char* pattern, const char* exename, int pid);
+bool CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType);
+

--- a/src/coreclr/src/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/src/debug/createdump/createdumpwindows.cpp
@@ -2,16 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "createdump.h"
+#include "psapi.h"
 
 //
 // The Windows create dump code
 //
 bool
-CreateDump(const char* dumpPath, int pid, MINIDUMP_TYPE minidumpType)
+CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType)
 {
     HANDLE hFile = INVALID_HANDLE_VALUE;
     HANDLE hProcess = NULL;
     bool result = false;
+
+    ArrayHolder<char> pszName = new char[MAX_LONGPATH + 1];
+    std::string dumpPath;
 
     hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     if (hProcess == NULL)
@@ -19,11 +23,21 @@ CreateDump(const char* dumpPath, int pid, MINIDUMP_TYPE minidumpType)
         fprintf(stderr, "Invalid process id '%d' error %d\n", pid, GetLastError());
         goto exit;
     }
+    if (GetModuleBaseNameA(hProcess, NULL, pszName, MAX_LONGPATH) <= 0)
+    {
+        fprintf(stderr, "Get process name FAILED %d\n", GetLastError());
+        goto exit;
+    }
+    if (!FormatDumpName(dumpPath, dumpPathTemplate, pszName, pid))
+    {
+        goto exit;
+    }
+    printf("Writing %s to file %s\n", dumpType, dumpPath.c_str());
 
-    hFile = CreateFileA(dumpPath, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    hFile = CreateFileA(dumpPath.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
-        fprintf(stderr, "Invalid dump path '%s' error %d\n", dumpPath, GetLastError());
+        fprintf(stderr, "Invalid dump path '%s' error %d\n", dumpPath.c_str(), GetLastError());
         goto exit;
     }
 

--- a/src/coreclr/src/debug/createdump/dumpname.cpp
+++ b/src/coreclr/src/debug/createdump/dumpname.cpp
@@ -16,20 +16,18 @@
 //  %%  A single % character.
 //  %d  PID of dumped process (for backwards createdump compatibility).
 //  %p  PID of dumped process.
-//  %P  PID of dumped process.
 //  %e  The process executable filename.
-//  %E  The process executable filename.
 //  %h  Hostname return by gethostname().
 //  %t  Time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
 //
 // Unsupported:
 //
 //  %c  Core file size soft resource limit of crashing process.
+//  %E  Pathname of executable, with slashes ('/') replaced by exclamation marks ('!').
 //  %g  Numeric real GID of dumped process.
-//  %i  TID of thread that triggered core dump, as seen in the PID
-//      namespace in which the thread resides.
-//  %I  TID of thread that triggered core dump, as seen in the
-//      initial PID namespace.
+//  %i  TID of thread that triggered core dump, as seen in the PID namespace in which the thread resides.
+//  %I  TID of thread that triggered core dump, as seen in the initial PID namespace.
+//  %P  PID of dumped process, as seen in the initial PID namespace.
 //  %s  Number of signal causing dump.
 //  %u  Numeric real UID of dumped process.
 //
@@ -68,7 +66,6 @@ FormatDumpName(std::string& name, const char* pattern, const char* exename, int 
                 // process Id
                 case 'd':
                 case 'p':
-                case 'P':
                     name.append(std::to_string(pid));
                     break;
 
@@ -103,9 +100,6 @@ FormatDumpName(std::string& name, const char* pattern, const char* exename, int 
 
                 // executable file path with / replaced with !
                 case 'E':
-                    name.append(exename);
-                    break;
-
                 // signal number that caused the dump
                 case 's':
                 // gid
@@ -117,6 +111,8 @@ FormatDumpName(std::string& name, const char* pattern, const char* exename, int 
                 // thread id that triggered the dump
                 case 'i': 
                 case 'I':
+                // pid of dumped process
+                case 'P':
                 default:
                     fprintf(stderr, "Invalid dump name format char '%c'\n", *p);
                     return false;

--- a/src/coreclr/src/debug/createdump/dumpname.cpp
+++ b/src/coreclr/src/debug/createdump/dumpname.cpp
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "createdump.h"
+#include <time.h>
+#ifdef HOST_WINDOWS
+#include <winsock.h>
+#endif
+
+//
+// Format the core dump name using a subset of the standard coredump pattern
+// defined here: https://man7.org/linux/man-pages/man5/core.5.html.
+//
+// Supported:
+//
+//  %%  A single % character.
+//  %d  PID of dumped process (for backwards createdump compatibility).
+//  %p  PID of dumped process.
+//  %P  PID of dumped process.
+//  %e  The process executable filename.
+//  %E  The process executable filename.
+//  %h  Hostname return by gethostname().
+//  %t  Time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
+//
+// Unsupported:
+//
+//  %c  Core file size soft resource limit of crashing process.
+//  %g  Numeric real GID of dumped process.
+//  %i  TID of thread that triggered core dump, as seen in the PID
+//      namespace in which the thread resides.
+//  %I  TID of thread that triggered core dump, as seen in the
+//      initial PID namespace.
+//  %s  Number of signal causing dump.
+//  %u  Numeric real UID of dumped process.
+//
+bool
+FormatDumpName(std::string& name, const char* pattern, const char* exename, int pid)
+{
+    const char* p = pattern;
+    if (*p == '|')
+    {
+        fprintf(stderr, "Pipe syntax in dump name not supported\n");
+        return false;
+    }
+
+#ifdef HOST_WINDOWS
+    WSAData wsadata;
+    int wsaerr = WSAStartup(1, &wsadata);
+#endif
+
+    while (*p)
+    {
+        if (*p != '%')
+        {
+            name.append(1, *p);
+        }
+        else
+        {
+            switch (*++p)
+            {
+                case '\0':
+                    return true;
+
+                case '%':
+                    name.append(1, '%');
+                    break;
+
+                // process Id
+                case 'd':
+                case 'p':
+                case 'P':
+                    name.append(std::to_string(pid));
+                    break;
+
+                // time of dump
+                case 't':
+                    time_t dumptime;
+                    time(&dumptime);
+                    name.append(std::to_string(dumptime));
+                    break;
+
+                // hostname
+                case 'h': {
+                    ArrayHolder<char> buffer = new char[MAX_LONGPATH + 1];
+                    if (gethostname(buffer, MAX_LONGPATH) != 0)
+                    {
+                        fprintf(stderr, "Could not get the host name for dump name: %d\n",
+#ifdef HOST_WINDOWS
+                            WSAGetLastError());
+#else
+                            errno);
+#endif
+                        return false;
+                    }
+                    name.append(buffer);
+                    break;
+                }
+
+                // executable file name
+                case 'e':
+                    name.append(exename);
+                    break;
+
+                // executable file path with / replaced with !
+                case 'E':
+                    name.append(exename);
+                    break;
+
+                // signal number that caused the dump
+                case 's':
+                // gid
+                case 'g':
+                // coredump size limit
+                case 'c':
+                // the numeric real UID of dumped process
+                case 'u':
+                // thread id that triggered the dump
+                case 'i': 
+                case 'I':
+                default:
+                    fprintf(stderr, "Invalid dump name format char '%c'\n", *p);
+                    return false;
+            }
+        }
+        ++p;
+    }
+    return true;
+}

--- a/src/coreclr/src/debug/createdump/main.cpp
+++ b/src/coreclr/src/debug/createdump/main.cpp
@@ -5,14 +5,14 @@
 
 #ifdef HOST_WINDOWS
 #define DEFAULT_DUMP_PATH "%TEMP%\\"
-#define DEFAULT_DUMP_TEMPLATE "dump.%d.dmp"
+#define DEFAULT_DUMP_TEMPLATE "dump.%p.dmp"
 #else
 #define DEFAULT_DUMP_PATH "/tmp/"
-#define DEFAULT_DUMP_TEMPLATE "coredump.%d"
+#define DEFAULT_DUMP_TEMPLATE "coredump.%p"
 #endif
 
 const char* g_help = "createdump [options] pid\n"
-"-f, --name - dump path and file name. The pid can be placed in the name with %d. The default is '" DEFAULT_DUMP_PATH DEFAULT_DUMP_TEMPLATE "'\n"
+"-f, --name - dump path and file name. The %p, %e, %h %t format characters are supported. The default is '" DEFAULT_DUMP_PATH DEFAULT_DUMP_TEMPLATE "'\n"
 "-n, --normal - create minidump.\n"
 "-h, --withheap - create minidump with heap (default).\n"
 "-t, --triage - create triage minidump.\n"
@@ -20,8 +20,6 @@ const char* g_help = "createdump [options] pid\n"
 "-d, --diag - enable diagnostic messages.\n";
 
 bool g_diagnostics = false;
-
-bool CreateDump(const char* dumpPathTemplate, int pid, MINIDUMP_TYPE minidumpType);
 
 //
 // Main entry point
@@ -116,7 +114,6 @@ int __cdecl main(const int argc, const char* argv[])
     if (pid != 0)
     {
         ArrayHolder<char> tmpPath = new char[MAX_LONGPATH];
-        ArrayHolder<char> dumpPath = new char[MAX_LONGPATH];
 
         if (dumpPathTemplate == nullptr)
         {
@@ -134,11 +131,7 @@ int __cdecl main(const int argc, const char* argv[])
             dumpPathTemplate = tmpPath;
         }
 
-        snprintf(dumpPath, MAX_LONGPATH, dumpPathTemplate, pid);
-
-        printf("Writing %s to file %s\n", dumpType, (char*)dumpPath);
-
-        if (CreateDump(dumpPath, pid, minidumpType))
+        if (CreateDump(dumpPathTemplate, pid, dumpType, minidumpType))
         {
             printf("Dump successfully written\n");
         }
@@ -146,6 +139,7 @@ int __cdecl main(const int argc, const char* argv[])
         {
             exitCode = -1;
         }
+
         fflush(stdout);
         fflush(stderr);
     }

--- a/src/coreclr/src/debug/createdump/main.cpp
+++ b/src/coreclr/src/debug/createdump/main.cpp
@@ -12,7 +12,11 @@
 #endif
 
 const char* g_help = "createdump [options] pid\n"
-"-f, --name - dump path and file name. The %p, %e, %h %t format characters are supported. The default is '" DEFAULT_DUMP_PATH DEFAULT_DUMP_TEMPLATE "'\n"
+"-f, --name - dump path and file name. The default is '" DEFAULT_DUMP_PATH DEFAULT_DUMP_TEMPLATE "'. These specifiers are substituted with following values:\n"
+"   %p  PID of dumped process.\n"
+"   %e  The process executable filename.\n"
+"   %h  Hostname return by gethostname().\n"
+"   %t  Time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).\n"
 "-n, --normal - create minidump.\n"
 "-h, --withheap - create minidump with heap (default).\n"
 "-t, --triage - create triage minidump.\n"

--- a/src/coreclr/src/vm/excep.cpp
+++ b/src/coreclr/src/vm/excep.cpp
@@ -4148,15 +4148,15 @@ GenerateCrashDump(
 void
 InitializeCrashDump()
 {
-    bool enabled = CLRConfig::IsConfigEnabled(CLRConfig::INTERNAL_DbgEnableMiniDump);
-    if (enabled)
+    DWORD enabled = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_DbgEnableMiniDump);
+    if (enabled == 1)
     {
         LPCWSTR dumpName = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_DbgMiniDumpName);
         int dumpType = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_DbgMiniDumpType);
-        bool diag = CLRConfig::IsConfigEnabled(CLRConfig::INTERNAL_CreateDumpDiagnostics);
+        DWORD diag = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_CreateDumpDiagnostics);
 
         SString commandLine;
-        BuildCreateDumpCommandLine(commandLine, dumpName, dumpType, diag);
+        BuildCreateDumpCommandLine(commandLine, dumpName, dumpType, diag == 1);
         g_createDumpCommandLine = commandLine.GetCopyOfUnicodeString();
     }
 }


### PR DESCRIPTION
Fix still generating dump with COMPlus_DbgEnableMiniDump=0 on Windows

Start adding coredump pattern to dump names.  Supported format characters:

  %%  A single % character.
  %d  PID of dumped process (for backwards createdump compatibility).
  %p  PID of dumped process.
  %e  The process executable filename.
  %h  Hostname return by gethostname().
  %t  Time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).

Issue: https://github.com/dotnet/runtime/issues/40558