### PR TITLE
Optimize IndexOfAny(byte,...) ICache for short lengths

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -632,29 +632,37 @@ namespace System
             {
                 lengthToExamine -= 8;
 
+                // The test
+                //    ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
+                // is equivalent to
+                //    (uValue0 == lookUp || uValue1 == lookUp)
+                // however it reduces the number of branches per loop (at the cost of short circuting)
+                // which is helpful for the instruction decode cache as the loop is very heavily branched
+                // (see: Intel 64 and IA-32 Architectures Optimization Reference Manual -> Optimization for Decoded ICache | Two Branches in a Decoded ICache Way)
+
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found3;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found4;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found5;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found6;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found7;
 
                 offset += 8;
@@ -665,16 +673,16 @@ namespace System
                 lengthToExamine -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found3;
 
                 offset += 4;
@@ -684,7 +692,7 @@ namespace System
             {
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found;
 
                 offset += 1;
@@ -944,29 +952,37 @@ namespace System
             {
                 lengthToExamine -= 8;
 
+                // The test
+                //    ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
+                // is equivalent to
+                //    (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                // however it reduces the number of branches per loop (at the cost of short circuting)
+                // which is helpful for the instruction decode cache as the loop is very heavily branched
+                // (see: Intel 64 and IA-32 Architectures Optimization Reference Manual -> Optimization for Decoded ICache | Two Branches in a Decoded ICache Way)
+
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found3;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found4;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found5;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found6;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found7;
 
                 offset += 8;
@@ -977,16 +993,16 @@ namespace System
                 lengthToExamine -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found3;
 
                 offset += 4;
@@ -997,7 +1013,7 @@ namespace System
                 lengthToExamine -= 1;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found;
 
                 offset += 1;
@@ -1226,29 +1242,37 @@ namespace System
                 lengthToExamine -= 8;
                 offset -= 8;
 
+                // The test
+                //    ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
+                // is equivalent to
+                //    (uValue0 == lookUp || uValue1 == lookUp)
+                // however it reduces the number of branches per loop (at the cost of short circuting)
+                // which is helpful for the instruction decode cache as the loop is very heavily branched
+                // (see: Intel 64 and IA-32 Architectures Optimization Reference Manual -> Optimization for Decoded ICache | Two Branches in a Decoded ICache Way)
+
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found7;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found6;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found5;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found4;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found3;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found;
             }
 
@@ -1258,16 +1282,16 @@ namespace System
                 offset -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found3;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                     goto Found;
             }
 
@@ -1351,29 +1375,37 @@ namespace System
                 lengthToExamine -= 8;
                 offset -= 8;
 
+                // The test
+                //    ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
+                // is equivalent to
+                //    (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                // however it reduces the number of branches per loop (at the cost of short circuting)
+                // which is helpful for the instruction decode cache as the loop is very heavily branched
+                // (see: Intel 64 and IA-32 Architectures Optimization Reference Manual -> Optimization for Decoded ICache | Two Branches in a Decoded ICache Way)
+
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found7;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found6;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found5;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found4;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found3;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found;
             }
 
@@ -1383,16 +1415,16 @@ namespace System
                 offset -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found3;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found2;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found1;
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found;
             }
 
@@ -1402,7 +1434,7 @@ namespace System
                 offset -= 1;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
                     goto Found;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -641,28 +641,44 @@ namespace System
                 // (see: Intel 64 and IA-32 Architectures Optimization Reference Manual -> Optimization for Decoded ICache | Two Branches in a Decoded ICache Way)
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found;
+                uint result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
+                // Load next lookUp before branch on result to hide some latency
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found1;
+                if (result == 0)
+                    goto Found;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found2;
+                if (result == 0)
+                    goto Found1;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found3;
+                if (result == 0)
+                    goto Found2;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found4;
+                if (result == 0)
+                    goto Found3;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found5;
+                if (result == 0)
+                    goto Found4;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found6;
+                if (result == 0)
+                    goto Found5;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
+                if (result == 0)
+                    goto Found6;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
+                if (result == 0)
                     goto Found7;
 
                 offset += 8;
