### PR TITLE
[wasm] Skip System.IO.Filesystem tests that involve trailing slash

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -244,7 +244,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40536", TestPlatforms.Browser)]
+        [PlatformSpecific(~TestPlatforms.Browser)] // Trailing slashes do not work on browser
         public void RecursiveDeleteWithTrailingSlash()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
@@ -173,7 +173,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40536", TestPlatforms.Browser)]
+        [PlatformSpecific(~TestPlatforms.Browser)] // Trailing slashes do not work on browser
         public void TrailingDirectorySeparators()
         {
             string testDirSource = Path.Combine(TestDirectory, GetTestFileName());

--- a/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
+++ b/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
@@ -24,7 +24,7 @@ namespace System.IO.Tests
         #region UniversalTests
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40536", TestPlatforms.Browser)]
+        [PlatformSpecific(~TestPlatforms.Browser)] // Trailing slashes do not work on browser.
         public void DirectoryPathUpdatesOnMove()
         {
             //NOTE: MoveTo adds a trailing separator character to the FullName of a DirectoryInfo


### PR DESCRIPTION
Resolves #40536 

When using `Directory.Move`, `Directory.Delete`, and `DirectoryInfo.MoveTo` on wasm, `System.IO.DirectoryNotFoundException` is hit when the paths have a trailing slash, and do not error when removing that trailing slash. Since the tests specifically cover the case of trailing slash, skip these tests for Browser.