### PR TITLE
[mono] Thread DllImportSearchPath flags down to LoadLibraryEx

### DIFF
--- a/src/mono/mono/utils/mono-dl-posix.c
+++ b/src/mono/mono/utils/mono-dl-posix.c
@@ -130,21 +130,21 @@ mono_dl_lookup_symbol (MonoDl *module, const char *name)
 }
 
 int
-mono_dl_convert_flags (int flags)
+mono_dl_convert_flags (int mono_flags, int native_flags)
 {
-	int lflags = 0;
+	int lflags = native_flags;
 
 #ifdef ENABLE_NETCORE
 	// Specifying both will default to LOCAL
-	if (flags & MONO_DL_GLOBAL && !(flags & MONO_DL_LOCAL))
+	if (mono_flags & MONO_DL_GLOBAL && !(mono_flags & MONO_DL_LOCAL))
 		lflags |= RTLD_GLOBAL;
 	else 
 		lflags |= RTLD_LOCAL;
 #else
-	lflags = flags & MONO_DL_LOCAL ? RTLD_LOCAL : RTLD_GLOBAL;
+	lflags = mono_flags & MONO_DL_LOCAL ? RTLD_LOCAL : RTLD_GLOBAL;
 #endif
 
-	if (flags & MONO_DL_LAZY)
+	if (mono_flags & MONO_DL_LAZY)
 		lflags |= RTLD_LAZY;
 	else
 		lflags |= RTLD_NOW;

--- a/src/mono/mono/utils/mono-dl-wasm.c
+++ b/src/mono/mono/utils/mono-dl-wasm.c
@@ -55,23 +55,23 @@ mono_dl_current_error_string (void)
 	return g_strdup ("");
 }
 
-
+// Copied from mono-dl-posix.c
 int
-mono_dl_convert_flags (int flags)
+mono_dl_convert_flags (int mono_flags, int native_flags)
 {
-	int lflags = 0;
+	int lflags = native_flags;
 
 #ifdef ENABLE_NETCORE
 	// Specifying both will default to LOCAL
-	if (flags & MONO_DL_LOCAL)
-		lflags |= RTLD_LOCAL;
-	else if (flags & MONO_DL_GLOBAL)
+	if (mono_flags & MONO_DL_GLOBAL && !(mono_flags & MONO_DL_LOCAL))
 		lflags |= RTLD_GLOBAL;
+	else 
+		lflags |= RTLD_LOCAL;
 #else
-	lflags = flags & MONO_DL_LOCAL ? RTLD_LOCAL : RTLD_GLOBAL;
+	lflags = mono_flags & MONO_DL_LOCAL ? RTLD_LOCAL : RTLD_GLOBAL;
 #endif
 
-	if (flags & MONO_DL_LAZY)
+	if (mono_flags & MONO_DL_LAZY)
 		lflags |= RTLD_LAZY;
 	else
 		lflags |= RTLD_NOW;

--- a/src/mono/mono/utils/mono-dl-windows.c
+++ b/src/mono/mono/utils/mono-dl-windows.c
@@ -57,7 +57,7 @@ mono_dl_open_file (const char *file, int flags)
 		guint32 last_error = 0;
 
 #if HAVE_API_SUPPORT_WIN32_LOAD_LIBRARY
-		hModule = LoadLibraryW (file_utf16);
+		hModule = LoadLibraryExW (file_utf16, NULL, flags);
 #elif HAVE_API_SUPPORT_WIN32_LOAD_PACKAGED_LIBRARY
 		hModule = LoadPackagedLibrary (file_utf16, NULL);
 #else
@@ -160,9 +160,10 @@ mono_dl_lookup_symbol (MonoDl *module, const char *symbol_name)
 }
 
 int
-mono_dl_convert_flags (int flags)
+mono_dl_convert_flags (int mono_flags, int native_flags)
 {
-	return 0;
+	// Mono flags are not applicable on Windows
+	return native_flags;
 }
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)

--- a/src/mono/mono/utils/mono-dl.c
+++ b/src/mono/mono/utils/mono-dl.c
@@ -221,10 +221,16 @@ mono_dl_open_self (char **error_msg)
 MonoDl*
 mono_dl_open (const char *name, int flags, char **error_msg)
 {
+	return mono_dl_open_full (name, flags, 0, error_msg);
+}
+
+MonoDl *
+mono_dl_open_full (const char *name, int mono_flags, int native_flags, char **error_msg)
+{
 	MonoDl *module;
 	void *lib;
 	MonoDlFallbackHandler *dl_fallback = NULL;
-	int lflags = mono_dl_convert_flags (flags);
+	int lflags = mono_dl_convert_flags (mono_flags, native_flags);
 	char *found_name;
 
 	if (error_msg)

--- a/src/mono/mono/utils/mono-dl.h
+++ b/src/mono/mono/utils/mono-dl.h
@@ -43,7 +43,11 @@ char*       mono_dl_build_path (const char *directory, const char *name, void **
 
 MonoDl*     mono_dl_open_runtime_lib (const char *lib_name, int flags, char **error_msg);
 
-MonoDl*     mono_dl_open_self (char **error_msg);
+MonoDl *
+mono_dl_open_self (char **error_msg);
+// This converts the MONO_DL_* enum to native flags, combines it with the other flags passed, and resolves some inconsistencies
+MonoDl *
+mono_dl_open_full (const char *name, int mono_flags, int native_flags, char **error_msg);
 
 
 //Platform API for mono_dl
@@ -52,7 +56,7 @@ const char** mono_dl_get_so_suffixes (void);
 void* mono_dl_open_file (const char *file, int flags);
 void mono_dl_close_handle (MonoDl *module);
 void* mono_dl_lookup_symbol (MonoDl *module, const char *name);
-int mono_dl_convert_flags (int flags);
+int mono_dl_convert_flags (int mono_flags, int native_flags);
 char* mono_dl_current_error_string (void);
 int mono_dl_get_executable_path (char *buf, int buflen);
 const char* mono_dl_get_system_dir (void);


### PR DESCRIPTION
This mostly completes support for the attribute. Our algorithm differs a bit from CoreCLR right now, so we don't support the legacy behavior flag since it makes less since in the context of our algorithm, but this should be good enough for most cases.