### PR TITLE
This is an attempt to fix the remaining GC stress bugs on ARM64.

### DIFF
--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -1958,7 +1958,14 @@ public:
         //   ** WARNING ** WARNING ** WARNING ** WARNING ** WARNING ** WARNING **  |
         // ------------------------------------------------------------------------
 
+
+#if defined(TARGET_AMD64) || defined(TARGET_X86)
+        // on the Intel architecture we have strong memory ordering guarantees
         m_fPreemptiveGCDisabled.StoreWithoutBarrier(1);
+#else
+        // weaker memory models need an interlocked operation to ensure consistency
+        FastInterlockOr(&m_fPreemptiveGCDisabled, 1);
+#endif
 
         if (g_TrapReturningThreads.LoadWithoutBarrier())
         {


### PR DESCRIPTION
I found a dump for an AV in background_sweep where we had crashed due to a null method table, yet the object pointed at was a valid free object. The AV was at coreclr!WKS::gc_heap::background_sweep+0x668, we load the method table to compute the size of the object:

                while ((o < end) && !background_object_marked (o, FALSE))
                {
                    o = o + Align (size (o), align_const);;    // <-- AV here
                    current_num_objs++;
                    if (current_num_objs >= num_objs)
                    {
                        current_sweep_pos = plug_end;
                        dprintf (1234, ("f: swept till %Ix", current_sweep_pos));
                        allow_fgc();
                        current_num_objs = 0;
                    }
                }

As a free object can only be generated by the GC itself, the theory is that a foreground GC allocated an object in gen 2 and created a free object for the unused space, but the background GC thread doesn't have an up-to-date picture of memory. The synchronization between foreground and background GC is via allow_fgc() which switches from cooperative GC mode to preemptive mode and back. If the timing is such that the background GC thread never sees m_fPreemptiveGCDisabled being true, then we may not execute a a memory barrier.

The fix tries to remedy this situation by introducing an interlocked instruction in DisablePreemptiveGC for non Intel-architecture targets. Whether this actually fixes the issues we are seeing is not clear yet.