### PR TITLE
[mono] Add `X86Base` support.

### DIFF
--- a/src/mono/mono/metadata/icall-decl.h
+++ b/src/mono/mono/metadata/icall-decl.h
@@ -304,4 +304,8 @@ ICALL_EXPORT gint32   ves_icall_System_Threading_LowLevelLifoSemaphore_TimedWait
 ICALL_EXPORT void     ves_icall_System_Threading_LowLevelLifoSemaphore_ReleaseInternal (gpointer sem_ptr, gint32 count);
 #endif
 
+#if defined(ENABLE_NETCORE)
+ICALL_EXPORT void ves_icall_System_Runtime_Intrinsics_X86_X86Base___cpuidex (int abcd[4], int function_id, int subfunction_id);
+#endif
+
 #endif // __MONO_METADATA_ICALL_DECL_H__

--- a/src/mono/mono/metadata/icall-decl.h
+++ b/src/mono/mono/metadata/icall-decl.h
@@ -304,7 +304,7 @@ ICALL_EXPORT gint32   ves_icall_System_Threading_LowLevelLifoSemaphore_TimedWait
 ICALL_EXPORT void     ves_icall_System_Threading_LowLevelLifoSemaphore_ReleaseInternal (gpointer sem_ptr, gint32 count);
 #endif
 
-#if defined(ENABLE_NETCORE)
+#if defined(ENABLE_NETCORE) && defined(TARGET_AMD64)
 ICALL_EXPORT void ves_icall_System_Runtime_Intrinsics_X86_X86Base___cpuidex (int abcd[4], int function_id, int subfunction_id);
 #endif
 

--- a/src/mono/mono/metadata/icall-def-netcore.h
+++ b/src/mono/mono/metadata/icall-def-netcore.h
@@ -373,6 +373,11 @@ HANDLES(NATIVEL_2, "GetSymbol", ves_icall_System_Runtime_InteropServices_NativeL
 HANDLES(NATIVEL_3, "LoadByName", ves_icall_System_Runtime_InteropServices_NativeLibrary_LoadByName, gpointer, 5, (MonoString, MonoReflectionAssembly, MonoBoolean, guint32, MonoBoolean))
 HANDLES(NATIVEL_4, "LoadFromPath", ves_icall_System_Runtime_InteropServices_NativeLibrary_LoadFromPath, gpointer, 2, (MonoString, MonoBoolean))
 
+#if defined(TARGET_AMD64)
+ICALL_TYPE(X86BASE, "System.Runtime.Intrinsics.X86.X86Base", X86BASE_1)
+NOHANDLES(ICALL(X86BASE_1, "__cpuidex", ves_icall_System_Runtime_Intrinsics_X86_X86Base___cpuidex))
+#endif
+
 ICALL_TYPE(ALC, "System.Runtime.Loader.AssemblyLoadContext", ALC_5)
 HANDLES(ALC_5, "GetLoadContextForAssembly", ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly, gpointer, 1, (MonoReflectionAssembly))
 HANDLES(ALC_4, "InternalGetLoadedAssemblies", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetLoadedAssemblies, MonoArray, 0, ())

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -316,6 +316,12 @@ const_int32 (int v)
 	return LLVMConstInt (LLVMInt32Type (), v, FALSE);
 }
 
