### PR TITLE
[WIP] Deadlock when creating typed HttpClient with DI and HttpClientFactory

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Extensions.Http
         private Timer _cleanupTimer;
         private readonly object _cleanupTimerLock;
         private readonly object _cleanupActiveLock;
+        private readonly HttpMessageHandlerBuilder _builder;
 
         // Collection of 'active' handlers.
         //
@@ -91,6 +92,7 @@ namespace Microsoft.Extensions.Http
             }
 
             _services = services;
+            _builder = _services.GetRequiredService<HttpMessageHandlerBuilder>();
             _scopeFactory = scopeFactory;
             _optionsMonitor = optionsMonitor;
             _filters = filters.ToArray();
@@ -103,7 +105,7 @@ namespace Microsoft.Extensions.Http
             {
                 return new Lazy<ActiveHandlerTrackingEntry>(() =>
                 {
-                    return CreateHandlerEntry(name);
+                    return CreateHandlerEntry(name, _builder);
                 }, LazyThreadSafetyMode.ExecutionAndPublication);
             };
 
@@ -148,7 +150,7 @@ namespace Microsoft.Extensions.Http
         }
 
         // Internal for tests
-        internal ActiveHandlerTrackingEntry CreateHandlerEntry(string name)
+        internal ActiveHandlerTrackingEntry CreateHandlerEntry(string name, HttpMessageHandlerBuilder builder)
         {
             IServiceProvider services = _services;
             var scope = (IServiceScope)null;
@@ -162,7 +164,6 @@ namespace Microsoft.Extensions.Http
 
             try
             {
-                HttpMessageHandlerBuilder builder = services.GetRequiredService<HttpMessageHandlerBuilder>();
                 builder.Name = name;
 
                 // This is similar to the initialization pattern in:


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/35986

Perhaps a more general fix would be to correct the DI limitation for when a singleton instantiation required a transient that is to be lazily instantiated.

I am assuming here in order to just fix HttpClientFactory issue, that it is OK to get HttpMessageHandlerBuilder first hand in the constructor and whenever we want to lazily call CreateHandlerEntry, then the builder is already available (we basically move the GetRequiredService call out of lazy block to fix the deadlock.)

Then perhaps in 6.0 we could look to also fix the DI limitation that causes us to use this workaround.

cc: @davidfowl @tarekgh @eerhardt 