### PR TITLE
Fix Memory Leak in System.DirectoryServices.Protocols caused by not freeing native memory

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -169,6 +169,9 @@ internal static partial class Interop
     [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_memfree", CharSet = CharSet.Ansi)]
     public static extern void ldap_memfree([In] IntPtr value);
 
+    [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_msgfree", CharSet = CharSet.Ansi)]
+    public static extern void ldap_msgfree([In] IntPtr value);
+
     [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_modify_ext", CharSet = CharSet.Ansi)]
     public static extern int ldap_modify([In] ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -54,6 +54,8 @@ namespace System.DirectoryServices.Protocols
 
         internal static void FreeMemory(IntPtr outValue) => Interop.ldap_memfree(outValue);
 
+        internal static void FreeMessage(IntPtr outValue) => Interop.ldap_msgfree(outValue);
+
         internal static int ModifyDirectoryEntry(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber) =>
                                 Interop.ldap_modify(ldapHandle, dn, attrs, servercontrol, clientcontrol, ref messageNumber);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Windows.cs
@@ -48,6 +48,8 @@ namespace System.DirectoryServices.Protocols
 
         internal static void FreeMemory(IntPtr outValue) => Interop.ldap_memfree(outValue);
 
+        internal static void FreeMessage(IntPtr outValue) => Interop.ldap_msgfree(outValue);
+
         internal static int ModifyDirectoryEntry(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber) =>
                                 Interop.ldap_modify(ldapHandle, dn, attrs, servercontrol, clientcontrol, ref messageNumber);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -1604,7 +1604,7 @@ namespace System.DirectoryServices.Protocols
 
                     if (ldapResult != IntPtr.Zero)
                     {
-                        LdapPal.FreeMemory(ldapResult);
+                        LdapPal.FreeMessage(ldapResult);
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/40946
Fixes https://github.com/dotnet/runtime/issues/39009

During the refactoring of S.DS.P, we changed some code that would get the search results back from an LDAP server and accidentally started calling the wrong native call to free the memory coming back from that result, causing it to a) have a big memory leak especially when we were getting a lot of results back and also b) we were sometimes causing a SegFault abort when we would sometimes free memory we didn't own. This PR will call ldap_msgfree instead of ldap_memfree to fix that issue and I have validated that the memory leak is fixed after this, and we don't have consistent repro for the memory corruption issue but will be most likely fixed by this as well.

cc: @tarekgh @danmosemsft @jkotas 