### PR TITLE
remove unused local

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -412,7 +412,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             // .NET Framework compat: The .NET Framework expands the filename to a full path for the purpose of performing a CAS permission check. While CAS is not present here,
             // we still need to call GetFullPath() so we get the same exception behavior if the fileName is bad.
-            Path.GetFullPath(fileName);
+            _ = Path.GetFullPath(fileName);
 
             return X509Pal.Instance.GetCertContentType(fileName);
         }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -412,7 +412,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             // .NET Framework compat: The .NET Framework expands the filename to a full path for the purpose of performing a CAS permission check. While CAS is not present here,
             // we still need to call GetFullPath() so we get the same exception behavior if the fileName is bad.
-            string fullPath = Path.GetFullPath(fileName);
+            Path.GetFullPath(fileName);
 
             return X509Pal.Instance.GetCertContentType(fileName);
         }


### PR DESCRIPTION
This fixes a part of #30457
In line 415, `Path.GetFullPath(fileName)` is just for getting exception when fileName is bad.
So, `fullPath` is not needed.
