### PR TITLE
Fix memory ordering issue in GCHeap::StressHeap

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -36550,6 +36550,13 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
                 unsigned sizeToNextObj = (unsigned)Align(size(str));
                 uint8_t* freeObj = ((uint8_t*) str) + sizeToNextObj - sizeOfNewObj;
                 pGenGCHeap->make_unused_array (freeObj, sizeOfNewObj);
+
+#if !defined(TARGET_AMD64) && !defined(TARGET_X86)
+                // ensure that the write to the new free object is seen by
+                // background GC *before* the write to the string length below
+                MemoryBarrier();
+#endif
+
                 str->SetStringLength(str->GetStringLength() - (sizeOfNewObj / sizeof(WCHAR)));
             }
             else


### PR DESCRIPTION
StressHeap contains a hack where we chop off the end of a string allocated for that purpose and make a new free object out of the chopped of piece. We also reduce the size of the string, so the GC sees the free object when walking the heap - the idea is to force compaction.

On processors with weak memory ordering semantics, we need a memory barrier to make sure the write to the new free object is seen *before* the write to the string length, otherwise the heap won't be walkable, leading to an AV in background_sweep.

I don't know at this point whether this will fix the arm64 GC stress issues we have been seeing, but the one dump I have been able to capture shows background_sweep crashing on a free object of size 0x2e8, which is exactly what StressHeap carves off the end of the string, plus there is a string will all null characters right before in memory, so we have some evidence that the free object whose method table was read as null by the GC was written by GCHeap::StressHeap.

cc @AndyAyersMS @trylek 