### PR TITLE
Fix build of tests with skipnative passed

### DIFF
--- a/src/coreclr/_build-commons.sh
+++ b/src/coreclr/_build-commons.sh
@@ -19,7 +19,6 @@ handle_arguments() {
         skipnative|-skipnative)
             __SkipNative=1
             __SkipCoreCLR=1
-            __CopyNativeProjectsAfterCombinedTestBuild=false
             ;;
 
         *)


### PR DESCRIPTION
`skipnative` option of build-test.sh currently also sets `__CopyNativeProjectsAfterCombinedTestBuild=false`, which, however, leads to build error:

```sh
./build-test.sh -release -x64 -clang9 -priority1 skipnative
```

Output:
```sh
Managed tests build success!
Creating test wrappers...
Microsoft (R) Build Engine version 16.7.0-preview-20360-03+188921e2f for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

/home/z/Dev/runtime/.dotnet/sdk/5.0.100-preview.8.20362.3/MSBuild.dll -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,/home/z/Dev/runtime/.dotnet/sdk/5.0.100-preview.8.20362.3/dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,/home/z/Dev/runtime/.dotnet/sdk/5.0.100-preview.8.20362.3/dotnet.dll -maxcpucount -verbosity:m /bl:/home/z/Dev/runtime/artifacts/log/Release/build_test_wrappers_coreclr.binlog /consoleloggerparameters:Summary /fileloggerparameters1:WarningsOnly;LogFile=/home/z/Dev/runtime/artifacts/log/Check_Test_Build.Linux.x64.Release.wrn /fileloggerparameters2:ErrorsOnly;LogFile=/home/z/Dev/runtime/artifacts/log/Check_Test_Build.Linux.x64.Release.err /fileloggerparameters:Verbosity=normal;LogFile=/home/z/Dev/runtime/artifacts/log/Check_Test_Build.Linux.x64.Release.log /nodereuse:false /p:BuildWrappers=true /p:TestBuildMode= /p:TargetsWindows=false /p:TargetOS=Linux /p:Configuration=Release /p:TargetArchitecture=x64 /p:RuntimeFlavor=coreclr /p:CLRTestPriorityToBuild=1 /home/z/Dev/runtime/src/coreclr/tests/src/runtest.proj
CSC : warning CS2008: No source files specified. [/home/z/Dev/runtime/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj]
  test_dependencies -> /home/z/Dev/runtime/artifacts/tests/coreclr/Linux.x64.Release/test_dependencies/test_dependencies.dll
  test_dependencies -> /home/z/Dev/runtime/artifacts/tests/coreclr/Linux.x64.Release/test_dependencies/test_dependencies.dll
/home/z/Dev/runtime/src/coreclr/tests/src/runtest.proj(37,9): error MSB4186: Invalid static method invocation syntax: "[System.IO.Path]::GetFullPath()". Method 'System.IO.Path.GetFullPath' not found. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order.

Build FAILED.

CSC : warning CS2008: No source files specified. [/home/z/Dev/runtime/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj]
/home/z/Dev/runtime/src/coreclr/tests/src/runtest.proj(37,9): error MSB4186: Invalid static method invocation syntax: "[System.IO.Path]::GetFullPath()". Method 'System.IO.Path.GetFullPath' not found. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order.
    1 Warning(s)
    1 Error(s)

Time Elapsed 00:00:01.70
Error: XUnit wrapper build failed. Refer to the build log files for details (above)
```

This PR removes `__CopyNativeProjectsAfterCombinedTestBuild=false`, and allows to build native and managed parts of tests separately. Specifically:

```sh
./build-test.sh -release portablebuild=false -x64 -clang9 -priority1 skipgenerateversion skipstressdependencies skipmanaged skipgeneratelayout skiprestorepackages /p:__SkipPackageRestore=true

./build-test.sh -release -x64 -clang9 -priority1 skipgenerateversion skipstressdependencies skipnative
```

Separate build of native and managed parts is useful for Tizen, since we want to build native part as non-portable and managed part as portable.

cc @alpencolt 