### PR TITLE
Make UseEnvironment/ContentRoot override config

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Host.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -57,9 +58,12 @@ namespace Microsoft.Extensions.Hosting
         {
             var builder = new HostBuilder();
 
-            builder.UseContentRoot(Directory.GetCurrentDirectory());
             builder.ConfigureHostConfiguration(config =>
             {
+                config.AddInMemoryCollection(new[]
+                {
+                    new KeyValuePair<string, string> (HostDefaults.ContentRootKey, Directory.GetCurrentDirectory())
+                });
                 config.AddEnvironmentVariables(prefix: "DOTNET_");
                 if (args != null)
                 {

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -147,11 +147,26 @@ namespace Microsoft.Extensions.Hosting
 
         private void CreateHostingEnvironment()
         {
+            // Explicit settings override config.
+            string environmentName = _hostConfiguration[HostDefaults.EnvironmentKey] ?? Environments.Production;
+            if (Properties.TryGetValue(HostDefaults.EnvironmentKey, out object envObj)
+                && (envObj is string env))
+            {
+                environmentName = env;
+            }
+
+            string contentRoot = _hostConfiguration[HostDefaults.ContentRootKey];
+            if (Properties.TryGetValue(HostDefaults.ContentRootKey, out object contentObj)
+                && (contentObj is string content))
+            {
+                contentRoot = content;
+            }
+
             _hostingEnvironment = new HostingEnvironment()
             {
                 ApplicationName = _hostConfiguration[HostDefaults.ApplicationKey],
-                EnvironmentName = _hostConfiguration[HostDefaults.EnvironmentKey] ?? Environments.Production,
-                ContentRootPath = ResolveContentRootPath(_hostConfiguration[HostDefaults.ContentRootKey], AppContext.BaseDirectory),
+                EnvironmentName = environmentName,
+                ContentRootPath = ResolveContentRootPath(contentRoot, AppContext.BaseDirectory),
             };
 
             if (string.IsNullOrEmpty(_hostingEnvironment.ApplicationName))

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -22,14 +21,8 @@ namespace Microsoft.Extensions.Hosting
         /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder UseEnvironment(this IHostBuilder hostBuilder, string environment)
         {
-            return hostBuilder.ConfigureHostConfiguration(configBuilder =>
-            {
-                configBuilder.AddInMemoryCollection(new[]
-                {
-                    new KeyValuePair<string, string>(HostDefaults.EnvironmentKey,
-                        environment  ?? throw new ArgumentNullException(nameof(environment)))
-                });
-            });
+            hostBuilder.Properties[HostDefaults.EnvironmentKey] = environment;
+            return hostBuilder;
         }
 
         /// <summary>
@@ -40,14 +33,8 @@ namespace Microsoft.Extensions.Hosting
         /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder UseContentRoot(this IHostBuilder hostBuilder, string contentRoot)
         {
-            return hostBuilder.ConfigureHostConfiguration(configBuilder =>
-            {
-                configBuilder.AddInMemoryCollection(new[]
-                {
-                    new KeyValuePair<string, string>(HostDefaults.ContentRootKey,
-                        contentRoot  ?? throw new ArgumentNullException(nameof(contentRoot)))
-                });
-            });
+            hostBuilder.Properties[HostDefaults.ContentRootKey] = contentRoot;
+            return hostBuilder;
         }
 
         /// <summary>


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/18499

UseEnvironment and UseContentRoot have a composition problem. Because they were implemented using config they're order sensitive and can be overridden by config. That has caused confusion especially for UseEnvironment. 

Proposal: Have UseEnvironment and UseContentRoot store their data in IHostBuilder.Properties rather than config and treat this as higher priority than config. This works well for UseEnvironment, but there are a few places where UseContentRoot is used to provide a default value that is intended to compose with config. Those can be easily expressed using ConfigureHostConfig like UseContentRoot used to.

There's at least one more UseContentRoot call in UseWindowsServices we might want to update.
https://github.com/dotnet/extensions/blob/f4066026ca06984b07e90e61a6390ac38152ba93/src/Hosting/WindowsServices/src/WindowsServiceLifetimeHostBuilderExtensions.cs#L50