### PR TITLE
Return host's file path when using Environment.GetCommandLineArgs()[0] in single-file apps

### DIFF
--- a/src/coreclr/src/vm/corhost.cpp
+++ b/src/coreclr/src/vm/corhost.cpp
@@ -27,7 +27,6 @@
 #include "comdelegate.h"
 #include "dllimportcallback.h"
 #include "eventtrace.h"
-#include "bundle.h"
 
 #include "win32threadpool.h"
 #include "eventtrace.h"
@@ -273,7 +272,7 @@ void SetCommandLineArgs(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR* argv)
     GCPROTECT_BEGIN(gc);
 
     gc.cmdLineArgs = (PTRARRAYREF)AllocateObjectArray(argc + 1 /* arg[0] should be the exe name*/, g_pStringClass);
-    OBJECTREF orAssemblyPath = StringObject::NewString(Bundle::AppIsBundle() ? Bundle::AppBundle->Path() : pwzAssemblyPath);
+    OBJECTREF orAssemblyPath = StringObject::NewString(Bundle::AppIsBundle() ? static_cast<LPCWSTR>(Bundle::AppBundle->Path()) : pwzAssemblyPath);
     gc.cmdLineArgs->SetAt(0, orAssemblyPath);
 
     for (int i = 0; i < argc; ++i)

--- a/src/coreclr/src/vm/corhost.cpp
+++ b/src/coreclr/src/vm/corhost.cpp
@@ -27,6 +27,7 @@
 #include "comdelegate.h"
 #include "dllimportcallback.h"
 #include "eventtrace.h"
+#include "bundle.h"
 
 #include "win32threadpool.h"
 #include "eventtrace.h"
@@ -272,7 +273,7 @@ void SetCommandLineArgs(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR* argv)
     GCPROTECT_BEGIN(gc);
 
     gc.cmdLineArgs = (PTRARRAYREF)AllocateObjectArray(argc + 1 /* arg[0] should be the exe name*/, g_pStringClass);
-    OBJECTREF orAssemblyPath = StringObject::NewString(pwzAssemblyPath);
+    OBJECTREF orAssemblyPath = StringObject::NewString(Bundle::AppIsBundle() ? Bundle::AppBundle->Path() : pwzAssemblyPath);
     gc.cmdLineArgs->SetAt(0, orAssemblyPath);
 
     for (int i = 0; i < argc; ++i)

--- a/src/installer/tests/Assets/TestProjects/EnvironmentGetCommandLineArgs/EnvironmentGetCommandLineArgs.csproj
+++ b/src/installer/tests/Assets/TestProjects/EnvironmentGetCommandLineArgs/EnvironmentGetCommandLineArgs.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/installer/tests/Assets/TestProjects/EnvironmentGetCommandLineArgs/Program.cs
+++ b/src/installer/tests/Assets/TestProjects/EnvironmentGetCommandLineArgs/Program.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace EnvironmentGetCommandLineArgs
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            foreach (var arg in Environment.GetCommandLineArgs())
+            {
+                Console.WriteLine(arg);
+            }
+        }
+    }
+}

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
@@ -21,6 +21,8 @@ namespace AppHost.Bundle.Tests
             var fixture = sharedTestState.TestFixture.Copy();
             var singleFile = BundleHelper.BundleApp(fixture);
 
+            // For single-file, Environment.GetCommandLineArgs[0]
+            // should return the file path of the host.
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -29,6 +31,20 @@ namespace AppHost.Bundle.Tests
                 .Pass()
                 .And
                 .HaveStdOutContaining(singleFile);
+
+            // For non single-file apps, Environment.GetCommandLineArgs[0]
+            // should return the file path of the managed entrypoint.
+            var dotnet = fixture.BuiltDotnet;
+            var appPath = BundleHelper.GetAppPath(fixture);
+
+            dotnet.Exec(appPath)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(appPath);
         }
 
         public class SharedTestState : IDisposable

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
@@ -31,12 +31,17 @@ namespace AppHost.Bundle.Tests
                 .Pass()
                 .And
                 .HaveStdOutContaining(singleFile);
+        }
 
-            // For non single-file apps, Environment.GetCommandLineArgs[0]
-            // should return the file path of the managed entrypoint.
+        [Fact]
+        public void GetEnvironmentArgs_0_Non_Bundled_App()
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
             var dotnet = fixture.BuiltDotnet;
             var appPath = BundleHelper.GetAppPath(fixture);
 
+            // For non single-file apps, Environment.GetCommandLineArgs[0]
+            // should return the file path of the managed entrypoint.
             dotnet.Exec(appPath)
                 .CaptureStdErr()
                 .CaptureStdOut()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
@@ -20,7 +20,6 @@ namespace AppHost.Bundle.Tests
         {
             var fixture = sharedTestState.TestFixture.Copy();
             var singleFile = BundleHelper.BundleApp(fixture);
-            var executablePath = BundleHelper.GetHostPath(fixture);
 
             Command.Create(singleFile)
                 .CaptureStdErr()
@@ -29,7 +28,7 @@ namespace AppHost.Bundle.Tests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining(executablePath);
+                .HaveStdOutContaining(singleFile);
         }
 
         public class SharedTestState : IDisposable

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleEnvironmentGetCommandLineArgs.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using BundleTests.Helpers;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using Xunit;
+
+namespace AppHost.Bundle.Tests
+{
+    public class BundleEnvironmentGetCommandLineArgs : IClassFixture<BundleEnvironmentGetCommandLineArgs.SharedTestState>
+    {
+        private SharedTestState sharedTestState;
+
+        public BundleEnvironmentGetCommandLineArgs(SharedTestState fixture)
+        {
+            sharedTestState = fixture;
+        }
+
+        [Fact]
+        public void GetEnvironmentArgs_0_Returns_Bundled_Executable_Path()
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
+            var singleFile = BundleHelper.BundleApp(fixture);
+            var executablePath = BundleHelper.GetHostPath(fixture);
+
+            Command.Create(singleFile)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(executablePath);
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public TestProjectFixture TestFixture { get; set; }
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+                TestFixture = new TestProjectFixture("EnvironmentGetCommandLineArgs", RepoDirectories);
+                TestFixture
+                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .PublishProject(runtime: TestFixture.CurrentRid, outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+            }
+
+            public void Dispose()
+            {
+                TestFixture.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #40874.