### PR TITLE
Fix perf regression in IntPtr operators on 32-bit platforms

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -148,7 +148,7 @@ namespace System
 
         [NonVersionable]
         public static unsafe IntPtr operator +(IntPtr pointer, int offset) =>
-            new IntPtr((nint)pointer._value + offset);
+            (nint)pointer._value + offset;
 
         [NonVersionable]
         public static IntPtr Subtract(IntPtr pointer, int offset) =>
@@ -156,7 +156,7 @@ namespace System
 
         [NonVersionable]
         public static unsafe IntPtr operator -(IntPtr pointer, int offset) =>
-            new IntPtr((nint)pointer._value - offset);
+            (nint)pointer._value - offset;
 
         public static int Size
         {

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -142,7 +142,7 @@ namespace System
 
         [NonVersionable]
         public static unsafe UIntPtr operator +(UIntPtr pointer, int offset) =>
-            new UIntPtr((nuint)pointer._value + (nuint)offset);
+            (nuint)pointer._value + (nuint)offset;
 
         [NonVersionable]
         public static UIntPtr Subtract(UIntPtr pointer, int offset) =>
@@ -150,7 +150,7 @@ namespace System
 
         [NonVersionable]
         public static unsafe UIntPtr operator -(UIntPtr pointer, int offset) =>
-            new UIntPtr((nuint)pointer._value - (nuint)offset);
+            (nuint)pointer._value - (nuint)offset;
 
         public static int Size
         {


### PR DESCRIPTION
Switching to C# built-in uint/nuint types caused these operators to use long/ulong IntPtr/UIntPtr constructors instead of int/uint IntPtr constructors that it were used before.

The fix is to avoid going through the IntPtr/UIntPtr constructors and just depend on the built-in uint/nuint implicit conversions.

Fixes #41167