### PR TITLE
Enable LoadInDefaultContext test on Browser

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -83,7 +83,6 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39202", TestPlatforms.Browser)]
         public void LoadInDefaultContext()
         {
             // This will attempt to load an assembly, by path, in the Default Load context via the Resolving event

--- a/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -61,7 +61,10 @@ namespace System.Runtime.Loader.Tests
 
         private static string GetDefaultAssemblyLoadDirectory()
         {
-            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (!PlatformDetection.IsBrowser)
+                return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            else
+                return "/";
         }
 
         private Assembly ResolveAssembly(AssemblyLoadContext sender, AssemblyName assembly)


### PR DESCRIPTION
I think this might have been fixed as part of https://github.com/dotnet/runtime/commit/e10da01d6557be2238ab55218f947001a3b35e57, so enable and see what happens. If not, I'll update the build to add the test assemblies to the VFS.

Fixes https://github.com/dotnet/runtime/issues/39202