### PR TITLE
Disable HttpTelemetry for HTTP 3 requests

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -359,7 +359,7 @@ namespace System.Net.Http
 
         public ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
-            return HttpTelemetry.Log.IsEnabled() && request.RequestUri != null ?
+            return HttpTelemetry.Log.IsEnabled() && request.Version.Major < 3 && request.RequestUri != null ?
                 SendAsyncWithLogging(request, async, doRequestAuth, cancellationToken) :
                 SendAsyncHelper(request, async, doRequestAuth, cancellationToken);
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -359,9 +359,16 @@ namespace System.Net.Http
 
         public ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
-            return HttpTelemetry.Log.IsEnabled() && request.Version.Major < 3 && request.RequestUri != null ?
-                SendAsyncWithLogging(request, async, doRequestAuth, cancellationToken) :
-                SendAsyncHelper(request, async, doRequestAuth, cancellationToken);
+            if (HttpTelemetry.Log.IsEnabled())
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/40896")]
+                if (request.Version.Major < 3 && request.RequestUri != null)
+                {
+                    return SendAsyncWithLogging(request, async, doRequestAuth, cancellationToken);
+                }
+            }
+
+            return SendAsyncHelper(request, async, doRequestAuth, cancellationToken);
         }
 
         private async ValueTask<HttpResponseMessage> SendAsyncWithLogging(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)


### PR DESCRIPTION
Avoid logging orphaned RequestStart events when using HTTP3, as the Http3 logic is not instrumented with Telemetry.

Contributes to #37428