### PR TITLE
Workaround for WSL1 process IO redirection bug

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -761,7 +761,23 @@ namespace System.Diagnostics
         private static Stream OpenStream(int fd, FileAccess access)
         {
             Debug.Assert(fd >= 0);
-            var socket = new Socket(new SafeSocketHandle((IntPtr)fd, ownsHandle: true));
+            var socketHandle = new SafeSocketHandle((IntPtr)fd, ownsHandle: true);
+            var socket = new Socket(socketHandle);
+
+            if (!socket.Connected)
+            {
+                // WSL1 workaround -- due to issues with sockets syscalls 
+                // socket pairs fd's are erroneously inferred as not connected.
+                // Fall back to using FileStream instead.
+
+                GC.SuppressFinalize(socket);
+                GC.SuppressFinalize(socketHandle);
+
+                return new FileStream(
+                    new SafeFileHandle((IntPtr)fd, ownsHandle: true),
+                    access, StreamBufferSize, isAsync: false);
+            }
+
             return new NetworkStream(socket, access, ownsSocket: true);
         }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -766,7 +766,7 @@ namespace System.Diagnostics
 
             if (!socket.Connected)
             {
-                // WSL1 workaround -- due to issues with sockets syscalls 
+                // WSL1 workaround -- due to issues with sockets syscalls
                 // socket pairs fd's are erroneously inferred as not connected.
                 // Fall back to using FileStream instead.
 


### PR DESCRIPTION
Attempts to implement a workaround for #40727. Alternative to #40832.

Has been tested with WSL1 and WSL2.