### PR TITLE
Unconditionally expand some of the Vector128 methods on x86/x64

### DIFF
--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -2176,6 +2176,30 @@ DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINF
         fTreatAsRegularMethodCall |= !fIsPlatformHWIntrinsic && fIsHWIntrinsic
             && (strncmp(className, "Vector64", _countof("Vector64") - 1) != 0)
             && (strncmp(className, "Vector128", _countof("Vector128") - 1) != 0);
+
+#elif defined(TARGET_X86) || defined(TARGET_AMD64)
+        // The following methods should be safe to expand unconditionally, since JIT either
+        //   1) does not generate code for them (e.g. for Vector128<T>.AsByte() or get_Count) or
+        //   2) uses instructions that belong to Sse or Sse2 (these are required baseline ISAs).
+        static const char* vector128MethodsSafeToExpand[] = { "As", "AsByte", "AsDouble", "AsInt16", "AsInt32", "AsInt64", "AsSByte",
+            "AsSingle", "AsUInt16", "AsUInt32", "AsUInt64", "Create", "CreateScalarUnsafe", "ToScalar", "get_Count", "get_Zero" };
+
+        if (!fIsPlatformHWIntrinsic && fIsHWIntrinsic)
+        {
+            fTreatAsRegularMethodCall = true;
+
+            if (strncmp(className, "Vector128", _countof("Vector128") - 1) == 0)
+            {
+                for (size_t i = 0; i < _countof(vector128MethodsSafeToExpand); i++)
+                {
+                    if (strcmp(methodName, vector128MethodsSafeToExpand[i]) == 0)
+                    {
+                        fTreatAsRegularMethodCall = false;
+                        break;
+                    }
+                }
+            }
+        }
 #else
         fTreatAsRegularMethodCall |= !fIsPlatformHWIntrinsic && fIsHWIntrinsic;
 #endif 


