### PR TITLE
Improve ThreadPool ExecutionContext fast-paths

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -445,7 +445,7 @@ jobs:
           - jitosr
           - jitosr_stress
           - jitguardeddevirtualization
-          - jitehwritethru
+          - jitehwritethrudisable
           - jitobjectstackallocation
           - jitpgo
         ${{ if in(parameters.testGroup, 'ilasm') }}:

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -247,7 +247,7 @@ CONFIG_INTEGER(EnablePOPCNT, W("EnablePOPCNT"), 1)           // Enable POPCNT
 CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 0)
 #endif                                                       // !defined(TARGET_AMD64) && !defined(TARGET_X86)
 
-CONFIG_INTEGER(EnableEHWriteThru, W("EnableEHWriteThru"), 0) // Enable the register allocator to support EH-write thru:
+CONFIG_INTEGER(EnableEHWriteThru, W("EnableEHWriteThru"), 1) // Enable the register allocator to support EH-write thru:
                                                              // partial enregistration of vars exposed on EH boundaries
 CONFIG_INTEGER(EnableMultiRegLocals, W("EnableMultiRegLocals"), 1) // Enable the enregistration of locals that are
                                                                    // defined or used in a multireg context.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -25,17 +25,10 @@ namespace System.Runtime.CompilerServices
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
             }
 
-            // enregistrer variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts
-            Thread currentThread0 = Thread.CurrentThread;
-            Thread currentThread = currentThread0;
-            ExecutionContext? previousExecutionCtx0 = currentThread0._executionContext;
-
-            // Store current ExecutionContext and SynchronizationContext as "previousXxx".
-            // This allows us to restore them and undo any Context changes made in stateMachine.MoveNext
-            // so that they won't "leak" out of the first await.
-            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
-            SynchronizationContext? previousSyncCtx = currentThread0._synchronizationContext;
+            Thread currentThread = Thread.CurrentThread;
+            ExecutionContext? previousExecutionCtx = currentThread._executionContext;
+            SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
 
             try
             {
@@ -43,21 +36,17 @@ namespace System.Runtime.CompilerServices
             }
             finally
             {
-                // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
-                SynchronizationContext? previousSyncCtx1 = previousSyncCtx;
-                Thread currentThread1 = currentThread;
                 // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
-                if (previousSyncCtx1 != currentThread1._synchronizationContext)
+                if (previousSyncCtx != currentThread._synchronizationContext)
                 {
                     // Restore changed SynchronizationContext back to previous
-                    currentThread1._synchronizationContext = previousSyncCtx1;
+                    currentThread._synchronizationContext = previousSyncCtx;
                 }
 
-                ExecutionContext? previousExecutionCtx1 = previousExecutionCtx;
-                ExecutionContext? currentExecutionCtx1 = currentThread1._executionContext;
-                if (previousExecutionCtx1 != currentExecutionCtx1)
+                ExecutionContext? currentExecutionCtx = currentThread._executionContext;
+                if (previousExecutionCtx != currentExecutionCtx)
                 {
-                    ExecutionContext.RestoreChangedContextToThread(currentThread1, previousExecutionCtx1, currentExecutionCtx1);
+                    ExecutionContext.RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilder.cs
@@ -83,7 +83,7 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.NoInlining)]
         private Task<VoidTaskResult> InitializeTaskAsPromise()
         {
-            Debug.Assert(m_task == null);
+            Debug.Assert(m_task is null);
             return m_task = new Task<VoidTaskResult>();
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -316,15 +316,13 @@ namespace System.Runtime.CompilerServices
                 Debug.Assert(StateMachine != null);
 
                 ExecutionContext? context = Context;
-                // Call directly if EC flow is suppressed or if context is Default on ThreadPool
-                if (context == null || context.IsDefault)
+                if (context is not null && !context.IsDefault)
                 {
-                    StateMachine.MoveNext();
+                    ExecutionContext.RestoreNonDefaultContextToThreadPool(threadPoolThread, context);
                 }
-                else
-                {
-                    ExecutionContext.RunForThreadPoolUnsafe(context, s_callback, this, threadPoolThread);
-                }
+
+                StateMachine.MoveNext();
+                // ThreadPoolWorkQueue.Dispatch will handle notifications and reset EC and SyncCtx back to default
 
                 // Can't do much here to work with the branch predictor without excessive gotos.
                 if (IsCompleted)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -407,21 +407,18 @@ namespace System.Runtime.CompilerServices
                                 edi = ExceptionDispatchInfo.Capture(ex);
                             }
 
