### PR TITLE
Improve Windows error handling in Diagnostics IPC

### DIFF
--- a/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -393,12 +393,12 @@ int32_t IpcStream::DiagnosticsIpc::Poll(IpcPollHandle *rgIpcPollHandles, uint32_
         if (!fSuccess)
         {
             DWORD error = ::GetLastError();
-            if (error == ERROR_PIPE_NOT_CONNECTED)
+            if (error == ERROR_PIPE_NOT_CONNECTED || error == ERROR_BROKEN_PIPE)
                 rgIpcPollHandles[index].revents = (uint8_t)IpcStream::DiagnosticsIpc::PollEvents::HANGUP;
             else
             {
                 if (callback != nullptr)
-                    callback("Client connection error", -1);
+                    callback("Client connection error", error);
                 rgIpcPollHandles[index].revents = (uint8_t)IpcStream::DiagnosticsIpc::PollEvents::ERR;
                 delete[] pHandles;
                 return -1;
@@ -434,39 +434,52 @@ bool IpcStream::Read(void *lpBuffer, const uint32_t nBytesToRead, uint32_t &nByt
 
     if (!fSuccess)
     {
-        if (timeoutMs == InfiniteTimeout)
+        DWORD dwReadError = GetLastError();
+        if (dwReadError == ERROR_IO_PENDING)
         {
-            fSuccess = GetOverlappedResult(_hPipe,
-                                           overlap,
-                                           &nNumberOfBytesRead,
-                                           true) != 0;
-        }
-        else
-        {
-            DWORD dwError = GetLastError();
-            if (dwError == ERROR_IO_PENDING)
+            // we are using Overlapped IO so
+            // this is expected and not an error
+            fSuccess = GetOverlappedResultEx(_hPipe,
+                                            overlap,
+                                            &nNumberOfBytesRead,
+                                            timeoutMs,
+                                            false) != 0;
+            if (!fSuccess)
             {
-                DWORD dwWait = WaitForSingleObject(_oOverlap.hEvent, (DWORD)timeoutMs);
-                if (dwWait == WAIT_OBJECT_0)
+                DWORD dwError = GetLastError();
+                switch (dwError)
                 {
-                    // get the result
-                    fSuccess = GetOverlappedResult(_hPipe,
-                                                   overlap,
-                                                   &nNumberOfBytesRead,
-                                                   true) != 0;
-                }
-                else
-                {
-                    // cancel IO and ensure the cancel happened
-                    if (CancelIo(_hPipe))
-                    {
-                        // check if the async write beat the cancellation
-                        fSuccess = GetOverlappedResult(_hPipe, overlap, &nNumberOfBytesRead, true) != 0;
-                    }
+                    case WAIT_IO_COMPLETION:
+                        // We aren't using IO Completion ports so we shouldn't see this...
+                    case ERROR_IO_INCOMPLETE:
+                        // should only happen if timeout is 0
+                        // this isn't technically an error, but the user requested a 0 timeout and the work hasn't been
+                        // completed yet, so we'll cancel.
+                    case WAIT_TIMEOUT:
+                        // We didn't complete the write in time... cancel the IO
+                        {
+                            fSuccess = CancelIoEx(_hPipe, overlap) != 0;
+                            if (!fSuccess)
+                            {
+                                DWORD dwCancelError = GetLastError();
+                            }
+                            else
+                            {
+                                fSuccess = GetOverlappedResult(_hPipe, overlap, &nNumberOfBytesRead, false) != 0;
+                                // failure either means we successfully cancelled the IO or something else went wrong.
+                                // not worth checking since we can't recover either way.
+                            }
+                        }
+                        break;
+                    default:
+                        break;
                 }
             }
         }
-        // TODO: Add error handling.
+        else
+        {
+            // TODO: Add error handling.
+        }
     }
 
     nBytesRead = static_cast<uint32_t>(nNumberOfBytesRead);
@@ -488,40 +501,52 @@ bool IpcStream::Write(const void *lpBuffer, const uint32_t nBytesToWrite, uint32
 
     if (!fSuccess)
     {
-        DWORD dwError = GetLastError();
-        if (dwError == ERROR_IO_PENDING)
+        DWORD dwReadError = GetLastError();
+        if (dwReadError == ERROR_IO_PENDING)
         {
-            if (timeoutMs == InfiniteTimeout)
+            // we are using Overlapped IO so
+            // this is expected and not an error
+            fSuccess = GetOverlappedResultEx(_hPipe,
+                                            overlap,
+                                            &nNumberOfBytesWritten,
+                                            timeoutMs,
+                                            false) != 0;
+            if (!fSuccess)
             {
-                // if we're waiting infinitely, don't bother with extra kernel call
-                fSuccess = GetOverlappedResult(_hPipe,
-                                               overlap,
-                                               &nNumberOfBytesWritten,
-                                                true) != 0;
-            }
-            else
-            {
-                DWORD dwWait = WaitForSingleObject(_oOverlap.hEvent, (DWORD)timeoutMs);
-                if (dwWait == WAIT_OBJECT_0)
+                DWORD dwError = GetLastError();
+                switch (dwError)
                 {
-                    // get the result
-                    fSuccess = GetOverlappedResult(_hPipe,
-                                                   overlap,
-                                                   &nNumberOfBytesWritten,
-                                                   true) != 0;
-                }
-                else
-                {
-                    // cancel IO and ensure the cancel happened
-                    if (CancelIo(_hPipe))
-                    {
-                        // check if the async write beat the cancellation
-                        fSuccess = GetOverlappedResult(_hPipe, overlap, &nNumberOfBytesWritten, true) != 0;
-                    }
+                    case WAIT_IO_COMPLETION:
+                        // We aren't using IO Completion ports so we shouldn't see this...
+                    case ERROR_IO_INCOMPLETE:
+                        // should only happen if timeout is 0
+                        // this isn't technically an error, but the user requested a 0 timeout and the work hasn't been
+                        // completed yet, so we'll cancel.
+                    case WAIT_TIMEOUT:
+                        // We didn't complete the write in time... cancel the IO
+                        {
+                            fSuccess = CancelIoEx(_hPipe, overlap) != 0;
+                            if (!fSuccess)
+                            {
+                                DWORD dwCancelError = GetLastError();
+                            }
+                            else
+                            {
+                                fSuccess = GetOverlappedResult(_hPipe, overlap, &nNumberOfBytesWritten, false) != 0;
+                                // failure either means we successfully cancelled the IO or something else went wrong.
+                                // not worth checking since we can't recover either way.
+                            }
+                        }
+                        break;
+                    default:
+                        break;
                 }
             }
         }
-        // TODO: Add error handling.
+        else
+        {
+            // TODO: Add error handling.
+        }
     }
 
     nBytesWritten = static_cast<uint32_t>(nNumberOfBytesWritten);

--- a/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -446,11 +446,9 @@ bool IpcStream::Read(void *lpBuffer, const uint32_t nBytesToRead, uint32_t &nByt
                                             false) != 0;
             if (!fSuccess)
             {
-                DWORD dwError = GetLastError();
-                switch (dwError)
+                DWORD dwOverlapError = GetLastError();
+                switch (dwOverlapError)
                 {
-                    case WAIT_IO_COMPLETION:
-                        // We aren't using IO Completion ports so we shouldn't see this...
                     case ERROR_IO_INCOMPLETE:
                         // should only happen if timeout is 0
                         // this isn't technically an error, but the user requested a 0 timeout and the work hasn't been
@@ -471,14 +469,20 @@ bool IpcStream::Read(void *lpBuffer, const uint32_t nBytesToRead, uint32_t &nByt
                             }
                         }
                         break;
+                    case WAIT_IO_COMPLETION:
+                        // We aren't using IO Completion ports so we shouldn't see this...
+                        _ASSERTE(!"IO Completion error when not using IO Completion Ports");
                     default:
+                        // unrecoverable errors
+                        _ASSERTE(!"IpcStream::Read - Unrecoverable error from GetOverlappedResult");
                         break;
                 }
             }
         }
         else
         {
-            // TODO: Add error handling.
+            // Other errors are unrecoverable and we should fall through to return failure
+            _ASSERTE(!"IpcStream::Read - Unrecoverable error from ReadFile");
         }
     }
 
@@ -513,11 +517,9 @@ bool IpcStream::Write(const void *lpBuffer, const uint32_t nBytesToWrite, uint32
                                             false) != 0;
             if (!fSuccess)
             {
-                DWORD dwError = GetLastError();
-                switch (dwError)
+                DWORD dwOverlapError = GetLastError();
+                switch (dwOverlapError)
                 {
-                    case WAIT_IO_COMPLETION:
-                        // We aren't using IO Completion ports so we shouldn't see this...
                     case ERROR_IO_INCOMPLETE:
                         // should only happen if timeout is 0
                         // this isn't technically an error, but the user requested a 0 timeout and the work hasn't been
@@ -538,14 +540,20 @@ bool IpcStream::Write(const void *lpBuffer, const uint32_t nBytesToWrite, uint32
                             }
                         }
                         break;
+                    case WAIT_IO_COMPLETION:
+                        // We aren't using IO Completion ports so we shouldn't see this...
+                        _ASSERTE(!"IO Completion error when not using IO Completion Ports");
                     default:
+                        // unrecoverable errors
+                        _ASSERTE(!"IpcStream::Write - Unrecoverable error from GetOverlappedResult");
                         break;
                 }
             }
         }
         else
         {
-            // TODO: Add error handling.
+            // Other errors are unrecoverable and we should fall through to return failure
+            _ASSERTE(!"IpcStream::Write - Unrecoverable error from WriteFile");
         }
     }
 

