### PR TITLE
Make suspend the default port configuration

### DIFF
--- a/src/coreclr/src/vm/ipcstreamfactory.cpp
+++ b/src/coreclr/src/vm/ipcstreamfactory.cpp
@@ -34,7 +34,7 @@ bool IsWhitespace(char c)
 
 bool IsEmpty(LPCSTR string)
 {
-    uint32_t len = strlen(string);
+    uint32_t len = static_cast<uint32_t>(strlen(string));
     for (uint32_t i = 0; i < len; i++)
         if (!IsWhitespace(string[i]))
             return false;

--- a/src/coreclr/src/vm/ipcstreamfactory.cpp
+++ b/src/coreclr/src/vm/ipcstreamfactory.cpp
@@ -27,6 +27,20 @@ CQuickArrayList<LPSTR> split(LPSTR string, LPCSTR delimiters)
     return parts;
 }
 
+bool IsWhitespace(char c)
+{
+    return (c == ' ' || c == '\r' || c == '\t' || c == '\n');
+}
+
+bool IsEmpty(LPCSTR string)
+{
+    uint32_t len = strlen(string);
+    for (uint32_t i = 0; i < len; i++)
+        if (!IsWhitespace(string[i]))
+            return false;
+    return true;
+}
+
 bool IpcStreamFactory::ConnectDiagnosticPort::GetIpcPollHandle(IpcStream::DiagnosticsIpc::IpcPollHandle *pIpcPollHandle, ErrorCallback callback)
 {
     STRESS_LOG0(LF_DIAGNOSTICS_PORT, LL_INFO1000, "IpcStreamFactory::ClientConnectionState::GetIpcPollHandle - ENTER.\n");
@@ -122,6 +136,12 @@ bool IpcStreamFactory::Configure(ErrorCallback callback)
             while (portConfigParts.Size() > 1)
                 builder.WithTag(portConfigParts.Pop());
             builder.WithPath(portConfigParts.Pop());
+
+            if (IsEmpty(builder.Path))
+            {
+                STRESS_LOG0(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::Configure - Ignoring port configuration with empty address\n");
+                continue;
+            }
 
             // Ignore listen type (see conversation in https://github.com/dotnet/runtime/pull/40499 for details)
             if (builder.Type == DiagnosticPortType::LISTEN)

--- a/src/coreclr/src/vm/ipcstreamfactory.h
+++ b/src/coreclr/src/vm/ipcstreamfactory.h
@@ -30,7 +30,7 @@ public:
     {
         LPSTR Path = nullptr;
         DiagnosticPortType Type = DiagnosticPortType::CONNECT;
-        DiagnosticPortSuspendMode SuspendMode = DiagnosticPortSuspendMode::NOSUSPEND;
+        DiagnosticPortSuspendMode SuspendMode = DiagnosticPortSuspendMode::SUSPEND;
 
         DiagnosticPortBuilder WithPath(LPSTR path) { Path = path; return *this; }
         DiagnosticPortBuilder WithType(DiagnosticPortType type) { Type = type; return *this; }

--- a/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
+++ b/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
@@ -28,7 +28,7 @@ namespace Tracing.Tests.PauseOnStartValidation
             var server = new ReverseServer(serverName);
             Task<bool> subprocessTask = Utils.RunSubprocess(
                 currentAssembly: Assembly.GetExecutingAssembly(),
-                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName},suspend" } },
+                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName}" } },
                 duringExecution: async (_) =>
                 {
                     Stream stream = await server.AcceptAsync();
@@ -56,7 +56,7 @@ namespace Tracing.Tests.PauseOnStartValidation
             using var memoryStream = new MemoryStream();
             Task<bool> subprocessTask = Utils.RunSubprocess(
                 currentAssembly: Assembly.GetExecutingAssembly(),
-                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName},suspend" } },
+                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName}" } },
                 duringExecution: async (pid) =>
                 {
                     Stream stream = await server.AcceptAsync();
@@ -114,7 +114,7 @@ namespace Tracing.Tests.PauseOnStartValidation
             using var memoryStream3 = new MemoryStream();
             Task<bool> subprocessTask = Utils.RunSubprocess(
                 currentAssembly: Assembly.GetExecutingAssembly(),
-                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName},suspend" } },
+                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName}" } },
                 duringExecution: async (pid) =>
                 {
                     Stream stream = await server.AcceptAsync();
@@ -207,7 +207,7 @@ namespace Tracing.Tests.PauseOnStartValidation
             using var memoryStream3 = new MemoryStream();
             Task<bool> subprocessTask = Utils.RunSubprocess(
                 currentAssembly: Assembly.GetExecutingAssembly(),
-                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName},suspend" } },
+                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName}" } },
                 duringExecution: async (pid) =>
                 {
                     Stream stream = await server.AcceptAsync();
@@ -271,7 +271,7 @@ namespace Tracing.Tests.PauseOnStartValidation
             using var memoryStream3 = new MemoryStream();
             Task<bool> subprocessTask = Utils.RunSubprocess(
                 currentAssembly: Assembly.GetExecutingAssembly(),
-                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName},suspend" } },
+                environment: new Dictionary<string,string> { { Utils.DiagnosticPortsEnvKey, $"{serverName}" } },
                 duringExecution: async (pid) =>
                 {
                     Stream stream = await server.AcceptAsync();

--- a/src/tests/tracing/eventpipe/reverse/reverse.cs
+++ b/src/tests/tracing/eventpipe/reverse/reverse.cs
@@ -28,7 +28,7 @@ namespace Tracing.Tests.ReverseValidation
                 currentAssembly: Assembly.GetExecutingAssembly(),
                 environment: new Dictionary<string,string> 
                 {
-                    { Utils.DiagnosticPortsEnvKey, $"{serverName}" }
+                    { Utils.DiagnosticPortsEnvKey, $"{serverName},nosuspend" }
                 },
                 duringExecution: async (_) =>
                 {
@@ -58,7 +58,7 @@ namespace Tracing.Tests.ReverseValidation
                 currentAssembly: Assembly.GetExecutingAssembly(),
                 environment: new Dictionary<string,string> 
                 {
-                    { Utils.DiagnosticPortsEnvKey, $"{serverName}" }
+                    { Utils.DiagnosticPortsEnvKey, $"{serverName},nosuspend" }
                 },
                 duringExecution: async (_) => 
                 {
@@ -83,7 +83,7 @@ namespace Tracing.Tests.ReverseValidation
                 currentAssembly: Assembly.GetExecutingAssembly(),
                 environment: new Dictionary<string,string> 
                 {
-                    { Utils.DiagnosticPortsEnvKey, $"{serverName}" }
+                    { Utils.DiagnosticPortsEnvKey, $"{serverName},nosuspend" }
                 },
                 duringExecution: async (int pid) =>
                 {
@@ -136,7 +136,7 @@ namespace Tracing.Tests.ReverseValidation
                 currentAssembly: Assembly.GetExecutingAssembly(),
                 environment: new Dictionary<string,string> 
                 {
-                    { Utils.DiagnosticPortsEnvKey, $"{serverName}" }
+                    { Utils.DiagnosticPortsEnvKey, $"{serverName},nosuspend" }
                 },
                 duringExecution: async (int pid) =>
                 {
@@ -177,7 +177,7 @@ namespace Tracing.Tests.ReverseValidation
                 currentAssembly: Assembly.GetExecutingAssembly(),
                 environment: new Dictionary<string,string> 
                 {
-                    { Utils.DiagnosticPortsEnvKey, $"{serverName}" }
+                    { Utils.DiagnosticPortsEnvKey, $"{serverName},nosuspend" }
                 },
                 duringExecution: async (int pid) =>
                 {
@@ -215,7 +215,7 @@ namespace Tracing.Tests.ReverseValidation
                 currentAssembly: Assembly.GetExecutingAssembly(),
                 environment: new Dictionary<string,string> 
                 {
-                    { Utils.DiagnosticPortsEnvKey, $"{serverName}" }
+                    { Utils.DiagnosticPortsEnvKey, $"{serverName},nosuspend" }
                 },
                 duringExecution: async (int pid) =>
                 {

--- a/src/tests/tracing/eventpipe/reverseouter/reverseouter.cs
+++ b/src/tests/tracing/eventpipe/reverseouter/reverseouter.cs
@@ -28,7 +28,7 @@ namespace Tracing.Tests.ReverseValidation
                 currentAssembly: Assembly.GetExecutingAssembly(),
                 environment: new Dictionary<string,string> 
                 {
-                    { Utils.DiagnosticPortsEnvKey, $"{serverName}" }
+                    { Utils.DiagnosticPortsEnvKey, $"{serverName},nosuspend" }
                 },
                 duringExecution: async (int pid) =>
                 {


### PR DESCRIPTION
Changes the default Diagnostic Port configuration to be `suspend`.  A Diagnostic Port configuration that doesn't specify `suspend` or `nosuspend` will now default to `suspend` and require a ResumeRuntime command on that connection.

I also added a check for empty paths.

CC @tommcdon @wiktork @jander-msft 