### PR TITLE
Remove ObsoletedInOSPlatformAttribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
@@ -74,43 +74,6 @@ namespace System.Runtime.Versioning
     }
 
     /// <summary>
-    /// Marks APIs that were obsoleted in a given operating system version.
-    ///
-    /// Primarily used by OS bindings to indicate APIs that should only be used in
-    /// earlier versions.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly |
-                    AttributeTargets.Class |
-                    AttributeTargets.Constructor |
-                    AttributeTargets.Enum |
-                    AttributeTargets.Event |
-                    AttributeTargets.Field |
-                    AttributeTargets.Method |
-                    AttributeTargets.Module |
-                    AttributeTargets.Property |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class ObsoletedInOSPlatformAttribute : OSPlatformAttribute
-    {
-        public ObsoletedInOSPlatformAttribute(string platformName) : base(platformName)
-        {
-        }
-
-        public ObsoletedInOSPlatformAttribute(string platformName, string message) : base(platformName)
-        {
-            Message = message;
-        }
-
-        public string? Message { get; }
-        public string? Url { get; set; }
-    }
-
-    /// <summary>
     /// Marks APIs that were removed in a given operating system version.
     /// </summary>
     /// <remarks>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9998,14 +9998,6 @@ namespace System.Runtime.Versioning
     {
         public SupportedOSPlatformAttribute(string platformName) : base(platformName) { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
-    public sealed class ObsoletedInOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
-    {
-        public ObsoletedInOSPlatformAttribute(string platformName) : base(platformName) { }
-        public ObsoletedInOSPlatformAttribute(string platformName, string message) : base(platformName) { }
-        public string? Message { get; }
-        public string? Url { get; set; }
-    }
     public abstract class OSPlatformAttribute : System.Attribute
     {
         private protected OSPlatformAttribute(string platformName) { }

--- a/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
@@ -20,20 +20,6 @@ namespace System.Runtime.Versioning.Tests
         }
 
         [Theory]
-        [InlineData("Windows8.0", "Obsolete", "http://test.com/obsoletedInOSPlatform")]
-        [InlineData("Linux", "Message", null)]
-        [InlineData("iOS13", null, null)]
-        [InlineData("", null, "http://test.com/obsoletedInOSPlatform")]
-        public void TestObsoletedInOSPlatformAttribute(string platformName, string message, string url)
-        {
-            var opa = message == null ? new ObsoletedInOSPlatformAttribute(platformName) { Url = url} : new ObsoletedInOSPlatformAttribute(platformName, message) { Url = url };
-
-            Assert.Equal(platformName, opa.PlatformName);
-            Assert.Equal(message, opa.Message);
-            Assert.Equal(url, opa.Url);
-        }
-
-        [Theory]
         [InlineData("Windows8.0")]
         [InlineData("Android4.1")]
         [InlineData("")]


### PR DESCRIPTION
This PR removes the `ObsoletedInOSPlatformAttribute` type from .NET 5.0.  After a bunch of testing with the Platform Compatibility Analyzer, we concluded that we aren't yet ready to ship the Obsoleted in OS Platform scenario, for several reasons:

1. We don't yet have any scenarios within the .NET Libraries themselves that exercise this, whereas we _are_ using both `SupportedOSPlatformAttribute` and `UnsupportedOSPlatformAttribute`
2. There are some remaining uncertainties around what the behavior should be if a platform is marked as _obsoleted_ without having previously been explicitly marked as _supported_
3. When this feature is juxtaposed with the improved `[Obsolete]` experience where custom diagnostic ids can be used, it feels inconsistent and inferior

We need to make sure the end-to-end experience is smooth, allowing obsoleted code to still be called while providing the user a good warning that the code will be removed in the future. We don't yet have that end-to-end experience as smooth as we need it to be.

We will remove this type from .NET 5 and likely resurrect it for .NET 6 when we expand our platform support to many more platforms and are likely to encounter the need for this attribute.  We'll update the related analyzer at that time as well.

There are not yet any usages of this attribute across any dotnet repositories.

/cc @adamsitnik @buyaa-n @eerhardt @terrajobst @wli3 @GrabYourPitchforks 