### PR TITLE
retire TLS1.0/1.1 ciphers from default list

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslGetProtocolSupport.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslGetProtocolSupport.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class OpenSsl
+    {
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslGetProtocolSupport")]
+        internal static extern int OpenSslGetProtocolSupport(int protocol);
+    }
+}

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -34,8 +34,8 @@ namespace System.Net.Http.Functional.Tests
 #endif
 
         [Theory]
-        [InlineData(SslProtocols.Tls, false)] // try various protocols to ensure we correctly set versions even when accepting all certs
-        [InlineData(SslProtocols.Tls, true)]
+        [InlineData(SslProtocols.Tls12, false)] // try various protocols to ensure we correctly set versions even when accepting all certs
+        [InlineData(SslProtocols.Tls12, true)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, true)]
 #if !NETFRAMEWORK

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -275,11 +275,7 @@ namespace System
 
         private static bool OpenSslGetTlsSupport(SslProtocols protocol)
         {
-            if (!IsOpenSslSupported)
-            {
-                // on Windows and macOS TLS1.0/1.1 are supported.
-                return false;
-            }
+            Debug.Assert(IsOpenSslSupported);
 
             int ret = Interop.OpenSsl.OpenSslGetProtocolSupport((int)protocol);
             return ret == 1;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO;
 using System.Security;
 using System.Security.Authentication;

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -58,6 +58,8 @@
   <ItemGroup>
     <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs"
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslGetProtocolSupport.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslGetProtocolSupport.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetEUid.cs"
              Link="Common\Interop\Unix\Interop.GetEUid.cs" />
   </ItemGroup>

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -770,4 +770,9 @@ void local_SSL_CTX_set_security_level(SSL_CTX* ctx, int32_t level)
     (void)ctx;
     (void)level;
 }
+
+int local_BIO_up_ref(BIO *bio)
+{
+    return CRYPTO_add(&bio->references, 1, CRYPTO_LOCK_BIO);
+}
 #endif

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -19,7 +19,7 @@
 
 #define CRYPTO_LOCK_X509 3
 #define CRYPTO_LOCK_EVP_PKEY 10
-
+#define CRYPTO_LOCK_BIO 21
 #define SSL_CTRL_GET_SESSION_REUSED 8
 #define SSL_CTRL_OPTIONS 32
 
@@ -772,6 +772,11 @@ void local_SSL_CTX_set_security_level(SSL_CTX* ctx, int32_t level)
 
 int local_BIO_up_ref(BIO *bio)
 {
-    return CRYPTO_add(&bio->references, 1, CRYPTO_LOCK_BIO);
+    if (!bio)
+    {
+        return 0;
+    }
+
+    return CRYPTO_add_lock(&bio->references, 1, CRYPTO_LOCK_BIO, __FILE__, __LINE__) > 1;
 }
 #endif

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -48,6 +48,39 @@ const ASN1_TIME* local_X509_get0_notAfter(const X509* x509)
     return NULL;
 }
 
