### PR TITLE
Sync HPackDecoder with ASP.NET Core changes

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
@@ -542,7 +542,7 @@ namespace System.Net.Http.HPack
             }
             else
             {
-                ref readonly HeaderField header = ref GetHeader(index);
+                ref readonly HeaderField header = ref GetDynamicHeader(index);
                 handler.OnHeader(header.Name, header.Value);
             }
 
@@ -557,7 +557,7 @@ namespace System.Net.Http.HPack
             }
             else
             {
-                _headerName = GetHeader(index).Name;
+                _headerName = GetDynamicHeader(index).Name;
                 _headerNameLength = _headerName.Length;
             }
             _state = State.HeaderValueLength;
@@ -644,7 +644,7 @@ namespace System.Net.Http.HPack
             return (b & HuffmanMask) != 0;
         }
 
-        private ref readonly HeaderField GetHeader(int index)
+        private ref readonly HeaderField GetDynamicHeader(int index)
         {
             try
             {

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
@@ -690,7 +690,7 @@ namespace System.Net.Http.HPack
             {
 #if !HPACK_SUPPORT_ONSTATICINDEXEDHEADER
                 return ref index <= H2StaticTable.Count
-                    ? ref H2StaticTable.Get(index -1)
+                    ? ref H2StaticTable.Get(index - 1)
                     : ref _dynamicTable[index - H2StaticTable.Count - 1];
 #else
                 return ref _dynamicTable[index - H2StaticTable.Count - 1];

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
@@ -690,7 +690,7 @@ namespace System.Net.Http.HPack
             {
 #if !HPACK_SUPPORT_ONSTATICINDEXEDHEADER
                 return ref index <= H2StaticTable.Count
-                    ? ref H2StaticTable.Get(index -1)	
+                    ? ref H2StaticTable.Get(index -1)
                     : ref _dynamicTable[index - H2StaticTable.Count - 1];
 #else
                 return ref _dynamicTable[index - H2StaticTable.Count - 1];

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
@@ -104,10 +104,31 @@ namespace System.Net.Http.Unit.Tests.HPack
         }
 
         [Fact]
-        public void DecodesIndexedHeaderField_StaticTable()
+        public void DecodesIndexedHeaderField_StaticTableWithValue()
         {
             _decoder.Decode(_indexedHeaderStatic, endHeaders: true, handler: _handler);
             Assert.Equal("GET", _handler.DecodedHeaders[":method"]);
+
+#if HPACK_SUPPORT_ONSTATICINDEXEDHEADER
+            Assert.Equal(":method", _handler.DecodedStaticHeaders[H2StaticTable.MethodGet].Key);
+            Assert.Equal("GET", _handler.DecodedStaticHeaders[H2StaticTable.MethodGet].Value);
+#endif
+        }
+
+        [Fact]
+        public void DecodesIndexedHeaderField_StaticTableWithoutValue()
+        {
+            byte[] encoded = _literalHeaderFieldWithIndexingIndexedName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded, endHeaders: true, handler: _handler);
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_userAgentString]);
+
+#if HPACK_SUPPORT_ONSTATICINDEXEDHEADER
+            Assert.Equal(_userAgentString, _handler.DecodedStaticHeaders[H2StaticTable.UserAgent].Key);
+            Assert.Equal(_headerValueString, _handler.DecodedStaticHeaders[H2StaticTable.UserAgent].Value);
+#endif
         }
 
         [Fact]
@@ -707,6 +728,9 @@ namespace System.Net.Http.Unit.Tests.HPack
     public class TestHttpHeadersHandler : IHttpHeadersHandler
     {
         public Dictionary<string, string> DecodedHeaders { get; } = new Dictionary<string, string>();
+#if HPACK_SUPPORT_ONSTATICINDEXEDHEADER
+        public Dictionary<int, KeyValuePair<string, string>> DecodedStaticHeaders { get; } = new Dictionary<int, KeyValuePair<string, string>>();
+#endif
 
         void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
@@ -718,14 +742,26 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
         {
+#if !HPACK_SUPPORT_ONSTATICINDEXEDHEADER
             // Not yet implemented for HPACK.
             throw new NotImplementedException();
+#else
+            ref readonly HeaderField entry = ref H2StaticTable.Get(index - 1);
+            ((IHttpHeadersHandler)this).OnHeader(entry.Name, entry.Value);
+            DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(entry.Name), Encoding.ASCII.GetString(entry.Value));
+#endif
         }
 
         void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
         {
+#if !HPACK_SUPPORT_ONSTATICINDEXEDHEADER
             // Not yet implemented for HPACK.
             throw new NotImplementedException();
+#else
+            byte[] name = H2StaticTable.Get(index - 1).Name;
+            ((IHttpHeadersHandler)this).OnHeader(name, value);
+            DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(name), Encoding.ASCII.GetString(value));
+#endif
         }
 
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
@@ -109,10 +109,8 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(_indexedHeaderStatic, endHeaders: true, handler: _handler);
             Assert.Equal("GET", _handler.DecodedHeaders[":method"]);
 