-                            // Enregister references as they have been stack spilled due to crossing EH.
-                            Thread thread = currentThread;
-                            SynchronizationContext? syncCtx = previousSyncCtx;
-                            if (thread._executionContext == null)
+                            if (currentThread._executionContext == null)
                             {
-                                if (thread._synchronizationContext != syncCtx)
+                                if (currentThread._synchronizationContext != previousSyncCtx)
                                 {
-                                    thread._synchronizationContext = syncCtx;
+                                    currentThread._synchronizationContext = previousSyncCtx;
                                 }
 
                                 edi?.Throw();
                             }
                             else
                             {
-                                ExecutionContext.RestoreDefaultContextThrowIfNeeded(thread, syncCtx, edi);
+                                ExecutionContext.RestoreDefaultContextThrowIfNeeded(currentThread, previousSyncCtx, edi);
                             }
                         }
                         else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -186,7 +186,7 @@ namespace System.Runtime.CompilerServices
             if (taskField is AsyncStateMachineBox<IAsyncStateMachine> weaklyTypedBox)
             {
                 // If this is the first await, we won't yet have a state machine, so store it.
-                if (weaklyTypedBox.StateMachine == null)
+                if (weaklyTypedBox.StateMachine is null)
                 {
                     Debugger.NotifyOfCrossThreadDependency(); // same explanation as with usage below
                     weaklyTypedBox.StateMachine = stateMachine;
@@ -313,7 +313,7 @@ namespace System.Runtime.CompilerServices
                 }
 
             Start:
-                Debug.Assert(StateMachine != null);
+                Debug.Assert(StateMachine is not null);
 
                 ExecutionContext? context = Context;
                 if (context is not null && !context.IsDefault)
@@ -379,18 +379,18 @@ namespace System.Runtime.CompilerServices
                 }
 
             Start:
-                Debug.Assert(StateMachine != null);
+                Debug.Assert(StateMachine is not null);
 
                 ExecutionContext? context = Context;
 
