### PR TITLE
Handle windows shutdown event

### DIFF
--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -401,7 +401,7 @@ static BOOL WINAPI DbgCtrlCHandler(DWORD dwCtrlType)
     else
 #endif // DEBUGGING_SUPPORTED
     {
-        if (dwCtrlType == CTRL_CLOSE_EVENT)
+        if (dwCtrlType == CTRL_CLOSE_EVENT || dwCtrlType == CTRL_LOGOFF_EVENT || dwCtrlType == CTRL_SHUTDOWN_EVENT)
         {
             // Initiate shutdown so the ProcessExit handlers run
             ForceEEShutdown(SCA_ReturnWhenShutdownComplete);

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -401,7 +401,7 @@ static BOOL WINAPI DbgCtrlCHandler(DWORD dwCtrlType)
     else
 #endif // DEBUGGING_SUPPORTED
     {
-        if (dwCtrlType == CTRL_CLOSE_EVENT || dwCtrlType == CTRL_LOGOFF_EVENT || dwCtrlType == CTRL_SHUTDOWN_EVENT)
+        if (dwCtrlType == CTRL_CLOSE_EVENT || dwCtrlType == CTRL_SHUTDOWN_EVENT)
         {
             // Initiate shutdown so the ProcessExit handlers run
             ForceEEShutdown(SCA_ReturnWhenShutdownComplete);


### PR DESCRIPTION
By doing a clean `EEShutdown`, including calling `ProcessExit` handlers, as suggested by @stephentoub in https://github.com/dotnet/runtime/issues/36089#issuecomment-630340044. This allows `ProcessExit` to respond to 'docker stop', which sends `CTRL_SHUTDOWN_EVENT` to windows containers. ~~I'm doing the same for the logoff event.~~

Automated testing is challenging since I don't see a documented way to trigger these events (other than triggering a shutdown or running in a container). I tested this locally to confirm that it produces the desired behavior on 'docker stop', and will do more testing for the ~~logoff and~~ shutdown events outside of docker.

https://github.com/dotnet/runtime/issues/36089#issuecomment-630391107 suggests removing removing `if (dwCtrlType == CTRL_CLOSE_EVENT)`. This would cause `ProcessExit` to fire on an unhandled Ctrl+C (currently it does not on windows or unix), so I am making the more targeted change for 5.0.

Fixes https://github.com/dotnet/runtime/issues/36089