### PR TITLE
Small library test clean up

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -45,7 +45,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public void TestThreadCount()
         {
             int numOfThreads = 10;

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -110,7 +110,7 @@ namespace System.Diagnostics.Tests
             await Task.WhenAll(Enumerable.Range(0, Tasks).Select(_ => Task.Run(work)).ToArray());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(0)]  // poll
         [InlineData(10)] // real timeout
         public void CurrentProcess_WaitNeverCompletes(int milliseconds)

--- a/src/libraries/System.IO/tests/IndentedTextWriter.cs
+++ b/src/libraries/System.IO/tests/IndentedTextWriter.cs
@@ -91,7 +91,7 @@ namespace System.CodeDom.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData("\r\n")]
         [InlineData("\n")]
         [InlineData("newline")]


### PR DESCRIPTION
- One library test in System.IO passes locally on browser wasm 
- Two library tests in System.Diagnostics.Process don't need conditional fact/theory attribute because the entire assembly is PNSE on browser wasm. 