### PR TITLE
Revert "FormUrlEncodedContent - make key non Nullable (#40267)"

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
@@ -12,13 +12,13 @@ namespace System.Net.Http
 {
     public class FormUrlEncodedContent : ByteArrayContent
     {
-        public FormUrlEncodedContent(IEnumerable<KeyValuePair<string, string?>> nameValueCollection)
+        public FormUrlEncodedContent(IEnumerable<KeyValuePair<string?, string?>> nameValueCollection)
             : base(GetContentByteArray(nameValueCollection))
         {
             Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
         }
 
-        private static byte[] GetContentByteArray(IEnumerable<KeyValuePair<string, string?>> nameValueCollection)
+        private static byte[] GetContentByteArray(IEnumerable<KeyValuePair<string?, string?>> nameValueCollection)
         {
             if (nameValueCollection == null)
             {
@@ -27,7 +27,7 @@ namespace System.Net.Http
 
             // Encode and concatenate data
             StringBuilder builder = new StringBuilder();
-            foreach (KeyValuePair<string, string?> pair in nameValueCollection)
+            foreach (KeyValuePair<string?, string?> pair in nameValueCollection)
             {
                 if (builder.Length > 0)
                 {


### PR DESCRIPTION
The issue is not so straightforward.
`FormUrlEncodedContent` in its logic expects `null` values in either key or a value and converts them to `String.Empty`, see method [`Encode`](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs#L37-L39).

By removing nullability from the key, we are removing ability to pass null values and have them encoded as empty strings (which has been allowed up until this change). This might actually break someone.

Proper solution to the original problem from #38494 could be to introduce a new ctor overload accepting `Dictionary<string, string>`.