### PR TITLE
Enable nullability on System.Xml.XPath

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathException.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathException.cs
@@ -17,7 +17,7 @@ namespace System.Xml.XPath
     {
         // we need to keep this members for V1 serialization compatibility
         private readonly string _res;
-        private readonly string[]? _args;
+        private readonly string?[]? _args;
 
         // message != null for V1 & V2 exceptions deserialized in Whidbey
         // message == null for created V2 exceptions; the exception message is stored in Exception._message
@@ -60,10 +60,10 @@ namespace System.Xml.XPath
 
         public XPathException() : this(string.Empty, (Exception?)null) { }
 
-        public XPathException(string message) : this(message, (Exception?)null) { }
+        public XPathException(string? message) : this(message, (Exception?)null) { }
 
-        public XPathException(string message, Exception? innerException) :
-            this(SR.Xml_UserException, new string[] { message }, innerException)
+        public XPathException(string? message, Exception? innerException) :
+            this(SR.Xml_UserException, new string?[] { message }, innerException)
         {
         }
 
@@ -92,7 +92,7 @@ namespace System.Xml.XPath
         {
         }
 
-        private XPathException(string res, string[]? args, Exception? inner) :
+        private XPathException(string res, string?[]? args, Exception? inner) :
             base(CreateMessage(res, args), inner)
         {
             HResult = HResults.XmlXPath;
@@ -100,7 +100,7 @@ namespace System.Xml.XPath
             _args = args;
         }
 
-        private static string CreateMessage(string res, string[]? args)
+        private static string CreateMessage(string res, string?[]? args)
         {
             try
             {

--- a/src/libraries/System.Xml.XPath/ref/System.Xml.XPath.cs
+++ b/src/libraries/System.Xml.XPath/ref/System.Xml.XPath.cs
@@ -20,8 +20,8 @@ namespace System.Xml.XPath
     {
         public XPathException() { }
         protected XPathException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public XPathException(string message) { }
-        public XPathException(string message, System.Exception innerException) { }
+        public XPathException(string? message) { }
+        public XPathException(string? message, System.Exception? innerException) { }
         public override string Message { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }

--- a/src/libraries/System.Xml.XPath/ref/System.Xml.XPath.csproj
+++ b/src/libraries/System.Xml.XPath/ref/System.Xml.XPath.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Xml.XPath.cs" />

--- a/src/libraries/System.Xml.XPath/src/System.Xml.XPath.csproj
+++ b/src/libraries/System.Xml.XPath/src/System.Xml.XPath.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Private.Xml\src\System.Private.Xml.csproj" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/2339
~No annotations are needed for the APIs exposed in this assembly.~
Add missing annotations to `XPathException`.