### PR DESCRIPTION
```
Found 1 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of diff: -13427 (-0.351% of base)
    diff is an improvement.

Top file improvements (bytes):
      -13427 : System.Private.CoreLib.dasm (-0.351% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method regressions (bytes):
         178 (136.923% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:GetHashCode():int:this
          85 (85.859% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:GetHashCode():int:this
          85 (85.859% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:GetHashCode():int:this
          76 (46.914% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:GetHashCode():int:this
          18 (16.981% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:GetHashCode():int:this
          18 (16.981% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:GetHashCode():int:this

Top method improvements (bytes):
        -410 (-32.985% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:NarrowUtf16ToAscii_Sse2(long,long,long):long
        -410 (-32.826% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:NarrowUtf16ToLatin1_Sse2(long,long,long):long
        -376 (-10.746% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(long,int,long,int,byref,byref):int
        -365 (-9.613% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(long,int,long,int,byref,byref):int
        -352 (-29.881% of base) : System.Private.CoreLib.dasm - System.Number:FormatDouble(byref,double,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo):System.String
        -349 (-30.190% of base) : System.Private.CoreLib.dasm - System.Number:FormatSingle(byref,float,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo):System.String
        -344 (-6.472% of base) : System.Private.CoreLib.dasm - System.Diagnostics.Tracing.EventPipePayloadDecoder:DecodePayload(byref,System.ReadOnlySpan`1[Byte]):System.Object[]
        -329 (-28.910% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunDouble(double,int,byref):bool
        -295 (-27.164% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunSingle(float,int,byref):bool
        -279 (-46.656% of base) : System.Private.CoreLib.dasm - System.Math:Round(double):double
        -262 (-51.779% of base) : System.Private.CoreLib.dasm - System.MathF:Round(float):float
        -259 (-19.343% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
        -253 (-18.810% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
        -205 (-49.757% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(System.Half):float
        -189 (-87.907% of base) : System.Private.CoreLib.dasm - System.MathF:<CopySign>g__SoftwareFallback|36_0(float,float):float
        -187 (-80.603% of base) : System.Private.CoreLib.dasm - System.Math:<CopySign>g__SoftwareFallback|46_0(double,double):double
        -177 (-19.387% of base) : System.Private.CoreLib.dasm - System.Number:NumberToFloatingPointBits(byref,byref):long
        -152 (-65.801% of base) : System.Private.CoreLib.dasm - System.MathF:BitIncrement(float):float
        -151 (-66.520% of base) : System.Private.CoreLib.dasm - System.MathF:BitDecrement(float):float
        -149 (-60.081% of base) : System.Private.CoreLib.dasm - System.Math:BitDecrement(double):double
        -149 (-57.752% of base) : System.Private.CoreLib.dasm - System.Math:BitIncrement(double):double
        -147 (-11.256% of base) : System.Private.CoreLib.dasm - System.Variant:MarshalHelperConvertObjectToVariant(System.Object,byref)
        -146 (-25.887% of base) : System.Private.CoreLib.dasm - System.Variant:ToObject():System.Object:this
        -144 (-5.806% of base) : System.Private.CoreLib.dasm - System.Variant:MarshalHelperCastVariant(System.Object,int,byref)
        -143 (-16.963% of base) : System.Private.CoreLib.dasm - System.Threading.ProcessorIdCache:ProcessorNumberSpeedCheck():bool
        -131 (-39.104% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(System.Half):double
        -126 (-24.803% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:WidenLatin1ToUtf16_Sse2(long,long,long)
        -115 (-72.785% of base) : System.Private.CoreLib.dasm - System.Math:Min(double,double):double
        -115 (-75.163% of base) : System.Private.CoreLib.dasm - System.Math:Min(float,float):float
        -114 (-19.930% of base) : System.Private.CoreLib.dasm - System.Number:Dragon4Double(double,int,bool,byref)
        -114 (-21.111% of base) : System.Private.CoreLib.dasm - System.Number:Dragon4Single(float,int,bool,byref)
        -113 (-64.205% of base) : System.Private.CoreLib.dasm - System.Math:CopySign(double,double):double
         -94 (-81.739% of base) : System.Private.CoreLib.dasm - System.MathF:CopySign(float,float):float
         -92 (-57.862% of base) : System.Private.CoreLib.dasm - System.Math:MaxMagnitude(double,double):double
         -92 (-57.862% of base) : System.Private.CoreLib.dasm - System.Math:MinMagnitude(double,double):double
         -92 (-59.740% of base) : System.Private.CoreLib.dasm - System.MathF:MaxMagnitude(float,float):float
         -92 (-59.740% of base) : System.Private.CoreLib.dasm - System.MathF:MinMagnitude(float,float):float
         -88 (-66.667% of base) : System.Private.CoreLib.dasm - System.MathF:Min(float,float):float
         -87 (-12.832% of base) : System.Private.CoreLib.dasm - System.Globalization.CalendricalCalculationsHelper:EquationOfTime(double):double
         -82 (-60.294% of base) : System.Private.CoreLib.dasm - System.Math:Max(double,double):double
         -82 (-62.595% of base) : System.Private.CoreLib.dasm - System.Math:Max(float,float):float
         -78 (-61.417% of base) : System.Private.CoreLib.dasm - System.MathF:Max(float,float):float
         -76 (-3.753% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:GetPointerToFirstInvalidByte(long,int,byref,byref):long
         -73 (-65.179% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadDoubleBigEndian(System.ReadOnlySpan`1[Byte],byref):bool
         -73 (-66.972% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadSingleBigEndian(System.ReadOnlySpan`1[Byte],byref):bool
         -70 (-30.043% of base) : System.Private.CoreLib.dasm - System.Globalization.CalendricalCalculationsHelper:EstimatePrior(double,double):double
         -69 (-24.820% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.ILGenerator:Emit(System.Reflection.Emit.OpCode,float):this
         -69 (-24.643% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.ILGenerator:Emit(System.Reflection.Emit.OpCode,double):this
         -67 (-4.536% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:<Invert>g__SseImpl|59_0(System.Numerics.Matrix4x4,byref):bool
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:Equals(System.Object):bool:this
         -67 (-41.358% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:Equals(System.Object):bool:this
         -67 (-41.875% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:Equals(System.Object):bool:this
         -65 (-91.549% of base) : System.Private.CoreLib.dasm - System.BitConverter:Int64BitsToDouble(long):double
         -65 (-92.857% of base) : System.Private.CoreLib.dasm - System.BitConverter:Int32BitsToSingle(int):float
         -65 (-39.634% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,int)
         -64 (-66.667% of base) : System.Private.CoreLib.dasm - System.Half:CreateSingleNaN(bool,long):float
         -63 (-66.316% of base) : System.Private.CoreLib.dasm - System.Half:CreateSingle(bool,ubyte,int):float
         -62 (-59.048% of base) : System.Private.CoreLib.dasm - System.Half:CreateDoubleNaN(bool,long):double
         -62 (-63.265% of base) : System.Private.CoreLib.dasm - System.Half:CreateDouble(bool,ushort,long):double
         -61 (-74.390% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:Write(long,float):this
         -61 (-74.390% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:Write(long,double):this
         -60 (-14.118% of base) : System.Private.CoreLib.dasm - System.Math:IEEERemainder(double,double):double
         -60 (-14.085% of base) : System.Private.CoreLib.dasm - System.MathF:IEEERemainder(float,float):float
         -58 (-46.400% of base) : System.Private.CoreLib.dasm - System.Number:ExtractFractionAndBiasedExponent(double,byref):long
         -58 (-52.727% of base) : System.Private.CoreLib.dasm - System.Number:ExtractFractionAndBiasedExponent(float,byref):int
         -58 (-37.419% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:TryFindFirstMatchedLane(System.Runtime.Intrinsics.Vector128`1[UInt16],byref):bool
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:Equals(System.Runtime.Intrinsics.Vector128`1[Int64]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:Equals(System.Runtime.Intrinsics.Vector128`1[Int32]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:Equals(System.Runtime.Intrinsics.Vector128`1[Int16]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:Equals(System.Runtime.Intrinsics.Vector128`1[Byte]):bool:this
         -58 (-69.880% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:Equals(System.Runtime.Intrinsics.Vector128`1[Double]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:Equals(System.Runtime.Intrinsics.Vector128`1[UInt16]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:Equals(System.Runtime.Intrinsics.Vector128`1[UInt64]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:Equals(System.Runtime.Intrinsics.Vector128`1[UInt32]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:Equals(System.Runtime.Intrinsics.Vector128`1[SByte]):bool:this
         -58 (-71.605% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:Equals(System.Runtime.Intrinsics.Vector128`1[Single]):bool:this
         -57 (-75.000% of base) : System.Private.CoreLib.dasm - System.BitConverter:ToSingle(System.Byte[],int):float
         -57 (-74.026% of base) : System.Private.CoreLib.dasm - System.BitConverter:ToDouble(System.Byte[],int):double
         -57 (-48.305% of base) : System.Private.CoreLib.dasm - System.Double:IsNormal(double):bool
         -57 (-48.305% of base) : System.Private.CoreLib.dasm - System.Double:IsSubnormal(double):bool
         -57 (-61.957% of base) : System.Private.CoreLib.dasm - System.Single:IsNormal(float):bool
         -57 (-61.957% of base) : System.Private.CoreLib.dasm - System.Single:IsSubnormal(float):bool
         -57 (-61.957% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:UnalignedCountVector128(byref):long (2 methods)
         -57 (-57.000% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadDoubleBigEndian(System.ReadOnlySpan`1[Byte]):double
         -57 (-58.763% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadSingleBigEndian(System.ReadOnlySpan`1[Byte]):float
         -57 (-75.000% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:ReadSingle(long):float:this
         -57 (-74.026% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:ReadDouble(long):double:this
         -56 (-32.941% of base) : System.Private.CoreLib.dasm - System.Number:NumberToDouble(byref):double
         -56 (-33.939% of base) : System.Private.CoreLib.dasm - System.Number:NumberToSingle(byref):float
         -55 (-70.513% of base) : System.Private.CoreLib.dasm - System.Variant:.ctor(float):this
         -55 (-71.429% of base) : System.Private.CoreLib.dasm - System.Variant:.ctor(double):this
         -55 (-62.500% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteDoubleBigEndian(System.Span`1[Byte],double):bool
         -55 (-64.706% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteSingleBigEndian(System.Span`1[Byte],float):bool
         -55 (-45.833% of base) : System.Private.CoreLib.dasm - System.IO.BinaryReader:ReadSingle():float:this
         -54 (-33.750% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,long)
         -54 (-32.530% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:NarrowFourUtf16CharsToLatin1AndWriteToBuffer(byref,long)
         -54 (-79.412% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(double):System.Runtime.Intrinsics.Vector128`1[Double]
         -54 (-79.412% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(float):System.Runtime.Intrinsics.Vector128`1[Single]
         -54 (-44.628% of base) : System.Private.CoreLib.dasm - System.IO.BinaryReader:ReadDouble():double:this
         -53 (-89.831% of base) : System.Private.CoreLib.dasm - System.BitConverter:DoubleToInt64Bits(double):long
         -53 (-91.379% of base) : System.Private.CoreLib.dasm - System.BitConverter:SingleToInt32Bits(float):int
         -53 (-58.242% of base) : System.Private.CoreLib.dasm - System.Double:IsFinite(double):bool
         -53 (-58.242% of base) : System.Private.CoreLib.dasm - System.Double:IsInfinity(double):bool
         -53 (-77.941% of base) : System.Private.CoreLib.dasm - System.Double:IsNegative(double):bool
         -53 (-71.622% of base) : System.Private.CoreLib.dasm - System.Single:IsFinite(float):bool
         -53 (-71.622% of base) : System.Private.CoreLib.dasm - System.Single:IsInfinity(float):bool
         -53 (-80.303% of base) : System.Private.CoreLib.dasm - System.Single:IsNegative(float):bool
         -47 (-52.222% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteDoubleBigEndian(System.Span`1[Byte],double)
         -47 (-54.023% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteSingleBigEndian(System.Span`1[Byte],float)
         -46 (-25.000% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:Lerp(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4,float):System.Numerics.Matrix4x4
         -45 (-15.625% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(float):System.Half
         -45 (-15.254% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(double):System.Half
         -45 (-32.143% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:op_Multiply(System.Numerics.Matrix4x4,float):System.Numerics.Matrix4x4
         -42 (-15.385% of base) : System.Private.CoreLib.dasm - DiyFp:CreateAndGetBoundaries(double,byref,byref):DiyFp
         -42 (-16.342% of base) : System.Private.CoreLib.dasm - DiyFp:CreateAndGetBoundaries(float,byref,byref):DiyFp
         -42 (-18.834% of base) : System.Private.CoreLib.dasm - DiyFp:.ctor(double):this
         -42 (-20.290% of base) : System.Private.CoreLib.dasm - DiyFp:.ctor(float):this
         -37 (-27.007% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:op_UnaryNegation(System.Numerics.Matrix4x4):System.Numerics.Matrix4x4
         -32 (-4.097% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:ToString():System.String:this
         -31 (-3.995% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:ToString():System.String:this
         -31 (-3.939% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:ToString():System.String:this
         -31 (-3.939% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:ToString():System.String:this
         -29 (-25.217% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf16Utility:GetNonAsciiBytes(System.Runtime.Intrinsics.Vector128`1[Byte],System.Runtime.Intrinsics.Vector128`1[Byte]):int
         -29 (-67.442% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(ubyte):System.Runtime.Intrinsics.Vector128`1[Byte]
         -29 (-61.702% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(short):System.Runtime.Intrinsics.Vector128`1[Int16]
         -29 (-61.702% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(byte):System.Runtime.Intrinsics.Vector128`1[SByte]
         -29 (-67.442% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(ushort):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -28 (-11.475% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[__Canon][System.__Canon]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[__Canon]):bool
         -27 (-71.053% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetCharVector128SpanLength(long,long):long
         -24 (-75.000% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetByteVector128SpanLength(long,int):long
         -24 (-3.230% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[__Canon][System.__Canon]:ToString():System.String:this
         -23 (-42.593% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|51_0(double):System.Runtime.Intrinsics.Vector128`1[Double]
         -23 (-42.593% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|56_0(float):System.Runtime.Intrinsics.Vector128`1[Single]
         -22 (-12.500% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[__Canon][System.__Canon]:GetHashCode():int:this
         -22 (-3.121% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:ToString():System.String:this
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Byte],System.Runtime.Intrinsics.Vector64`1[Byte]):System.Runtime.Intrinsics.Vector128`1[Byte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Double],System.Runtime.Intrinsics.Vector64`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Int16],System.Runtime.Intrinsics.Vector64`1[Int16]):System.Runtime.Intrinsics.Vector128`1[Int16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Int32],System.Runtime.Intrinsics.Vector64`1[Int32]):System.Runtime.Intrinsics.Vector128`1[Int32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Int64],System.Runtime.Intrinsics.Vector64`1[Int64]):System.Runtime.Intrinsics.Vector128`1[Int64]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[SByte],System.Runtime.Intrinsics.Vector64`1[SByte]):System.Runtime.Intrinsics.Vector128`1[SByte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Single],System.Runtime.Intrinsics.Vector64`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[UInt16],System.Runtime.Intrinsics.Vector64`1[UInt16]):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[UInt32],System.Runtime.Intrinsics.Vector64`1[UInt32]):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[UInt64],System.Runtime.Intrinsics.Vector64`1[UInt64]):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|40_0(System.Runtime.Intrinsics.Vector64`1[Byte],System.Runtime.Intrinsics.Vector64`1[Byte]):System.Runtime.Intrinsics.Vector128`1[Byte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|41_0(System.Runtime.Intrinsics.Vector64`1[Double],System.Runtime.Intrinsics.Vector64`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|42_0(System.Runtime.Intrinsics.Vector64`1[Int16],System.Runtime.Intrinsics.Vector64`1[Int16]):System.Runtime.Intrinsics.Vector128`1[Int16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|43_0(System.Runtime.Intrinsics.Vector64`1[Int32],System.Runtime.Intrinsics.Vector64`1[Int32]):System.Runtime.Intrinsics.Vector128`1[Int32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|44_0(System.Runtime.Intrinsics.Vector64`1[Int64],System.Runtime.Intrinsics.Vector64`1[Int64]):System.Runtime.Intrinsics.Vector128`1[Int64]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|45_0(System.Runtime.Intrinsics.Vector64`1[SByte],System.Runtime.Intrinsics.Vector64`1[SByte]):System.Runtime.Intrinsics.Vector128`1[SByte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|46_0(System.Runtime.Intrinsics.Vector64`1[Single],System.Runtime.Intrinsics.Vector64`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|47_0(System.Runtime.Intrinsics.Vector64`1[UInt16],System.Runtime.Intrinsics.Vector64`1[UInt16]):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|48_0(System.Runtime.Intrinsics.Vector64`1[UInt32],System.Runtime.Intrinsics.Vector64`1[UInt32]):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|49_0(System.Runtime.Intrinsics.Vector64`1[UInt64],System.Runtime.Intrinsics.Vector64`1[UInt64]):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -21 (-2.979% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:ToString():System.String:this
         -16 (-33.333% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|50_0(ubyte):System.Runtime.Intrinsics.Vector128`1[Byte]
         -16 (-34.783% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|54_0(long):System.Runtime.Intrinsics.Vector128`1[Int64]
         -16 (-34.783% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|59_0(long):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -16 (-2.421% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:ToString():System.String:this
         -15 (-30.612% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|52_0(short):System.Runtime.Intrinsics.Vector128`1[Int16]
         -15 (-34.091% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|53_0(int):System.Runtime.Intrinsics.Vector128`1[Int32]
         -15 (-31.250% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|55_0(byte):System.Runtime.Intrinsics.Vector128`1[SByte]
         -15 (-31.250% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|57_0(ushort):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -15 (-34.091% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|58_0(int):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -15 (-14.851% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:GetHashCode():int:this
         -15 (-15.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:GetHashCode():int:this
         -15 (-2.283% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:ToString():System.String:this
         -15 (-15.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:GetHashCode():int:this
         -15 (-2.283% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:ToString():System.String:this
         -15 (-2.311% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:ToString():System.String:this
         -15 (-14.851% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:GetHashCode():int:this
         -13 (-3.963% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:WidenAsciiToUtf16_Sse2(long,long,long):long

Top method regressions (percentages):
         178 (136.923% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:GetHashCode():int:this
          85 (85.859% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:GetHashCode():int:this
          85 (85.859% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:GetHashCode():int:this
          76 (46.914% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:GetHashCode():int:this
          18 (16.981% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:GetHashCode():int:this
          18 (16.981% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:GetHashCode():int:this

Top method improvements (percentages):
         -65 (-92.857% of base) : System.Private.CoreLib.dasm - System.BitConverter:Int32BitsToSingle(int):float
         -65 (-91.549% of base) : System.Private.CoreLib.dasm - System.BitConverter:Int64BitsToDouble(long):double
         -53 (-91.379% of base) : System.Private.CoreLib.dasm - System.BitConverter:SingleToInt32Bits(float):int
         -53 (-89.831% of base) : System.Private.CoreLib.dasm - System.BitConverter:DoubleToInt64Bits(double):long
        -189 (-87.907% of base) : System.Private.CoreLib.dasm - System.MathF:<CopySign>g__SoftwareFallback|36_0(float,float):float
         -94 (-81.739% of base) : System.Private.CoreLib.dasm - System.MathF:CopySign(float,float):float
        -187 (-80.603% of base) : System.Private.CoreLib.dasm - System.Math:<CopySign>g__SoftwareFallback|46_0(double,double):double
         -53 (-80.303% of base) : System.Private.CoreLib.dasm - System.Single:IsNegative(float):bool
         -54 (-79.412% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(double):System.Runtime.Intrinsics.Vector128`1[Double]
         -54 (-79.412% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(float):System.Runtime.Intrinsics.Vector128`1[Single]
         -53 (-77.941% of base) : System.Private.CoreLib.dasm - System.Double:IsNegative(double):bool
        -115 (-75.163% of base) : System.Private.CoreLib.dasm - System.Math:Min(float,float):float
         -24 (-75.000% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetByteVector128SpanLength(long,int):long
         -57 (-75.000% of base) : System.Private.CoreLib.dasm - System.BitConverter:ToSingle(System.Byte[],int):float
         -57 (-75.000% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:ReadSingle(long):float:this
         -61 (-74.390% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:Write(long,float):this
         -61 (-74.390% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:Write(long,double):this
         -57 (-74.026% of base) : System.Private.CoreLib.dasm - System.BitConverter:ToDouble(System.Byte[],int):double
         -57 (-74.026% of base) : System.Private.CoreLib.dasm - System.IO.UnmanagedMemoryAccessor:ReadDouble(long):double:this
        -115 (-72.785% of base) : System.Private.CoreLib.dasm - System.Math:Min(double,double):double
         -53 (-71.622% of base) : System.Private.CoreLib.dasm - System.Single:IsFinite(float):bool
         -53 (-71.622% of base) : System.Private.CoreLib.dasm - System.Single:IsInfinity(float):bool
         -58 (-71.605% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:Equals(System.Runtime.Intrinsics.Vector128`1[Single]):bool:this
         -55 (-71.429% of base) : System.Private.CoreLib.dasm - System.Variant:.ctor(double):this
         -27 (-71.053% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetCharVector128SpanLength(long,long):long
         -55 (-70.513% of base) : System.Private.CoreLib.dasm - System.Variant:.ctor(float):this
         -58 (-69.880% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:Equals(System.Runtime.Intrinsics.Vector128`1[Double]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:Equals(System.Runtime.Intrinsics.Vector128`1[Int64]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:Equals(System.Runtime.Intrinsics.Vector128`1[Int32]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:Equals(System.Runtime.Intrinsics.Vector128`1[Int16]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:Equals(System.Runtime.Intrinsics.Vector128`1[Byte]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:Equals(System.Runtime.Intrinsics.Vector128`1[UInt16]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:Equals(System.Runtime.Intrinsics.Vector128`1[UInt64]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:Equals(System.Runtime.Intrinsics.Vector128`1[UInt32]):bool:this
         -58 (-69.048% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:Equals(System.Runtime.Intrinsics.Vector128`1[SByte]):bool:this
         -29 (-67.442% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(ubyte):System.Runtime.Intrinsics.Vector128`1[Byte]
         -29 (-67.442% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(ushort):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -73 (-66.972% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadSingleBigEndian(System.ReadOnlySpan`1[Byte],byref):bool
         -64 (-66.667% of base) : System.Private.CoreLib.dasm - System.Half:CreateSingleNaN(bool,long):float
         -88 (-66.667% of base) : System.Private.CoreLib.dasm - System.MathF:Min(float,float):float
        -151 (-66.520% of base) : System.Private.CoreLib.dasm - System.MathF:BitDecrement(float):float
         -63 (-66.316% of base) : System.Private.CoreLib.dasm - System.Half:CreateSingle(bool,ubyte,int):float
        -152 (-65.801% of base) : System.Private.CoreLib.dasm - System.MathF:BitIncrement(float):float
         -73 (-65.179% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadDoubleBigEndian(System.ReadOnlySpan`1[Byte],byref):bool
         -55 (-64.706% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteSingleBigEndian(System.Span`1[Byte],float):bool
        -113 (-64.205% of base) : System.Private.CoreLib.dasm - System.Math:CopySign(double,double):double
         -62 (-63.265% of base) : System.Private.CoreLib.dasm - System.Half:CreateDouble(bool,ushort,long):double
         -82 (-62.595% of base) : System.Private.CoreLib.dasm - System.Math:Max(float,float):float
         -55 (-62.500% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteDoubleBigEndian(System.Span`1[Byte],double):bool
         -57 (-61.957% of base) : System.Private.CoreLib.dasm - System.Single:IsNormal(float):bool
         -57 (-61.957% of base) : System.Private.CoreLib.dasm - System.Single:IsSubnormal(float):bool
         -57 (-61.957% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:UnalignedCountVector128(byref):long (2 methods)
         -29 (-61.702% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(short):System.Runtime.Intrinsics.Vector128`1[Int16]
         -29 (-61.702% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:CreateScalar(byte):System.Runtime.Intrinsics.Vector128`1[SByte]
         -78 (-61.417% of base) : System.Private.CoreLib.dasm - System.MathF:Max(float,float):float
         -82 (-60.294% of base) : System.Private.CoreLib.dasm - System.Math:Max(double,double):double
        -149 (-60.081% of base) : System.Private.CoreLib.dasm - System.Math:BitDecrement(double):double
         -92 (-59.740% of base) : System.Private.CoreLib.dasm - System.MathF:MaxMagnitude(float,float):float
         -92 (-59.740% of base) : System.Private.CoreLib.dasm - System.MathF:MinMagnitude(float,float):float
         -62 (-59.048% of base) : System.Private.CoreLib.dasm - System.Half:CreateDoubleNaN(bool,long):double
         -57 (-58.763% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadSingleBigEndian(System.ReadOnlySpan`1[Byte]):float
         -53 (-58.242% of base) : System.Private.CoreLib.dasm - System.Double:IsFinite(double):bool
         -53 (-58.242% of base) : System.Private.CoreLib.dasm - System.Double:IsInfinity(double):bool
         -92 (-57.862% of base) : System.Private.CoreLib.dasm - System.Math:MaxMagnitude(double,double):double
         -92 (-57.862% of base) : System.Private.CoreLib.dasm - System.Math:MinMagnitude(double,double):double
        -149 (-57.752% of base) : System.Private.CoreLib.dasm - System.Math:BitIncrement(double):double
         -57 (-57.000% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadDoubleBigEndian(System.ReadOnlySpan`1[Byte]):double
         -47 (-54.023% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteSingleBigEndian(System.Span`1[Byte],float)
         -58 (-52.727% of base) : System.Private.CoreLib.dasm - System.Number:ExtractFractionAndBiasedExponent(float,byref):int
         -47 (-52.222% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteDoubleBigEndian(System.Span`1[Byte],double)
        -262 (-51.779% of base) : System.Private.CoreLib.dasm - System.MathF:Round(float):float
        -205 (-49.757% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(System.Half):float
         -57 (-48.305% of base) : System.Private.CoreLib.dasm - System.Double:IsNormal(double):bool
         -57 (-48.305% of base) : System.Private.CoreLib.dasm - System.Double:IsSubnormal(double):bool
        -279 (-46.656% of base) : System.Private.CoreLib.dasm - System.Math:Round(double):double
         -58 (-46.400% of base) : System.Private.CoreLib.dasm - System.Number:ExtractFractionAndBiasedExponent(double,byref):long
         -55 (-45.833% of base) : System.Private.CoreLib.dasm - System.IO.BinaryReader:ReadSingle():float:this
         -54 (-44.628% of base) : System.Private.CoreLib.dasm - System.IO.BinaryReader:ReadDouble():double:this
         -23 (-42.593% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|51_0(double):System.Runtime.Intrinsics.Vector128`1[Double]
         -23 (-42.593% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|56_0(float):System.Runtime.Intrinsics.Vector128`1[Single]
         -67 (-41.875% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:Equals(System.Object):bool:this
         -67 (-41.358% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:Equals(System.Object):bool:this
         -67 (-41.104% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:Equals(System.Object):bool:this
         -65 (-39.634% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,int)
        -131 (-39.104% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(System.Half):double
         -58 (-37.419% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:TryFindFirstMatchedLane(System.Runtime.Intrinsics.Vector128`1[UInt16],byref):bool
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Byte],System.Runtime.Intrinsics.Vector64`1[Byte]):System.Runtime.Intrinsics.Vector128`1[Byte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Double],System.Runtime.Intrinsics.Vector64`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Int16],System.Runtime.Intrinsics.Vector64`1[Int16]):System.Runtime.Intrinsics.Vector128`1[Int16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Int32],System.Runtime.Intrinsics.Vector64`1[Int32]):System.Runtime.Intrinsics.Vector128`1[Int32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Int64],System.Runtime.Intrinsics.Vector64`1[Int64]):System.Runtime.Intrinsics.Vector128`1[Int64]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[SByte],System.Runtime.Intrinsics.Vector64`1[SByte]):System.Runtime.Intrinsics.Vector128`1[SByte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[Single],System.Runtime.Intrinsics.Vector64`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[UInt16],System.Runtime.Intrinsics.Vector64`1[UInt16]):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[UInt32],System.Runtime.Intrinsics.Vector64`1[UInt32]):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(System.Runtime.Intrinsics.Vector64`1[UInt64],System.Runtime.Intrinsics.Vector64`1[UInt64]):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|40_0(System.Runtime.Intrinsics.Vector64`1[Byte],System.Runtime.Intrinsics.Vector64`1[Byte]):System.Runtime.Intrinsics.Vector128`1[Byte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|41_0(System.Runtime.Intrinsics.Vector64`1[Double],System.Runtime.Intrinsics.Vector64`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|42_0(System.Runtime.Intrinsics.Vector64`1[Int16],System.Runtime.Intrinsics.Vector64`1[Int16]):System.Runtime.Intrinsics.Vector128`1[Int16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|43_0(System.Runtime.Intrinsics.Vector64`1[Int32],System.Runtime.Intrinsics.Vector64`1[Int32]):System.Runtime.Intrinsics.Vector128`1[Int32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|44_0(System.Runtime.Intrinsics.Vector64`1[Int64],System.Runtime.Intrinsics.Vector64`1[Int64]):System.Runtime.Intrinsics.Vector128`1[Int64]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|45_0(System.Runtime.Intrinsics.Vector64`1[SByte],System.Runtime.Intrinsics.Vector64`1[SByte]):System.Runtime.Intrinsics.Vector128`1[SByte]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|46_0(System.Runtime.Intrinsics.Vector64`1[Single],System.Runtime.Intrinsics.Vector64`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|47_0(System.Runtime.Intrinsics.Vector64`1[UInt16],System.Runtime.Intrinsics.Vector64`1[UInt16]):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|48_0(System.Runtime.Intrinsics.Vector64`1[UInt32],System.Runtime.Intrinsics.Vector64`1[UInt32]):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -21 (-36.207% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|49_0(System.Runtime.Intrinsics.Vector64`1[UInt64],System.Runtime.Intrinsics.Vector64`1[UInt64]):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -16 (-34.783% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|54_0(long):System.Runtime.Intrinsics.Vector128`1[Int64]
         -16 (-34.783% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|59_0(long):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -15 (-34.091% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|53_0(int):System.Runtime.Intrinsics.Vector128`1[Int32]
         -15 (-34.091% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|58_0(int):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -56 (-33.939% of base) : System.Private.CoreLib.dasm - System.Number:NumberToSingle(byref):float
         -54 (-33.750% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,long)
         -16 (-33.333% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|50_0(ubyte):System.Runtime.Intrinsics.Vector128`1[Byte]
        -410 (-32.985% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:NarrowUtf16ToAscii_Sse2(long,long,long):long
         -56 (-32.941% of base) : System.Private.CoreLib.dasm - System.Number:NumberToDouble(byref):double
        -410 (-32.826% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:NarrowUtf16ToLatin1_Sse2(long,long,long):long
         -54 (-32.530% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:NarrowFourUtf16CharsToLatin1AndWriteToBuffer(byref,long)
         -45 (-32.143% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:op_Multiply(System.Numerics.Matrix4x4,float):System.Numerics.Matrix4x4
         -15 (-31.250% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|55_0(byte):System.Runtime.Intrinsics.Vector128`1[SByte]
         -15 (-31.250% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|57_0(ushort):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -15 (-30.612% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<CreateScalar>g__SoftwareFallback|52_0(short):System.Runtime.Intrinsics.Vector128`1[Int16]
        -349 (-30.190% of base) : System.Private.CoreLib.dasm - System.Number:FormatSingle(byref,float,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo):System.String
         -70 (-30.043% of base) : System.Private.CoreLib.dasm - System.Globalization.CalendricalCalculationsHelper:EstimatePrior(double,double):double
        -352 (-29.881% of base) : System.Private.CoreLib.dasm - System.Number:FormatDouble(byref,double,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo):System.String
        -329 (-28.910% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunDouble(double,int,byref):bool
        -295 (-27.164% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunSingle(float,int,byref):bool
         -37 (-27.007% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:op_UnaryNegation(System.Numerics.Matrix4x4):System.Numerics.Matrix4x4
        -146 (-25.887% of base) : System.Private.CoreLib.dasm - System.Variant:ToObject():System.Object:this
         -29 (-25.217% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf16Utility:GetNonAsciiBytes(System.Runtime.Intrinsics.Vector128`1[Byte],System.Runtime.Intrinsics.Vector128`1[Byte]):int
         -46 (-25.000% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:Lerp(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4,float):System.Numerics.Matrix4x4
         -69 (-24.820% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.ILGenerator:Emit(System.Reflection.Emit.OpCode,float):this
        -126 (-24.803% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:WidenLatin1ToUtf16_Sse2(long,long,long)
         -69 (-24.643% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.ILGenerator:Emit(System.Reflection.Emit.OpCode,double):this
        -114 (-21.111% of base) : System.Private.CoreLib.dasm - System.Number:Dragon4Single(float,int,bool,byref)
         -42 (-20.290% of base) : System.Private.CoreLib.dasm - DiyFp:.ctor(float):this
        -114 (-19.930% of base) : System.Private.CoreLib.dasm - System.Number:Dragon4Double(double,int,bool,byref)
        -177 (-19.387% of base) : System.Private.CoreLib.dasm - System.Number:NumberToFloatingPointBits(byref,byref):long
        -259 (-19.343% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
         -42 (-18.834% of base) : System.Private.CoreLib.dasm - DiyFp:.ctor(double):this
        -253 (-18.810% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
        -143 (-16.963% of base) : System.Private.CoreLib.dasm - System.Threading.ProcessorIdCache:ProcessorNumberSpeedCheck():bool
         -42 (-16.342% of base) : System.Private.CoreLib.dasm - DiyFp:CreateAndGetBoundaries(float,byref,byref):DiyFp
         -45 (-15.625% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(float):System.Half
         -42 (-15.385% of base) : System.Private.CoreLib.dasm - DiyFp:CreateAndGetBoundaries(double,byref,byref):DiyFp
         -45 (-15.254% of base) : System.Private.CoreLib.dasm - System.Half:op_Explicit(double):System.Half
         -15 (-15.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:GetHashCode():int:this
         -15 (-15.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:GetHashCode():int:this
         -15 (-14.851% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:GetHashCode():int:this
         -15 (-14.851% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:GetHashCode():int:this
         -60 (-14.118% of base) : System.Private.CoreLib.dasm - System.Math:IEEERemainder(double,double):double
         -60 (-14.085% of base) : System.Private.CoreLib.dasm - System.MathF:IEEERemainder(float,float):float
         -87 (-12.832% of base) : System.Private.CoreLib.dasm - System.Globalization.CalendricalCalculationsHelper:EquationOfTime(double):double
         -22 (-12.500% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[__Canon][System.__Canon]:GetHashCode():int:this
         -28 (-11.475% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[__Canon][System.__Canon]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[__Canon]):bool
        -147 (-11.256% of base) : System.Private.CoreLib.dasm - System.Variant:MarshalHelperConvertObjectToVariant(System.Object,byref)
        -376 (-10.746% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(long,int,long,int,byref,byref):int
        -365 (-9.613% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(long,int,long,int,byref,byref):int
        -344 (-6.472% of base) : System.Private.CoreLib.dasm - System.Diagnostics.Tracing.EventPipePayloadDecoder:DecodePayload(byref,System.ReadOnlySpan`1[Byte]):System.Object[]
        -144 (-5.806% of base) : System.Private.CoreLib.dasm - System.Variant:MarshalHelperCastVariant(System.Object,int,byref)
         -67 (-4.536% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:<Invert>g__SseImpl|59_0(System.Numerics.Matrix4x4,byref):bool
         -32 (-4.097% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:ToString():System.String:this
         -31 (-3.995% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:ToString():System.String:this
         -13 (-3.963% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:WidenAsciiToUtf16_Sse2(long,long,long):long
         -31 (-3.939% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:ToString():System.String:this
         -31 (-3.939% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:ToString():System.String:this
         -76 (-3.753% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:GetPointerToFirstInvalidByte(long,int,byref,byref):long
         -24 (-3.230% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[__Canon][System.__Canon]:ToString():System.String:this
         -22 (-3.121% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:ToString():System.String:this
         -21 (-2.979% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:ToString():System.String:this
         -16 (-2.421% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:ToString():System.String:this
         -15 (-2.311% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:ToString():System.String:this
         -15 (-2.283% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:ToString():System.String:this
         -15 (-2.283% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:ToString():System.String:this

186 total methods with Code Size differences (180 improved, 6 regressed), 28496 unchanged.
```