### PR TITLE
[browser][wasm] Fix assembly name not found due to rename of assembly.

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -10,7 +10,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 {
     public static class HelperMarshal
     {
-        internal const string INTEROP_CLASS = "[System.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:";
+        internal const string INTEROP_CLASS = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:";
         internal static int _i32Value;
         private static void InvokeI32(int a, int b)
         {


### PR DESCRIPTION
Due to the renaming of the assembly System.Runtime.InteropServices.JavaScript to System.Private.Runtime.InteropServices.JavaScript the marshal tests will fail once they are turned back on.

This PR does not reactivate the tests only fixes a problem that will be presented in the future if someone is working on those tests in the future.

The active issue that turns off those tests is https://github.com/dotnet/runtime/issues/40112.  Once this issue is addressed then the tests can be turned back on.

Closes https://github.com/dotnet/runtime/issues/41036