### PR TITLE
[coop] Add configuration option to disable stack scan

### DIFF
--- a/src/mono/mono/metadata/sgen-client-mono.h
+++ b/src/mono/mono/metadata/sgen-client-mono.h
@@ -722,6 +722,7 @@ gboolean sgen_is_critical_method (MonoMethod *method);
 void sgen_set_use_managed_allocator (gboolean flag);
 gboolean sgen_is_managed_allocator (MonoMethod *method);
 gboolean sgen_has_managed_allocator (void);
+void sgen_disable_native_stack_scan (void);
 
 void sgen_scan_for_registered_roots_in_domain (MonoDomain *domain, int root_type);
 void sgen_null_links_for_domain (MonoDomain *domain);

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -993,6 +993,7 @@ static MonoMethod* alloc_method_cache [ATYPE_NUM];
 static MonoMethod* slowpath_alloc_method_cache [ATYPE_NUM];
 static MonoMethod* profiler_alloc_method_cache [ATYPE_NUM];
 static gboolean use_managed_allocator = TRUE;
+static gboolean debug_coop_no_stack_scan;
 
 #ifdef MANAGED_ALLOCATION
 /* FIXME: Do this in the JIT, where specialized allocation sequences can be created
@@ -1120,6 +1121,12 @@ void
 sgen_set_use_managed_allocator (gboolean flag)
 {
 	use_managed_allocator = flag;
+}
+
+void
+sgen_disable_native_stack_scan (void)
+{
+	debug_coop_no_stack_scan = TRUE;
 }
 
 MonoMethod*
@@ -2361,30 +2368,32 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 
 		aligned_stack_start = get_aligned_stack_start (info);
 		g_assert (info->client_info.suspend_done);
-		SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %" G_GSIZE_FORMAT "d, pinned=%" G_GSIZE_FORMAT "d", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
-		if (mono_gc_get_gc_callbacks ()->thread_mark_func && !conservative_stack_mark) {
-			mono_gc_get_gc_callbacks ()->thread_mark_func (info->client_info.runtime_data, (guint8 *)aligned_stack_start, (guint8 *)info->client_info.info.stack_end, precise, &ctx);
-		} else if (!precise) {
-			if (!conservative_stack_mark) {
-				fprintf (stderr, "Precise stack mark not supported - disabling.\n");
-				conservative_stack_mark = TRUE;
+		if (!debug_coop_no_stack_scan) {
+			SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %" G_GSIZE_FORMAT "d, pinned=%" G_GSIZE_FORMAT "d", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
+			if (mono_gc_get_gc_callbacks ()->thread_mark_func && !conservative_stack_mark) {
+				mono_gc_get_gc_callbacks ()->thread_mark_func (info->client_info.runtime_data, (guint8 *)aligned_stack_start, (guint8 *)info->client_info.info.stack_end, precise, &ctx);
+			} else if (!precise) {
+				if (!conservative_stack_mark) {
+					fprintf (stderr, "Precise stack mark not supported - disabling.\n");
+					conservative_stack_mark = TRUE;
+				}
+				//FIXME we should eventually use the new stack_mark from coop
+				sgen_conservatively_pin_objects_from ((void **)aligned_stack_start, (void **)info->client_info.info.stack_end, start_nursery, end_nursery, PIN_TYPE_STACK);
 			}
-			//FIXME we should eventually use the new stack_mark from coop
-			sgen_conservatively_pin_objects_from ((void **)aligned_stack_start, (void **)info->client_info.info.stack_end, start_nursery, end_nursery, PIN_TYPE_STACK);
-		}
 
-		if (!precise) {
-			sgen_conservatively_pin_objects_from ((void**)&info->client_info.ctx, (void**)(&info->client_info.ctx + 1),
-				start_nursery, end_nursery, PIN_TYPE_STACK);
+			if (!precise) {
+				sgen_conservatively_pin_objects_from ((void**)&info->client_info.ctx, (void**)(&info->client_info.ctx + 1),
+					start_nursery, end_nursery, PIN_TYPE_STACK);
 
-			{
-				// This is used on Coop GC for platforms where we cannot get the data for individual registers.
-				// We force a spill of all registers into the stack and pass a chunk of data into sgen.
-				//FIXME under coop, for now, what we need to ensure is that we scan any extra memory from info->client_info.info.stack_end to stack_mark
-				MonoThreadUnwindState *state = &info->client_info.info.thread_saved_state [SELF_SUSPEND_STATE_INDEX];
-				if (state && state->gc_stackdata) {
-					sgen_conservatively_pin_objects_from ((void **)state->gc_stackdata, (void**)((char*)state->gc_stackdata + state->gc_stackdata_size),
-						start_nursery, end_nursery, PIN_TYPE_STACK);
+				{
+					// This is used on Coop GC for platforms where we cannot get the data for individual registers.
+					// We force a spill of all registers into the stack and pass a chunk of data into sgen.
+					//FIXME under coop, for now, what we need to ensure is that we scan any extra memory from info->client_info.info.stack_end to stack_mark
+					MonoThreadUnwindState *state = &info->client_info.info.thread_saved_state [SELF_SUSPEND_STATE_INDEX];
+					if (state && state->gc_stackdata) {
+						sgen_conservatively_pin_objects_from ((void **)state->gc_stackdata, (void**)((char*)state->gc_stackdata + state->gc_stackdata_size),
+							start_nursery, end_nursery, PIN_TYPE_STACK);
+					}
 				}
 			}
 		}

--- a/src/mono/mono/sgen/sgen-gc.c
+++ b/src/mono/mono/sgen/sgen-gc.c
@@ -3749,6 +3749,8 @@ sgen_gc_init (void)
 #endif
 				/* If aot code is used, allocation from there won't expect the layout with canaries enabled */
 				sgen_set_use_managed_allocator (FALSE);
+			} else if (!strcmp (opt, "coop-no-stack-scan")) {
+				sgen_disable_native_stack_scan ();
 			} else if (!sgen_client_handle_gc_debug (opt)) {
 				sgen_env_var_error (MONO_GC_DEBUG_NAME, "Ignoring.", "Unknown option `%s`.", opt);
 
@@ -3776,6 +3778,7 @@ sgen_gc_init (void)
 				fprintf (stderr, "  print-allowance\n");
 				fprintf (stderr, "  print-pinning\n");
 				fprintf (stderr, "  print-gchandles\n");
+				fprintf (stderr, "  coop-no-stack-scan\n");
 				fprintf (stderr, "  heap-dump=<filename>\n");
 				fprintf (stderr, "  binary-protocol=<filename>[:<file-size-limit>]\n");
 				fprintf (stderr, "  nursery-canaries\n");


### PR DESCRIPTION
When this experiment is enabled, the GC doesn't scan stack or registers. This mode is meant to disable scanning of native frames. This implementation only makes sense in full interpreter mode, where the interp stack is scanned separately from the thread stack. Longer term we could use this mode to scan only the managed stack, also in jit mode.

The point of this mode is to be able to stress test the GC in a wasm like environment, where stack can't be scanned. We can more easily reproduce and investigate GC crashes in this configuration, that would also happen on wasm.