--- a/src/coreclr/src/vm/ipcstreamfactory.cpp
+++ b/src/coreclr/src/vm/ipcstreamfactory.cpp
@@ -318,7 +318,7 @@ IpcStream *IpcStreamFactory::GetNextAvailableStream(ErrorCallback callback)
                 {
                     case IpcStream::DiagnosticsIpc::PollEvents::HANGUP:
                         ((DiagnosticPort*)(rgIpcPollHandles[i].pUserData))->Reset(callback);
-                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - HUP :: Poll attempt: %d, connection %d hung up.\n", nPollAttempts, i);
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - HUP :: Poll attempt: %d, connection %d hung up. Connect is reset.\n", nPollAttempts, i);
                         pollTimeoutMs = s_pollTimeoutMinMs;
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::SIGNALED:
@@ -330,7 +330,8 @@ IpcStream *IpcStreamFactory::GetNextAvailableStream(ErrorCallback callback)
                         STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - SIG :: Poll attempt: %d, connection %d signalled.\n", nPollAttempts, i);
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::ERR:
-                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - ERR :: Poll attempt: %d, connection %d errored.\n", nPollAttempts, i);
+                        ((DiagnosticPort*)(rgIpcPollHandles[i].pUserData))->Reset(callback);
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - ERR :: Poll attempt: %d, connection %d errored. Connection is reset.\n", nPollAttempts, i);
                         fSawError = true;
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::NONE:


### PR DESCRIPTION
fixes #41007

These changes are intended to be backported to 5.0-rc1 once merged into master.

As described in #41007, the runtime was treating `ERROR_BROKEN_PIPE` as a generic error rather than a hangup error.  These changes correct that misbehavior and reset the connection on generic errors in case additional errors have been missed.  Additionally, they simplify the logic of `IpcStream::{Read|Write}` to use `GetOverlappedResultEx` which directly takes a timeout rather than `GetOverlappedResult` followed by `WaitForSingleObject`.

CC @jander-msft @tommcdon

---

## Customer Impact

This currently impacts `dotnet-monitor` on Windows.

If a Connect Diagnostic Port on Windows doesn't call `DisconnectNamedPipe` before closing it will cause runtimes to be unable to connect to another Connect Diagnostic Port at the same address.  For example, `dotnet-monitor` currently does not call `DisconnectNamedPipe` before closing, so if a user restarts `dotnet-monitor` they won't see any apps show up if they connected before.

## Testing

I have tested these changes locally with `dotnet-monitor` both under a debugger and without the debugger.  These fix the observed issue.  I did not add an individual test for this scenario, but one could be created.

## Risk

This is a low risk patch.  It simply improves the error handling and corrects a misbehavior.