### PR TITLE
Implement concept of unstable ABI into crossgen2

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -13,9 +13,11 @@ namespace ILCompiler
     public class VectorFieldLayoutAlgorithm : FieldLayoutAlgorithm
     {
         private readonly FieldLayoutAlgorithm _fallbackAlgorithm;
+        private readonly bool _vectorAbiIsStable;
 
-        public VectorFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm)
+        public VectorFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm, bool vectorAbiIsStable)
         {
+            _vectorAbiIsStable = vectorAbiIsStable;
             _fallbackAlgorithm = fallbackAlgorithm;
         }
 
@@ -73,6 +75,7 @@ namespace ILCompiler
                 FieldAlignment = alignment,
                 FieldSize = layoutFromMetadata.FieldSize,
                 Offsets = layoutFromMetadata.Offsets,
+                LayoutAbiStable = _vectorAbiIsStable
             };
         }
 

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1247,6 +1247,7 @@ namespace Internal.JitInterface
         {
             var methodIL = (MethodIL)HandleToObject((IntPtr)module);
             var methodSig = (MethodSignature)methodIL.GetObject((int)sigTOK);
+
             Get_CORINFO_SIG_INFO(methodSig, sig);
 
             if (sig->callConv == CorInfoCallConv.CORINFO_CALLCONV_UNMANAGED)
@@ -1260,6 +1261,8 @@ namespace Internal.JitInterface
             {
                 sig->flags |= CorInfoSigInfoFlags.CORINFO_SIGFLAG_FAT_CALL;
             }
+#else
+            VerifyMethodSignatureIsStable(methodSig);
 #endif
         }
 
@@ -2916,6 +2919,14 @@ namespace Internal.JitInterface
                 default:
                     // Reloc points to something outside of the generated blocks
                     var targetObject = HandleToObject((IntPtr)target);
+
+#if READYTORUN
+                    if (targetObject is RequiresRuntimeJitIfUsedSymbol requiresRuntimeSymbol)
+                    {
+                        throw new RequiresRuntimeJitException(requiresRuntimeSymbol.Message);
+                    }
+#endif
+
                     relocTarget = (ISymbolNode)targetObject;
                     break;
             }

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
@@ -48,6 +48,11 @@ namespace Internal.TypeSystem
             /// True if information about the shape of value type has been computed.
             /// </summary>
             public const int ComputedValueTypeShapeCharacteristics = 0x40;
+
+            /// <summary>
+            /// True if the layout of the type is not stable for use in the ABI
+            /// </summary>
+            public const int ComputedInstanceLayoutAbiUnstable = 0x80;
         }
 
         private class StaticBlockInfo
@@ -153,6 +158,21 @@ namespace Internal.TypeSystem
                     ComputeInstanceLayout(InstanceLayoutKind.TypeOnly);
                 }
                 return _instanceByteAlignment;
+            }
+        }
+
+        /// <summary>
+        /// The type has stable Abi layout
+        /// </summary>
+        public bool LayoutAbiStable
+        {
+            get
+            {
+                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedInstanceTypeLayout))
+                {
+                    ComputeInstanceLayout(InstanceLayoutKind.TypeOnly);
+                }
+                return !_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedInstanceLayoutAbiUnstable);
             }
         }
 
@@ -335,6 +355,10 @@ namespace Internal.TypeSystem
             _instanceFieldAlignment = computedLayout.FieldAlignment;
             _instanceByteCountUnaligned = computedLayout.ByteCountUnaligned;
             _instanceByteAlignment = computedLayout.ByteCountAlignment;
