### PR TITLE
Reduce memory allocations for Process.GetProcessesByName

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -28,22 +28,8 @@ namespace System.Diagnostics
                 processName = string.Empty;
             }
 
-            Process[] procs = GetProcesses(machineName);
-            var list = new List<Process>();
-
-            for (int i = 0; i < procs.Length; i++)
-            {
-                if (string.Equals(processName, procs[i].ProcessName, StringComparison.OrdinalIgnoreCase))
-                {
-                    list.Add(procs[i]);
-                }
-                else
-                {
-                    procs[i].Dispose();
-                }
-            }
-
-            return list.ToArray();
+            return GetProcesses(machineName, process =>
+                string.Equals(processName, process.ProcessName, StringComparison.OrdinalIgnoreCase));
         }
 
         [CLSCompliant(false)]

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1055,13 +1055,35 @@ namespace System.Diagnostics
         /// </devdoc>
         public static Process[] GetProcesses(string machineName)
         {
+            return GetProcesses(machineName, null);
+        }
+
+        /// <devdoc>
+        ///    <para>
+        ///       Creates a new <see cref='System.Diagnostics.Process'/>
+        ///       component for each
+        ///       process resource on the specified computer.
+        ///    </para>
+        /// </devdoc>
+        internal static Process[] GetProcesses(string machineName, Predicate<ProcessInfo>? processFilter)
+        {
             bool isRemoteMachine = ProcessManager.IsRemoteMachine(machineName);
             ProcessInfo[] processInfos = ProcessManager.GetProcessInfos(machineName);
             Process[] processes = new Process[processInfos.Length];
+            int processesLength = 0;
             for (int i = 0; i < processInfos.Length; i++)
             {
                 ProcessInfo processInfo = processInfos[i];
-                processes[i] = new Process(machineName, isRemoteMachine, processInfo.ProcessId, processInfo);
+                if (processFilter == null || processFilter(processInfo))
+                {
+                    processes[processesLength++] = new Process(machineName, isRemoteMachine, processInfo.ProcessId, processInfo);
+                }
+            }
+            if (processesLength < processInfos.Length)
+            {
+                Process[] filteredProcesses = new Process[processesLength];
+                Array.Copy(processes, filteredProcesses, processesLength);
+                return filteredProcesses;
             }
             return processes;
         }


### PR DESCRIPTION
Fix #40768

Seems felipepessoto's suggestion is not the best choice because there is no any issue on Linux and we have different code paths for local/remote machines on Windows.