+int local_X509_set1_notBefore(X509* x509, const ASN1_TIME* time)
+{
+    if (x509 && x509->cert_info && x509->cert_info->validity)
+    {
+        if (x509->cert_info->validity->notBefore)
+        {
+            ASN1_TIME_free(x509->cert_info->validity->notBefore);
+        }
+
+        x509->cert_info->validity->notBefore = ASN1_STRING_dup(time);
+        return x509->cert_info->validity->notBefore != NULL;
+    }
+
+    return 0;
+}
+
+int local_X509_set1_notAfter(X509* x509, const ASN1_TIME* time)
+{
+
+    if (x509 && x509->cert_info && x509->cert_info->validity)
+    {
+        if (x509->cert_info->validity->notAfter)
+        {
+            ASN1_TIME_free(x509->cert_info->validity->notAfter);
+        }
+
+        x509->cert_info->validity->notAfter = ASN1_STRING_dup(time);
+        return x509->cert_info->validity->notBefore != NULL;
+    }
+
+    return 0;
+}
+
 const ASN1_TIME* local_X509_CRL_get0_nextUpdate(const X509_CRL* crl)
 {
     if (crl && crl->crl)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -66,7 +66,6 @@ int local_X509_set1_notBefore(X509* x509, const ASN1_TIME* time)
 
 int local_X509_set1_notAfter(X509* x509, const ASN1_TIME* time)
 {
-
     if (x509 && x509->cert_info && x509->cert_info->validity)
     {
         if (x509->cert_info->validity->notAfter)
@@ -75,7 +74,7 @@ int local_X509_set1_notAfter(X509* x509, const ASN1_TIME* time)
         }
 
         x509->cert_info->validity->notAfter = ASN1_STRING_dup(time);
-        return x509->cert_info->validity->notBefore != NULL;
+        return x509->cert_info->validity->notAfter != NULL;
     }
 
     return 0;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -20,6 +20,7 @@
 #define CRYPTO_LOCK_X509 3
 #define CRYPTO_LOCK_EVP_PKEY 10
 #define CRYPTO_LOCK_BIO 21
+
 #define SSL_CTRL_GET_SESSION_REUSED 8
 #define SSL_CTRL_OPTIONS 32
 
@@ -52,12 +53,16 @@ int local_X509_set1_notBefore(X509* x509, const ASN1_TIME* time)
 {
     if (x509 && x509->cert_info && x509->cert_info->validity)
     {
-        if (x509->cert_info->validity->notBefore)
+        if (time != x509->cert_info->validity->notBefore)
         {
-            ASN1_TIME_free(x509->cert_info->validity->notBefore);
+            if (x509->cert_info->validity->notBefore)
+            {
+                ASN1_TIME_free(x509->cert_info->validity->notBefore);
+            }
+
+            x509->cert_info->validity->notBefore = ASN1_STRING_dup(time);
         }
 
-        x509->cert_info->validity->notBefore = ASN1_STRING_dup(time);
         return x509->cert_info->validity->notBefore != NULL;
     }
 
@@ -68,12 +73,16 @@ int local_X509_set1_notAfter(X509* x509, const ASN1_TIME* time)
 {
     if (x509 && x509->cert_info && x509->cert_info->validity)
     {
-        if (x509->cert_info->validity->notAfter)
+        if (time != x509->cert_info->validity->notAfter)
         {
-            ASN1_TIME_free(x509->cert_info->validity->notAfter);
+            if (x509->cert_info->validity->notAfter)
+            {
+                ASN1_TIME_free(x509->cert_info->validity->notAfter);
+            }
+
+            x509->cert_info->validity->notAfter = ASN1_STRING_dup(time);
         }
 
-        x509->cert_info->validity->notAfter = ASN1_STRING_dup(time);
         return x509->cert_info->validity->notAfter != NULL;
     }
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.h
@@ -43,6 +43,8 @@ X509_VERIFY_PARAM* local_X509_STORE_get0_param(X509_STORE* ctx);
 const ASN1_TIME* local_X509_get0_notAfter(const X509* x509);
 const ASN1_TIME* local_X509_get0_notBefore(const X509* x509);
 ASN1_BIT_STRING* local_X509_get0_pubkey_bitstr(const X509* x509);
+int local_X509_set1_notBefore(X509* x509, const ASN1_TIME*);
+int local_X509_set1_notAfter(X509* x509, const ASN1_TIME*);
 const X509_ALGOR* local_X509_get0_tbs_sigalg(const X509* x509);
 X509_PUBKEY* local_X509_get_X509_PUBKEY(const X509* x509);
 int32_t local_X509_get_version(const X509* x509);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/apibridge.h
@@ -6,6 +6,7 @@
 #pragma once
 #include "pal_types.h"
 
+int local_BIO_up_ref(BIO *a);
 const BIGNUM* local_DSA_get0_key(const DSA* dsa, const BIGNUM** pubKey, const BIGNUM** privKey);
 void local_DSA_get0_pqg(const DSA* dsa, const BIGNUM** p, const BIGNUM** q, const BIGNUM** g);
 const DSA_METHOD* local_DSA_get_method(const DSA* dsa);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
@@ -165,3 +165,18 @@ struct x509_store_st
     const void* _ignored2;
     X509_VERIFY_PARAM* param;
 };
+
+struct bio_st {
+    const void* _ignored1;
+    const void* _ignored2;
+    const void* _ignored3;
+    int _ignored4;
+    int _ignored5;
+    int _ignored6;
+    int _ignored7;
+    int _ignored8;
+    const void*_ignored9;
+    const void*_ignored10;
+    const void*_ignored11;
+    int references;
+};

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -166,6 +166,8 @@ STACK_OF(X509)* X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
 X509_VERIFY_PARAM* X509_STORE_get0_param(X509_STORE* ctx);
 const ASN1_TIME* X509_get0_notAfter(const X509* x509);
 const ASN1_TIME* X509_get0_notBefore(const X509* x509);
+int X509_set1_notAfter(X509* x509, const ASN1_TIME*);
+int X509_set1_notBefore(X509* x509, const ASN1_TIME*);
 ASN1_BIT_STRING* X509_get0_pubkey_bitstr(const X509* x509);
 const X509_ALGOR* X509_get0_tbs_sigalg(const X509* x509);
 X509_PUBKEY* X509_get_X509_PUBKEY(const X509* x509);
@@ -214,6 +216,9 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(ASN1_STRING_dup) \
     REQUIRED_FUNCTION(ASN1_STRING_free) \
     REQUIRED_FUNCTION(ASN1_STRING_print_ex) \
+    REQUIRED_FUNCTION(ASN1_TIME_new) \
+    REQUIRED_FUNCTION(ASN1_TIME_set) \
+    REQUIRED_FUNCTION(ASN1_TIME_free) \
     REQUIRED_FUNCTION(BASIC_CONSTRAINTS_free) \
     REQUIRED_FUNCTION(BIO_ctrl) \
     REQUIRED_FUNCTION(BIO_ctrl_pending) \
@@ -222,6 +227,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(BIO_new) \
     REQUIRED_FUNCTION(BIO_new_file) \
     REQUIRED_FUNCTION(BIO_read) \
+    REQUIRED_FUNCTION(BIO_up_ref) \
     REQUIRED_FUNCTION(BIO_s_mem) \
     REQUIRED_FUNCTION(BIO_write) \
     REQUIRED_FUNCTION(BN_bin2bn) \
@@ -231,6 +237,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(BN_free) \
     REQUIRED_FUNCTION(BN_new) \
     REQUIRED_FUNCTION(BN_num_bits) \
+    REQUIRED_FUNCTION(BN_set_word) \
     LEGACY_FUNCTION(CRYPTO_add_lock) \
     LEGACY_FUNCTION(CRYPTO_num_locks) \
     LEGACY_FUNCTION(CRYPTO_set_locking_callback) \
@@ -531,9 +538,12 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     FALLBACK_FUNCTION(X509_get_X509_PUBKEY) \
     FALLBACK_FUNCTION(X509_get0_notBefore) \
     FALLBACK_FUNCTION(X509_get0_notAfter) \
+    FALLBACK_FUNCTION(X509_set1_notBefore) \
+    FALLBACK_FUNCTION(X509_set1_notAfter) \
     FALLBACK_FUNCTION(X509_get0_pubkey_bitstr) \
     FALLBACK_FUNCTION(X509_get0_tbs_sigalg) \
     REQUIRED_FUNCTION(X509_issuer_name_hash) \
+    REQUIRED_FUNCTION(X509_NAME_add_entry_by_txt) \
     REQUIRED_FUNCTION(X509_NAME_entry_count) \
     REQUIRED_FUNCTION(X509_NAME_ENTRY_get_data) \
     REQUIRED_FUNCTION(X509_NAME_ENTRY_get_object) \
@@ -541,8 +551,11 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(X509_NAME_get_entry) \
     REQUIRED_FUNCTION(X509_NAME_get_index_by_NID) \
     FALLBACK_FUNCTION(X509_NAME_get0_der) \
+    REQUIRED_FUNCTION(X509_new) \
     REQUIRED_FUNCTION(X509_PUBKEY_get) \
     FALLBACK_FUNCTION(X509_PUBKEY_get0_param) \
+    REQUIRED_FUNCTION(X509_set_pubkey) \
+    REQUIRED_FUNCTION(X509_sign) \
     REQUIRED_FUNCTION(X509_subject_name_hash) \
     REQUIRED_FUNCTION(X509_STORE_add_cert) \
     REQUIRED_FUNCTION(X509_STORE_add_crl) \
@@ -608,6 +621,9 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define ASN1_STRING_dup ASN1_STRING_dup_ptr
 #define ASN1_STRING_free ASN1_STRING_free_ptr
 #define ASN1_STRING_print_ex ASN1_STRING_print_ex_ptr
+#define ASN1_TIME_free ASN1_TIME_free_ptr
+#define ASN1_TIME_new ASN1_TIME_new_ptr
+#define ASN1_TIME_set ASN1_TIME_set_ptr
 #define BASIC_CONSTRAINTS_free BASIC_CONSTRAINTS_free_ptr
 #define BIO_ctrl BIO_ctrl_ptr
 #define BIO_ctrl_pending BIO_ctrl_pending_ptr
@@ -616,6 +632,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define BIO_new BIO_new_ptr
 #define BIO_new_file BIO_new_file_ptr
 #define BIO_read BIO_read_ptr
+#define BIO_up_ref BIO_up_ref_ptr
 #define BIO_s_mem BIO_s_mem_ptr
 #define BIO_write BIO_write_ptr
 #define BN_bin2bn BN_bin2bn_ptr
@@ -625,6 +642,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define BN_free BN_free_ptr
 #define BN_new BN_new_ptr
 #define BN_num_bits BN_num_bits_ptr
+#define BN_set_word BN_set_word_ptr
 #define CRYPTO_add_lock CRYPTO_add_lock_ptr
 #define CRYPTO_num_locks CRYPTO_num_locks_ptr
 #define CRYPTO_set_locking_callback CRYPTO_set_locking_callback_ptr
@@ -919,6 +937,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_free X509_free_ptr
 #define X509_get0_notAfter X509_get0_notAfter_ptr
 #define X509_get0_notBefore X509_get0_notBefore_ptr
+#define X509_set1_notAfter X509_set1_notAfter_ptr
+#define X509_set1_notBefore X509_set1_notBefore_ptr
 #define X509_get0_pubkey_bitstr X509_get0_pubkey_bitstr_ptr
 #define X509_get0_tbs_sigalg X509_get0_tbs_sigalg_ptr
 #define X509_get_default_cert_dir X509_get_default_cert_dir_ptr
@@ -935,16 +955,20 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_get_X509_PUBKEY X509_get_X509_PUBKEY_ptr
 #define X509_get_version X509_get_version_ptr
 #define X509_issuer_name_hash X509_issuer_name_hash_ptr
+#define X509_NAME_add_entry_by_txt X509_NAME_add_entry_by_txt_ptr
 #define X509_NAME_entry_count X509_NAME_entry_count_ptr
 #define X509_NAME_ENTRY_get_data X509_NAME_ENTRY_get_data_ptr
 #define X509_NAME_ENTRY_get_object X509_NAME_ENTRY_get_object_ptr
 #define X509_NAME_free X509_NAME_free_ptr
 #define X509_NAME_get0_der X509_NAME_get0_der_ptr
 #define X509_NAME_get_entry X509_NAME_get_entry_ptr
+#define X509_new X509_new_ptr
 #define X509_NAME_get_index_by_NID X509_NAME_get_index_by_NID_ptr
 #define X509_PUBKEY_get0_param X509_PUBKEY_get0_param_ptr
 #define X509_PUBKEY_get X509_PUBKEY_get_ptr
 #define X509_subject_name_hash X509_subject_name_hash_ptr
+#define X509_set_pubkey X509_set_pubkey_ptr
+#define X509_sign X509_sign_ptr
 #define X509_STORE_add_cert X509_STORE_add_cert_ptr
 #define X509_STORE_add_crl X509_STORE_add_crl_ptr
 #define X509_STORE_CTX_cleanup X509_STORE_CTX_cleanup_ptr
@@ -1048,6 +1072,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_is_init_finished local_SSL_is_init_finished
 #define X509_CRL_get0_nextUpdate local_X509_CRL_get0_nextUpdate
 #define X509_NAME_get0_der local_X509_NAME_get0_der
+#define X509_new local_X509_new
 #define X509_PUBKEY_get0_param local_X509_PUBKEY_get0_param
 #define X509_STORE_CTX_get0_cert local_X509_STORE_CTX_get0_cert
 #define X509_STORE_CTX_get0_chain local_X509_STORE_CTX_get0_chain
@@ -1055,6 +1080,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_STORE_get0_param local_X509_STORE_get0_param
 #define X509_get0_notAfter local_X509_get0_notAfter
 #define X509_get0_notBefore local_X509_get0_notBefore
+#define X509_set1_notAfter local_X509_set1_notAfter
+#define X509_set1_notBefore local_X509_set1_notBefore
 #define X509_get0_pubkey_bitstr local_X509_get0_pubkey_bitstr
 #define X509_get0_tbs_sigalg local_X509_get0_tbs_sigalg
 #define X509_get_X509_PUBKEY local_X509_get_X509_PUBKEY

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -118,6 +118,7 @@ typedef struct stack_st OPENSSL_STACK;
 #define OPENSSL_INIT_LOAD_CONFIG 0x00000040L
 #define OPENSSL_INIT_LOAD_SSL_STRINGS 0x00200000L
 
+int BIO_up_ref(BIO *a);
 const BIGNUM* DSA_get0_key(const DSA* dsa, const BIGNUM** pubKey, const BIGNUM** privKey);
 void DSA_get0_pqg(const DSA* dsa, const BIGNUM** p, const BIGNUM** q, const BIGNUM** g);
 const DSA_METHOD* DSA_get_method(const DSA* dsa);
@@ -227,7 +228,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(BIO_new) \
     REQUIRED_FUNCTION(BIO_new_file) \
     REQUIRED_FUNCTION(BIO_read) \
-    REQUIRED_FUNCTION(BIO_up_ref) \
+    FALLBACK_FUNCTION(BIO_up_ref) \
     REQUIRED_FUNCTION(BIO_s_mem) \
     REQUIRED_FUNCTION(BIO_write) \
     REQUIRED_FUNCTION(BN_bin2bn) \
@@ -1049,6 +1050,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define NEED_OPENSSL_1_0 true
 
 // Alias "future" API to the local_ version.
+#define BIO_up_ref local_BIO_up_ref
 #define DSA_get0_key local_DSA_get0_key
 #define DSA_get0_pqg local_DSA_get0_pqg
 #define DSA_get_method local_DSA_get_method

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -963,12 +963,12 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_NAME_free X509_NAME_free_ptr
 #define X509_NAME_get0_der X509_NAME_get0_der_ptr
 #define X509_NAME_get_entry X509_NAME_get_entry_ptr
-#define X509_new X509_new_ptr
 #define X509_NAME_get_index_by_NID X509_NAME_get_index_by_NID_ptr
+#define X509_new X509_new_ptr
 #define X509_PUBKEY_get0_param X509_PUBKEY_get0_param_ptr
 #define X509_PUBKEY_get X509_PUBKEY_get_ptr
-#define X509_subject_name_hash X509_subject_name_hash_ptr
 #define X509_set_pubkey X509_set_pubkey_ptr
+#define X509_subject_name_hash X509_subject_name_hash_ptr
 #define X509_sign X509_sign_ptr
 #define X509_STORE_add_cert X509_STORE_add_cert_ptr
 #define X509_STORE_add_crl X509_STORE_add_crl_ptr

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -786,5 +786,5 @@ int32_t CryptoNative_OpenSslGetProtocolSupport(SslProtocols protocol)
         SSL_free(server);
     }
 
-    return ret;
+    return ret == 1;
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -43,7 +43,7 @@ static int32_t g_config_specified_ciphersuites = 0;
 
 static void DetectCiphersuiteConfiguration()
 {
-    // This routine will always produce g_config_specified_ciphersuites = 0 on OpenSSL 1.0.x,
+    // This routine will always produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x,
     // so if we're building direct for 1.0.x (the only time NEED_OPENSSL_1_1 is undefined) then
     // just omit all the code here.
     //
@@ -90,6 +90,12 @@ static void DetectCiphersuiteConfiguration()
     {
         // There's no system_default configuration, so no default CipherString.
         ERR_clear_error();
+
+        if (API_EXISTS(SSL_state))
+        {
+            // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
+            g_config_specified_ciphersuites = 1;
+        }
     }
     else
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -3,6 +3,10 @@
 
 #include "pal_ssl.h"
 #include "openssl.h"
+#include "pal_evp_pkey.h"
+#include "pal_evp_pkey_rsa.h"
+#include "pal_rsa.h"
+#include "pal_x509.h"
 
 #include <assert.h>
 #include <string.h>
@@ -24,9 +28,6 @@ c_static_assert(PAL_SSL_ERROR_ZERO_RETURN == SSL_ERROR_ZERO_RETURN);
     "ECDHE-ECDSA-AES128-SHA256:" \
     "ECDHE-RSA-AES256-SHA384:" \
     "ECDHE-RSA-AES128-SHA256:" \
-    /* Temporary TLS 1.0/1.1 compat after this line */\
-    "ECDHE-ECDSA-AES256-SHA:" \
-    "ECDHE-RSA-AES256-SHA:" \
 
 int32_t CryptoNative_EnsureOpenSslInitialized(void);
 
@@ -137,7 +138,7 @@ const SSL_METHOD* CryptoNative_SslV2_3Method()
     return method;
 }
 
-SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method)
+SSL_CTX* CryptoNative_SslCtxCreate(const SSL_METHOD* method)
 {
     SSL_CTX* ctx = SSL_CTX_new(method);
 
@@ -638,4 +639,152 @@ int32_t CryptoNative_SslGetCurrentCipherId(SSL* ssl, int32_t* cipherId)
     *cipherId = SSL_CIPHER_get_id(cipher) & 0xFFFF;
 
     return 1;
+}
+
+// This function generates key pair and creates simple certificate.
+static int MakeSelfSignedCertificate(X509 * cert, EVP_PKEY* evp)
+{
+    RSA* rsa = CryptoNative_RsaCreate();
+    ASN1_TIME* time = ASN1_TIME_new();
+    BIGNUM* bn = BN_new();
+    BN_set_word(bn, RSA_F4);
+    X509_NAME * asnName;
+    unsigned char * name = (unsigned char*)"localhost";
+
+    int ret = 0;
+
+    if (rsa != NULL && CryptoNative_RsaGenerateKeyEx(rsa, 2048, bn) == 1)
+    {
+        if (CryptoNative_EvpPkeySetRsa(evp, rsa) == 1)
+        {
+            rsa = NULL;
+        }
+
+        X509_set_pubkey(cert, evp);
+
+        asnName = X509_get_subject_name(cert);
+        X509_NAME_add_entry_by_txt(asnName, "CN", MBSTRING_ASC, name, -1, -1, 0);
+
+        asnName =  X509_get_issuer_name(cert);
+        X509_NAME_add_entry_by_txt(asnName, "CN", MBSTRING_ASC, name, -1, -1, 0);
+
+        ASN1_TIME_set(time, 0);
+        X509_set1_notBefore(cert, time);
+        X509_set1_notAfter(cert, time);
+
+        ret = X509_sign(cert, evp, EVP_sha256());
+    }
+
+    if (bn != NULL)
+    {
+        BN_free(bn);
+    }
+
+    if (rsa != NULL)
+    {
+        RSA_free(rsa);
+    }
+
+    if (time != NULL)
+    {
+        ASN1_TIME_free(time);
+    }
+
+    return ret;
+}
+
+int32_t CryptoNative_OpenSslGetProtocolSupport(SslProtocols protocol)
+{
+    int ret = 0;
+
+    SSL_CTX* clientCtx = CryptoNative_SslCtxCreate(TLS_method());
+    SSL_CTX* serverCtx = CryptoNative_SslCtxCreate(TLS_method());
+    X509 * cert = X509_new();
+    EVP_PKEY* evp = CryptoNative_EvpPkeyCreate();
+    BIO *bio1 = BIO_new(BIO_s_mem());
+    BIO *bio2 = BIO_new(BIO_s_mem());
+
+    SSL* client = NULL;
+    SSL* server = NULL;
+
+    if (clientCtx != NULL && serverCtx != NULL && cert != NULL && evp != NULL && bio1 != NULL && bio2 != NULL)
+    {
+        CryptoNative_SetProtocolOptions(serverCtx, protocol);
+        CryptoNative_SetProtocolOptions(clientCtx, protocol);
+        SSL_CTX_set_verify(clientCtx, SSL_VERIFY_NONE, NULL);
+        SSL_CTX_set_verify(serverCtx, SSL_VERIFY_NONE, NULL);
+
+        if (MakeSelfSignedCertificate(cert, evp))
+        {
+            CryptoNative_SslCtxUseCertificate(serverCtx, cert);
+            CryptoNative_SslCtxUsePrivateKey(serverCtx, evp);
+
+            server = CryptoNative_SslCreate(serverCtx);
+            SSL_set_accept_state(server);
+
+            client = CryptoNative_SslCreate(clientCtx);
+            SSL_set_connect_state(client);
+
+            // set BIOs in opposite
+            SSL_set_bio(client, bio1, bio2);
+            SSL_set_bio(server, bio2, bio1);
+            // SSL_set_bio takes ownership so we need to up reference since same BIO is shared.
+            BIO_up_ref(bio1);
+            BIO_up_ref(bio2);
+            bio1 = NULL;
+            bio2 = NULL;
+
+            // Try handshake, client side first.
+            SSL* side = client;
+            int sslError = 0;
+            while (1)
+            {
+                ret = SSL_do_handshake(side);
+                if (ret == 1)
+                {
+                    break;
+                }
+
+                sslError = SSL_get_error(side, ret);
+                if (sslError != SSL_ERROR_WANT_READ)
+                {
+                    break;
+                }
+
+                side = side == client ? server : client;
+            }
+        }
+    }
+
+    if (cert != NULL)
+    {
+        X509_free(cert);
+    }
+
+    if (evp != NULL)
+    {
+        CryptoNative_EvpPkeyDestroy(evp);
+    }
+
+    if (bio1)
+    {
+        BIO_free(bio1);
+    }
+
+    if (bio2)
+    {
+        BIO_free(bio2);
+    }
+
+    if (client != NULL)
+    {
+        SSL_free(client);
+    }
+
+    if (server != NULL)
+    {
+        SSL_free(server);
+    }
+
+    return ret;
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -51,6 +51,14 @@ static void DetectCiphersuiteConfiguration()
     // make the portable version easier.
 #ifdef NEED_OPENSSL_1_1
 
+    if (API_EXISTS(SSL_state))
+    {
+        // For portable builds NEED_OPENSSL_1_1 is always set.
+        // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
+        g_config_specified_ciphersuites = 1;
+        return;
+    }
+
     // Check to see if there's a registered default CipherString. If not, we will use our own.
     SSL_CTX* ctx = SSL_CTX_new(TLS_method());
     assert(ctx != NULL);
@@ -90,12 +98,6 @@ static void DetectCiphersuiteConfiguration()
     {
         // There's no system_default configuration, so no default CipherString.
         ERR_clear_error();
-
-        if (API_EXISTS(SSL_state))
-        {
-            // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
-            g_config_specified_ciphersuites = 1;
-        }
     }
     else
     {
@@ -109,7 +111,7 @@ static void DetectCiphersuiteConfiguration()
 
     SSL_CTX_free(ctx);
 
-#elif !defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(SSL_SYSTEM_DEFAULT_CIPHER_LIST)
+#else
 
     // The Fedora, RHEL, and CentOS builds replace the normal defaults (with a configuration model).
     // Consider their non-portable builds to always have specified ciphersuites in config.

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -792,5 +792,7 @@ int32_t CryptoNative_OpenSslGetProtocolSupport(SslProtocols protocol)
         SSL_free(server);
     }
 
+    ERR_clear_error();
+
     return ret == 1;
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -143,7 +143,7 @@ Shims the SSL_CTX_new method.
 
 Returns the new SSL_CTX instance.
 */
-PALEXPORT SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method);
+PALEXPORT SSL_CTX* CryptoNative_SslCtxCreate(const SSL_METHOD* method);
 
 /*
 Sets the specified protocols in the SSL_CTX options.
@@ -397,3 +397,8 @@ Looks up a cipher by the IANA identifier, returns a shared string for the OpenSS
 and emits a value indicating if the cipher belongs to the SSL2-TLS1.2 list, or the TLS1.3+ list.
 */
 PALEXPORT const char* CryptoNative_GetOpenSslCipherSuiteName(SSL* ssl, int32_t cipherSuite, int32_t* isTls12OrLower);