+            if (!computedLayout.LayoutAbiStable)
+            {
+                _fieldLayoutFlags.AddFlags(FieldLayoutFlags.ComputedInstanceLayoutAbiUnstable);
+            }
 
             if (computedLayout.Offsets != null)
             {

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -76,6 +76,7 @@ namespace Internal.TypeSystem
         public LayoutInt FieldAlignment;
         public LayoutInt ByteCountUnaligned;
         public LayoutInt ByteCountAlignment;
+        public bool LayoutAbiStable; // Is the layout stable such that it can safely be used in function calling conventions
 
         /// <summary>
         /// If Offsets is non-null, then all field based layout is complete.

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
@@ -29,7 +29,8 @@ namespace Internal.TypeSystem
                 FieldAlignment = LayoutInt.Indeterminate,
                 ByteCountUnaligned = LayoutInt.Indeterminate,
                 ByteCountAlignment = LayoutInt.Indeterminate,
-                Offsets = Array.Empty<FieldAndOffset>()
+                Offsets = Array.Empty<FieldAndOffset>(),
+                LayoutAbiStable = true
             };
         }
 

--- a/src/coreclr/src/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
@@ -30,7 +30,8 @@ namespace Internal.TypeSystem
                 ByteCountAlignment = canonicalType.InstanceByteAlignment,
                 FieldAlignment = canonicalType.InstanceFieldAlignment,
                 FieldSize = canonicalType.InstanceFieldSize,
-                Offsets = Array.Empty<FieldAndOffset>()
+                Offsets = Array.Empty<FieldAndOffset>(),
+                LayoutAbiStable = canonicalType.LayoutAbiStable
             };
 
             return result;

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -26,12 +26,14 @@ namespace ILCompiler
         private VectorOfTFieldLayoutAlgorithm _vectorOfTFieldLayoutAlgorithm;
         private VectorFieldLayoutAlgorithm _vectorFieldLayoutAlgorithm;
 
-        public ReadyToRunCompilerContext(TargetDetails details, SharedGenericsMode genericsMode)
+        public ReadyToRunCompilerContext(TargetDetails details, SharedGenericsMode genericsMode, bool bubbleIncludesCorelib)
             : base(details, genericsMode)
         {
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
             _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
-            _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
+
+            // Only the Arm64 JIT respects the OS rules for vector type abi currently
+            _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, (details.Architecture == TargetArchitecture.ARM64) ? true : bubbleIncludesCorelib);
 
             string matchingVectorType = "Unknown";
             if (details.MaximumSimdVectorLength == SimdVectorLength.Vector128Bit)
@@ -39,8 +41,8 @@ namespace ILCompiler
             else if (details.MaximumSimdVectorLength == SimdVectorLength.Vector256Bit)
                 matchingVectorType = "Vector256`1";
 
-            _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, _vectorFieldLayoutAlgorithm, matchingVectorType);
-
+            // No architecture has completely stable handling of Vector<T> in the abi (Arm64 may change to SVE)
+            _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, _vectorFieldLayoutAlgorithm, matchingVectorType, bubbleIncludesCorelib);
         }
 
         public override FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
@@ -112,12 +114,14 @@ namespace ILCompiler
         private FieldLayoutAlgorithm _vectorFallbackAlgorithm;
         private string _similarVectorName;
         private DefType _similarVectorOpenType;
+        private bool _vectorAbiIsStable;
 
-        public VectorOfTFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm, FieldLayoutAlgorithm vectorFallbackAlgorithm, string similarVector)
+        public VectorOfTFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm, FieldLayoutAlgorithm vectorFallbackAlgorithm, string similarVector, bool vectorAbiIsStable)
         {
             _fallbackAlgorithm = fallbackAlgorithm;
             _vectorFallbackAlgorithm = vectorFallbackAlgorithm;
             _similarVectorName = similarVector;
+            _vectorAbiIsStable = vectorAbiIsStable;
         }
 
         private DefType GetSimilarVector(DefType vectorOfTType)
@@ -158,6 +162,7 @@ namespace ILCompiler
                     ByteCountUnaligned = LayoutInt.Indeterminate,
                     ByteCountAlignment = LayoutInt.Indeterminate,
                     Offsets = fieldsAndOffsets.ToArray(),
+                    LayoutAbiStable = false,
                 };
                 return instanceLayout;
             }
