### PR TITLE
Fix wrong copy prop after `ASG(promoted LCL_VAR with 1 field, call)`.

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6512,7 +6512,7 @@ public:
     void optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
-    bool optIsSsaLocal(GenTree* tree);
+    unsigned optIsSsaLocal(GenTree* tree);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();
     INDEBUG(void optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName));

--- a/src/coreclr/src/jit/copyprop.cpp
+++ b/src/coreclr/src/jit/copyprop.cpp
@@ -36,8 +36,8 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrSt
             {
                 continue;
             }
-            unsigned lclNum = tree->AsLclVarCommon()->GetLclNum();
-            if (!lvaInSsa(lclNum))
+            const unsigned lclNum = optIsSsaLocal(tree);
+            if (lclNum == BAD_VAR_NUM)
             {
                 continue;
             }
@@ -150,10 +150,10 @@ void Compiler::optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, Lc
     {
         return;
     }
-    unsigned lclNum = tree->AsLclVarCommon()->GetLclNum();
+    const unsigned lclNum = optIsSsaLocal(tree);
 
     // Skip non-SSA variables.
-    if (!lvaInSsa(lclNum))
+    if (lclNum == BAD_VAR_NUM)
     {
         return;
     }

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -6789,6 +6789,10 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
             {
                 fgMutateAddressExposedLocal(tree DEBUGARG("COPYBLK - address-exposed local"));
             }
+            else
+            {
+                JITDUMP("LHS V%02u not in ssa at [%06u], so no VN assigned\n", lhsLclNum, dspTreeID(lclVarTree));
+            }
         }
         else
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_41100/Runtime_41100.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_41100/Runtime_41100.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// The test was showing a wrong copy propogation when a struct field was rewritten by 
+// a call assignment to the parent struct but that assignment was not supported by copyprop.
+
+using System;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+class X
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void E(ImmutableArray<string> a) {}
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ImmutableArray<string> G() => ImmutableArray<string>.Empty;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ImmutableArray<string> H()
+    {
+        string[] a = new string[100];
+        
+        for (int i = 0; i < a.Length; i++)
+        {
+            a[i] = "hello";
+        }
+
+        return ImmutableArray.Create<string>(a);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]    
+    public static int F()
+    {
+        var a = H();
+        int r = 0;
+
+        foreach (var s in a)
+        {
+            if (s.Equals("hello")) r++;
+        }
+
+        var aa = a;
+
+        if (r > 0)
+
+        {
+            foreach (var s in a)
+            {
+                if (s.Equals("hello")) r--;
+            }
+        
+            aa = G();
+
+            foreach (var s in a)
+            {
+                if (s.Equals("hello")) r++;
+            }
+        }
+
+        E(aa);
+
+        return r;
+    }
+
+    public static int Main() => F();
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_41100/Runtime_41100.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_41100/Runtime_41100.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Diffs for the library from #41100 :
```
PMI CodeSize Diffs for C:\Users\AC-93\.nuget\packages\microsoft.net.compilers.toolset\3.8.0-3.20416.3\tasks\netcoreapp3.1\bincore\Microsoft.CodeAnalysis.CSharp.dll for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: 38 (0.001% of base)
    diff is a regression.
Top file regressions (bytes):
          38 : Microsoft.CodeAnalysis.CSharp.dasm (0.001% of base)
1 total files with Code Size differences (0 improved, 1 regressed), 0 unchanged.
Top method regressions (bytes):
          44 (5.556% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEMethodSymbol:get_ExplicitInterfaceImplementations():ImmutableArray`1:this