-                if (context != null)
+                if (context is not null)
                 {
                     if (context.IsDefault)
                     {
                         // 1st preference: Default context.
                         Thread currentThread = Thread.CurrentThread;
                         ExecutionContext? currentContext = currentThread._executionContext;
-                        if (currentContext == null || currentContext.IsDefault)
+                        if (currentContext is null || currentContext.IsDefault)
                         {
                             // Preferred: On Default and to run on Default; however we need to undo any changes that happen in call.
                             SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
@@ -405,7 +405,7 @@ namespace System.Runtime.CompilerServices
                                 edi = ExceptionDispatchInfo.Capture(ex);
                             }
 
-                            if (currentThread._executionContext == null)
+                            if (currentThread._executionContext is null)
                             {
                                 if (currentThread._synchronizationContext != previousSyncCtx)
                                 {
@@ -499,7 +499,7 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.NoInlining)]
         private Task<TResult> InitializeTaskAsPromise()
         {
-            Debug.Assert(m_task == null);
+            Debug.Assert(m_task is null);
             return m_task = new Task<TResult>();
         }
 
@@ -531,7 +531,7 @@ namespace System.Runtime.CompilerServices
             if (m_task is null)
             {
                 m_task = GetTaskForResult(result);
-                Debug.Assert(m_task != null, $"{nameof(GetTaskForResult)} should never return null");
+                Debug.Assert(m_task is not null, $"{nameof(GetTaskForResult)} should never return null");
             }
             else
             {
@@ -545,7 +545,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="task">The task to complete.</param>
         internal static void SetExistingTaskResult(Task<TResult> task, TResult? result)
         {
-            Debug.Assert(task != null, "Expected non-null task");
+            Debug.Assert(task is not null, "Expected non-null task");
 
             if (TplEventSource.Log.IsEnabled())
             {
@@ -569,7 +569,7 @@ namespace System.Runtime.CompilerServices
 
         internal static void SetException(Exception exception, ref Task<TResult>? taskField)
         {
-            if (exception == null)
+            if (exception is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.exception);
             }
@@ -711,7 +711,7 @@ namespace System.Runtime.CompilerServices
                     return s_defaultResultTask;
                 }
             }
-            else if (result == null) // optimized away for value types
+            else if (result is null) // optimized away for value types
             {
                 return s_defaultResultTask;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
@@ -470,7 +470,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else
                 {
-                    ExecutionContext.RunForThreadPoolUnsafe(context, s_callback, this);
+                    ExecutionContext.RunForThreadPoolUnsafe(context, s_callback, this, Thread.CurrentThread);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
@@ -504,21 +504,18 @@ namespace System.Runtime.CompilerServices
                                 edi = ExceptionDispatchInfo.Capture(ex);
                             }
 
-                            // Enregister references as they have been stack spilled due to crossing EH.
-                            Thread thread = currentThread;
-                            SynchronizationContext? syncCtx = previousSyncCtx;
-                            if (thread._executionContext == null)
+                            if (currentThread._executionContext == null)
                             {
-                                if (thread._synchronizationContext != syncCtx)
+                                if (currentThread._synchronizationContext != previousSyncCtx)
                                 {
-                                    thread._synchronizationContext = syncCtx;
+                                    currentThread._synchronizationContext = previousSyncCtx;
                                 }
 
                                 edi?.Throw();
                             }
                             else
                             {
-                                ExecutionContext.RestoreDefaultContextThrowIfNeeded(thread, syncCtx, edi);
+                                ExecutionContext.RestoreDefaultContextThrowIfNeeded(currentThread, previousSyncCtx, edi);
                             }
                         }
                         else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -86,7 +86,7 @@ namespace System.Threading
         {
             Debug.Assert(isFlowSuppressed != m_isFlowSuppressed);
 
-            if (m_localValues == null || AsyncLocalValueMap.IsEmpty(m_localValues))
+            if (m_localValues is null || AsyncLocalValueMap.IsEmpty(m_localValues))
             {
                 return isFlowSuppressed ?
                     DefaultFlowSuppressed :
@@ -116,7 +116,7 @@ namespace System.Threading
         {
             Thread currentThread = Thread.CurrentThread;
             ExecutionContext? executionContext = currentThread._executionContext;
-            if (executionContext == null || !executionContext.m_isFlowSuppressed)
+            if (executionContext is null || !executionContext.m_isFlowSuppressed)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_CannotRestoreUnsupressedFlow);
             }
@@ -127,17 +127,17 @@ namespace System.Threading
         public static bool IsFlowSuppressed()
         {
             ExecutionContext? executionContext = Thread.CurrentThread._executionContext;
-            return executionContext != null && executionContext.m_isFlowSuppressed;
+            return executionContext is not null && executionContext.m_isFlowSuppressed;
         }
 
-        internal bool HasChangeNotifications => m_localChangeNotifications != null;
+        internal bool HasChangeNotifications => m_localChangeNotifications is not null;
 
         internal bool IsDefault => m_isDefault;
 
         public static void Run(ExecutionContext executionContext, ContextCallback callback, object? state)
         {
             // Note: ExecutionContext.Run is an extremely hot function and used by every await, ThreadPool execution, etc.
-            if (executionContext == null)
+            if (executionContext is null)
             {
                 ThrowNullContext();
             }
@@ -152,7 +152,7 @@ namespace System.Threading
             // Capture references to Thread Contexts
             Thread currentThread = Thread.CurrentThread;
             ExecutionContext? previousExecutionCtx = currentThread._executionContext;
-            if (previousExecutionCtx != null && previousExecutionCtx.m_isDefault)
+            if (previousExecutionCtx is not null && previousExecutionCtx.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 previousExecutionCtx = null;
@@ -160,7 +160,7 @@ namespace System.Threading
 
             SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
 
-            if (executionContext != null && executionContext.m_isDefault)
+            if (executionContext is not null && executionContext.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 executionContext = null;
@@ -211,7 +211,7 @@ namespace System.Threading
         /// <param name="executionContext">The ExecutionContext to set.</param>
         public static void Restore(ExecutionContext executionContext)
         {
-            if (executionContext == null)
+            if (executionContext is null)
             {
                 ThrowNullContext();
             }
@@ -224,13 +224,13 @@ namespace System.Threading
             Thread currentThread = Thread.CurrentThread;
 
             ExecutionContext? currentExecutionCtx = currentThread._executionContext;
-            if (currentExecutionCtx != null && currentExecutionCtx.m_isDefault)
+            if (currentExecutionCtx is not null && currentExecutionCtx.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 currentExecutionCtx = null;
             }
 
-            if (executionContext != null && executionContext.m_isDefault)
+            if (executionContext is not null && executionContext.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 executionContext = null;
@@ -246,7 +246,7 @@ namespace System.Threading
         internal static void RestoreNonDefaultContextToThreadPool(Thread threadPoolThread, ExecutionContext executionContext)
         {
             Debug.Assert(threadPoolThread == Thread.CurrentThread);
-            Debug.Assert(executionContext != null);
+            Debug.Assert(executionContext is not null);
             Debug.Assert(!executionContext.IsDefault);
             CheckThreadPoolAndContextsAreDefault();
 
@@ -264,7 +264,7 @@ namespace System.Threading
             // ThreadPool starts on Default Context so we don't need to save the "previous" state as we know it is Default (null)
 
             // Default is a null ExecutionContext internally
-            if (executionContext != null && !executionContext.m_isDefault)
+            if (executionContext is not null && !executionContext.m_isDefault)
             {
                 // Non-Default context to restore
                 RestoreChangedContextToThread(threadPoolThread, contextToRestore: executionContext, currentContext: null);
@@ -287,7 +287,7 @@ namespace System.Threading
 
             // Restore changed SynchronizationContext back to Default
             threadPoolThread._synchronizationContext = null;
-            if (currentExecutionCtx != null)
+            if (currentExecutionCtx is not null)
             {
                 // The EC always needs to be reset for this overload, as it will flow back to the caller if it performs
                 // extra work prior to returning to the Dispatch loop. For example for Task-likes it will flow out of await points
@@ -300,7 +300,7 @@ namespace System.Threading
 
         internal static void RunOnDefaultContext(Thread currentThread, ExecutionContext? previousExecutionCtx, ContextCallback callback, object? state)
         {
-            Debug.Assert(previousExecutionCtx != null && !previousExecutionCtx.m_isDefault);
+            Debug.Assert(previousExecutionCtx is not null && !previousExecutionCtx.m_isDefault);
 
             SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
             RestoreChangedContextToThread(currentThread, contextToRestore: null, previousExecutionCtx);
@@ -342,8 +342,8 @@ namespace System.Threading
 
             // Restore changed ExecutionContext back to previous
             currentThread._executionContext = contextToRestore;
-            if ((currentContext != null && currentContext.HasChangeNotifications) ||
-                (contextToRestore != null && contextToRestore.HasChangeNotifications))
+            if ((currentContext is not null && currentContext.HasChangeNotifications) ||
+                (contextToRestore is not null && contextToRestore.HasChangeNotifications))
             {
                 // There are change notifications; trigger any affected
                 OnValuesChanged(currentContext, contextToRestore);
@@ -360,7 +360,7 @@ namespace System.Threading
             currentThread._synchronizationContext = null;
             currentThread._executionContext = null;
 
-            if (currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications)
+            if (currentExecutionCtx is not null && currentExecutionCtx.HasChangeNotifications)
             {
                 OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
 
@@ -381,7 +381,7 @@ namespace System.Threading
                 currentThread._synchronizationContext = previousSyncCtx;
             }
 
-            if (currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications)
+            if (currentExecutionCtx is not null && currentExecutionCtx.HasChangeNotifications)
             {
                 OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
 
@@ -398,8 +398,8 @@ namespace System.Threading
         internal static void CheckThreadPoolAndContextsAreDefault()
         {
             Debug.Assert(!Thread.IsThreadStartSupported || Thread.CurrentThread.IsThreadPoolThread); // there are no dedicated threadpool threads on runtimes where we can't start threads
-            Debug.Assert(Thread.CurrentThread._executionContext == null, "ThreadPool thread not on Default ExecutionContext.");
-            Debug.Assert(Thread.CurrentThread._synchronizationContext == null, "ThreadPool thread not on Default SynchronizationContext.");
+            Debug.Assert(Thread.CurrentThread._executionContext is null, "ThreadPool thread not on Default ExecutionContext.");
+            Debug.Assert(Thread.CurrentThread._synchronizationContext is null, "ThreadPool thread not on Default SynchronizationContext.");
         }
 
         internal static void OnValuesChanged(ExecutionContext? previousExecutionCtx, ExecutionContext? nextExecutionCtx)
@@ -411,16 +411,16 @@ namespace System.Threading
             IAsyncLocal[]? nextChangeNotifications = nextExecutionCtx?.m_localChangeNotifications;
 
             // At least one side must have notifications
-            Debug.Assert(previousChangeNotifications != null || nextChangeNotifications != null);
+            Debug.Assert(previousChangeNotifications is not null || nextChangeNotifications is not null);
 
             // Fire Change Notifications
             try
             {
-                if (previousChangeNotifications != null && nextChangeNotifications != null)
+                if (previousChangeNotifications is not null && nextChangeNotifications is not null)
                 {
                     // Notifications can't exist without values
-                    Debug.Assert(previousExecutionCtx!.m_localValues != null);
-                    Debug.Assert(nextExecutionCtx!.m_localValues != null);
+                    Debug.Assert(previousExecutionCtx!.m_localValues is not null);
+                    Debug.Assert(nextExecutionCtx!.m_localValues is not null);
                     // Both contexts have change notifications, check previousExecutionCtx first
                     foreach (IAsyncLocal local in previousChangeNotifications)
                     {
@@ -451,29 +451,29 @@ namespace System.Threading
                         }
                     }
                 }
-                else if (previousChangeNotifications != null)
+                else if (previousChangeNotifications is not null)
                 {
                     // Notifications can't exist without values
-                    Debug.Assert(previousExecutionCtx!.m_localValues != null);
+                    Debug.Assert(previousExecutionCtx!.m_localValues is not null);
                     // No current values, so just check previous against null
                     foreach (IAsyncLocal local in previousChangeNotifications)
                     {
                         previousExecutionCtx.m_localValues.TryGetValue(local, out object? previousValue);
-                        if (previousValue != null)
+                        if (previousValue is not null)
                         {
                             local.OnValueChanged(previousValue, null, contextChanged: true);
                         }
                     }
                 }
-                else // Implied: nextChangeNotifications != null
+                else // Implied: nextChangeNotifications is not null
                 {
                     // Notifications can't exist without values
-                    Debug.Assert(nextExecutionCtx!.m_localValues != null);
+                    Debug.Assert(nextExecutionCtx!.m_localValues is not null);
                     // No previous values, so just check current against null
                     foreach (IAsyncLocal local in nextChangeNotifications!)
                     {
                         nextExecutionCtx.m_localValues.TryGetValue(local, out object? currentValue);
-                        if (currentValue != null)
+                        if (currentValue is not null)
                         {
                             local.OnValueChanged(null, currentValue, contextChanged: true);
                         }
@@ -498,13 +498,13 @@ namespace System.Threading
         internal static object? GetLocalValue(IAsyncLocal local)
         {
             ExecutionContext? current = Thread.CurrentThread._executionContext;
-            if (current == null)
+            if (current is null)
             {
                 return null;
             }
 
             Debug.Assert(!current.IsDefault);
-            Debug.Assert(current.m_localValues != null, "Only the default context should have null, and we shouldn't be here on the default context");
+            Debug.Assert(current.m_localValues is not null, "Only the default context should have null, and we shouldn't be here on the default context");
             current.m_localValues.TryGetValue(local, out object? value);
             return value;
         }
@@ -515,10 +515,10 @@ namespace System.Threading
 
             object? previousValue = null;
             bool hadPreviousValue = false;
-            if (current != null)
+            if (current is not null)
             {
                 Debug.Assert(!current.IsDefault);
-                Debug.Assert(current.m_localValues != null, "Only the default context should have null, and we shouldn't be here on the default context");
+                Debug.Assert(current.m_localValues is not null, "Only the default context should have null, and we shouldn't be here on the default context");
 
                 hadPreviousValue = current.m_localValues.TryGetValue(local, out previousValue);
             }
@@ -538,10 +538,10 @@ namespace System.Threading
             IAsyncLocal[]? newChangeNotifications = null;
             IAsyncLocalValueMap newValues;
             bool isFlowSuppressed = false;
-            if (current != null)
+            if (current is not null)
             {
                 Debug.Assert(!current.IsDefault);
-                Debug.Assert(current.m_localValues != null, "Only the default context should have null, and we shouldn't be here on the default context");
+                Debug.Assert(current.m_localValues is not null, "Only the default context should have null, and we shouldn't be here on the default context");
 
                 isFlowSuppressed = current.m_isFlowSuppressed;
                 newValues = current.m_localValues.Set(local, newValue, treatNullValueAsNonexistent: !needChangeNotifications);
@@ -560,7 +560,7 @@ namespace System.Threading
             {
                 if (hadPreviousValue)
                 {
-                    Debug.Assert(newChangeNotifications != null);
+                    Debug.Assert(newChangeNotifications is not null);
                     Debug.Assert(Array.IndexOf(newChangeNotifications, local) >= 0);
                 }
                 else if (newChangeNotifications == null)
@@ -609,7 +609,7 @@ namespace System.Threading
 
         public void Undo()
         {
-            if (_thread == null)
+            if (_thread is null)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_CannotUseAFCMultiple);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -148,26 +148,17 @@ namespace System.Threading
         internal static void RunInternal(ExecutionContext? executionContext, ContextCallback callback, object? state)
         {
             // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
-            // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
-            //       https://github.com/dotnet/runtime/blob/master/docs/design/features/eh-writethru.md
 
-            // Enregister variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts
-            Thread currentThread0 = Thread.CurrentThread;
-            Thread currentThread = currentThread0;
-            ExecutionContext? previousExecutionCtx0 = currentThread0._executionContext;
-            if (previousExecutionCtx0 != null && previousExecutionCtx0.m_isDefault)
+            Thread currentThread = Thread.CurrentThread;
+            ExecutionContext? previousExecutionCtx = currentThread._executionContext;
+            if (previousExecutionCtx != null && previousExecutionCtx.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
-                previousExecutionCtx0 = null;
+                previousExecutionCtx = null;
             }
 
-            // Store current ExecutionContext and SynchronizationContext as "previousXxx".
-            // This allows us to restore them and undo any Context changes made in callback.Invoke
-            // so that they won't "leak" back into caller.
-            // These variables will cross EH so be forced to stack
-            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
-            SynchronizationContext? previousSyncCtx = currentThread0._synchronizationContext;
+            SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
 
             if (executionContext != null && executionContext.m_isDefault)
             {
@@ -175,9 +166,9 @@ namespace System.Threading
                 executionContext = null;
             }
 
-            if (previousExecutionCtx0 != executionContext)
+            if (previousExecutionCtx != executionContext)
             {
-                RestoreChangedContextToThread(currentThread0, executionContext, previousExecutionCtx0);
+                RestoreChangedContextToThread(currentThread, executionContext, previousExecutionCtx);
             }
 
             ExceptionDispatchInfo? edi = null;
@@ -193,21 +184,17 @@ namespace System.Threading
                 edi = ExceptionDispatchInfo.Capture(ex);
             }
 
-            // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
-            SynchronizationContext? previousSyncCtx1 = previousSyncCtx;
-            Thread currentThread1 = currentThread;
             // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
-            if (currentThread1._synchronizationContext != previousSyncCtx1)
+            if (currentThread._synchronizationContext != previousSyncCtx)
             {
                 // Restore changed SynchronizationContext back to previous
-                currentThread1._synchronizationContext = previousSyncCtx1;
+                currentThread._synchronizationContext = previousSyncCtx;
             }
 
-            ExecutionContext? previousExecutionCtx1 = previousExecutionCtx;
-            ExecutionContext? currentExecutionCtx1 = currentThread1._executionContext;
-            if (currentExecutionCtx1 != previousExecutionCtx1)
+            ExecutionContext? currentExecutionCtx = currentThread._executionContext;
+            if (currentExecutionCtx != previousExecutionCtx)
             {
-                RestoreChangedContextToThread(currentThread1, previousExecutionCtx1, currentExecutionCtx1);
+                RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
             }
 
             // If exception was thrown by callback, rethrow it now original contexts are restored

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -242,7 +242,6 @@ namespace System.Threading
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void RestoreNonDefaultContextToThreadPool(Thread threadPoolThread, ExecutionContext executionContext)
         {
             Debug.Assert(threadPoolThread == Thread.CurrentThread);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -316,28 +316,6 @@ namespace System.Threading
             // ThreadPoolWorkQueue.Dispatch will handle notifications and reset EC and SyncCtx back to default
         }
 
-        internal static void RunForThreadPoolUnsafe(ExecutionContext executionContext, ContextCallback callback, object state)
-            => RunForThreadPoolUnsafe(executionContext, callback, state, Thread.CurrentThread);
-
-        internal static void RunForThreadPoolUnsafe<TState>(ExecutionContext executionContext, Action<TState> callback, in TState state)
-        {
-            // We aren't running in try/catch as the ThreadPool Dispatch loop will handle it.
-
-            CheckThreadPoolAndContextsAreDefault();
-            Debug.Assert(executionContext != null && !executionContext.m_isDefault, "ExecutionContext argument is Default.");
-
-            // Restore Non-Default context
-            Thread.CurrentThread._executionContext = executionContext;
-            if (executionContext.HasChangeNotifications)
-            {
-                OnValuesChanged(previousExecutionCtx: null, executionContext);
-            }
-
-            callback.Invoke(state);
-
-            // ThreadPoolWorkQueue.Dispatch will handle notifications and reset EC and SyncCtx back to default
-        }
-
         internal static void RunOnDefaultContext(Thread currentThread, ExecutionContext? previousExecutionCtx, ContextCallback callback, object? state)
         {
             Debug.Assert(previousExecutionCtx != null && !previousExecutionCtx.m_isDefault);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/IThreadPoolWorkItem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/IThreadPoolWorkItem.cs
@@ -8,4 +8,11 @@ namespace System.Threading
     {
         void Execute();
     }
+
+    /// <summary>Represents a work item that can be executed by the ThreadPool and is given ThreadPool thread.</summary>
+    internal interface IThreadPoolWorkItemWithThread : IThreadPoolWorkItem
+    {
+        void IThreadPoolWorkItem.Execute() => throw new NotImplementedException();
+        void Execute(Thread threadPoolThread);
+    }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2243,9 +2243,7 @@ namespace System.Threading.Tasks
         /// can override to customize their behavior, which is usually done by promises
         /// that want to reuse the same object as a queued work item.
         /// </summary>
-        internal virtual void ExecuteFromThreadPool(Thread threadPoolThread) => ExecuteEntryUnsafe(threadPoolThread);
-
-        internal void ExecuteEntryUnsafe(Thread? threadPoolThread) // used instead of ExecuteEntry() when we don't have to worry about double-execution prevent
+        internal virtual void ExecuteFromThreadPool(Thread threadPoolThread)
         {
             // Remember that we started running the task delegate.
             m_stateFlags |= TASK_STATE_DELEGATE_INVOKED;
@@ -2253,6 +2251,21 @@ namespace System.Threading.Tasks
             if (!IsCancellationRequested & !IsCanceled)
             {
                 ExecuteWithThreadLocal(ref t_currentTask, threadPoolThread);
+            }
+            else
+            {
+                ExecuteEntryCancellationRequestedOrCanceled();
+            }
+        }
+
+        internal void ExecuteEntryUnsafe() // used instead of ExecuteEntry() when we don't have to worry about double-execution prevent
+        {
+            // Remember that we started running the task delegate.
+            m_stateFlags |= TASK_STATE_DELEGATE_INVOKED;
+
+            if (!IsCancellationRequested & !IsCanceled)
+            {
+                ExecuteWithThreadLocal(ref t_currentTask);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -642,15 +642,17 @@ namespace System.Threading.Tasks
                 ExecutionContext.CheckThreadPoolAndContextsAreDefault();
                 // If there's no execution context or Default, just invoke the delegate as ThreadPool is on Default context.
                 // We don't have to use ExecutionContext.Run for the Default context here as there is no extra processing after the delegate
-                if (context == null || context.IsDefault)
+                if (context != null && !context.IsDefault)
                 {
-                    m_action();
+                    // Restore Non-Default context
+                    Thread.CurrentThread._executionContext = context;
+                    if (context.HasChangeNotifications)
+                    {
+                        ExecutionContext.OnValuesChanged(previousExecutionCtx: null, context);
+                    }
                 }
-                // If there is an execution context, get the cached delegate and run the action under the context.
-                else
-                {
-                    ExecutionContext.RunForThreadPoolUnsafe(context, s_invokeAction, m_action);
-                }
+
+                m_action();
 
                 // ThreadPoolWorkQueue.Dispatch handles notifications and reset context back to default
             }
@@ -669,7 +671,6 @@ namespace System.Threading.Tasks
             Debug.Assert(state is Action);
             ((Action)state)();
         };
-        private static readonly Action<Action> s_invokeAction = (action) => action();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static ContextCallback GetInvokeActionCallback() => s_invokeContextCallback;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -32,7 +32,7 @@ namespace System.Threading.Tasks
         private static readonly ParameterizedThreadStart s_longRunningThreadWork = static s =>
         {
             Debug.Assert(s is Task);
-            ((Task)s).ExecuteEntryUnsafe(threadPoolThread: null);
+            ((Task)s).ExecuteEntryUnsafe();
         };
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace System.Threading.Tasks
 
             try
             {
-                task.ExecuteEntryUnsafe(threadPoolThread: null); // handles switching Task.Current etc.
+                task.ExecuteEntryUnsafe(); // handles switching Task.Current etc.
             }
             finally
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.ConstrainedExecution;
 using System.Security.Principal;
 using System.Runtime.Versioning;
@@ -154,7 +155,22 @@ namespace System.Threading
             }
         }
 
-        public static Thread CurrentThread => t_currentThread ?? InitializeCurrentThread();
+        public static Thread CurrentThread
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                // Arranged like this the conditional is a not predicted branch, with conditional ?? it switches.
+                // However needs to be aggressively inlined in this arrangement.
+                Thread? currentThread = t_currentThread;
+                if (currentThread != null)
+                {
+                    return currentThread;
+                }
+
+                return InitializeCurrentThread();
+            }
+        }
 
         public ExecutionContext? ExecutionContext => ExecutionContext.Capture();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -665,6 +665,15 @@ namespace System.Threading
                 // If we get here, it's because our quantum expired.  Tell the VM we're returning normally.
                 return true;
             }
+            catch
+            {
+                // We want to stop the first pass of EH here. That way we can restore the
+                // previous context before any of our callers' EH filters run.
+
+                // Return to clean ExecutionContext and SynchronizationContext
+                ExecutionContext.ResetThreadPoolThread(Thread.CurrentThread);
+                throw;
+            }
             finally
             {
                 //

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -636,7 +636,7 @@ namespace System.Threading
             }
             else
             {
-                ExecutionContext.RunForThreadPoolUnsafe(context, s_callCallbackInContext, this);
+                ExecutionContext.RunForThreadPoolUnsafe(context, s_callCallbackInContext, this, Thread.CurrentThread);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace System.Threading
@@ -586,7 +587,14 @@ namespace System.Threading
             if (canceled)
                 return;
 
-            CallCallback(isThreadPool);
+            if (isThreadPool)
+            {
+                CallCallbackOnThreadPool();
+            }
+            else
+            {
+                CallCallback();
+            }
 
             bool shouldSignal = false;
             lock (_associatedTimerQueue)
@@ -615,7 +623,24 @@ namespace System.Threading
             }
         }
 
-        internal void CallCallback(bool isThreadPool)
+        internal void CallCallbackOnThreadPool()
+        {
+            if (FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
+                FrameworkEventSource.Log.ThreadTransferReceiveObj(this, 1, string.Empty);
+
+            // Call directly if EC flow is suppressed or if context is Default on ThreadPool
+            ExecutionContext? context = _executionContext;
+            if (context == null || context.IsDefault)
+            {
+                _timerCallback(_state);
+            }
+            else
+            {
+                ExecutionContext.RunForThreadPoolUnsafe(context, s_callCallbackInContext, this);
+            }
+        }
+
+        internal void CallCallback()
         {
             if (FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
                 FrameworkEventSource.Log.ThreadTransferReceiveObj(this, 1, string.Empty);
@@ -626,15 +651,35 @@ namespace System.Threading
             {
                 _timerCallback(_state);
             }
+            else if (!context.IsDefault)
+            {
+                ExecutionContext.RunInternal(context, s_callCallbackInContext, this);
+            }
             else
             {
-                if (isThreadPool)
+                Thread currentThread = Thread.CurrentThread;
+                ExecutionContext? currentContext = currentThread._executionContext;
+                if (currentContext != null && !currentContext.IsDefault)
                 {
-                    ExecutionContext.RunFromThreadPoolDispatchLoop(Thread.CurrentThread, context, s_callCallbackInContext, this);
+                    // Current thread is not on Default
+                    ExecutionContext.RunOnDefaultContext(currentThread, currentContext, s_callCallbackInContext, this);
                 }
                 else
                 {
-                    ExecutionContext.RunInternal(context, s_callCallbackInContext, this);
+                    // On Default and to run on Default; however we need to undo any changes that happen in call.
+                    SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
+                    ExceptionDispatchInfo? edi = null;
+                    try
+                    {
+                        // Run directly
+                        _timerCallback(_state);
+                    }
+                    catch (Exception ex)
+                    {
+                        edi = ExceptionDispatchInfo.Capture(ex);
+                    }
+
+                    ExecutionContext.RestoreDefaultContextThrowIfNeeded(currentThread, previousSyncCtx, edi);
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -143,7 +143,7 @@ namespace System.Threading
                 TimerQueueTimer? timer = _shortTimers;
                 for (int listNum = 0; listNum < 2; listNum++) // short == 0, long == 1
                 {
-                    while (timer != null)
+                    while (timer is not null)
                     {
                         Debug.Assert(timer._dueTime != Timeout.UnsignedInfinite, "A timer in the list must have a valid due time.");
 
@@ -200,7 +200,7 @@ namespace System.Threading
 
                             // If this is the first timer, we'll fire it on this thread (after processing
                             // all others). Otherwise, queue it to the ThreadPool.
-                            if (timerToFireOnThisThread == null)
+                            if (timerToFireOnThisThread is null)
                             {
                                 timerToFireOnThisThread = timer;
                             }
@@ -243,7 +243,7 @@ namespace System.Threading
                         long remaining = _currentAbsoluteThreshold - nowTicks;
                         if (remaining > 0)
                         {
-                            if (_shortTimers == null && _longTimers != null)
+                            if (_shortTimers is null && _longTimers is not null)
                             {
                                 // We don't have any short timers left and we haven't examined the long list,
                                 // which means we likely don't have an accurate nextTimerDuration.
@@ -328,7 +328,7 @@ namespace System.Threading
             // Use timer._short to decide to which list to add.
             ref TimerQueueTimer? listHead = ref timer._short ? ref _shortTimers : ref _longTimers;
             timer._next = listHead;
-            if (timer._next != null)
+            if (timer._next is not null)
             {
                 timer._next._prev = timer;
             }
@@ -339,7 +339,7 @@ namespace System.Threading
         private void UnlinkTimer(TimerQueueTimer timer)
         {
             TimerQueueTimer? t = timer._next;
-            if (t != null)
+            if (t is not null)
             {
                 t._prev = timer._prev;
             }
@@ -356,7 +356,7 @@ namespace System.Threading
             }
 
             t = timer._prev;
-            if (t != null)
+            if (t is not null)
             {
                 t._next = timer._next;
             }
@@ -553,13 +553,13 @@ namespace System.Threading
                 }
 
                 Debug.Assert(
-                    notifyWhenNoCallbacksRunning == null ||
+                    notifyWhenNoCallbacksRunning is null ||
                     notifyWhenNoCallbacksRunning is Task<bool>);
 
                 // There are callbacks queued or running, so we need to store a Task<bool>
                 // that'll be used to signal the caller when all callbacks complete. Do so as long as
                 // there wasn't a previous CloseAsync call that did.
-                if (notifyWhenNoCallbacksRunning == null)
+                if (notifyWhenNoCallbacksRunning is null)
                 {
                     var t = new Task<bool>((object?)null, TaskCreationOptions.RunContinuationsAsynchronously);
                     _notifyWhenNoCallbacksRunning = t;
@@ -600,7 +600,7 @@ namespace System.Threading
             lock (_associatedTimerQueue)
             {
                 _callbacksRunning--;
-                if (_canceled && _callbacksRunning == 0 && _notifyWhenNoCallbacksRunning != null)
+                if (_canceled && _callbacksRunning == 0 && _notifyWhenNoCallbacksRunning is not null)
                     shouldSignal = true;
             }
 
@@ -645,7 +645,7 @@ namespace System.Threading
 
             // Call directly if EC flow is suppressed
             ExecutionContext? context = _executionContext;
-            if (context == null)
+            if (context is null)
             {
                 _timerCallback(_state);
             }
@@ -657,7 +657,7 @@ namespace System.Threading
             {
                 Thread currentThread = Thread.CurrentThread;
                 ExecutionContext? currentContext = currentThread._executionContext;
-                if (currentContext != null && !currentContext.IsDefault)
+                if (currentContext is not null && !currentContext.IsDefault)
                 {
                     // Current thread is not on Default
                     ExecutionContext.RunOnDefaultContext(currentThread, currentContext, s_callCallbackInContext, this);
@@ -824,7 +824,7 @@ namespace System.Threading
                                 uint period,
                                 bool flowExecutionContext = true)
         {
-            if (callback == null)
+            if (callback is null)
                 throw new ArgumentNullException(nameof(callback));
 
             _timer = new TimerHolder(new TimerQueueTimer(callback, state, dueTime, period, flowExecutionContext));
@@ -887,7 +887,7 @@ namespace System.Threading
 
         public bool Dispose(WaitHandle notifyObject)
         {
-            if (notifyObject == null)
+            if (notifyObject is null)
                 throw new ArgumentNullException(nameof(notifyObject));
 
             return _timer.Close(notifyObject);

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -146,7 +146,7 @@
     <TestEnvironment Include="jitosr_stress" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TC_OnStackReplacement_InitialCounter="1" OSR_HitLimit="1" TieredCompilation="1" />
     <TestEnvironment Include="jitpgo" TieredPGO="1" TieredCompilation="1" />
     <TestEnvironment Include="jitguardeddevirtualization" JitEnableGuardedDevirtualization="1" TieredCompilation="0" />
-    <TestEnvironment Include="jitehwritethru" EnableEhWriteThru="1" TieredCompilation="0" />
+    <TestEnvironment Include="jitehwritethrudisable" EnableEhWriteThru="0" TieredCompilation="0" />
     <TestEnvironment Include="jitobjectstackallocation" JitObjectStackAllocation="1" TieredCompilation="0" />
     <TestEnvironment Include="ilasmroundtrip" RunningIlasmRoundTrip="1" />
     <TestEnvironment Include="clrinterpreter" TieredCompilation="1" />


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/41214 + EH WriteThrough

Reduce TLS access for Thread.CurrentThread

Also direct calls rather than non-inline call throughs followed by indirect callbacks