### PR TITLE
Restrict generational aware analysis to processes that matches the command line configuration

### DIFF
--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -715,6 +715,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisGen, W("GCGenAnalysisGen"), 0, "The generation to trigger generational aware analysis")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisBytes, W("GCGenAnalysisBytes"), 0, "The number of bytes to trigger generational aware analysis")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisIndex, W("GCGenAnalysisIndex"), 0, "The gc index to trigger generational aware analysis")
+RETAIL_CONFIG_STRING_INFO(INTERNAL_GCGenAnalysisCmd, W("GCGenAnalysisCmd"), "An optional filter to match with the command line used to spawn the process")
 
 //
 // Diagnostics Ports

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -133,6 +133,8 @@
                             <opcode name="GCJoin" message="$(string.RuntimePublisher.GCJoinOpcodeMessage)" symbol="CLR_GC_JOIN_OPCODE" value="203"> </opcode>
                             <opcode name="GCPerHeapHistory" message="$(string.RuntimePublisher.GCPerHeapHistoryOpcodeMessage)" symbol="CLR_GC_GCPERHEAPHISTORY_OPCODE" value="204"> </opcode>
                             <opcode name="GCGlobalHeapHistory" message="$(string.RuntimePublisher.GCGlobalHeapHistoryOpcodeMessage)" symbol="CLR_GC_GCGLOBALHEAPHISTORY_OPCODE" value="205"> </opcode>
+                            <opcode name="GenAwareBegin" message="$(string.RuntimePublisher.GenAwareBeginOpcodeMessage)" symbol="CLR_GC_GENAWAREBEGIN_OPCODE" value="206"> </opcode>
+                            <opcode name="GenAwareEnd" message="$(string.RuntimePublisher.GenAwareEndOpcodeMessage)" symbol="CLR_GC_GENAWAREEND_OPCODE" value="207"> </opcode>
                         </opcodes>
                     </task>
 
@@ -989,6 +991,17 @@
                             <GCNoUserData xmlns="myNs">
                                 <ClrInstanceID> %1 </ClrInstanceID>
                             </GCNoUserData>
+                        </UserData>
+                    </template>
+
+                    <template tid="GenAwareTemplate">
+                        <data name="Count" inType="win:UInt32" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <GenAwareTemplate xmlns="myNs">
+                                <Count> %1 </Count>
+                                <ClrInstanceID> %2 </ClrInstanceID>
+                            </GenAwareTemplate>
                         </UserData>
                     </template>
 
@@ -3714,6 +3727,16 @@
                            task="GarbageCollection"
                            symbol="GCGlobalHeapHistory_V3" message="$(string.RuntimePublisher.GCGlobalHeap_V3EventMessage)"/>
 
+                    <event value="206" version="0" level="win:Informational"  template="GenAwareTemplate"
+                           keywords ="GCHeapDumpKeyword"  opcode="GenAwareBegin"
+                           task="GarbageCollection"
+                           symbol="GenAwareBegin" message="$(string.RuntimePublisher.GenAwareBeginEventMessage)"/>
+
+                    <event value="207" version="0" level="win:Informational"  template="GenAwareTemplate"
+                           keywords ="GCHeapDumpKeyword"  opcode="GenAwareEnd"
+                           task="GarbageCollection"
+                           symbol="GenAwareEnd" message="$(string.RuntimePublisher.GenAwareEndEventMessage)"/>
+
                     <!-- CLR Debugger events 240-249 -->
                     <event value="240" version="0" level="win:Informational"
                            keywords="DebuggerKeyword" opcode="win:Start"
@@ -3794,14 +3817,6 @@
                            keywords ="AssemblyLoaderKeyword" opcode="KnownPathProbed"
                            task="AssemblyLoader"
                            symbol="KnownPathProbed" message="$(string.RuntimePublisher.KnownPathProbedEventMessage)"/>
-
-                    <event value="297" version="0" level="win:Informational"
-                           keywords ="GCHeapDumpKeyword"
-                           symbol="GenAwareBegin" message="$(string.RuntimePublisher.GenAwareBeginEventMessage)"/>
-
-                    <event value="298" version="0" level="win:Informational"
-                           keywords ="GCHeapDumpKeyword"
-                           symbol="GenAwareEnd" message="$(string.RuntimePublisher.GenAwareEndEventMessage)"/>
                 </events>
             </provider>
 
