### PR TITLE
Small Performance improvment for GetBaseKeyFromKeyName method

### DIFF
--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
@@ -40,28 +40,32 @@ namespace Microsoft.Win32
                 throw new ArgumentNullException(nameof(keyName));
             }
 
-            int i = keyName.IndexOf('\\');
-            int length = i != -1 ? i : keyName.Length;
-
-            // Determine the potential base key from the length.
-            RegistryKey? baseKey = null;
-            switch (length)
+            const int minBaseKeyLength = 10; // HKEY_USERS
+            if (keyName.Length >= minBaseKeyLength)
             {
-                case 10: baseKey = Users; break; // HKEY_USERS
-                case 17: baseKey = char.ToUpperInvariant(keyName[6]) == 'L' ? ClassesRoot : CurrentUser; break; // HKEY_C[L]ASSES_ROOT, otherwise HKEY_CURRENT_USER
-                case 18: baseKey = LocalMachine; break; // HKEY_LOCAL_MACHINE
-                case 19: baseKey = CurrentConfig; break; // HKEY_CURRENT_CONFIG
-                case 21: baseKey = PerformanceData; break; // HKEY_PERFORMANCE_DATA
-            }
+                int i = keyName.IndexOf('\\', startIndex: minBaseKeyLength);
+                int length = i != -1 ? i : keyName.Length;
 
