### PR TITLE
Fix Char.GetUnicodeCategory to returns correct results

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -47,11 +47,6 @@ namespace System
         // - 0x40 bit if set means 'is uppercase letter'
         // - 0x20 bit if set means 'is lowercase letter'
         // - bottom 5 bits are the UnicodeCategory of the character
-        //
-        // n.b. This data is locked to an earlier version of the Unicode standard (2.0, perhaps?), so
-        // the UnicodeCategory data contained here doesn't necessarily reflect the UnicodeCategory data
-        // contained within the CharUnicodeInfo or Rune types, which generally follow the latest Unicode
-        // standard.
         private static ReadOnlySpan<byte> Latin1CharInfo => new byte[]
         {
         //  0     1     2     3     4     5     6     7     8     9     A     B     C     D     E     F
@@ -525,7 +520,7 @@ namespace System
             if (IsLatin1(c))
             {
                 return CheckLetterOrDigit(GetLatin1UnicodeCategory(c));
-        }
+            }
             return CheckLetterOrDigit(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -54,6 +54,7 @@ namespace System
         // standard.
         private static ReadOnlySpan<byte> Latin1CharInfo => new byte[]
         {
+        //  0     1     2     3     4     5     6     7     8     9     A     B     C     D     E     F
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x8E, 0x8E, 0x8E, 0x8E, 0x8E, 0x0E, 0x0E, // U+0000..U+000F
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, // U+0010..U+001F
             0x8B, 0x18, 0x18, 0x18, 0x1A, 0x18, 0x18, 0x18, 0x14, 0x15, 0x18, 0x19, 0x18, 0x13, 0x18, 0x18, // U+0020..U+002F
@@ -64,8 +65,8 @@ namespace System
             0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x14, 0x19, 0x15, 0x19, 0x0E, // U+0070..U+007F
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x8E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, // U+0080..U+008F
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, // U+0090..U+009F
-            0x8B, 0x18, 0x1A, 0x1A, 0x1A, 0x1A, 0x1C, 0x1C, 0x1B, 0x1C, 0x21, 0x16, 0x19, 0x13, 0x1C, 0x1B, // U+00A0..U+00AF
-            0x1C, 0x19, 0x0A, 0x0A, 0x1B, 0x21, 0x1C, 0x18, 0x1B, 0x0A, 0x21, 0x17, 0x0A, 0x0A, 0x0A, 0x18, // U+00B0..U+00BF
+            0x8B, 0x18, 0x1A, 0x1A, 0x1A, 0x1A, 0x1C, 0x14, 0x1B, 0x1C, 0x04, 0x16, 0x19, 0x0F, 0x1C, 0x1B, // U+00A0..U+00AF
+            0x1C, 0x19, 0x0A, 0x0A, 0x1B, 0x21, 0x18, 0x18, 0x1B, 0x0A, 0x04, 0x17, 0x0A, 0x0A, 0x0A, 0x18, // U+00B0..U+00BF
             0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, // U+00C0..U+00CF
             0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x19, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x21, // U+00D0..U+00DF
             0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, // U+00E0..U+00EF
@@ -73,16 +74,10 @@ namespace System
         };
 
         // Return true for all characters below or equal U+00ff, which is ASCII + Latin-1 Supplement.
-        private static bool IsLatin1(char ch)
-        {
-            return (uint)ch < (uint)Latin1CharInfo.Length;
-        }
+        private static bool IsLatin1(char ch) => (uint)ch < (uint)Latin1CharInfo.Length;
 
         // Return true for all characters below or equal U+007f, which is ASCII.
-        private static bool IsAscii(char ch)
-        {
-            return (uint)ch <= '\x007f';
-        }
+        private static bool IsAscii(char ch) => (uint)ch <= '\x007f';
 
         // Return the Unicode category for Unicode character <= 0x00ff.
         private static UnicodeCategory GetLatin1UnicodeCategory(char ch)
@@ -96,7 +91,7 @@ namespace System
         //
 
         //
-        // Overriden Instance Methods
+        // Overridden Instance Methods
         //
 
         // Calculate a hashcode for a 2 byte Unicode character.
@@ -200,7 +195,7 @@ namespace System
         //
         // Static Methods
         //
-        /*=================================ISDIGIT======================================
+        /*=================================IsDigit======================================
         **A wrapper for char.  Returns a boolean indicating whether    **
         **character c is considered to be a digit.                                    **
         ==============================================================================*/
@@ -226,17 +221,17 @@ namespace System
             return IsInRange(uc, UnicodeCategory.UppercaseLetter, UnicodeCategory.OtherLetter);
         }
 