@@ -7619,6 +7634,8 @@
                 <string id="RuntimePublisher.GCJoinOpcodeMessage" value="GCJoin" />
                 <string id="RuntimePublisher.GCPerHeapHistoryOpcodeMessage" value="PerHeapHistory" />
                 <string id="RuntimePublisher.GCGlobalHeapHistoryOpcodeMessage" value="GlobalHeapHistory" />
+                <string id="RuntimePublisher.GenAwareBeginOpcodeMessage" value="GenAwareBegin" />
+                <string id="RuntimePublisher.GenAwareEndOpcodeMessage" value="GenAwareEnd" />
                 <string id="RuntimePublisher.FinalizeObjectOpcodeMessage" value="FinalizeObject" />
                 <string id="RuntimePublisher.BulkTypeOpcodeMessage" value="BulkType" />
                 <string id="RuntimePublisher.MethodDetailsOpcodeMessage" value="MethodDetails" />

--- a/src/coreclr/src/vm/ceeload.cpp
+++ b/src/coreclr/src/vm/ceeload.cpp
@@ -11312,6 +11312,21 @@ LPCWSTR GetManagedCommandLine()
     return s_pCommandLine;
 }
 
+LPCWSTR GetCommandLineForDiagnostics()
+{
+    // Get the managed command line.
+    LPCWSTR pCmdLine = GetManagedCommandLine();
+
+    // Checkout https://github.com/dotnet/coreclr/pull/24433 for more information about this fall back.
+    if (pCmdLine == nullptr)
+    {
+        // Use the result from GetCommandLineW() instead
+        pCmdLine = GetCommandLineW();
+    }
+
+    return pCmdLine;
+}
+
 void Append_Next_Item(LPWSTR* ppCursor, SIZE_T* pRemainingLen, LPCWSTR pItem, bool addSpace)
 {
     // read the writeback args and setup pCursor and remainingLen
@@ -11417,14 +11432,7 @@ static void ProfileDataAllocateScenarioInfo(ProfileEmitter * pEmitter, LPCSTR sc
     //
     {
         // Get the managed command line.
-        LPCWSTR pCmdLine = GetManagedCommandLine();
-
-        // Checkout https://github.com/dotnet/coreclr/pull/24433 for more information about this fall back.
-        if (pCmdLine == nullptr)
-        {
-            // Use the result from GetCommandLineW() instead
-            pCmdLine = GetCommandLineW();
-        }
+        LPCWSTR pCmdLine = GetCommandLineForDiagnostics();
 
         S_SIZE_T cCmdLine = S_SIZE_T(wcslen(pCmdLine));
         cCmdLine += 1;

--- a/src/coreclr/src/vm/ceeload.h
+++ b/src/coreclr/src/vm/ceeload.h
@@ -3419,9 +3419,9 @@ struct VASigCookieEx : public VASigCookie
     const BYTE *m_pArgs;        // pointer to first unfixed unmanaged arg
 };
 
-// Rerieve the full command line for the current process.
-LPCWSTR GetManagedCommandLine();
 // Save the command line for the current process.
 void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv);
+
+LPCWSTR GetCommandLineForDiagnostics();
 
 #endif // !CEELOAD_H_

--- a/src/coreclr/src/vm/eeconfig.cpp
+++ b/src/coreclr/src/vm/eeconfig.cpp
@@ -38,7 +38,7 @@ Volatile<DWORD> GCStressPolicy::InhibitHolder::s_nGcStressDisabled = 0;
 
 /**************************************************************/
 // Poor mans narrow
-LPUTF8 NarrowWideChar(__inout_z LPWSTR str)
+LPUTF8 NarrowWideChar(__inout_z LPCWSTR str)
 {
     CONTRACT (LPUTF8)
     {
@@ -50,7 +50,7 @@ LPUTF8 NarrowWideChar(__inout_z LPWSTR str)
     } CONTRACT_END;
 
     if (str != 0) {
-        LPWSTR fromPtr = str;
+        LPCWSTR fromPtr = str;
         LPUTF8 toPtr = (LPUTF8) str;
         LPUTF8 result = toPtr;
         while(*fromPtr != 0)

--- a/src/coreclr/src/vm/eventpipe.cpp
+++ b/src/coreclr/src/vm/eventpipe.cpp
@@ -499,14 +499,7 @@ void EventPipe::DisableHelper(EventPipeSessionID id)
 static void LogProcessInformationEvent(EventPipeEventSource &eventSource)
 {
     // Get the managed command line.
-    LPCWSTR pCmdLine = GetManagedCommandLine();
-
-    // Checkout https://github.com/dotnet/coreclr/pull/24433 for more information about this fall back.
-    if (pCmdLine == nullptr)
-    {
-        // Use the result from GetCommandLineW() instead
-        pCmdLine = GetCommandLineW();
-    }
+    LPCWSTR pCmdLine = GetCommandLineForDiagnostics();
 
     // Log the process information event.
     eventSource.SendProcessInfo(pCmdLine);

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -1604,12 +1604,12 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGene
 #endif
         {
             gcGenAnalysisEventPipeSession->Resume();
-            FireEtwGenAwareBegin();
+            FireEtwGenAwareBegin((int)gcIndex, GetClrInstanceId());
             s_forcedGCInProgress = true;
             GCProfileWalkHeap(true);
             s_forcedGCInProgress = false;
             reportGenerationBounds();
-            FireEtwGenAwareEnd();
+            FireEtwGenAwareEnd((int)gcIndex, GetClrInstanceId());
             gcGenAnalysisEventPipeSession->Pause();
             gcGenAnalysisState = GcGenAnalysisState::Done;
             EnableFinalization(true);

--- a/src/coreclr/src/vm/genanalysis.cpp
+++ b/src/coreclr/src/vm/genanalysis.cpp
@@ -18,27 +18,33 @@ uint32_t gcGenAnalysisBufferMB = 0;
 #ifndef GEN_ANALYSIS_STRESS
     if (gcGenAnalysisConfigured == GcGenAnalysisState::Uninitialized)
     {
-        if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
+        bool match = true;
+        CLRConfigStringHolder gcGenAnalysisCmd(CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisCmd));
+        if (gcGenAnalysisCmd != nullptr)
         {
+            // Get the managed command line.
+            LPCWSTR pCmdLine = GetCommandLineForDiagnostics();
+            match = wcsncmp(pCmdLine, gcGenAnalysisCmd, wcslen(gcGenAnalysisCmd)) == 0;
+        }
+        if (match && !CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
+        {
+            match = false;
+        }
+        if (match && !CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisBytes")))
+        {
+            match = false;
+        }
+        if (match)
+        {
+            gcGenAnalysisBytes = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisBytes);
             gcGenAnalysisGen = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisGen);
-            if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisBytes")))
-            {
-                gcGenAnalysisBytes = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisBytes);
-                if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisIndex")))
-                {
-                    gcGenAnalysisIndex = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisIndex);
-                    gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
-                    gcGenAnalysisBufferMB = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeCircularMB);
-                }
-                else
-                {
-                    gcGenAnalysisConfigured = GcGenAnalysisState::Disabled;
-                }
-            }
-            else
-            {
-                gcGenAnalysisConfigured = GcGenAnalysisState::Disabled;
-            }
+            gcGenAnalysisIndex = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisIndex);
+            gcGenAnalysisBufferMB = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeCircularMB);
+            gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
+        }
+        else
+        {
+            gcGenAnalysisConfigured = GcGenAnalysisState::Disabled;
         }
     }
     if ((gcGenAnalysisConfigured == GcGenAnalysisState::Enabled) && (gcGenAnalysisState == GcGenAnalysisState::Uninitialized))

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -278,14 +278,7 @@ void ProcessDiagnosticsProtocolHelper::GetProcessInfo(DiagnosticsIpc::IpcMessage
     struct ProcessInfoPayload payload = {};
 
     // Get cmdline
-    payload.CommandLine = GetManagedCommandLine();
-
-    // Checkout https://github.com/dotnet/coreclr/pull/24433 for more information about this fall back.
-    if (payload.CommandLine == nullptr)
-    {
-        // Use the result from GetCommandLineW() instead
-        payload.CommandLine = GetCommandLineW();
-    }
+    payload.CommandLine = GetCommandLineForDiagnostics();
 
     // get OS + Arch info
     payload.OS = EventPipeEventSource::s_pOSInformation;


### PR DESCRIPTION
This change helps with the scenario where customers who wanted to perform the analysis but otherwise have little control over the spawning of the process that requires the analysis.

This also adds `gc_index` to the payload of the delimiter events to make it easier to correlate with traces obtained at the same time (e.g through `PerfView /GCCollectOnly`.)