### PR TITLE
Update analyzers and various fixes to be able to build with latest RC1 SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,10 @@
       tell Microsoft.Common.props not to import Directory.Build.props again
     -->
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+
+    <!-- We reference Microsoft.CodeAnalysis.NetAnalyzers as a package reference instead
+    of using the SDK ones to be able to update the analyzers independently -->
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,10 +6,6 @@
       tell Microsoft.Common.props not to import Directory.Build.props again
     -->
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-
-    <!-- We reference Microsoft.CodeAnalysis.NetAnalyzers as a package reference instead
-    of using the SDK ones to be able to update the analyzers independently -->
-    <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
 
   <!--
@@ -88,6 +84,9 @@
 
     <!-- We don't want Private packages to be shipped to NuGet.org -->
     <IsShippingPackage Condition="($(MSBuildProjectName.Contains('Private')) or $(IsExperimentalAssembly)) and '$(MSBuildProjectExtension)' == '.pkgproj'">false</IsShippingPackage>
+
+    <!-- By default the SDK produces ref assembly for 5.0 or later -->
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!-- Language configuration -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,8 @@
     tell Microsoft.Common.targets not to import Directory.Build.targets again
     -->
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+
+    <EnableNETAnalyzers Condition="'$(EnableAnalyzers)' != 'true'">false</EnableNETAnalyzers>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)liveBuilds.targets" />

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="3.3.0-beta3.20410.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0-rc1.20413.9" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/referenceAssemblies.props
+++ b/eng/referenceAssemblies.props
@@ -4,6 +4,9 @@
                             !$(BuildTargetFramework.StartsWith('net4'))">
     <AdditionalBuildTargetFrameworks>$(AdditionalBuildTargetFrameworks);netstandard2.0</AdditionalBuildTargetFrameworks>
     <AdditionalBuildTargetFrameworks Condition="!$(BuildTargetFramework.StartsWith('netcoreapp2.0'))">$(AdditionalBuildTargetFrameworks);netstandard2.1</AdditionalBuildTargetFrameworks>
+
+    <!-- Reference assemblies are special and don't initialize fields or have empty finalizers, etc. -->
+    <EnableAnalyzers>false</EnableAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -6,6 +6,11 @@
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and ('$(_ShortFrameworkIdentifier)' == '' or '$(_ShortFrameworkVersion)' == '')">
+    <_ShortFrameworkIdentifier>$(TargetFramework.TrimEnd('.0123456789'))</_ShortFrameworkIdentifier>
+    <_ShortFrameworkVersion>$(TargetFramework.Substring($(_ShortFrameworkIdentifier.Length)))</_ShortFrameworkVersion>
+  </PropertyGroup>
+
   <!-- .NETCoreApp 2.x DisableImplicitAssemblyReferences support. -->
   <Choose>
     <When Condition="'$(DisableImplicitAssemblyReferences)' == 'true' and

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -229,7 +229,7 @@
     <!-- We decided to keep this disabled by default: https://github.com/dotnet/runtime/issues/15152 -->
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
-    <EnableAnalyzers Condition="'$(EnableAnalyzers)' == '' and '$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.ilproj'">true</EnableAnalyzers>   
+    <EnableAnalyzers Condition="'$(EnableAnalyzers)' == '' and '$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.ilproj'">true</EnableAnalyzers>
   </PropertyGroup>
 
   <!-- Set up common paths -->

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -229,7 +229,7 @@
     <!-- We decided to keep this disabled by default: https://github.com/dotnet/runtime/issues/15152 -->
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
-    <EnableAnalyzers Condition="'$(EnableAnalyzers)' == '' and '$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.ilproj'">true</EnableAnalyzers>
+    <EnableAnalyzers Condition="'$(EnableAnalyzers)' == '' and '$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.ilproj'">true</EnableAnalyzers>   
   </PropertyGroup>
 
   <!-- Set up common paths -->


### PR DESCRIPTION
When installing latest SDK RC1 which comes with VS Internal Preview Updated  or latest P8 SDK, we're getting the net analyzers for 5.0 TFM by default, causing errors like:

```
CSC : error CS8034: Unable to load Analyzer assembly C:\Users\chucks\.nuget\packages\microsoft.codeanalysis.netanalyzers\3.3.0-beta3.20407.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll : Assembly with same name is already loaded [C:\dotnet\runtime\src\libraries\System.Linq.Expressions\src\System.Linq.Expressions.csproj]
CSC : error CS8034: Unable to load Analyzer assembly C:\Users\chucks\.nuget\packages\microsoft.codeanalysis.netanalyzers\3.3.0-beta3.20407.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll : Assembly with same name is already loaded [C:\dotnet\runtime\src\libraries\System.Linq.Expressions\src\System.Linq.Expressions.csproj]
CSC : error CS8034: Unable to load Analyzer assembly C:\Users\chucks\.nuget\packages\microsoft.codeanalysis.netanalyzers\3.3.0-beta3.20407.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll : Assembly with same name is already loaded [C:\dotnet\runtime\src\libraries\System.Linq.Expressions\src\System.Linq.Expressions.csproj]
CSC : error CS8034: Unable to load Analyzer assembly C:\Users\chucks\.nuget\packages\microsoft.codeanalysis.netanalyzers\3.3.0-beta3.20407.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll : Assembly with same name is already loaded [C:\dotnet\runtime\src\libraries\System.Linq.Expressions\src\System.Linq.Expressions.csproj]
```

Update to latest analyzers which with latest SDK fixes this issue.

Also, disable Producing reference assemblies as latest SDK enables them by default for net5.0 tfm.

The newest SDK no longer defines `_ShortFrameworkIdentifier` and `_ShortFrameworkVersion` which we depend for our AssemblySearchDirectories in order to support named reference in our projects. Without this we get: 

```
C:\Program Files\dotnet\sdk\5.0.100-rc.1.20414.5\Microsoft.Common.CurrentVersion.targets(2085,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Collections". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\repos\runtime\src\libraries\Microsoft.Win32.SystemEvents\src\Microsoft.Win32.SystemEvents.csproj]
```

cc: @stephentoub @jeffhandley @dotnet/runtime-infrastructure 