### PR TITLE
Limit Debugger.Log() calls in EventSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3702,7 +3702,7 @@ namespace System.Diagnostics.Tracing
                     m_outOfBandMessageCount = 16;    // Mark that we hit the limit.  Notify them that this is the case.
                     msg = "Reached message limit.   End of EventSource error messages.";
                 }
-                
+
                 // send message to debugger
                 System.Diagnostics.Debugger.Log(0, null, string.Format("EventSource Error: {0}{1}", msg, System.Environment.NewLine));
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3693,10 +3693,6 @@ namespace System.Diagnostics.Tracing
         {
             try
             {
-                // send message to debugger without delay
-                System.Diagnostics.Debugger.Log(0, null, string.Format("EventSource Error: {0}{1}", msg, System.Environment.NewLine));
-
-                // Send it to all listeners.
                 if (m_outOfBandMessageCount < 16 - 1)     // Note this is only if size byte
                     m_outOfBandMessageCount++;
                 else
@@ -3706,7 +3702,11 @@ namespace System.Diagnostics.Tracing
                     m_outOfBandMessageCount = 16;    // Mark that we hit the limit.  Notify them that this is the case.
                     msg = "Reached message limit.   End of EventSource error messages.";
                 }
+                
+                // send message to debugger
+                System.Diagnostics.Debugger.Log(0, null, string.Format("EventSource Error: {0}{1}", msg, System.Environment.NewLine));
 
+                // Send it to all listeners.
                 WriteEventString(msg);
                 WriteStringToAllListeners("EventSourceMessage", msg);
             }


### PR DESCRIPTION
Fixing #40799 

Previously we would send a message via Debugger.Log() for event call to ReportOutOfBandMessage().
Now we only do it the first 16 times, then all errors after that are silent. This should alleviate performance
overhead from a scenarios with a large number of errors.

I made this change quickly via github to help out Bing. I have never compiled or tested it prior to the PR
but fingers crossed it appears simple enough that it has a decent chance to work : )

@sywhang @josalem @davmason 