-        /*=================================ISLETTER=====================================
+        /*=================================IsLetter=====================================
         **A wrapper for char.  Returns a boolean indicating whether    **
         **character c is considered to be a letter.                                   **
         ==============================================================================*/
         // Determines whether a character is a letter.
         public static bool IsLetter(char c)
         {
-            if (IsLatin1(c))
+            if (IsAscii(c))
             {
                 // For the version of the Unicode standard the Char type is locked to, the
-                // Latin-1 range doesn't include letters in categories other than "upper" and "lower".
+                // ASCII range doesn't include letters in categories other than "upper" and "lower".
                 return (Latin1CharInfo[c] & (IsUpperCaseLetterFlag | IsLowerCaseLetterFlag)) != 0;
             }
             return CheckLetter(CharUnicodeInfo.GetUnicodeCategory(c));
@@ -248,7 +243,7 @@ namespace System
             return (Latin1CharInfo[c] & IsWhiteSpaceFlag) != 0;
         }
 
-        /*===============================ISWHITESPACE===================================
+        /*===============================IsWhiteSpace===================================
         **A wrapper for char.  Returns a boolean indicating whether    **
         **character c is considered to be a whitespace character.                     **
         ==============================================================================*/
@@ -264,7 +259,7 @@ namespace System
         }
 
         /*===================================IsUpper====================================
-        **Arguments: c -- the characater to be checked.
+        **Arguments: c -- the character to be checked.
         **Returns:  True if c is an uppercase character.
         ==============================================================================*/
         // Determines whether a character is upper-case.
@@ -278,7 +273,7 @@ namespace System
         }
 
         /*===================================IsLower====================================
-        **Arguments: c -- the characater to be checked.
+        **Arguments: c -- the character to be checked.
         **Returns:  True if c is an lowercase character.
         ==============================================================================*/
         // Determines whether a character is lower-case.
@@ -297,7 +292,7 @@ namespace System
         }
 
         /*================================IsPunctuation=================================
-        **Arguments: c -- the characater to be checked.
+        **Arguments: c -- the character to be checked.
         **Returns:  True if c is an punctuation mark
         ==============================================================================*/
         // Determines whether a character is a punctuation mark.
@@ -340,7 +335,7 @@ namespace System
             return culture.TextInfo.ToUpper(c);
         }
 
