### PR TITLE
Throw when non-nullable struct converters indicate that they handle nullable structs

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -543,6 +543,6 @@
     <value>When 'JsonNumberHandlingAttribute' is placed on a property or field, the property or field must be a number or a collection. See member '{0}' on type '{1}'.</value>
   </data>
   <data name="ConverterCanConvertNullableRedundant" xml:space="preserve">
-    <value>The converter '{0}' which handles type '{1}' should not indicate that it also handles type '{2}'. The converter will be used automatically if no converter which handles type '{2}' is provided.</value>
+    <value>The converter '{0}' handles type '{1}' but is being asked to convert type '{2}'. Either create a separate converter for type '{2}' or change the converter's 'CanConvert' method to only return 'true' for a single type.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -542,4 +542,7 @@
   <data name="NumberHandlingOnPropertyTypeMustBeNumberOrCollection" xml:space="preserve">
     <value>When 'JsonNumberHandlingAttribute' is placed on a property or field, the property or field must be a number or a collection. See member '{0}' on type '{1}'.</value>
   </data>
+  <data name="ConverterCanConvertNullableRedundant" xml:space="preserve">
+    <value>The converter '{0}' which handles type '{1}' should not indicate that it also handles type '{2}'. The converter will be used automatically if no converter which handles type '{2}' is provided.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -249,6 +249,13 @@ namespace System.Text.Json
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_ConverterCanConvertNullableRedundant(Type runtimePropertyType, JsonConverter jsonConverter)
+        {
+            throw new InvalidOperationException(SR.Format(SR.ConverterCanConvertNullableRedundant, jsonConverter.GetType(), jsonConverter.TypeToConvert, runtimePropertyType));
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotHonored(
             ReadOnlySpan<byte> propertyName,
             ref Utf8JsonReader reader,

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.NullableTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.NullableTypes.cs
@@ -280,40 +280,56 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void TestNullableStructInClass_ConverterOnProperty()
+        public static void StructConverter_SaysCanConvertNullableStruct_ConverterOnProperty()
         {
-            string serialized = JsonSerializer.Serialize(new ClassWithNullableStruct_ConverterOnProperty { MyStruct = new TestStruct { InnerValue = 5 } });
+            string converterTypeAsStr = typeof(JsonTestStructValueChangingConverter).ToString();
+            string structTypeAsStr = typeof(TestStruct).ToString();
+            string nullableStructTypeAsStr = typeof(TestStruct?).ToString();
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => JsonSerializer.Serialize(new ClassWithNullableStruct_ConverterOnProperty { MyStruct = new TestStruct() }));
+            string exAsStr = ex.ToString();
+            Assert.Contains(converterTypeAsStr, exAsStr);
+            Assert.Contains(structTypeAsStr, exAsStr);
+            Assert.Contains(nullableStructTypeAsStr, exAsStr);
+
+            ex = Assert.Throws<InvalidOperationException>(() =>
+                JsonSerializer.Deserialize<ClassWithNullableStruct_ConverterOnProperty>(""));
+            exAsStr = ex.ToString();
+            Assert.Contains(converterTypeAsStr, exAsStr);
+            Assert.Contains(structTypeAsStr, exAsStr);
+            Assert.Contains(nullableStructTypeAsStr, exAsStr);
+        }
+
+        [Fact]
+        public static void StructConverter_SaysCanConvertNullableStruct_ConverterOnType()
+        {
+            // Converter cannot be applied directly to nullable type, so the serializer wraps the converter it with NullableConverter<T> as expected.
+
+            string serialized = JsonSerializer.Serialize(new ClassWithNullableStruct_ConverterOnType { MyStruct = new TestStructWithConverter { InnerValue = 5 } });
             Assert.Equal(@"{""MyStruct"":{""InnerValue"":10}}", serialized);
 
-            ClassWithNullableStruct_ConverterOnProperty obj = JsonSerializer.Deserialize<ClassWithNullableStruct_ConverterOnProperty>(serialized);
+            ClassWithNullableStruct_ConverterOnType obj = JsonSerializer.Deserialize<ClassWithNullableStruct_ConverterOnType>(serialized);
             Assert.Equal(15, obj.MyStruct?.InnerValue);
         }
 
         [Fact]
-        public static void TestNullableStructInClass_ConverterOnType()
-        {
-            string serialized = JsonSerializer.Serialize(new ClassWithNullableStruct_ConverterOnStruct { MyStruct = new TestStructWithConverter { InnerValue = 5 } });
-            Assert.Equal(@"{""MyStruct"":{""InnerValue"":10}}", serialized);
-
-            ClassWithNullableStruct_ConverterOnStruct obj = JsonSerializer.Deserialize<ClassWithNullableStruct_ConverterOnStruct>(serialized);
-            Assert.Equal(15, obj.MyStruct?.InnerValue);
-        }
-
-        [Fact]
-        public static void TestNullableStructInClass_ConverterOnOptions()
+        public static void StructConverter_SaysCanConvertNullableStruct_ConverterOnOptions()
         {
             var options = new JsonSerializerOptions { Converters = { new JsonTestStructValueChangingConverter() } };
 
-            string serialized = JsonSerializer.Serialize(new ClassWithNullableStruct { MyStruct = new TestStruct { InnerValue = 5 } }, options);
-            Assert.Equal(@"{""MyStruct"":{""InnerValue"":10}}", serialized);
+            Assert.Throws<InvalidOperationException>(
+                () => JsonSerializer.Serialize(new ClassWithNullableStruct { MyStruct = new TestStruct() }, options));
 
-            ClassWithNullableStruct obj = JsonSerializer.Deserialize<ClassWithNullableStruct>(serialized, options);
-            Assert.Equal(15, obj.MyStruct?.InnerValue);
+            Assert.Throws<InvalidOperationException>(() =>
+                JsonSerializer.Deserialize<ClassWithNullableStruct>("", options));
         }
 
         [Fact]
-        public static void TestNullableStruct_AsRootType()
+        public static void StructConverter_SaysCanConvertNullableStruct_StructAsRootType_ConverterOnType()
         {
+            // Converter cannot be applied directly to nullable type, so the serializer wraps the converter it with NullableConverter<T> as expected.
+
             TestStructWithConverter? obj = new TestStructWithConverter { InnerValue = 5 };
             string serialized = JsonSerializer.Serialize(obj);
             Assert.Equal(@"{""InnerValue"":10}", serialized);
@@ -322,13 +338,26 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(15, obj?.InnerValue);
         }
 
+        [Fact]
+        public static void StructConverter_SaysCanConvertNullableStruct_StructAsRootType_ConverterOnOptions()
+        {
+            var options = new JsonSerializerOptions { Converters = { new JsonTestStructValueChangingConverter() } };
+
+            TestStruct? obj = new TestStruct { InnerValue = 5 };
+
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(obj, options));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                JsonSerializer.Deserialize<TestStruct?>("", options));
+        }
+
         private class ClassWithNullableStruct_ConverterOnProperty
         {
             [JsonConverter(typeof(JsonTestStructValueChangingConverter))]
             public TestStruct? MyStruct { get; set; }
         }
 
