### PR TITLE
Change nullability of public IXmlNamespaceResolver parameters where appropriate

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
@@ -1784,7 +1784,7 @@ namespace System.Xml
             return base.ReadContentAsObject();
         }
 
-        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             int origPos = _pos;
             try
@@ -4229,7 +4229,7 @@ namespace System.Xml
             return xsst.ValueConverter;
         }
 
-        private object ValueAs(BinXmlToken token, Type returnType, IXmlNamespaceResolver namespaceResolver)
+        private object ValueAs(BinXmlToken token, Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             object value;
             CheckValueTokenBounds();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckReader.cs
@@ -278,7 +278,7 @@ namespace System.Xml
             return _coreReader.ReadContentAsString();
         }
 
-        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             CheckAsync();
             return _coreReader.ReadContentAs(returnType, namespaceResolver);
@@ -801,7 +801,7 @@ namespace System.Xml
             return task;
         }
 
-        public override Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public override Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             CheckAsync();
             var task = _coreReader.ReadContentAsAsync(returnType, namespaceResolver);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
@@ -378,7 +378,7 @@ namespace System.Xml
 
         // Concatenates values of textual nodes of the current content, ignoring comments and PIs, expanding entity references,
         // and converts the content to the requested type. Stops at start tags and end tags.
-        public virtual object ReadContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public virtual object ReadContentAs(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             if (!CanReadContentAs())
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
@@ -48,7 +48,7 @@ namespace System.Xml
 
         // Concatenates values of textual nodes of the current content, ignoring comments and PIs, expanding entity references,
         // and converts the content to the requested type. Stops at start tags and end tags.
-        public virtual async Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public virtual async Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             if (!CanReadContentAs())
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReader.cs
@@ -799,7 +799,7 @@ namespace System.Xml
             }
         }
 
-        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             try
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
@@ -214,7 +214,7 @@ namespace System.Xml
             }
         }
 
-        public override async Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public override async Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             try
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
@@ -728,7 +728,7 @@ namespace System.Xml
             }
         }
 
-        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public override object ReadContentAs(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             if (!CanReadContentAs(this.NodeType))
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReaderAsync.cs
@@ -74,7 +74,7 @@ namespace System.Xml
             }
         }
 
-        public override async Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver)
+        public override async Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver? namespaceResolver)
         {
             if (!CanReadContentAs(this.NodeType))
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathExpr.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathExpr.cs
@@ -51,7 +51,7 @@ namespace System.Xml.XPath
 
         public abstract void SetContext(XmlNamespaceManager nsManager);
 
-        public abstract void SetContext(IXmlNamespaceResolver nsResolver);
+        public abstract void SetContext(IXmlNamespaceResolver? nsResolver);
 
         public abstract XPathResultType ReturnType { get; }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathNavigator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathNavigator.cs
@@ -1186,7 +1186,7 @@ namespace System.Xml.XPath
             return this.Select(XPathExpression.Compile(xpath));
         }
 
-        public virtual XPathNodeIterator Select(string xpath, IXmlNamespaceResolver resolver)
+        public virtual XPathNodeIterator Select(string xpath, IXmlNamespaceResolver? resolver)
         {
             return this.Select(XPathExpression.Compile(xpath, resolver));
         }
@@ -1206,7 +1206,7 @@ namespace System.Xml.XPath
             return Evaluate(XPathExpression.Compile(xpath), null);
         }
 
-        public virtual object Evaluate(string xpath, IXmlNamespaceResolver resolver)
+        public virtual object Evaluate(string xpath, IXmlNamespaceResolver? resolver)
         {
             return this.Evaluate(XPathExpression.Compile(xpath, resolver));
         }


### PR DESCRIPTION
As per https://github.com/dotnet/runtime/pull/40744#discussion_r470396889:
Changes parameter to `IXmlNamespaceResolver?` in the following methods:

```cs
XmlReader.ReadContentAs(Type, IXmlNamespaceResolver?)
XmlReader.ReadContentAsAsync(Type, IXmlNamespaceResolver?)
XPathExpression.SetContext(IXmlNamespaceResolver?)
XPathNavigator.Select(string, IXmlNamespaceResolver?)
XPathNavigator.Evaluate(string, IXmlNamespaceResolver?)
```