### PR TITLE
[Browser] fallback to Invariant mode if mono_wasm_load_icu_data wasn't called

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_static.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_static.c
@@ -12,6 +12,7 @@
 #include <unicode/utrace.h>
 
 static int32_t isLoaded = 0;
+static int32_t isDataSet = 0;
 
 static void log_icu_error(const char* name, UErrorCode status)
 {
@@ -29,8 +30,6 @@ static void U_CALLCONV icu_trace_data(const void* context, int32_t fnNumber, int
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 
-EMSCRIPTEN_KEEPALIVE gboolean icu_loaded = FALSE;
-
 EMSCRIPTEN_KEEPALIVE int32_t mono_wasm_load_icu_data(void * pData);
 
 EMSCRIPTEN_KEEPALIVE int32_t mono_wasm_load_icu_data(void * pData)
@@ -46,7 +45,7 @@ EMSCRIPTEN_KEEPALIVE int32_t mono_wasm_load_icu_data(void * pData)
         //// see https://github.com/unicode-org/icu/blob/master/docs/userguide/icu_data/tracing.md
         // utrace_setFunctions(0, 0, 0, icu_trace_data);
         // utrace_setLevel(UTRACE_VERBOSE);
-        icu_loaded = TRUE;
+        isDataSet = 1;
         return 1;
     }
 }
@@ -54,7 +53,7 @@ EMSCRIPTEN_KEEPALIVE int32_t mono_wasm_load_icu_data(void * pData)
 
 int32_t GlobalizationNative_LoadICU(void)
 {
-    if (!icu_loaded) {
+    if (!isDataSet) {
         // don't try to locate icudt.dat automatically if mono_wasm_load_icu_data wasn't called
         // and fallback to invariant mode
         return 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -20,11 +20,16 @@ namespace System.Globalization
                 {
                     LoadAppLocalIcu(icuSuffixAndVersion);
                 }
-                else if (Interop.Globalization.LoadICU() == 0)
+                else if (Interop.Globalization.LoadICU() == 0 && !OperatingSystem.IsBrowser())
                 {
                     string message = "Couldn't find a valid ICU package installed on the system. " +
                                     "Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.";
                     Environment.FailFast(message);
+                }
+                else if (OperatingSystem.IsBrowser())
+                {
+                    // fallback to Invariant for Browser
+                    return true;
                 }
             }
             return invariantEnabled;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -20,16 +20,18 @@ namespace System.Globalization
                 {
                     LoadAppLocalIcu(icuSuffixAndVersion);
                 }
-                else if (Interop.Globalization.LoadICU() == 0 && !OperatingSystem.IsBrowser())
+                else
                 {
-                    string message = "Couldn't find a valid ICU package installed on the system. " +
-                                    "Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.";
-                    Environment.FailFast(message);
-                }
-                else if (OperatingSystem.IsBrowser())
-                {
-                    // fallback to Invariant for Browser
-                    return true;
+                    int loaded = Interop.Globalization.LoadICU();
+                    if (loaded == 0 && !OperatingSystem.IsBrowser())
+                    {
+                        string message = "Couldn't find a valid ICU package installed on the system. " +
+                                        "Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.";
+                        Environment.FailFast(message);
+                    }
+
+                    // fallback to Invariant mode if LoadICU failed (Browser).
+                    return loaded == 0;
                 }
             }
             return invariantEnabled;


### PR DESCRIPTION
Don't rely on built-in "default ICU search path" behavior or `DOTNET_ICU_DIR` (it's not used anywhere) if `mono_wasm_load_icu_data` wasn't called
as we most likely will just try to load some system ICU - our code is configured to work only with our specific version, e.g. in https://github.com/dotnet/runtime/issues/40527 it fails because the icudat it found doesn't contain `misc/supplementalData/version` (it's my guess).