### PR TITLE
Strip binaries more aggressively

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -323,7 +323,7 @@ function(strip_symbols targetName outputFilename)
         POST_BUILD
         VERBATIM
         COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
-        COMMAND ${CMAKE_OBJCOPY} --strip-debug ${strip_source_file}
+        COMMAND ${CMAKE_OBJCOPY} --strip-unneeded ${strip_source_file}
         COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
         COMMENT "Stripping symbols from ${strip_source_file} into file ${strip_destination_file}"
         )

--- a/src/coreclr/src/debug/daccess/CMakeLists.txt
+++ b/src/coreclr/src/debug/daccess/CMakeLists.txt
@@ -45,11 +45,14 @@ add_dependencies(daccess eventing_headers)
 if(CLR_CMAKE_HOST_OSX OR CLR_CMAKE_HOST_FREEBSD OR CLR_CMAKE_HOST_NETBSD OR CLR_CMAKE_HOST_SUNOS)
   add_definitions(-DUSE_DAC_TABLE_RVA)
 
+  set(args $<$<NOT:$<BOOL:${CLR_CMAKE_HOST_OSX}>>:--dynamic> $<TARGET_FILE:coreclr> ${GENERATED_INCLUDE_DIR}/dactablerva.h)
+
   add_custom_command(
     OUTPUT  ${GENERATED_INCLUDE_DIR}/dactablerva.h
     DEPENDS coreclr
     VERBATIM
-    COMMAND sh ${CLR_DIR}/src/pal/tools/gen-dactable-rva.sh $<TARGET_FILE:coreclr> ${GENERATED_INCLUDE_DIR}/dactablerva.h
+    COMMAND_EXPAND_LISTS
+    COMMAND sh ${CLR_DIR}/src/pal/tools/gen-dactable-rva.sh ${args}
     COMMENT Generating ${GENERATED_INCLUDE_DIR}/dactablerva.h
   )
 

--- a/src/coreclr/src/pal/tools/gen-dactable-rva.sh
+++ b/src/coreclr/src/pal/tools/gen-dactable-rva.sh
@@ -1,1 +1,7 @@
-${NM:-nm} -P -D -t x $1 | awk -F ' ' '/g_dacTable/ { print "#define DAC_TABLE_RVA 0x" substr("0000000000000000" $3, length($3) + 1); exit }' > $2
+if [ "$1" = "--dynamic" ]; then
+  __DynamicSymbolsOption="-D"
+  shift
+else
+  __DynamicSymbolsOption=""
+fi
+${NM:-nm} $__DynamicSymbolsOption -P -t x $1 | awk -F ' ' '/g_dacTable/ { print "#define DAC_TABLE_RVA 0x" substr("0000000000000000" $3, length($3) + 1); exit }' > $2

--- a/src/coreclr/src/pal/tools/gen-dactable-rva.sh
+++ b/src/coreclr/src/pal/tools/gen-dactable-rva.sh
@@ -1,1 +1,1 @@
-${NM:-nm} -P -t x $1 | awk -F ' ' '/g_dacTable/ { print "#define DAC_TABLE_RVA 0x" substr("0000000000000000" $3, length($3) + 1); exit }' > $2
+${NM:-nm} -P -D -t x $1 | awk -F ' ' '/g_dacTable/ { print "#define DAC_TABLE_RVA 0x" substr("0000000000000000" $3, length($3) + 1); exit }' > $2


### PR DESCRIPTION
We are currently stripping only debug symbols, but there are also other
symbols that can be stripped without affecting debuggability or anything
else. We were stripping the binaries in corefx that way in the past,
but some time ago we have unified the stripping between the former
three repos and started to strip just the debugging symbols.

This change strips all unneeded symbols, which results in significant
reduction of the binaries sizes. The table below shows the reduction 
for x64 Linux:

| File | Before | After | Delta |
|-|-:|-:|-:|
| libSystem.IO.Compression.Native.so | 921680 | 805280 | 116400 |
| libSystem.IO.Ports.Native.so | 22552 | 18528 | 4024 |
| libSystem.Native.so | 95256 | 71784 | 23472 |
| libSystem.Net.Security.Native.so | 19112 | 14488 | 4624 |
| libSystem.Security.Cryptography.Native.OpenSsl.so | 163376 | 120952 | 42424 | 
| libclrgc.so | 854528 | 695976 | 158552 |
| libclrjit.so | 3323160 | 3093656 | 229504 |
| libcoreclr.so | 8732272 | 7027024 | 1705248 |
| libmscordaccore.so | 3174184 | 2568936 | 605248 |
| libmscordbi.so | 2389368 | 1828536 | 560832 |
| dotnet | 97368 | 72272 | 25096 |
| apphost | 103512 | 77352 | 26160 |
| libhostfxr.so | 416304 | 330184 | 86120 |
| libhostpolicy.so | 382720 | 293336 | 89384 |
| **Total** | **20695392** | **17018304** | **3677088** |

