### PR TITLE
Clean up the System.Net.Requests library tests because the respective library is PNSE on browser wasm

### DIFF
--- a/src/libraries/System.Net.Requests/tests/FileWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/FileWebRequestTest.cs
@@ -87,7 +87,7 @@ namespace System.Net.Tests
         public abstract Task<WebResponse> GetResponseAsync(WebRequest request);
         public abstract Task<Stream> GetRequestStreamAsync(WebRequest request);
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadFile_ContainsExpectedContent()
         {
             string path = Path.GetTempFileName();
@@ -124,7 +124,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WriteFile_ContainsExpectedContent()
         {
             string path = Path.GetTempFileName();
@@ -150,7 +150,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WriteThenReadFile_WriteAccessResultsInNullResponseStream()
         {
             string path = Path.GetTempFileName();
@@ -182,7 +182,7 @@ namespace System.Net.Tests
 
         protected virtual bool EnableConcurrentReadWriteTests => true;
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task RequestAfterResponse_throws()
         {
             string path = Path.GetTempFileName();
@@ -201,7 +201,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(null)]
         [InlineData(false)]
         [InlineData(true)]


### PR DESCRIPTION
`System.Net.Requests` has been modified to throw PNSE at assembly level on browser wasm in https://github.com/dotnet/runtime/pull/40274 so it's no longer needed to mark any particular browser-related issues there. 