### PR TITLE
Remove call to memset in EventPipeBuffer constructor

### DIFF
--- a/src/coreclr/src/vm/eventpipebuffer.cpp
+++ b/src/coreclr/src/vm/eventpipebuffer.cpp
@@ -30,13 +30,6 @@ EventPipeBuffer::EventPipeBuffer(unsigned int bufferSize, EventPipeThread* pWrit
     // to servicing releases. We may come back in the future to reassess this and potentially improve
     // the throughput via more performant solution afterwards.
     m_pBuffer = (BYTE*)ClrVirtualAlloc(NULL, bufferSize, MEM_COMMIT, PAGE_READWRITE);
-
-    // memset may be unnecessary here because VirtualAlloc with MEM_COMMIT zero-initializes the pages and mmap also zero-initializes
-    // if MAP_UNINITIALIZED isn't passed (which ClrVirtualAlloc doesn't). If this memset ends up being a perf cost in future investigations
-    // we may remove this. But for risk mitigation we're leaving it as-is.
-    // (See https://github.com/dotnet/runtime/pull/35924#discussion_r421282564 for discussion on this)
-    memset(m_pBuffer, 0, bufferSize);
-    
     m_pLimit = m_pBuffer + bufferSize;
     m_pCurrent = GetNextAlignedAddress(m_pBuffer);
 


### PR DESCRIPTION
In heavy-write scenarios, it is possible for EventPipeBufferManager::AllocateBufferForThread to block the flushing thread (the thread that is flushing out events out of EventPipeBufferManager to the underlying IPC channel) because they both need to grab the spinlock in EventPipeBufferManager.

From a benchmark I wrote, the `memset` here was found as taking 10% of the thread time for the flushing thread, and I was able to verify that removing this improves overall throughput of Event writes by ~15% in the benchmark program I have with 24 threads writing events as fast as they can.

