### PR TITLE
PR: Add test code coverage for Host.StopAsync

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -20,6 +20,18 @@ namespace Microsoft.Extensions.Hosting
     public partial class HostTests
     {
         [Fact]
+        public async Task StopAsyncWithCancellation()
+        {
+            var builder = new HostBuilder();
+            var host = builder.Build();
+            await host.StartAsync();
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+            Assert.True(cts.Token.IsCancellationRequested);
+            await host.StopAsync(cts.Token);
+        }
+
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34580", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void CreateDefaultBuilder_IncludesContentRootByDefault()
         {

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Hosting
         public async Task StopAsyncWithCancellation()
         {
             var builder = new HostBuilder();
-            var host = builder.Build();
+            using var host = builder.Build();
             await host.StartAsync();
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Hosting
         {
             var expected = Directory.GetCurrentDirectory();
             var builder = Host.CreateDefaultBuilder();
-            var host = builder.Build();
+            using var host = builder.Build();
             var config = host.Services.GetRequiredService<IConfiguration>();
             Assert.Equal(expected, config["ContentRoot"]);
             var env = host.Services.GetRequiredService<IHostEnvironment>();
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.Hosting
         {
             var expected = Directory.GetParent(Directory.GetCurrentDirectory()).FullName; // It must exist
             var builder = Host.CreateDefaultBuilder(new string[] { "--contentroot", expected });
-            var host = builder.Build();
+            using var host = builder.Build();
             var env = host.Services.GetRequiredService<IHostEnvironment>();
             Assert.Equal(expected, env.ContentRootPath);
         }
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Hosting
         public void CreateDefaultBuilder_RegistersEventSourceLogger()
         {
             var listener = new TestEventListener();
-            var host = Host.CreateDefaultBuilder()
+            using var host = Host.CreateDefaultBuilder()
                 .Build();
 
             var logger = host.Services.GetRequiredService<ILogger<HostTests>>();
@@ -101,7 +101,7 @@ namespace Microsoft.Extensions.Hosting
                 }
             });
             var loggerProvider = new ScopeDelegateLoggerProvider(logger);
-            var host = Host.CreateDefaultBuilder()
+            using var host = Host.CreateDefaultBuilder()
                 .ConfigureLogging(logging =>
                 {
                     logging.AddProvider(loggerProvider);
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Hosting
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34580", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void CreateDefaultBuilder_EnablesScopeValidation()
         {
-            var host = Host.CreateDefaultBuilder()
+            using var host = Host.CreateDefaultBuilder()
                 .UseEnvironment(Environments.Development)
                 .ConfigureServices(serices =>
                 {
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.Hosting
 
             var dynamicConfigMessage1 = SaveRandomConfig();
 
-            var host = Host.CreateDefaultBuilder()
+            using var host = Host.CreateDefaultBuilder()
                 .UseContentRoot(Path.GetDirectoryName(appSettingsPath))
                 .ConfigureHostConfiguration(builder =>
                 {
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.Hosting
 
             var dynamicConfigMessage1 = SaveRandomConfig();
 
-            var host = Host.CreateDefaultBuilder()
+            using var host = Host.CreateDefaultBuilder()
                 .UseContentRoot(Path.GetDirectoryName(appSettingsPath))
                 .ConfigureHostConfiguration(builder =>
                 {


### PR DESCRIPTION
Verifies StopAsync() doesn't throw CanceledException given a canceled token

Fix #40700