### PR TITLE
Improve condition for generating CoreCLR / Mono test execution scripts

### DIFF
--- a/src/coreclr/tests/src/Directory.Build.targets
+++ b/src/coreclr/tests/src/Directory.Build.targets
@@ -196,7 +196,7 @@
   <Import Project="CLRTest.Execute.targets" />
   <Target Name="CreateExecuteScript"
           BeforeTargets="Build;CopyAllNativeProjectReferenceBinaries"
-          Condition="'$(_CopyNativeProjectBinaries)' == 'true' And '$(GenerateRunScript)' != 'false' And ('$(_WillCLRTestProjectBuild)' == 'true')"
+          Condition="'$(CLRTestBuildAllTargets)' != 'allTargets' And '$(GenerateRunScript)' != 'false' And ('$(_WillCLRTestProjectBuild)' == 'true')"
           DependsOnTargets="GenerateExecutionScriptsInternal" />
 
   <Target Name="UpdateReferenceItems"


### PR DESCRIPTION
I have received heads-up from two sources - @naricc's work on Mono webassembly
testing and @gbalykov's recent PR

https://github.com/dotnet/runtime/pull/40979

that there's something weird going on in the execution script creation logic.
I have investigated the exact purpose of the condition referring to
<code>_CopyNativeProjectBinaries</code>. I believe the intent of the condition
was to suppress the creation of execution scripts during managed test build
once we switched over to building managed test components only once.

The problem is that the common build of managed test components reused by
runs on all OS'es and architectures uses the <code>allTargets</code> specification
to build all test projects including those that only work on some platforms. This is
one of the reasons why we cannot emit the execution scripts at managed test
component build time - we would emit them even for tests that later on in the
pipeline turn out to be disabled for a particular platform or build configuration.
The other reason is practical - today the CLRTest.*.targets scripts only generate
one version of the script (cmd vs. sh) - but that would be easy to fix.

Based on these findings I propose modifying the condition to check the 'allTargets'
flag instead. In local builds (where we typically build managed test components
for just a single target platform using the src/coreclr/build-test script) the option
allTargets is not set and so the execution script can be easily created as part of
the managed build. In the runtime pipeline case, the execution scripts end up
getting emitted during the <code>copynativeonly</code> step before sending
the tests to Helix as by this time the targeting platform and configuration for the
run is completely resolved.

Thanks

Tomas