### PR TITLE
[wasm] Skip EnsureThrowWhenCopyToNonSharedFile on Browser

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -365,7 +365,7 @@ namespace System.IO.Tests
     /// <summary>
     /// Single tests that shouldn't be duplicated by inheritance.
     /// </summary>
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/40867", TestPlatforms.Browser)]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public sealed class File_Copy_Single : FileSystemTest
     {
         [Fact]

--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -365,7 +365,7 @@ namespace System.IO.Tests
     /// <summary>
     /// Single tests that shouldn't be duplicated by inheritance.
     /// </summary>
-    [PlatformSpecific(~TestPlatforms.Browser)]
+    [PlatformSpecific(~TestPlatforms.Browser)] // https://github.com/dotnet/runtime/issues/40867 - flock not supported
     public sealed class File_Copy_Single : FileSystemTest
     {
         [Fact]


### PR DESCRIPTION
Fixes #40867 

