### PR TITLE
Refactor redundant validating datetime length logic in System.Text.Json

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -249,8 +249,6 @@ namespace System.Text.Json
             }
 
             // We now have YYYY-MM-DD [dateX]
-
-            Debug.Assert(source.Length >= 10);
             if (source.Length == 10)
             {
                 // Just a calendar date

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -211,12 +211,6 @@ namespace System.Text.Json
         {
             parseData = default;
 
-            // Source does not have enough characters for YYYY-MM-DD
-            if (source.Length < 10)
-            {
-                return false;
-            }
-
             // Parse the calendar date
             // -----------------------
             // ISO 8601-1:2019 5.2.2.1b "Calendar date complete extended format"

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -211,6 +211,9 @@ namespace System.Text.Json
         {
             parseData = default;
 
+            // too short datetime
+            Debug.Assert(source.Length >= 10);
+
             // Parse the calendar date
             // -----------------------
             // ISO 8601-1:2019 5.2.2.1b "Calendar date complete extended format"

--- a/src/libraries/System.Text.Json/tests/JsonDateTimeTestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonDateTimeTestData.cs
@@ -105,6 +105,13 @@ namespace System.Text.Json.Tests
 
         public static IEnumerable<object[]> InvalidISO8601Tests()
         {
+            // Too short
+            yield return new object[] { "\"1997-07\"" };
+            yield return new object[] { "\"1996\"" };
+            yield return new object[] { "\"997-07-16\"" };
+            yield return new object[] { "\"1997-07-6\"" };
+            yield return new object[] { "\"1997-7-06\"" };
+
             // Invalid YYYY-MM-DD
             yield return new object[] { "\"0997 07-16\"" };
             yield return new object[] { "\"0997-0a-16\"" };
@@ -115,12 +122,8 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"0997-07-16,0997-07-16\"" };
             yield return new object[] { "\"1997-07-16T19:20abc\"" };
             yield return new object[] { "\"1997-07-16T19:20, 123\"" };
-            yield return new object[] { "\"997-07-16\"" };
-            yield return new object[] { "\"1997-07\"" };
-            yield return new object[] { "\"1997-7-06\"" };
             yield return new object[] { "\"1997-07-16T\"" };
             yield return new object[] { "\"1997-07-16*\"" };
-            yield return new object[] { "\"1997-07-6\"" };
             yield return new object[] { "\"1997-07-6T01\"" };
             yield return new object[] { "\"1997-07-16Z\"" };
             yield return new object[] { "\"1997-07-16+01:00\"" };


### PR DESCRIPTION
#32341

## Pull request
I figured out that validating datetime length logic has redundancy. 

TryParseDateTimeOffset in ```JsonHelpers.Date.cs```  includes logic that validating datetime length is more than 10 

**10 means that "yyyy-mm-dd" format**
```
private static bool TryParseDateTimeOffset(ReadOnlySpan<byte> source, out DateTimeParseData parseData)
{
    parseData = default;
    // Source does not have enough characters for YYYY-MM-DD
    if (source.Length < 10)
    {
        return false;
    }

    ...
}
```

and ```TryParseDateTimeOffset``` function is always called after calling ```IsValidDateTimeOffsetParseLength``` function that checks whether datetime length is more than 10 or not. 

```
[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static bool IsValidDateTimeOffsetParseLength(int length)
{
    return IsInRangeInclusive(length, JsonConstants.MinimumDateTimeParseLength, 
                                                          JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
}
```
so workflow it's like

```
// validate datetime length is more than 10 if not return false 
if (!IsValidDateTimeOffsetParseLength(source.Length)) 
{  
    return false;
}

// .... do somethings

// validate again before we did
if (source.Length < 10)
{
    return false;
}
``` 

So, I suggest to remove it in ```TryParseDateTimeOffset```
```
if (source.Length < 10)
{
    return false;
}
``` 

## Advantage if it'll be approved
* it can increase System.Json.Text test coverage.

![image](https://user-images.githubusercontent.com/32787543/90126466-b1749400-dd9e-11ea-9f1e-82f348e5e28f.png)

* build more reasonable logic by removing duplicated validating logic.