### PR TITLE
Update linker warning numbers

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -182,9 +182,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="5.0.0-preview.3.20412.1">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="5.0.0-preview.3.20413.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>fc5e4aa86ad543ab3a730e0e0e8dacc6a379d4a5</Sha>
+      <Sha>2b04c065c84aa8f30600e3b1989c537fc77de95b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20411.1">
       <Uri>https://github.com/dotnet/xharness</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -143,7 +143,7 @@
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>3.0.0-preview-20200715.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
-    <MicrosoftNETILLinkTasksVersion>5.0.0-preview.3.20412.1</MicrosoftNETILLinkTasksVersion>
+    <MicrosoftNETILLinkTasksVersion>5.0.0-preview.3.20413.1</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-preview.8.20410.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- Mono LLVM -->

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -225,8 +225,6 @@
       <!-- keep DynamicDependencyAttribute unless a project explicitly disables it -->
       <ILLinkArgs Condition="'$(ILLinkKeepDepAttributes)' != 'false'">$(ILLinkArgs) --keep-dep-attributes true</ILLinkArgs>
       <!-- suppress warnings with the following codes:
-           IL2006: The generic parameter 'T' from A with dynamically accessed member kinds B is passed into the generic parameter
-                   'T' from 'System.Lazy<T>' which requires dynamically accessed member kinds 'PublicParameterlessConstructor'
            IL2008: Could not find type A specified in resource B
            IL2009: Could not find method A in type B specified in resource C
            IL2012: Could not find field A in type B specified in resource C
@@ -236,7 +234,14 @@
            IL2050: P/invoke method A declares a parameter with COM marshalling. Correctness of COM interop
                    cannot be guaranteed after trimming. Interfaces and interface members might be removed.
       -->
-      <ILLinkArgs>$(ILLinkArgs) --nowarn IL2006;IL2008;IL2009;IL2012;IL2025;IL2026;IL2035;IL2050</ILLinkArgs>
+      <LinkerNoWarn>IL2008;IL2009;IL2012;IL2025;IL2026;IL2035;IL2050</LinkerNoWarn>
+      <!-- IL2032,IL2055,IL2057-IL2061: Reflection intrinsics with unknown arguments -->
+      <LinkerNoWarn>$(LinkerNoWarn);IL2032;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061</LinkerNoWarn>
+      <!-- IL2062-IL2066: Unknown values passed to locations with DynamicallyAccessedMemberTypes -->
+      <LinkerNoWarn>$(LinkerNoWarn);IL2062;IL2063;IL2064;IL2065;IL2066</LinkerNoWarn>
+      <!-- IL2067-IL2091: Unsatisfied DynamicallyAccessedMembers requirements -->
+      <LinkerNoWarn>$(LinkerNoWarn);IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091</LinkerNoWarn>
+      <ILLinkArgs>$(ILLinkArgs) --nowarn $(LinkerNoWarn)</ILLinkArgs>
     </PropertyGroup>
 
     <MakeDir Directories="$(ILLinkTrimInputPath)" />

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -7,7 +7,14 @@
     <RuntimePackDir>{RuntimePackDir}</RuntimePackDir>
     <TargetingPackDir>{TargetingPackDir}</TargetingPackDir>
 
