### PR TITLE
Change null handling in custom converters for backwards compat

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -21,9 +21,21 @@ namespace System.Text.Json.Serialization
             // In the future, this will be check for !IsSealed (and excluding value types).
             CanBePolymorphic = TypeToConvert == JsonClassInfo.ObjectType;
             IsValueType = TypeToConvert.IsValueType;
-            HandleNull = IsValueType;
             CanBeNull = !IsValueType || Nullable.GetUnderlyingType(TypeToConvert) != null;
             IsInternalConverter = GetType().Assembly == typeof(JsonConverter).Assembly;
+
+            if (HandleNull)
+            {
+                HandleNullOnRead = true;
+                HandleNullOnWrite = true;
+            }
+
+            // For the HandleNull == false case, either:
+            // 1) The default values are assigned in this type's virtual HandleNull property
+            // or
+            // 2) A converter overroad HandleNull and returned false so HandleNullOnRead and HandleNullOnWrite
+            // will be their default values of false.
+
             CanUseDirectReadOrWrite = !CanBePolymorphic && IsInternalConverter && ClassType == ClassType.Value;
         }
 
@@ -61,7 +73,34 @@ namespace System.Text.Json.Serialization
         /// <remarks>
         /// The default value is <see langword="true"/> for converters for value types, and <see langword="false"/> for converters for reference types.
         /// </remarks>
