### PR TITLE
Reenable crossgen2smoke under GC stress

### DIFF
--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -35,6 +35,13 @@ WARNING:   When setting properties based on their current state (for example:
     <PropertyGroup>
       <CrossgenBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(CrossGenTest)' != 'false'">
         <![CDATA[
+
+if [ "$(AlwaysUseCrossGen2)" == "true" ]; then
+    export RunCrossGen=
+    export RunCrossGen2=1
+    export CompositeBuildMode=1
+fi
+
 # CrossGen Script
 if [ ! -z ${RunCrossGen+x} ]%3B then
     export COMPlus_ZapRequire=$(ZapRequire)
@@ -59,6 +66,7 @@ if [ ! -z ${RunCrossGen+x} ]%3B then
         ReleaseLock
     fi
 fi
+
 # CrossGen2 Script
 if [ ! -z ${RunCrossGen2+x} ]%3B then
     TakeLock
@@ -163,6 +171,12 @@ fi
       <CrossgenBatchScript Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(CrossGenTest)' != 'false'">
         <![CDATA[
 
+if /i "$(AlwaysUseCrossGen2)" == "true" (
+    set RunCrossGen=
+    set RunCrossGen2=1
+    set CompositeBuildMode=1
+)
+
 REM CrossGen Script
 if defined RunCrossGen (
     if defined LargeVersionBubble ( set OptionalArguments=!OptionalArguments! /largeversionbubble)
@@ -187,6 +201,7 @@ if defined RunCrossGen (
         )
     )
 )
+
 REM CrossGen2 Script
 if defined RunCrossGen2 (
     set ExtraCrossGen2Args=!ExtraCrossGen2Args! $(CrossGen2TestExtraArguments)

--- a/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
@@ -5,9 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
 
-    <!-- Disable for GCStress due to timeout test failures: https://github.com/dotnet/runtime/issues/33949 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
-
     <!-- ilasm round-trip testing doesn't make sense for this test -->
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     

--- a/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
@@ -11,9 +11,6 @@
     <!-- Crossgen2 currently targets x64 and ARM64 only -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64'">true</CLRTestTargetUnsupported>
 
-    <!-- Generate ILDLL so that the DLL can be the crossgenned assembly -->
-    <TargetExt>.ildll</TargetExt>
-
     <!-- This is an explicit crossgen test -->
     <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
   </PropertyGroup>

--- a/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
@@ -15,7 +15,7 @@
     <TargetExt>.ildll</TargetExt>
 
     <!-- This is an explicit crossgen test -->
-    <CrossGenTest>false</CrossGenTest>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include=".\helperdll.csproj" />
@@ -24,18 +24,4 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-copy helperildll.dll helperildll.ildll
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-cp helperildll.dll helperildll.ildll
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/tests/readytorun/determinism/crossgen2determinism.csproj
@@ -18,16 +18,16 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 set CoreRT_DeterminismSeed=1
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:..\..\crossgen2\crossgen2smoke\helperdll.dll -r:..\..\crossgen2\crossgen2smoke\helperildll.dll -o:crossgen2smoke1.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.ildll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:..\..\crossgen2\crossgen2smoke\helperdll.dll -r:..\..\crossgen2\crossgen2smoke\helperildll.dll -o:crossgen2smoke1.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.dll
 set CoreRT_DeterminismSeed=2
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:..\..\crossgen2\crossgen2smoke\helperdll.dll -r:..\..\crossgen2\crossgen2smoke\helperildll.dll -o:crossgen2smoke2.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.ildll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:..\..\crossgen2\crossgen2smoke\helperdll.dll -r:..\..\crossgen2\crossgen2smoke\helperildll.dll -o:crossgen2smoke2.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.dll
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 export CoreRT_DeterminismSeed=1
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:../../crossgen2/crossgen2smoke/helperdll.dll -r:../../crossgen2/crossgen2smoke/helperildll.dll -o:crossgen2smoke1.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:../../crossgen2/crossgen2smoke/helperdll.dll -r:../../crossgen2/crossgen2smoke/helperildll.dll -o:crossgen2smoke1.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.dll
 export CoreRT_DeterminismSeed=2
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:../../crossgen2/crossgen2smoke/helperdll.dll -r:../../crossgen2/crossgen2smoke/helperildll.dll -o:crossgen2smoke2.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:../../crossgen2/crossgen2smoke/helperdll.dll -r:../../crossgen2/crossgen2smoke/helperildll.dll -o:crossgen2smoke2.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.dll
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
As I recently fixed the underlying issue - we were inadvertently
running the Crossgen2 compiler itself in GC stress mode and
timing out due to the long compilation times - we can now
reenable this test in GC stress mode.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/33949

/cc: @dotnet/crossgen-contrib 