### PR TITLE
Mark some System.Collection APIs as unsupported on Browser WASM

### DIFF
--- a/src/libraries/System.Collections.Specialized/Directory.Build.props
+++ b/src/libraries/System.Collections.Specialized/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Collections.Specialized/ref/System.Collections.Specialized.cs
+++ b/src/libraries/System.Collections.Specialized/ref/System.Collections.Specialized.cs
@@ -95,6 +95,7 @@ namespace System.Collections.Specialized
         protected NameObjectCollectionBase(int capacity, System.Collections.IEqualityComparer? equalityComparer) { }
         [System.ObsoleteAttribute("Please use NameObjectCollectionBase(Int32, IEqualityComparer) instead.")]
         protected NameObjectCollectionBase(int capacity, System.Collections.IHashCodeProvider? hashProvider, System.Collections.IComparer? comparer) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         protected NameObjectCollectionBase(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual int Count { get { throw null; } }
         protected bool IsReadOnly { get { throw null; } set { } }
@@ -115,7 +116,9 @@ namespace System.Collections.Specialized
         protected void BaseSet(int index, object? value) { }
         protected void BaseSet(string? name, object? value) { }
         public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public virtual void OnDeserialization(object? sender) { }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         public partial class KeysCollection : System.Collections.ICollection, System.Collections.IEnumerable
@@ -142,6 +145,7 @@ namespace System.Collections.Specialized
         [System.ObsoleteAttribute("Please use NameValueCollection(Int32, IEqualityComparer) instead.")]
         public NameValueCollection(int capacity, System.Collections.IHashCodeProvider? hashProvider, System.Collections.IComparer? comparer) { }
         public NameValueCollection(int capacity, System.Collections.Specialized.NameValueCollection col) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         protected NameValueCollection(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual string?[] AllKeys { get { throw null; } }
         public string? this[int index] { get { throw null; } }

--- a/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -13,6 +13,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 
 namespace System.Collections.Specialized
 {
@@ -77,16 +78,19 @@ namespace System.Collections.Specialized
             Reset(capacity);
         }
 
+        [UnsupportedOSPlatform("browser")]
         protected NameObjectCollectionBase(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public virtual void OnDeserialization(object? sender)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
+++ b/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
@@ -10,6 +10,7 @@
 using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Runtime.Versioning;
 
 namespace System.Collections.Specialized
 {
@@ -94,6 +95,7 @@ namespace System.Collections.Specialized
         {
         }
 
+        [UnsupportedOSPlatform("browser")]
         protected NameValueCollection(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/libraries/System.Collections/Directory.Build.props
+++ b/src/libraries/System.Collections/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -294,7 +294,9 @@ namespace System.Collections.Generic
             public void Dispose() { }
             public bool MoveNext() { throw null; }
             void System.Collections.IEnumerator.Reset() { }
+            [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
             void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object? sender) { }
+            [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
             void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
@@ -632,7 +634,9 @@ namespace System.Collections.Generic
             public void Dispose() { }
             public bool MoveNext() { throw null; }
             void System.Collections.IEnumerator.Reset() { }
+            [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
             void System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object? sender) { }
+            [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
             void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 
 namespace System.Collections.Generic
 {
@@ -596,11 +597,13 @@ namespace System.Collections.Generic
             {
             }
 
+            [UnsupportedOSPlatform("browser")]
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 throw new PlatformNotSupportedException();
             }
 
+            [UnsupportedOSPlatform("browser")]
             void IDeserializationCallback.OnDeserialization(object? sender)
             {
                 throw new PlatformNotSupportedException();

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using Interlocked = System.Threading.Interlocked;
+using System.Runtime.Versioning;
 
 namespace System.Collections.Generic
 {
@@ -1922,11 +1923,13 @@ namespace System.Collections.Generic
                 Initialize();
             }
 
+            [UnsupportedOSPlatform("browser")]
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 throw new PlatformNotSupportedException();
             }
 
+            [UnsupportedOSPlatform("browser")]
             void IDeserializationCallback.OnDeserialization(object? sender)
             {
                 throw new PlatformNotSupportedException();


### PR DESCRIPTION

The following methods from System.Collections.* namespaces were listed by the platform compatibility analyzer (https://github.com/dotnet/platform-compat) as throwing PNSE on Browser WASM so they can be marked as unsupported using 
`UnsupportedOSPlatformAttribute("browser")` attribute:
DocID |Namespace| Type | Member | Nesting |
-- | -- | -- | -- | --
M:System.Collections.Generic.LinkedList`1.Enumerator.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext) | System.Collections.Generic | LinkedList+Enumerator | System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo,   StreamingContext) | 0
M:System.Collections.Generic.LinkedList`1.Enumerator.System#Runtime#Serialization#IDeserializationCallback#OnDeserialization(System.Object) | System.Collections.Generic | LinkedList+Enumerator | System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(Object) | 0
M:System.Collections.Generic.SortedSet`1.Enumerator.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext) | System.Collections.Generic | SortedSet+Enumerator | System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo,   StreamingContext) | 0
M:System.Collections.Generic.SortedSet`1.Enumerator.System#Runtime#Serialization#IDeserializationCallback#OnDeserialization(System.Object) | System.Collections.Generic | SortedSet+Enumerator | System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(Object) | 0
M:System.Collections.Specialized.NameObjectCollectionBase.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext) | System.Collections.Specialized | NameObjectCollectionBase | .ctor(SerializationInfo, StreamingContext) | 0
M:System.Collections.Specialized.NameObjectCollectionBase.OnDeserialization(System.Object) | System.Collections.Specialized | NameObjectCollectionBase | OnDeserialization(Object) | 0
M:System.Collections.Specialized.NameObjectCollectionBase.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext) | System.Collections.Specialized | NameObjectCollectionBase | GetObjectData(SerializationInfo, StreamingContext) | 0
M:System.Collections.Specialized.NameValueCollection.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext) | System.Collections.Specialized | NameValueCollection | .ctor(SerializationInfo, StreamingContext) | 1

Part of https://github.com/dotnet/runtime/issues/41087