-        /*=================================TOUPPER======================================
+        /*=================================ToUpper======================================
         **A wrapper for char.ToUpperCase.  Converts character c to its **
         **uppercase equivalent.  If c is already an uppercase character or is not an  **
         **alphabetic, nothing happens.                                                **
@@ -367,7 +362,7 @@ namespace System
             return culture.TextInfo.ToLower(c);
         }
 
-        /*=================================TOLOWER======================================
+        /*=================================ToLower======================================
         **A wrapper for char.ToLowerCase.  Converts character c to its **
         **lowercase equivalent.  If c is already a lowercase character or is not an   **
         **alphabetic, nothing happens.                                                **
@@ -498,7 +493,7 @@ namespace System
             {
                 return IsInRange(c, '0', '9');
             }
-            return CharUnicodeInfo.GetUnicodeCategory(s, index) == UnicodeCategory.DecimalDigitNumber;
+            return CharUnicodeInfo.GetUnicodeCategoryInternal(s, index) == UnicodeCategory.DecimalDigitNumber;
         }
 
         public static bool IsLetter(string s, int index)
@@ -510,12 +505,12 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
             char c = s[index];
-            if (IsLatin1(c))
+            if (IsAscii(c))
             {
-                // The Latin-1 range doesn't include letters in categories other than "upper" and "lower"
+                // The ASCII range doesn't include letters in categories other than "upper" and "lower"
                 return (Latin1CharInfo[c] & (IsUpperCaseLetterFlag | IsLowerCaseLetterFlag)) != 0;
             }
-            return CheckLetter(CharUnicodeInfo.GetUnicodeCategory(s, index));
+            return CheckLetter(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         public static bool IsLetterOrDigit(string s, int index)
@@ -530,8 +525,8 @@ namespace System
             if (IsLatin1(c))
             {
                 return CheckLetterOrDigit(GetLatin1UnicodeCategory(c));
-            }
-            return CheckLetterOrDigit(CharUnicodeInfo.GetUnicodeCategory(s, index));
+        }
+            return CheckLetterOrDigit(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         public static bool IsLower(string s, int index)
@@ -548,7 +543,7 @@ namespace System
                 return (Latin1CharInfo[c] & IsLowerCaseLetterFlag) != 0;
             }
 
-            return CharUnicodeInfo.GetUnicodeCategory(s, index) == UnicodeCategory.LowercaseLetter;
+            return CharUnicodeInfo.GetUnicodeCategoryInternal(s, index) == UnicodeCategory.LowercaseLetter;
         }
 
         /*=================================CheckNumber=====================================
@@ -590,7 +585,7 @@ namespace System
                 }
                 return CheckNumber(GetLatin1UnicodeCategory(c));
             }
-            return CheckNumber(CharUnicodeInfo.GetUnicodeCategory(s, index));
+            return CheckNumber(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -614,11 +609,11 @@ namespace System
             {
                 return CheckPunctuation(GetLatin1UnicodeCategory(c));
             }
-            return CheckPunctuation(CharUnicodeInfo.GetUnicodeCategory(s, index));
+            return CheckPunctuation(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         /*================================= CheckSeparator ============================
-        ** Check if the specified UnicodeCategory belongs to the seprator categories.
+        ** Check if the specified UnicodeCategory belongs to the separator categories.
         ==============================================================================*/
 
         internal static bool CheckSeparator(UnicodeCategory uc)
@@ -655,7 +650,7 @@ namespace System
             {
                 return IsSeparatorLatin1(c);
             }
-            return CheckSeparator(CharUnicodeInfo.GetUnicodeCategory(s, index));
+            return CheckSeparator(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         public static bool IsSurrogate(char c)
@@ -707,7 +702,7 @@ namespace System
             {
                 return CheckSymbol(GetLatin1UnicodeCategory(c));
             }
-            return CheckSymbol(CharUnicodeInfo.GetUnicodeCategory(s, index));
+            return CheckSymbol(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         public static bool IsUpper(string s, int index)
@@ -724,7 +719,7 @@ namespace System
                 return (Latin1CharInfo[c] & IsUpperCaseLetterFlag) != 0;
             }
 
-            return CharUnicodeInfo.GetUnicodeCategory(s, index) == UnicodeCategory.UppercaseLetter;
+            return CharUnicodeInfo.GetUnicodeCategoryInternal(s, index) == UnicodeCategory.UppercaseLetter;
         }
 
         public static bool IsWhiteSpace(string s, int index)
