### PR TITLE
Ignore the executable file be deleted in Process Start

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -92,9 +92,18 @@ namespace System.Diagnostics
         }
 
         /// <summary>Gets the path to the current executable, or null if it could not be retrieved.</summary>
-        private static string GetExePath()
+        private static string? GetExePath()
         {
-            return Interop.libproc.proc_pidpath(Environment.ProcessId);
+            try
+            {
+                return Interop.libproc.proc_pidpath(Environment.ProcessId);
+            }
+            catch (Win32Exception)
+            {
+                // It will throw System.ComponentModel.Win32Exception (2): No such file or Directory when
+                // the executable file be deleted.
+                return null;
+            }
         }
 
         // ----------------------------------

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -101,7 +101,7 @@ namespace System.Diagnostics
             catch (Win32Exception)
             {
                 // It will throw System.ComponentModel.Win32Exception (2): No such file or Directory when
-                // the executable file be deleted.
+                // the executable file is deleted.
                 return null;
             }
         }


### PR DESCRIPTION
In MAC System when using Process.Start method to start a excetuable file it can still delete this file and the Interop.libproc.proc_pidpath method still execute and return a win32 exception