### PR TITLE
[release/5.0] Port 41142: Ensure non-shipping symbol packages get indexed

### DIFF
--- a/src/installer/publish/Directory.Build.targets
+++ b/src/installer/publish/Directory.Build.targets
@@ -88,7 +88,7 @@
       <PotentialSymbolNupkgToPublishFile
         Include="
           @(NupkgToPublishFile->Replace('\NonShipping\', '\Shipping\')->Replace('.nupkg', '.symbols.nupkg'));
-          @(NupkgToPublishFile->Replace('\NonShipping\', '\NonShipping\symbols')->Replace('.nupkg', '.symbols.nupkg'));
+          @(NupkgToPublishFile->Replace('\NonShipping\', '\NonShipping\symbols\')->Replace('.nupkg', '.symbols.nupkg'));
           @(NupkgToPublishFile->Replace('\Shipping\', '\Shipping\symbols\')->Replace('.nupkg', '.symbols.nupkg'))" />
 
       <SymbolNupkgToPublishFile

--- a/src/installer/publish/Directory.Build.targets
+++ b/src/installer/publish/Directory.Build.targets
@@ -88,10 +88,11 @@
       <PotentialSymbolNupkgToPublishFile
         Include="
           @(NupkgToPublishFile->Replace('\NonShipping\', '\Shipping\')->Replace('.nupkg', '.symbols.nupkg'));
+          @(NupkgToPublishFile->Replace('\NonShipping\', '\NonShipping\symbols')->Replace('.nupkg', '.symbols.nupkg'));
           @(NupkgToPublishFile->Replace('\Shipping\', '\Shipping\symbols\')->Replace('.nupkg', '.symbols.nupkg'))" />
 
       <SymbolNupkgToPublishFile
-        Include="@(PotentialSymbolNupkgToPublishFile)"
+        Include="@(PotentialSymbolNupkgToPublishFile -> Distinct())"
         Condition="Exists('%(Identity)')" />
     </ItemGroup>
 


### PR DESCRIPTION
## Customer Impact

Without this the following packages don't get their symbols indexed:

Libraries:
- `Microsoft.Private.CoreFx.OOB`
- `System.Utf8String.Experimental`

Runtime:
- `runtime.linux-arm.Microsoft.CrossOsDiag.Private.CoreCLR`
- `runtime.linux-arm64.Microsoft.CrossOsDiag.Private.CoreCLR`
- `runtime.linux-musl-arm64.Microsoft.CrossOsDiag.Private.CoreCLR`
- `runtime.linux-musl-x64.Microsoft.CrossOsDiag.Private.CoreCLR`
- `runtime.linux-x64.Microsoft.CrossOsDiag.Private.CoreCLR`


The last 5 are necessary for partner team scenarios like Watson, that require symbols to be indexed in the symbol server as that is the only main acquisition method.

cc: @sdmaclea, @tommcdon 

## Testing

Ran an official run against master: https://dev.azure.com/dnceng/internal/_build/results?buildId=783265&view=logs&j=4d50a8bf-a143-51c7-5cc8-defff437e23b&t=4d50a8bf-a143-51c7-5cc8-defff437e23b

The diff in the manifests are only the mentioned packages. This also aligns with Arcade conventions.

## Risk

Very low.