### PR TITLE
Address warnings for possibly null array elements

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -152,7 +152,7 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool AreSame<T>(ref T left, ref T right)
+        public static bool AreSame<T>([AllowNull] ref T left, [AllowNull] ref T right)
         {
             throw new PlatformNotSupportedException();
 
@@ -172,7 +172,7 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsAddressGreaterThan<T>(ref T left, ref T right)
+        public static bool IsAddressGreaterThan<T>([AllowNull] ref T left, [AllowNull] ref T right)
         {
             throw new PlatformNotSupportedException();
 
@@ -192,7 +192,7 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsAddressLessThan<T>(ref T left, ref T right)
+        public static bool IsAddressLessThan<T>([AllowNull] ref T left, [AllowNull] ref T right)
         {
             throw new PlatformNotSupportedException();
 
@@ -368,7 +368,7 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static IntPtr ByteOffset<T>(ref T origin, ref T target)
+        public static IntPtr ByteOffset<T>([AllowNull] ref T origin, [AllowNull] ref T target)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -473,8 +473,8 @@ namespace System.Collections.Generic
             {
                 if (pivot == null)
                 {
-                    while (Unsafe.IsAddressLessThan(ref leftRef, ref nextToLastRef) && (leftRef = ref Unsafe.Add(ref leftRef, 1)) == null) ;
-                    while (Unsafe.IsAddressGreaterThan(ref rightRef, ref zeroRef) && (rightRef = ref Unsafe.Add(ref rightRef, -1)) == null) ;
+                    while (Unsafe.IsAddressLessThan(ref leftRef!, ref nextToLastRef) && (leftRef = ref Unsafe.Add(ref leftRef, 1)) == null) ;
+                    while (Unsafe.IsAddressGreaterThan(ref rightRef!, ref zeroRef) && (rightRef = ref Unsafe.Add(ref rightRef, -1)) == null) ;
                 }
                 else
                 {
@@ -552,7 +552,7 @@ namespace System.Collections.Generic
                     j--;
                 }
 
-                Unsafe.Add(ref MemoryMarshal.GetReference(keys), j + 1) = t;
+                Unsafe.Add(ref MemoryMarshal.GetReference(keys), j + 1) = t!;
             }
         }
 
@@ -1054,7 +1054,7 @@ namespace System.Collections.Generic
                     j--;
                 }
 
-                keys[j + 1] = t;
+                keys[j + 1] = t!;
                 values[j + 1] = tValue;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -473,8 +473,8 @@ namespace System.Collections.Generic
             {
                 if (pivot == null)
                 {
-                    while (Unsafe.IsAddressLessThan(ref leftRef!, ref nextToLastRef) && (leftRef = ref Unsafe.Add(ref leftRef, 1)) == null) ;
-                    while (Unsafe.IsAddressGreaterThan(ref rightRef!, ref zeroRef) && (rightRef = ref Unsafe.Add(ref rightRef, -1)) == null) ;
+                    while (Unsafe.IsAddressLessThan(ref leftRef, ref nextToLastRef) && (leftRef = ref Unsafe.Add(ref leftRef, 1)) == null) ;
+                    while (Unsafe.IsAddressGreaterThan(ref rightRef, ref zeroRef) && (rightRef = ref Unsafe.Add(ref rightRef, -1)) == null) ;
                 }
                 else
                 {

--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.CompilerServices
         public unsafe static void* Add<T>(void* source, int elementOffset) { throw null; }
         public static ref T Add<T>(ref T source, int elementOffset) { throw null; }
         public static ref T Add<T>(ref T source, System.IntPtr elementOffset) { throw null; }
-        public static bool AreSame<T>(ref T left, ref T right) { throw null; }
+        public static bool AreSame<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref T right) { throw null; }
         public unsafe static void* AsPointer<T>(ref T value) { throw null; }
         public unsafe static ref T AsRef<T>(void* source) { throw null; }
         public static ref T AsRef<T>(in T source) { throw null; }
@@ -21,7 +21,7 @@ namespace System.Runtime.CompilerServices
 #endif
         public static T? As<T>(object? o) where T : class? { throw null; }
         public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
-        public static System.IntPtr ByteOffset<T>(ref T origin, ref T target) { throw null; }
+        public static System.IntPtr ByteOffset<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref T origin, [System.Diagnostics.CodeAnalysis.AllowNull] ref T target) { throw null; }
         public static void CopyBlock(ref byte destination, ref byte source, uint byteCount) { }
         public unsafe static void CopyBlock(void* destination, void* source, uint byteCount) { }
         public static void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount) { }
@@ -32,8 +32,8 @@ namespace System.Runtime.CompilerServices
         public unsafe static void InitBlock(void* startAddress, byte value, uint byteCount) { }
         public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
         public unsafe static void InitBlockUnaligned(void* startAddress, byte value, uint byteCount) { }
-        public static bool IsAddressGreaterThan<T>(ref T left, ref T right) { throw null; }
-        public static bool IsAddressLessThan<T>(ref T left, ref T right) { throw null; }
+        public static bool IsAddressGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref T right) { throw null; }
+        public static bool IsAddressLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref T right) { throw null; }
         public static bool IsNullRef<T>(ref T source) { throw null; }
         public static ref T NullRef<T>() { throw null; }
         public static T ReadUnaligned<T>(ref byte source) { throw null; }


### PR DESCRIPTION
As of https://github.com/dotnet/roslyn/pull/46405, the C# compiler considers constraint types for conversions involving type parameter types.

A warning is reported for the following for instance:
```C#
#nullable enable

interface I { }

class Program
{
    static void F0<T>(ref T x, ref T y)
    {
    }
    static void F<T>(ref T x, ref T y) where T : I
    {
        if (x == null) { }
        F0(ref x, ref y); // warning: x may be null
    }
}
```

This results in several new warnings building dotnet/runtime (see https://github.com/dotnet/roslyn/issues/46577).