### PR TITLE
Fix some interactions between tiering and multi-core JIT

### DIFF
--- a/src/coreclr/src/vm/multicorejit.h
+++ b/src/coreclr/src/vm/multicorejit.h
@@ -114,7 +114,7 @@ public:
     PCODE GetEntryPoint() const
     {
         WRAPPER_NO_CONTRACT;
-        return PINSTRToPCODE(m_entryPointAndTierInfo & ~(TADDR)TierInfo::Mask);
+        return IsNull() ? NULL : PINSTRToPCODE(m_entryPointAndTierInfo & ~(TADDR)TierInfo::Mask);
     }
 
     bool WasTier0Jit() const

--- a/src/coreclr/src/vm/multicorejit.h
+++ b/src/coreclr/src/vm/multicorejit.h
@@ -73,15 +73,77 @@ struct MulticoreJitPlayerStat
 };
 
 
+#ifndef DACCESS_COMPILE
+class MulticoreJitPrepareCodeConfig;
+#endif
+
+class MulticoreJitCodeInfo
+{
+private:
+    enum class TierInfo : TADDR
+    {
+        None = 0,
+        WasTier0Jit = 1 << 0,
+        JitSwitchedToOptimized = 1 << 1,
+        Mask = None | WasTier0Jit | JitSwitchedToOptimized
+    };
+
+    TADDR m_entryPointAndTierInfo;
+
+public:
+    MulticoreJitCodeInfo() : m_entryPointAndTierInfo(NULL)
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
+
+#ifndef DACCESS_COMPILE
+public:
+    MulticoreJitCodeInfo(PCODE entryPoint, const MulticoreJitPrepareCodeConfig *pConfig);
+#endif
+
+private:
+    void VerifyIsNotNull() const;
+
+public:
+    bool IsNull() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_entryPointAndTierInfo == NULL;
+    }
+
+    PCODE GetEntryPoint() const
+    {
+        WRAPPER_NO_CONTRACT;
+        return PINSTRToPCODE(m_entryPointAndTierInfo & ~(TADDR)TierInfo::Mask);
+    }
+
+    bool WasTier0Jit() const
+    {
+        WRAPPER_NO_CONTRACT;
+        VerifyIsNotNull();
+
+        return (m_entryPointAndTierInfo & (TADDR)TierInfo::WasTier0Jit) != 0;
+    }
+
+    bool JitSwitchedToOptimized() const
+    {
+        WRAPPER_NO_CONTRACT;
+        VerifyIsNotNull();
+
+        return (m_entryPointAndTierInfo & (TADDR)TierInfo::JitSwitchedToOptimized) != 0;
+    }
+};
+
+
 // Code Storage
 
 class MulticoreJitCodeStorage
 {
 private:
-    MapSHashWithRemove<PVOID,PCODE> m_nativeCodeMap;
-    CrstExplicitInit                m_crstCodeMap;  // protecting m_nativeCodeMap
-    unsigned                        m_nStored;
-    unsigned                        m_nReturned;
+    MapSHashWithRemove<PVOID, MulticoreJitCodeInfo> m_nativeCodeMap;
+    CrstExplicitInit                                m_crstCodeMap;  // protecting m_nativeCodeMap
+    unsigned                                        m_nStored;
+    unsigned                                        m_nReturned;
 
 public:
 
@@ -100,9 +162,9 @@ public:
 
 #endif
 
-    void StoreMethodCode(MethodDesc * pMethod, PCODE pCode);
+    void StoreMethodCode(MethodDesc * pMethod, MulticoreJitCodeInfo codeInfo);
 
-    PCODE QueryMethodCode(MethodDesc * pMethod, BOOL shouldRemoveCode);
+    MulticoreJitCodeInfo QueryAndRemoveMethodCode(MethodDesc * pMethod);
 
     inline unsigned GetRemainingMethodCount() const
     {
@@ -212,7 +274,7 @@ public:
 
     static bool IsMethodSupported(MethodDesc * pMethod);
 
-    PCODE RequestMethodCode(MethodDesc * pMethod);
+    MulticoreJitCodeInfo RequestMethodCode(MethodDesc * pMethod);
 
     void RecordMethodJit(MethodDesc * pMethod);
 

--- a/src/coreclr/src/vm/multicorejitimpl.h
+++ b/src/coreclr/src/vm/multicorejitimpl.h
@@ -427,7 +427,7 @@ public:
 
     void RecordMethodJit(MethodDesc * pMethod, bool application);
 
-    PCODE RequestMethodCode(MethodDesc * pMethod, MulticoreJitManager * pManager);
+    MulticoreJitCodeInfo RequestMethodCode(MethodDesc * pMethod, MulticoreJitManager * pManager);
 
     HRESULT StartProfile(const WCHAR * pRoot, const WCHAR * pFileName, int suffix, LONG nSession);
 

--- a/src/coreclr/src/vm/prestub.cpp
+++ b/src/coreclr/src/vm/prestub.cpp
@@ -596,11 +596,15 @@ PCODE MethodDesc::GetPrecompiledR2RCode(PrepareCodeConfig* pConfig)
     return pCode;
 }
 
-PCODE MethodDesc::GetMulticoreJitCode()
+PCODE MethodDesc::GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0Jit)
 {
     STANDARD_VM_CONTRACT;
+    _ASSERTE(pConfig != NULL);
+    _ASSERTE(pConfig->GetMethodDesc() == this);
+    _ASSERTE(pWasTier0Jit != NULL);
+    _ASSERTE(!*pWasTier0Jit);
 
-    PCODE pCode = NULL;
+    MulticoreJitCodeInfo codeInfo;
 #ifdef FEATURE_MULTICOREJIT
     // Quick check before calling expensive out of line function on this method's domain has code JITted by background thread
     MulticoreJitManager & mcJitManager = GetAppDomain()->GetMulticoreJitManager();
@@ -608,11 +612,25 @@ PCODE MethodDesc::GetMulticoreJitCode()
     {
         if (MulticoreJitManager::IsMethodSupported(this))
         {
-            pCode = mcJitManager.RequestMethodCode(this); // Query multi-core JIT manager for compiled code
+            codeInfo = mcJitManager.RequestMethodCode(this); // Query multi-core JIT manager for compiled code
+        #ifdef FEATURE_TIERED_COMPILATION
+            if (!codeInfo.IsNull())
+            {
+                if (codeInfo.WasTier0Jit())
+                {
+                    *pWasTier0Jit = true;
+                }
+                if (codeInfo.JitSwitchedToOptimized())
+                {
+                    pConfig->SetJitSwitchedToOptimized();
+                }
+            }
+        #endif
         }
     }
-#endif
-    return pCode;
+#endif // FEATURE_MULTICOREJIT
+
+    return codeInfo.GetEntryPoint();
 }
 
 COR_ILMETHOD_DECODER* MethodDesc::GetAndVerifyMetadataILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pDecoderMemory)
