### PR TITLE
Enable Http2.0 tests for Http telemetry

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -351,7 +351,11 @@ namespace System.Net.Http
                     _creditWaiter = null;
                 }
 
-                if (HttpTelemetry.Log.IsEnabled()) _request.OnStopped();
+                if (HttpTelemetry.Log.IsEnabled())
+                {
+                    bool aborted = _requestCompletionState == StreamCompletionState.Failed || _responseCompletionState == StreamCompletionState.Failed;
+                    _request.OnStopped(aborted);
+                }
             }
 
             private void Cancel()

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -20,6 +20,8 @@ namespace System.Net.Http.Functional.Tests
 
     public sealed class TelemetryTest_Http20 : TelemetryTest
     {
+        protected override Version UseVersion => HttpVersion.Version20;
+
         public TelemetryTest_Http20(ITestOutputHelper output) : base(output) { }
     }
 
@@ -135,7 +137,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal("RequestStart", startEvent.EventName);
             Assert.Equal(6, startEvent.Payload.Count);
 
-            Assert.Equal("http", (string)startEvent.Payload[0]);
+            Assert.StartsWith("http", (string)startEvent.Payload[0]);
             Assert.NotEmpty((string)startEvent.Payload[1]); // host
             Assert.True(startEvent.Payload[2] is int port && port >= 0 && port <= 65535);
             Assert.NotEmpty((string)startEvent.Payload[3]); // pathAndQuery


### PR DESCRIPTION
In my PR that added tests for Http Telemetry, I forgot to override `UseVersion` in the Http20 case, so we ended up testing Http11 twice.

Fixed the scenario of the OnStopped being called before OnAborted, so RequestAborted was never logged for Http20, discovered once enabling the 2.0 tests.