@@ -779,7 +774,7 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
-            return CharUnicodeInfo.GetNumericValue(s, index);
+            return CharUnicodeInfo.GetNumericValueInternal(s, index);
         }
 
         /*================================= IsHighSurrogate ============================

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
@@ -6,8 +6,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Unicode;
-using Internal.Runtime.CompilerServices;
 using System.Runtime.CompilerServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Globalization
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Unicode;
 using Internal.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace System.Globalization
 {
@@ -224,8 +225,11 @@ namespace System.Globalization
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
-            return GetNumericValueNoBoundsCheck((uint)GetCodePointFromString(s, index));
+            return GetNumericValueInternal(s, index);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static double GetNumericValueInternal(string s, int index) => GetNumericValueNoBoundsCheck((uint)GetCodePointFromString(s, index));
 
         private static double GetNumericValueNoBoundsCheck(uint codePoint)
         {

--- a/src/libraries/System.Runtime/tests/System/CharTests.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.cs
@@ -278,17 +278,17 @@ namespace System.Tests
         {
             var categories = new UnicodeCategory[]
             {
-            UnicodeCategory.UppercaseLetter,
-            UnicodeCategory.LowercaseLetter,
-            UnicodeCategory.TitlecaseLetter,
-            UnicodeCategory.ModifierLetter,
-            UnicodeCategory.OtherLetter
+                UnicodeCategory.UppercaseLetter,
+                UnicodeCategory.LowercaseLetter,
+                UnicodeCategory.TitlecaseLetter,
+                UnicodeCategory.ModifierLetter,
+                UnicodeCategory.OtherLetter
             };
             foreach (char c in GetTestChars(categories))
-                Assert.True(char.IsLetter(c.ToString(), 0));
+                Assert.True(char.IsLetter(c.ToString(), 0), $"'{c}':{(int)c:x4} Is Not Letter");
 
             foreach (char c in GetTestCharsNotInCategory(categories))
-                Assert.False(char.IsLetter(c.ToString(), 0));
+                Assert.False(char.IsLetter(c.ToString(), 0), $"'{c}':{(int)c:x4} Is Not Letter");
         }
 
         [Fact]
@@ -667,10 +667,10 @@ namespace System.Tests
         {
             var categories = new UnicodeCategory[]
             {
-            UnicodeCategory.MathSymbol,
-            UnicodeCategory.ModifierSymbol,
-            UnicodeCategory.CurrencySymbol,
-            UnicodeCategory.OtherSymbol
+                UnicodeCategory.MathSymbol,
+                UnicodeCategory.ModifierSymbol,
+                UnicodeCategory.CurrencySymbol,
+                UnicodeCategory.OtherSymbol
             };
             foreach (char c in GetTestChars(categories))
                 Assert.True(char.IsSymbol(c.ToString(), 0));
@@ -966,36 +966,36 @@ namespace System.Tests
 
         private static char[][] s_latinTestSet = new char[][]
         {
-        new char[] {'\u0047','\u004c','\u0051','\u0056','\u00c0','\u00c5','\u00ca','\u00cf','\u00d4','\u00da'}, // UnicodeCategory.UppercaseLetter
-        new char[] {'\u0062','\u0068','\u006e','\u0074','\u007a','\u00e1','\u00e7','\u00ed','\u00f3','\u00fa'}, // UnicodeCategory.LowercaseLetter
-        new char[] {}, // UnicodeCategory.TitlecaseLetter
-        new char[] {}, // UnicodeCategory.ModifierLetter
-        new char[] {}, // UnicodeCategory.OtherLetter
-        new char[] {}, // UnicodeCategory.NonSpacingMark
-        new char[] {}, // UnicodeCategory.SpacingCombiningMark
-        new char[] {}, // UnicodeCategory.EnclosingMark
-        new char[] {'\u0030','\u0031','\u0032','\u0033','\u0034','\u0035','\u0036','\u0037','\u0038','\u0039'}, // UnicodeCategory.DecimalDigitNumber
-        new char[] {}, // UnicodeCategory.LetterNumber
-        new char[] {'\u00b2','\u00b3','\u00b9','\u00bc','\u00bd','\u00be'}, // UnicodeCategory.OtherNumber
-        new char[] {'\u0020','\u00a0'}, // UnicodeCategory.SpaceSeparator
-        new char[] {}, // UnicodeCategory.LineSeparator
-        new char[] {}, // UnicodeCategory.ParagraphSeparator
-        new char[] {'\u0005','\u000b','\u0011','\u0017','\u001d','\u0082','\u0085','\u008e','\u0094','\u009a'}, // UnicodeCategory.Control
-        new char[] {}, // UnicodeCategory.Format
-        new char[] {}, // UnicodeCategory.Surrogate
-        new char[] {}, // UnicodeCategory.PrivateUse
-        new char[] {'\u005f'}, // UnicodeCategory.ConnectorPunctuation
-        new char[] {'\u002d','\u00ad'}, // UnicodeCategory.DashPunctuation
-        new char[] {'\u0028','\u005b','\u007b'}, // UnicodeCategory.OpenPunctuation
-        new char[] {'\u0029','\u005d','\u007d'}, // UnicodeCategory.ClosePunctuation
-        new char[] {'\u00ab'}, // UnicodeCategory.InitialQuotePunctuation
-        new char[] {'\u00bb'}, // UnicodeCategory.FinalQuotePunctuation
-        new char[] {'\u002e','\u002f','\u003a','\u003b','\u003f','\u0040','\u005c','\u00a1','\u00b7','\u00bf'}, // UnicodeCategory.OtherPunctuation
-        new char[] {'\u002b','\u003c','\u003d','\u003e','\u007c','\u007e','\u00ac','\u00b1','\u00d7','\u00f7'}, // UnicodeCategory.MathSymbol
-        new char[] {'\u0024','\u00a2','\u00a3','\u00a4','\u00a5'}, // UnicodeCategory.CurrencySymbol
-        new char[] {'\u005e','\u0060','\u00a8','\u00af','\u00b4','\u00b8'}, // UnicodeCategory.ModifierSymbol
-        new char[] {'\u00a6','\u00a7','\u00a9','\u00ae','\u00b0','\u00b6'}, // UnicodeCategory.OtherSymbol
-        new char[] {}, // UnicodeCategory.OtherNotAssigned
+        /* UppercaseLetter         */ new char[] {'\u0047','\u004c','\u0051','\u0056','\u00c0','\u00c5','\u00ca','\u00cf','\u00d4','\u00da'},
+        /* LowercaseLetter         */ new char[] {'\u0062','\u0068','\u006e','\u0074','\u007a','\u00e1','\u00e7','\u00ed','\u00f3','\u00fa'},
+        /* TitlecaseLetter         */ new char[] {},
+        /* ModifierLetter          */ new char[] {},
+        /* OtherLetter             */ new char[] {'\u00aa','\u00ba'},
+        /* NonSpacingMark          */ new char[] {},
+        /* SpacingCombiningMark    */ new char[] {},
+        /* EnclosingMark           */ new char[] {},
+        /* DecimalDigitNumber      */ new char[] {'\u0030','\u0031','\u0032','\u0033','\u0034','\u0035','\u0036','\u0037','\u0038','\u0039'},
+        /* LetterNumber            */ new char[] {},
+        /* OtherNumber             */ new char[] {'\u00b2','\u00b3','\u00b9','\u00bc','\u00bd','\u00be'},
+        /* SpaceSeparator          */ new char[] {'\u0020','\u00a0'},
+        /* LineSeparator           */ new char[] {},
+        /* ParagraphSeparator      */ new char[] {},
+        /* Control                 */ new char[] {'\u0005','\u000b','\u0011','\u0017','\u001d','\u0082','\u0085','\u008e','\u0094','\u009a'},
+        /* Format                  */ new char[] {'\u00ad'},
+        /* Surrogate               */ new char[] {},
+        /* PrivateUse              */ new char[] {},
+        /* ConnectorPunctuation    */ new char[] {'\u005f'},
+        /* DashPunctuation         */ new char[] {'\u002d'},
+        /* OpenPunctuation         */ new char[] {'\u0028','\u005b','\u007b'},
+        /* ClosePunctuation        */ new char[] {'\u0029','\u005d','\u007d'},
+        /* InitialQuotePunctuation */ new char[] {'\u00ab'},
+        /* FinalQuotePunctuation   */ new char[] {'\u00bb'},
+        /* OtherPunctuation        */ new char[] {'\u002e','\u002f','\u003a','\u003b','\u003f','\u0040','\u005c','\u00a1','\u00a7','\u00b6','\u00b7','\u00bf'},
+        /* MathSymbol              */ new char[] {'\u002b','\u003c','\u003d','\u003e','\u007c','\u007e','\u00ac','\u00b1','\u00d7','\u00f7'},
+        /* CurrencySymbol          */ new char[] {'\u0024','\u00a2','\u00a3','\u00a4','\u00a5'},
+        /* ModifierSymbol          */ new char[] {'\u005e','\u0060','\u00a8','\u00af','\u00b4','\u00b8'},
+        /* OtherSymbol             */ new char[] {'\u00a6','\u00a9','\u00ae','\u00b0'},
+        /* OtherNotAssigned        */ new char[] {},
         };
 
         private static char[][] s_unicodeTestSet = new char[][]
