### PR TITLE
Add remaining System.Net.Http Telemetry

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <WindowsRID>win</WindowsRID>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -277,6 +277,8 @@
              Link="Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
+    <Compile Include="$(CommonPath)Extensions\ValueStopwatch\ValueStopwatch.cs"
+             Link="Common\Extensions\ValueStopwatch\ValueStopwatch.cs" />
   </ItemGroup>
   <!-- Header support -->
   <ItemGroup>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -1,9 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Net.Http
@@ -18,10 +17,18 @@ namespace System.Net.Http
         private PollingCounter? _startedRequestsCounter;
         private PollingCounter? _currentRequestsCounter;
         private PollingCounter? _abortedRequestsCounter;
+        private PollingCounter? _totalHttp11ConnectionsCounter;
+        private PollingCounter? _totalHttp20ConnectionsCounter;
+        private PollingCounter? _totalHttp20StreamsCounter;
+        private EventCounter? _requestsQueueDurationCounter;
 
         private long _startedRequests;
         private long _stoppedRequests;
         private long _abortedRequests;
+
+        private long _openedHttp11Connections;
+        private long _openedHttp20Connections;
+        private long _openedHttp20Streams;
 
         // NOTE
         // - The 'Start' and 'Stop' suffixes on the following event names have special meaning in EventSource. They
@@ -49,6 +56,62 @@ namespace System.Net.Http
         {
             Interlocked.Increment(ref _abortedRequests);
             WriteEvent(eventId: 3);
+        }
+
+        [Event(4, Level = EventLevel.Informational)]
+        public void Http11ConnectionEstablished()
+        {
+            Interlocked.Increment(ref _openedHttp11Connections);
+            WriteEvent(eventId: 4);
+        }
+
+        [Event(5, Level = EventLevel.Informational)]
+        public void Http11ConnectionClosed()
+        {
+            long count = Interlocked.Decrement(ref _openedHttp11Connections);
+            Debug.Assert(count >= 0);
+            WriteEvent(eventId: 5);
+        }
+
+        [Event(6, Level = EventLevel.Informational)]
+        public void Http20ConnectionEstablished()
+        {
+            Interlocked.Increment(ref _openedHttp20Connections);
+            WriteEvent(eventId: 6);
+        }
+
+        [Event(7, Level = EventLevel.Informational)]
+        public void Http20ConnectionClosed()
+        {
+            long count = Interlocked.Decrement(ref _openedHttp20Connections);
+            Debug.Assert(count >= 0);
+            WriteEvent(eventId: 7);
+        }
+
+        [Event(8, Level = EventLevel.Informational)]
+        public void Http11RequestLeftQueue(double timeOnQueueMilliseconds)
+        {
+            _requestsQueueDurationCounter!.WriteMetric(timeOnQueueMilliseconds);
+            WriteEvent(eventId: 8, timeOnQueueMilliseconds);
+        }
+
+        [Event(9, Level = EventLevel.Informational)]
+        public void ResponseHeadersBegin()
+        {
+            WriteEvent(eventId: 9);
+        }
+
+        [NonEvent]
+        public void Http20StreamEstablished()
+        {
+            Interlocked.Increment(ref _openedHttp20Streams);
+        }
+
+        [NonEvent]
+        public void Http20StreamClosed()
+        {
+            long count = Interlocked.Decrement(ref _openedHttp20Streams);
+            Debug.Assert(count >= 0);
         }
 
         protected override void OnEventCommand(EventCommandEventArgs command)