@@ -771,29 +789,38 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
                 return pCode;
             }
 
-            pCode = GetMulticoreJitCode();
-            if (pCode != NULL)
+            // Multi-core-jitted code is generated for the default code version at the initial optimization tier, and so is only
+            // applicable to the default code version
+            NativeCodeVersion codeVersion = pConfig->GetCodeVersion();
+            if (codeVersion.IsDefaultVersion())
             {
-                if (pConfig->SetNativeCode(pCode, &pCode))
+                bool wasTier0Jit = false;
+                pCode = GetMulticoreJitCode(pConfig, &wasTier0Jit);
+                if (pCode != NULL)
                 {
-                #ifdef FEATURE_CODE_VERSIONING
-                    pConfig->SetGeneratedOrLoadedNewCode();
-                #endif
                 #ifdef FEATURE_TIERED_COMPILATION
-                    if (pConfig->GetMethodDesc()->IsEligibleForTieredCompilation() &&
-                        pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0)
-                    {
-                        pConfig->SetShouldCountCalls();
-                    }
+                    // Finalize the optimization tier before SetNativeCode() is called
+                    bool shouldCountCalls = wasTier0Jit && pConfig->FinalizeOptimizationTierForTier0Jit();
                 #endif
+
+                    if (pConfig->SetNativeCode(pCode, &pCode))
+                    {
+                    #ifdef FEATURE_CODE_VERSIONING
+                        pConfig->SetGeneratedOrLoadedNewCode();
+                    #endif
+                    #ifdef FEATURE_TIERED_COMPILATION
+                        if (shouldCountCalls)
+                        {
+                            pConfig->SetShouldCountCalls();
+                        }
+                    #endif
+                    }
+                    pEntry->m_hrResultCode = S_OK;
+                    return pCode;
                 }
-                pEntry->m_hrResultCode = S_OK;
-                return pCode;
             }