+static LLVMValueRef
+const_int64 (int64_t v)
+{
+	return LLVMConstInt (LLVMInt64Type (), v, FALSE);
+}
+
 /*
  * IntPtrType:
  *
@@ -5714,7 +5720,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 		}
 		case OP_X86_BSF32:
 		case OP_X86_BSF64: {
-			LLVMValueRef args [2] = {
+			LLVMValueRef args [] = {
 				lhs,
 				LLVMConstInt (LLVMInt1Type (), 1, TRUE),
 			};
@@ -5724,14 +5730,14 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 		}
 		case OP_X86_BSR32:
 		case OP_X86_BSR64: {
-			LLVMValueRef args [2] = {
+			LLVMValueRef args [] = {
 				lhs,
 				LLVMConstInt (LLVMInt1Type (), 1, TRUE),
 			};
 			int op = ins->opcode == OP_X86_BSR32 ? INTRINS_CTLZ_I32 : INTRINS_CTLZ_I64;
-			int width = ins->opcode == OP_X86_BSR32 ? 32 : 64;
+			LLVMValueRef width = ins->opcode == OP_X86_BSR32 ? const_int32 (31) : const_int64 (63);
 			LLVMValueRef tz = call_intrins (ctx, op, args, "");
-			values [ins->dreg] = LLVMBuildXor (builder, tz, const_int32 (width - 1), dname);
+			values [ins->dreg] = LLVMBuildXor (builder, tz, width, dname);
 			break;
 		}
 #endif

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -5712,6 +5712,28 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			values [ins->dreg] = LLVMBuildAdd (builder, v2, LLVMConstInt (IntPtrType (), ins->inst_imm, FALSE), dname);
 			break;
 		}
+		case OP_X86_BSF32:
+		case OP_X86_BSF64: {
+			LLVMValueRef args [2] = {
+				lhs,
+				LLVMConstInt (LLVMInt1Type (), 1, TRUE),
+			};
+			int op = ins->opcode == OP_X86_BSF32 ? INTRINS_CTTZ_I32 : INTRINS_CTTZ_I64;
+			values [ins->dreg] = call_intrins (ctx, op, args, dname);
+			break;
+		}
+		case OP_X86_BSR32:
+		case OP_X86_BSR64: {
+			LLVMValueRef args [2] = {
+				lhs,
+				LLVMConstInt (LLVMInt1Type (), 1, TRUE),
+			};
+			int op = ins->opcode == OP_X86_BSR32 ? INTRINS_CTLZ_I32 : INTRINS_CTLZ_I64;
+			int width = ins->opcode == OP_X86_BSR32 ? 32 : 64;
+			LLVMValueRef tz = call_intrins (ctx, op, args, "");
+			values [ins->dreg] = LLVMBuildXor (builder, tz, const_int32 (width - 1), dname);
+			break;
+		}
 #endif
 
 		case OP_ICONV_TO_I1:

--- a/src/mono/mono/mini/mini-ops.h
+++ b/src/mono/mono/mini/mini-ops.h
@@ -1330,6 +1330,10 @@ MINI_OP(OP_X86_FP_LOAD_I4,         "x86_fp_load_i4", FREG, IREG, NONE)
 MINI_OP(OP_X86_SETEQ_MEMBASE,      "x86_seteq_membase", NONE, IREG, NONE)
 MINI_OP(OP_X86_SETNE_MEMBASE,      "x86_setne_membase", NONE, IREG, NONE)
 MINI_OP(OP_X86_FXCH,               "x86_fxch", NONE, NONE, NONE)
+MINI_OP(OP_X86_BSF32,              "x86_bsf32", IREG, IREG, NONE)
+MINI_OP(OP_X86_BSR32,              "x86_bsr32", IREG, IREG, NONE)
+MINI_OP(OP_X86_BSF64,              "x86_bsf64", LREG, LREG, NONE)
+MINI_OP(OP_X86_BSR64,              "x86_bsr64", LREG, LREG, NONE)
 #endif
 
 #if defined(TARGET_AMD64)

--- a/src/mono/mono/mini/simd-intrinsics-netcore.c
+++ b/src/mono/mono/mini/simd-intrinsics-netcore.c
@@ -1123,6 +1123,7 @@ static SimdIntrinsic bmi2_methods [] = {
 static SimdIntrinsic x86base_methods [] = {
 	{SN_BitScanForward},
 	{SN_BitScanReverse},
+	{SN_get_IsSupported}
 };
 
 static MonoInst*

--- a/src/mono/mono/mini/simd-intrinsics-netcore.c
+++ b/src/mono/mono/mini/simd-intrinsics-netcore.c
@@ -4,6 +4,7 @@
 
 #include <config.h>
 #include <mono/utils/mono-compiler.h>
+#include <mono/metadata/icall-decl.h>
 #include "mini.h"
 
 #if defined(DISABLE_JIT)
@@ -14,8 +15,6 @@ mono_simd_intrinsics_init (void)
 }
 
 #else
-
-#include <mono/metadata/icall-decl.h>
 
 /*
  * Only LLVM is supported as a backend.
@@ -2103,16 +2102,6 @@ emit_vector256_t (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fs
 	return NULL;
 }
 
-gboolean
-mono_cpuidex (int id, int sub_id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx);
-
-void
-ves_icall_System_Runtime_Intrinsics_X86_X86Base___cpuidex (int abcd[4], int function_id, int subfunction_id)
-{
-	mono_cpuidex (function_id, subfunction_id,
-		&abcd [0], &abcd [1], &abcd [2], &abcd [3]);
-}
-
 #endif // !TARGET_ARM64
 
 MonoInst*
@@ -2184,3 +2173,16 @@ MONO_EMPTY_SOURCE_FILE (simd_intrinsics_netcore);
 #endif
 
 #endif /* DISABLE_JIT */
+
+
+#if defined(ENABLE_NETCORE) && defined(TARGET_AMD64)
+gboolean
+mono_cpuidex (int id, int sub_id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx);
+
+void
+ves_icall_System_Runtime_Intrinsics_X86_X86Base___cpuidex (int abcd[4], int function_id, int subfunction_id)
+{
+	mono_cpuidex (function_id, subfunction_id,
+		&abcd [0], &abcd [1], &abcd [2], &abcd [3]);
+}
+#endif