-            // If a potential base key was found, see if keyName actually starts with the potential base key's name.
-            if (baseKey != null && keyName.StartsWith(baseKey.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                subKeyName = (i == -1 || i == keyName.Length) ?
-                    string.Empty :
-                    keyName.Substring(i + 1, keyName.Length - i - 1);
+                // Determine the potential base key from the length.
+                RegistryKey? baseKey = null;
+                switch (length)
+                {
+                    case 10: baseKey = Users; break; // HKEY_USERS
+                    case 17: baseKey = char.ToUpperInvariant(keyName[6]) == 'L' ? ClassesRoot : CurrentUser; break; // HKEY_C[L]ASSES_ROOT, otherwise HKEY_CURRENT_USER
+                    case 18: baseKey = LocalMachine; break; // HKEY_LOCAL_MACHINE
+                    case 19: baseKey = CurrentConfig; break; // HKEY_CURRENT_CONFIG
+                    case 21: baseKey = PerformanceData; break; // HKEY_PERFORMANCE_DATA
+                }
 
-                return baseKey;
+                // If a potential base key was found, see if keyName actually starts with the potential base key's name.
+                if (baseKey != null && keyName.StartsWith(baseKey.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    subKeyName = (i == -1 || i == keyName.Length) ?
+                        string.Empty :
+                        keyName.Substring(i + 1, keyName.Length - i - 1);
+
+                    return baseKey;
+                }
             }
 
             throw new ArgumentException(SR.Format(SR.Arg_RegInvalidKeyName, nameof(keyName)), nameof(keyName));


### PR DESCRIPTION
No BaseKeys have a length less than 10

The Benchmark code: https://github.com/lindexi/lindexi_gd/tree/ae481a39/HearwhejiyehallyiheFubaduwheefu

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.450 (2004/?/20H1)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.301
  [Host]     : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
|                   Method |              keyName |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |
|------------------------- |--------------------- |----------:|----------:|----------:|----------:|------:|--------:|
| **OldGetBaseKeyFromKeyName** |                     **** | **0.0055 ns** | **0.0001 ns** | **0.0001 ns** | **0.0055 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |                      | 0.0019 ns | 0.0000 ns | 0.0000 ns | 0.0019 ns |  0.35 |    0.01 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |                **Error** | **0.0067 ns** | **0.0002 ns** | **0.0002 ns** | **0.0066 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |                Error | 0.0026 ns | 0.0001 ns | 0.0001 ns | 0.0026 ns |  0.39 |    0.01 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |            **Error\123** | **0.0069 ns** | **0.0001 ns** | **0.0001 ns** | **0.0069 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |            Error\123 | 0.0018 ns | 0.0001 ns | 0.0001 ns | 0.0018 ns |  0.26 |    0.01 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |          **Error\12345** | **0.0074 ns** | **0.0002 ns** | **0.0002 ns** | **0.0073 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |          Error\12345 | 0.0090 ns | 0.0002 ns | 0.0001 ns | 0.0090 ns |  1.22 |    0.05 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |    **HKEY\CLASSES_ROOT** | **0.0060 ns** | **0.0001 ns** | **0.0001 ns** | **0.0060 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |    HKEY\CLASSES_ROOT | 0.0260 ns | 0.0004 ns | 0.0004 ns | 0.0260 ns |  4.34 |    0.06 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |  **HKEY\CURRENT_CONFIG** | **0.0063 ns** | **0.0001 ns** | **0.0001 ns** | **0.0063 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |  HKEY\CURRENT_CONFIG | 0.0186 ns | 0.0003 ns | 0.0002 ns | 0.0185 ns |  2.93 |    0.04 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |    **HKEY\CURRENT_USER** | **0.0064 ns** | **0.0001 ns** | **0.0001 ns** | **0.0063 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |    HKEY\CURRENT_USER | 0.0252 ns | 0.0002 ns | 0.0002 ns | 0.0252 ns |  3.95 |    0.06 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |   **HKEY\LOCAL_MACHINE** | **0.0062 ns** | **0.0001 ns** | **0.0001 ns** | **0.0062 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |   HKEY\LOCAL_MACHINE | 0.0192 ns | 0.0003 ns | 0.0003 ns | 0.0192 ns |  3.07 |    0.08 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** | **HKEY\(...)_DATA [21]** | **0.0066 ns** | **0.0002 ns** | **0.0005 ns** | **0.0065 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName | HKEY\(...)_DATA [21] | 0.0213 ns | 0.0005 ns | 0.0006 ns | 0.0214 ns |  3.00 |    0.20 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |    **HKEY_CLASSES_ROOT** | **0.0221 ns** | **0.0003 ns** | **0.0002 ns** | **0.0221 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |    HKEY_CLASSES_ROOT | 0.0216 ns | 0.0003 ns | 0.0003 ns | 0.0216 ns |  0.97 |    0.02 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** | **HKEY_(...)yName [28]** | **0.0485 ns** | **0.0010 ns** | **0.0012 ns** | **0.0483 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName | HKEY_(...)yName [28] | 0.0504 ns | 0.0018 ns | 0.0050 ns | 0.0487 ns |  1.13 |    0.11 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |  **HKEY_CURRENT_CONFIG** | **0.0173 ns** | **0.0003 ns** | **0.0003 ns** | **0.0172 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |  HKEY_CURRENT_CONFIG | 0.0143 ns | 0.0004 ns | 0.0004 ns | 0.0142 ns |  0.84 |    0.03 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** | **HKEY_(...)yName [30]** | **0.0432 ns** | **0.0009 ns** | **0.0013 ns** | **0.0434 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName | HKEY_(...)yName [30] | 0.0425 ns | 0.0009 ns | 0.0016 ns | 0.0420 ns |  1.00 |    0.06 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |    **HKEY_CURRENT_USER** | **0.0231 ns** | **0.0004 ns** | **0.0003 ns** | **0.0230 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |    HKEY_CURRENT_USER | 0.0222 ns | 0.0005 ns | 0.0011 ns | 0.0218 ns |  0.94 |    0.05 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** | **HKEY_(...)yName [28]** | **0.0573 ns** | **0.0032 ns** | **0.0094 ns** | **0.0536 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName | HKEY_(...)yName [28] | 0.0511 ns | 0.0019 ns | 0.0054 ns | 0.0487 ns |  0.92 |    0.16 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** |   **HKEY_LOCAL_MACHINE** | **0.0162 ns** | **0.0003 ns** | **0.0003 ns** | **0.0162 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName |   HKEY_LOCAL_MACHINE | 0.0155 ns | 0.0004 ns | 0.0005 ns | 0.0153 ns |  0.95 |    0.03 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** | **HKEY_(...)yName [29]** | **0.0537 ns** | **0.0032 ns** | **0.0095 ns** | **0.0519 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName | HKEY_(...)yName [29] | 0.0458 ns | 0.0012 ns | 0.0034 ns | 0.0450 ns |  0.87 |    0.15 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** | **HKEY_(...)_DATA [21]** | **0.0183 ns** | **0.0004 ns** | **0.0005 ns** | **0.0181 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName | HKEY_(...)_DATA [21] | 0.0168 ns | 0.0006 ns | 0.0016 ns | 0.0164 ns |  0.90 |    0.05 |
|                          |                      |           |           |           |           |       |         |
| **OldGetBaseKeyFromKeyName** | **HKEY_(...)yName [32]** | **0.0439 ns** | **0.0008 ns** | **0.0007 ns** | **0.0439 ns** |  **1.00** |    **0.00** |
| NewGetBaseKeyFromKeyName | HKEY_(...)yName [32] | 0.0424 ns | 0.0006 ns | 0.0005 ns | 0.0426 ns |  0.97 |    0.02 |
