### PR TITLE
Fix NativeBinDir for individual projects when BuildTargetFramework is  not set

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -71,7 +71,9 @@
   <!-- Common repo directories -->
   <PropertyGroup>
     <!-- Need to try and keep the same logic as the native builds as we need this for packaging -->
-    <NativeBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(BuildTargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)'))</NativeBinDir>
+    <_targetFrameworkValue>$([MSBuild]::ValueOrDefault('$(BuildTargetFramework)', '$(TargetFramework)'))</_targetFrameworkValue>
+    <_targetFrameworkValue>$([MSBuild]::ValueOrDefault('$(_targetFrameworkValue)', '$(NetCoreAppCurrent)'))</_targetFrameworkValue>
+    <NativeBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(_targetFrameworkValue)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)'))</NativeBinDir>
     <PkgDir>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'pkg'))</PkgDir>
   </PropertyGroup>
 


### PR DESCRIPTION
When doing things like for example 

Fixes: #41027

```
dotnet build src/libraries/src.proj /t:BuildWasmRuntimes /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=Release
```

To re-generate the wasm runtime, we depend on the NativeBinDir and BuildTargetFramework is not set on that case.

cc: @steveisok @Anipik @ViktorHofer @akoeplinger 