### PR TITLE
Fix stack overflow createdump triggering on Windows

### DIFF
--- a/src/coreclr/src/vm/eepolicy.cpp
+++ b/src/coreclr/src/vm/eepolicy.cpp
@@ -583,7 +583,9 @@ void DisplayStackOverflowException()
 DWORD LogStackOverflowStackTraceThread(void* arg)
 {
     LogCallstackForLogWorker((Thread*)arg);
-
+#ifdef HOST_WINDOWS
+    CreateCrashDumpIfEnabled();
+#endif
     return 0;
 }
 

--- a/src/coreclr/src/vm/excep.cpp
+++ b/src/coreclr/src/vm/excep.cpp
@@ -4119,10 +4119,11 @@ LaunchCreateDump(LPCWSTR lpCommandLine)
 void
 CreateCrashDumpIfEnabled()
 {
-    // If enabled, launch the create minidump utility and wait until it completes
-    if (g_createDumpCommandLine != nullptr)
+    // If enabled, launch the create minidump utility and wait until it completes. Only launch createdump once for this process.
+    LPCWSTR createDumpCommandLine = InterlockedExchangeT<LPCWSTR>(&g_createDumpCommandLine, nullptr);
+    if (createDumpCommandLine != nullptr)
     {
-        LaunchCreateDump(g_createDumpCommandLine);
+        LaunchCreateDump(createDumpCommandLine);
     }
 }
 


### PR DESCRIPTION
Stack overflow on background or on a task (via Task.Run) didn't trigger createdump because it crashed in the CreateProcess attempting to launch it. 

This fix does the createdump launch in the stack overflow thread that gets created for logging.  Also made sure only one dump is generated for the process.   