### PR TITLE
[mono][interp] optimize boxing for x == null where x is value type

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5319,23 +5319,24 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 
 				const gboolean vt = mint_type (m_class_get_byval_arg (klass)) == MINT_TYPE_VT;
 
-                /* box + ldnull + ceq/cgt_un -> true/false */
-                if (*(td->ip + 5) == CEE_LDNULL) {
-                    guint8 ceq = *(td->ip + 7);
-                    if ((ceq == CEE_CEQ || ceq == CEE_CGT_UN) &&
-                        // make sure all opcodes are in the same bb
-                        !td->is_bb_start[in_offset] && !td->is_bb_start[in_offset + 5] && !td->is_bb_start[in_offset + 7]) {
-                        // clear instruction we wanted to box
-                        interp_clear_ins (td, td->last_ins);
-                        // push true or false instead
-                        SET_SIMPLE_TYPE (td->sp - 1, STACK_TYPE_I4);
-                        SIMPLE_OP (td, ceq == CEE_CEQ ? MINT_LDC_I4_0 : MINT_LDC_I4_1);
-                        td->ip += 7;
-                        if (vt)
-                            td->vt_sp -= ALIGN_TO (mono_class_value_size (klass, NULL), MINT_VT_ALIGNMENT);
-                        break;
-                    }
-                }
+				// optimize "box + ldnull + ceq/cgt_un" to true/false
+				// e.g. `t == null` in generic code when t is a vt/primitive (but not nullable)
+				if (*(td->ip + 5) == CEE_LDNULL) {
+					guint8 ceq = *(td->ip + 7);
+					if ((ceq == CEE_CEQ || ceq == CEE_CGT_UN) &&
+						// make sure all opcodes are in the same bb
+						!td->is_bb_start[in_offset] && !td->is_bb_start[in_offset + 5] && !td->is_bb_start[in_offset + 7]) {
+						// clear instruction we wanted to box
+						interp_clear_ins (td, td->last_ins);
+						// push true or false instead
+						SET_SIMPLE_TYPE (td->sp - 1, STACK_TYPE_I4);
+						SIMPLE_OP (td, ceq == CEE_CEQ ? MINT_LDC_I4_0 : MINT_LDC_I4_1);
+						td->ip += 7;
+						if (vt)
+							td->vt_sp -= ALIGN_TO (mono_class_value_size (klass, NULL), MINT_VT_ALIGNMENT);
+						break;
+					}
+				}
 
 				if (vt) {
 					size = mono_class_value_size (klass, NULL);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5319,11 +5319,15 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 
 				const gboolean vt = mint_type (m_class_get_byval_arg (klass)) == MINT_TYPE_VT;
 
-                /* box + ldnull + ceq/cgt_un -> 1/0 */
+                /* box + ldnull + ceq/cgt_un -> true/false */
                 if (*(td->ip + 5) == CEE_LDNULL) {
                     guint8 ceq = *(td->ip + 7);
-                    if (ceq == CEE_CEQ || ceq == CEE_CGT_UN) {
+                    if ((ceq == CEE_CEQ || ceq == CEE_CGT_UN) &&
+                        // make sure all opcodes are in the same bb
+                        !td->is_bb_start[in_offset] && !td->is_bb_start[in_offset + 5] && !td->is_bb_start[in_offset + 7]) {
+                        // clear instruction we wanted to box
                         interp_clear_ins (td, td->last_ins);
+                        // push true or false instead
                         SET_SIMPLE_TYPE (td->sp - 1, STACK_TYPE_I4);
                         SIMPLE_OP (td, ceq == CEE_CEQ ? MINT_LDC_I4_0 : MINT_LDC_I4_1);
                         td->ip += 7;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5321,7 +5321,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 
 				// optimize "box + ldnull + ceq/cgt_un" to true/false
 				// e.g. `t == null` in generic code when t is a vt/primitive (but not nullable)
-				if (td->sp + 7 >= td->stack && *(td->ip + 5) == CEE_LDNULL) {
+				if ((td->ip - td->il_code + 7) < td->code_size && *(td->ip + 5) == CEE_LDNULL) {
 					guint8 ceq = *(td->ip + 7);
 					if ((ceq == CEE_CEQ || ceq == CEE_CGT_UN) &&
 						// make sure all opcodes are in the same bb

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5321,7 +5321,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 
 				// optimize "box + ldnull + ceq/cgt_un" to true/false
 				// e.g. `t == null` in generic code when t is a vt/primitive (but not nullable)
-				if (*(td->ip + 5) == CEE_LDNULL) {
+				if (td->sp + 7 >= td->stack && *(td->ip + 5) == CEE_LDNULL) {
 					guint8 ceq = *(td->ip + 7);
 					if ((ceq == CEE_CEQ || ceq == CEE_CGT_UN) &&
 						// make sure all opcodes are in the same bb


### PR DESCRIPTION
this is a quite popular pattern with generics - T ==/!= null introduces expensive "boxing" (allocation) for value types,

#### e.g. for `Test<int>`:
```csharp
bool Test<T>(T t)
{
    return t == null;
}
```
#### Was:
```
Runtime method: Program:Test<int> (int) 000000406D3F8400
Locals size 8, VT stack size: 0
Calculated stack size: 2, stated size: 8
IR_0000: ldloc.i4   0
IR_0002: box        0,0
IR_0005: ldnull
IR_0006: ceq.i8
IR_0007: ret
```
#### Now:
```
Runtime method: Program:Test<int> (int) 00000091171F8270
Locals size 8, VT stack size: 0
Calculated stack size: 1, stated size: 8
IR_0000: ldc.i4.0
IR_0001: ret
```
