### PR TITLE
[wasm] Changing debugger wasm test

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1482,7 +1482,8 @@ namespace DebuggerTests
 
                 AssertEqual("WriteLine", top_frame["functionName"]?.Value<string>(), "Expected to be in WriteLine method");
                 var script_id = top_frame["functionLocation"]["scriptId"].Value<string>();
-                AssertEqual("dotnet://System.Console.dll/Console.cs", scripts[script_id], "Expected to stopped in System.Console.WriteLine");
+                if (!scripts[script_id].Equals("dotnet://System.Console.dll/Console.cs") && !scripts[script_id].Equals("dotnet://mscorlib.dll/Console.cs"))
+                    Assert.True(false, "Expected to stopped in System.Console.WriteLine");
             });
         }
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1482,8 +1482,7 @@ namespace DebuggerTests
 
                 AssertEqual("WriteLine", top_frame["functionName"]?.Value<string>(), "Expected to be in WriteLine method");
                 var script_id = top_frame["functionLocation"]["scriptId"].Value<string>();
-                if (!scripts[script_id].Equals("dotnet://System.Console.dll/Console.cs") && !scripts[script_id].Equals("dotnet://mscorlib.dll/Console.cs"))
-                    Assert.True(false, "Expected to stopped in System.Console.WriteLine");
+                Assert.Matches ("^dotnet://(mscorlib|System\\.Console)\\.dll/Console.cs", scripts[script_id]);
             });
         }
 


### PR DESCRIPTION
Change test to run the same test on mono/mono and on dotnet/runtime.

Relates to https://github.com/mono/mono/pull/20242.