### PR TITLE
Do not address expose a struct having 1 slot

### DIFF
--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -1027,13 +1027,14 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 #else  // !UNIX_AMD64_ABI
         compArgSize += argSize;
 #endif // !UNIX_AMD64_ABI
-        if (info.compIsVarArgs || isHfaArg || isSoftFPPreSpill)
+        if (info.compIsVarArgs || (isHfaArg && varDsc->lvHfaSlots() != 1) || isSoftFPPreSpill)
         {
 #if defined(TARGET_X86)
             varDsc->lvStkOffs = compArgSize;
 #else  // !TARGET_X86
             // TODO-CQ: We shouldn't have to go as far as to declare these
             // address-exposed -- DoNotEnregister should suffice.
+
             lvaSetVarAddrExposed(varDscInfo->varNum);
 #endif // !TARGET_X86
         }


### PR DESCRIPTION
I noticed the following inefficiency where we always pushing the SIMD_8 or SIMD_16 on stack. After talking to @CarolEidt , it turned out to be a simple fix which gives good gains.

```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll for  protononjit.dll
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -17388 (-0.34% of base)
    diff is an improvement.
Top file improvements (bytes):
      -17388 : System.Private.CoreLib.dasm (-0.34% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.
Top method regressions (bytes):
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Byte][System.Byte]:Equals(System.Runtime.Intrinsics.Vector64`1[Byte]):bool:this
          12 ( 5.77% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Double][System.Double]:Equals(System.Runtime.Intrinsics.Vector64`1[Double]):bool:this
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int64][System.Int64]:Equals(System.Runtime.Intrinsics.Vector64`1[Int64]):bool:this
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int32][System.Int32]:Equals(System.Runtime.Intrinsics.Vector64`1[Int32]):bool:this
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int16][System.Int16]:Equals(System.Runtime.Intrinsics.Vector64`1[Int16]):bool:this
          12 ( 5.77% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Single][System.Single]:Equals(System.Runtime.Intrinsics.Vector64`1[Single]):bool:this
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[SByte][System.SByte]:Equals(System.Runtime.Intrinsics.Vector64`1[SByte]):bool:this
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt64][System.UInt64]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt64]):bool:this
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt32][System.UInt32]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt32]):bool:this
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt16][System.UInt16]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt16]):bool:this
Top method improvements (bytes):
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[Byte],System.Runtime.Intrinsics.Vector128`1[Byte]):System.Runtime.Intrinsics.Vector256`1[Byte]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector128`1[Double]):System.Runtime.Intrinsics.Vector256`1[Double]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[Int16],System.Runtime.Intrinsics.Vector128`1[Int16]):System.Runtime.Intrinsics.Vector256`1[Int16]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[Int32],System.Runtime.Intrinsics.Vector128`1[Int32]):System.Runtime.Intrinsics.Vector256`1[Int32]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[Int64],System.Runtime.Intrinsics.Vector128`1[Int64]):System.Runtime.Intrinsics.Vector256`1[Int64]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[SByte],System.Runtime.Intrinsics.Vector128`1[SByte]):System.Runtime.Intrinsics.Vector256`1[SByte]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector128`1[Single]):System.Runtime.Intrinsics.Vector256`1[Single]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[UInt16],System.Runtime.Intrinsics.Vector128`1[UInt16]):System.Runtime.Intrinsics.Vector256`1[UInt16]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[UInt32],System.Runtime.Intrinsics.Vector128`1[UInt32]):System.Runtime.Intrinsics.Vector256`1[UInt32]
         -32 (-22.86% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(System.Runtime.Intrinsics.Vector128`1[UInt64],System.Runtime.Intrinsics.Vector128`1[UInt64]):System.Runtime.Intrinsics.Vector256`1[UInt64]
         -24 (-42.86% of base) : System.Private.CoreLib.dasm - System.Numerics.VectorMath:ConditionalSelectBitwise(System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector128`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -24 (-42.86% of base) : System.Private.CoreLib.dasm - System.Numerics.VectorMath:ConditionalSelectBitwise(System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector128`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[UInt32],System.Runtime.Intrinsics.Vector64`1[UInt32]):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[UInt64],System.Runtime.Intrinsics.Vector64`1[UInt64]):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[UInt16],System.Runtime.Intrinsics.Vector64`1[UInt16]):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector64`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[SByte],System.Runtime.Intrinsics.Vector64`1[SByte]):System.Runtime.Intrinsics.Vector128`1[SByte]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector64`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Byte],System.Runtime.Intrinsics.Vector64`1[Byte]):System.Runtime.Intrinsics.Vector128`1[Byte]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Int32],System.Runtime.Intrinsics.Vector64`1[Int32]):System.Runtime.Intrinsics.Vector128`1[Int32]
