### PR TITLE
[aot] Avoid emitting generic instances with vtype arguments on wasm to save space.

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -4559,8 +4559,10 @@ mono_aot_can_dedup (MonoMethod *method)
 	if (method->is_inflated && !mono_method_is_generic_sharable_full (method, TRUE, FALSE, FALSE) &&
 		!mini_is_gsharedvt_signature (mono_method_signature_internal (method)) &&
 		!mini_is_gsharedvt_klass (method->klass)) {
-		/* No point in dedup-ing private instances */
 		MonoGenericContext *context = mono_method_get_context (method);
+		if (context->method_inst && mini_is_gsharedvt_inst (context->method_inst))
+			return FALSE;
+		/* No point in dedup-ing private instances */
 		if ((context->class_inst && inst_is_private (context->class_inst)) ||
 			(context->method_inst && inst_is_private (context->method_inst)))
 			return FALSE;

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -4469,6 +4469,21 @@ mini_is_gsharedvt_sharable_inst (MonoGenericInst *inst)
 }
 
 gboolean
+mini_is_gsharedvt_inst (MonoGenericInst *inst)
+{
+	int i;
+
+	for (i = 0; i < inst->type_argc; ++i) {
+		MonoType *type = inst->type_argv [i];
+
+		if (mini_is_gsharedvt_type (type))
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+gboolean
 mini_is_gsharedvt_sharable_method (MonoMethod *method)
 {
 	MonoMethodSignature *sig;

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2719,6 +2719,9 @@ mono_is_partially_sharable_inst (MonoGenericInst *inst);
 gboolean
 mini_is_gsharedvt_gparam (MonoType *t);
 
+gboolean
+mini_is_gsharedvt_inst (MonoGenericInst *inst);
+
 MonoGenericContext* mini_method_get_context (MonoMethod *method);
 
 int mono_method_check_context_used (MonoMethod *method);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20252,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>