### PR TITLE
add extra padding for icmp6stat to support macOS 11

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -473,7 +473,8 @@ int32_t SystemNative_EnumerateGatewayAddressesForInterface(uint32_t interfaceInd
         }
 
         byteCount = tmpEstimatedSize;
-        buffer = realloc(buffer, byteCount);
+        free(buffer);
+        buffer = malloc(byteCount);
         if (buffer == NULL)
         {
             errno = ENOMEM;

--- a/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
@@ -6,7 +6,7 @@
 // These functions are only used for platforms which support
 // using sysctl to gather protocol statistics information.
 // Currently, this is all keyed off of whether the include tcp_var.h
-// exists, but we may want to make this more granular for differnet platforms.
+// exists, but we may want to make this more granular for different platforms.
 
 #if HAVE_NETINET_TCP_VAR_H
 
@@ -27,6 +27,7 @@
 #include <net/if.h>
 
 #include <sys/types.h>
+#include <stdatomic.h>
 #if HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
@@ -55,6 +56,17 @@
 #if HAVE_NETINET_ICMP_VAR_H
 #include <netinet/icmp_var.h>
 #endif
+
+static _Atomic(int) icmp6statSize = sizeof(struct icmp6stat);
+
+static size_t GetEstimatedSize(const char* name)
+{
+    void* oldp = NULL;
+    size_t oldlenp = 0;
+
+    sysctlbyname(name, oldp, &oldlenp, NULL, 0);
+    return oldlenp;
+}
 
 int32_t SystemNative_GetTcpGlobalStatistics(TcpGlobalStatistics* retStats)
 {
@@ -228,26 +240,49 @@ int32_t SystemNative_GetIcmpv4GlobalStatistics(Icmpv4GlobalStatistics* retStats)
 
 int32_t SystemNative_GetIcmpv6GlobalStatistics(Icmpv6GlobalStatistics* retStats)
 {
-    // macOS 11.0 added new member to icmp6stat. To make it binary compatible we simply allocate
-    // little bit more and that is ok on older systems. This will make it more resilient to additions in future.
-    // This avoid runtime detection and dynamic allocation. And we do not care about the new value.
-
-    #define ICMP6_STAT_PAD 32
-
-    size_t oldlenp;
-
     assert(retStats != NULL);
-    unsigned char buffer[sizeof(struct icmp6stat) + ICMP6_STAT_PAD];
-    oldlenp = sizeof(buffer);
 
-    if (sysctlbyname("net.inet6.icmp6.stats", &buffer, &oldlenp, NULL, 0))
+    size_t oldlenp = atomic_load(&icmp6statSize);
+    const char* sysctlName = "net.inet6.icmp6.stats";
+    void* buffer = malloc(oldlenp);
+    if (!buffer)
     {
+        memset(retStats, 0, sizeof(Icmpv6GlobalStatistics));
+        errno = ENOMEM;
+        return -1;
+    }
+
+    int result = sysctlbyname(sysctlName, buffer, &oldlenp, NULL, 0);
+    if (result && errno == ENOMEM)
+    {
+        // We did not provide enough memory.
+        // macOS 11.0 added new member to icmp6stat so as FreeBSED reported changes between versions.
+        oldlenp = GetEstimatedSize(sysctlName);
+        buffer = realloc(buffer, oldlenp);
+        if (buffer)
+        {
+            result = sysctlbyname(sysctlName, buffer, &oldlenp, NULL, 0);
+            if (result == 0)
+            {
+                // if the call succeeded, update icmp6statSize
+                atomic_store(&icmp6statSize, oldlenp);
+            }
+        }
+    }
+
+    if (result)
+    {
+        if (buffer)
+        {
+            free(buffer);
+        }
+
         memset(retStats, 0, sizeof(Icmpv6GlobalStatistics));
         return -1;
     }
 
-    uint64_t* inHist = ((struct icmp6stat*)(&buffer))->icp6s_inhist;
-    uint64_t* outHist = ((struct icmp6stat*)(&buffer))->icp6s_outhist;
+    uint64_t* inHist = ((struct icmp6stat*)(buffer))->icp6s_inhist;
+    uint64_t* outHist = ((struct icmp6stat*)(buffer))->icp6s_outhist;
 
     retStats->DestinationUnreachableMessagesReceived = inHist[ICMP6_DST_UNREACH];
     retStats->DestinationUnreachableMessagesSent = outHist[ICMP6_DST_UNREACH];
@@ -278,6 +313,8 @@ int32_t SystemNative_GetIcmpv6GlobalStatistics(Icmpv6GlobalStatistics* retStats)
     retStats->TimeExceededMessagesReceived = inHist[ICMP6_TIME_EXCEEDED];
     retStats->TimeExceededMessagesSent = outHist[ICMP6_TIME_EXCEEDED];
 
+    free(buffer);
+
     return 0;
 }
 
@@ -296,22 +333,14 @@ int32_t SystemNative_GetActiveTcpConnectionInfos(__attribute__((unused)) NativeT
     return 0;
 }
 #else
-static size_t GetEstimatedTcpPcbSize()
-{
-    void* oldp = NULL;
-    void* newp = NULL;
-    size_t oldlenp, newlen = 0;
-
-    sysctlbyname("net.inet.tcp.pcblist", oldp, &oldlenp, newp, newlen);
-    return oldlenp;
-}
-
 int32_t SystemNative_GetActiveTcpConnectionInfos(NativeTcpConnectionInformation* infos, int32_t* infoCount)
 {
     assert(infos != NULL);
     assert(infoCount != NULL);
 
-    size_t estimatedSize = GetEstimatedTcpPcbSize();
+    const char* sysctlName = "net.inet.tcp.pcblist";
+
+    size_t estimatedSize = GetEstimatedSize(sysctlName);
     uint8_t* buffer = (uint8_t*)malloc(estimatedSize * sizeof(uint8_t));
     if (buffer == NULL)
     {
@@ -322,7 +351,7 @@ int32_t SystemNative_GetActiveTcpConnectionInfos(NativeTcpConnectionInformation*
     void* newp = NULL;
     size_t newlen = 0;
 
-    while (sysctlbyname("net.inet.tcp.pcblist", buffer, &estimatedSize, newp, newlen) != 0)
+    while (sysctlbyname(sysctlName, buffer, &estimatedSize, newp, newlen) != 0)
     {
         free(buffer);
         size_t tmpEstimatedSize;
@@ -404,22 +433,14 @@ int32_t SystemNative_GetActiveUdpListeners(__attribute__((unused)) IPEndPointInf
     return 0;
 }
 #else
-static size_t GetEstimatedUdpPcbSize()
-{
-    void* oldp = NULL;
-    void* newp = NULL;
-    size_t oldlenp, newlen = 0;
-
-    sysctlbyname("net.inet.udp.pcblist", oldp, &oldlenp, newp, newlen);
-    return oldlenp;
-}
-
 int32_t SystemNative_GetActiveUdpListeners(IPEndPointInfo* infos, int32_t* infoCount)
 {
     assert(infos != NULL);
     assert(infoCount != NULL);
 
-    size_t estimatedSize = GetEstimatedUdpPcbSize();
+    const char* sysctlName = "net.inet.udp.pcblist";
+
+    size_t estimatedSize = GetEstimatedSize(sysctlName);
     uint8_t* buffer = (uint8_t*)malloc(estimatedSize * sizeof(uint8_t));
     if (buffer == NULL)
     {
@@ -430,7 +451,7 @@ int32_t SystemNative_GetActiveUdpListeners(IPEndPointInfo* infos, int32_t* infoC
     void* newp = NULL;
     size_t newlen = 0;
 
-    while (sysctlbyname("net.inet.udp.pcblist", buffer, &estimatedSize, newp, newlen) != 0)
+    while (sysctlbyname(sysctlName, buffer, &estimatedSize, newp, newlen) != 0)
     {
         free(buffer);
         size_t tmpEstimatedSize;

--- a/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
@@ -242,7 +242,7 @@ int32_t SystemNative_GetIcmpv6GlobalStatistics(Icmpv6GlobalStatistics* retStats)
 {
     assert(retStats != NULL);
 
-    size_t oldlenp = atomic_load(&icmp6statSize);
+    size_t oldlenp = (size_t)atomic_load(&icmp6statSize);
     const char* sysctlName = "net.inet6.icmp6.stats";
     void* buffer = malloc(oldlenp);
     if (!buffer)


### PR DESCRIPTION
This fixes #40938 and networking stats on macOS 11.
The problem is that Apple added extra filed (to the and) and that breaks binary compatibility. 
We could do runtime size detection and allocate needed memory dynamically. 
But I think it is better to keep the code simple so I added little padding for sysctl call. 
It does not care if we give it more and it fits updated structure (with some small room for next additions) 

I verified that code built on 10.0 agains old headers works OK on 11.0. (and we do not care about the new value)