### PR TITLE
[wasm] Skip Assert.InRange in Copy.cs for Browser

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -140,7 +140,12 @@ namespace System.IO.Tests
             }
 
             // Ensure last write/access time on the new file is appropriate
-            if (PlatformDetection.IsNotBrowser) // There is only one write time on browser vfs
+            //
+            // For browser, there is technically only 1 time.  It's the max
+            // of LastWrite and LastAccess.  On browser, File.SetLastWriteTime
+            // overwrites LastWrite and LastAccess, and File.Copy
+            // overwrites LastWrite , so this check doesn't apply.
+            if (PlatformDetection.IsNotBrowser)
             {
                 Assert.InRange(File.GetLastWriteTimeUtc(testFileDest), lastWriteTime.AddSeconds(-1), lastWriteTime.AddSeconds(1));
             }

--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -14,13 +14,6 @@ namespace System.IO.Tests
             File.Copy(source, dest);
         }
 
-        protected virtual void CopyReadOnlyFile(string source, string dest)
-        {
-            byte[] bits = File.ReadAllBytes(source);
-            File.WriteAllBytes(dest, bits);
-            File.SetAttributes(dest, FileAttributes.ReadOnly);
-        }
-
         #region UniversalTests
 
         [Fact]
@@ -115,7 +108,6 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(CopyFileWithData_MemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40867", TestPlatforms.Browser)]
         public void CopyFileWithData(char[] data, bool readOnly)
         {
             string testFileSource = GetTestFilePath();
@@ -127,21 +119,8 @@ namespace System.IO.Tests
                 stream.Write(data, 0, data.Length);
             }
 
-            DateTime lastWriteTime; 
-            if (PlatformDetection.IsBrowser)
-            {
-                // For browser, there is technically only 1 time.  It's the max
-                // of LastWrite and LastAccess.  Setting to a date/time in the future
-                // is a way of making this test work similarly.
-                //
-                // https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.utime
-                //
-                lastWriteTime = DateTime.UtcNow.Add(TimeSpan.FromHours(1));
-            }
-            else
-            {
-                lastWriteTime = DateTime.UtcNow.Subtract(TimeSpan.FromHours(1));
-            }
+            // Set the last write time of the source file to something a while ago
+            DateTime lastWriteTime = DateTime.UtcNow.Subtract(TimeSpan.FromHours(1));
             File.SetLastWriteTime(testFileSource, lastWriteTime);
 
             if (readOnly)
@@ -150,16 +129,7 @@ namespace System.IO.Tests
             }
 
             // Copy over the data
-            //
-            // For browser, work around limitation of File.Copy, which
-            // fails when trying to open the dest file
-            if (PlatformDetection.IsBrowser && readOnly)
-            {
-                CopyReadOnlyFile(testFileSource, testFileDest);
-                File.SetLastWriteTime(testFileDest, lastWriteTime);
-            }
-            else
-                Copy(testFileSource, testFileDest);
+            Copy(testFileSource, testFileDest);
 
             // Ensure copy transferred written data
             using (StreamReader stream = new StreamReader(File.OpenRead(testFileDest)))
@@ -170,7 +140,10 @@ namespace System.IO.Tests
             }
 
             // Ensure last write/access time on the new file is appropriate
-            Assert.InRange(File.GetLastWriteTimeUtc(testFileDest), lastWriteTime.AddSeconds(-1), lastWriteTime.AddSeconds(1));
+            if (PlatformDetection.IsNotBrowser) // There is only one write time on browser vfs
+            {
+                Assert.InRange(File.GetLastWriteTimeUtc(testFileDest), lastWriteTime.AddSeconds(-1), lastWriteTime.AddSeconds(1));
+            }
 
             Assert.Equal(readOnly, (File.GetAttributes(testFileDest) & FileAttributes.ReadOnly) != 0);
             if (readOnly)


### PR DESCRIPTION
This PR reverts #40663.

By reverting https://github.com/dotnet/corefx/pull/37583 in #40753, the file time being set https://github.com/dotnet/runtime/blob/154e971c2f026963c2cd2e15d78e27601801151e/src/libraries/Native/Unix/System.Native/pal_io.c#L1157 is now overwritten by https://github.com/dotnet/runtime/blob/154e971c2f026963c2cd2e15d78e27601801151e/src/libraries/Native/Unix/System.Native/pal_io.c#L1173 probably due to Emscripten's implementation. (By commenting out L1173-L1177 the [test](https://github.com/dotnet/runtime/blob/154e971c2f026963c2cd2e15d78e27601801151e/src/libraries/System.IO.FileSystem/tests/File/Copy.cs#L119) passes)

Moreover, from some testing, it looks like `File.SetAttributes` will overwrite a file's LastWrite and LastAccess time on browser also probably due to Emscripten's implementation. 

The workaround in #40663 sets the file's LastWrite after `Copy` for readOnly files, but if we have to do that for both readOnly and non-readOnly because [L1157](https://github.com/dotnet/runtime/blob/154e971c2f026963c2cd2e15d78e27601801151e/src/libraries/Native/Unix/System.Native/pal_io.c#L1157) is defeated by [L1173](https://github.com/dotnet/runtime/blob/154e971c2f026963c2cd2e15d78e27601801151e/src/libraries/Native/Unix/System.Native/pal_io.c#L1173), then the `Assert.InRange` check is trivial and we should instead skip this assert on Browser. 