### PR TITLE
Fix mono_wasm_invoke_js_blazor in dotnet_support.js

### DIFF
--- a/src/mono/wasm/runtime/dotnet_support.js
+++ b/src/mono/wasm/runtime/dotnet_support.js
@@ -31,6 +31,9 @@ var DotNetSupportLib = {
 	},
 
 	mono_wasm_invoke_js_blazor: function(exceptionMessage, callInfo, arg0, arg1, arg2)	{
+		var mono_string = DOTNET._dotnet_get_global()._mono_string_cached
+			|| (DOTNET._dotnet_get_global()._mono_string_cached = Module.cwrap('mono_wasm_string_from_js', 'number', ['string']));
+
 		try {
 			var blazorExports = DOTNET._dotnet_get_global().Blazor;
 			if (!blazorExports) {


### PR DESCRIPTION
### Summary

References to `mono_string` in `mono_wasm_invoke_js_blazor` resulted in a `ReferenceError` since `mono_string` was not defined. This impacted any JS interop calls that threw unhandled exceptions. This fix creates a local variable `mono_string` similar to how it is done in `mono_wasm_invoke_js_marshalled`.