-    <LinkerNoWarn>IL2006;IL2026</LinkerNoWarn>
+    <!-- These can be removed once we get an SDK with https://github.com/mono/linker/pull/1385. -->
+    <LinkerNoWarn>IL2026</LinkerNoWarn>
+    <!-- IL2032,IL2055,IL2057-IL2061: Reflection intrinsics with unknown arguments -->
+    <LinkerNoWarn>$(LinkerNoWarn);IL2032;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061</LinkerNoWarn>
+    <!-- IL2062-IL2066: Unknown values passed to locations with DynamicallyAccessedMemberTypes -->
+    <LinkerNoWarn>$(LinkerNoWarn);IL2062;IL2063;IL2064;IL2065;IL2066</LinkerNoWarn>
+    <!-- IL2067-IL2091: Unsatisfied DynamicallyAccessedMembers requirements -->
+    <LinkerNoWarn>$(LinkerNoWarn);IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091</LinkerNoWarn>
     <!-- https://github.com/dotnet/runtime/issues/40336 - need to suppress IL2008;IL2009;IL2037 on non-Windows -->
     <LinkerNoWarn Condition="!$(RuntimeIdentifier.StartsWith('win'))">$(LinkerNoWarn);IL2008;IL2009;IL2037</LinkerNoWarn>
     <_ExtraTrimmerArgs>{ExtraTrimmerArgs} $(_ExtraTrimmerArgs) --nowarn $(LinkerNoWarn)</_ExtraTrimmerArgs>

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -26,7 +26,7 @@ namespace System.Runtime.InteropServices
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern int SizeOfHelper(Type t, bool throwIfNotMarshalable);
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Trimming doesn't affect types eligible for marshalling. Different exception for invalid inputs doesn't matter.")]
         public static IntPtr OffsetOf(Type t, string fieldName)
         {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3863,7 +3863,9 @@ namespace System
                 throw new NotSupportedException(SR.Acc_CreateVoid);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2082:UnrecognizedReflectionPattern",
+            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         internal object? CreateInstanceImpl(
             BindingFlags bindingAttr, Binder? binder, object?[]? args, CultureInfo? culture)

--- a/src/coreclr/src/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/ValueType.cs
@@ -20,7 +20,7 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract class ValueType
     {
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Trimmed fields don't make a difference for equality")]
         public override bool Equals(object? obj)
         {

--- a/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.cs
+++ b/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Internal
                     defaultValue = CreateValueType(parameter.ParameterType);
                 }
 
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
                     Justification = "CreateInstance is only called on a ValueType, which will always have a default constructor.")]
                 object? CreateValueType(Type t) => Activator.CreateInstance(t);
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 VisitCallSiteMain(callSite, context));
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:UnrecognizedReflectionPattern",
             Justification = "Calling Array.Empty<T>() is safe since the T doesn't have linker annotations.")]
         internal static MethodInfo GetArrayEmptyMethodInfo(Type itemType) =>
             ArrayEmptyMethodInfo.MakeGenericMethod(itemType);

--- a/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
@@ -97,9 +97,11 @@ namespace System
             throw new ArgumentException(SR.Arg_MustBeType, nameof(type));
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
-            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057:UnrecognizedReflectionPattern",
+            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
             Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         private static ObjectHandle? CreateInstanceInternal(string assemblyString,
                                                            string typeName,

--- a/src/libraries/System.Private.CoreLib/src/System/Attribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Attribute.cs
@@ -15,7 +15,7 @@ namespace System
         protected Attribute() { }
 
 #if !CORERT
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Unused fields don't make a difference for equality")]
         public override bool Equals(object? obj)
         {
@@ -49,7 +49,7 @@ namespace System
             return true;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Unused fields don't make a difference for hashcode quality")]
         public override int GetHashCode()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureTypeExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureTypeExtensions.cs
@@ -110,7 +110,7 @@ namespace System.Reflection
             return signatureType.TryResolve(genericMethod.GetGenericArguments());
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
             Justification = "Used to find matching method overloads. Only used for assignability checks.")]
         private static Type? TryResolve(this SignatureType signatureType, Type[] genericMethodParameters)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeInfo.cs
@@ -39,7 +39,7 @@ namespace System.Reflection
                     yield return method;
             }
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
                 Justification = "The yield return state machine doesn't propagate annotations")]
             static MethodInfo[] GetDeclaredOnlyMethods(
                 Type type) => type.GetMethods(TypeInfo.DeclaredOnlyLookup);
