### PR TITLE
Remove unused local 

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -245,7 +245,6 @@ namespace Internal.Cryptography.Pal
                     out keySpec,
                     out freeKey))
                 {
-                    int dwErrorCode = Marshal.GetLastWin32Error();
 
                     // The documentation for CryptAcquireCertificatePrivateKey says that freeKey
                     // should already be false if "key acquisition fails", and it can be presumed


### PR DESCRIPTION
This fixes a part of #30457 
remove unused local variable _dwErrorCode_ at line 248.
Please check it