+
+/*
+Checks if given protocol version is supported.
+*/
+PALEXPORT int32_t CryptoNative_OpenSslGetProtocolSupport(SslProtocols protocol);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -54,8 +54,8 @@ namespace System.Net.Security.Tests
                 () =>
                 {
                     return ServerAsyncSslHelper(
-                        serverProtocol,
                         clientProtocol,
+                        serverProtocol,
                         expectedToFail: true);
                 });
 
@@ -299,12 +299,26 @@ namespace System.Net.Security.Tests
 #pragma warning restore 0618
             }
 
-            yield return new object[] { SslProtocols.Tls, SslProtocols.Tls11, typeof(AuthenticationException) };
-            yield return new object[] { SslProtocols.Tls, SslProtocols.Tls12, typeof(AuthenticationException) };
-            yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls, typeof(AuthenticationException) };
-            yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls12, typeof(AuthenticationException) };
-            yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls, typeof(AuthenticationException) };
-            yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls11, typeof(AuthenticationException) };
+            // It is OK if server does not support given protocol. It should still fail.
+            // But if client does not support it, it will simply fail without sending out any data.
+
+            if (PlatformDetection.SupportsTls10)
+            {
+                yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls, typeof(AuthenticationException) };
+                yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls, typeof(AuthenticationException) };
+            }
+
+            if (PlatformDetection.SupportsTls11)
+            {
+                yield return new object[] { SslProtocols.Tls, SslProtocols.Tls11, typeof(AuthenticationException) };
+                yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls11, typeof(AuthenticationException) };
+            }
+
+            if (PlatformDetection.SupportsTls12)
+            {
+                yield return new object[] { SslProtocols.Tls, SslProtocols.Tls12, typeof(AuthenticationException) };
+                yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls12, typeof(AuthenticationException) };
+            }
         }
 
         public static IEnumerable<Object[]> SupportedProtocolData()


### PR DESCRIPTION
This is follow-up on #39633 and #40303. Product change is update to DOTNET_DEFAULT_CIPHERSTRING to have it the way how @bartonjs originally wanted. As #40303 fixed most tests, this should just work now.

Bulk of this change is update to PlatformDetection.SupportsTlsXX. In the past that would be based on OS version but since this impacts wide ranges of distributions, the static mapping is difficult to maintain and it created fragility for developers as their systems may be different. 

So instead of static map, This change updated detection of Tls 1.0/1.1 to actually try to do handshake using our PAL  CryptoNative_SslCtxCreate(). I originally wanted to do that using Interop but that is heavily intertwined with SslStream and build and dependencies were messy so I eventually give up. Also the platform detection is used in may places and build is special so I did not want to pull inn dependency on SslStream. 

Instead, I added one function to OpenSSL PAL. That has minimal code to generate certificate on the flaw and test handshake using memory BIO. I had to pull in few more functions but the outcome is self contained and the decision only depends on OpenSSL it self. I may eventually updated other parts as well but for now I'm happy it coverts the two "problematic" version.  


contributes to #30767