### PR TITLE
Fix annotation in DataTableReaderListener

### DIFF
--- a/src/libraries/System.Data.Common/src/System/Data/DataTableReaderListener.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTableReaderListener.cs
@@ -7,7 +7,7 @@ namespace System.Data
 {
     internal sealed class DataTableReaderListener
     {
-        private DataTable _currentDataTable;
+        private DataTable? _currentDataTable;
         private bool _isSubscribed;
         private readonly WeakReference _readerWeak;
 


### PR DESCRIPTION
When running the new nullable constructor analysis on runtime we
discovered what appears to be a missing annotation in
`DataTableReaderListener`.

Note: the second `if` check in the constructor seems like dead code.
It's checking for the field to be non-null before ever setting the field
to a value. Probably could be deleted.