### PR TITLE
Re-enable ImplementedInterfaces tests on Mono

### DIFF
--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -479,7 +479,6 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40868", TestRuntimes.Mono)]
         [InlineData(typeof(InheritedInteraface), new Type[] { typeof(TI_NonGenericInterface2) })]
         [InlineData(typeof(StructWithInheritedInterface), new Type[] { typeof(TI_NonGenericInterface2), typeof(InheritedInteraface) })]
         [InlineData(typeof(NonGenericClassWithNonGenericInterface), new Type[] { typeof(TI_NonGenericInterface1) })]


### PR DESCRIPTION
Still unable to reproduce locally, but I'd like fresh CI artifacts. 

Except... now this seems to be passing. Bizarre.

Fixes https://github.com/dotnet/runtime/issues/40868