@@ -85,7 +85,7 @@ namespace System.Reflection
                     yield return t.GetTypeInfo();
                 }
 
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
                     Justification = "The yield return state machine doesn't propagate annotations")]
                 static Type[] GetDeclaredOnlyNestedTypes(
                     Type type) => type.GetNestedTypes(TypeInfo.DeclaredOnlyLookup);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -92,7 +92,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Gets a description of the state of the state machine object, suitable for debug purposes.</summary>
         /// <param name="stateMachine">The state machine object.</param>
         /// <returns>A description of the state machine.</returns>
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "It's okay if unused fields disappear from debug views")]
         internal static string GetAsyncStateMachineDescription(IAsyncStateMachine stateMachine)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -508,7 +508,7 @@ namespace System.Runtime.InteropServices
             PrelinkCore(m);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "This only needs to prelink methods that are actually used")]
         public static void PrelinkAll(Type c)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Type.Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.Enum.cs
@@ -105,7 +105,7 @@ namespace System
             return values;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Literal fields on enums can never be trimmed")]
         // This will return enumValues and enumNames sorted by the values.
         private void GetEnumData(out string[] enumNames, out Array enumValues)

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -151,7 +151,7 @@ namespace System
         protected abstract ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[] types, ParameterModifier[]? modifiers);
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetConstructors(BindingFlags.Public) but this is what the body is doing")]
         public ConstructorInfo[] GetConstructors() => GetConstructors(BindingFlags.Public | BindingFlags.Instance);
 
@@ -165,7 +165,7 @@ namespace System
         public abstract EventInfo? GetEvent(string name, BindingFlags bindingAttr);
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetEvents(BindingFlags.Public) but this is what the body is doing")]
         public virtual EventInfo[] GetEvents() => GetEvents(Type.DefaultLookup);
 
@@ -179,7 +179,7 @@ namespace System
         public abstract FieldInfo? GetField(string name, BindingFlags bindingAttr);
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetFields(BindingFlags.Public) but this is what the body is doing")]
         public FieldInfo[] GetFields() => GetFields(Type.DefaultLookup);
 
@@ -193,7 +193,7 @@ namespace System
             | DynamicallyAccessedMemberTypes.PublicProperties
             | DynamicallyAccessedMemberTypes.PublicConstructors
             | DynamicallyAccessedMemberTypes.PublicNestedTypes)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetMember(BindingFlags.Public) but this is what the body is doing")]
         public MemberInfo[] GetMember(string name) => GetMember(name, Type.DefaultLookup);
 