-        private class ClassWithNullableStruct_ConverterOnStruct
+        private class ClassWithNullableStruct_ConverterOnType
         {
             public TestStructWithConverter? MyStruct { get; set; }
         }
@@ -349,32 +378,11 @@ namespace System.Text.Json.Serialization.Tests
             public override bool CanConvert(Type typeToConvert) =>
                 typeToConvert == typeof(TestStruct) || typeToConvert == typeof(TestStruct?);
 
-            public override TestStruct Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            {
-                Debug.Assert(reader.TokenType == JsonTokenType.StartObject);
-                reader.Read();
+            public override TestStruct Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+                throw new NotImplementedException();
 
-                Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
-                Debug.Assert(reader.GetString() == "InnerValue");
-                reader.Read();
-
-                var obj = new TestStruct
-                {
-                    InnerValue = reader.GetInt32() + 5
-                };
-
-                reader.Read();
-                Debug.Assert(reader.TokenType == JsonTokenType.EndObject);
-
-                return obj;
-            }
-
-            public override void Write(Utf8JsonWriter writer, TestStruct value, JsonSerializerOptions options)
-            {
-                writer.WriteStartObject();
-                writer.WriteNumber("InnerValue", value.InnerValue + 5);
-                writer.WriteEndObject();
-            }
+            public override void Write(Utf8JsonWriter writer, TestStruct value, JsonSerializerOptions options) =>
+                throw new NotImplementedException();
         }
 
         private class JsonTestStructWithConverterValueChangingConverter : JsonConverter<TestStructWithConverter>
@@ -384,13 +392,6 @@ namespace System.Text.Json.Serialization.Tests
 
             public override TestStructWithConverter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                Console.WriteLine("called");
-
-                if (reader.TokenType == JsonTokenType.Null)
-                {
-                    throw new NullNotAllowedException();
-                }
-
                 if (reader.TokenType != JsonTokenType.StartObject)
                 {
                     throw new JsonException();
@@ -422,65 +423,10 @@ namespace System.Text.Json.Serialization.Tests
 
             public override void Write(Utf8JsonWriter writer, TestStructWithConverter value, JsonSerializerOptions options)
             {
-                Console.WriteLine("called");
                 writer.WriteStartObject();
                 writer.WriteNumber("InnerValue", value.InnerValue + 5);
                 writer.WriteEndObject();
             }
-        }
-
-        private class NullNotAllowedException : Exception
-        {
-        }
-
-        [Fact]
-        public static void NullableStruct_HandleNull_Default()
-        {
-            // Regardless of HandleNull selection, we don't pass null to underlying converters of the internal Nullable<T> converter.
-
-            string serialized = JsonSerializer.Serialize(new ClassWithNullableStruct_ConverterOnStruct());
-            Assert.Equal(@"{""MyStruct"":null}", serialized);
-
-            ClassWithNullableStruct_ConverterOnStruct obj = JsonSerializer.Deserialize<ClassWithNullableStruct_ConverterOnStruct>(serialized);
-            Assert.Null(obj.MyStruct?.InnerValue);
-        }
-
-        [Fact]
-        public static void NullableStruct_HandleNull_OptIn()
-        {
-            // Regardless of HandleNull selection, we don't pass null to underlying converters of the internal Nullable<T> converter.
-
-            var options = new JsonSerializerOptions { Converters = { new NullableStructConverter_HandleNullOptIn() } };
-
-            string serialized = JsonSerializer.Serialize(new ClassWithNullableStruct_ConverterOnStruct(), options);
-            Assert.Equal(@"{""MyStruct"":null}", serialized);
-
-            ClassWithNullableStruct_ConverterOnStruct obj = JsonSerializer.Deserialize<ClassWithNullableStruct_ConverterOnStruct>(serialized, options);
-            Assert.Null(obj.MyStruct?.InnerValue);
-        }
-
-        private class NullableStructConverter_HandleNullOptIn : JsonTestStructWithConverterValueChangingConverter
-        {
-            public override bool HandleNull => true;
-        }
-
-        [Fact]
-        public static void NullableStruct_HandleNull_OptOut()
-        {
-            // Regardless of HandleNull selection, we don't pass null to underlying converters of the internal Nullable<T> converter.
-
-            var options = new JsonSerializerOptions { Converters = { new NullableStructConverter_HandleNullOptOut() } };
-
-            string serialized = JsonSerializer.Serialize(new ClassWithNullableStruct_ConverterOnStruct(), options);
-            Assert.Equal(@"{""MyStruct"":null}", serialized);
-
-            ClassWithNullableStruct_ConverterOnStruct obj = JsonSerializer.Deserialize<ClassWithNullableStruct_ConverterOnStruct>(serialized, options);
-            Assert.Null(obj.MyStruct?.InnerValue);
-        }
-
-        private class NullableStructConverter_HandleNullOptOut : JsonTestStructWithConverterValueChangingConverter
-        {
-            public override bool HandleNull => false;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36621.

The issue repro'd when a converter had [this sort of `CanConvert` implementation](https://github.com/layomia/dotnet_runtime/blob/310d7082e881b7f07855fc41b5565152b8cbd92c/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.NullableTypes.cs#L349-L350.):

```cs
public override bool CanConvert(Type typeToConvert) =>
    typeToConvert == typeof(TestStruct) || typeToConvert == typeof(TestStruct?);
```

This caused the converter itself to be set as the converter for a nullable-struct property, rather than a `NullableConverter` wrapping the custom converter. This means we were trying to set an arg of `T` rather than `T?` in the generated IL method which called the setter, which subsequently caused the `InvalidProgramException`.

The serializer automatically uses an available `JsonConverter<T>` when no `JsonConverter<T?>` is present i.e. the sample `CanConvert` implementation above is redundant. Without this override, the issue did not repro as a `NullableConverter` instance wrapping the custom converter is used.

Rather than leaking an `InvalidProgramException`, we change the exception to an `InvalidOperationException` with a meaningful message. The resolution is for `JsonConverter<T>` converters not to have the above kind of `CanConvert` implementation, where the `typeToConvert == typeof(TestStruct?)` is what would cause an exception.