### PR TITLE
[runtime] Catch attempts to create enum types with an underlying type that is itself an incomplete enum type.

### DIFF
--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -3712,9 +3712,11 @@ typebuilder_setup_one_field (MonoDynamicImage *dynamic_image, MonoClass *klass, 
 		if (klass->enumtype && strcmp (field->name, "value__") == 0) // used by enum classes to store the instance value
 			field->type->attrs |= FIELD_ATTRIBUTE_RT_SPECIAL_NAME;
 
-		if (!klass->enumtype && !mono_type_get_underlying_type (field->type)) {
-			mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);
-			goto leave;
+		if (!mono_type_get_underlying_type (field->type)) {
+			if (!(klass->enumtype && mono_metadata_type_equal (field->type, m_class_get_byval_arg (klass)))) {
+				mono_class_set_type_load_failure (klass, "Field '%s' is an enum type with a bad underlying type", field->name);
+				goto leave;
+			}
 		}
 
 		if ((fb->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA) && (rva_data = fb->rva_data)) {


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20282,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Previously, only non-enum types containing fields with incomplete enum
types were forbidden.

(Original: https://github.com/mono/mono/pull/19456)