@@ -1077,7 +1077,7 @@ namespace System.Tests
             //                          lower          upper    Culture
             yield return new object[] { 'a', 'A', "en-US" };
             yield return new object[] { 'i', 'I', "en-US" };
-            
+
             if (PlatformDetection.IsNotInvariantGlobalization)
             {
                 yield return new object[] { '\u0131', 'I', "tr-TR" };
@@ -1133,37 +1133,7 @@ namespace System.Tests
 
             for (int i = 0; i <= char.MaxValue; i++)
             {
-                UnicodeCategory expected;
-
-                // The code points in the switch block below must be special-cased
-                // because they switched categories between versions of the Unicode
-                // specification. For compatibility reasons Char keeps its own copy
-                // of the categories for the first 256 code points, as it's locked
-                // to an earlier version of the standard. For an example of a code
-                // point that switched categories, see the discussion on U+00AD
-                // SOFT HYPHEN at https://www.unicode.org/versions/Unicode4.0.0/.
-
-                switch (i)
-                {
-                    case '\u00a7':
-                    case '\u00b6':
-                        expected = UnicodeCategory.OtherSymbol;
-                        break;
-
-                    case '\u00aa':
-                    case '\u00ba':
-                        expected = UnicodeCategory.LowercaseLetter;
-                        break;
-
-                    case '\u00ad':
-                        expected = UnicodeCategory.DashPunctuation;
-                        break;
-
-                    default:
-                        expected = UnicodeData.GetUnicodeCategory(i);
-                        break;
-                }
-
+                UnicodeCategory expected = UnicodeData.GetUnicodeCategory(i);
                 if (expected != char.GetUnicodeCategory((char)i))
                 {
                     // We'll build up the exception message ourselves so the dev knows what code point failed.
@@ -1204,27 +1174,7 @@ namespace System.Tests
 
             for (uint i = 0; i <= char.MaxValue; i++)
             {
-                bool expected;
-
-                switch (i)
-                {
-                    case '\u00AA': // FEMININE ORDINAL INDICATOR
-                    case '\u00BA': // MASCULINE ORDINAL INDICATOR
-
-                        // In Unicode 6.1 the code points U+00AA and U+00BA were reassigned
-                        // from category Ll to category Lo. However, for compatibility reasons,
-                        // Char uses the older version of the Unicode standard for code points
-                        // in the range U+0000..U+00FF. So we'll special-case these here.
-                        // More info: https://www.unicode.org/review/pri181/
-
-                        expected = true;
-                        break;
-
-                    default:
-                        expected = UnicodeData.GetUnicodeCategory((char)i) == UnicodeCategory.LowercaseLetter;
-                        break;
-                }
-
+                bool expected = UnicodeData.GetUnicodeCategory((char)i) == UnicodeCategory.LowercaseLetter;
                 if (expected != char.IsLower((char)i))
                 {
                     // We'll build up the exception message ourselves so the dev knows what code point failed.

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2251,7 +2251,7 @@ namespace System.Tests
                         }
                         else
                         {
-                            Assert.True(tzi.BaseUtcOffset == ts, $"{offset} != {tzi.BaseUtcOffset}, dn:{tzi.DisplayName}, sn:{tzi.StandardName}");
+                            Assert.True(tzi.BaseUtcOffset == ts || tzi.GetUtcOffset(DateTime.Now) == ts, $"{offset} != {tzi.BaseUtcOffset}, dn:{tzi.DisplayName}, sn:{tzi.StandardName}");
                         }
                     }
                 }
@@ -2266,7 +2266,7 @@ namespace System.Tests
             Assert.True(ReferenceEquals(TimeZoneInfo.FindSystemTimeZoneById("UTC"), TimeZoneInfo.Utc));
         }
 
-        // We test the existance of a specific English time zone name to avoid failures on non-English platforms.
+        // We test the existence of a specific English time zone name to avoid failures on non-English platforms.
         [ConditionalFact(nameof(IsEnglishUILanguageAndRemoteExecutorSupported))]
         public static void TestNameWithInvariantCulture()
         {


### PR DESCRIPTION
Fixes #10990

Details listed in the [breaking changes doc](https://github.com/dotnet/docs/issues/20246).