### PR TITLE
Ensure local is initialized in code generated for binary operator

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -1123,6 +1123,8 @@ namespace System.Linq.Expressions.Compiler
                         Label exit = _ilg.DefineLabel();
                         Label exitNull = _ilg.DefineLabel();
                         LocalBuilder anyNull = GetLocal(typeof(bool));
+                        _ilg.Emit(OpCodes.Ldc_I4_0);
+                        _ilg.Emit(OpCodes.Stloc, anyNull);
                         for (int i = 0, n = paramList.Length; i < n; i++)
                         {
                             ParameterExpression v = paramList[i];


### PR DESCRIPTION
Ensure local is initialized since the same local index may be re-used within the method.

Fixes #479.