@@ -92,6 +155,27 @@ namespace System.Net.Http
                 _currentRequestsCounter ??= new PollingCounter("current-requests", this, () => -Interlocked.Read(ref _stoppedRequests) + Interlocked.Read(ref _startedRequests))
                 {
                     DisplayName = "Current Requests"
+                };
+
+                _totalHttp11ConnectionsCounter ??= new PollingCounter("http11-connections-current-total", this, () => Interlocked.Read(ref _openedHttp11Connections))
+                {
+                    DisplayName = "Current Http 1.1 Connections"
+                };
+
+                _totalHttp20ConnectionsCounter ??= new PollingCounter("http20-connections-current-total", this, () => Interlocked.Read(ref _openedHttp20Connections))
+                {
+                    DisplayName = "Current Http 2.0 Connections"
+                };
+
+                _totalHttp20StreamsCounter ??= new PollingCounter("http20-streams-current-total", this, () => Interlocked.Read(ref _openedHttp20Streams))
+                {
+                    DisplayName = "Current Http 2.0 Streams"
+                };
+
+                _requestsQueueDurationCounter ??= new EventCounter("http11-requests-queue-duration", this)
+                {
+                    DisplayName = "HTTP 1.1 Requests Queue Duration",
+                    DisplayUnits = "ms"
                 };
             }
         }
@@ -145,6 +229,21 @@ namespace System.Net.Http
 
                     WriteEventCore(eventId, NumEventDatas, descrs);
                 }
+            }
+        }
+
+        [NonEvent]
+        private unsafe void WriteEvent(int eventId, double arg1)
+        {
+            if (IsEnabled())
+            {
+                EventData descr = new EventData
+                {
+                    DataPointer = (IntPtr)(&arg1),
+                    Size = sizeof(double)
+                };
+
+                WriteEventCore(eventId, eventDataCount: 1, &descr);
             }
         }
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -19,7 +19,6 @@ namespace System.Net.Http
         private PollingCounter? _abortedRequestsCounter;
         private PollingCounter? _totalHttp11ConnectionsCounter;
         private PollingCounter? _totalHttp20ConnectionsCounter;
-        private PollingCounter? _totalHttp20StreamsCounter;
         private EventCounter? _requestsQueueDurationCounter;
 
         private long _startedRequests;
@@ -28,7 +27,6 @@ namespace System.Net.Http
 
         private long _openedHttp11Connections;
         private long _openedHttp20Connections;
-        private long _openedHttp20Streams;
 
         // NOTE
         // - The 'Start' and 'Stop' suffixes on the following event names have special meaning in EventSource. They
@@ -101,19 +99,6 @@ namespace System.Net.Http
             WriteEvent(eventId: 9);
         }
 
-        [NonEvent]
-        public void Http20StreamEstablished()
-        {
-            Interlocked.Increment(ref _openedHttp20Streams);
-        }
-
-        [NonEvent]
-        public void Http20StreamClosed()
-        {
-            long count = Interlocked.Decrement(ref _openedHttp20Streams);
-            Debug.Assert(count >= 0);
-        }
-
         protected override void OnEventCommand(EventCommandEventArgs command)
         {
             if (command.Command == EventCommand.Enable)
@@ -165,11 +150,6 @@ namespace System.Net.Http
                 _totalHttp20ConnectionsCounter ??= new PollingCounter("http20-connections-current-total", this, () => Interlocked.Read(ref _openedHttp20Connections))
                 {
                     DisplayName = "Current Http 2.0 Connections"
-                };
-
-                _totalHttp20StreamsCounter ??= new PollingCounter("http20-streams-current-total", this, () => Interlocked.Read(ref _openedHttp20Streams))
-                {
-                    DisplayName = "Current Http 2.0 Streams"
                 };
 
                 _requestsQueueDurationCounter ??= new EventCounter("http11-requests-queue-duration", this)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -60,7 +60,8 @@ namespace System.Net.Http
         //     (meaning we must assume all streams have been processed by the server)
         private int _lastStreamId = -1;
 
-        // 0 = Not opened yet, 1 = Marked as opened, 2 = Closed
+        private const int TelemetryStatus_Opened = 1;
+        private const int TelemetryStatus_Closed = 2;
         private int _markedByTelemetryStatus;
 
         // This will be set when a connection IO error occurs
@@ -146,7 +147,7 @@ namespace System.Net.Http
             if (HttpTelemetry.Log.IsEnabled())
             {
                 HttpTelemetry.Log.Http20ConnectionEstablished();
-                _markedByTelemetryStatus = 1;
+                _markedByTelemetryStatus = TelemetryStatus_Opened;
             }
 
             if (NetEventSource.Log.IsEnabled()) TraceConnection(_stream);
@@ -1680,7 +1681,7 @@ namespace System.Net.Http
 
             if (HttpTelemetry.Log.IsEnabled())
             {
-                if (Interlocked.Exchange(ref _markedByTelemetryStatus, 2) == 1)
+                if (Interlocked.Exchange(ref _markedByTelemetryStatus, TelemetryStatus_Closed) == TelemetryStatus_Opened)
                 {
                     HttpTelemetry.Log.Http20ConnectionClosed();
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1409,8 +1409,6 @@ namespace System.Net.Http
 
                     return s.mustFlush || s.endStream;
                 }, cancellationToken).ConfigureAwait(false);
-
-                http2Stream.MarkAsOpened();
                 return http2Stream;
             }
             catch