--- a/src/mono/mono/mini/simd-methods-netcore.h
+++ b/src/mono/mono/mini/simd-methods-netcore.h
@@ -233,3 +233,6 @@ METHOD(ReverseElementBits)
 // Crc32
 METHOD(ComputeCrc32)
 METHOD(ComputeCrc32C)
+// X86Base
+METHOD(BitScanForward)
+METHOD(BitScanReverse)

--- a/src/mono/mono/utils/mono-hwcap-x86.c
+++ b/src/mono/mono/utils/mono-hwcap-x86.c
@@ -29,8 +29,8 @@
 #include <intrin.h>
 #endif
 
-static gboolean
-cpuid (int id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx)
+gboolean
+mono_cpuidex (int id, int sub_id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx)
 {
 #if defined(_MSC_VER)
 	int info [4];
@@ -80,7 +80,7 @@ cpuid (int id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx)
 	/* Now issue the actual cpuid instruction. We can use
 	   MSVC's __cpuid on both 32-bit and 64-bit. */
 #if defined(_MSC_VER)
-	__cpuid (info, id);
+	__cpuidex (info, id, sub_id);
 	*p_eax = info [0];
 	*p_ebx = info [1];
 	*p_ecx = info [2];
@@ -93,13 +93,13 @@ cpuid (int id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx)
 		"cpuid\n\t"
 		"xchgl\t%%ebx, %k1\n\t"
 		: "=a" (*p_eax), "=&r" (*p_ebx), "=c" (*p_ecx), "=d" (*p_edx)
-		: "0" (id)
+		: "0" (id), "2" (sub_id)
 	);
 #else
 	__asm__ __volatile__ (
 		"cpuid\n\t"
 		: "=a" (*p_eax), "=b" (*p_ebx), "=c" (*p_ecx), "=d" (*p_edx)
-		: "a" (id)
+		: "a" (id), "2" (sub_id)
 	);
 #endif
 
@@ -111,7 +111,7 @@ mono_hwcap_arch_init (void)
 {
 	int eax, ebx, ecx, edx;
 
-	if (cpuid (1, &eax, &ebx, &ecx, &edx)) {
+	if (mono_cpuidex (1, 0, &eax, &ebx, &ecx, &edx)) {
 		if (edx & (1 << 15)) {
 			mono_hwcap_x86_has_cmov = TRUE;
 
@@ -144,16 +144,16 @@ mono_hwcap_arch_init (void)
 			mono_hwcap_x86_has_avx = TRUE;
 	}
 
-	if (cpuid (0x80000000, &eax, &ebx, &ecx, &edx)) {
+	if (mono_cpuidex (0x80000000, 0, &eax, &ebx, &ecx, &edx)) {
 		if ((unsigned int) eax >= 0x80000001 && ebx == 0x68747541 && ecx == 0x444D4163 && edx == 0x69746E65) {
-			if (cpuid (0x80000001, &eax, &ebx, &ecx, &edx)) {
+			if (mono_cpuidex (0x80000001, 0, &eax, &ebx, &ecx, &edx)) {
 				if (ecx & (1 << 6))
 					mono_hwcap_x86_has_sse4a = TRUE;
 			}
 		}
 	}
 
-	if (cpuid (0x80000001, &eax, &ebx, &ecx, &edx)) {
+	if (mono_cpuidex (0x80000001, 0, &eax, &ebx, &ecx, &edx)) {
 		if (ecx & (1 << 5))
 			mono_hwcap_x86_has_lzcnt = TRUE;
 	}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.Mono.cs
@@ -8,6 +8,6 @@ namespace System.Runtime.Intrinsics.X86
     public abstract partial class X86Base
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        extern private static unsafe void __cpuidex(int* cpuInfo, int functionId, int subFunctionId);
+        private static extern unsafe void __cpuidex(int* cpuInfo, int functionId, int subFunctionId);
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.Mono.cs
@@ -1,13 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Runtime.Intrinsics.X86
 {
     public abstract partial class X86Base
     {
-        private static unsafe void __cpuidex(int* cpuInfo, int functionId, int subFunctionId)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        extern private static unsafe void __cpuidex(int* cpuInfo, int functionId, int subFunctionId);
     }
 }


### PR DESCRIPTION
Implement `BitScanForward` and `BitScanReverse` as intrinsics.

Implement `__cpuidex` as a netcore-only icall. Rename `cpuid` (in
mono-hwcap-x86.c) to `mono_cpuidex`, give it extern linkage, and add
support for extended CPUID.

Related: https://github.com/dotnet/runtime/pull/40167