### PR TITLE
 Include <sys/sysctl.h> only for FreeBSD in pal.cpp

### DIFF
--- a/src/coreclr/src/pal/src/init/pal.cpp
+++ b/src/coreclr/src/pal/src/init/pal.cpp
@@ -94,12 +94,10 @@ int CacheLineSize;
 #if defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/param.h>
+#include <sys/sysctl.h>
 #endif
 #if HAVE_GETAUXVAL
 #include <sys/auxv.h>
-#endif
-#if HAVE_SYS_SYSCTL_H || defined(__FreeBSD__)
-#include <sys/sysctl.h>
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
This fixes build on Ubuntu 20.04.
Fixes https://github.com/dotnet/runtime/issues/40919

cc @Gnbrkm41