### PR TITLE
Fix Memory Leak in System.DirectoryServices.Protocols caused by not freeing native memory

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -169,6 +169,9 @@ internal static partial class Interop
     [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_memfree", CharSet = CharSet.Ansi)]
     public static extern void ldap_memfree([In] IntPtr value);
 
+    [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_msgfree", CharSet = CharSet.Ansi)]
+    public static extern void ldap_msgfree([In] IntPtr value);
+
     [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_modify_ext", CharSet = CharSet.Ansi)]
     public static extern int ldap_modify([In] ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -54,6 +54,8 @@ namespace System.DirectoryServices.Protocols
 
         internal static void FreeMemory(IntPtr outValue) => Interop.ldap_memfree(outValue);
 
+        internal static void FreeMessage(IntPtr outValue) => Interop.ldap_msgfree(outValue);
+
         internal static int ModifyDirectoryEntry(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber) =>
                                 Interop.ldap_modify(ldapHandle, dn, attrs, servercontrol, clientcontrol, ref messageNumber);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Windows.cs
@@ -48,6 +48,8 @@ namespace System.DirectoryServices.Protocols
 
         internal static void FreeMemory(IntPtr outValue) => Interop.ldap_memfree(outValue);
 
+        internal static void FreeMessage(IntPtr outValue) => Interop.ldap_msgfree(outValue);
+
         internal static int ModifyDirectoryEntry(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber) =>
                                 Interop.ldap_modify(ldapHandle, dn, attrs, servercontrol, clientcontrol, ref messageNumber);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -1604,7 +1604,7 @@ namespace System.DirectoryServices.Protocols
 
                     if (ldapResult != IntPtr.Zero)
                     {
-                        LdapPal.FreeMemory(ldapResult);
+                        LdapPal.FreeMessage(ldapResult);
                     }
                 }
             }


### PR DESCRIPTION
Porting https://github.com/dotnet/runtime/pull/41053 to release/5.0
Fixes #40946

## Description
During a recent refactoring of System.DirectoryServices.Protocols code that added Linux implementation for the library, one bug was introduced since we started calling the wrong PInvoke in order to free some native resources which lead to a memory leak that would hit both the Windows and Unix case. This PR will make sure we call the right free instead so that the native resources are freed up correctly.

## Customer Impact
Customers will not get a memory leak regression.

## Regression?
Yes

## Risk
low. Extensive testing was performed using both Benchmark.NET and the VS profiler in order to validate that these changes are now correctly freeing up the resources.

## Test changes in this PR
We don't have the ability to test against a real LDAP server yet which is what would have caught this issue, but we have had several test runs since the original change was introduced where we would have native memory corruption and test execution would come to a halt. This change will make it so that will stop happening as we now know who was freeing up memory incorrectly.

cc: @danmosemsft @tarekgh 