### PR TITLE
[wasm] Remove unnecessary console messages.

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -256,7 +256,7 @@ typedef struct {
 static void*
 create_breakpoint_events (GPtrArray *ss_reqs, GPtrArray *bp_reqs, MonoJitInfo *ji, EventKind kind)
 {
-	printf ("ss_reqs %d bp_reqs %d\n", ss_reqs->len, bp_reqs->len);
+	DEBUG_PRINTF (1, "ss_reqs %d bp_reqs %d\n", ss_reqs->len, bp_reqs->len);
 	if ((ss_reqs && ss_reqs->len) || (bp_reqs && bp_reqs->len)) {
 		BpEvents *evts = g_new0 (BpEvents, 1); //just a non-null value to make sure we can raise it on process_breakpoint_events
 		evts->is_ss = (ss_reqs && ss_reqs->len);
@@ -283,7 +283,7 @@ no_seq_points_found (MonoMethod *method, int offset)
 	/*
 	 * This can happen in full-aot mode with assemblies AOTed without the 'soft-debug' option to save space.
 	 */
-	printf ("Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
+	DEBUG_PRINTF (1, "Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
 }
 
 #define DBG_NOT_SUSPENDED 1
@@ -291,7 +291,7 @@ no_seq_points_found (MonoMethod *method, int offset)
 static int
 ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 {
-	printf ("ss_create_init_args\n");
+	DEBUG_PRINTF (1, "ss_create_init_args\n");
 	int dummy = 0;
 	ss_req->start_sp = ss_req->last_sp = &dummy;
 	compute_frames ();

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -697,7 +697,7 @@ var MonoSupportLib = {
 		},
 
 		mono_wasm_start_single_stepping: function (kind) {
-			console.log (">> mono_wasm_start_single_stepping " + kind);
+			console.debug (">> mono_wasm_start_single_stepping " + kind);
 			if (!this.mono_wasm_setup_single_step)
 				this.mono_wasm_setup_single_step = Module.cwrap ("mono_wasm_setup_single_step", 'number', [ 'number']);
 
@@ -869,7 +869,7 @@ var MonoSupportLib = {
 			if (ENVIRONMENT_IS_NODE) {
 				var fs = require('fs');
 				return function (asset) {
-					console.log ("MONO_WASM: Loading... " + asset);
+					console.debug ("MONO_WASM: Loading... " + asset);
 					var binary = fs.readFileSync (asset);
 					var resolve_func2 = function (resolve, reject) {
 						resolve (new Uint8Array (binary));
@@ -902,7 +902,7 @@ var MonoSupportLib = {
 			if (ctx.tracing)
 				console.log ("MONO_WASM: Loaded:", asset.name, "size", bytes.length, "from", url);
 			else
-				console.log ("MONO_WASM: Loaded:", asset.name);
+				console.debug ("MONO_WASM: Loaded:", asset.name);
 
 			var virtualName = asset.virtual_path || asset.name;
 			var offset = null;
@@ -1079,7 +1079,7 @@ var MonoSupportLib = {
 
 			var load_runtime = Module.cwrap ('mono_wasm_load_runtime', null, ['string', 'number']);
 
-			console.log ("MONO_WASM: Initializing mono runtime");
+			console.debug ("MONO_WASM: Initializing mono runtime");
 
 			this.mono_wasm_globalization_init (args.globalization_mode);
 
@@ -1189,7 +1189,7 @@ var MonoSupportLib = {
 								(asset.name.match (/\.pdb$/) && MONO.mono_wasm_ignore_pdb_load_errors);
 
 							if (isOk)
-								console.log (msg);
+								console.debug (msg);
 							else {
 								console.error (msg);
 								throw new Error (msg);
@@ -1248,9 +1248,9 @@ var MonoSupportLib = {
 
 			if (!invariantMode) {
 				if (this.num_icu_assets_loaded_successfully > 0) {
-					console.log ("MONO_WASM: ICU data archive(s) loaded, disabling invariant mode");
+					console.debug ("MONO_WASM: ICU data archive(s) loaded, disabling invariant mode");
 				} else if (globalization_mode !== "icu") {
-					console.log ("MONO_WASM: ICU data archive(s) not loaded, using invariant globalization mode");
+					console.debug ("MONO_WASM: ICU data archive(s) not loaded, using invariant globalization mode");
 					invariantMode = true;
 				} else {
 					var msg = "invariant globalization mode is inactive and no ICU data archives were loaded";
@@ -1754,7 +1754,6 @@ var MonoSupportLib = {
 	},
 
 	mono_wasm_fire_bp: function () {
-		console.log ("mono_wasm_fire_bp");
 		// eslint-disable-next-line no-debugger
 		debugger;
 	},

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -901,8 +901,6 @@ var MonoSupportLib = {
 			var bytes = new Uint8Array (blob);
 			if (ctx.tracing)
 				console.log ("MONO_WASM: Loaded:", asset.name, "size", bytes.length, "from", url);
-			else
-				console.debug ("MONO_WASM: Loaded:", asset.name);
 
 			var virtualName = asset.virtual_path || asset.name;
 			var offset = null;


### PR DESCRIPTION
Changing some console.log to console.debug to not pollute the console.
Changing printf to DEBUG_PRINTF to follow the debug level chosen by user.
Remove unnecessary console.log.
Fix #40721 