### PR TITLE
Remove duplicate System.Private.CoreLib.ni.pdb symbol file from the crossgen2 symbol package.

### DIFF
--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -90,6 +90,12 @@
       <File Include="@(Crossgen2File)">
         <TargetPath>tools</TargetPath>
       </File>
+      <!-- 
+        System.Private.CoreLib's R2R pdb ends up in two locations (CoreCLR and the depproj output).
+        Remove them here and let the symbol file location infra find exactly one.
+      -->
+      <CoreLibSymbolFile Include="@(Crossgen2File)" Condition="'%(FileName)%(Extension)' == 'System.Private.CoreLib.ni.pdb'" />
+      <File Remove="@(CoreLibSymbolFile)" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
This fixes symbol validation errors due to the Crossgen2 package having the System.Private.CoreLib.ni.pdb file in the package twice at the same path.