### PR TITLE
Correctly handle a cached CRL with no NextUpdate

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -96,6 +96,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
         internal bool CorruptRevocationSignature { get; set; }
         internal DateTimeOffset? RevocationExpiration { get; set; }
         internal bool CorruptRevocationIssuerName { get; set; }
+        internal bool OmitNextUpdateInCrl { get; set; }
 
         // All keys created in this method are smaller than recommended,
         // but they only live for a few seconds (at most),
@@ -343,7 +344,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                     writer.WriteUtcTime(_cert.NotBefore);
 
                     // nextUpdate
-                    writer.WriteUtcTime(RevocationExpiration.Value);
+                    if (!OmitNextUpdateInCrl)
+                    {
+                        writer.WriteUtcTime(RevocationExpiration.Value);
+                    }
                 }
                 else
                 {
@@ -351,7 +355,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                     writer.WriteUtcTime(now);
 
                     // nextUpdate
-                    writer.WriteUtcTime(newExpiry);
+                    if (!OmitNextUpdateInCrl)
+                    {
+                        writer.WriteUtcTime(newExpiry);
+                    }
                 }
 
                 // revokedCertificates (don't write down if empty)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -91,13 +91,21 @@ namespace Internal.Cryptography.Pal
                         return false;
                     }
 
+                    IntPtr nextUpdatePtr = Interop.Crypto.GetX509CrlNextUpdate(crl);
+
+                    // If there is no crl.NextUpdate, this indicates that the CA is not providing
+                    // any more updates to the CRL.
+                    if (nextUpdatePtr == IntPtr.Zero)
+                    {
+                        return false;
+                    }
+
                     // If crl.LastUpdate is in the past, downloading a new version isn't really going
                     // to help, since we can't rewind the Internet. So this is just going to fail, but
                     // at least it can fail without using the network.
                     //
                     // If crl.NextUpdate is in the past, try downloading a newer version.
-                    DateTime nextUpdate = OpenSslX509CertificateReader.ExtractValidityDateTime(
-                        Interop.Crypto.GetX509CrlNextUpdate(crl));
+                    DateTime nextUpdate = OpenSslX509CertificateReader.ExtractValidityDateTime(nextUpdatePtr);
 
                     // OpenSSL is going to convert our input time to universal, so we should be in Local or
                     // Unspecified (local-assumed).

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -91,6 +91,11 @@ namespace Internal.Cryptography.Pal
                         return false;
                     }
 
+                    // If crl.LastUpdate is in the past, downloading a new version isn't really going
+                    // to help, since we can't rewind the Internet. So this is just going to fail, but
+                    // at least it can fail without using the network.
+                    //
+                    // If crl.NextUpdate is in the past, try downloading a newer version.
                     IntPtr nextUpdatePtr = Interop.Crypto.GetX509CrlNextUpdate(crl);
                     DateTime nextUpdate;
 
@@ -113,11 +118,6 @@ namespace Internal.Cryptography.Pal
                     }
                     else
                     {
-                        // If crl.LastUpdate is in the past, downloading a new version isn't really going
-                        // to help, since we can't rewind the Internet. So this is just going to fail, but
-                        // at least it can fail without using the network.
-                        //
-                        // If crl.NextUpdate is in the past, try downloading a newer version.
                         nextUpdate = OpenSslX509CertificateReader.ExtractValidityDateTime(nextUpdatePtr);
                     }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -940,6 +940,54 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 });
         }
 
+        [Fact]
+        public static void TestRevocationWithNoNextUpdate_NotRevoked()
+        {
+            SimpleTest(
+                PkiOptions.CrlEverywhere,
+                (root, intermediate, endEntity, holder) =>
+                {
+                    intermediate.OmitNextUpdateInCrl = true;
+
+                    // Build a chain once to get the no NextUpdate in the CRL
+                    // cache. We don't care about the build result.
+                    holder.Chain.Build(endEntity);
+
+                    SimpleRevocationBody(
+                        holder,
+                        endEntity,
+                        rootRevoked: false,
+                        issrRevoked: false,
+                        leafRevoked: false);
+                });
+        }
+
+        [Fact]
+        public static void TestRevocationWithNoNextUpdate_Revoked()
+        {
+            SimpleTest(
+                PkiOptions.CrlEverywhere,
+                (root, intermediate, endEntity, holder) =>
+                {
+                    intermediate.OmitNextUpdateInCrl = true;
+
+                    DateTimeOffset now = DateTimeOffset.UtcNow;
+                    intermediate.Revoke(endEntity, now);
+                    holder.Chain.ChainPolicy.VerificationTime = now.AddSeconds(1).UtcDateTime;
+
+                    // Build a chain once to get the no NextUpdate in the CRL
+                    // cache. We don't care about the build result.
+                    holder.Chain.Build(endEntity);
+
+                    SimpleRevocationBody(
+                        holder,
+                        endEntity,
+                        rootRevoked: false,
+                        issrRevoked: false,
+                        leafRevoked: true);
+                });
+        }
+
         private static void RevokeEndEntityWithInvalidRevocation(
             ChainHolder holder,
             CertificateAuthority intermediate,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -941,6 +941,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/31249", TestPlatforms.OSX)]
         public static void TestRevocationWithNoNextUpdate_NotRevoked()
         {
             SimpleTest(
@@ -963,6 +964,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/31249", TestPlatforms.OSX)]
         public static void TestRevocationWithNoNextUpdate_Revoked()
         {
             SimpleTest(


### PR DESCRIPTION
Fixes #40708 