### PR TITLE
Port EventPipe CoreCLR changes to Mono.

### DIFF
--- a/src/mono/mono/eventpipe/ep-buffer-manager.h
+++ b/src/mono/mono/eventpipe/ep-buffer-manager.h
@@ -134,7 +134,6 @@ struct _EventPipeBufferManager_Internal {
 	uint32_t num_buffers_stolen;
 	uint32_t num_buffers_leaked;
 #endif
-	volatile uint32_t write_event_suspending;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_BUFFER_MANAGER_GETTER_SETTER)

--- a/src/mono/mono/eventpipe/ep-event-source.c
+++ b/src/mono/mono/eventpipe/ep-event-source.c
@@ -209,8 +209,8 @@ ep_event_source_send_process_info (
 	ep_char16_t *arch_info_utf16 = NULL;
 
 	command_line_utf16 = ep_rt_utf8_to_utf16_string (command_line, -1);
-	os_info_utf16 = ep_rt_utf8_to_utf16_string (_ep_os_info, -1);
-	arch_info_utf16 = ep_rt_utf8_to_utf16_string (_ep_arch_info, -1);
+	os_info_utf16 = ep_rt_utf8_to_utf16_string (ep_event_source_get_os_info (), -1);
+	arch_info_utf16 = ep_rt_utf8_to_utf16_string (ep_event_source_get_arch_info (), -1);
 
 	EventData data [3] = { { 0 } };
 	if (command_line_utf16)

--- a/src/mono/mono/eventpipe/ep-event-source.c
+++ b/src/mono/mono/eventpipe/ep-event-source.c
@@ -190,6 +190,8 @@ ep_event_source_enable (
 	EP_ASSERT (event_source != NULL);
 	EP_ASSERT (session != NULL);
 
+	ep_requires_lock_held ();
+
 	EventPipeSessionProvider *session_provider = ep_session_provider_alloc (event_source->provider_name, (uint64_t)-1, EP_EVENT_LEVEL_LOG_ALWAYS, NULL);
 	if (session_provider != NULL)
 		ep_session_add_session_provider (session, session_provider);

--- a/src/mono/mono/eventpipe/ep-event-source.h
+++ b/src/mono/mono/eventpipe/ep-event-source.h
@@ -34,6 +34,24 @@ struct _EventPipeEventSource {
 };
 #endif
 
+static
+inline
+const char *
+ep_event_source_get_os_info (void)
+{
+	extern const char *_ep_os_info;
+	return _ep_os_info;
+}
+
+static
+inline
+const char *
+ep_event_source_get_arch_info (void)
+{
+	extern const char *_ep_arch_info;
+	return _ep_arch_info;
+}
+
 EventPipeEventSource *
 ep_event_source_alloc (void);
 

--- a/src/mono/mono/eventpipe/ep-event.h
+++ b/src/mono/mono/eventpipe/ep-event.h
@@ -52,8 +52,11 @@ struct _EventPipeEvent {
 EP_DEFINE_GETTER(EventPipeEvent *, event, uint64_t, keywords)
 EP_DEFINE_GETTER_REF(EventPipeEvent *, event, volatile int64_t *, enabled_mask)
 EP_DEFINE_SETTER(EventPipeEvent *, event, int64_t, enabled_mask)
+EP_DEFINE_GETTER(EventPipeEvent *, event, uint8_t *, metadata)
 EP_DEFINE_GETTER(EventPipeEvent *, event, EventPipeProvider *, provider)
 EP_DEFINE_GETTER(EventPipeEvent *, event, uint32_t, event_id)
+EP_DEFINE_GETTER(EventPipeEvent *, event, uint32_t, event_version)
+EP_DEFINE_GETTER(EventPipeEvent *, event, uint32_t, metadata_len)
 EP_DEFINE_GETTER(EventPipeEvent *, event, EventPipeEventLevel, level)
 EP_DEFINE_GETTER(EventPipeEvent *, event, bool, need_stack)
 

--- a/src/mono/mono/eventpipe/ep-file.h
+++ b/src/mono/mono/eventpipe/ep-file.h
@@ -48,6 +48,7 @@ struct _EventPipeFile_Internal {
 	uint32_t sampling_rate_in_ns;
 	uint32_t stack_id_counter;
 	volatile uint32_t metadata_id_counter;
+	volatile uint32_t initialized;
 	// The format to serialize.
 	EventPipeSerializationFormat format;
 };

--- a/src/mono/mono/eventpipe/ep-provider.c
+++ b/src/mono/mono/eventpipe/ep-provider.c
@@ -257,6 +257,24 @@ ep_on_error:
 	ep_exit_error_handler ();
 }
 
+void
+ep_provider_set_delete_deferred (
+	EventPipeProvider *provider,
+	bool deferred)
+{
+	EP_ASSERT (provider != NULL);
+	provider->delete_deferred = deferred;
+
+	// EventSources will be collected once they ungregister themselves,
+	// so we can't call back in to them.
+	if (provider->callback_func && provider->callback_data_free_func)
+		provider->callback_data_free_func (provider->callback_func, provider->callback_data);
+
+	provider->callback_func = NULL;
+	provider->callback_data_free_func = NULL;
+	provider->callback_data = NULL;
+}
+
 const EventPipeProviderCallbackData *
 provider_set_config (
 	EventPipeProvider *provider,

--- a/src/mono/mono/eventpipe/ep-provider.h
+++ b/src/mono/mono/eventpipe/ep-provider.h
@@ -56,7 +56,6 @@ struct _EventPipeProvider {
 EP_DEFINE_GETTER(EventPipeProvider *, provider, const ep_char8_t *, provider_name)
 EP_DEFINE_GETTER(EventPipeProvider *, provider, const ep_char16_t *, provider_name_utf16)
 EP_DEFINE_GETTER(EventPipeProvider *, provider, bool, delete_deferred)
-EP_DEFINE_SETTER(EventPipeProvider *, provider, bool, delete_deferred)
 EP_DEFINE_GETTER(EventPipeProvider *, provider, uint64_t, sessions)
 
 static
@@ -115,6 +114,11 @@ ep_provider_add_event (
 	bool need_stack,
 	const uint8_t *metadata,
 	uint32_t metadata_len);
+
+void
+ep_provider_set_delete_deferred (
+	EventPipeProvider *provider,
+	bool deferred);
 
 #endif /* ENABLE_PERFTRACING */
 #endif /** __EVENTPIPE_PROVIDER_H__ **/

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -75,6 +75,7 @@
 #define EP_RT_DEFINE_ARRAY(array_name, array_type, item_type) \
 	static inline void ep_rt_ ## array_name ## _alloc (array_type *ep_array) { ep_array->array = g_array_new (FALSE, FALSE, sizeof (item_type)); } \
 	static inline void ep_rt_ ## array_name ## _free (array_type *ep_array) { g_array_free (ep_array->array, TRUE); } \
+	static inline void ep_rt_ ## array_name ## _clear (array_type *ep_array) { g_array_set_size (ep_array->array, 0); } \
 	static inline void ep_rt_ ## array_name ## _append (array_type *ep_array, item_type item) { g_array_append_val (ep_array->array, item); } \
 	static inline size_t ep_rt_ ## array_name ## _size (const array_type *ep_array) { return ep_array->array->len; }
 
@@ -373,6 +374,9 @@ ep_rt_atomic_dec_int64_t (volatile int64_t *value)
 /*
  * EventPipe.
  */
+
+EP_RT_DEFINE_ARRAY (session_id_array, ep_rt_session_id_array_t, EventPipeSessionID)
+EP_RT_DEFINE_ARRAY_ITERATOR (session_id_array, ep_rt_session_id_array_t, ep_rt_session_id_array_iterator_t, EventPipeSessionID)
 
 static
 inline

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -77,6 +77,15 @@
 	static inline void ep_rt_ ## array_name ## _free (array_type *ep_array) { g_array_free (ep_array->array, TRUE); } \
 	static inline void ep_rt_ ## array_name ## _clear (array_type *ep_array) { g_array_set_size (ep_array->array, 0); } \
 	static inline void ep_rt_ ## array_name ## _append (array_type *ep_array, item_type item) { g_array_append_val (ep_array->array, item); } \
+	static inline bool ep_rt_ ## array_name ## _remove (array_type *ep_array, const item_type item) { \
+		for (gint i = 0; i < ep_array->array->len; ++i ) { \
+			if (g_array_index (ep_array->array, item_type, i) == item) { \
+				ep_array->array = g_array_remove_index_fast (ep_array->array, i); \
+				return true; \
+			} \
+		} \
+		return false; \
+	} \
 	static inline size_t ep_rt_ ## array_name ## _size (const array_type *ep_array) { return ep_array->array->len; }
 
 #define EP_RT_DEFINE_ARRAY_ITERATOR(array_name, array_type, iterator_type, item_type) \
@@ -621,7 +630,21 @@ ep_rt_sample_profiler_get_sampling_rate (void)
 static
 inline
 void
-ep_rt_sample_set_sampling_rate (uint32_t nanoseconds)
+ep_rt_sample_profiler_set_sampling_rate (uint32_t nanoseconds)
+{
+	//TODO: Not supported.
+}
+
+static
+void
+ep_rt_sample_profiler_can_start_sampling (void)
+{
+	//TODO: Not supported.
+}
+
+static
+void
+ep_rt_notify_profiler_provider_created (EventPipeProvider *provider)
 {
 	//TODO: Not supported.
 }

--- a/src/mono/mono/eventpipe/ep-rt-types-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-types-mono.h
@@ -109,6 +109,9 @@ typedef struct _rt_mono_array_iterator_internal_t ep_rt_buffer_list_array_iterat
 typedef struct _rt_mono_array_internal_t ep_rt_thread_array_t;
 typedef struct _rt_mono_array_iterator_internal_t ep_rt_thread_array_iterator_t;
 
+typedef struct _rt_mono_array_internal_t ep_rt_session_id_array_t;
+typedef struct _rt_mono_array_iterator_internal_t ep_rt_session_id_array_iterator_t;
+
 typedef MonoThreadHandle ep_rt_thread_handle_t;
 
 typedef gpointer ep_rt_file_handle_t;

--- a/src/mono/mono/eventpipe/ep-rt.h
+++ b/src/mono/mono/eventpipe/ep-rt.h
@@ -43,6 +43,7 @@
 #define EP_RT_DECLARE_ARRAY(array_name, array_type, item_type) \
 	static void ep_rt_ ## array_name ## _alloc (array_type *ep_array); \
 	static void ep_rt_ ## array_name ## _free (array_type *ep_array); \
+	static void ep_rt_ ## array_name ## _clear (array_type *ep_array); \
 	static void ep_rt_ ## array_name ## _append (array_type *ep_array, item_type item); \
 	static size_t ep_rt_ ## array_name ## _size (const array_type *ep_array);
 
@@ -99,6 +100,9 @@ ep_rt_atomic_dec_int64_t (volatile int64_t *value);
 /*
  * EventPipe.
  */
+
+EP_RT_DECLARE_ARRAY (session_id_array, ep_rt_session_id_array_t, EventPipeSessionID)
+EP_RT_DECLARE_ARRAY_ITERATOR (session_id_array, ep_rt_session_id_array_t, ep_rt_session_id_array_iterator_t, EventPipeSessionID)
 
 static
 void

--- a/src/mono/mono/eventpipe/ep-rt.h
+++ b/src/mono/mono/eventpipe/ep-rt.h
@@ -45,6 +45,7 @@
 	static void ep_rt_ ## array_name ## _free (array_type *ep_array); \
 	static void ep_rt_ ## array_name ## _clear (array_type *ep_array); \
 	static void ep_rt_ ## array_name ## _append (array_type *ep_array, item_type item); \
+	static bool ep_rt_ ## array_name ## _remove (array_type *ep_array, const item_type item); \
 	static size_t ep_rt_ ## array_name ## _size (const array_type *ep_array);
 
 #define EP_RT_DECLARE_ARRAY_ITERATOR(array_name, array_type, iterator_type, item_type) \
@@ -231,7 +232,15 @@ ep_rt_sample_profiler_get_sampling_rate (void);
 
 static
 void
-ep_rt_sample_set_sampling_rate (uint32_t nanoseconds);
+ep_rt_sample_profiler_set_sampling_rate (uint32_t nanoseconds);
+
+static
+void
+ep_rt_sample_profiler_can_start_sampling (void);
+
+static
+void
+ep_rt_notify_profiler_provider_created (EventPipeProvider *provider);
 
 /*
  * EventPipeSessionProvider.

--- a/src/mono/mono/eventpipe/ep-session.h
+++ b/src/mono/mono/eventpipe/ep-session.h
@@ -34,6 +34,8 @@ struct _EventPipeSession_Internal {
 	EventPipeBufferManager *buffer_manager;
 	// Object used to flush event data (File, IPC stream, etc.).
 	EventPipeFile *file;
+	// For synchoronous sessions.
+	EventPipeSessionSynchronousCallback synchronous_callback;
 	// Start date and time in UTC.
 	ep_systemtime_t session_start_time;
 	// Start timestamp.
@@ -79,7 +81,7 @@ ep_session_alloc (
 	uint32_t circular_buffer_size_in_mb,
 	const EventPipeProviderConfiguration *providers,
 	uint32_t providers_len,
-	bool rundown_enabled);
+	EventPipeSessionSynchronousCallback sync_callback);
 
 void
 ep_session_free (EventPipeSession *session);
@@ -137,8 +139,12 @@ ep_session_write_all_buffers_to_file (
 	EventPipeSession *session,
 	bool *events_written);
 
+// If a session is non-synchronous (i.e. a file, pipe, etc) WriteEvent will
+// put the event in a buffer and return as quick as possible. If a session is
+// synchronous (callback to the profiler) then this method will block until the
+// profiler is done parsing and reacting to it.
 bool
-ep_session_write_event_buffered (
+ep_session_write_event (
 	EventPipeSession *session,
 	EventPipeThread *thread,
 	EventPipeEvent *ep_event,

--- a/src/mono/mono/eventpipe/ep-stream.c
+++ b/src/mono/mono/eventpipe/ep-stream.c
@@ -374,10 +374,7 @@ ep_file_stream_writer_alloc (const ep_char8_t *output_file_path)
 	instance->file_stream = ep_file_stream_alloc ();
 	ep_raise_error_if_nok (instance->file_stream != NULL);
 
-	if (!ep_file_stream_open_write (instance->file_stream, output_file_path)) {
-		EP_ASSERT (!"Unable to open file for write.");
-		ep_raise_error ();
-	}
+	ep_raise_error_if_nok (ep_file_stream_open_write (instance->file_stream, output_file_path) == true);
 
 ep_on_exit:
 	return instance;

--- a/src/mono/mono/eventpipe/ep-thread.h
+++ b/src/mono/mono/eventpipe/ep-thread.h
@@ -72,11 +72,20 @@ ep_thread_addref (EventPipeThread *thread);
 void
 ep_thread_release (EventPipeThread *thread);
 
+void
+ep_thread_init (void);
+
+void
+ep_thread_fini (void);
+
 EventPipeThread *
 ep_thread_get (void);
 
 EventPipeThread *
 ep_thread_get_or_create (void);
+
+void
+ep_thread_get_threads (ep_rt_thread_array_t *threads);
 
 void
 ep_thread_create_activity_id (

--- a/src/mono/mono/eventpipe/ep-types.h
+++ b/src/mono/mono/eventpipe/ep-types.h
@@ -145,7 +145,8 @@ typedef enum {
 typedef enum {
 	EP_SESSION_TYPE_FILE,
 	EP_SESSION_TYPE_LISTENER,
-	EP_SESSION_TYPE_IPCSTREAM
+	EP_SESSION_TYPE_IPCSTREAM,
+	EP_SESSION_TYPE_SYNCHRONOUS
 } EventPipeSessionType ;
 
 typedef enum {
@@ -182,6 +183,20 @@ typedef void (*EventPipeCallback)(
 typedef void (*EventPipeCallbackDataFree)(
 	EventPipeCallback callback,
 	void *callback_data);
+
+typedef void (*EventPipeSessionSynchronousCallback)(
+	EventPipeProvider *provider,
+	int32_t event_id,
+	int32_t event_version,
+	uint32_t metadata_blob_len,
+	const uint8_t *metadata_blob,
+	uint32_t event_data_len,
+	const uint8_t *event_data,
+	const uint8_t *activity_id,
+	const uint8_t *related_activity_id,
+	EventPipeThread *event_thread,
+	uint32_t stack_frames_len,
+	uintptr_t *stack_frames);
 
 /*
  * EventFilterDescriptor.

--- a/src/mono/mono/eventpipe/ep.h
+++ b/src/mono/mono/eventpipe/ep.h
@@ -182,7 +182,7 @@ ep_enable (
 	EventPipeSerializationFormat format,
 	bool rundown_requested,
 	IpcStream *stream,
-	bool enable_sample_profiler);
+	EventPipeSessionSynchronousCallback sync_callback);
 
 EventPipeSessionID
 ep_enable_2 (
@@ -193,13 +193,16 @@ ep_enable_2 (
 	EventPipeSerializationFormat format,
 	bool rundown_requested,
 	IpcStream *stream,
-	bool enable_sample_profiler);
+	EventPipeSessionSynchronousCallback sync_callback);
 
 void
 ep_disable (EventPipeSessionID id);
 
 EventPipeSession *
 ep_get_session (EventPipeSessionID session_id);
+
+bool
+ep_is_session_enabled (EventPipeSessionID session_id);
 
 void
 ep_start_streaming (EventPipeSessionID session_id);
@@ -219,6 +222,11 @@ ep_delete_provider (EventPipeProvider *provider);
 
 EventPipeProvider *
 ep_get_provider (const ep_char8_t *provider_name);
+
+void
+ep_add_provider_to_session (
+	EventPipeSessionProvider *provider,
+	EventPipeSession *session);
 
 void
 ep_init (void);
@@ -274,6 +282,14 @@ static
 inline
 void
 ep_init (void)
+{
+	;
+}
+
+static
+inline
+void
+ep_finish_init (void)
 {
 	;
 }

--- a/src/mono/mono/eventpipe/test/ep-session-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-session-tests.c
@@ -108,7 +108,10 @@ test_add_session_providers (void)
 
 	test_location = 4;
 
-	ep_session_add_session_provider (test_session, test_session_provider);
+	EP_LOCK_ENTER (section2)
+		ep_session_add_session_provider (test_session, test_session_provider);
+	EP_LOCK_EXIT (section2)
+
 	test_session_provider = NULL;
 
 	if (!ep_session_is_valid (test_session)) {

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -191,7 +191,7 @@ test_enable_disable (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
-		false);
+		NULL);
 
 	if (!session_id) {
 		result = FAILED ("Failed to enable session");
@@ -313,7 +313,7 @@ test_enable_disable_default_provider_config (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
-		false);
+		NULL);
 
 	if (!session_id) {
 		result = FAILED ("Failed to enable session");
@@ -361,7 +361,7 @@ test_enable_disable_provider_config (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
-		false);
+		NULL);
 
 	if (!session_id) {
 		result = FAILED ("Failed to enable session");
@@ -441,7 +441,7 @@ test_enable_disable_provider_parse_default_config (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
-		false);
+		NULL);
 
 	if (!session_id) {
 		result = FAILED ("Failed to enable session");
@@ -512,7 +512,7 @@ test_create_delete_provider_with_callback (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
-		false);
+		NULL);
 
 	if (!session_id) {
 		result = FAILED ("Failed to enable session");
@@ -613,7 +613,7 @@ test_session_start_streaming (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
-		false);
+		NULL);
 
 	if (!session_id) {
 		result = FAILED ("Failed to enable session");
@@ -662,7 +662,7 @@ test_session_write_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -671,7 +671,7 @@ test_session_write_event (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event_buffered ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
@@ -715,7 +715,7 @@ test_session_write_event_seq_point (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -724,7 +724,7 @@ test_session_write_event_seq_point (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event_buffered ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
@@ -772,7 +772,7 @@ test_session_write_wait_get_next_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -781,7 +781,7 @@ test_session_write_wait_get_next_event (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event_buffered ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
@@ -853,7 +853,7 @@ test_session_write_get_next_event (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event_buffered ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
@@ -923,16 +923,14 @@ test_session_write_suspend_event (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event_buffered ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_thread_get (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
 
 	test_location = 5;
 
-	EP_LOCK_ENTER (section1)
-		ep_session_suspend_write_event ((EventPipeSession *)session_id);
-	EP_LOCK_EXIT (section1)
+	// ep_session_suspend_write_event_happens in disable session.
 
 ep_on_exit:
 	ep_disable (session_id);

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -320,7 +320,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_Enable (
 		(EventPipeSerializationFormat)format,
 		true,
 		NULL,
-		true);
+		NULL);
 	ep_start_streaming (session_id);
 
 	if (config_providers) {

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4555,6 +4555,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 #if defined(ENABLE_PERFTRACING) && !defined(DISABLE_EVENTPIPE)
 	ep_init ();
+	ep_finish_init ();
 #endif
 
 	if (mono_aot_only) {


### PR DESCRIPTION
Port changes done in the following CoreCLR PR's affecting corresponding Mono runtime EventPipe library sources:

https://github.com/dotnet/runtime/pull/36720
https://github.com/dotnet/runtime/pull/37002
https://github.com/dotnet/runtime/pull/38967
https://github.com/dotnet/runtime/pull/40191
https://github.com/dotnet/runtime/pull/40332
https://github.com/dotnet/runtime/pull/40499

EventPipe native code changes track by https://github.com/dotnet/runtime/issues/36820.