### PR TITLE
Improve tailcallstress testing

### DIFF
--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
@@ -1061,7 +1061,7 @@ namespace System.Threading.Tasks.Tests
             {
                 int newVal = Interlocked.Increment(ref counter);
                 if (newVal == 1) throw new Exception("some non-cancellation-related exception");
-                if (newVal == 2) cts.Cancel();
+                if (newVal >= 2) cts.Cancel();
             };
             for (int i = 0; i < numActions; i++) actions[i] = a3;
 

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -29,8 +29,8 @@ namespace System.Threading.Threads.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void ConstructorTest()
         {
-            const int SmallStackSizeBytes = 64 << 10; // 64 KB, currently accepted in all supported platforms, and is the PAL minimum
-            const int LargeStackSizeBytes = 16 << 20; // 16 MB
+            const int SmallStackSizeBytes = 128 << 10; // 128 KB
+            const int LargeStackSizeBytes = 16 << 20;  // 16 MB
 
             int pageSizeBytes = Environment.SystemPageSize;
 


### PR DESCRIPTION
1. Dispatch all tail calls under TailCallStress via helpers. That
increases our coverage since valid non-tail-prefixed calls are
dispatched as fast calls in normal non-stress mode.

2. Don't attempt to tail call from methods that have a localloc
unless there is an explicit tail prefix. Note that we already disallowed
fast tail calls from such methods so this change only affects
tailcallstress mode.

3. Fix a bug in TestInvokeDOPAndCancel. As the test was written
this assert was firing under tailcallstress:
https://github.com/dotnet/runtime/blob/480c49b2419ab4a0b34bfd86754abc2f17079c77/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs#L1074
When this call to `cts.Cancel`:
https://github.com/dotnet/runtime/blob/480c49b2419ab4a0b34bfd86754abc2f17079c77/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs#L1065
is dispatched via helpers, it takes much longer than when it's
dispatched via a fast tail call (we have to jit a couple of IL stubs).
Because of that, it's possible that all other actions complete on the
other thread before cancellation is completed.