@@ -175,6 +180,7 @@ namespace ILCompiler
                     FieldAlignment = layoutFromSimilarIntrinsicVector.FieldAlignment,
                     FieldSize = layoutFromSimilarIntrinsicVector.FieldSize,
                     Offsets = layoutFromMetadata.Offsets,
+                    LayoutAbiStable = _vectorAbiIsStable,
                 };
 #else
                 return new ComputedInstanceFieldLayout
@@ -184,6 +190,7 @@ namespace ILCompiler
                     FieldAlignment = layoutFromMetadata.FieldAlignment,
                     FieldSize = layoutFromSimilarIntrinsicVector.FieldSize,
                     Offsets = layoutFromMetadata.Offsets,
+                    LayoutAbiStable = _vectorAbiIsStable,
                 };
 #endif
             }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
@@ -36,6 +36,7 @@ namespace ILCompiler
                 FieldAlignment = layoutFromMetadata.FieldAlignment,
                 FieldSize = layoutFromMetadata.FieldSize,
                 Offsets = layoutFromMetadata.Offsets,
+                LayoutAbiStable = true,
             };
         }
 

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -24,6 +24,16 @@ using ILCompiler.DependencyAnalysis.ReadyToRun;
 
 namespace Internal.JitInterface
 {
+    internal class RequiresRuntimeJitIfUsedSymbol
+    {
+        public RequiresRuntimeJitIfUsedSymbol(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+    }
+
     public class MethodWithToken
     {
         public readonly MethodDesc Method;
@@ -224,7 +234,7 @@ namespace Internal.JitInterface
 
             try
             {
-                if (!ShouldSkipCompilation(MethodBeingCompiled))
+                if (!ShouldSkipCompilation(MethodBeingCompiled) && !MethodSignatureIsUnstable(MethodBeingCompiled.Signature, out var _))
                 {
                     MethodIL methodIL = _compilation.GetMethodIL(MethodBeingCompiled);
                     if (methodIL != null)
@@ -1509,6 +1519,42 @@ namespace Internal.JitInterface
             _methodCodeNode.Fixups.Add(node);
         }
 
+        private static bool MethodSignatureIsUnstable(MethodSignature methodSig, out string unstableMessage)
+        {
+            foreach (TypeDesc t in methodSig)
+            {
+                DefType defType = t as DefType;
+
+                if (defType != null)
+                {
+                    if (!defType.LayoutAbiStable)
+                    {
+                        unstableMessage = $"Abi unstable type {defType}";
+                        return true;
+                    }
+                }
+            }
+            unstableMessage = null;
+            return false;
+        }
+
+        private void UpdateConstLookupWithRequiresRuntimeJitSymbolIfNeeded(ref CORINFO_CONST_LOOKUP constLookup, MethodDesc method)
+        {
+            if (MethodSignatureIsUnstable(method.Signature, out string unstableMessage))
+            {
+                constLookup.addr = (void*)ObjectToHandle(new RequiresRuntimeJitIfUsedSymbol(unstableMessage));
+                constLookup.accessType = InfoAccessType.IAT_PVALUE;
+            }
+        }
+
+        private void VerifyMethodSignatureIsStable(MethodSignature methodSig)
+        {
+            if (MethodSignatureIsUnstable(methodSig, out var unstableMessage))
+            {
+                throw new RequiresRuntimeJitException(unstableMessage);
+            }
+        }
+
         private void getCallInfo(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_CALLINFO_FLAGS flags, CORINFO_CALL_INFO* pResult)
         {
             MethodDesc methodToCall;
@@ -1569,12 +1615,17 @@ namespace Internal.JitInterface
                             _compilation.SymbolNodeFactory.InterfaceDispatchCell(
                                 new MethodWithToken(targetMethod, HandleToModuleToken(ref pResolvedToken, targetMethod), constrainedType: null, unboxing: false),
                                 MethodBeingCompiled));
+
+                        // If the abi of the method isn't stable, this will cause a usage of the RequiresRuntimeJitSymbol, which will trigger a RequiresRuntimeJitException
+                        UpdateConstLookupWithRequiresRuntimeJitSymbolIfNeeded(ref pResult->codePointerOrStubLookup.constLookup, targetMethod);
                         }
                     break;
 
 
                 case CORINFO_CALL_KIND.CORINFO_CALL_CODE_POINTER:
                     Debug.Assert(pResult->codePointerOrStubLookup.lookupKind.needsRuntimeLookup);
+                    // Eagerly check abi stability here as no symbol usage can be used to delay the check
+                    VerifyMethodSignatureIsStable(targetMethod.Signature);
 
                     // There is no easy way to detect method referenced via generic lookups in generated code.
                     // Report this method reference unconditionally.
@@ -1604,12 +1655,18 @@ namespace Internal.JitInterface
                                 new MethodWithToken(nonUnboxingMethod, HandleToModuleToken(ref pResolvedToken, nonUnboxingMethod), constrainedType, unboxing: isUnboxingStub),
                                 isInstantiatingStub: useInstantiatingStub,
                                 isPrecodeImportRequired: (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) != 0));
+
+                        // If the abi of the method isn't stable, this will cause a usage of the RequiresRuntimeJitSymbol, which will trigger a RequiresRuntimeJitException
+                        UpdateConstLookupWithRequiresRuntimeJitSymbolIfNeeded(ref pResult->codePointerOrStubLookup.constLookup, targetMethod);
                     }
                     break;
 
                 case CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_VTABLE:
                     // Only calls within the CoreLib version bubble support fragile NI codegen with vtable based calls, for better performance (because 
                     // CoreLib and the runtime will always be updated together anyways - this is a special case)