@@ -277,7 +277,7 @@ namespace System
         protected virtual MethodInfo? GetMethodImpl(string name, int genericParameterCount, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException();
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetMethods(BindingFlags.Public) but this is what the body is doing")]
         public MethodInfo[] GetMethods() => GetMethods(Type.DefaultLookup);
 
@@ -291,7 +291,7 @@ namespace System
         public abstract Type? GetNestedType(string name, BindingFlags bindingAttr);
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetNestedTypes(BindingFlags.Public) but this is what the body is doing")]
         public Type[] GetNestedTypes() => GetNestedTypes(Type.DefaultLookup);
 
@@ -310,7 +310,7 @@ namespace System
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetPropertyImpl(BindingFlags.Public) but this is what the body is doing")]
         public PropertyInfo? GetProperty(string name, Type? returnType)
         {
@@ -342,7 +342,7 @@ namespace System
         protected abstract PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers);
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recognize GetProperties(BindingFlags.Public) but this is what the body is doing")]
         public PropertyInfo[] GetProperties() => GetProperties(Type.DefaultLookup);
 
@@ -431,7 +431,7 @@ namespace System
         public virtual bool IsInstanceOfType([NotNullWhen(true)] object? o) => o == null ? false : IsAssignableFrom(o.GetType());
         public virtual bool IsEquivalentTo([NotNullWhen(true)] Type? other) => this == other;
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "The single instance field on enum types is never trimmed")]
         public virtual Type GetEnumUnderlyingType()
         {

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -14,8 +14,6 @@
       <!-- update debug symbols -->
       <ILLinkArgs>$(ILLinkArgs) -b true</ILLinkArgs>
       <!-- suppress warnings with the following codes:
-           IL2006: The generic parameter 'T' from A with dynamically accessed member kinds B is passed into the generic parameter
-                   'T' from 'System.Lazy<T>' which requires dynamically accessed member kinds 'PublicParameterlessConstructor'
            IL2009: Could not find method A in type B specified in resource C
            IL2025: Duplicate preserve of A in B
            IL2026: Calling A which has B can break functionality when trimming application code. The target method might be removed.
@@ -23,7 +21,13 @@
            IL2050: P/invoke method A declares a parameter with COM marshalling. Correctness of COM interop
                    cannot be guaranteed after trimming. Interfaces and interface members might be removed.
       -->
-      <LinkerNoWarn>IL2006;IL2009;IL2025;IL2026;IL2035;IL2050</LinkerNoWarn>
+      <LinkerNoWarn>IL2009;IL2025;IL2026;IL2035;IL2050</LinkerNoWarn>
+      <!-- IL2032,IL2055,IL2057-IL2061: Reflection intrinsics with unknown arguments -->
+      <LinkerNoWarn>$(LinkerNoWarn);IL2032;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061</LinkerNoWarn>
+      <!-- IL2062-IL2066: Unknown values passed to locations with DynamicallyAccessedMemberTypes -->
+      <LinkerNoWarn>$(LinkerNoWarn);IL2062;IL2063;IL2064;IL2065;IL2066</LinkerNoWarn>
+      <!-- IL2067-IL2091: Unsatisfied DynamicallyAccessedMembers requirements -->
+      <LinkerNoWarn>$(LinkerNoWarn);IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091</LinkerNoWarn>
       <!-- https://github.com/dotnet/runtime/issues/40336 - need to also suppress the following on non-Windows:
            IL2008: Could not find type A specified in resource B
            IL2037: No members were resolved for 'GetDefaultInstance'

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -250,7 +250,7 @@ namespace System
             return null;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Invoke method is never removed from delegates")]
         private static bool IsMatchingCandidate(Type type, object? target, MethodInfo method, bool allowClosed, out DelegateData? delegateData)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -593,7 +593,7 @@ namespace System.Reflection
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern bool IsDefinedInternal(ICustomAttributeProvider obj, Type AttributeType);
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Linker analyzes base properties and marks them")]
         private static PropertyInfo? GetBasePropertyDefinition(RuntimePropertyInfo property)
         {
@@ -624,7 +624,7 @@ namespace System.Reflection
 
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Linker analyzes base events and marks them")]
         private static EventInfo? GetBaseEventDefinition(RuntimeEventInfo evt)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.Mono.cs
@@ -150,7 +150,7 @@ namespace System.Reflection.Emit
             return parameters![pos];
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't analyze RuntimeResolve but it's an identity function")]
         internal MethodBase RuntimeResolve()
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInst.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInst.cs
@@ -163,7 +163,7 @@ namespace System.Reflection.Emit
         }
 
         // Called from the runtime to return the corresponding finished ConstructorInfo object
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Reflection.Emit is not subject to trimming")]
         internal ConstructorInfo RuntimeResolve()
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.Mono.cs
@@ -320,7 +320,7 @@ namespace System.Reflection.Emit
             return decode_string(data, pos, out pos);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057:UnrecognizedReflectionPattern",
             Justification = "Types referenced from custom attributes are preserved")]
         internal static UnmanagedMarshal get_umarshal(CustomAttributeBuilder customBuilder, bool is_field)
         {
@@ -498,7 +498,9 @@ namespace System.Reflection.Emit
             public object?[] namedParamValues;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057:UnrecognizedReflectionPattern",
+            Justification = "Types referenced from custom attributes are preserved")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Types referenced from custom attributes are preserved")]
         internal static CustomAttributeInfo decode_cattr(CustomAttributeBuilder customBuilder)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.Mono.cs
@@ -48,7 +48,7 @@ namespace System.Reflection.Emit
         private FieldBuilder _underlyingField;
         private Type _underlyingType;
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2064:UnrecognizedReflectionPattern",
             Justification = "Reflection.Emit is not subject to trimming")]
         internal EnumBuilder(ModuleBuilder mb, string name, TypeAttributes visibility, Type underlyingType)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
