### PR TITLE
Use type pattern rather than type check and redundant cast

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -879,18 +879,18 @@ namespace System.Net.Http
 
                 try
                 {
-                    if (connection is HttpConnection)
+                    if (connection is HttpConnection httpConnection)
                     {
-                        ((HttpConnection)connection).Acquire();
+                        httpConnection.Acquire();
                         try
                         {
                             response = await (doRequestAuth && Settings._credentials != null ?
-                                AuthenticationHelper.SendWithNtConnectionAuthAsync(request, async, Settings._credentials, (HttpConnection)connection, this, cancellationToken) :
-                                SendWithNtProxyAuthAsync((HttpConnection)connection, request, async, cancellationToken)).ConfigureAwait(false);
+                                AuthenticationHelper.SendWithNtConnectionAuthAsync(request, async, Settings._credentials, httpConnection, this, cancellationToken) :
+                                SendWithNtProxyAuthAsync(httpConnection, request, async, cancellationToken)).ConfigureAwait(false);
                         }
                         finally
                         {
-                            ((HttpConnection)connection).Release();
+                            httpConnection.Release();
                         }
                     }
                     else


### PR DESCRIPTION
In reading through the code, I spotted an opportunity to expand the usage of the `is` keyword with a [type pattern](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/is#type-pattern). This avoids what appears to be several redundant explicit casts.