-#if HPACK_SUPPORT_ONSTATICINDEXEDHEADER
             Assert.Equal(":method", _handler.DecodedStaticHeaders[H2StaticTable.MethodGet].Key);
             Assert.Equal("GET", _handler.DecodedStaticHeaders[H2StaticTable.MethodGet].Value);
-#endif
         }
 
         [Fact]
@@ -125,10 +123,8 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded, endHeaders: true, handler: _handler);
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_userAgentString]);
 
-#if HPACK_SUPPORT_ONSTATICINDEXEDHEADER
             Assert.Equal(_userAgentString, _handler.DecodedStaticHeaders[H2StaticTable.UserAgent].Key);
             Assert.Equal(_headerValueString, _handler.DecodedStaticHeaders[H2StaticTable.UserAgent].Value);
-#endif
         }
 
         [Fact]
@@ -728,9 +724,7 @@ namespace System.Net.Http.Unit.Tests.HPack
     public class TestHttpHeadersHandler : IHttpHeadersHandler
     {
         public Dictionary<string, string> DecodedHeaders { get; } = new Dictionary<string, string>();
-#if HPACK_SUPPORT_ONSTATICINDEXEDHEADER
         public Dictionary<int, KeyValuePair<string, string>> DecodedStaticHeaders { get; } = new Dictionary<int, KeyValuePair<string, string>>();
-#endif
 
         void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
@@ -742,26 +736,16 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
         {
-#if !HPACK_SUPPORT_ONSTATICINDEXEDHEADER
-            // Not yet implemented for HPACK.
-            throw new NotImplementedException();
-#else
             ref readonly HeaderField entry = ref H2StaticTable.Get(index - 1);
             ((IHttpHeadersHandler)this).OnHeader(entry.Name, entry.Value);
             DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(entry.Name), Encoding.ASCII.GetString(entry.Value));
-#endif
         }
 
         void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
         {
-#if !HPACK_SUPPORT_ONSTATICINDEXEDHEADER
-            // Not yet implemented for HPACK.
-            throw new NotImplementedException();
-#else
             byte[] name = H2StaticTable.Get(index - 1).Name;
             ((IHttpHeadersHandler)this).OnHeader(name, value);
             DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(name), Encoding.ASCII.GetString(value));
-#endif
         }
 
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -440,7 +440,7 @@ namespace System.Net.Http
             void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
             {
                 // TODO: https://github.com/dotnet/runtime/issues/1505
-                ref readonly var entry = ref H2StaticTable.Get(index - 1);
+                ref readonly HeaderField entry = ref H2StaticTable.Get(index - 1);
                 OnHeader(entry.Name, entry.Value);
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Headers;
+using System.Net.Http.HPack;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Text;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -440,13 +440,14 @@ namespace System.Net.Http
             void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
             {
                 // TODO: https://github.com/dotnet/runtime/issues/1505
-                Debug.Fail("Currently unused by HPACK, this should never be called.");
+                ref readonly var entry = ref H2StaticTable.Get(index - 1);
+                OnHeader(entry.Name, entry.Value);
             }
 
             void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
             {
                 // TODO: https://github.com/dotnet/runtime/issues/1505
-                Debug.Fail("Currently unused by HPACK, this should never be called.");
+                OnHeader(H2StaticTable.Get(index - 1).Name, value);
             }
 
             public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)

--- a/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -177,7 +177,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             public void OnStaticIndexedHeader(int index)
             {
-                ref readonly var entry = ref H2StaticTable.Get(index - 1);
+                ref readonly HeaderField entry = ref H2StaticTable.Get(index - 1);
                 OnHeader(entry.Name, entry.Value);
             }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -177,12 +177,13 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             public void OnStaticIndexedHeader(int index)
             {
-                throw new NotImplementedException();
+                ref readonly var entry = ref H2StaticTable.Get(index - 1);
+                OnHeader(entry.Name, entry.Value);
             }
 
             public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
             {
-                throw new NotImplementedException();
+                OnHeader(H2StaticTable.Get(index - 1).Name, value);
             }
         }
     }


### PR DESCRIPTION
Sync with HPackDecoder changes in https://github.com/dotnet/aspnetcore/pull/24730

~Define `HPACK_SUPPORT_ONSTATICINDEXEDHEADER` to use new behavior. runtime doesn't define the variable so it is unchanged.~

~In .NET 6 runtime can optimize around the static index and the compiler variable and older code path can be removed.~