### PR TITLE
Pass length to PathCharString.Append on SunOS

### DIFF
--- a/src/coreclr/src/pal/src/init/pal.cpp
+++ b/src/coreclr/src/pal/src/init/pal.cpp
@@ -1378,7 +1378,7 @@ bool GetEntrypointExecutableAbsolutePath(PathCharString& entrypointExecutable)
         {
             entrypointExecutable.Set(cwd, strlen(cwd));
             entrypointExecutable.Append('/');
-            entrypointExecutable.Append(path);
+            entrypointExecutable.Append(path, strlen(path));
 
             result = true;
             free(cwd);


### PR DESCRIPTION
This fixes illumos build From [logs](https://github.com/am11/runtime/runs/992988526?check_suite_focus=true):

```sh
   /runtime/src/coreclr/src/pal/src/init/pal.cpp:1379:45: error: no matching function for call to 'StackString<260, char>::Append(const char*&)'
               entrypointExecutable.Append(path);
                                               ^
```

cc @janvorli