### PR TITLE
Fix Runtime_40444 test exclusion in issues.targets

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -76,7 +76,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/muldimjagary/muldimjagary/*">
             <Issue>https://github.com/dotnet/runtime/issues/5933</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_40444/*">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_40444/Runtime_40444/*">
             <Issue>https://github.com/dotnet/runtime/issues/40885</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/generics/Variance/Methods/Method002/*">


### PR DESCRIPTION
After I noticed that the test Runtime_40444 is still failing in PR
runs after I disabled it in issues.targets, I found out that
I had missed the extra folder level in the exclusion spec.

Thanks

Tomas

/cc: @dotnet/runtime-infrastructure 