### PR TITLE
Set MaxConcurrentStreams = 100 on new Http2Connection until first SETTINGS frame

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -583,6 +583,27 @@ namespace System.Net.Test.Common
 
         public async Task<SettingsFrame> ReadAndSendSettingsAsync(TimeSpan? ackTimeout, params SettingsEntry[] settingsEntries)
         {
+            SettingsFrame clientSettingsFrame = await ReadSettingsAsync().ConfigureAwait(false);
+            await SendSettingsAsync(ackTimeout, settingsEntries).ConfigureAwait(false);
+            return clientSettingsFrame;
+        }
+
+        public async Task SendSettingsAsync(TimeSpan? ackTimeout, SettingsEntry[] settingsEntries)
+        {
+            // Send the initial server settings frame.
+            SettingsFrame settingsFrame = new SettingsFrame(settingsEntries);
+            await WriteFrameAsync(settingsFrame).ConfigureAwait(false);
+
+            // Send the client settings frame ACK.
+            Frame settingsAck = new Frame(0, FrameType.Settings, FrameFlags.Ack, 0);
+            await WriteFrameAsync(settingsAck).ConfigureAwait(false);
+
+            // The client will send us a SETTINGS ACK eventually, but not necessarily right away.
+            await ExpectSettingsAckAsync((int?)ackTimeout?.TotalMilliseconds ?? 5000);
+        }
+
+        public async Task<SettingsFrame> ReadSettingsAsync()
+        {
             // Receive the initial client settings frame.
             Frame receivedFrame = await ReadFrameAsync(_timeout).ConfigureAwait(false);
             Assert.Equal(FrameType.Settings, receivedFrame.Type);
@@ -596,18 +617,6 @@ namespace System.Net.Test.Common
             Assert.Equal(FrameType.WindowUpdate, receivedFrame.Type);
             Assert.Equal(FrameFlags.None, receivedFrame.Flags);
             Assert.Equal(0, receivedFrame.StreamId);
-
-            // Send the initial server settings frame.
-            SettingsFrame settingsFrame = new SettingsFrame(settingsEntries);
-            await WriteFrameAsync(settingsFrame).ConfigureAwait(false);
-
-            // Send the client settings frame ACK.
-            Frame settingsAck = new Frame(0, FrameType.Settings, FrameFlags.Ack, 0);
-            await WriteFrameAsync(settingsAck).ConfigureAwait(false);
-
-            // The client will send us a SETTINGS ACK eventually, but not necessarily right away.
-            await ExpectSettingsAckAsync((int?)ackTimeout?.TotalMilliseconds ?? 5000);
-
             return clientSettingsFrame;
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -266,7 +266,7 @@ namespace System.Net.Http
                     if (NetEventSource.Log.IsEnabled()) Trace($"Frame 0: {frameHeader}.");
 
                     // Process the initial SETTINGS frame. This will send an ACK.
-                    ProcessSettingsFrame(frameHeader, true);
+                    ProcessSettingsFrame(frameHeader, initialFrame: true);
                 }
                 catch (IOException e)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -613,7 +613,7 @@ namespace System.Net.Http
                 if (initialFrame && !maxConcurrentStreamsReceived)
                 {
                     // Set to 'infinite' because MaxConcurrentStreams was not set on the initial SETTINGS frame.
-                    _maxConcurrentStreams = int.MaxValue;
+                    ChangeMaxConcurrentStreams(int.MaxValue);
                 }
 
                 _incomingBuffer.Discard(frameHeader.PayloadLength);


### PR DESCRIPTION
Http2Connection is currently created with an 'infinite' MaxConcurrentStreams value as it's demanded by RFC. However, the most of servers does not support unbound active streams number on an HTTP/2 connection because it would make them vulnerable against DOS attacks. Thus, they send a specific MaxConcurrentStreams value with the first SETTINGS frame and respond with REFUSE_STREAM error to opening extra streams attempts. Correct processing this error on client side gets tricky in request burst scenarios due to a very asynchronous nature of HTTP/2. In such cases, client can start sending DATA frames on streams above the limit which make the server to respond with GOAWAY terminating the connection.

Proper fix of the aforementioned issue would be pretty complex, so this PR applies a simple workaround by setting MaxConncurrentStreams to 100 instead of 'infinite' in Http2Connection constructor.

Fixes #40249 