### PR TITLE
map macOS compat 10.16 version to 11.0

### DIFF
--- a/src/installer/corehost/cli/hostmisc/pal.unix.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.unix.cpp
@@ -563,11 +563,13 @@ pal::string_t pal::get_current_os_rid_platform()
         {
             int majorVersion = stoi(release.substr(0, pos));
             // compat path with 10.x
-            if (majorVersion > 20)
+            if (majorVersion < 20)
             {
                 // Extract the major version and subtract 4 from it
                 // to get the Minor version used in OSX versioning scheme.
                 // That is, given a version 10.X.Y, we will get X below.
+                //
+                // macOS Cataline 10.15.5 has kernel 19.5.0
                 int minorVersion = majorVersion - 4;
                 if (minorVersion < 10)
                 {

--- a/src/installer/corehost/cli/hostmisc/pal.unix.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.unix.cpp
@@ -553,7 +553,6 @@ pal::string_t pal::get_current_os_rid_platform()
     // We will, instead, use kern.osrelease and use its major version number
     // as a means to formulate the OSX 10.X RID.
     //
-    // Needless to say, this will need to be updated if OSX RID were to become 11.* ever.
     size_t size = sizeof(str);
     int ret = sysctlbyname("kern.osrelease", str, &size, nullptr, 0);
     if (ret == 0)
@@ -562,18 +561,29 @@ pal::string_t pal::get_current_os_rid_platform()
         size_t pos = release.find('.');
         if (pos != std::string::npos)
         {
-            // Extract the major version and subtract 4 from it
-            // to get the Minor version used in OSX versioning scheme.
-            // That is, given a version 10.X.Y, we will get X below.
-            int minorVersion = stoi(release.substr(0, pos)) - 4;
-            if (minorVersion < 10)
+            int majorVersion = stoi(release.substr(0, pos));
+            // compat path with 10.x
+            if (majorVersion > 20)
             {
-                // On OSX, our minimum supported RID is 10.12.
-                minorVersion = 12;
-            }
+                // Extract the major version and subtract 4 from it
+                // to get the Minor version used in OSX versioning scheme.
+                // That is, given a version 10.X.Y, we will get X below.
+                int minorVersion = majorVersion - 4;
+                if (minorVersion < 10)
+                {
+                    // On OSX, our minimum supported RID is 10.12.
+                    minorVersion = 12;
+                }
 
-            ridOS.append(_X("osx.10."));
-            ridOS.append(pal::to_string(minorVersion));
+                ridOS.append(_X("osx.10."));
+                ridOS.append(pal::to_string(minorVersion));
+            }
+            else
+            {
+                // 11.0 shipped with kernel 20.0
+                ridOS.append(_X("osx.11."));
+                ridOS.append(pal::to_string(majorVersion - 20));
+            }
         }
     }
 

--- a/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
@@ -51,6 +51,15 @@ internal static partial class Interop
                 }
             }
 
+            if (major == 10 && minor == 16)
+            {
+                // We get "compat" version for 11.0 unless we build with updated SDK.
+                // Hopefully that will be before 11.x comes out
+                // For now, this maps 10.16 to 11.0.
+                major = 11;
+                minor = 0;
+            }
+
             return new Version(major, minor, patch);
         }
 


### PR DESCRIPTION
It seems like we get "wrong" os version because we build and link against older macOS SDK. 
With that we get 10.16 instead of 11.0 as expected. 

For time being this adds mapping from 10.16 to 11.0. 
It also updates RID calculation. That one is based on kernel version.
11.0 ships with 20.0 and the current logic needed to be updated as well. 

fixes  #41012
