### PR TITLE
Add dependencies for BrowserDebugHost into Microsoft.NETCore.BrowserDebugHost.Transport nupkg

### DIFF
--- a/src/mono/netcore/nuget/Microsoft.NETCore.BrowserDebugHost.Transport/Microsoft.NETCore.BrowserDebugHost.Transport.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NETCore.BrowserDebugHost.Transport/Microsoft.NETCore.BrowserDebugHost.Transport.pkgproj
@@ -11,11 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageFile Include="$(ArtifactsDir)bin\BrowserDebugHost\$(TargetArchitecture)\$(Configuration)\BrowserDebugProxy.dll">
-      <TargetPath>tools\$(NetCoreAppCurrent)\BrowserDebugProxy.dll</TargetPath>
-    </PackageFile>
-    <PackageFile Include="$(ArtifactsDir)bin\BrowserDebugHost\$(TargetArchitecture)\$(Configuration)\BrowserDebugHost.dll">
-      <TargetPath>tools\$(NetCoreAppCurrent)\BrowserDebugHost.dll</TargetPath>
+    <PackageFile Include="$(ArtifactsDir)bin\BrowserDebugHost\$(TargetArchitecture)\$(Configuration)\*.dll">
+      <TargetPath>tools\$(NetCoreAppCurrent)\</TargetPath>
     </PackageFile>
     <PackageFile Include="$(ArtifactsDir)bin\BrowserDebugHost\$(TargetArchitecture)\$(Configuration)\BrowserDebugHost.runtimeconfig.json">
       <TargetPath>tools\$(NetCoreAppCurrent)\BrowserDebugHost.runtimeconfig.json</TargetPath>

--- a/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj
+++ b/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/debugger/BrowserDebugProxy/BrowserDebugProxy.csproj
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/BrowserDebugProxy.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Before we were only packaging the host and proxy assemblies, but we need their dependencies as well.
Moved the `CopyLocalLockFileAssemblies=true` to BrowserDebugHost.csproj to make sure we get all dependencies there.

/cc @captainsafia 