### PR TITLE
Non-validated HttpHeaders enumeration

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -523,13 +523,13 @@ namespace System.Net.Http.Headers
     public readonly struct HeaderStringValues : System.Collections.Generic.IEnumerable<string>
     {
         public HeaderStringValues(string value) { }
-        public HeaderStringValues(System.Collections.Generic.IEnumerable<string?> value) { }
+        public HeaderStringValues(System.Collections.Generic.IEnumerable<string> value) { }
         public Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<string> System.Collections.Generic.IEnumerable<string>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public struct Enumerator : System.Collections.Generic.IEnumerator<string>
         {
-            public Enumerator(System.Collections.Generic.IEnumerable<string?>? values, string? value) { }
+            public Enumerator(System.Collections.Generic.IEnumerable<string>? values, string? value) { }
             public bool MoveNext() { throw null; }
             public readonly string Current { get { throw null; } }
             public void Dispose() { throw null; }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -474,6 +474,23 @@ namespace System.Net.Http.Headers
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.EntityTagHeaderValue? parsedValue) { throw null; }
     }
+    public readonly partial struct HeaderStringValues : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
+    {
+        public HeaderStringValues(System.Collections.Generic.IEnumerable<string> value) { throw null; }
+        public HeaderStringValues(string value) { throw null; }
+        public System.Net.Http.Headers.HeaderStringValues.Enumerator GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<string> System.Collections.Generic.IEnumerable<string>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<string>, System.Collections.IEnumerator, System.IDisposable
+        {
+            public Enumerator(System.Collections.Generic.IEnumerable<string>? values, string? value) { throw null; }
+            public readonly string Current { get { throw null; } }
+            object? System.Collections.IEnumerator.Current { get { throw null; } }
+            public void Dispose() { }
+            public bool MoveNext() { throw null; }
+            void System.Collections.IEnumerator.Reset() { }
+        }
+    }
     public sealed partial class HttpContentHeaders : System.Net.Http.Headers.HttpHeaders
     {
         internal HttpContentHeaders() { }
@@ -492,7 +509,7 @@ namespace System.Net.Http.Headers
     public abstract partial class HttpHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Collections.Generic.IEnumerable<string>>>, System.Collections.IEnumerable
     {
         protected HttpHeaders() { }
-        public HttpHeadersNonValidated NonValidated { get { throw null; } }
+        public System.Net.Http.Headers.HttpHeadersNonValidated NonValidated { get { throw null; } }
         public void Add(string name, System.Collections.Generic.IEnumerable<string?> values) { }
         public void Add(string name, string? value) { }
         public void Clear() { }
@@ -506,35 +523,18 @@ namespace System.Net.Http.Headers
         public bool TryAddWithoutValidation(string name, string? value) { throw null; }
         public bool TryGetValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
     }
-    public readonly struct HttpHeadersNonValidated : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>>
+    public readonly partial struct HttpHeadersNonValidated : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>, System.Collections.IEnumerable
     {
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>> GetEnumerator() { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>>.GetEnumerator() { throw null; }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>> GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>>
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>, System.Collections.IEnumerator, System.IDisposable
         {
-            public bool MoveNext() { throw null; }
-            public readonly System.Collections.Generic.KeyValuePair<string, HeaderStringValues> Current { get { throw null; } }
-            public void Dispose() { throw null; }
+            public readonly System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues> Current { get { throw null; } }
             object? System.Collections.IEnumerator.Current { get { throw null; } }
-            void System.Collections.IEnumerator.Reset() { throw null; }
-        }
-    }
-    public readonly struct HeaderStringValues : System.Collections.Generic.IEnumerable<string>
-    {
-        public HeaderStringValues(string value) { }
-        public HeaderStringValues(System.Collections.Generic.IEnumerable<string> value) { }
-        public Enumerator GetEnumerator() { throw null; }
-        System.Collections.Generic.IEnumerator<string> System.Collections.Generic.IEnumerable<string>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public struct Enumerator : System.Collections.Generic.IEnumerator<string>
-        {
-            public Enumerator(System.Collections.Generic.IEnumerable<string>? values, string? value) { }
+            public void Dispose() { }
             public bool MoveNext() { throw null; }
-            public readonly string Current { get { throw null; } }
-            public void Dispose() { throw null; }
-            object? System.Collections.IEnumerator.Current { get { throw null; } }
-            void System.Collections.IEnumerator.Reset() { throw null; }
+            void System.Collections.IEnumerator.Reset() { }
         }
     }
     public sealed partial class HttpHeaderValueCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable where T : class

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -483,7 +483,8 @@ namespace System.Net.Http.Headers
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<string>, System.Collections.IEnumerator, System.IDisposable
         {
-            public Enumerator(System.Collections.Generic.IEnumerable<string>? values, string? value) { throw null; }
+            public Enumerator(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+            public Enumerator(string value) { throw null; }
             public readonly string Current { get { throw null; } }
             object? System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -483,8 +483,6 @@ namespace System.Net.Http.Headers
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<string>, System.Collections.IEnumerator, System.IDisposable
         {
-            public Enumerator(System.Collections.Generic.IEnumerable<string> values) { throw null; }
-            public Enumerator(string value) { throw null; }
             public readonly string Current { get { throw null; } }
             object? System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -492,6 +492,7 @@ namespace System.Net.Http.Headers
     public abstract partial class HttpHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Collections.Generic.IEnumerable<string>>>, System.Collections.IEnumerable
     {
         protected HttpHeaders() { }
+        public HttpHeadersNonValidated NonValidated { get { throw null; } }
         public void Add(string name, System.Collections.Generic.IEnumerable<string?> values) { }
         public void Add(string name, string? value) { }
         public void Clear() { }
@@ -504,6 +505,37 @@ namespace System.Net.Http.Headers
         public bool TryAddWithoutValidation(string name, System.Collections.Generic.IEnumerable<string?> values) { throw null; }
         public bool TryAddWithoutValidation(string name, string? value) { throw null; }
         public bool TryGetValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
+    }
+    public readonly struct HttpHeadersNonValidated : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>>
+    {
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>> GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, HeaderStringValues>>
+        {
+            public bool MoveNext() { throw null; }
+            public readonly System.Collections.Generic.KeyValuePair<string, HeaderStringValues> Current { get { throw null; } }
+            public void Dispose() { throw null; }
+            object? System.Collections.IEnumerator.Current { get { throw null; } }
+            void System.Collections.IEnumerator.Reset() { throw null; }
+        }
+    }
+    public readonly struct HeaderStringValues : System.Collections.Generic.IEnumerable<string>
+    {
+        public HeaderStringValues(string value) { }
+        public HeaderStringValues(System.Collections.Generic.IEnumerable<string?> value) { }
+        public Enumerator GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<string> System.Collections.Generic.IEnumerable<string>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public struct Enumerator : System.Collections.Generic.IEnumerator<string>
+        {
+            public Enumerator(System.Collections.Generic.IEnumerable<string?>? values, string? value) { }
+            public bool MoveNext() { throw null; }
+            public readonly string Current { get { throw null; } }
+            public void Dispose() { throw null; }
+            object? System.Collections.IEnumerator.Current { get { throw null; } }
+            void System.Collections.IEnumerator.Reset() { throw null; }
+        }
     }
     public sealed partial class HttpHeaderValueCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable where T : class
     {

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -476,7 +476,7 @@ namespace System.Net.Http.Headers
     }
     public readonly partial struct HeaderStringValues : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
-        public HeaderStringValues(System.Collections.Generic.IEnumerable<string> value) { throw null; }
+        public HeaderStringValues(System.Collections.Generic.IEnumerable<string> values) { throw null; }
         public HeaderStringValues(string value) { throw null; }
         public System.Net.Http.Headers.HeaderStringValues.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<string> System.Collections.Generic.IEnumerable<string>.GetEnumerator() { throw null; }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -524,7 +524,7 @@ namespace System.Net.Http.Headers
     }
     public readonly partial struct HttpHeadersNonValidated : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>, System.Collections.IEnumerable
     {
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>> GetEnumerator() { throw null; }
+        public System.Net.Http.Headers.HttpHeadersNonValidated.Enumerator GetEnumerator() { throw null; }
         System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, System.Net.Http.Headers.HeaderStringValues>>, System.Collections.IEnumerator, System.IDisposable

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1426,6 +1426,7 @@ namespace System.Net.Http.Headers
             void IEnumerator.Reset()
             {
                 _headerStore.Reset();
+                Current = default;
             }
         }
     }
@@ -1505,6 +1506,7 @@ namespace System.Net.Http.Headers
             void IEnumerator.Reset()
             {
                 _values?.Reset();
+                Current = default!;
                 _completed = false;
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1432,7 +1432,7 @@ namespace System.Net.Http.Headers
 
     public readonly struct HeaderStringValues : IEnumerable<string>
     {
-        private readonly IEnumerable<string?>? _values;
+        private readonly IEnumerable<string>? _values;
         private readonly string? _value;
 
         public HeaderStringValues(string value)
@@ -1441,7 +1441,7 @@ namespace System.Net.Http.Headers
             _values = null;
         }
 
-        public HeaderStringValues(IEnumerable<string?> value)
+        public HeaderStringValues(IEnumerable<string> value)
         {
             _values = value;
             _value = null;
@@ -1455,11 +1455,11 @@ namespace System.Net.Http.Headers
 
         public struct Enumerator : IEnumerator<string>
         {
-            private readonly IEnumerator<string?>? _values;
+            private readonly IEnumerator<string>? _values;
             private readonly string? _value;
             private bool _completed;
 
-            public Enumerator(IEnumerable<string?>? values, string? value)
+            public Enumerator(IEnumerable<string>? values, string? value)
             {
                 _values = values?.GetEnumerator();
                 _value = value;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1055,8 +1055,8 @@ namespace System.Net.Http.Headers
         {
             Debug.Assert(info != null);
 
-            // We can get here only through Add methods which treat `value` as already parsed and do not add it into RawValue,
-            // so we have to manually add it into OriginalRawValue to return from non-validating enumeration.
+            // We can get here only through Add methods which treat 'value' as already parsed and do not add it into RawValue,
+            // so we have to manually add it into OriginalRawValue for it to be returned from non-validating enumeration.
             AddValueToOriginalRawValue(info, value);
 
             if (descriptor.Parser == null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -594,6 +594,8 @@ namespace System.Net.Http.Headers
         {
             HeaderStoreItemInfo destinationInfo = CreateAndAddHeaderToStore(descriptor);
 
+            destinationInfo.OriginalRawValue = sourceInfo.OriginalRawValue;
+
             // We have custom header values. The parsed values are strings.
             if (descriptor.Parser == null)
             {
@@ -853,6 +855,11 @@ namespace System.Net.Http.Headers
 
             bool result = TryParseAndAddRawHeaderValue(descriptor, info, value, false);
 
+            if (result)
+            {
+                AddValueToOriginalRawValue(info, value);
+            }
+
             if (result && addToStore && (info.ParsedValue != null))
             {
                 // If we get here, then the value could be parsed correctly. If we created a new HeaderStoreItemInfo, add
@@ -1037,15 +1044,20 @@ namespace System.Net.Http.Headers
             }
         }
 
+        private void AddValueToOriginalRawValue(HeaderStoreItemInfo info, string? value)
+        {
+            object? originalRawValue = info.OriginalRawValue;
+            AddValueToStoreValue<string>(value ?? string.Empty, ref originalRawValue);
+            info.OriginalRawValue = originalRawValue;
+        }
+
         private void ParseAndAddValue(HeaderDescriptor descriptor, HeaderStoreItemInfo info, string? value)
         {
             Debug.Assert(info != null);
 
             // We can get here only through Add methods which treat `value` as already parsed and do not add it into RawValue,
             // so we have to manually add it into OriginalRawValue to return from non-validating enumeration.
-            object? originalRawValue = info.OriginalRawValue;
-            AddValueToStoreValue<string>(value ?? string.Empty, ref originalRawValue);
-            info.OriginalRawValue = originalRawValue;
+            AddValueToOriginalRawValue(info, value);
 
             if (descriptor.Parser == null)
             {

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1678,15 +1678,15 @@ namespace System.Net.Http.Tests
             Assert.Equal("custom0", enumerator.Current.Value.ElementAt(0));
 
             // Starting using the non-validating enumerator will NOT trigger parsing of raw values.
-            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
 
             Assert.True(enumerator.MoveNext());
             Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
             Assert.Equal(2, enumerator.Current.Value.Count());
-            Assert.Equal(parsedPrefix + "1", enumerator.Current.Value.ElementAt(0));
-            Assert.Equal(parsedPrefix + "2", enumerator.Current.Value.ElementAt(1));
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.ElementAt(0));
+            Assert.Equal(rawPrefix + "2", enumerator.Current.Value.ElementAt(1));
 
-            Assert.Equal(0, headers.Parser.TryParseValueCallCount);
+            Assert.Equal(1, headers.Parser.TryParseValueCallCount);
 
             Assert.False(enumerator.MoveNext(), "Only 2 values expected, but enumerator returns a third one.");
         }
@@ -1702,13 +1702,10 @@ namespace System.Net.Http.Tests
 
             Assert.True(enumerator.MoveNext());
             Assert.Equal(customHeaderName, enumerator.Current.Key);
-            Assert.True(enumerator.MoveNext());
-            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
-            Assert.Equal(2, enumerator.Current.Value.Count());
+            Assert.Equal(1, enumerator.Current.Value.Count());
             Assert.Equal(string.Empty, enumerator.Current.Value.ElementAt(0));
-            Assert.Equal(string.Empty, enumerator.Current.Value.ElementAt(1));
 
-            Assert.False(enumerator.MoveNext(), "Only 2 values expected, but enumerator returns a third one.");
+            Assert.False(enumerator.MoveNext(), "Only the (empty) custom value should be returned.");
         }
 
         [Fact]
@@ -1720,16 +1717,16 @@ namespace System.Net.Http.Tests
             headers.Add("custom3", "customValue3");
             headers.Add("custom4", "customValue4");
 
-            System.Collections.IEnumerable headersAsIEnumerable = headers.NonValidated;
+            IEnumerable headersAsIEnumerable = headers.NonValidated;
 
             var enumerator = headersAsIEnumerable.GetEnumerator();
 
-            KeyValuePair<string, IEnumerable<HeaderStringValues>> currentValue;
+            KeyValuePair<string, HeaderStringValues> currentValue;
 
             for (int i = 1; i <= 4; i++)
             {
                 Assert.True(enumerator.MoveNext());
-                currentValue = (KeyValuePair<string, IEnumerable<HeaderStringValues>>)enumerator.Current;
+                currentValue = (KeyValuePair<string, HeaderStringValues>)enumerator.Current;
                 Assert.Equal("custom" + i, currentValue.Key);
                 Assert.Equal(1, currentValue.Value.Count());
             }

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1735,6 +1735,90 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
+        public void NonValidated_AddAndUpdateSingleValueHeader_EnumeratorReturnsLatestValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(headers.Descriptor, rawPrefix + "1");
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.Single());
+            Assert.False(enumerator.MoveNext());
+
+            headers.SetParsedValue(headers.Descriptor, rawPrefix + "2");
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "2", enumerator.Current.Value.Single());
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void NonValidated_AddAndRemoveSingleValueHeader_EnumeratorReturnsNoValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(headers.Descriptor, rawPrefix + "1");
+            headers.Add(customHeaderName, "customValue1");
+            headers.RemoveParsedValue(headers.Descriptor, parsedPrefix + "1");
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(customHeaderName, enumerator.Current.Key);
+            Assert.Equal("customValue1", enumerator.Current.Value.Single());
+            Assert.False(enumerator.MoveNext());
+
+            headers.Add(headers.Descriptor, rawPrefix + "1");
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.Single());
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(customHeaderName, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal("customValue1", enumerator.Current.Value.Single());
+
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void NonValidated_AddAndRemoveValueToMultivalueHeader_EnumeratorReturnsLatestParsedValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(headers.Descriptor, rawPrefix + "1");
+            headers.Add(headers.Descriptor, rawPrefix + "2");
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(2, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.ElementAt(0));
+            Assert.Equal(rawPrefix + "2", enumerator.Current.Value.ElementAt(1));
+            Assert.False(enumerator.MoveNext());
+
+            headers.RemoveParsedValue(headers.Descriptor, parsedPrefix + "1");
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(parsedPrefix + "2", enumerator.Current.Value.ElementAt(0));
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
         public void AddParsedValue_AddSingleValueToNonExistingHeader_HeaderGetsCreatedAndValueAdded()
         {
             Uri headerValue = new Uri("http://example.org/");

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1976,6 +1976,32 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
+        public void NonValidated_TryAddWithoutValidationThenAddParsedValue_EnumeratorReturnsValuesReconstructedFromParsed()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(headers.Descriptor, rawPrefix + "1");
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.ElementAt(0));
+            Assert.False(enumerator.MoveNext());
+
+            headers.AddParsedValue(headers.Descriptor, rawPrefix + "2");
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(2, enumerator.Current.Value.Count());
+            Assert.Equal(parsedPrefix + "1", enumerator.Current.Value.ElementAt(0));
+            Assert.Equal(rawPrefix + "2", enumerator.Current.Value.ElementAt(1));
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
         public void NonValidated_AddAnotherHeadersCollection_EnumeratorReturnsAllClonedRawValues()
         {
             MockHeaders anotherHeaders = new MockHeaders();
@@ -2035,6 +2061,32 @@ namespace System.Net.Http.Tests
             Assert.Equal(2, enumerator.Current.Value.Count());
             Assert.Equal(rawPrefix + "1", enumerator.Current.Value.ElementAt(0));
             Assert.Equal(rawPrefix + "2", enumerator.Current.Value.ElementAt(1));
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void NonValidated_MutableHeaderValueChangedExternally_EnumeratorReturnsValueReconstructedFromParsed()
+        {
+            HttpContentHeaders headers = new HttpContentHeaders(new StringContent("test1"));
+            const string RawContentTypeValue = "text/plain; charset=ASCII";
+            headers.TryAddWithoutValidation(KnownHeaders.ContentType.Descriptor, RawContentTypeValue);
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(KnownHeaders.ContentType.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(RawContentTypeValue, enumerator.Current.Value.ElementAt(0));
+            Assert.False(enumerator.MoveNext());
+
+            headers.ContentType.CharSet = "UTF-8";
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(KnownHeaders.ContentType.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal("text/plain; charset=UTF-8", enumerator.Current.Value.ElementAt(0));
             Assert.False(enumerator.MoveNext());
         }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1654,6 +1654,7 @@ namespace System.Net.Http.Tests
 
             var enumerator = headers.NonValidated.GetEnumerator();
             Assert.False(enumerator.MoveNext());
+            enumerator.Dispose();
         }
 
         [Fact]
@@ -1815,6 +1816,109 @@ namespace System.Net.Http.Tests
             Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
             Assert.Equal(1, enumerator.Current.Value.Count());
             Assert.Equal(parsedPrefix + "2", enumerator.Current.Value.ElementAt(0));
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void NonValidated_AddAndUpdateRawSingleValueHeader_EnumeratorReturnsLatestValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(headers.Descriptor, rawPrefix + "1");
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.Single());
+            Assert.False(enumerator.MoveNext());
+
+            headers.SetParsedValue(headers.Descriptor, rawPrefix + "2");
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "2", enumerator.Current.Value.Single());
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void NonValidated_AddAndRemoveRawSingleValueHeader_EnumeratorReturnsNoValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(headers.Descriptor, rawPrefix + "1");
+            headers.TryAddWithoutValidation(customHeaderName, "customValue1");
+            headers.RemoveParsedValue(headers.Descriptor, parsedPrefix + "1");
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(customHeaderName, enumerator.Current.Key);
+            Assert.Equal("customValue1", enumerator.Current.Value.Single());
+            Assert.False(enumerator.MoveNext());
+
+            headers.Add(headers.Descriptor, rawPrefix + "1");
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.Single());
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(customHeaderName, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal("customValue1", enumerator.Current.Value.Single());
+
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void NonValidated_AddAndRemoveRawValueToMultivalueHeader_EnumeratorReturnsLatestParsedValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.TryAddWithoutValidation(headers.Descriptor, rawPrefix + "1");
+            headers.TryAddWithoutValidation(headers.Descriptor, rawPrefix + "2");
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(2, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.ElementAt(0));
+            Assert.Equal(rawPrefix + "2", enumerator.Current.Value.ElementAt(1));
+            Assert.False(enumerator.MoveNext());
+
+            headers.RemoveParsedValue(headers.Descriptor, parsedPrefix + "1");
+
+            enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(parsedPrefix + "2", enumerator.Current.Value.ElementAt(0));
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void NonValidated_AddRawHeaderValueThenRetrieveItAsParsed_EnumeratorReturnsOriginalRawValue()
+        {
+            MockHeaders headers = new MockHeaders();
+            headers.Add(headers.Descriptor, rawPrefix + "1");
+
+            object? parsedValue = headers.GetParsedValues(headers.Descriptor);
+
+            Assert.Equal(parsedPrefix + "1", parsedValue);
+
+            var enumerator = headers.NonValidated.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(headers.Descriptor.Name, enumerator.Current.Key);
+            Assert.Equal(1, enumerator.Current.Value.Count());
+            Assert.Equal(rawPrefix + "1", enumerator.Current.Value.ElementAt(0));
             Assert.False(enumerator.MoveNext());
         }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1907,7 +1907,7 @@ namespace System.Net.Http.Tests
         public void NonValidated_AddRawHeaderValueThenRetrieveItAsParsed_EnumeratorReturnsOriginalRawValue()
         {
             MockHeaders headers = new MockHeaders();
-            headers.Add(headers.Descriptor, rawPrefix + "1");
+            headers.TryAddWithoutValidation(headers.Descriptor, rawPrefix + "1");
 
             object? parsedValue = headers.GetParsedValues(headers.Descriptor);
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1658,6 +1658,33 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
+        public void NonValidated_GetDefaultHttpHeadersNonValidatedEnumerator_ReturnsEmptyEnumerator()
+        {
+            var enumerator = default(HttpHeadersNonValidated.Enumerator);
+            Assert.False(enumerator.MoveNext());
+            Assert.Equal(default(KeyValuePair<string, HeaderStringValues>), enumerator.Current);
+            enumerator.Dispose();
+        }
+
+        [Fact]
+        public void NonValidated_GetEnumeratorFromUninitializedHeaderStringValues_ReturnsEmptyEnumerator()
+        {
+            var enumerator = default(HeaderStringValues).GetEnumerator();
+            Assert.False(enumerator.MoveNext());
+            Assert.Null(enumerator.Current);
+            enumerator.Dispose();
+        }
+
+        [Fact]
+        public void NonValidated_GetDefaultHeaderStringValuesEnumerator_ReturnsEmptyEnumerator()
+        {
+            var enumerator = default(HeaderStringValues.Enumerator);
+            Assert.False(enumerator.MoveNext());
+            Assert.Null(enumerator.Current);
+            enumerator.Dispose();
+        }
+
+        [Fact]
         public void NonValidated_FirstHeaderWithOneValueSecondHeaderWithTwoValues_EnumeratorReturnsTwoHeaders()
         {
             MockHeaders headers = new MockHeaders();


### PR DESCRIPTION
New `HttpHeaders.NonValidated` property returns a `HttpHeadersNonValidated` instance enumerating headers' raw values without any parsing or validation. It does **not change existing parsing logic**, but introduces a new `OriginalRawValue` property storing the raw header value. The old `RawValue` gets reset after each parsing, but `OriginalRawValue` preserves its value. If `RawValue` doesn't exist at all (in example, this happens when a value set through strongly-typed accessors), `HttpHeadersNonValidated` does call a parser to convert `ParsedValue` to a string representation the same way as it's done in the default validating enumeration logic.

@geoffkizer @karelz  This PR looks **totally safe** from the perspective of the existing parsing logic.

Fixes #35126

P.S. I will add a few more unit tests here.