### PR TITLE
look for dhcp lease file in multiple locations

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceProperties.cs
@@ -69,8 +69,12 @@ namespace System.Net.NetworkInformation
 
         private IPAddressCollection GetDhcpServerAddresses()
         {
-            List<IPAddress> internalCollection
-                = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(NetworkFiles.DHClientLeasesFile, _linuxNetworkInterface.Name);
+            List<IPAddress> internalCollection = new List<IPAddress>();
+
+            StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(internalCollection, NetworkFiles.DHClientLeasesFile, _linuxNetworkInterface.Name);
+            StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(internalCollection, string.Format(NetworkFiles.DHClientInterfaceLeasesFile, _linuxNetworkInterface.Name), _linuxNetworkInterface.Name);
+            StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(internalCollection, string.Format(NetworkFiles.DHClientSecondaryInterfaceLeasesFile, _linuxNetworkInterface.Name), _linuxNetworkInterface.Name);
+
             return new InternalIPAddressCollection(internalCollection);
         }
 

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
@@ -23,6 +23,8 @@ namespace System.Net.NetworkInformation
         public const string Udp4ConnectionsFile = "/proc/net/udp";
         public const string Udp6ConnectionsFile = "/proc/net/udp6";
         public const string DHClientLeasesFile = "/var/lib/dhcp/dhclient.leases";
+        public const string DHClientInterfaceLeasesFile = "/var/lib/dhcp/dhclient.{0}.leases";
+        public const string DHClientSecondaryInterfaceLeasesFile = "/var/lib/dhcp/dhclient6.{0}.leases";
         public const string SmbConfFile = "/etc/samba/smb.conf";
 
         // Individual file names

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
@@ -79,12 +79,11 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        internal static List<IPAddress> ParseDhcpServerAddressesFromLeasesFile(string filePath, string name)
+        internal static void ParseDhcpServerAddressesFromLeasesFile(List<IPAddress> collection, string filePath, string name)
         {
             // Parse the /var/lib/dhcp/dhclient.leases file, if it exists.
             // If any errors occur, like the file not existing or being
             // improperly formatted, just bail and return an empty collection.
-            List<IPAddress> collection = new List<IPAddress>();
             try
             {
                 if (File.Exists(filePath)) // avoid an exception in most cases if path doesn't already exist
@@ -123,8 +122,6 @@ namespace System.Net.NetworkInformation
             {
                 // If any parsing or file reading exception occurs, just ignore it and return the collection.
             }
-
-            return collection;
         }
 
         internal static List<IPAddress> ParseWinsServerAddressesFromSmbConfFile(string smbConfFilePath)

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
@@ -69,7 +69,8 @@ namespace System.Net.NetworkInformation.Tests
         {
             string fileName = GetTestFilePath();
             FileUtil.NormalizeLineEndings("NetworkFiles/dhclient.leases", fileName);
-            List<IPAddress> dhcpServerAddresses = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(fileName, "wlan0");
+            List<IPAddress> dhcpServerAddresses = new List<IPAddress>();
+            StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(dhcpServerAddresses, fileName, "wlan0");
             Assert.Equal(1, dhcpServerAddresses.Count);
             Assert.Equal(IPAddress.Parse("10.105.128.4"), dhcpServerAddresses[0]);
         }


### PR DESCRIPTION
As sated in #31054, DHCP leases can be stored in locations other then `"/var/lib/dhcp/dhclient.leases"`
Since the `ParseDhcpServerAddressesFromLeasesFile()` never throws, the fix is to check three known locations. 
That may still not cover all the cases but at least it covers Ubuntu (and perhaps others) 

Since this depends on OS configuration, I did not add any automated test.
I did manual verification and I verified that on my system interfaces with DHCP return DHCP server list. 

fixes #31054
