### PR TITLE
Fix for issue 40444 - Thread.MemoryBarrier() should prevent hoisting of memory reads

### DIFF
--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -7920,10 +7920,11 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         }
                         break;
 
-                    case GT_LOCKADD: // Binop
-                    case GT_XADD:    // Binop
-                    case GT_XCHG:    // Binop
-                    case GT_CMPXCHG: // Specialop
+                    case GT_LOCKADD:
+                    case GT_XADD:
+                    case GT_XCHG:
+                    case GT_CMPXCHG:
+                    case GT_MEMORYBARRIER:
                     {
                         assert(!tree->OperIs(GT_LOCKADD) && "LOCKADD should not appear before lowering");
                         memoryHavoc |= memoryKindSet(GcHeap, ByrefExposed);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_40444/Runtime_40444.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_40444/Runtime_40444.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Runtime.CompilerServices;
+
+class Runtime_40444
+{
+    
+    public static int t2_result = 0;
+    public static int t2_finished;
+    
+    static void Thread2()
+    {
+        t2_result++;
+        t2_finished = 1;
+    }
+    
+//    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int TestVolatileRead(ref int address)
+    {
+        int ret = address;
+        Thread.MemoryBarrier(); // Call MemoryBarrier to ensure the proper semantic in a portable way.
+        return ret;
+    }
+
+    static bool Test()
+    {
+        bool result = false;
+        t2_finished = 0;
+
+        // Run Thread2() in a new thread
+        new Thread(new ThreadStart(Thread2)).Start();
+        
+        // Wait for Thread2 to signal that it has a result by setting
+        // t2_finished to 1.
+        for (int i=0; i<10000000; i++)
+        {
+            if (TestVolatileRead(ref t2_finished)==1)
+            {
+                Console.WriteLine("{1}: result = {0}", t2_result, i);
+                result = true;
+                break;
+            }
+        }
+        if (result == false)
+        {
+            Console.WriteLine("FAILED");
+        }
+        return result;
+    }
+
+    static int Main()
+    {
+        for (int i=0; i<100; i++)
+        {
+            if (!Test())
+            {
+                return -1;
+            }
+        }
+        Console.WriteLine("Passed");
+        return t2_result;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_40444/Runtime_40444.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_40444/Runtime_40444.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add the GT_MEMORYBARRIER operator to the set of instructions that need to record a ByrefExposed memory havoc impact in loops

This prevents the hoisting of memory loads out of such a loop