### PR TITLE
Add SafeBuffer Span<T> methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -237,13 +237,10 @@ namespace System.Runtime.InteropServices
             {
                 DangerousAddRef(ref mustCallRelease);
 
-                if (!buffer.IsEmpty)
+                fixed (byte* pStructure = &Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(buffer)))
                 {
-                    fixed (byte* pStructure = MemoryMarshal.AsBytes(buffer))
-                    {
-                        for (int i = 0; i < buffer.Length; i++)
-                            Buffer.Memmove(pStructure + sizeofT * i, ptr + alignedSizeofT * i, sizeofT);
-                    }
+                    for (int i = 0; i < buffer.Length; i++)
+                        Buffer.Memmove(pStructure + sizeofT * i, ptr + alignedSizeofT * i, sizeofT);
                 }
             }
             finally
@@ -320,15 +317,10 @@ namespace System.Runtime.InteropServices
             {
                 DangerousAddRef(ref mustCallRelease);
 
-                if (!data.IsEmpty)
+                fixed (byte* pStructure = &Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(data)))
                 {
-                    {
-                        fixed (byte* pStructure = MemoryMarshal.AsBytes(data))
-                        {
-                            for (int i = 0; i < data.Length; i++)
-                                Buffer.Memmove(ptr + alignedSizeofT * i, pStructure + sizeofT * i, sizeofT);
-                        }
-                    }
+                    for (int i = 0; i < data.Length; i++)
+                        Buffer.Memmove(ptr + alignedSizeofT * i, pStructure + sizeofT * i, sizeofT);
                 }
             }
             finally

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -172,16 +172,8 @@ namespace System.Runtime.InteropServices.Tests
                 new TestStruct { I = 77, L = 88, D = 99 },
                 new TestStruct { I = 100, L = 200, D = 300 },
             };
-            Span<TestStruct> structSpan = stackalloc TestStruct[]
-            {
-                new TestStruct { I = 11, L = 22, D = 33 },
-                new TestStruct { I = 44, L = 55, D = 66 },
-                new TestStruct { I = 77, L = 88, D = 99 },
-                new TestStruct { I = 100, L = 200, D = 300 },
-            };
             TestArray(structArray);
             TestSpan<TestStruct>(structArray);
-            TestSpan<TestStruct>(structSpan);
 
             void TestArray<T>(T[] data)
                 where T : struct

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -160,10 +160,8 @@ namespace System.Runtime.InteropServices.Tests
             using var buffer = new HGlobalBuffer(200);
 
             int[] intArray = new int[] { 11, 22, 33, 44 };
-            Span<int> intSpan = stackalloc int[] { 44, 33, 22, 11 };
             TestArray(intArray);
             TestSpan<int>(intArray);
-            TestSpan<int>(intSpan);
 
             TestStruct[] structArray = new TestStruct[]
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -77,6 +77,16 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
+        public void ReadWriteSpan_EmptySpan_Passes()
+        {
+            var buffer = new SubBuffer(true);
+            buffer.Initialize(0);
+
+            buffer.ReadSpan<int>(0, Span<int>.Empty);
+            buffer.WriteSpan<int>(0, ReadOnlySpan<int>.Empty);
+        }
+
+        [Fact]
         public void ReadArray_NegativeIndex_ThrowsArgumentOutOfRangeException()
         {
             var wrapper = new SubBuffer(true);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9736,10 +9736,14 @@ namespace System.Runtime.InteropServices
         [System.CLSCompliantAttribute(false)]
         public void ReadArray<T>(ulong byteOffset, T[] array, int index, int count) where T : struct { }
         [System.CLSCompliantAttribute(false)]
+        public void ReadSpan<T>(ulong byteOffset, System.Span<T> buffer) where T : struct { }
+        [System.CLSCompliantAttribute(false)]
         public T Read<T>(ulong byteOffset) where T : struct { throw null; }
         public void ReleasePointer() { }
         [System.CLSCompliantAttribute(false)]
         public void WriteArray<T>(ulong byteOffset, T[] array, int index, int count) where T : struct { }
+        [System.CLSCompliantAttribute(false)]
+        public void WriteSpan<T>(ulong byteOffset, System.ReadOnlySpan<T> data) where T : struct { }
         [System.CLSCompliantAttribute(false)]
         public void Write<T>(ulong byteOffset, T value) where T : struct { }
     }


### PR DESCRIPTION
Closes #27831

I can't find tests for `SafeBuffer` class, so I didn't add tests for newly added methods.