@@ -289,7 +289,7 @@ namespace System.Reflection.Emit
             num_types++;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
             Justification = "Reflection.Emit is not subject to trimming")]
         private TypeBuilder DefineType(string name, TypeAttributes attr, Type? parent, Type[]? interfaces, PackingSize packingSize, int typesize)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -103,7 +103,7 @@ namespace System.Reflection.Emit
             pmodule = mb;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2074:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't analyze ResolveUserType but it's an identity function")]
 
         [DynamicDependency(nameof(state))]  // Automatically keeps all previous fields too due to StructLayout
@@ -486,7 +486,7 @@ namespace System.Reflection.Emit
         }
 
         [ComVisible(true)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Reflection.Emit is not subject to trimming")]
         public ConstructorBuilder DefineDefaultConstructor(MethodAttributes attributes)
         {
@@ -794,7 +794,7 @@ namespace System.Reflection.Emit
 
         // We require emitted types to have all members on their bases to be accessible.
         // This is basically an identity function for `this`.
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2083:UnrecognizedReflectionPattern",
             Justification = "Reflection emitted types have all of their members")]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public
@@ -1052,7 +1052,7 @@ namespace System.Reflection.Emit
 
         /* Needed to keep signature compatibility with MS.NET */
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recongnize GetEvents(BindingFlags.Public) but this is what the body is doing")]
         public override EventInfo[] GetEvents()
         {
@@ -1619,7 +1619,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2074:UnrecognizedReflectionPattern",
             Justification = "Linker doesn't recongnize ResolveUserType")]
         public void SetParent([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent)
         {
@@ -1837,7 +1837,7 @@ namespace System.Reflection.Emit
             return generic_params;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Linker thinks Type.GetConstructor(ConstructorInfo) is one of the public APIs because it doesn't analyze method signatures. We already have ConstructorInfo.")]
         public static ConstructorInfo GetConstructor(Type type, ConstructorInfo constructor)
         {
@@ -1887,7 +1887,7 @@ namespace System.Reflection.Emit
             return false;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
             Justification = "Type.MakeGenericType is used to create a typical instantiation")]
         public static MethodInfo GetMethod(Type type, MethodInfo method)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -72,7 +72,7 @@ namespace System.Reflection.Emit
             this.type_arguments = args;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
             Justification = "Reflection.Emit is not subject to trimming")]
         internal override Type InternalResolve()
         {
@@ -122,7 +122,7 @@ namespace System.Reflection.Emit
             return InflateType(type, type_arguments, method_args);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
             Justification = "Reflection emitted types have all of their members")]
         internal static Type? InflateType(Type? type, Type[]? type_args, Type[]? method_args)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -369,7 +369,7 @@ namespace System.Reflection
          * The idea behing this optimization is to use a pair of delegates to simulate the same effect of doing a reflection call.
          * The first delegate cast the this argument to the right type and the second does points to the target method.
          */
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:UnrecognizedReflectionPattern",
             Justification = "MethodInfo used with MakeGenericMethod doesn't have DynamicallyAccessedMembers generic parameters")]
         private static GetterAdapter CreateGetterDelegate(MethodInfo method)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
@@ -373,7 +373,7 @@ namespace System.Runtime.InteropServices
 
         private static Dictionary<(Type, string), ICustomMarshaler>? MarshalerInstanceCache;
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Implementation detail of MarshalAs.CustomMarshaler")]
         internal static ICustomMarshaler? GetCustomMarshalerInstance(Type type, string cookie)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1699,7 +1699,9 @@ namespace System
                 throw new NotSupportedException(Environment.GetResourceString("Acc_CreateVoid"));
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2082:UnrecognizedReflectionPattern",
+            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         internal object? CreateInstanceImpl(
             BindingFlags bindingAttr, Binder? binder, object?[]? args, CultureInfo? culture)
@@ -1896,7 +1898,7 @@ namespace System
             return GetCorrespondingInflatedConstructor(fromNoninstanciated);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "We already have a FieldInfo so this will succeed")]
         internal override FieldInfo GetField(FieldInfo fromNoninstanciated)
         {


### PR DESCRIPTION
In response to https://github.com/mono/linker/pull/1385.
This updates the linker and replaces the global suppressions for IL2006 with the warnings that it was split into.