@@ -673,16 +689,23 @@ namespace System
                 lengthToExamine -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found;
+                uint result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found1;
+                if (result == 0)
+                    goto Found;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
-                    goto Found2;
+                if (result == 0)
+                    goto Found1;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
+                if (result == 0)
+                    goto Found2;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp);
+                if (result == 0)
                     goto Found3;
 
                 offset += 4;
@@ -692,7 +715,7 @@ namespace System
             {
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
+                if (((uValue0 ^ lookUp) * (uValue1 ^ lookUp)) == 0)
                     goto Found;
 
                 offset += 1;
@@ -898,7 +921,7 @@ namespace System
                         continue;
                     }
 
-                    goto Difference;
+                    goto VectorMatch;
                 }
 
                 // Move to Vector length from end for final compare
@@ -913,11 +936,13 @@ namespace System
                     goto NotFound;
                 }
 
-            Difference:
+            VectorMatch:
                 offset += (nuint)LocateFirstFoundByte(search);
+                goto Found;
             }
 
-            goto Found;
+            Debug.Fail("Unreachable");
+            goto NotFound;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -926,63 +951,90 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            uint uValue1 = value1;
-            uint uValue2 = value2;
+            uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
             nuint lengthToExamine = (nuint)(uint)length;
 
             if (Sse2.IsSupported || AdvSimd.Arm64.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
-                if (length >= Vector128<byte>.Count * 2)
+                nint vectorDiff = (nint)length - Vector128<byte>.Count;
+                if (vectorDiff >= 0)
                 {
-                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
+                    // >= Sse2 intrinsics are supported, and length is enough to use them so use that path.
+                    // We jump forward to the intrinsics at the end of the method so a naive branch predict
+                    // will choose the non-intrinsic path so short lengths which don't gain anything aren't
+                    // overly disadvantaged by having to jump over a lot of code. Whereas the longer lengths
+                    // more than make this back from the intrinsics.
+                    lengthToExamine = (nuint)vectorDiff;
+                    goto IntrinsicsCompare;
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
-                if (length >= Vector<byte>.Count * 2)
+                // Calculate lengthToExamine here for test, as it is used later
+                nint vectorDiff = (nint)length - Vector<byte>.Count;
+                if (vectorDiff >= 0)
                 {
-                    lengthToExamine = UnalignedCountVector(ref searchSpace);
+                    // Similar as above for Vector version
+                    lengthToExamine = (nuint)vectorDiff;
+                    goto IntrinsicsCompare;
                 }
             }
-        SequentialScan:
+
             uint lookUp;
             while (lengthToExamine >= 8)
             {
                 lengthToExamine -= 8;
 
                 // The test
-                //    ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
+                //    ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) == 0)
                 // is equivalent to
-                //    (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
+                //    (uValue0 == lookUp || uValue1 == lookUp)
                 // however it reduces the number of branches per loop (at the cost of short circuting)
                 // which is helpful for the instruction decode cache as the loop is very heavily branched
                 // (see: Intel 64 and IA-32 Architectures Optimization Reference Manual -> Optimization for Decoded ICache | Two Branches in a Decoded ICache Way)
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found;
+                uint result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
+                // Load next lookUp before branch on result to hide some latency
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found1;
+                if (result == 0)
+                    goto Found;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found2;
+                if (result == 0)
+                    goto Found1;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found3;
+                if (result == 0)
+                    goto Found2;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found4;
+                if (result == 0)
+                    goto Found3;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found5;
+                if (result == 0)
+                    goto Found4;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found6;
+                if (result == 0)
+                    goto Found5;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
+                if (result == 0)
+                    goto Found6;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
+                if (result == 0)
                     goto Found7;
 
                 offset += 8;
@@ -993,16 +1045,23 @@ namespace System
                 lengthToExamine -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found;
+                uint result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found1;
+                if (result == 0)
+                    goto Found;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
-                    goto Found2;
+                if (result == 0)
+                    goto Found1;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
+                if (result == 0)
+                    goto Found2;
+
+                result = (uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp);
+                if (result == 0)
                     goto Found3;
 
                 offset += 4;
@@ -1010,199 +1069,16 @@ namespace System
 
             while (lengthToExamine > 0)
             {
-                lengthToExamine -= 1;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if ((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp) == 0)
+                if (((uValue0 ^ lookUp) * (uValue1 ^ lookUp) * (uValue2 ^ lookUp)) == 0)
                     goto Found;
 
                 offset += 1;
+                lengthToExamine -= 1;
             }
 
-            if (Avx2.IsSupported)
-            {
-                if (offset < (nuint)(uint)length)
-                {
-                    lengthToExamine = GetByteVector256SpanLength(offset, length);
-                    if (lengthToExamine > offset)
-                    {
-                        Vector256<byte> values0 = Vector256.Create(value0);
-                        Vector256<byte> values1 = Vector256.Create(value1);
-                        Vector256<byte> values2 = Vector256.Create(value2);
-                        do
-                        {
-                            Vector256<byte> search = LoadVector256(ref searchSpace, offset);
-
-                            Vector256<byte> matches0 = Avx2.CompareEqual(values0, search);
-                            Vector256<byte> matches1 = Avx2.CompareEqual(values1, search);
-                            Vector256<byte> matches2 = Avx2.CompareEqual(values2, search);
-                            // Bitwise Or to combine the matches and MoveMask to convert them to bitflags
-                            int matches = Avx2.MoveMask(Avx2.Or(Avx2.Or(matches0, matches1), matches2));
-                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
-                            if (matches == 0)
-                            {
-                                // Zero flags set so no matches
-                                offset += (nuint)Vector256<byte>.Count;
-                                continue;
-                            }
-
-                            // Find bitflag offset of first match and add to current offset
-                            return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
-                        } while (lengthToExamine > offset);
-                    }
-
-                    lengthToExamine = GetByteVector128SpanLength(offset, length);
-                    if (lengthToExamine > offset)
-                    {
-                        Vector128<byte> values0 = Vector128.Create(value0);
-                        Vector128<byte> values1 = Vector128.Create(value1);
-                        Vector128<byte> values2 = Vector128.Create(value2);
-
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
-
-                        Vector128<byte> matches0 = Sse2.CompareEqual(values0, search);
-                        Vector128<byte> matches1 = Sse2.CompareEqual(values1, search);
-                        Vector128<byte> matches2 = Sse2.CompareEqual(values2, search);
-                        // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.Or(Sse2.Or(matches0, matches1), matches2));
-                        if (matches == 0)
-                        {
-                            // Zero flags set so no matches
-                            offset += (nuint)Vector128<byte>.Count;
-                        }
-                        else
-                        {
-                            // Find bitflag offset of first match and add to current offset
-                            return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
-                        }
-                    }
-
-                    if (offset < (nuint)(uint)length)
-                    {
-                        lengthToExamine = ((nuint)(uint)length - offset);
-                        goto SequentialScan;
-                    }
-                }
-            }
-            else if (Sse2.IsSupported)
-            {
-                if (offset < (nuint)(uint)length)
-                {
-                    lengthToExamine = GetByteVector128SpanLength(offset, length);
-
-                    Vector128<byte> values0 = Vector128.Create(value0);
-                    Vector128<byte> values1 = Vector128.Create(value1);
-                    Vector128<byte> values2 = Vector128.Create(value2);
-
-                    while (lengthToExamine > offset)
-                    {
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
-
-                        Vector128<byte> matches0 = Sse2.CompareEqual(values0, search);
-                        Vector128<byte> matches1 = Sse2.CompareEqual(values1, search);
-                        Vector128<byte> matches2 = Sse2.CompareEqual(values2, search);
-                        // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.Or(Sse2.Or(matches0, matches1), matches2));
-                        if (matches == 0)
-                        {
-                            // Zero flags set so no matches
-                            offset += (nuint)Vector128<byte>.Count;
-                            continue;
-                        }
-
-                        // Find bitflag offset of first match and add to current offset
-                        return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
-                    }
-
-                    if (offset < (nuint)(uint)length)
-                    {
-                        lengthToExamine = ((nuint)(uint)length - offset);
-                        goto SequentialScan;
-                    }
-                }
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                if (offset < (nuint)(uint)length)
-                {
-                    lengthToExamine = GetByteVector128SpanLength(offset, length);
-
-                    // Mask to help find the first lane in compareResult that is set.
-                    // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
-                    Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
-                    int matchedLane = 0;
-
-                    Vector128<byte> values0 = Vector128.Create(value0);
-                    Vector128<byte> values1 = Vector128.Create(value1);
-                    Vector128<byte> values2 = Vector128.Create(value2);
-
-                    while (lengthToExamine > offset)
-                    {
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
-
-                        // Same method as above
-                        Vector128<byte> matches0 = AdvSimd.CompareEqual(values0, search);
-                        Vector128<byte> matches1 = AdvSimd.CompareEqual(values1, search);
-                        Vector128<byte> matches2 = AdvSimd.CompareEqual(values2, search);
-
-                        Vector128<byte> compareResult = AdvSimd.Or(AdvSimd.Or(matches0, matches1), matches2);
-
-                        if (!TryFindFirstMatchedLane(mask, compareResult, ref matchedLane))
-                        {
-                            // Zero flags set so no matches
-                            offset += (nuint)Vector128<byte>.Count;
-                            continue;
-                        }
-
-                        // Find bitflag offset of first match and add to current offset
-                        return (int)(offset + (uint)matchedLane);
-                    }
-
-                    if (offset < (nuint)(uint)length)
-                    {
-                        lengthToExamine = ((nuint)(uint)length - offset);
-                        goto SequentialScan;
-                    }
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                if (offset < (nuint)(uint)length)
-                {
-                    lengthToExamine = GetByteVectorSpanLength(offset, length);
-
-                    Vector<byte> values0 = new Vector<byte>(value0);
-                    Vector<byte> values1 = new Vector<byte>(value1);
-                    Vector<byte> values2 = new Vector<byte>(value2);
-
-                    while (lengthToExamine > offset)
-                    {
-                        Vector<byte> search = LoadVector(ref searchSpace, offset);
-
-                        var matches = Vector.BitwiseOr(
-                                        Vector.BitwiseOr(
-                                            Vector.Equals(search, values0),
-                                            Vector.Equals(search, values1)),
-                                        Vector.Equals(search, values2));
-
-                        if (Vector<byte>.Zero.Equals(matches))
-                        {
-                            offset += (nuint)Vector<byte>.Count;
-                            continue;
-                        }
-
-                        // Find offset of first match and add to current offset
-                        return (int)offset + LocateFirstFoundByte(matches);
-                    }
-
-                    if (offset < (nuint)(uint)length)
-                    {
-                        lengthToExamine = ((nuint)(uint)length - offset);
-                        goto SequentialScan;
-                    }
-                }
-            }
+        NotFound:
             return -1;
         Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
             return (int)offset;
@@ -1220,6 +1096,228 @@ namespace System
             return (int)(offset + 6);
         Found7:
             return (int)(offset + 7);
+
+        IntrinsicsCompare:
+            // When we move into a Vectorized block, we process everything of Vector size;
+            // and then for any remainder we do a final compare of Vector size but starting at
+            // the end and forwards, which may overlap on an earlier compare.
+
+            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
+            if (Sse2.IsSupported)
+            {
+                int matches;
+                if (Avx2.IsSupported)
+                {
+                    Vector256<byte> search;
+                    // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
+                    // We have already subtracted Vector128<byte>.Count from lengthToExamine so compare against that
+                    // to see if we have double the size for Vector256<byte>.Count
+                    if (lengthToExamine >= (nuint)Vector128<byte>.Count)
+                    {
+                        Vector256<byte> values0 = Vector256.Create(value0);
+                        Vector256<byte> values1 = Vector256.Create(value1);
+                        Vector256<byte> values2 = Vector256.Create(value2);
+
+                        // Subtract Vector128<byte>.Count so we have now subtracted Vector256<byte>.Count
+                        lengthToExamine -= (nuint)Vector128<byte>.Count;
+                        // First time this checks again against 0, however we will move into final compare if it fails.
+                        while (lengthToExamine > offset)
+                        {
+                            search = LoadVector256(ref searchSpace, offset);
+                            // Bitwise Or to combine the flagged matches for the second value to our match flags
+                            matches = Avx2.MoveMask(
+                                        Avx2.Or(
+                                            Avx2.Or(
+                                                Avx2.CompareEqual(values0, search),
+                                                Avx2.CompareEqual(values1, search)),
+                                            Avx2.CompareEqual(values2, search)));
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
+                            if (matches == 0)
+                            {
+                                // None matched
+                                offset += (nuint)Vector256<byte>.Count;
+                                continue;
+                            }
+
+                            goto IntrinsicsMatch;
+                        }
+
+                        // Move to Vector length from end for final compare
+                        search = LoadVector256(ref searchSpace, lengthToExamine);
+                        offset = lengthToExamine;
+                        // Same as method as above
+                        matches = Avx2.MoveMask(
+                                    Avx2.Or(
+                                        Avx2.Or(
+                                            Avx2.CompareEqual(values0, search),
+                                            Avx2.CompareEqual(values1, search)),
+                                        Avx2.CompareEqual(values2, search)));
+                        if (matches == 0)
+                        {
+                            // None matched
+                            goto NotFound;
+                        }
+
+                        goto IntrinsicsMatch;
+                    }
+                }
+
+                // Initial size check was done on method entry.
+                Debug.Assert(length >= Vector128<byte>.Count);
+                {
+                    Vector128<byte> search;
+                    Vector128<byte> values0 = Vector128.Create(value0);
+                    Vector128<byte> values1 = Vector128.Create(value1);
+                    Vector128<byte> values2 = Vector128.Create(value2);
+                    // First time this checks against 0 and we will move into final compare if it fails.
+                    while (lengthToExamine > offset)
+                    {
+                        search = LoadVector128(ref searchSpace, offset);
+
+                        matches = Sse2.MoveMask(
+                                    Sse2.Or(
+                                        Sse2.Or(
+                                            Sse2.CompareEqual(values0, search),
+                                            Sse2.CompareEqual(values1, search)),
+                                        Sse2.CompareEqual(values2, search)));
+                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                        // So the bit position in 'matches' corresponds to the element offset.
+                        if (matches == 0)
+                        {
+                            // None matched
+                            offset += (nuint)Vector128<byte>.Count;
+                            continue;
+                        }
+
+                        goto IntrinsicsMatch;
+                    }
+                    // Move to Vector length from end for final compare
+                    search = LoadVector128(ref searchSpace, lengthToExamine);
+                    offset = lengthToExamine;
+                    // Same as method as above
+                    matches = Sse2.MoveMask(
+                                Sse2.Or(
+                                    Sse2.Or(
+                                        Sse2.CompareEqual(values0, search),
+                                        Sse2.CompareEqual(values1, search)),
+                                    Sse2.CompareEqual(values2, search)));
+                    if (matches == 0)
+                    {
+                        // None matched
+                        goto NotFound;
+                    }
+                }
+
+            IntrinsicsMatch:
+                // Find bitflag offset of first difference and add to current offset
+                offset += (nuint)BitOperations.TrailingZeroCount(matches);
+                goto Found;
+            }
+            else if (AdvSimd.Arm64.IsSupported)
+            {
+                // Mask to help find the first lane in compareResult that is set.
+                // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
+                Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
+                int matchedLane = 0;
+
+                Vector128<byte> search;
+                Vector128<byte> matches;
+                Vector128<byte> values0 = Vector128.Create(value0);
+                Vector128<byte> values1 = Vector128.Create(value1);
+                Vector128<byte> values2 = Vector128.Create(value2);
+                // First time this checks against 0 and we will move into final compare if it fails.
+                while (lengthToExamine > offset)
+                {
+                    search = LoadVector128(ref searchSpace, offset);
+
+                    matches = AdvSimd.Or(
+                                AdvSimd.Or(
+                                    AdvSimd.CompareEqual(values0, search),
+                                    AdvSimd.CompareEqual(values1, search)),
+                                AdvSimd.CompareEqual(values2, search));
+
+                    if (!TryFindFirstMatchedLane(mask, matches, ref matchedLane))
+                    {
+                        // Zero flags set so no matches
+                        offset += (nuint)Vector128<byte>.Count;
+                        continue;
+                    }
+
+                    // Find bitflag offset of first match and add to current offset
+                    offset += (uint)matchedLane;
+
+                    goto Found;
+                }
+
+                // Move to Vector length from end for final compare
+                search = LoadVector128(ref searchSpace, lengthToExamine);
+                offset = lengthToExamine;
+                // Same as method as above
+                matches = AdvSimd.Or(
+                            AdvSimd.Or(
+                                AdvSimd.CompareEqual(values0, search),
+                                AdvSimd.CompareEqual(values1, search)),
+                            AdvSimd.CompareEqual(values2, search));
+
+                if (!TryFindFirstMatchedLane(mask, matches, ref matchedLane))
+                {
+                    // None matched
+                    goto NotFound;
+                }
+
+                // Find bitflag offset of first match and add to current offset
+                offset += (nuint)(uint)matchedLane;
+
+                goto Found;
+            }
+            else if (Vector.IsHardwareAccelerated)
+            {
+                Vector<byte> values0 = new Vector<byte>(value0);
+                Vector<byte> values1 = new Vector<byte>(value1);
+                Vector<byte> values2 = new Vector<byte>(value2);
+
+                Vector<byte> search;
+                // First time this checks against 0 and we will move into final compare if it fails.
+                while (lengthToExamine > offset)
+                {
+                    search = LoadVector(ref searchSpace, offset);
+                    search = Vector.BitwiseOr(
+                                Vector.BitwiseOr(
+                                    Vector.Equals(search, values0),
+                                    Vector.Equals(search, values1)),
+                                Vector.Equals(search, values2));
+                    if (Vector<byte>.Zero.Equals(search))
+                    {
+                        // None matched
+                        offset += (nuint)Vector<byte>.Count;
+                        continue;
+                    }
+
+                    goto VectorMatch;
+                }
+
+                // Move to Vector length from end for final compare
+                search = LoadVector(ref searchSpace, lengthToExamine);
+                offset = lengthToExamine;
+                search = Vector.BitwiseOr(
+                            Vector.BitwiseOr(
+                                Vector.Equals(search, values0),
+                                Vector.Equals(search, values1)),
+                            Vector.Equals(search, values2));
+                if (Vector<byte>.Zero.Equals(search))
+                {
+                    // None matched
+                    goto NotFound;
+                }
+
+            VectorMatch:
+                offset += (nuint)LocateFirstFoundByte(search);
+                goto Found;
+            }
+
+            Debug.Fail("Unreachable");
+            goto NotFound;
         }
 
         public static int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)


### PR DESCRIPTION
> ### 3.4.2.6 Optimization for Decoded ICache 
> ...
> #### Two Branches in a Decoded ICache Way
>
> The Decoded ICache can hold up to **two branches** in a way. **Dense branches in a 32 byte aligned chunk,
or their ordering with other instructions may prohibit all the micro-ops of the instructions in the chunk
from entering the Decoded ICache.** This does not happen often. When it does happen, you can space the
code with NOP instructions where appropriate. Make sure that these NOP instructions are not part of hot
code.

Example of reducing ~3 branches per 32 bytes to 1 per 32 bytes

![image](https://user-images.githubusercontent.com/1142958/90317636-c8dc8a00-df22-11ea-9a5f-113ce210575e.png)

