### PR TITLE
Handle potential null in ALC.ResolveSatelliteAssembly

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -727,7 +727,9 @@ namespace System.Runtime.Loader
 
             AssemblyLoadContext parentALC = GetLoadContext(parentAssembly)!;
 
-            string parentDirectory = Path.GetDirectoryName(parentAssembly.Location)!;
+            string? parentDirectory = Path.GetDirectoryName(parentAssembly.Location);
+            if (parentDirectory == null)
+                 return null;
 
             string assemblyPath = Path.Combine(parentDirectory, assemblyName.CultureName!, $"{assemblyName.Name}.dll");
 


### PR DESCRIPTION
This was found on wasm, where assemblies are primarily loaded from a bundle rather than on the filesystem itself and return "" for Assembly.Location. This bug should affect desktop too if you have System.Private.CoreLib in the root of the file system (for whatever reason).

This manifested oddly in https://github.com/dotnet/aspnetcore/pull/24773 because we threw an exception while trying to look up the corlib satellite assembly, which in turn triggered another load on that same resource due to the exception text, the usual recursive problem. The solution is to not throw the exception in the first place.