### PR TITLE
Not all object converters return a JsonElement

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -196,14 +196,13 @@ namespace System.Text.Json.Serialization
                         ref reader);
                 }
 
-                if (CanBePolymorphic && options.ReferenceHandler != null)
+                if (CanBePolymorphic && options.ReferenceHandler != null && value is JsonElement element)
                 {
                     // Edge case where we want to lookup for a reference when parsing into typeof(object)
                     // instead of return `value` as a JsonElement.
                     Debug.Assert(TypeToConvert == typeof(object));
-                    Debug.Assert(value is JsonElement);
 
-                    if (JsonSerializer.TryGetReferenceFromJsonElement(ref state, (JsonElement)(object)value, out object? referenceValue))
+                    if (JsonSerializer.TryGetReferenceFromJsonElement(ref state, element, out object? referenceValue))
                     {
                         value = (T)referenceValue;
                     }

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.cs
@@ -119,5 +119,46 @@ namespace System.Text.Json.Serialization.Tests
             Customer c = JsonSerializer.Deserialize<Customer>(utf8, options);
             Assert.Null(c);
         }
+
+        public class ObjectBoolConverter : JsonConverter<object>
+        {
+            public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.True)
+                {
+                    return true;
+                }
+
+                if (reader.TokenType == JsonTokenType.False)
+                {
+                    return false;
+                }
+
+                throw new JsonException();
+            }
+
+            public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public static void VerifyObjectConverterWithPreservedReferences()
+        {
+            var json = "true";
+            byte[] utf8 = Encoding.UTF8.GetBytes(json);
+
+            var options = new JsonSerializerOptions()
+            {
+                ReferenceHandler = ReferenceHandler.Preserve,
+            };
+            options.Converters.Add(new ObjectBoolConverter());
+
+            object obj = (JsonSerializer.Deserialize<object>(utf8, options));
+
+            Assert.IsType<bool>(obj);
+            Assert.Equal(true, obj);
+        }
     }
 }


### PR DESCRIPTION
Fixes #40906 (Converters aren't used when ReferenceHandler is set).

The bug was introduced in #38979 (Support resolve reference for typeof(object) on deserialize) that depends on the wrong assumption that **all** `JsonConverter<object>` return a `JsonElement`. When a custom converter returns any other value (value or ref),  there is no reason to try to resolve it as JSON reference. 