-            else
-            {
-                return JitCompileCodeLockedEventWrapper(pConfig, pEntryLock);
-            }
+
+            return JitCompileCodeLockedEventWrapper(pConfig, pEntryLock);
         }
     }
 }
@@ -952,22 +979,6 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
 #endif
     }
 
-
-#ifdef FEATURE_MULTICOREJIT
-    // Non-initial code versions and multicore jit initial compilation all skip this
-    if (pConfig->NeedsMulticoreJitNotification())
-    {
-        MulticoreJitManager & mcJitManager = GetAppDomain()->GetMulticoreJitManager();
-        if (mcJitManager.IsRecorderActive())
-        {
-            if (MulticoreJitManager::IsMethodSupported(this))
-            {
-                mcJitManager.RecordMethodJit(this); // Tell multi-core JIT manager to record method on successful JITting
-            }
-        }
-    }
-#endif
-
 #ifdef FEATURE_INTERPRETER
     if (isJittedMethod)
 #endif
@@ -1058,42 +1069,9 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
 #endif // HAVE_GCCOVER
 
 #ifdef FEATURE_TIERED_COMPILATION
-    // Update the optimization tier if necessary before SetNativeCode() is called. As soon as SetNativeCode() is called, another
-    // thread may get the native code and the optimization tier for that code version, and it should have already been
-    // finalized.
-    bool shouldCountCalls = false;
-    if (pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0))
-    {
-        _ASSERTE(pConfig->GetMethodDesc()->IsEligibleForTieredCompilation());
-
-        if (pConfig->JitSwitchedToOptimized())
-        {
-#ifdef _DEBUG
-            // Call counting may already have been disabled due to the possibility of concurrent or reentering JIT of the same
-            // native code version of a method. The current optimization tier should be consistent with the change being made
-            // (Tier 0 to Optimized), such that the tier is not changed in an unexpected way or at an unexpected time. Since
-            // changes to the optimization tier are unlocked, this assertion is just a speculative check on possible values.
-            NativeCodeVersion::OptimizationTier previousOptimizationTier = pConfig->GetCodeVersion().GetOptimizationTier();
-            _ASSERTE(
-                previousOptimizationTier == NativeCodeVersion::OptimizationTier0 ||
-                previousOptimizationTier == NativeCodeVersion::OptimizationTierOptimized);
-#endif // _DEBUG
-
-            // Update the tier in the code version. The JIT may have decided to switch from tier 0 to optimized, in which case
-            // call counting would have to be disabled for the method.
-            NativeCodeVersion codeVersion = pConfig->GetCodeVersion();
-            if (codeVersion.IsDefaultVersion())
-            {
-                pConfig->GetMethodDesc()->GetLoaderAllocator()->GetCallCountingManager()->DisableCallCounting(codeVersion);
-            }
-            codeVersion.SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
-        }
-        else
-        {
-            shouldCountCalls = true;
-        }
-    }
-#endif // FEATURE_TIERED_COMPILATION
+    // Finalize the optimization tier before SetNativeCode() is called
+    bool shouldCountCalls = pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0) && pConfig->FinalizeOptimizationTierForTier0Jit();
+#endif
 
     // Aside from rejit, performing a SetNativeCodeInterlocked at this point
     // generally ensures that there is only one winning version of the native
@@ -1126,6 +1104,25 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     SavePitchingCandidate(this, *pSizeOfCode);
 #endif
 
+#ifdef FEATURE_MULTICOREJIT
+    // Multi-core JIT is only applicable to the default code version. A method is recorded in the profile only when
+    // SetNativeCode() above succeeds to avoid recording duplicates in the multi-core JIT profile.
+    if (pConfig->NeedsMulticoreJitNotification())
+    {
+        _ASSERTE(pConfig->GetCodeVersion().IsDefaultVersion());
+        _ASSERTE(!pConfig->IsForMulticoreJit());
+
+        MulticoreJitManager & mcJitManager = GetAppDomain()->GetMulticoreJitManager();
+        if (mcJitManager.IsRecorderActive())
+        {
+            if (MulticoreJitManager::IsMethodSupported(this))
+            {
+                mcJitManager.RecordMethodJit(this); // Tell multi-core JIT manager to record method on successful JITting
+            }
+        }
+    }
+#endif
+
     // We succeeded in jitting the code, and our jitted code is the one that's going to run now.
     pEntry->m_hrResultCode = S_OK;
 
