### PR TITLE
Fix initialization of DelayMethodCallThunksSection

### DIFF
--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -683,7 +683,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
         m_methodDefEntryPoints = NativeArray(&m_nativeReader, pEntryPointsDir->VirtualAddress);
     }
 
-    m_pSectionDelayLoadMethodCallThunks = m_component.FindSection(ReadyToRunSectionType::DelayLoadMethodCallThunks);
+    m_pSectionDelayLoadMethodCallThunks = m_pComposite->FindSection(ReadyToRunSectionType::DelayLoadMethodCallThunks);
 
     IMAGE_DATA_DIRECTORY * pinstMethodsDir = m_pComposite->FindSection(ReadyToRunSectionType::InstanceMethodEntryPoints);
     if (pinstMethodsDir != NULL)


### PR DESCRIPTION
This is a per-native-image, not a per-component section, therefore
we must fetch it from the composite header. As JanV discovered,
this was the cause of the biggest runtime failure bucket in
composite CG2 runs in GC stress mode.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib 