### PR TITLE
Don't load assemblies inside bundle when using LoadFrom

### DIFF
--- a/src/coreclr/src/vm/assemblynative.cpp
+++ b/src/coreclr/src/vm/assemblynative.cpp
@@ -238,9 +238,8 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
 
     if (pwzILPath != NULL)
     {
-
         pILImage = PEImage::OpenImage(pwzILPath,
-                                      MDInternalImport_NoCache,
+                                      MDInternalImport_Default,
                                       BundleFileLocation::Invalid());
 
         // Need to verify that this is a valid CLR assembly.

--- a/src/coreclr/src/vm/assemblynative.cpp
+++ b/src/coreclr/src/vm/assemblynative.cpp
@@ -238,9 +238,10 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
 
     if (pwzILPath != NULL)
     {
+
         pILImage = PEImage::OpenImage(pwzILPath,
-                                      MDInternalImport_Default,
-                                      Bundle::ProbeAppBundle(pwzILPath));
+                                      MDInternalImport_NoCache,
+                                      BundleFileLocation::Invalid());
 
         // Need to verify that this is a valid CLR assembly.
         if (!pILImage->CheckILFormat())
@@ -260,7 +261,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
     {
         pNIImage = PEImage::OpenImage(pwzNIPath,
                                       MDInternalImport_TrustedNativeImage,
-                                      Bundle::ProbeAppBundle(pwzNIPath));
+                                      BundleFileLocation::Invalid());
 
         if (pNIImage->HasReadyToRunHeader())
         {

--- a/src/coreclr/src/vm/peimage.cpp
+++ b/src/coreclr/src/vm/peimage.cpp
@@ -367,9 +367,9 @@ BOOL PEImage::CompareImage(UPTR u1, UPTR u2)
     EX_TRY
     {
         SString path(SString::Literal, pLocator->m_pPath);
-        BOOL lookInBundle = pLocator->m_bLookInBundle;
+        BOOL isInBundle = pLocator->m_bIsInBundle;
         if (PathEquals(path, pImage->GetPath()) &&
-            (lookInBundle == pImage->IsInBundle()))
+            (!isInBundle == !pImage->IsInBundle()))
             ret = TRUE;
     }
     EX_CATCH_HRESULT(hr); //<TODO>ignores failure!</TODO>

--- a/src/coreclr/src/vm/peimage.cpp
+++ b/src/coreclr/src/vm/peimage.cpp
@@ -229,7 +229,7 @@ ULONG PEImage::Release()
             LOG((LF_LOADER, LL_INFO100, "PEImage: Closing Image %S\n", (LPCWSTR) m_path));
             if(m_bInHashMap)
             {
-                PEImageLocator locator(this);
+                PEImageLocator locator(this, m_bundleFileLocation.IsValid());
                 PEImage* deleted = (PEImage *)s_Images->DeleteValue(GetIDHash(), &locator);
                 _ASSERTE(deleted == this);
             }
@@ -367,7 +367,9 @@ BOOL PEImage::CompareImage(UPTR u1, UPTR u2)
     EX_TRY
     {
         SString path(SString::Literal, pLocator->m_pPath);
-        if (PathEquals(path, pImage->GetPath()))
+        BOOL lookInBundle = pLocator->m_bLookInBundle;
+        if (PathEquals(path, pImage->GetPath()) &&
+            (lookInBundle || !(pImage->IsInBundle())))
             ret = TRUE;
     }
     EX_CATCH_HRESULT(hr); //<TODO>ignores failure!</TODO>

--- a/src/coreclr/src/vm/peimage.cpp
+++ b/src/coreclr/src/vm/peimage.cpp
@@ -369,7 +369,7 @@ BOOL PEImage::CompareImage(UPTR u1, UPTR u2)
         SString path(SString::Literal, pLocator->m_pPath);
         BOOL lookInBundle = pLocator->m_bLookInBundle;
         if (PathEquals(path, pImage->GetPath()) &&
-            (lookInBundle || !(pImage->IsInBundle())))
+            (lookInBundle == pImage->IsInBundle()))
             ret = TRUE;
     }
     EX_CATCH_HRESULT(hr); //<TODO>ignores failure!</TODO>

--- a/src/coreclr/src/vm/peimage.cpp
+++ b/src/coreclr/src/vm/peimage.cpp
@@ -229,7 +229,7 @@ ULONG PEImage::Release()
             LOG((LF_LOADER, LL_INFO100, "PEImage: Closing Image %S\n", (LPCWSTR) m_path));
             if(m_bInHashMap)
             {
-                PEImageLocator locator(this, m_bundleFileLocation.IsValid());
+                PEImageLocator locator(this);
                 PEImage* deleted = (PEImage *)s_Images->DeleteValue(GetIDHash(), &locator);
                 _ASSERTE(deleted == this);
             }

--- a/src/coreclr/src/vm/peimage.h
+++ b/src/coreclr/src/vm/peimage.h
@@ -121,7 +121,7 @@ public:
 
     static PTR_PEImage FindById(UINT64 uStreamAsmId, DWORD dwModuleId);
     static PTR_PEImage FindByPath(LPCWSTR pPath,
-                                  BOOL lookInBundle = TRUE);
+                                  BOOL isInBundle = TRUE);
     static PTR_PEImage FindByShortPath(LPCWSTR pPath);
     static PTR_PEImage FindByLongPath(LPCWSTR pPath);
     void AddToHashMap();
@@ -248,15 +248,15 @@ private:
         LPCWSTR m_pPath;
         BOOL m_bIsInBundle;
 
-        PEImageLocator(LPCWSTR pPath, BOOL bLookInBundle)
+        PEImageLocator(LPCWSTR pPath, BOOL bIsInBundle)
             : m_pPath(pPath),
-              m_bIsInBundle(bLookInBundle)
+              m_bIsInBundle(bIsInBundle)
         {
         }
 
-        PEImageLocator(PEImage * pImage, BOOL bLookInBundle)
+        PEImageLocator(PEImage * pImage, BOOL bIsInBundle)
             : m_pPath(pImage->m_path.GetUnicode()),
-              m_bIsInBundle(bLookInBundle)
+              m_bIsInBundle(bIsInBundle)
         {
         }
     };

--- a/src/coreclr/src/vm/peimage.h
+++ b/src/coreclr/src/vm/peimage.h
@@ -120,7 +120,8 @@ public:
     };
 
     static PTR_PEImage FindById(UINT64 uStreamAsmId, DWORD dwModuleId);
-    static PTR_PEImage FindByPath(LPCWSTR pPath);
+    static PTR_PEImage FindByPath(LPCWSTR pPath,
+                                  BOOL lookInBundle = true);
     static PTR_PEImage FindByShortPath(LPCWSTR pPath);
     static PTR_PEImage FindByLongPath(LPCWSTR pPath);
     void AddToHashMap();

--- a/src/coreclr/src/vm/peimage.h
+++ b/src/coreclr/src/vm/peimage.h
@@ -254,10 +254,10 @@ private:
         {
         }
 
-        PEImageLocator(PEImage * pImage, BOOL bIsInBundle)
-            : m_pPath(pImage->m_path.GetUnicode()),
-              m_bIsInBundle(bIsInBundle)
+        PEImageLocator(PEImage * pImage)
+            : m_pPath(pImage->m_path.GetUnicode())
         {
+            m_bIsInBundle = pImage->IsInBundle();
         }
     };
 

--- a/src/coreclr/src/vm/peimage.h
+++ b/src/coreclr/src/vm/peimage.h
@@ -121,7 +121,7 @@ public:
 
     static PTR_PEImage FindById(UINT64 uStreamAsmId, DWORD dwModuleId);
     static PTR_PEImage FindByPath(LPCWSTR pPath,
-                                  BOOL lookInBundle = true);
+                                  BOOL lookInBundle = TRUE);
     static PTR_PEImage FindByShortPath(LPCWSTR pPath);
     static PTR_PEImage FindByLongPath(LPCWSTR pPath);
     void AddToHashMap();
@@ -246,17 +246,17 @@ private:
     {
 
         LPCWSTR m_pPath;
-        BOOL m_bLookInBundle;
+        BOOL m_bIsInBundle;
 
         PEImageLocator(LPCWSTR pPath, BOOL bLookInBundle)
             : m_pPath(pPath),
-              m_bLookInBundle(bLookInBundle)
+              m_bIsInBundle(bLookInBundle)
         {
         }
 
         PEImageLocator(PEImage * pImage, BOOL bLookInBundle)
             : m_pPath(pImage->m_path.GetUnicode()),
-              m_bLookInBundle(bLookInBundle)
+              m_bIsInBundle(bLookInBundle)
         {
         }
     };

--- a/src/coreclr/src/vm/peimage.h
+++ b/src/coreclr/src/vm/peimage.h
@@ -246,14 +246,17 @@ private:
     {
 
         LPCWSTR m_pPath;
+        BOOL m_bLookInBundle;
 
-        PEImageLocator(LPCWSTR pPath)
-            : m_pPath(pPath)
+        PEImageLocator(LPCWSTR pPath, BOOL bLookInBundle)
+            : m_pPath(pPath),
+              m_bLookInBundle(bLookInBundle)
         {
         }
 
-        PEImageLocator(PEImage * pImage)
-            : m_pPath(pImage->m_path.GetUnicode())
+        PEImageLocator(PEImage * pImage, BOOL bLookInBundle)
+            : m_pPath(pImage->m_path.GetUnicode()),
+              m_bLookInBundle(bLookInBundle)
         {
         }
     };

--- a/src/coreclr/src/vm/peimage.inl
+++ b/src/coreclr/src/vm/peimage.inl
@@ -478,7 +478,7 @@ inline void  PEImage::Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation)
 
 
 /*static*/
-inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL lookInBundle /* = true */)
+inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle /* = TRUE */)
 {
     CONTRACTL
     {
@@ -492,7 +492,7 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL lookInBundle /* = tru
 
     int CaseHashHelper(const WCHAR *buffer, COUNT_T count);
 
-    PEImageLocator locator(pPath, lookInBundle);
+    PEImageLocator locator(pPath, isInBundle);
 #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
     DWORD dwHash=path.Hash();
 #else

--- a/src/coreclr/src/vm/peimage.inl
+++ b/src/coreclr/src/vm/peimage.inl
@@ -492,13 +492,12 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL lookInBundle /* = tru
 
     int CaseHashHelper(const WCHAR *buffer, COUNT_T count);
 
-    PEImageLocator locator(pPath);
+    PEImageLocator locator(pPath, lookInBundle);
 #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
     DWORD dwHash=path.Hash();
 #else
     DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) wcslen(pPath));
 #endif
-    dwHash = (dwHash << 1) | lookInBundle;
     return (PEImage *) s_Images->LookupValue(dwHash, &locator);
 
 }
@@ -605,12 +604,10 @@ inline ULONG PEImage::GetIDHash()
     }
     CONTRACT_END;
 
-    // Start the hash with the image path and set its latest bit
-    // depending on whether the image is bundled.
 #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
-    RETURN ((m_path.Hash() << 1) | IsInBundle());
+    RETURN m_path.Hash();
 #else
-    RETURN ((m_path.HashCaseInsensitive() << 1) | IsInBundle());
+    RETURN m_path.HashCaseInsensitive();
 #endif
 }
 


### PR DESCRIPTION
Related to #40138. We should not try loading any assembly that exists within the bundler when calling `Assembly.LoadFromPath`. This fixes the scenario described in the linked issue.