+
+                    // Eagerly check abi stability here as no symbol usage can be used to delay the check
+                    VerifyMethodSignatureIsStable(targetMethod.Signature);
                     break;
 
                 case CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_LDVIRTFTN:

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1542,7 +1542,7 @@ namespace Internal.JitInterface
         {
             if (MethodSignatureIsUnstable(method.Signature, out string unstableMessage))
             {
-                constLookup.addr = (void*)ObjectToHandle(new RequiresRuntimeJitIfUsedSymbol(unstableMessage));
+                constLookup.addr = (void*)ObjectToHandle(new RequiresRuntimeJitIfUsedSymbol(unstableMessage + " calling " + method));
                 constLookup.accessType = InfoAccessType.IAT_PVALUE;
             }
         }

--- a/src/coreclr/src/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/Program.cs
@@ -291,7 +291,36 @@ namespace ILCompiler
                     SharedGenericsMode genericsMode = SharedGenericsMode.CanonicalReferenceTypes;
 
                     var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT, instructionSetSupport.GetVectorTSimdVector());
-                    _typeSystemContext = new ReadyToRunCompilerContext(targetDetails, genericsMode);
+
+                    bool versionBubbleIncludesCoreLib = false;
+                    if (_commandLineOptions.InputBubble)
+                    {
+                        versionBubbleIncludesCoreLib = true;
+                    }
+                    else
+                    {
+                        foreach (var inputFile in _inputFilePaths)
+                        {
+                            if (String.Compare(inputFile.Key, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase) == 0)
+                            {
+                                versionBubbleIncludesCoreLib = true;
+                                break;
+                            }
+                        }
+                        if (!versionBubbleIncludesCoreLib)
+                        {
+                            foreach (var inputFile in _unrootedInputFilePaths)
+                            {
+                                if (String.Compare(inputFile.Key, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase) == 0)
+                                {
+                                    versionBubbleIncludesCoreLib = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    _typeSystemContext = new ReadyToRunCompilerContext(targetDetails, genericsMode, versionBubbleIncludesCoreLib);
 
                     string compositeRootPath = _commandLineOptions.CompositeRootPath?.FullName;
 


### PR DESCRIPTION
- Use for the Vector types based on current defined stability rules
- Will prevent compilation of methods with not yet stable abis, or calls to methods with said unstable apis

Fixes #13522