### PR TITLE
Set default timeout to 120 for OSX build pools

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -26,15 +26,9 @@ jobs:
     pool: ${{ parameters.pool }}
     container: ${{ parameters.container }}
     condition: and(succeeded(), ${{ parameters.condition }})
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     workspace:
       clean: all
-
-    # macOS hosted pool machines are slower so we need to give a greater timeout for global-build
-    # which builds multiple subsets.
-    ${{ if and(contains(parameters.pool.vmImage, 'macOS'), eq(parameters.timeoutInMinutes, '')) }}:
-      timeoutInMinutes: 120
-    ${{ if or(not(contains(parameters.pool.vmImage, 'macOS')), ne(parameters.timeoutInMinutes, '')) }}:
-      timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
     variables:
       - name: _osParameter

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -136,6 +136,9 @@ jobs:
 
 
     ${{ if eq(parameters.helixQueuesTemplate, '') }}:
+      # macOS hosted pool machines are slower so we need to give a greater timeout than the 60 mins default.
+      ${{ if and(eq(parameters.jobParameters.timeoutInMinutes, ''), in(parameters.osGroup, 'OSX', 'iOS', 'tvOS')) }}:
+        timeoutInMinutes: 120
       ${{ insert }}: ${{ parameters.jobParameters }}
     ${{ if ne(parameters.helixQueuesTemplate, '') }}:
       jobTemplate: ${{ parameters.jobTemplate }}


### PR DESCRIPTION
60 minutes is not enough for some OSX jobs that use the new hosted macOS machines that are half the size of the old ones so builds can easily timeout. 

Move it out from `global-build-job` to `xplat-setup`. 

Validated that the yml was expanded correctly on a test job:
```yml
    displayName: CoreCLR  Product Build OSX x64 checked
    pool:
      vmImage: macOS-10.14
    timeoutInMinutes: 120
```

```yml
    displayName: Build tvOS x64 Release AllSubsets_Mono
    pool:
      vmImage: macOS-10.14
    timeoutInMinutes: 120
```

cc: @dotnet/runtime-infrastructure 