Top method regressions (percentages):
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int64][System.Int64]:Equals(System.Runtime.Intrinsics.Vector64`1[Int64]):bool:this
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int32][System.Int32]:Equals(System.Runtime.Intrinsics.Vector64`1[Int32]):bool:this
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt64][System.UInt64]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt64]):bool:this
          12 ( 6.25% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt32][System.UInt32]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt32]):bool:this
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Byte][System.Byte]:Equals(System.Runtime.Intrinsics.Vector64`1[Byte]):bool:this
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int16][System.Int16]:Equals(System.Runtime.Intrinsics.Vector64`1[Int16]):bool:this
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[SByte][System.SByte]:Equals(System.Runtime.Intrinsics.Vector64`1[SByte]):bool:this
          12 ( 6.00% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt16][System.UInt16]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt16]):bool:this
          12 ( 5.77% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Double][System.Double]:Equals(System.Runtime.Intrinsics.Vector64`1[Double]):bool:this
          12 ( 5.77% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Single][System.Single]:Equals(System.Runtime.Intrinsics.Vector64`1[Single]):bool:this
Top method improvements (percentages):
         -24 (-42.86% of base) : System.Private.CoreLib.dasm - System.Numerics.VectorMath:ConditionalSelectBitwise(System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector128`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -24 (-42.86% of base) : System.Private.CoreLib.dasm - System.Numerics.VectorMath:ConditionalSelectBitwise(System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector128`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|40_0(System.Runtime.Intrinsics.Vector64`1[Byte],System.Runtime.Intrinsics.Vector64`1[Byte]):System.Runtime.Intrinsics.Vector128`1[Byte]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|41_0(System.Runtime.Intrinsics.Vector64`1[Double],System.Runtime.Intrinsics.Vector64`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|42_0(System.Runtime.Intrinsics.Vector64`1[Int16],System.Runtime.Intrinsics.Vector64`1[Int16]):System.Runtime.Intrinsics.Vector128`1[Int16]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|43_0(System.Runtime.Intrinsics.Vector64`1[Int32],System.Runtime.Intrinsics.Vector64`1[Int32]):System.Runtime.Intrinsics.Vector128`1[Int32]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|44_0(System.Runtime.Intrinsics.Vector64`1[Int64],System.Runtime.Intrinsics.Vector64`1[Int64]):System.Runtime.Intrinsics.Vector128`1[Int64]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|45_0(System.Runtime.Intrinsics.Vector64`1[SByte],System.Runtime.Intrinsics.Vector64`1[SByte]):System.Runtime.Intrinsics.Vector128`1[SByte]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|46_0(System.Runtime.Intrinsics.Vector64`1[Single],System.Runtime.Intrinsics.Vector64`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|47_0(System.Runtime.Intrinsics.Vector64`1[UInt16],System.Runtime.Intrinsics.Vector64`1[UInt16]):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|48_0(System.Runtime.Intrinsics.Vector64`1[UInt32],System.Runtime.Intrinsics.Vector64`1[UInt32]):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -16 (-28.57% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:<Create>g__SoftwareFallback|49_0(System.Runtime.Intrinsics.Vector64`1[UInt64],System.Runtime.Intrinsics.Vector64`1[UInt64]):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[UInt32],System.Runtime.Intrinsics.Vector64`1[UInt32]):System.Runtime.Intrinsics.Vector128`1[UInt32]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[UInt64],System.Runtime.Intrinsics.Vector64`1[UInt64]):System.Runtime.Intrinsics.Vector128`1[UInt64]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[UInt16],System.Runtime.Intrinsics.Vector64`1[UInt16]):System.Runtime.Intrinsics.Vector128`1[UInt16]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector64`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[SByte],System.Runtime.Intrinsics.Vector64`1[SByte]):System.Runtime.Intrinsics.Vector128`1[SByte]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector64`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Byte],System.Runtime.Intrinsics.Vector64`1[Byte]):System.Runtime.Intrinsics.Vector128`1[Byte]
         -24 (-26.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[Int32],System.Runtime.Intrinsics.Vector64`1[Int32]):System.Runtime.Intrinsics.Vector128`1[Int32]
2284 total methods with Code Size differences (2274 improved, 10 regressed), 25063 unchanged.
```

Below is the sample diff of [TryFindFirstMatchedLane](https://github.com/dotnet/runtime/blob/a7278fd9ba86f3e7dae72efe6e350c87a08fe926/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs#L1702).

![image](https://user-images.githubusercontent.com/12488060/90568100-14c84280-e160-11ea-99bf-dfb207c45af9.png)

The regression I am seeing inside ` System.Runtime.Intrinsics.Vector64`1[Byte][System.Byte]:Equals(System.Runtime.Intrinsics.Vector64`1[Byte]):bool:this` is because of following diffs. I think we might be able to improve it, but I haven't done much investigation.

![image](https://user-images.githubusercontent.com/12488060/90574431-be620080-e16d-11ea-9fb6-014e58f92123.png)

I haven't done much investigation yet. Probably I will sync up with @CarolEidt .
