### PR TITLE
Ensure value-type handling converter created by factory can be used to handle corresponding nullable value types

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -323,6 +323,11 @@ namespace System.Text.Json
                 Type? underlyingType = Nullable.GetUnderlyingType(typeToConvert);
                 if (underlyingType != null && converter.CanConvert(underlyingType))
                 {
+                    if (converter is JsonConverterFactory converterFactory)
+                    {
+                        converter = converterFactory.GetConverterInternal(underlyingType, this);
+                    }
+
                     // Allow nullable handling to forward to the underlying type's converter.
                     return NullableConverterFactory.CreateValueConverter(underlyingType, converter);
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37047 (System.MissingMethodException : Constructor on type 'System.Text.Json.Serialization.NullableConverter[...]' not found).

Previously we assumed that the converter input to `NullableConverterFactory.CreateValueConverter` would always be a `JsonConverter<T>` instance. This is incorrect - the converter can also be a `JsonConverterFactory`, as evidenced by the added test/repro. This assumption caused the `MissingMethodException` since we were previously attempting to pass a `JsonConverterFactory` where the `NullableConverter<T>` factory was expecting a `JsonConverter<T>` instance.