@@ -1144,6 +1141,9 @@ PrepareCodeConfig::PrepareCodeConfig(NativeCodeVersion codeVersion, BOOL needsMu
     m_ProfilerRejectedPrecompiledCode(FALSE),
     m_ReadyToRunRejectedPrecompiledCode(FALSE),
     m_callerGCMode(CallerGCMode::Unknown),
+#ifdef FEATURE_MULTICOREJIT
+    m_isForMulticoreJit(false),
+#endif
 #ifdef FEATURE_CODE_VERSIONING
     m_profilerMayHaveActivatedNonDefaultCodeVersion(false),
     m_generatedOrLoadedNewCode(false),
@@ -1157,12 +1157,6 @@ PrepareCodeConfig::PrepareCodeConfig(NativeCodeVersion codeVersion, BOOL needsMu
 #endif
     m_nextInSameThread(nullptr)
 {}
-
-MethodDesc* PrepareCodeConfig::GetMethodDesc()
-{
-    LIMITED_METHOD_CONTRACT;
-    return m_pMethodDesc;
-}
 
 PCODE PrepareCodeConfig::IsJitCancellationRequested()
 {
@@ -1210,12 +1204,6 @@ void PrepareCodeConfig::SetCallerGCMode(CallerGCMode mode)
 {
     LIMITED_METHOD_CONTRACT;
     m_callerGCMode = mode;
-}
-
-NativeCodeVersion PrepareCodeConfig::GetCodeVersion()
-{
-    LIMITED_METHOD_CONTRACT;
-    return m_nativeCodeVersion;
 }
 
 BOOL PrepareCodeConfig::SetNativeCode(PCODE pCode, PCODE * ppAlternateCodeToUse)
@@ -1277,7 +1265,9 @@ PrepareCodeConfig::JitOptimizationTier PrepareCodeConfig::GetJitOptimizationTier
         else if (config->JitSwitchedToOptimized())
         {
             _ASSERTE(methodDesc->IsEligibleForTieredCompilation());
-            _ASSERTE(config->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTierOptimized);
+            _ASSERTE(
+                config->IsForMulticoreJit() ||
+                config->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTierOptimized);
             return JitOptimizationTier::Optimized;
         }
         else if (methodDesc->IsEligibleForTieredCompilation())
@@ -1324,11 +1314,56 @@ const char *PrepareCodeConfig::GetJitOptimizationTierStr(PrepareCodeConfig *conf
     }
 }
 
+#ifdef FEATURE_TIERED_COMPILATION
+// This function should be called before SetNativeCode() to update the optimization tier if necessary before SetNativeCode() is
+// called. As soon as SetNativeCode() is called, another thread may get the native code and the optimization tier for that code
+// version, and it should have already been finalized.
+bool PrepareCodeConfig::FinalizeOptimizationTierForTier0Jit()
+{
+    _ASSERTE(GetMethodDesc()->IsEligibleForTieredCompilation());
+
+    if (IsForMulticoreJit())
+    {
+        // When using multi-core JIT, the jitted code would not be used until the method is called. Don't make changes to the
+        // optimization tier yet, just record some information that may be used later when the method is called.
+        ((MulticoreJitPrepareCodeConfig *)this)->SetWasTier0Jit();
+        return false; // don't count calls
+    }
+
+    if (JitSwitchedToOptimized())
+    {
+    #ifdef _DEBUG
+        // Call counting may already have been disabled due to the possibility of concurrent or reentering JIT of the same
+        // native code version of a method. The current optimization tier should be consistent with the change being made
+        // (Tier 0 to Optimized), such that the tier is not changed in an unexpected way or at an unexpected time. Since changes
+        // to the optimization tier are unlocked, this assertion is just a speculative check on possible values.
+        NativeCodeVersion::OptimizationTier previousOptimizationTier = GetCodeVersion().GetOptimizationTier();
+        _ASSERTE(
+            previousOptimizationTier == NativeCodeVersion::OptimizationTier0 ||
+            previousOptimizationTier == NativeCodeVersion::OptimizationTierOptimized);
+    #endif // _DEBUG
+
+        // Update the tier in the code version. The JIT may have decided to switch from tier 0 to optimized, in which case
+        // call counting would have to be disabled for the method.
+        NativeCodeVersion codeVersion = GetCodeVersion();
+        if (codeVersion.IsDefaultVersion())
+        {
+            GetMethodDesc()->GetLoaderAllocator()->GetCallCountingManager()->DisableCallCounting(codeVersion);
+        }
+        codeVersion.SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
+        return false; // don't count calls
+    }
+
+    return true; // should count calls if SetNativeCode() succeeds
+}
+#endif // FEATURE_TIERED_COMPILATION
+
 #ifdef FEATURE_CODE_VERSIONING
 VersionedPrepareCodeConfig::VersionedPrepareCodeConfig() {}
 
 VersionedPrepareCodeConfig::VersionedPrepareCodeConfig(NativeCodeVersion codeVersion) :
-    PrepareCodeConfig(codeVersion, TRUE, FALSE)
+    // Multi-core JIT is only applicable to the default code version, so don't request a notification
+    PrepareCodeConfig(codeVersion, FALSE, FALSE)
 {
     LIMITED_METHOD_CONTRACT;
 

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -893,6 +893,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r/*">
             <Issue>https://github.com/dotnet/runtime/issues/38291</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
+            <Issue>https://github.com/dotnet/runtime/issues/38291</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/IJW/NativeVarargs/NativeVarargsTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/38096</Issue>
         </ExcludeList>
@@ -955,6 +958,9 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
+            <Issue>Tests features specific to coreclr</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/CollectibleAssemblies/ByRefLocals/**">
             <Issue>https://github.com/dotnet/runtime/issues/40394</Issue>
         </ExcludeList>

--- a/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.cs
+++ b/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -11,10 +12,17 @@ public static class BasicTest
     {
         const int Pass = 100;
 
+        ProfileOptimization.SetProfileRoot(Environment.CurrentDirectory);
+        ProfileOptimization.StartProfile("profile.mcj");
+
+        // Let multi-core JIT start jitting
+        Thread.Sleep(100);
+
         PromoteToTier1(Foo, () => FooWithLoop(2));
         Foo();
         FooWithLoop(2);
 
+        ProfileOptimization.StartProfile(null);
         return Pass;
     }
 

--- a/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTestWithMcj.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="RunBasicTestWithMcj.cmd">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="RunBasicTestWithMcj.sh">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+mkdir r2r
+"%CORE_ROOT%\crossgen" -ReadyToRun -Platform_Assemblies_Paths "%CORE_ROOT%" -out r2r\$(MSBuildProjectName).dll $(MSBuildProjectName).dll
+set CLRCustomTestLauncher=RunBasicTestWithMcj.cmd
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+mkdir r2r
+"$CORE_ROOT/crossgen" -ReadyToRun -Platform_Assemblies_Paths "$CORE_ROOT" -out r2r/$(MSBuildProjectName).dll $(MSBuildProjectName).dll
+export CLRCustomTestLauncher=./RunBasicTestWithMcj.sh
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
@@ -21,13 +21,14 @@
 $(CLRTestBatchPreCommands)
 mkdir r2r
 "%CORE_ROOT%\crossgen" -ReadyToRun -Platform_Assemblies_Paths "%CORE_ROOT%" -out r2r\$(MSBuildProjectName).dll $(MSBuildProjectName).dll
-set CLRCustomTestLauncher=RunBasicTestWithMcj.cmd
+set CLRCustomTestLauncher=RunBasicTestWithMcj.cmd --runCustomTest
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 mkdir r2r
 "$CORE_ROOT/crossgen" -ReadyToRun -Platform_Assemblies_Paths "$CORE_ROOT" -out r2r/$(MSBuildProjectName).dll $(MSBuildProjectName).dll
-export CLRCustomTestLauncher=./RunBasicTestWithMcj.sh
+chmod +x ./RunBasicTestWithMcj.sh
+export CLRCustomTestLauncher="./RunBasicTestWithMcj.sh --runCustomTest"
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.cmd
+++ b/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.cmd
@@ -1,6 +1,9 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+rem *.cmd and *.sh files may be considered test entry points. If launched directly, consider it a pass.
+if "%~1" neq "--runCustomTest" exit /b 0
+
 set CLRTestExpectedExitCode=100
 
 echo Collect profile without R2R, use profile without R2R

--- a/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.cmd
+++ b/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.cmd
@@ -30,6 +30,15 @@ call "%CORE_ROOT%\corerun" r2r\BasicTestWithMcj.dll
 set CLRTestExitCode=!ErrorLevel!
 if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
 
+echo Collect profile with R2R, use profile without R2R
+del /f /q profile.mcj 2>nul
+call "%CORE_ROOT%\corerun" r2r\BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+call "%CORE_ROOT%\corerun" BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+
 echo Collect profile with R2R disabled, use profile with R2R enabled
 del /f /q profile.mcj 2>nul
 set COMPlus_ReadyToRun=0

--- a/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.cmd
+++ b/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.cmd
@@ -1,0 +1,47 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+set CLRTestExpectedExitCode=100
+
+echo Collect profile without R2R, use profile without R2R
+del /f /q profile.mcj 2>nul
+call "%CORE_ROOT%\corerun" BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+call "%CORE_ROOT%\corerun" BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+
+echo Collect profile with R2R, use profile with R2R
+del /f /q profile.mcj 2>nul
+call "%CORE_ROOT%\corerun" r2r\BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+call "%CORE_ROOT%\corerun" r2r\BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+
+echo Collect profile without R2R, use profile with R2R
+del /f /q profile.mcj 2>nul
+call "%CORE_ROOT%\corerun" BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+call "%CORE_ROOT%\corerun" r2r\BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+
+echo Collect profile with R2R disabled, use profile with R2R enabled
+del /f /q profile.mcj 2>nul
+set COMPlus_ReadyToRun=0
+call "%CORE_ROOT%\corerun" r2r\BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+set COMPlus_ReadyToRun=
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+call "%CORE_ROOT%\corerun" r2r\BasicTestWithMcj.dll
+set CLRTestExitCode=!ErrorLevel!
+if %CLRTestExitCode% neq %CLRTestExpectedExitCode% exit /b %CLRTestExitCode%
+
+del /f /q profile.mcj 2>nul
+exit /b %CLRTestExpectedExitCode%
+
+endlocal

--- a/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.sh
+++ b/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+CLRTestExpectedExitCode=100
+
+echo Collect profile without R2R, use profile without R2R
+rm -f profile.mcj
+"$CORE_ROOT/corerun" BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+"$CORE_ROOT/corerun" BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+
+echo Collect profile with R2R, use profile with R2R
+rm -f profile.mcj
+"$CORE_ROOT/corerun" r2r/BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+"$CORE_ROOT/corerun" r2r/BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+
+echo Collect profile without R2R, use profile with R2R
+rm -f profile.mcj
+"$CORE_ROOT/corerun" BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+"$CORE_ROOT/corerun" r2r/BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+
+echo Collect profile with R2R disabled, use profile with R2R enabled
+rm -f profile.mcj
+export COMPlus_ReadyToRun=0
+"$CORE_ROOT/corerun" r2r/BasicTestWithMcj.dll
+CLRTestExitCode=$?
+unset COMPlus_ReadyToRun
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+"$CORE_ROOT/corerun" r2r/BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+
+rm -f profile.mcj
+exit $CLRTestExpectedExitCode

--- a/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.sh
+++ b/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# *.cmd and *.sh files may be considered test entry points. If launched directly, consider it a pass.
+if [ "$1" != "--runCustomTest" ]; then
+  exit 0
+fi
+
 CLRTestExpectedExitCode=100
 
 echo Collect profile without R2R, use profile without R2R

--- a/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.sh
+++ b/src/tests/baseservices/TieredCompilation/RunBasicTestWithMcj.sh
@@ -41,6 +41,19 @@ if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
   exit $CLRTestExitCode
 fi
 
+echo Collect profile with R2R, use profile without R2R
+rm -f profile.mcj
+"$CORE_ROOT/corerun" r2r/BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+"$CORE_ROOT/corerun" BasicTestWithMcj.dll
+CLRTestExitCode=$?
+if [ $CLRTestExitCode -ne $CLRTestExpectedExitCode ]; then
+  exit $CLRTestExitCode
+fi
+
 echo Collect profile with R2R disabled, use profile with R2R enabled
 rm -f profile.mcj
 export COMPlus_ReadyToRun=0


### PR DESCRIPTION
Issues:
- When a multi-core JIT profile includes a method for which prejitted code is available, and the method contains a loop, when playing back the profile the multi-core JIT of the method disables call counting for the method, then when the method gets called the prejitted code is used but does not get tiered up later. Also hits assertion failures.
- Some cases where this may happen is if the profile is older than the prejitted state of an assembly, or if a profile is collected with R2R disabled (or without the assembly R2R'ed) and then played back on an R2R'ed assembly with R2R enabled.
- Tier 1 rejits also record the method in the multi-core JIT profile, another case where the above situation can occur

Fixes:
- Only record a method in the multi-core JIT profile for the default code version and only once for the code version
- When playing back a profile, don't disable call counting for a method immediately. Just record some info that may be used later when the method is actually gets called, if the multi-core jitted code gets used, to disable call counting if necessary.