### PR TITLE
[mono] Don't leak coop handles, fix type in managed ALC struct

### DIFF
--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -178,7 +178,7 @@ mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
 {
 	HANDLE_FUNCTION_ENTER ();
 	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
-	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
+	MonoAssemblyLoadContext *alc = MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
 	HANDLE_FUNCTION_RETURN_VAL (alc);
 }
 

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -176,9 +176,10 @@ mono_alc_is_default (MonoAssemblyLoadContext *alc)
 MonoAssemblyLoadContext *
 mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
 {
+	HANDLE_FUNCTION_ENTER ();
 	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
-	return alc;
+	HANDLE_FUNCTION_RETURN_VAL (alc);
 }
 
 MonoGCHandle

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1663,7 +1663,7 @@ typedef struct {
 	MonoEvent *resolving;
 	MonoEvent *unloading;
 	MonoString *name;
-	gpointer *native_assembly_load_context;
+	MonoAssemblyLoadContext *native_assembly_load_context;
 	gint64 id;
 	gint32 internal_state;
 	MonoBoolean is_collectible;


### PR DESCRIPTION
The important change here is not leaking the coop handles, the other is because I'm too lazy to create two separate PRs for this.