### PR TITLE
Renamed EventSources "Microsoft-"->"Private.InternalDiagnostics.".

### DIFF
--- a/src/libraries/Common/tests/System/Net/EventSourceTestLogging.cs
+++ b/src/libraries/Common/tests/System/Net/EventSourceTestLogging.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net.Test.Common
 {
-    [EventSource(Name = "Microsoft-System-Net-TestLogging")]
+    [EventSource(Name = "System.Net.TestLogging")]
     internal class EventSourceTestLogging : EventSource
     {
         private static EventSourceTestLogging s_log = new EventSourceTestLogging();

--- a/src/libraries/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
+++ b/src/libraries/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
@@ -12,7 +12,7 @@ Without further ado, here is an example on how to use the `EventCounter`
 
 ```c#
 // Give your event sources a descriptive name using the EventSourceAttribute, otherwise the name of the class is used. 
-[EventSource(Name = "Samples-EventCounterDemos-Minimal")]
+[EventSource(Name = "Samples.EventCounterDemos.Minimal")]
 public sealed class MinimalEventCounterSource : EventSource
 {
     // define the singleton instance of the event source
@@ -49,7 +49,7 @@ So, with that, we logged the metric to the `EventCounter`, but unless we can act
 There is an extra keyword that you will need to specify the turn on the EventCounters.
 
 ```
-PerfView /onlyProviders=*Samples-EventCounterDemos-Minimal:EventCounterIntervalSec=1 collect
+PerfView /onlyProviders=*Samples.EventCounterDemos.Minimal:EventCounterIntervalSec=1 collect
 ```
 
 Note the part about `EventCounterIntervalSec`, that indicate the frequency of the sampling.
@@ -73,7 +73,7 @@ Notice that this command also logs the events, so we will get both the events an
 As we mentioned, to avoid overhead, sometimes we will want just the counters. This command can be used to log *only* the counters:
 
 ```
-PerfView /onlyProviders=*Samples-EventCounterDemos-Minimal:*:Critical:EventCounterIntervalSec=1 collect
+PerfView /onlyProviders=*Samples.EventCounterDemos.Minimal:*:Critical:EventCounterIntervalSec=1 collect
 ```
 
 Notice the `Critical` keyword in the command line, that is used to filter out the other events with lower priorities.

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NetEventSource.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NetEventSource.WinHttpHandler.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Http-WinHttpHandler", LocalizationResources = "FxResources.System.Net.Http.WinHttpHandler.SR")]
+    [EventSource(Name = "System.Net.Http.WinHttpHandler.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Http.WinHttpHandler.SR")]
     internal sealed partial class NetEventSource : EventSource
     {
     }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NetEventSource.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NetEventSource.WinHttpHandler.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Http.WinHttpHandler.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Http.WinHttpHandler.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Http.WinHttpHandler", LocalizationResources = "FxResources.System.Net.Http.WinHttpHandler.SR")]
     internal sealed partial class NetEventSource : EventSource
     {
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Http", LocalizationResources = "FxResources.System.Net.Http.SR")]
+    [EventSource(Name = "System.Net.Http.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Http.SR")]
     internal sealed partial class NetEventSource : EventSource
     {
         private const int UriBaseAddressId = NextAvailableEventId;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Http.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Http.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Http", LocalizationResources = "FxResources.System.Net.Http.SR")]
     internal sealed partial class NetEventSource : EventSource
     {
         private const int UriBaseAddressId = NextAvailableEventId;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -35,8 +35,8 @@ namespace System.Net.Http.Functional.Tests
             Type esType = typeof(HttpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("System.Net.Http.InternalDiagnostics", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("9eaaf4fe-565c-5c63-2b5c-af4f2795360e"), EventSource.GetGuid(esType));
+            Assert.Equal("Private.InternalDiagnostics.System.Net.Http", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("a60cec70-947b-5b80-efe2-7c5547b99b3d"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, "assemblyPathToIncludeInManifest"));
         }
@@ -182,7 +182,7 @@ namespace System.Net.Http.Functional.Tests
         {
             RemoteExecutor.Invoke(async (useVersionString, useSslString) =>
             {
-                using (var listener = new TestEventListener("System.Net.Http.InternalDiagnostics", EventLevel.Verbose))
+                using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Http", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     await listener.RunWithCallbackAsync(events.Enqueue, async () =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -30,14 +30,13 @@ namespace System.Net.Http.Functional.Tests
         public DiagnosticsTest(ITestOutputHelper output) : base(output) { }
 
         [Fact]
-        public static void EventSource_ExistsWithCorrectId()
+        public void EventSource_ExistsWithCorrectId()
         {
-            Type esType = typeof(HttpClient).GetTypeInfo().Assembly
-                .GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
+            Type esType = typeof(HttpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("Microsoft-System-Net-Http", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("bdd9a83e-1929-5482-0d73-2fe5e1c0e16d"), EventSource.GetGuid(esType));
+            Assert.Equal("System.Net.Http.InternalDiagnostics", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("9eaaf4fe-565c-5c63-2b5c-af4f2795360e"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, "assemblyPathToIncludeInManifest"));
         }
@@ -183,7 +182,7 @@ namespace System.Net.Http.Functional.Tests
         {
             RemoteExecutor.Invoke(async (useVersionString, useSslString) =>
             {
-                using (var listener = new TestEventListener("Microsoft-System-Net-Http", EventLevel.Verbose))
+                using (var listener = new TestEventListener("System.Net.Http.InternalDiagnostics", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     await listener.RunWithCallbackAsync(events.Enqueue, async () =>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -46,7 +46,7 @@ public static class Program
         cmd.AddOption(new Option("-connectionLifetime", "Max connection lifetime length (milliseconds).") { Argument = new Argument<int?>("connectionLifetime", null) });
         cmd.AddOption(new Option("-ops", "Indices of the operations to use") { Argument = new Argument<int[]?>("space-delimited indices", null) });
         cmd.AddOption(new Option("-xops", "Indices of the operations to exclude") { Argument = new Argument<int[]?>("space-delimited indices", null) });
-        cmd.AddOption(new Option("-trace", "Enable Microsoft-System-Net-Http tracing.") { Argument = new Argument<string>("\"console\" or path") });
+        cmd.AddOption(new Option("-trace", "Enable System.Net.Http.InternalDiagnostics tracing.") { Argument = new Argument<string>("\"console\" or path") });
         cmd.AddOption(new Option("-aspnetlog", "Enable ASP.NET warning and error logging.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-listOps", "List available options.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-seed", "Seed for generating pseudo-random parameters for a given -n argument.") { Argument = new Argument<int?>("seed", null) });

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -351,7 +351,7 @@ namespace HttpStress
 
             protected override void OnEventSourceCreated(EventSource eventSource)
             {
-                if (eventSource.Name == "System.Net.Http.InternalDiagnostics")
+                if (eventSource.Name == "Private.InternalDiagnostics.System.Net.Http")
                     EnableEvents(eventSource, EventLevel.LogAlways);
             }
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -351,7 +351,7 @@ namespace HttpStress
 
             protected override void OnEventSourceCreated(EventSource eventSource)
             {
-                if (eventSource.Name == "Microsoft-System-Net-Http")
+                if (eventSource.Name == "System.Net.Http.InternalDiagnostics")
                     EnableEvents(eventSource, EventLevel.LogAlways);
             }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/NetEventSource.HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/NetEventSource.HttpListener.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.HttpListener.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.HttpListener.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.HttpListener", LocalizationResources = "FxResources.System.Net.HttpListener.SR")]
     internal sealed partial class NetEventSource
     {
     }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/NetEventSource.HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/NetEventSource.HttpListener.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-HttpListener", LocalizationResources = "FxResources.System.Net.HttpListener.SR")]
+    [EventSource(Name = "System.Net.HttpListener.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.HttpListener.SR")]
     internal sealed partial class NetEventSource
     {
     }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/NetEventSource.Mail.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/NetEventSource.Mail.cs
@@ -7,6 +7,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Mail.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Mail.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Mail", LocalizationResources = "FxResources.System.Net.Mail.SR")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/NetEventSource.Mail.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/NetEventSource.Mail.cs
@@ -7,6 +7,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Mail", LocalizationResources = "FxResources.System.Net.Mail.SR")]
+    [EventSource(Name = "System.Net.Mail.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Mail.SR")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -17,8 +17,8 @@ namespace System.Net.Mail.Tests
             Type esType = typeof(SmtpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("System.Net.Mail.InternalDiagnostics", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("5a6c4eca-308a-5298-9c54-b07e54c2817e"), EventSource.GetGuid(esType));
+            Assert.Equal("Private.InternalDiagnostics.System.Net.Mail", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("6fff04ac-5aab-530c-03b3-b1b32d2538e9"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -28,7 +28,7 @@ namespace System.Net.Mail.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("System.Net.Mail.InternalDiagnostics", EventLevel.Verbose))
+                using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Mail", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -17,8 +17,8 @@ namespace System.Net.Mail.Tests
             Type esType = typeof(SmtpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("Microsoft-System-Net-Mail", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("42c8027b-f048-58d2-537d-a4a9d5ee7038"), EventSource.GetGuid(esType));
+            Assert.Equal("System.Net.Mail.InternalDiagnostics", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("5a6c4eca-308a-5298-9c54-b07e54c2817e"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -28,7 +28,7 @@ namespace System.Net.Mail.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("Microsoft-System-Net-Mail", EventLevel.Verbose))
+                using (var listener = new TestEventListener("System.Net.Mail.InternalDiagnostics", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NetEventSource.NameResolution.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NetEventSource.NameResolution.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-NameResolution")]
+    [EventSource(Name = "System.Net.NameResolution.InternalDiagnostics")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NetEventSource.NameResolution.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NetEventSource.NameResolution.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.NameResolution.InternalDiagnostics")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.NameResolution")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -21,11 +21,11 @@ namespace System.Net.NameResolution.Tests
         [Fact]
         public static void EventSource_ExistsWithCorrectId()
         {
-            Type esType = typeof(Dns).GetTypeInfo().Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
+            Type esType = typeof(Dns).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("Microsoft-System-Net-NameResolution", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("5f302add-3825-520e-8fa0-627b206e2e7e"), EventSource.GetGuid(esType));
+            Assert.Equal("System.Net.NameResolution.InternalDiagnostics", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("6353daf0-15ed-5bb4-52b9-99e1a61f34a2"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, "assemblyPathToIncludeInManifest"));
         }
@@ -33,7 +33,7 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact]
         public void GetHostEntry_InvalidHost_LogsError()
         {
-            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Error))
+            using (var listener = new TestEventListener("System.Net.NameResolution.InternalDiagnostics", EventLevel.Error))
             {
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
 
@@ -68,7 +68,7 @@ namespace System.Net.NameResolution.Tests
         [PlatformSpecific(~TestPlatforms.Windows)]  // Unreliable on Windows.
         public void GetHostEntryAsync_InvalidHost_LogsError()
         {
-            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Error))
+            using (var listener = new TestEventListener("System.Net.NameResolution.InternalDiagnostics", EventLevel.Error))
             {
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
 
@@ -102,7 +102,7 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact]
         public void GetHostEntry_ValidName_NoErrors()
         {
-            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Verbose))
+            using (var listener = new TestEventListener("System.Net.NameResolution.InternalDiagnostics", EventLevel.Verbose))
             {
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
 

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -24,8 +24,8 @@ namespace System.Net.NameResolution.Tests
             Type esType = typeof(Dns).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("System.Net.NameResolution.InternalDiagnostics", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("6353daf0-15ed-5bb4-52b9-99e1a61f34a2"), EventSource.GetGuid(esType));
+            Assert.Equal("Private.InternalDiagnostics.System.Net.NameResolution", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("460a591a-715b-5647-5264-944bef811147"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, "assemblyPathToIncludeInManifest"));
         }
@@ -33,7 +33,7 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact]
         public void GetHostEntry_InvalidHost_LogsError()
         {
-            using (var listener = new TestEventListener("System.Net.NameResolution.InternalDiagnostics", EventLevel.Error))
+            using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Error))
             {
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
 
@@ -68,7 +68,7 @@ namespace System.Net.NameResolution.Tests
         [PlatformSpecific(~TestPlatforms.Windows)]  // Unreliable on Windows.
         public void GetHostEntryAsync_InvalidHost_LogsError()
         {
-            using (var listener = new TestEventListener("System.Net.NameResolution.InternalDiagnostics", EventLevel.Error))
+            using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Error))
             {
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
 
@@ -102,7 +102,7 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact]
         public void GetHostEntry_ValidName_NoErrors()
         {
-            using (var listener = new TestEventListener("System.Net.NameResolution.InternalDiagnostics", EventLevel.Verbose))
+            using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Verbose))
             {
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
 

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetEventSource.NetworkInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetEventSource.NetworkInformation.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.NetworkInformation.InternalDiagnostics")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.NetworkInformation")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetEventSource.NetworkInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetEventSource.NetworkInformation.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-NetworkInformation")]
+    [EventSource(Name = "System.Net.NetworkInformation.InternalDiagnostics")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
@@ -14,8 +14,8 @@ namespace System.Net.NetworkInformation.Tests
             Type esType = typeof(NetworkChange).Assembly.GetType("System.Net.NetEventSource", throwOnError: false, ignoreCase: false);
             if (esType != null)
             {
-                Assert.Equal("Microsoft-System-Net-NetworkInformation", EventSource.GetName(esType));
-                Assert.Equal(Guid.Parse("b8e42167-0eb2-5e39-97b5-acaca593d3a2"), EventSource.GetGuid(esType));
+                Assert.Equal("System.Net.NetworkInformation.InternalDiagnostics", EventSource.GetName(esType));
+                Assert.Equal(Guid.Parse("7582bbd8-72f0-59b1-1b87-3a2a334eb61e"), EventSource.GetGuid(esType));
 
                 Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
             }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/LoggingTest.cs
@@ -14,8 +14,8 @@ namespace System.Net.NetworkInformation.Tests
             Type esType = typeof(NetworkChange).Assembly.GetType("System.Net.NetEventSource", throwOnError: false, ignoreCase: false);
             if (esType != null)
             {
-                Assert.Equal("System.Net.NetworkInformation.InternalDiagnostics", EventSource.GetName(esType));
-                Assert.Equal(Guid.Parse("7582bbd8-72f0-59b1-1b87-3a2a334eb61e"), EventSource.GetGuid(esType));
+                Assert.Equal("Private.InternalDiagnostics.System.Net.NetworkInformation", EventSource.GetName(esType));
+                Assert.Equal(Guid.Parse("e090a35b-1033-5de3-89e3-01cde7c158ce"), EventSource.GetGuid(esType));
 
                 Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
             }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/NetEventSource.Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/NetEventSource.Ping.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Ping")]
+    [EventSource(Name = "System.Net.Ping.InternalDiagnostics")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/NetEventSource.Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/NetEventSource.Ping.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Ping.InternalDiagnostics")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Ping")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
@@ -14,8 +14,8 @@ namespace System.Net.NetworkInformation.Tests
             Type esType = typeof(Ping).Assembly.GetType("System.Net.NetEventSource", throwOnError: false, ignoreCase: false);
             if (esType != null)
             {
-                Assert.Equal("Microsoft-System-Net-Ping", EventSource.GetName(esType));
-                Assert.Equal(Guid.Parse("a771ec4a-7260-59ce-0475-db257437ed8c"), EventSource.GetGuid(esType));
+                Assert.Equal("System.Net.Ping.InternalDiagnostics", EventSource.GetName(esType));
+                Assert.Equal(Guid.Parse("fcf5966e-222a-59ec-8e5a-4bb038152090"), EventSource.GetGuid(esType));
                 Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
             }
         }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
@@ -14,8 +14,8 @@ namespace System.Net.NetworkInformation.Tests
             Type esType = typeof(Ping).Assembly.GetType("System.Net.NetEventSource", throwOnError: false, ignoreCase: false);
             if (esType != null)
             {
-                Assert.Equal("System.Net.Ping.InternalDiagnostics", EventSource.GetName(esType));
-                Assert.Equal(Guid.Parse("fcf5966e-222a-59ec-8e5a-4bb038152090"), EventSource.GetGuid(esType));
+                Assert.Equal("Private.InternalDiagnostics.System.Net.Ping", EventSource.GetName(esType));
+                Assert.Equal(Guid.Parse("37627c1f-34a9-539e-ab8c-84303b966b74"), EventSource.GetGuid(esType));
                 Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
             }
         }

--- a/src/libraries/System.Net.Primitives/src/System/Net/NetEventSource.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/NetEventSource.Primitives.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Primitives")]
+    [EventSource(Name = "System.Net.Primitives.InternalDiagnostics")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/NetEventSource.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/NetEventSource.Primitives.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Primitives.InternalDiagnostics")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Primitives")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -17,8 +17,8 @@ namespace System.Net.Primitives.Functional.Tests
             Type esType = typeof(IPAddress).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("System.Net.Primitives.InternalDiagnostics", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("c690e77d-9380-59fa-d4e1-a5fc7a803a25"), EventSource.GetGuid(esType));
+            Assert.Equal("Private.InternalDiagnostics.System.Net.Primitives", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("534f3517-0a04-520f-9d69-4778dd119fe1"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -28,7 +28,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("System.Net.Primitives.InternalDiagnostics", EventLevel.Verbose))
+                using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Primitives", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/LoggingTest.cs
@@ -17,8 +17,8 @@ namespace System.Net.Primitives.Functional.Tests
             Type esType = typeof(IPAddress).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("Microsoft-System-Net-Primitives", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("a9f9e4e1-0cf5-5005-b530-3d37959d5e84"), EventSource.GetGuid(esType));
+            Assert.Equal("System.Net.Primitives.InternalDiagnostics", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("c690e77d-9380-59fa-d4e1-a5fc7a803a25"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -28,7 +28,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("Microsoft-System-Net-Primitives", EventLevel.Verbose))
+                using (var listener = new TestEventListener("System.Net.Primitives.InternalDiagnostics", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Net.Requests/src/System/Net/NetEventSource.Requests.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/NetEventSource.Requests.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Requests.InternalDiagnostics")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Requests")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Requests/src/System/Net/NetEventSource.Requests.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/NetEventSource.Requests.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Requests")]
+    [EventSource(Name = "System.Net.Requests.InternalDiagnostics")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/libraries/System.Net.Requests/tests/LoggingTest.cs
@@ -15,8 +15,8 @@ namespace System.Net.Tests
             Type esType = typeof(WebRequest).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("System.Net.Requests.InternalDiagnostics", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("51eafc09-2b9b-5c9b-16dd-98cbab55a00d"), EventSource.GetGuid(esType));
+            Assert.Equal("Private.InternalDiagnostics.System.Net.Requests", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("de972c9f-4457-5dc5-e37b-aaf8033eb3a9"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }

--- a/src/libraries/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/libraries/System.Net.Requests/tests/LoggingTest.cs
@@ -15,8 +15,8 @@ namespace System.Net.Tests
             Type esType = typeof(WebRequest).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("Microsoft-System-Net-Requests", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("3763dc7e-7046-5576-9041-5616e21cc2cf"), EventSource.GetGuid(esType));
+            Assert.Equal("System.Net.Requests.InternalDiagnostics", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("51eafc09-2b9b-5c9b-16dd-98cbab55a00d"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
@@ -11,7 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Security.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Security.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Security", LocalizationResources = "FxResources.System.Net.Security.SR")]
     internal sealed partial class NetEventSource
     {
         private const int SecureChannelCtorId = NextAvailableEventId;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
@@ -11,7 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Security", LocalizationResources = "FxResources.System.Net.Security.SR")]
+    [EventSource(Name = "System.Net.Security.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Security.SR")]
     internal sealed partial class NetEventSource
     {
         private const int SecureChannelCtorId = NextAvailableEventId;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -17,8 +17,8 @@ namespace System.Net.Security.Tests
             Type esType = typeof(SslStream).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("System.Net.Security.InternalDiagnostics", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("0017888f-1af4-5401-ee54-e3da71eb3a12"), EventSource.GetGuid(esType));
+            Assert.Equal("Private.InternalDiagnostics.System.Net.Security", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("a0d627f0-c0f5-5a45-558a-6634a894c155"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -28,7 +28,7 @@ namespace System.Net.Security.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("System.Net.Security.InternalDiagnostics", EventLevel.Verbose))
+                using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Security", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -17,8 +17,8 @@ namespace System.Net.Security.Tests
             Type esType = typeof(SslStream).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("Microsoft-System-Net-Security", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("066c0e27-a02d-5a98-9a4d-078cc3b1a896"), EventSource.GetGuid(esType));
+            Assert.Equal("System.Net.Security.InternalDiagnostics", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("0017888f-1af4-5401-ee54-e3da71eb3a12"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -28,7 +28,7 @@ namespace System.Net.Security.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("Microsoft-System-Net-Security", EventLevel.Verbose))
+                using (var listener = new TestEventListener("System.Net.Security.InternalDiagnostics", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Net
 {
-    [EventSource(Name = "Microsoft-System-Net-Sockets", Guid = "e03c0352-f9c9-56ff-0ea7-b94ba8cabc6b", LocalizationResources = "FxResources.System.Net.Sockets.SR")]
+    [EventSource(Name = "System.Net.Sockets.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Sockets.SR")]
     internal sealed partial class NetEventSource
     {
         private const int AcceptedId = NextAvailableEventId;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Net
 {
-    [EventSource(Name = "System.Net.Sockets.InternalDiagnostics", LocalizationResources = "FxResources.System.Net.Sockets.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Sockets", LocalizationResources = "FxResources.System.Net.Sockets.SR")]
     internal sealed partial class NetEventSource
     {
         private const int AcceptedId = NextAvailableEventId;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -25,8 +25,8 @@ namespace System.Net.Sockets.Tests
             Type esType = typeof(Socket).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("System.Net.Sockets.InternalDiagnostics", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("08166fc4-c58c-5fd8-576d-069966be45b3"), EventSource.GetGuid(esType));
+            Assert.Equal("Private.InternalDiagnostics.System.Net.Sockets", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("ae391de7-a2cb-557c-dd34-fe00d0b98c7f"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -37,7 +37,7 @@ namespace System.Net.Sockets.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("System.Net.Sockets.InternalDiagnostics", EventLevel.Verbose))
+                using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.Sockets", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -25,8 +25,8 @@ namespace System.Net.Sockets.Tests
             Type esType = typeof(Socket).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);
 
-            Assert.Equal("Microsoft-System-Net-Sockets", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("e03c0352-f9c9-56ff-0ea7-b94ba8cabc6b"), EventSource.GetGuid(esType));
+            Assert.Equal("System.Net.Sockets.InternalDiagnostics", EventSource.GetName(esType));
+            Assert.Equal(Guid.Parse("08166fc4-c58c-5fd8-576d-069966be45b3"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
         }
@@ -37,7 +37,7 @@ namespace System.Net.Sockets.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                using (var listener = new TestEventListener("Microsoft-System-Net-Sockets", EventLevel.Verbose))
+                using (var listener = new TestEventListener("System.Net.Sockets.InternalDiagnostics", EventLevel.Verbose))
                 {
                     var events = new ConcurrentQueue<EventWrittenEventArgs>();
                     listener.RunWithCallback(events.Enqueue, () =>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -211,7 +211,7 @@ namespace System.Diagnostics.Tracing
     /// <remarks>
     /// This is a minimal definition for a custom event source:
     /// <code>
-    /// [EventSource(Name="Samples-Demos-Minimal")]
+    /// [EventSource(Name="Samples.Demos.Minimal")]
     /// sealed class MinimalEventSource : EventSource
     /// {
     ///     public static MinimalEventSource Log = new MinimalEventSource();


### PR DESCRIPTION
Unified naming conventions in existing networking `EventSources` to follow the namespace to which they belong, as well as correspond to the newly added telemetries.

Added suffix ".InternalDiagnostics" for old logging events to prevent them from being accidentally turned on with the new telemetry.

Existing `EventSources` that haven't been changed:
- ["Microsoft-System-Net-Quic"](https://github.com/dotnet/runtime/blob/master/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/NetEventSource.Quic.cs#L8): shared with ASP.NET Core. I assume it cannot be willy-nilly changed without prior aggreement.
- ["Microsoft-Extensions-DependencyInjection"](https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs#L11): out of networking scope.
- ["Microsoft-Extensions-Logging"](https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs#L79): out of networking scope.
- ["Microsoft-Diagnostics-DiagnosticSource"](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs#L147): out of networking scope.

Contributes to #38754 

Rational: the logging is useful for diagnostics, we shouldn't just delete it without proper replacement.
In 6.0 we can go through individual events and clean it. This is compromise that's doable in such short time.