### PR TITLE
more managed pointer rooting

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -679,6 +679,7 @@ var BindingSupportLib = {
 			var args_start = null;
 			var buffer = null;
 			var [resultRoot, exceptionRoot] = MONO.mono_wasm_new_roots (2);
+			var argsRootBuffer = null;
 
 			// check if the method signature needs argument mashalling
 			if (has_args_marshal && has_args) {
@@ -721,9 +722,15 @@ var BindingSupportLib = {
 				//  collected until the method call completes.
 
 				// assume at least 8 byte alignment from malloc
-				buffer = Module._malloc (converter.size + (args.length * 4));
+				var converterElements = ((converter.size + 3) / 4) | 0;
+				var bufferElements = (converterElements + args.length) | 0;
+
+				argsRootBuffer = MONO.mono_wasm_new_root_buffer (bufferElements);
+				var buffer = argsRootBuffer.get_address (0);
 				var indirect_start = buffer; // buffer + buffer % 8
-				args_start = indirect_start + converter.size;
+				args_start = argsRootBuffer.get_address (converterElements);
+
+				console.log (bufferElements, converterElements, indirect_start, args_start);
 
 				var slot = args_start;
 				var indirect_value = indirect_start;
@@ -739,6 +746,8 @@ var BindingSupportLib = {
 
 					Module.setValue (slot, obj, "*");
 					slot += 4;
+
+					console.log ("arg", i, argsRootBuffer.get (i), argsRootBuffer.get (converterElements + i));
 				}
 			}
 
@@ -758,7 +767,7 @@ var BindingSupportLib = {
 
 				return this._unbox_mono_obj_rooted (resultRoot);
 			} finally {
-				MONO.mono_wasm_release_roots (resultRoot, exceptionRoot);
+				MONO.mono_wasm_release_roots (resultRoot, exceptionRoot, argsRootBuffer);
 			}
 		},
 

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -722,7 +722,10 @@ var BindingSupportLib = {
 				//  collected until the method call completes.
 
 				// assume at least 8 byte alignment from malloc
-				buffer = Module._malloc (converter.size + (args.length * 4));
+				var bufferSizeBytes = converter.size + (args.length * 4);
+				var bufferSizeElements = (bufferSizeBytes / 4) | 0;
+				argsRootBuffer = MONO.mono_wasm_new_root_buffer (bufferSizeElements);
+				buffer = Module._malloc (bufferSizeBytes);
 				var indirect_start = buffer; // buffer + buffer % 8
 				args_start = indirect_start + converter.size;
 
@@ -736,6 +739,8 @@ var BindingSupportLib = {
 						Module.setValue (indirect_value, obj, handler.indirect);
 						obj = indirect_value;
 						indirect_value += 8;
+					} else {
+						argsRootBuffer.set (i, obj);
 					}
 
 					Module.setValue (slot, obj, "*");

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -722,15 +722,9 @@ var BindingSupportLib = {
 				//  collected until the method call completes.
 
 				// assume at least 8 byte alignment from malloc
-				var converterElements = ((converter.size + 3) / 4) | 0;
-				var bufferElements = (converterElements + args.length) | 0;
-
-				argsRootBuffer = MONO.mono_wasm_new_root_buffer (bufferElements);
-				var buffer = argsRootBuffer.get_address (0);
+				buffer = Module._malloc (converter.size + (args.length * 4));
 				var indirect_start = buffer; // buffer + buffer % 8
-				args_start = argsRootBuffer.get_address (converterElements);
-
-				console.log (bufferElements, converterElements, indirect_start, args_start);
+				args_start = indirect_start + converter.size;
 
 				var slot = args_start;
 				var indirect_value = indirect_start;
@@ -746,8 +740,6 @@ var BindingSupportLib = {
 
 					Module.setValue (slot, obj, "*");
 					slot += 4;
-
-					console.log ("arg", i, argsRootBuffer.get (i), argsRootBuffer.get (converterElements + i));
 				}
 			}
 

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -96,7 +96,7 @@ var MonoSupportLib = {
 				if (this.__offset) {
 					MONO.mono_wasm_deregister_root (this.__offset);
 					MONO._zero_region (this.__offset, this.__count * 4);
-					Module.free (this.__offset);
+					Module._free (this.__offset);
 				}
 
 				this.__handle = this.__offset = this.__count = this.__offset32 = undefined;

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -95,7 +95,7 @@ var MonoSupportLib = {
 			release: function () {
 				if (this.__offset) {
 					MONO.mono_wasm_deregister_root (this.__offset);
-					MONO._fill_region (this.__offset, this.__count * 4, 0);
+					MONO._zero_region (this.__offset, this.__count * 4);
 					Module.free (this.__offset);
 				}
 
@@ -163,7 +163,7 @@ var MonoSupportLib = {
 			return result;
 		},
 
-		_zero_region: function (byteOffset, sizeBytes, value) {
+		_zero_region: function (byteOffset, sizeBytes) {
 			(new Uint8Array (Module.HEAPU8.buffer, byteOffset, sizeBytes)).fill (0);
 		},
 
@@ -190,7 +190,7 @@ var MonoSupportLib = {
 			if ((offset % 4) !== 0)
 				throw new Error ("Malloc returned an unaligned offset");
 
-			this._zero_region (offset, capacityBytes, 0);
+			this._zero_region (offset, capacityBytes);
 
 			var result = Object.create (this._mono_wasm_root_buffer_prototype);
 			result.__offset = offset;

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -109,9 +109,9 @@ var MonoSupportLib = {
 					this._scratch_root_free_indices[i] = i;
 				this._scratch_root_free_indices.reverse ();
 
-				Object.defineProperty (MONO._mono_wasm_root_prototype, "value", {
-					get: MONO._mono_wasm_root_prototype.get,
-					set: MONO._mono_wasm_root_prototype.set,
+				Object.defineProperty (this._mono_wasm_root_prototype, "value", {
+					get: this._mono_wasm_root_prototype.get,
+					set: this._mono_wasm_root_prototype.set,
 					configurable: false
 				});
 			}
@@ -132,9 +132,9 @@ var MonoSupportLib = {
 		// Once you are done using the root buffer, you must call its release() method.
 		// For small numbers of roots, it is preferable to use the mono_wasm_new_root and mono_wasm_new_roots APIs instead.
 		mono_wasm_new_root_buffer: function (capacity, msg) {
-			if (!MONO.mono_wasm_register_root || !MONO.mono_wasm_deregister_root) {
-				MONO.mono_wasm_register_root = Module.cwrap ("mono_wasm_register_root", "number", ["number", "number", "string"]);
-				MONO.mono_wasm_deregister_root = Module.cwrap ("mono_wasm_deregister_root", null, ["number"]);
+			if (!this.mono_wasm_register_root || !this.mono_wasm_deregister_root) {
+				this.mono_wasm_register_root = Module.cwrap ("mono_wasm_register_root", "number", ["number", "number", "string"]);
+				this.mono_wasm_deregister_root = Module.cwrap ("mono_wasm_deregister_root", null, ["number"]);
 			}
 
 			if (capacity <= 0)
@@ -147,11 +147,11 @@ var MonoSupportLib = {
 
 			this._zero_region (offset, capacityBytes, 0);
 
-			var result = Object.create (MONO._mono_wasm_root_buffer_prototype);
+			var result = Object.create (this._mono_wasm_root_buffer_prototype);
 			result.__offset = offset;
 			result.__offset32 = offset / 4;
 			result.__count = capacity;	
-			result.__handle = MONO.mono_wasm_register_root (offset, capacityBytes, msg || 0);
+			result.__handle = this.mono_wasm_register_root (offset, capacityBytes, msg || 0);
 
 			return result;
 		},
@@ -165,7 +165,7 @@ var MonoSupportLib = {
 			var index = this._mono_wasm_claim_scratch_index ();
 			var buffer = this._scratch_root_buffer;
 				
-			var result = Object.create (MONO._mono_wasm_root_prototype);
+			var result = Object.create (this._mono_wasm_root_prototype);
 			result.__buffer = buffer;
 			result.__index = index;
 

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -82,14 +82,18 @@ var MonoSupportLib = {
 		_mono_wasm_root_buffer_prototype: {
 			/** @returns {NativePointer} */
 			get_address: function (index) {
+				return this.__offset + (index * 4);
+			},
+			/** @returns {number} */
+			get_address_32: function (index) {
 				return this.__offset32 + index;
 			},
 			/** @returns {ManagedPointer} */
 			get: function (index) {
-				return Module.HEAP32[this.get_address(index)];
+				return Module.HEAP32[this.get_address_32(index)];
 			},
 			set: function (index, value) {
-				Module.HEAP32[this.get_address(index)] = value;
+				Module.HEAP32[this.get_address_32(index)] = value;
 				return value;
 			},
 			release: function () {
@@ -110,6 +114,10 @@ var MonoSupportLib = {
 			/** @returns {NativePointer} */
 			get_address: function () {
 				return this.__buffer.get_address (this.__index);
+			},
+			/** @returns {number} */
+			get_address_32: function () {
+				return this.__buffer.get_address_32 (this.__index);
 			},
 			/** @returns {ManagedPointer} */
 			get: function () {
@@ -184,6 +192,8 @@ var MonoSupportLib = {
 
 			if (capacity <= 0)
 				throw new Error ("capacity >= 1");
+
+			capacity = capacity | 0;
 				
 			var capacityBytes = capacity * 4;
 			var offset = Module._malloc (capacityBytes);

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -10,6 +10,29 @@
  * @property {object} o - value parsed as JSON
  */
 
+/**
+ * @typedef WasmRoot - a single address in the managed heap, visible to the GC
+ * @type {object}
+ * @property {WasmPointer} value - address in the managed heap
+ * @property {function} get - retrieves address
+ * @property {function} set - updates the address
+ * @property {function} release - releases the root storage for future use
+ */
+
+/**
+ * @typedef WasmRootBuffer - a collection of addresses in the managed heap, visible to the GC
+ * @type {object}
+ * @property {number} length - number of elements the root buffer can hold
+ * @property {function} get - retrieves an element by index
+ * @property {function} set - sets an element's value by index
+ * @property {function} release - releases the root storage for future use
+ */
+
+/**
+ * @typedef WasmPointer
+ * @type {number} - address in the managed heap
+ */
+
 var MonoSupportLib = {
 	$MONO__postset: 'MONO.export_functions (Module);',
 	$MONO: {
@@ -50,6 +73,7 @@ var MonoSupportLib = {
 		},
 
 		_mono_wasm_root_buffer_prototype: {
+			/** @returns {WasmPointer} */
 			get: function (index) {
 				return Module.HEAP32[this.__offset32 + index];
 			},
@@ -73,6 +97,7 @@ var MonoSupportLib = {
 		_scratch_root_free_indices: null,
 
 		_mono_wasm_root_prototype: {
+			/** @returns {WasmPointer} */
 			get: function () {
 				var result = this.__buffer.get (this.__index);
 				return result;
@@ -81,6 +106,7 @@ var MonoSupportLib = {
 				this.__buffer.set (this.__index, value);
 				return value;
 			},
+			/** @returns {WasmPointer} */
 			valueOf: function () {
 				return this.get ();
 			},
@@ -127,10 +153,15 @@ var MonoSupportLib = {
 			(new Uint8Array (Module.HEAPU8.buffer, byteOffset, sizeBytes)).fill (0);
 		},
 
-		// Allocates a block of memory that can safely contain pointers into the managed heap.
-		// The result object has get(index) and set(index, value) methods that can be used to retrieve and store managed pointers.
-		// Once you are done using the root buffer, you must call its release() method.
-		// For small numbers of roots, it is preferable to use the mono_wasm_new_root and mono_wasm_new_roots APIs instead.
+		/**
+		 * Allocates a block of memory that can safely contain pointers into the managed heap.
+		 * The result object has get(index) and set(index, value) methods that can be used to retrieve and store managed pointers.
+		 * Once you are done using the root buffer, you must call its release() method.
+		 * For small numbers of roots, it is preferable to use the mono_wasm_new_root and mono_wasm_new_roots APIs instead.
+		 * @param {number} capacity - the maximum number of elements the buffer can hold.
+		 * @param {string} [msg] - a description of the root buffer (for debugging)
+		 * @returns {WasmRootBuffer}
+		 */
 		mono_wasm_new_root_buffer: function (capacity, msg) {
 			if (!this.mono_wasm_register_root || !this.mono_wasm_deregister_root) {
 				this.mono_wasm_register_root = Module.cwrap ("mono_wasm_register_root", "number", ["number", "number", "string"]);
@@ -151,16 +182,21 @@ var MonoSupportLib = {
 			result.__offset = offset;
 			result.__offset32 = offset / 4;
 			result.__count = capacity;	
+			result.length = capacity;
 			result.__handle = this.mono_wasm_register_root (offset, capacityBytes, msg || 0);
 
 			return result;
 		},
 
-		// Allocates temporary storage for a pointer into the managed heap.
-		// Pointers stored here will be visible to the GC, ensuring that the object they point to aren't moved or collected.
-		// If you already have a managed pointer you can pass it as an argument to initialize the temporary storage.
-		// The result object has get() and set(value) methods, along with a .value property.
-		// When you are done using the root you must call its .release() method.
+		/**
+		 * Allocates temporary storage for a pointer into the managed heap.
+		 * Pointers stored here will be visible to the GC, ensuring that the object they point to aren't moved or collected.
+		 * If you already have a managed pointer you can pass it as an argument to initialize the temporary storage.
+		 * The result object has get() and set(value) methods, along with a .value property.
+		 * When you are done using the root you must call its .release() method.
+		 * @param {WasmPointer} [value] - an address in the managed heap to initialize the root with (or 0)
+		 * @returns {WasmRoot}
+		 */
 		mono_wasm_new_root: function (value) {
 			var index = this._mono_wasm_claim_scratch_index ();
 			var buffer = this._scratch_root_buffer;
@@ -181,10 +217,14 @@ var MonoSupportLib = {
 			return result;
 		},
 
-		// Allocates 1 or more temporary roots, accepting either a number of roots or an array of pointers.
-		// mono_wasm_new_roots(n): returns an array of N zero-initialized roots.
-		// mono_wasm_new_roots([a, b, ...]) returns an array of new roots initialized with each element.
-		// Each root must be released with its release method, or using the mono_wasm_release_roots API.
+		/**
+		 * Allocates 1 or more temporary roots, accepting either a number of roots or an array of pointers.
+		 * mono_wasm_new_roots(n): returns an array of N zero-initialized roots.
+		 * mono_wasm_new_roots([a, b, ...]) returns an array of new roots initialized with each element.
+		 * Each root must be released with its release method, or using the mono_wasm_release_roots API.
+		 * @param {(number | WasmPointer[])} count_or_values - either a number of roots or an array of pointers
+		 * @returns {WasmRoot[]}
+		 */
 		mono_wasm_new_roots: function (count_or_values) {
 			var result;
 
@@ -203,10 +243,13 @@ var MonoSupportLib = {
 			return result;
 		},
 
-		// Releases 1 or more root or root buffer objects.
-		// Multiple objects may be passed on the argument list.
-		// 'undefined' may be passed as an argument so it is safe to call this method from finally blocks
-		//  even if you are not sure all of your roots have been created yet.
+		/**
+		 * Releases 1 or more root or root buffer objects.
+		 * Multiple objects may be passed on the argument list.
+		 * 'undefined' may be passed as an argument so it is safe to call this method from finally blocks
+		 *  even if you are not sure all of your roots have been created yet.
+		 * @param {... WasmRoot} roots 
+		 */
 		mono_wasm_release_roots: function () {
 			for (var i = 0; i < arguments.length; i++) {
 				if (!arguments[i])

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -80,20 +80,28 @@ var MonoSupportLib = {
 		},
 
 		_mono_wasm_root_buffer_prototype: {
+			_check_in_range: function (index) {
+				if ((index >= this.__count) || (index < 0))
+					throw new Error ("index out of range");
+			},
 			/** @returns {NativePointer} */
 			get_address: function (index) {
+				this._check_in_range (index);
 				return this.__offset + (index * 4);
 			},
 			/** @returns {number} */
 			get_address_32: function (index) {
+				this._check_in_range (index);
 				return this.__offset32 + index;
 			},
 			/** @returns {ManagedPointer} */
 			get: function (index) {
-				return Module.HEAP32[this.get_address_32(index)];
+				this._check_in_range (index);				
+				return Module.HEAP32[this.get_address_32 (index)];
 			},
 			set: function (index, value) {
-				Module.HEAP32[this.get_address_32(index)] = value;
+				this._check_in_range (index);
+				Module.HEAP32[this.get_address_32 (index)] = value;
 				return value;
 			},
 			release: function () {
@@ -204,7 +212,7 @@ var MonoSupportLib = {
 
 			var result = Object.create (this._mono_wasm_root_buffer_prototype);
 			result.__offset = offset;
-			result.__offset32 = offset / 4;
+			result.__offset32 = (offset / 4) | 0;
 			result.__count = capacity;	
 			result.length = capacity;
 			result.__handle = this.mono_wasm_register_root (offset, capacityBytes, msg || 0);


### PR DESCRIPTION
This PR updates more of our bindings and library code to store managed pointers in roots so that objects can't be collected or moved. I need to do additional work on this because I've been carefully auditing all our code to try and figure out which variables are managed pointers, but this should fix a few high-risk bits of code. We may have on-demand GC disabled by default, but some applications may need to turn it on and we have to leave it active on CI so this should be a stability improvement for those scenarios.