### PR TITLE
Fix GetAppdomainStaticAddress for non-collectible assemblies

### DIFF
--- a/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
@@ -3085,7 +3085,7 @@ HRESULT ProfToEEInterfaceImpl::GetRVAStaticAddress(ClassID classId,
  * Returns:
  *    S_OK on success,
  *    E_INVALIDARG if not an app domain static,
- *    CORPROF_E_DATAINCOMPLETE if not yet initialized.
+ *    CORPROF_E_DATAINCOMPLETE if not yet initialized or the module is being unloaded.
  *
  */
 HRESULT ProfToEEInterfaceImpl::GetAppDomainStaticAddress(ClassID classId,

--- a/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
@@ -3146,8 +3146,10 @@ HRESULT ProfToEEInterfaceImpl::GetAppDomainStaticAddress(ClassID classId,
         return CORPROF_E_DATAINCOMPLETE;
     }
 
-    if (typeHandle.GetModule()->GetLoaderAllocator() == NULL ||
-        typeHandle.GetModule()->GetLoaderAllocator()->GetExposedObject() == NULL)
+    // We might have caught a collectible assembly in the middle of being collected
+    Module *pModule = typeHandle.GetModule();
+    if (pModule->IsCollectible() &&
+        (pModule->GetLoaderAllocator() == NULL || pModule->GetLoaderAllocator()->GetExposedObject() == NULL))
     {
         return CORPROF_E_DATAINCOMPLETE;
     }

--- a/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.cpp
+++ b/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.cpp
@@ -24,6 +24,8 @@ GetAppDomainStaticAddress::GetAppDomainStaticAddress() :
     refCount(0),
     failures(0),
     successes(0),
+    collectibleCount(0),
+    nonCollectibleCount(0),
     jitEventCount(0),
     gcTriggerThread(),
     gcWaitEvent(),
@@ -111,13 +113,14 @@ HRESULT GetAppDomainStaticAddress::Shutdown()
         this->pCorProfilerInfo = nullptr;
     }
 
-    if(failures == 0 && successes > 0)
+    if(failures == 0 && successes > 0 && collectibleCount > 0 && nonCollectibleCount > 0)
     {
         printf("PROFILER TEST PASSES\n");
     }
     else
     {
-        printf("Test failed number of failures=%d successes=%d\n", failures.load(), successes.load());
+        printf("Test failed number of failures=%d successes=%d collectibleCount=%d nonCollectibleCount=%d\n",
+            failures.load(), successes.load(), collectibleCount.load(), nonCollectibleCount.load());
     }
     fflush(stdout);
 
@@ -403,7 +406,7 @@ HRESULT GetAppDomainStaticAddress::GarbageCollectionFinished()
             // Module is being unloaded...
             continue;
         }
-        if (FAILED(hr))
+        else if (FAILED(hr))
         {
             printf("GetModuleMetaData returned 0x%x  for ModuleID 0x%" PRIxPTR "\n", hr, classModuleId);
             ++failures;
@@ -434,7 +437,7 @@ HRESULT GetAppDomainStaticAddress::GarbageCollectionFinished()
             // Class load not complete.  We can not inspect yet.
             continue;
         }
-        if (FAILED(hr))
+        else if (FAILED(hr))
         {
             printf("GetClassIDInfo2returned 0x%x\n", hr);
             ++failures;
@@ -514,6 +517,18 @@ HRESULT GetAppDomainStaticAddress::GarbageCollectionFinished()
                         printf("GetAppDomainStaticAddress Failed HR 0x%x\n", hr);
                         ++failures;
                         continue;
+                    }
+                    else if (hr != CORPROF_E_DATAINCOMPLETE)
+                    {
+                        String moduleName = GetModuleIDName(classModuleId);
+                        if (EndsWith(moduleName, L"unloadlibrary.dll"))
+                        {
+                            ++collectibleCount;
+                        }
+                        else
+                        {
+                            ++nonCollectibleCount;
+                        }
                     }
                 }
             }

