### PR TITLE
Fixed the problem that Environment Variable configuration provider doesn't work if the prefix has 2 underscores

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             return key.Replace("__", ConfigurationPath.KeyDelimiter);
         }
 
-        private static IEnumerable<DictionaryEntry> AzureEnvToAppEnv(DictionaryEntry entry)
+        private IEnumerable<DictionaryEntry> AzureEnvToAppEnv(DictionaryEntry entry)
         {
             string key = (string)entry.Key;
             string prefix = string.Empty;
@@ -96,7 +96,15 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             }
             else
             {
-                entry.Key = NormalizeKey(key);
+                if (_prefix != null && _prefix.EndsWith("__"))
+                {
+                    entry.Key = _prefix + NormalizeKey(key.Substring(_prefix.Length));
+                }
+                else
+                {
+                    entry.Key = NormalizeKey(key);
+                }
+
                 yield return entry;
                 yield break;
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -153,6 +153,23 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:_db1_ProviderName"));
         }
 
+        [Fact]
+        public void LoadEnvironmentVariablesWithPrefixThatEndsWithDoubleUnderscore()
+        {
+            var dict = new Hashtable()
+                {
+                    {"TEST__TEST1__TEST2", "42"},
+                    {"TEST__TEST1__TEST3", "12"},
+                };
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider("TEST__");
+
+            envConfigSrc.Load(dict);
+
+            Assert.Equal("42", envConfigSrc.Get("TEST1:TEST2"));
+            Assert.Equal("12", envConfigSrc.Get("TEST1:TEST3"));
+        }
+
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void BindingDoesNotThrowIfReloadedDuringBinding()
         {


### PR DESCRIPTION
Proposal for fixing dotnet/runtime#40911.

The original problem was that loading a key-value pair _["TEST__TEST1__TEST2" : "42"]_  with _prefix "TEST__"results in null because after Normalizing the Key "TEST_TEST1_TEST2" , it becomes "TEST:TEST1:TEST2" so the key no longer starts with intended prefix "TEST__".

As this problem occured because NormalizeKey is executed without any consideration of local variable _prefix which is provided via constructor. I changed AzureEnvToAppEnv to check if the prefix ends with "__" before Normalizing.

Now loading _["TEST__TEST1__TEST2" : "42"]_  with _prefix "TEST__"_ results in _env["TEST1:TEST2] == "42"_.
