### PR TITLE
Avoid having two copies of System.Private.CoreLib.ni.pdb in the same NuGet package directory

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -86,11 +86,13 @@
 
     <PropertyGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
       <CoreCLRArtifactsPath>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)'))</CoreCLRArtifactsPath>
+      <CoreCLRArtifactsPdbDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)','PDB'))</CoreCLRArtifactsPdbDir>
       <!--
         Even though CoreCLRSharedFrameworkDir is statically initialized, set it again in case the
         value is different after CoreCLRArtifactsPath is normalized.
       -->
       <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)','sharedFramework'))</CoreCLRSharedFrameworkDir>
+      <CoreCLRSharedFrameworkPdbDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRSharedFrameworkDir)','PDB'))</CoreCLRSharedFrameworkPdbDir>
       <CoreCLRCrossTargetComponentDir
         Condition="'$(CoreCLRCrossTargetComponentDirName)' != ''">$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)','$(CoreCLRCrossTargetComponentDirName)','sharedFramework'))</CoreCLRCrossTargetComponentDir>
     </PropertyGroup>
@@ -112,18 +114,19 @@
       <RuntimeFiles Include="@(_systemPrivateCoreLib)" />
       <RuntimeFiles
         Include="
-          $(CoreCLRSharedFrameworkDir)PDB/*.pdb;
-          $(CoreCLRSharedFrameworkDir)PDB/*.dbg;
-          $(CoreCLRSharedFrameworkDir)PDB/*.dwarf" />
+          $(CoreCLRSharedFrameworkPdbDir)*.pdb;
+          $(CoreCLRSharedFrameworkPdbDir)*.dbg;
+          $(CoreCLRSharedFrameworkPdbDir)*.dwarf" />
       <RuntimeFiles
-        Include="$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.pdb;" />
-      <RuntimeFiles Condition="Exists('$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb')"
-        Include="$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb" />
+        Include="$(CoreCLRArtifactsPdbDir)System.Private.CoreLib.pdb" />
+      <RuntimeFiles Condition="Exists('$(CoreCLRArtifactsPdbDir)System.Private.CoreLib.ni.pdb')"
+        Include="$(CoreCLRArtifactsPdbDir)System.Private.CoreLib.ni.pdb" />
+
       <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''"
         Include="
-          $(CoreCLRCrossTargetComponentDir)PDB/*.pdb;
-          $(CoreCLRCrossTargetComponentDir)PDB/*.dbg;
-          $(CoreCLRCrossTargetComponentDir)PDB/*.dwarf" />
+          $(CoreCLRSharedFrameworkPdbDir)*.pdb;
+          $(CoreCLRSharedFrameworkPdbDir)*.dbg;
+          $(CoreCLRSharedFrameworkPdbDir)*.dwarf" />
 
       <CoreCLRCrossTargetFiles>
         <TargetPath>runtime/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -87,7 +87,11 @@
     </MSBuild>
 
     <ItemGroup>
-      <File Include="@(Crossgen2File)">
+      <!-- Avoid having two copies of System.Private.CoreLib.ni.pdb in the same directory -->
+      <Crossgen2File Update="@(Crossgen2File)" SavedIdentity="%(Identity)" />
+      <Crossgen2FileDistinct Include="@(Crossgen2File->'%(Filename)%(Extension)'->Distinct())" />
+
+      <File Include="@(Crossgen2FileDistinct->'%(SavedIdentity)')" RemoveMetadata="SavedIdentity">
         <TargetPath>tools</TargetPath>
       </File>
     </ItemGroup>


### PR DESCRIPTION
Fixes #34412. I have found that other symbol packages (e.g., `Microsoft.NETCore.App.Runtime.win-x64.5.0.0-dev.symbols.nupkg`) also contain two copies of `System.Private.CoreLib.ni.pdb`; however, we put them into two different directories (thus no error):
* artifacts\bin\coreclr\Windows_NT.x64.Release\PDB\System.Private.CoreLib.ni.pdb
TargetPath = runtimes/win-x64/native
* artifacts\bin\win-x64.Release\symbols\netcoreapp\runtimes\win-x64\native\System.Private.CoreLib.ni.pdb
TargetPath = runtimes/win-x64/lib/net5.0

And for `Microsoft.NETCore.App.Crossgen2.win-x64.5.0.0-dev.symbols.nupkg` package we override those `TargetPath`s with the same value here: https://github.com/dotnet/runtime/blob/da669c474cc595efce538f33c8de593926a9ee21/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj#L90-L92 The fix is to remove duplicate filenames from the list of files to package.  While debugging it, I noticed that we create and process multiple items for some PDB files: one containing `PDB/`, another containing `PDB\`. Fix that as well.