### PR TITLE
Cast cache Add should handle odd entry versions as inconsistent/taken.

### DIFF
--- a/src/coreclr/src/vm/castcache.cpp
+++ b/src/coreclr/src/vm/castcache.cpp
@@ -244,7 +244,23 @@ void CastCache::TrySet(TADDR source, TADDR target, BOOL result)
             //        We improve average lookup by giving preference to the "richer" entries.
             //        If we used Robin Hood strategy we could eventually end up with all
             //        entries in the table being maximally "poor".
-            DWORD version = pEntry->version;
+
+            // VolatileLoadWithoutBarrier is to ensure that the version cannot be re-fetched between here and CompareExchange.
+            DWORD version = VolatileLoadWithoutBarrier(&pEntry->version);
+
+            // mask the lower version bit to make it even.
+            // This way we will detect both if version is changing (odd) or has changed (even, but different).
+            version &= ~1;
+
+            if ((version & VERSION_NUM_MASK) >= (VERSION_NUM_MASK - 2))
+            {
+                // If exactly 2 ^ VERSION_NUM_SIZE updates happens between here and publishing, we may not recognise a race.
+                // It is extremely unlikely, but to not worry about the possibility, lets not allow version to go this high and just get a new cache.
+                // This will not happen often.
+                FlushCurrentCache();
+                return;
+            }
+
             if (version == 0 || (version >> VERSION_NUM_SIZE) > i)
             {
                 DWORD newVersion = (i << VERSION_NUM_SIZE) + (version & VERSION_NUM_MASK) + 1;
@@ -294,14 +310,12 @@ void CastCache::TrySet(TADDR source, TADDR target, BOOL result)
     {
         CastCacheEntry* pEntry = &Elements(tableData)[(bucket + victim) & TableMask(tableData)];
 
-        DWORD version = pEntry->version;
-        if ((version & VERSION_NUM_MASK) >= (VERSION_NUM_MASK - 2))
-        {
-            // It is unlikely for a reader to sit between versions while exactly 2^VERSION_NUM_SIZE updates happens.
-            // Anyways, to not bother about the possibility, lets get a new cache. It will not happen often, if ever.
-            FlushCurrentCache();
-            return;
-        }
+        // VolatileLoadWithoutBarrier is to ensure that the version cannot be re-fetched between here and CompareExchange.
+        DWORD version = VolatileLoadWithoutBarrier(&pEntry->version);
+
+        // mask the lower version bit to make it even.
+        // This way we will detect both if version is changing (odd) or has changed (even, but different).
+        version &= ~1;
 
         DWORD newVersion = (victimDistance << VERSION_NUM_SIZE) + (version & VERSION_NUM_MASK) + 1;
         DWORD versionOrig = InterlockedCompareExchangeT(&pEntry->version, newVersion, version);


### PR DESCRIPTION

For details - It is not exactly a race, but the bug requires extremely heavy writer contention to be exposed. 

Cast cache mutual exclusion uses race detection that is based on monotonically increasing versioning of cache entries. - For example if entry version has changed in the process of reading, we cannot assume we have read consistent data.

At some point the implementation was switched to odd/even versioning scheme that uses only one version field – odd version indicating an entry that is being updated and even version indicating a consistent entry. 
The reading side was modified to understand odd-versioned entries as inconsistent, but the writing side was not. 

Fixes:https://github.com/dotnet/runtime/issues/41054