Top method improvements (bytes):
          -3 (-0.057% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodBodySynthesizer:MakeSubmissionInitialization(ArrayBuilder`1,SyntaxNode,MethodSymbol,SynthesizedSubmissionFields,CSharpCompilation)
          -3 (-0.372% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SynthesizedParameterSymbol:DeriveParameters(MethodSymbol,MethodSymbol):ImmutableArray`1
Top method regressions (percentages):
          44 (5.556% of base) : Microsoft.CodeAnalysis.CSharp.dasm - PEMethodSymbol:get_ExplicitInterfaceImplementations():ImmutableArray`1:this
Top method improvements (percentages):
          -3 (-0.372% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SynthesizedParameterSymbol:DeriveParameters(MethodSymbol,MethodSymbol):ImmutableArray`1
          -3 (-0.057% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodBodySynthesizer:MakeSubmissionInitialization(ArrayBuilder`1,SyntaxNode,MethodSymbol,SynthesizedSubmissionFields,CSharpCompilation)
3 total methods with Code Size differences (2 improved, 1 regressed), 37448 unchanged.
Completed analysis in 6.31s
```

diffs in `PEMethodSymbol:get_ExplicitInterfaceImplementations` are the fix, diffs in `DeriveParameters` and `MakeSubmissionInitialization` are correct, but the base version asm was correct as well (a replacement was wrong but the result was valid).

0 diffs in master framework libraries (crossgen), pmi diffs:
```
Total bytes of diff: -5 (-0.000% of base)
    diff is an improvement.
Top file regressions (bytes):
           3 : Microsoft.CodeAnalysis.CSharp.dasm (0.000% of base)
Top file improvements (bytes):
          -8 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.000% of base)
2 total files with Code Size differences (1 improved, 1 regressed), 263 unchanged.
Top method regressions (bytes):
           3 (0.067% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodBodySynthesizer:ConstructFieldLikeEventAccessorBody_Regular(SourceEventSymbol,bool,CSharpCompilation,DiagnosticBag):BoundBlock
Top method improvements (bytes):
          -5 (-0.108% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindLambdaBody(LambdaSymbol,DiagnosticBag,byref):BoundBlock:this
          -3 (-0.146% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - LocalRewriter:RewriteWinRtEvent(BoundAddRemoveHandlerStatement,BoundEventAccess,bool):BoundStatement:this
```

The regression in `MethodBodySynthesizer:ConstructFieldLikeEventAccessorBody_Regular` is the result of using an unstable mechanism to choose the copy prop replacement,  so additional inserts (because we now add for `ASG(LCL_VAR, call)`) change one replacement and it was less optimal. Both the base and the diff were producing correct asm.

The same for `Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindLambdaBody(LambdaSymbol,DiagnosticBag,byref):BoundBlock:this` and `LocalRewriter:RewriteWinRtEvent(BoundAddRemoveHandlerStatement,BoundEventAccess,bool):BoundStatement:this`.


<details>
  <summary>Example of the copy diff.</summary>

```
N003 (  1,  3) [000034] -A------R---              *  ASG       ref   
N002 (  1,  1) [000033] D------N----              +--*  LCL_VAR   ref    V07 loc3         d:2
N001 (  1,  1) [000032] ------------              \--*  LCL_VAR   ref    V05 loc1         u:2

N003 (  1,  3) [003384] -A------R---              *  ASG       ref   
N002 (  1,  1) [003383] D------N----              +--*  LCL_VAR   ref    V66 tmp36        d:2
N001 (  1,  1) [000611] ------?-----              \--*  LCL_VAR   ref    V05 loc1         u:2

N009 ( 15, 20) [003382] -A-X--------              *  JTRUE     void  
N008 ( 13, 18) [000602] JA-X--?N----              \--*  EQ        int   
N002 (  3,  2) [000601] ---X--?-----                 +--*  IND       long  
N001 (  1,  1) [000595] ------?-----                 |  \--*  LCL_VAR   ref    V05 loc1         u:2
N007 (  9, 15) [000599] -A----?-----                 \--*  COMMA     long  
N005 (  6, 13) [000597] -A----?-R---                    +--*  ASG       long  
N004 (  3,  2) [000596] D-----?N----                    |  +--*  LCL_VAR   long   V65 tmp35        d:2
N003 (  2, 10) [000594] ------?-----                    |  \--*  CNS_INT(h) long   0xd1ffab1e class
N006 (  3,  2) [000598] ------?-----                    \--*  LCL_VAR   long   V65 tmp35        u:2

```

in the base we were replacing `000595` with `V66` from `000033`, in the diff we replace it with `V07` from `33` because `V07` and `V66` switched the order in the hashtable as a random side-effect from correct handling of
```
N007 ( 21, 21) [000496] -ACXG---R---              *  ASG       struct (copy) $VN.Void
N006 (  3,  2) [000494] D------N----              +--*  LCL_VAR   struct<System.Collections.Immutable.ImmutableArray`1[__Canon], 8>(P) V58 tmp28        d:2
                                                  +--*    ref    V58.array (offs=0x00) -> V255 tmp225      
N005 ( 17, 18) [000481] --CXG-------              \--*  CALL      struct System.Collections.Immutable.ImmutableArray.Create $5ca
N003 (  1,  1) [000480] ------------ arg1 in rdx     +--*  LCL_VAR   ref    V19 loc15        u:2 $393
N004 (  2, 10) [000482] ------------ arg0 in rcx     \--*  CNS_INT(h) long   0xd1ffab1e method $223
```
there.
</details>

The BING spmi was showing me 3 diffs but it was actually the same method 3 times and **it was generating a bad code before**, now it is fixed, not sure why `removeDuplicate` did not delete them (-c 105012, 456212, 449211).

The pri1 spmi collection has not found any diffs not caught by PMI.


Fixes #41100, will be ported to RC1.

Thanks Andy for the analysis, the repro test, and the proposed fix.