### PR TITLE
Remove CheckForOverflowUnderflow from eventsource redist

### DIFF
--- a/src/libraries/Microsoft.Diagnostics.Tracing.EventSource.Redist/src/Microsoft.Diagnostics.Tracing.EventSource.Redist.csproj
+++ b/src/libraries/Microsoft.Diagnostics.Tracing.EventSource.Redist/src/Microsoft.Diagnostics.Tracing.EventSource.Redist.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Microsoft\Diagnostics\Tracing\StubEnvironment.cs" />


### PR DESCRIPTION
Fixes #31389

We don't set CheckForOverflowUnderflow when building EventSource for System.Private.CoreLib, I don't think it makes sense to set it for the redist.