@@ -1815,12 +1813,11 @@ namespace System.Net.Http
         {
             if (NetEventSource.Log.IsEnabled()) Trace($"{request}");
 
-            Http2Stream? http2Stream = null;
             try
             {
                 // Send request headers
                 bool shouldExpectContinue = request.Content != null && request.HasHeaders && request.Headers.ExpectContinue == true;
-                http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue).ConfigureAwait(false);
+                Http2Stream http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue).ConfigureAwait(false);
 
                 bool duplex = request.Content != null && request.Content.AllowDuplex;
 
@@ -1880,8 +1877,6 @@ namespace System.Net.Http
             }
             catch (Exception e)
             {
-                http2Stream?.MarkAsClosed();
-
                 if (e is IOException ||
                     e is ObjectDisposedException ||
                     e is Http2ProtocolException ||

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -576,6 +576,8 @@ namespace System.Net.Http
 
             public void OnHeadersStart()
             {
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersBegin();
+
                 Debug.Assert(!Monitor.IsEntered(SyncObject));
                 lock (SyncObject)
                 {
@@ -857,8 +859,6 @@ namespace System.Net.Http
                         (wait, emptyResponse) = TryEnsureHeaders();
                         Debug.Assert(!wait);
                     }
-
-                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersBegin();
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -84,31 +84,6 @@ namespace System.Net.Http
 
             private int _headerBudgetRemaining;
 
-            // 0 = Not opened yet, 1 = Marked as opened, 2 = Closed
-            private int _markedByTelemetryStatus;
-
-            public void MarkAsOpened()
-            {
-                if (HttpTelemetry.Log.IsEnabled())
-                {
-                    Debug.Assert(_markedByTelemetryStatus == 0);
-                    _markedByTelemetryStatus = 1;
-
-                    HttpTelemetry.Log.Http20StreamEstablished();
-                }
-            }
-
-            public void MarkAsClosed()
-            {
-                if (HttpTelemetry.Log.IsEnabled())
-                {
-                    if (Interlocked.Exchange(ref _markedByTelemetryStatus, 2) == 1)
-                    {
-                        HttpTelemetry.Log.Http20StreamClosed();
-                    }
-                }
-            }
-
             private const int StreamWindowSize = DefaultInitialWindowSize;
 
             // See comment on ConnectionWindowThreshold.
@@ -911,11 +886,6 @@ namespace System.Net.Http
                 {
                     CookieHelper.ProcessReceivedCookies(_response, _connection._pool.Settings._cookieContainer!);
                 }
-
-                if (emptyResponse)
-                {
-                    MarkAsClosed();
-                }
             }
 
             private void ExtendWindow(int amount)
@@ -1329,8 +1299,6 @@ namespace System.Net.Http
                     // canceled, and b) clean up the associated state in the Http2Connection.
 
                     http2Stream.CloseResponseBody();
-
-                    http2Stream.MarkAsClosed();
 
                     base.Dispose(disposing);
                 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
@@ -13,18 +14,6 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public sealed class TelemetryTest_Http11 : TelemetryTest
-    {
-        public TelemetryTest_Http11(ITestOutputHelper output) : base(output) { }
-    }
-
-    public sealed class TelemetryTest_Http20 : TelemetryTest
-    {
-        protected override Version UseVersion => HttpVersion.Version20;
-
-        public TelemetryTest_Http20(ITestOutputHelper output) : base(output) { }
-    }
-
     public abstract class TelemetryTest : HttpClientHandlerTestBase
     {
         public TelemetryTest(ITestOutputHelper output) : base(output) { }
@@ -47,12 +36,13 @@ namespace System.Net.Http.Functional.Tests
         {
             RemoteExecutor.Invoke(async useVersionString =>
             {
+                Version version = Version.Parse(useVersionString);
                 using var listener = new TestEventListener("System.Net.Http", EventLevel.Verbose, eventCounterInterval: 0.1d);
 
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
                 await listener.RunWithCallbackAsync(events.Enqueue, async () =>
                 {
-                    await GetFactoryForVersion(Version.Parse(useVersionString)).CreateClientAndServerAsync(
+                    await GetFactoryForVersion(version).CreateClientAndServerAsync(
                         async uri =>
                         {
                             using HttpClient client = CreateHttpClient(useVersionString);
@@ -76,11 +66,24 @@ namespace System.Net.Http.Functional.Tests
                 ValidateStartEventPayload(start);
 
                 EventWrittenEventArgs stop = Assert.Single(events, e => e.EventName == "RequestStop");
-                Assert.Equal(0, stop.Payload.Count);
+                Assert.Empty(stop.Payload);
 
                 Assert.DoesNotContain(events, e => e.EventName == "RequestAborted");
 
-                VerifyEventCounters(events, shouldHaveFailures: false);
+                if (version.Major == 1)
+                {
+                    Assert.Single(events, e => e.EventName == "Http11ConnectionEstablished");
+                    Assert.Single(events, e => e.EventName == "Http11ConnectionClosed");
+                }
+                else
+                {
+                    Assert.Single(events, e => e.EventName == "Http20ConnectionEstablished");
+                    Assert.Single(events, e => e.EventName == "Http20ConnectionClosed");
+                }
+
+                Assert.Single(events, e => e.EventName == "ResponseHeadersBegin");
+
+                VerifyEventCounters(events, requestCount: 1, shouldHaveFailures: false);
             }, UseVersion.ToString()).Dispose();
         }
 
@@ -123,16 +126,16 @@ namespace System.Net.Http.Functional.Tests
                 ValidateStartEventPayload(start);
 
                 EventWrittenEventArgs abort = Assert.Single(events, e => e.EventName == "RequestAborted");
-                Assert.Equal(0, abort.Payload.Count);
+                Assert.Empty(abort.Payload);
 
                 EventWrittenEventArgs stop = Assert.Single(events, e => e.EventName == "RequestStop");
-                Assert.Equal(0, stop.Payload.Count);
+                Assert.Empty(stop.Payload);
 
-                VerifyEventCounters(events, shouldHaveFailures: true);
+                VerifyEventCounters(events, requestCount: 1, shouldHaveFailures: true);
             }, UseVersion.ToString()).Dispose();
         }
 
-        private static void ValidateStartEventPayload(EventWrittenEventArgs startEvent)
+        protected static void ValidateStartEventPayload(EventWrittenEventArgs startEvent)
         {
             Assert.Equal("RequestStart", startEvent.EventName);
             Assert.Equal(6, startEvent.Payload.Count);
@@ -145,7 +148,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(startEvent.Payload[5] is int versionMinor && (versionMinor == 1 || versionMinor == 0));
         }
 
-        private static void VerifyEventCounters(ConcurrentQueue<EventWrittenEventArgs> events, bool shouldHaveFailures)
+        protected static void VerifyEventCounters(ConcurrentQueue<EventWrittenEventArgs> events, int requestCount, bool shouldHaveFailures, bool shouldHaveQueuedRequests = false)
         {
             Dictionary<string, double[]> eventCounters = events
                 .Where(e => e.EventName == "EventCounters")
@@ -154,7 +157,7 @@ namespace System.Net.Http.Functional.Tests
                 .ToDictionary(p => p.Key, p => p.ToArray());
 
             Assert.True(eventCounters.TryGetValue("requests-started", out double[] requestsStarted));
-            Assert.Equal(1, requestsStarted[^1]);
+            Assert.Equal(requestCount, requestsStarted[^1]);
 
             Assert.True(eventCounters.TryGetValue("requests-started-rate", out double[] requestRate));
             Assert.Contains(requestRate, r => r > 0);
@@ -175,6 +178,123 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(eventCounters.TryGetValue("current-requests", out double[] currentRequests));
             Assert.Contains(currentRequests, c => c > 0);
             Assert.Equal(0, currentRequests[^1]);
+
+            Assert.True(eventCounters.TryGetValue("http11-connections-current-total", out double[] http11ConnectionsTotal));
+            Assert.All(http11ConnectionsTotal, c => Assert.True(c >= 0));
+            Assert.Equal(0, http11ConnectionsTotal[^1]);
+
+            Assert.True(eventCounters.TryGetValue("http20-connections-current-total", out double[] http20ConnectionsTotal));
+            Assert.All(http20ConnectionsTotal, c => Assert.True(c >= 0));
+            Assert.Equal(0, http20ConnectionsTotal[^1]);
+
+            Assert.True(eventCounters.TryGetValue("http20-streams-current-total", out double[] http20StreamsTotal));
+            Assert.All(http20StreamsTotal, s => Assert.True(s >= 0));
+            Assert.Equal(0, http20StreamsTotal[^1]);
+
+            Assert.True(eventCounters.TryGetValue("http11-requests-queue-duration", out double[] requestQueueDurations));
+            Assert.Equal(0, requestQueueDurations[^1]);
+            if (shouldHaveQueuedRequests)
+            {
+                Assert.Contains(requestQueueDurations, d => d > 0);
+                Assert.All(requestQueueDurations, d => Assert.True(d >= 0));
+            }
+            else
+            {
+                Assert.All(requestQueueDurations, d => Assert.True(d == 0));
+            }
         }
+    }
+
+    public sealed class TelemetryTest_Http11 : TelemetryTest
+    {
+        public TelemetryTest_Http11(ITestOutputHelper output) : base(output) { }
+
+        [OuterLoop]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void EventSource_ConnectionPoolAtMaxConnections_LogsRequestLeftQueue()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                using var listener = new TestEventListener("System.Net.Http", EventLevel.Verbose, eventCounterInterval: 0.1d);
+
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                await listener.RunWithCallbackAsync(events.Enqueue, async () =>
+                {
+                    var firstRequestReceived = new SemaphoreSlim(0, 1);
+                    var secondRequestSent = new SemaphoreSlim(0, 1);
+
+                    await LoopbackServer.CreateClientAndServerAsync(
+                        async uri =>
+                        {
+                            using var handler = new SocketsHttpHandler
+                            {
+                                MaxConnectionsPerServer = 1
+                            };
+
+                            using var client = new HttpClient(handler);
+
+                            Task firstRequest = client.GetStringAsync(uri);
+                            Assert.True(await firstRequestReceived.WaitAsync(TimeSpan.FromSeconds(10)));
+
+                            // We are now at the connection limit, the next request will wait for the first one to complete
+                            Task secondRequest = client.GetStringAsync(uri);
+                            secondRequestSent.Release();
+
+                            await new[] { firstRequest, secondRequest }.WhenAllOrAnyFailed();
+                        },
+                        async server =>
+                        {
+                            await server.AcceptConnectionAsync(async connection =>
+                            {
+                                firstRequestReceived.Release();
+                                await connection.ReadRequestDataAsync();
+                                Assert.True(await secondRequestSent.WaitAsync(TimeSpan.FromSeconds(10)));
+                                await Task.Delay(100);
+                                await connection.SendResponseAsync();
+                            });
+
+                            await server.HandleRequestAsync();
+                        });
+
+                    await Task.Delay(300);
+                });
+                Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
+
+                EventWrittenEventArgs[] starts = events.Where(e => e.EventName == "RequestStart").ToArray();
+                Assert.Equal(2, starts.Length);
+                Assert.All(starts, s => ValidateStartEventPayload(s));
+
+                EventWrittenEventArgs[] stops = events.Where(e => e.EventName == "RequestStop").ToArray();
+                Assert.Equal(2, stops.Length);
+                Assert.All(stops, s => Assert.Empty(s.Payload));
+
+                Assert.DoesNotContain(events, e => e.EventName == "RequestAborted");
+
+                EventWrittenEventArgs[] connectionsEstablished = events.Where(e => e.EventName == "Http11ConnectionEstablished").ToArray();
+                Assert.Equal(2, connectionsEstablished.Length);
+                Assert.All(connectionsEstablished, c => Assert.Empty(c.Payload));
+
+                EventWrittenEventArgs[] connectionsClosed = events.Where(e => e.EventName == "Http11ConnectionClosed").ToArray();
+                Assert.Equal(2, connectionsClosed.Length);
+                Assert.All(connectionsClosed, c => Assert.Empty(c.Payload));
+
+                EventWrittenEventArgs requestLeftQueue = Assert.Single(events, e => e.EventName == "Http11RequestLeftQueue");
+                double duration = Assert.IsType<double>(Assert.Single(requestLeftQueue.Payload));
+                Assert.True(duration > 0);
+
+                EventWrittenEventArgs[] responseHeadersBegin = events.Where(e => e.EventName == "ResponseHeadersBegin").ToArray();
+                Assert.Equal(2, responseHeadersBegin.Length);
+                Assert.All(responseHeadersBegin, r => Assert.Empty(r.Payload));
+
+                VerifyEventCounters(events, requestCount: 2, shouldHaveFailures: false, shouldHaveQueuedRequests: true);
+            }).Dispose();
+        }
+    }
+
+    public sealed class TelemetryTest_Http20 : TelemetryTest
+    {
+        protected override Version UseVersion => HttpVersion.Version20;
+
+        public TelemetryTest_Http20(ITestOutputHelper output) : base(output) { }
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -187,10 +187,6 @@ namespace System.Net.Http.Functional.Tests
             Assert.All(http20ConnectionsTotal, c => Assert.True(c >= 0));
             Assert.Equal(0, http20ConnectionsTotal[^1]);
 
-            Assert.True(eventCounters.TryGetValue("http20-streams-current-total", out double[] http20StreamsTotal));
-            Assert.All(http20StreamsTotal, s => Assert.True(s >= 0));
-            Assert.Equal(0, http20StreamsTotal[^1]);
-
             Assert.True(eventCounters.TryGetValue("http11-requests-queue-duration", out double[] requestQueueDurations));
             Assert.Equal(0, requestQueueDurations[^1]);
             if (shouldHaveQueuedRequests)


### PR DESCRIPTION
Adds the following events:
- `Http11ConnectionEstablished`
- `Http11ConnectionClosed`
- `Http20ConnectionEstablished`
- `Http20ConnectionClosed`
- `Http11RequestLeftQueue`
- `ResponseHeadersBegin`

Adds the following counters:
- `http11-connections-current-total`
- `http20-connections-current-total`
- `http11-requests-queue-duration`

Contributes to #37428