### PR TITLE
[RyuJIT] Make indirect loads invariant for const strings

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -6076,7 +6076,7 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
 
         case IAT_PVALUE: // The value needs to be accessed via an indirection
             // Create an indirection
-            tree = gtNewIndOfIconHandleNode(TYP_REF, (size_t)pValue, GTF_ICON_STR_HDL, false);
+            tree = gtNewIndOfIconHandleNode(TYP_REF, (size_t)pValue, GTF_ICON_STR_HDL, true);
 #ifdef DEBUG
             tree->gtGetOp1()->AsIntCon()->gtTargetHandle = (size_t)pValue;
 #endif


### PR DESCRIPTION
I noticed `GT_IND` nodes (indirect loads) are not marked with `GTF_IND_INVARIANT` for string literals. It prevents such loads from being hoisted from loops or CSEd. e.g.:
```csharp
public void CSE(string a)
{
    Console.WriteLine("hello");
    Console.WriteLine("hello");
    Console.WriteLine("hello");
}

public void LoopHoist()
{
    for (int i = 0; i < 1000; i++)
        Console.WriteLine("hello");
}
```
Codegen diff (left: master, right: this PR): https://www.diffchecker.com/mA9SAvhc

Jit-diff:
```
Found 160 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of diff: -57144 (-0.110% of base)
    diff is an improvement.

Top file regressions (bytes):
        1625 : System.Management.dasm (0.417% of base)
         205 : Microsoft.CodeAnalysis.dasm (0.012% of base)
         156 : Microsoft.CodeAnalysis.CSharp.dasm (0.004% of base)
          74 : System.Linq.dasm (0.007% of base)
          50 : Microsoft.Diagnostics.FastSerialization.dasm (0.050% of base)
          40 : System.Resources.Writer.dasm (0.458% of base)
          37 : xunit.runner.utility.netcoreapp10.dasm (0.019% of base)
          36 : System.Windows.Extensions.dasm (0.221% of base)
          24 : Microsoft.Extensions.DependencyModel.dasm (0.050% of base)
          18 : Microsoft.Extensions.Options.DataAnnotations.dasm (2.326% of base)
          18 : System.ServiceProcess.ServiceController.dasm (0.064% of base)
          15 : dotnet-Microsoft.XmlSerializer.Generator.dasm (0.043% of base)
          13 : System.Runtime.Numerics.dasm (0.018% of base)
          10 : System.Composition.Hosting.dasm (0.012% of base)
           7 : System.Reflection.Context.dasm (0.013% of base)
           6 : Microsoft.Extensions.Logging.dasm (0.023% of base)
           6 : System.Runtime.Serialization.Formatters.dasm (0.006% of base)
           5 : Microsoft.Extensions.Configuration.Ini.dasm (0.113% of base)
           5 : System.Drawing.Common.dasm (0.001% of base)
           5 : System.Net.Http.WinHttpHandler.dasm (0.006% of base)

Top file improvements (bytes):
      -15762 : System.Private.CoreLib.dasm (-0.321% of base)
       -9973 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.327% of base)
       -4206 : System.Numerics.Tensors.dasm (-1.301% of base)
       -3662 : System.ComponentModel.TypeConverter.dasm (-1.280% of base)
       -2755 : System.Private.Xml.dasm (-0.077% of base)
       -2372 : System.Text.Json.dasm (-0.377% of base)
       -1679 : System.Memory.dasm (-0.522% of base)
       -1504 : System.Security.Cryptography.Xml.dasm (-0.854% of base)
       -1422 : System.Security.Cryptography.Pkcs.dasm (-0.312% of base)
       -1256 : System.Security.Cryptography.Algorithms.dasm (-0.354% of base)
        -840 : System.Threading.Tasks.Dataflow.dasm (-0.096% of base)
        -699 : System.Net.Http.dasm (-0.091% of base)
        -608 : System.DirectoryServices.AccountManagement.dasm (-0.167% of base)
        -584 : FSharp.Core.dasm (-0.018% of base)
        -567 : System.ServiceModel.Syndication.dasm (-0.391% of base)
        -479 : System.Security.Cryptography.X509Certificates.dasm (-0.300% of base)
        -462 : System.Threading.Channels.dasm (-0.258% of base)
        -452 : System.DirectoryServices.dasm (-0.104% of base)
        -429 : System.Reflection.Metadata.dasm (-0.101% of base)
        -412 : System.Security.Cryptography.Cng.dasm (-0.218% of base)

141 total files with Code Size differences (117 improved, 24 regressed), 126 unchanged.

Top method regressions (bytes):
        1179 (10.126% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFDateTimeFunction():this
        1018 (6.558% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateTypeConverterClass():System.CodeDom.CodeTypeDeclaration:this
         608 (8.722% of base) : System.Private.Xml.dasm - System.Xml.Xsl.Xslt.XsltLoader:.ctor():this
         282 (2.546% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFTimeIntervalFunction():this
         267 (2.793% of base) : System.Data.Common.dasm - System.Data.XmlTreeGen:SchemaTree(System.Xml.XmlDocument,System.Xml.XmlWriter,System.Data.DataSet,System.Data.DataTable,bool):this
         175 (5.514% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCapture.PacketFragmentArgs:get_ParsedPacket():System.String:this
         143 (0.961% of base) : System.Data.Common.dasm - System.Data.XmlTreeGen:HandleTable(System.Data.DataTable,System.Xml.XmlDocument,System.Xml.XmlElement,bool):System.Xml.XmlElement:this
         106 (5.340% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanFormat:FormatCustomized(System.TimeSpan,System.ReadOnlySpan`1[Char],System.Globalization.DateTimeFormatInfo,System.Text.StringBuilder):System.Text.StringBuilder
         104 (6.883% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:GetPointerToFirstInvalidByte(long,int,byref,byref):long
          99 (5.925% of base) : System.Private.CoreLib.dasm - System.Buffers.Text.Utf8Parser:TryParseNumber(System.ReadOnlySpan`1[Byte],byref,byref,int,byref):bool
          85 (2.118% of base) : System.Private.Xml.dasm - System.Xml.Serialization.XmlSerializationWriterILGen:WriteEnumMethod(System.Xml.Serialization.EnumMapping):this
          82 (3.285% of base) : System.Private.Xml.dasm - System.Xml.Serialization.TempAssembly:GenerateRefEmitAssembly(System.Xml.Serialization.XmlMapping[],System.Type[],System.String):System.Reflection.Assembly
          79 (4.471% of base) : System.Private.CoreLib.dasm - System.Threading.Tasks.Task:RunContinuations(System.Object):this
          74 (6.503% of base) : System.Private.CoreLib.dasm - System.String:SplitWithPostProcessing(System.ReadOnlySpan`1[Int32],System.ReadOnlySpan`1[Int32],int,int,int):System.String[]:this
          73 (12.696% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[Vector`1,Int64][System.Numerics.Vector`1[System.Single],System.Int64]:.ctor(System.Collections.Generic.IDictionary`2[Vector`1,Int64],System.Collections.Generic.IEqualityComparer`1[Vector`1]):this
          70 (1.928% of base) : System.Net.Http.dasm - <SendRequestBodyAsync>d__36:MoveNext():this
          70 (10.955% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIEncoding:GetBytesWithFallback(System.ReadOnlySpan`1[Char],int,System.Span`1[Byte],int,System.Text.EncoderNLS):int:this
          69 (3.252% of base) : System.IO.Pipelines.dasm - <ReadAsync>d__27:MoveNext():this
          69 (11.183% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIEncoding:GetCharsWithFallback(System.ReadOnlySpan`1[Byte],int,System.Span`1[Char],int,System.Text.DecoderNLS):int:this
          68 (2.316% of base) : System.Private.CoreLib.dasm - System.Text.UnicodeEncoding:GetChars(long,int,long,int,System.Text.DecoderNLS):int:this

Top method improvements (bytes):
       -4445 (-3.916% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -3433 (-20.071% of base) : System.ComponentModel.TypeConverter.dasm - CultureInfoMapper:CreateMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
       -2552 (-15.608% of base) : System.Private.CoreLib.dasm - System.Globalization.CultureData:get_RegionNames():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
       -1324 (-2.923% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -1022 (-3.419% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivateTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -779 (-1.181% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.ETWMapping, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
        -672 (-2.489% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -637 (-4.175% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.AspNet.AspNetTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -602 (-10.825% of base) : System.Security.Cryptography.Algorithms.dasm - System.Security.Cryptography.CryptoConfig:get_DefaultNameHT():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
        -598 (-5.796% of base) : System.Private.Xml.dasm - System.Xml.Schema.SchemaNames:.ctor(System.Xml.XmlNameTable):this
        -521 (-10.525% of base) : System.Private.Xml.dasm - System.Xml.Serialization.TypeScope:AddSoapEncodedTypes(System.String)
        -413 (-6.444% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.MetadataReader:InitializeProjectedTypes()
        -412 (-12.588% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanFormat:TryFormatStandard(System.TimeSpan,int,System.String,System.Span`1[Char],byref):bool
        -362 (-6.363% of base) : System.Net.WebHeaderCollection.dasm - System.Net.HeaderInfoTable:CreateHeaderHashtable():System.Collections.Hashtable
        -358 (-14.818% of base) : System.Security.Cryptography.Algorithms.dasm - System.Security.Cryptography.CryptoConfig:get_DefaultOidHT():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
        -310 (-4.860% of base) : System.Private.CoreLib.dasm - System.Globalization.TextInfo:ChangeCaseCommon(System.String):System.String:this (7 methods)
        -296 (-16.771% of base) : System.Security.Cryptography.Xml.dasm - System.Security.Cryptography.Xml.DSAKeyValue:GetXml(System.Xml.XmlDocument):System.Xml.XmlElement:this
        -271 (-9.106% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.BlockContext:CreateMissingEnd(ushort,byref):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.StatementSyntax:this
        -264 (-5.452% of base) : System.Private.CoreLib.dasm - System.Globalization.TextInfo:ChangeCaseCommon(byref,byref,int):this (6 methods)
        -231 (-8.747% of base) : System.Numerics.Tensors.dasm - System.Numerics.Tensors.CompressedSparseTensor`1[Byte][System.Byte]:InsertAt(int,ubyte,int,int):this

Top method regressions (percentages):
          73 (12.696% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[Vector`1,Int64][System.Numerics.Vector`1[System.Single],System.Int64]:.ctor(System.Collections.Generic.IDictionary`2[Vector`1,Int64],System.Collections.Generic.IEqualityComparer`1[Vector`1]):this
          69 (11.183% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIEncoding:GetCharsWithFallback(System.ReadOnlySpan`1[Byte],int,System.Span`1[Char],int,System.Text.DecoderNLS):int:this
          70 (10.955% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIEncoding:GetBytesWithFallback(System.ReadOnlySpan`1[Char],int,System.Span`1[Byte],int,System.Text.EncoderNLS):int:this
          45 (10.297% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - AnonymousTypeTemplateSymbol:SynthesizeDebuggerDisplayAttribute():Microsoft.CodeAnalysis.VisualBasic.Symbols.SynthesizedAttributeData:this
          12 (10.169% of base) : System.Private.Xml.dasm - System.Xml.XPath.XPathNavigator:get_XmlLang():System.String:this
        1179 (10.126% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFDateTimeFunction():this
         608 (8.722% of base) : System.Private.Xml.dasm - System.Xml.Xsl.Xslt.XsltLoader:.ctor():this
          60 (8.683% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.ArraySortHelper`1[Vector`1][System.Numerics.Vector`1[System.Single]]:PickPivotAndPartition(System.Span`1[Vector`1],System.Comparison`1[Vector`1]):int
          23 (8.487% of base) : System.Private.CoreLib.dasm - System.Utf8String:AreEquivalentOrdinalSkipShortCircuitingChecks(System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Char]):bool
          46 (8.244% of base) : System.Memory.dasm - System.Buffers.SequenceReader`1[Int16][System.Int16]:TryReadToAny(byref,System.ReadOnlySpan`1[Int16],bool):bool:this (2 methods)
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[ReadOnlyMemory`1][System.ReadOnlyMemory`1[System.Char]]:.ctor():this
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Char][System.Char]:.ctor():this
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Byte][System.Byte]:.ctor():this
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int16][System.Int16]:.ctor():this
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int32][System.Int32]:.ctor():this
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Double][System.Double]:.ctor():this
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Vector`1][System.Numerics.Vector`1[System.Single]]:.ctor():this
          11 (7.971% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int64][System.Int64]:.ctor():this
          27 (7.692% of base) : System.Memory.dasm - System.Buffers.SequenceReader`1[Double][System.Double]:TryReadTo(byref,double,bool):bool:this (2 methods)
          17 (7.692% of base) : System.Private.CoreLib.dasm - System.Text.Utf8Span:StartsWith(System.Text.Rune):bool:this

Top method improvements (percentages):
         -75 (-35.714% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Diagnostics.Tracing.StackSources.FilterParams:.ctor():this
         -65 (-29.412% of base) : System.Data.Common.dasm - System.Data.SimpleType:.ctor(System.String):this
         -25 (-26.316% of base) : System.Private.Xml.dasm - NodeData:ClearName():this
         -75 (-26.224% of base) : System.Data.Common.dasm - System.Data.SimpleType:.ctor(System.Xml.Schema.XmlSchemaSimpleType):this
         -55 (-25.229% of base) : System.Net.Primitives.dasm - System.Net.Cookie:.ctor():this
         -65 (-24.164% of base) : System.Net.Primitives.dasm - System.Net.Cookie:.ctor(System.String,System.String):this
         -28 (-22.764% of base) : System.Net.Primitives.dasm - System.Net.SystemNetworkCredential:.ctor():this
         -28 (-22.764% of base) : System.Net.Primitives.dasm - System.Net.NetworkCredential:.ctor():this
       -3433 (-20.071% of base) : System.ComponentModel.TypeConverter.dasm - CultureInfoMapper:CreateMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -21 (-19.444% of base) : System.Private.Xml.dasm - System.Xml.XmlDocument:CreateElement(System.String):System.Xml.XmlElement:this
         -25 (-18.797% of base) : System.Private.Xml.dasm - System.Xml.ValidatingReaderNodeData:Clear(int):this
         -26 (-18.571% of base) : System.Private.Xml.dasm - System.Xml.XmlDocument:CreateAttribute(System.String):System.Xml.XmlAttribute:this
         -65 (-17.857% of base) : System.Private.CoreLib.dasm - System.Collections.Concurrent.ConcurrentQueue`1[Byte][System.Byte]:GetCount(System.Collections.Concurrent.ConcurrentQueueSegment`1[Byte],int,System.Collections.Concurrent.ConcurrentQueueSegment`1[Byte],int):long
         -65 (-17.857% of base) : System.Private.CoreLib.dasm - System.Collections.Concurrent.ConcurrentQueue`1[Int16][System.Int16]:GetCount(System.Collections.Concurrent.ConcurrentQueueSegment`1[Int16],int,System.Collections.Concurrent.ConcurrentQueueSegment`1[Int16],int):long
         -65 (-17.857% of base) : System.Private.CoreLib.dasm - System.Collections.Concurrent.ConcurrentQueue`1[Int32][System.Int32]:GetCount(System.Collections.Concurrent.ConcurrentQueueSegment`1[Int32],int,System.Collections.Concurrent.ConcurrentQueueSegment`1[Int32],int):long
         -65 (-17.857% of base) : System.Private.CoreLib.dasm - System.Collections.Concurrent.ConcurrentQueue`1[Double][System.Double]:GetCount(System.Collections.Concurrent.ConcurrentQueueSegment`1[Double],int,System.Collections.Concurrent.ConcurrentQueueSegment`1[Double],int):long
         -65 (-17.857% of base) : System.Private.CoreLib.dasm - System.Collections.Concurrent.ConcurrentQueue`1[Vector`1][System.Numerics.Vector`1[System.Single]]:GetCount(System.Collections.Concurrent.ConcurrentQueueSegment`1[Vector`1],int,System.Collections.Concurrent.ConcurrentQueueSegment`1[Vector`1],int):long
         -65 (-17.857% of base) : System.Private.CoreLib.dasm - System.Collections.Concurrent.ConcurrentQueue`1[Int64][System.Int64]:GetCount(System.Collections.Concurrent.ConcurrentQueueSegment`1[Int64],int,System.Collections.Concurrent.ConcurrentQueueSegment`1[Int64],int):long
         -10 (-16.949% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf16Utility:GetNonAsciiBytes(System.Runtime.Intrinsics.Vector128`1[Byte],System.Runtime.Intrinsics.Vector128`1[Byte]):int
         -15 (-16.854% of base) : System.Configuration.ConfigurationManager.dasm - System.Configuration.ExeConfigurationFileMap:.ctor():this

8702 total methods with Code Size differences (6810 improved, 1892 regressed), 332489 unchanged.

1 files had text diffs but no metric diffs.
System.Security.Permissions.dasm had 8 diffs
```

this PR just sets "bool invariant flag" (see [here](https://github.com/dotnet/runtime/blob/69b95dc0fdbc12fe22c4eec76fd0020cff9697f7/src/coreclr/src/jit/gentree.cpp#L6001-L6005)). 
However, I understand this change is questionable and I guess the current behavior is intentional, so thoughts? @dotnet/jit-contrib 