### PR TITLE
Disable default non-portable build for armel

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -146,13 +146,6 @@ initDistroRidGlobal()
         fi
     fi
 
-    if [ "$buildArch" = "armel" ]; then
-        # Armel cross build is Tizen specific and does not support Portable RID build
-        __PortableBuild=0
-        export __PortableBuild
-        isPortable=0
-    fi
-
     initNonPortableDistroRid "${targetOs}" "${buildArch}" "${isPortable}" "${rootfsDir}"
 
     if [ "$buildArch" = "wasm" ]; then


### PR DESCRIPTION
This is required for build of native part of tests as non-portable and managed part of tests as portable. Also, this makes armel tizen build consistent with arm64 tizen build scheme, which requires `--portable false` option. Example of tizen build:
```sh
ROOTFS_DIR=`pwd`/.tools/rootfs/armel ./build.sh --portablebuild false --cross --clang9 --arch armel --configuration Release --subset clr+libs.native
ROOTFS_DIR=`pwd`/.tools/rootfs/armel ./build.sh --cross --clang9 --arch armel --configuration Release --subset libs.ref+libs.src+libs.pretest+libs.packages+libs.tests
```

Build of tests can be performed similar to https://github.com/dotnet/runtime/pull/40979#issuecomment-676206947:
```sh
cd src/coreclr
ROOTFS_DIR=`pwd`/../../.tools/rootfs/armel ./build-test.sh -release portablebuild=false -cross -armel -clang9 -priority1 skipgenerateversion skipstressdependencies skipmanaged skipgeneratelayout skiprestorepackages /p:__SkipPackageRestore=true
ROOTFS_DIR=`pwd`/../../.tools/rootfs/armel ./build-test.sh -release -cross -armel -clang9 -priority1 skipgenerateversion skipstressdependencies skipnative skipgeneratelayout skiptestwrappers
ROOTFS_DIR=`pwd`/../../.tools/rootfs/armel ./build-test.sh -release -cross -armel -clang9 -priority1 skipgenerateversion skipstressdependencies copynativeonly
ROOTFS_DIR=`pwd`/../../.tools/rootfs/armel ./build-test.sh -release -cross -armel -clang9 -priority1 skipgenerateversion skipstressdependencies generatelayoutonly
```

cc @alpencolt @jkotas 