### PR TITLE
Normalize directory separator of paths in FileSpec

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileEntry.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileEntry.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NET.HostModel.Bundle
         public FileEntry(FileType fileType, string relativePath, long offset, long size)
         {
             Type = fileType;
-            RelativePath = relativePath.Replace(Path.DirectorySeparatorChar, DirectorySeparatorChar);
+            RelativePath = relativePath.Replace('\\', DirectorySeparatorChar);
             Offset = offset;
             Size = size;
         }

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileSpec.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileSpec.cs
@@ -20,8 +20,8 @@ namespace Microsoft.NET.HostModel.Bundle
 
         public FileSpec(string sourcePath, string bundleRelativePath)
         {
-            SourcePath = NormalizeDirectorySeparator(sourcePath);
-            BundleRelativePath = NormalizeDirectorySeparator(bundleRelativePath);
+            SourcePath = sourcePath;
+            BundleRelativePath = bundleRelativePath;
             Excluded = false;
         }
 
@@ -32,16 +32,6 @@ namespace Microsoft.NET.HostModel.Bundle
         }
 
         public override string ToString() => $"SourcePath: {SourcePath}, RelativePath: {BundleRelativePath} {(Excluded ? "[Excluded]" : "")}";
-
-        private static string NormalizeDirectorySeparator(string path)
-        {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                return path;
-            }
-
-            return path.Replace('\\', '/');
-        }
     }
 }
 

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileSpec.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileSpec.cs
@@ -20,8 +20,8 @@ namespace Microsoft.NET.HostModel.Bundle
 
         public FileSpec(string sourcePath, string bundleRelativePath)
         {
-            SourcePath = sourcePath;
-            BundleRelativePath = bundleRelativePath;
+            SourcePath = NormalizeDirectorySeparator(sourcePath);
+            BundleRelativePath = NormalizeDirectorySeparator(bundleRelativePath);
             Excluded = false;
         }
 
@@ -32,6 +32,16 @@ namespace Microsoft.NET.HostModel.Bundle
         }
 
         public override string ToString() => $"SourcePath: {SourcePath}, RelativePath: {BundleRelativePath} {(Excluded ? "[Excluded]" : "")}";
+
+        private static string NormalizeDirectorySeparator(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return path;
+            }
+
+            return path.Replace('\\', '/');
+        }
     }
 }
 


### PR DESCRIPTION
The SDK uses a [backslash as a directory separator](https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L556) for copied satellite assemblies, which causes trouble when generating a single file bundle in Unix, where it's completely valid to use `\` in filenames, thus erroneously embedding these files as 'en-US\Something.resource.dll'.