### PR TITLE
Update Mono building docs with wasm-specific advice

### DIFF
--- a/docs/workflow/building/mono/README.md
+++ b/docs/workflow/building/mono/README.md
@@ -10,19 +10,19 @@ Before proceeding further, please click on the link above that matches your mach
 
 ## Concept
 
-To build the Mono runtime, you must first do a complete runtime build (coreclr, libraries, and then mono).  At the repo root, simply execute:
+To build a complete runtime environment, you need to build both the Mono runtime and libraries.  At the repo root, simply execute:
 
 ```bash
-./build.sh
+./build.sh --subset mono+libs
 ```
 or on Windows,
 ```bat
-build.cmd
+build.cmd -subset mono+libs
 ```
 Note that the debug configuration is the default option. It generates a 'debug' output and that includes asserts, fewer code optimizations, and is easier for debugging. If you want to make performance measurements, or just want tests to execute more quickly, you can also build the 'release' version which does not have these checks by adding the flag `-configuration release` (or `-c release`).
 
 
-Once you've built the whole runtime and assuming you want to work with just mono, you want to use the following command:
+Once you've built the complete runtime and assuming you want to work with just mono, you want to use the following command:
 
 ```bash
 ./build.sh --subset mono
@@ -48,6 +48,34 @@ For `build.sh`
 `/p:DisableCrossgen=true` - Skips building the installer if you don't need it (builds faster)
 
 The build has a number of options that you can learn about using build -?.
+
+### WebAssembly
+
+In addition to the normal build requirements, WebAssembly builds require a local emsdk to be downloaded. This can either be external or acquired via a make target.
+
+To acquire it externally, move to a directory outside of the runtime repository and run:
+```bash
+git clone https://github.com/emscripten-core/emsdk.git
+```
+
+To use the make target, from the root of the runtime repo:
+```bash
+cd src/mono/wasm
+make provision-wasm
+cd ../../..
+```
+
+When building for WebAssembly, regardless of the machine architecture, you must set the `EMSDK_PATH` environmental variable and architecture/os, calling build.sh like so:
+```bash
+EMSDK_PATH={path to emsdk repo} ./build.sh --subset mono+libs --arch wasm --os browser -c release
+```
+
+If using the locally provisioned emsdk, this will be:
+```bash
+EMSDK_PATH={path to runtime repo}/src/mono/wasm/emsdk ./build.sh --subset mono+libs --arch wasm --os browser -c release
+```
+
+Artifacts will be placed in `artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/Release/`. When rebuilding with `build.sh`, you _must_ rebuild with `mono+libs` even for mono-only changes, or this directory will not be updated. Alternative, you can rebuild just the runtime-specific bits from the `src/mono/wasm` directory by running either `make runtime` or `make corlib` when modifying Mono or System.Private.CoreLib respectively.
 
 ## Packages
 


### PR DESCRIPTION
You also no longer need to build CoreCLR for most things, so I've updated the doc accordingly.