-        public virtual bool HandleNull { get; }
+        public virtual bool HandleNull
+        {
+            get
+            {
+                // HandleNull is only called by the framework once during initialization and any
+                // subsequent calls elsewhere would just re-initialize to the same values (we don't
+                // track a "hasInitialized" flag since that isn't necessary).
+
+                // If the type doesn't support null, allow the converter a chance to modify.
+                // These semantics are backwards compatible with 3.0.
+                HandleNullOnRead = !CanBeNull;
+
+                // The framework handles null automatically on writes.
+                HandleNullOnWrite = false;
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Does the converter want to be called when reading null tokens.
+        /// </summary>
+        internal bool HandleNullOnRead { get; private set; }
+
+        /// <summary>
+        /// Does the converter want to be called for null values.
+        /// </summary>
+        internal bool HandleNullOnWrite { get; private set; }
 
         /// <summary>
         /// Can <see langword="null"/> be assigned to <see cref="TypeToConvert"/>?
@@ -109,7 +148,7 @@ namespace System.Text.Json.Serialization
                 Debug.Assert(!state.IsContinuation);
 
                 // For perf and converter simplicity, handle null here instead of forwarding to the converter.
-                if (reader.TokenType == JsonTokenType.Null && !HandleNull)
+                if (reader.TokenType == JsonTokenType.Null && !HandleNullOnRead)
                 {
                     if (!CanBeNull)
                     {
@@ -184,7 +223,7 @@ namespace System.Text.Json.Serialization
             // For performance, only perform validation on internal converters on debug builds.
             if (IsInternalConverter)
             {
-                if (reader.TokenType == JsonTokenType.Null && !HandleNull && !wasContinuation)
+                if (reader.TokenType == JsonTokenType.Null && !HandleNullOnRead && !wasContinuation)
                 {
                     if (!CanBeNull)
                     {
@@ -206,7 +245,7 @@ namespace System.Text.Json.Serialization
                 if (!wasContinuation)
                 {
                     // For perf and converter simplicity, handle null here instead of forwarding to the converter.
-                    if (reader.TokenType == JsonTokenType.Null && !HandleNull)
+                    if (reader.TokenType == JsonTokenType.Null && !HandleNullOnRead)
                     {
                         if (!CanBeNull)
                         {
@@ -267,7 +306,7 @@ namespace System.Text.Json.Serialization
             {
                 if (value == null)
                 {
-                    if (!HandleNull)
+                    if (!HandleNullOnWrite)
                     {
                         writer.WriteNullValue();
                     }
@@ -303,9 +342,9 @@ namespace System.Text.Json.Serialization
                     }
                 }
             }
-            else if (value == null && !HandleNull)
+            else if (value == null && !HandleNullOnWrite)
             {
-                // We do not pass null values to converters unless HandleNull is true. Null values for properties were
+                // We do not pass null values to converters unless HandleNullOnWrite is true. Null values for properties were
                 // already handled in GetMemberAndWriteJson() so we don't need to check for IgnoreNullValues here.
                 writer.WriteNullValue();
                 return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -135,7 +135,7 @@ namespace System.Text.Json
             {
                 Debug.Assert(Converter.CanBeNull);
 
-                if (Converter.HandleNull)
+                if (Converter.HandleNullOnWrite)
                 {
                     // No object, collection, or re-entrancy converter handles null.
                     Debug.Assert(Converter.ClassType == ClassType.Value);
@@ -194,7 +194,7 @@ namespace System.Text.Json
             bool success;
 
             bool isNullToken = reader.TokenType == JsonTokenType.Null;
-            if (isNullToken && !Converter.HandleNull && !state.IsContinuation)
+            if (isNullToken && !Converter.HandleNullOnRead && !state.IsContinuation)
             {
                 if (!Converter.CanBeNull)
                 {
@@ -242,7 +242,7 @@ namespace System.Text.Json
         {
             bool success;
             bool isNullToken = reader.TokenType == JsonTokenType.Null;
-            if (isNullToken && !Converter.HandleNull && !state.IsContinuation)
+            if (isNullToken && !Converter.HandleNullOnRead && !state.IsContinuation)
             {
                 if (!Converter.CanBeNull)
                 {

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.HandleNull.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.HandleNull.cs
@@ -172,15 +172,17 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(val);
             Assert.Equal("null", JsonSerializer.Serialize(val));
 
-            // Per null handling default value for value types (true), converter handles null.
+            // For compat, deserialize does not call converter for null token unless the type doesn't support
+            // null or HandleNull is overridden and returns 'true'.
+            // For compat, serialize does not call converter for null unless null is a valid value and HandleNull is true.
             var options = new JsonSerializerOptions();
             options.Converters.Add(new NullableInt32NullConverter_SpecialCaseNull());
 
             val = JsonSerializer.Deserialize<int?>("null", options);
-            Assert.Equal(-1, val);
+            Assert.Null(val);
 
             val = null;
-            Assert.Equal("-1", JsonSerializer.Serialize(val, options));
+            Assert.Equal("null", JsonSerializer.Serialize(val, options));
         }
 
         private class NullableInt32NullConverter_SpecialCaseNull : JsonConverter<int?>

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.NullableTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.NullableTypes.cs
@@ -160,32 +160,35 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void NullableConverterIsPassedNull()
+        public static void NullableConverterIsNotPassedNull()
         {
+            // For compat, deserialize does not call converter for null token unless the type doesn't support
+            // null or HandleNull is overridden and returns 'true'.
+            // For compat, serialize does not call converter for null unless null is a valid value and HandleNull is true.
+
             var options = new JsonSerializerOptions();
             options.Converters.Add(new NullIntTo42Converter());
 
             {
                 int? myInt = JsonSerializer.Deserialize<int?>("null", options);
-                Assert.True(myInt.HasValue);
-                Assert.Equal(42, myInt.Value);
+                Assert.Null(myInt);
             }
 
             {
                 string json = JsonSerializer.Serialize<int?>(null, options);
-                Assert.Equal("42", json);
+                Assert.Equal("null", json);
             }
 
             {
                 int?[] ints = JsonSerializer.Deserialize<int?[]>("[null, null]", options);
                 Assert.Equal(2, ints.Length);
-                Assert.Equal(42, ints[0]);
-                Assert.Equal(42, ints[1]);
+                Assert.Null(ints[0]);
+                Assert.Null(ints[1]);
             }
 
             {
                 string json = JsonSerializer.Serialize<int?[]>(new int?[] { null, null }, options);
-                Assert.Equal("[42,42]", json);
+                Assert.Equal("[null,null]", json);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37940

The default 5.0 behavior of when a custom converter is called with null tokens (on read) and null values (on write) is not the same as 3.0\3.1 and this PR changes that back.

In 3.0:
  - deserialize does not call the converter's Read method for null token unless the converter's type doesn't support null. The framework needed these semantics, for example, with `JsonElement` since that is a value type but the converter for that needed to write the JSON as an empty object ("{}"). Normally the converter would throw an exception (directly or indirectly by letting the reader throw it) since a value type that can't be null can't understand a null token. Note that converters based on `Nullable<T>` wouldn't get called either since `Nullable<T>` supports null.
  - serialize does not call the converter's Write method for null

The basic idea in 3.0 was the framework handles null in all cases except the edge case mentioned above. In 5.0 now, we added the `HandlesNull` property that a converter can return `true` and get called.