--- a/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.cpp
+++ b/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.cpp
@@ -521,7 +521,7 @@ HRESULT GetAppDomainStaticAddress::GarbageCollectionFinished()
                     else if (hr != CORPROF_E_DATAINCOMPLETE)
                     {
                         String moduleName = GetModuleIDName(classModuleId);
-                        if (EndsWith(moduleName, L"unloadlibrary.dll"))
+                        if (EndsWith(moduleName, WCHAR("unloadlibrary.dll")))
                         {
                             ++collectibleCount;
                         }

--- a/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.h
+++ b/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.h
@@ -88,6 +88,8 @@ private:
     std::atomic<int> refCount;
     std::atomic<ULONG32> failures;
     std::atomic<ULONG32> successes;
+    std::atomic<ULONG32> collectibleCount;
+    std::atomic<ULONG32> nonCollectibleCount;
 
     std::atomic<int> jitEventCount;
     std::thread gcTriggerThread;

--- a/src/tests/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
+++ b/src/tests/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
@@ -165,32 +165,6 @@ HRESULT MetaDataGetDispenser::GetDispenser(IMetaDataDispenserEx **disp)
 
 #else // WIN32
 
-bool EndsWith(const char *lhs, const char *rhs)
-{
-    size_t lhsLen = strlen(lhs);
-    size_t rhsLen = strlen(rhs);
-    if (lhsLen < rhsLen)
-    {
-        return false;
-    }
-
-    size_t lhsPos = lhsLen - rhsLen;
-    size_t rhsPos = 0;
-
-    while (rhsPos < rhsLen)
-    {
-        if (lhs[lhsPos] != rhs[rhsPos])
-        {
-            return false;
-        }
-
-        ++lhsPos;
-        ++rhsPos;
-    }
-
-    return true;
-}
-
 #ifdef __APPLE__
 string GetCoreCLRPath()
 {

--- a/src/tests/profiler/native/profilerstring.h
+++ b/src/tests/profiler/native/profilerstring.h
@@ -261,7 +261,7 @@ public:
         return temp;
     }
 
-    size_t Size() const
+    size_t Length() const
     {
         return wcslen(buffer);
     }
@@ -280,4 +280,56 @@ inline std::wostream& operator<<(std::wostream& os, const String& obj)
     }
 
     return os;
+}
+
+inline bool EndsWith(const char *lhs, const char *rhs)
+{
+    size_t lhsLen = strlen(lhs);
+    size_t rhsLen = strlen(rhs);
+    if (lhsLen < rhsLen)
+    {
+        return false;
+    }
+
+    size_t lhsPos = lhsLen - rhsLen;
+    size_t rhsPos = 0;
+
+    while (rhsPos < rhsLen)
+    {
+        if (lhs[lhsPos] != rhs[rhsPos])
+        {
+            return false;
+        }
+
+        ++lhsPos;
+        ++rhsPos;
+    }
+
+    return true;
+}
+
+inline bool EndsWith(const String &lhs, const String &rhs)
+{
+    size_t lhsLength = lhs.Length();
+    size_t rhsLength = rhs.Length();
+    if (lhsLength < rhsLength)
+    {
+        return false;
+    }
+
+    size_t lhsPos = lhsLength - rhsLength;
+    size_t rhsPos = 0;
+
+    while (rhsPos < rhsLength)
+    {
+        if (std::tolower(lhs[lhsPos]) != std::tolower(rhs[rhsPos]))
+        {
+            return false;
+        }
+
+        ++lhsPos;
+        ++rhsPos;
+    }
+
+    return true;
 }

--- a/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -492,27 +492,3 @@ ModuleID ReJITProfiler::GetModuleIDForFunction(FunctionID functionId)
                                             typeArgs);
     return moduleId;
 }
-
-bool ReJITProfiler::EndsWith(const String &lhs, const String &rhs)
-{
-    if (lhs.Size() < rhs.Size())
-    {
-        return false;
-    }
-
-    size_t lhsPos = lhs.Size() - rhs.Size();
-    size_t rhsPos = 0;
-
-    while (rhsPos < rhs.Size())
-    {
-        if (std::tolower(lhs[lhsPos]) != std::tolower(rhs[rhsPos]))
-        {
-            return false;
-        }
-
-        ++lhsPos;
-        ++rhsPos;
-    }
-
-    return true;
-}

--- a/src/tests/profiler/native/rejitprofiler/rejitprofiler.h
+++ b/src/tests/profiler/native/rejitprofiler/rejitprofiler.h
@@ -51,7 +51,6 @@ private:
     FunctionID GetFunctionIDFromToken(ModuleID module, mdMethodDef token);
     mdMethodDef GetMethodDefForFunction(FunctionID functionId);
     ModuleID GetModuleIDForFunction(FunctionID functionId);
-    bool EndsWith(const String &lhs, const String &rhs);
 
     ICorProfilerInfo10 *_profInfo10;
     std::atomic<int> _failures;


### PR DESCRIPTION
Fixes #40954

#34677 had a bug in it that it would check if pModule->GetLoaderAllocator()->GetExposedObject was NULL, which is the right thing to check for collectible modules but non-collectible modules it will always be NULL.