### PR TITLE
[mono] Pass -Wc++-compat on all platforms, -Werror on OSX, fix errors

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -888,7 +888,7 @@ AC_ARG_ENABLE(visibility-hidden,
 WARN=''
 if test x"$GCC" = xyes; then
 		WARN='-Wall -Wunused -Wmissing-declarations -Wpointer-arith -Wno-cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes'
-		CFLAGS="$CFLAGS -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wno-format-zero-length"
+		CFLAGS="$CFLAGS -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wno-format-zero-length -Werror=c++-compat"
 
 		# We require C99 with some GNU extensions, e.g. `linux` macro
 		CFLAGS="$CFLAGS -std=gnu99"
@@ -925,6 +925,10 @@ if test x"$GCC" = xyes; then
 		   WARN="$WARN -Wno-unused-function -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand"
 		   # We rely on zero length arrays in structs
 		   WARN="$WARN -Wno-zero-length-array"
+		   # Common warnings we have only fixed completely on OSX
+		   WARN="$WARN -Werror=unused-variable -Werror=missing-prototypes"
+		else
+		   WARN="$WARN -Werror=maybe-uninitalized"
 		fi
 else
 	# The Sun Forte compiler complains about inline functions that access static variables

--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -888,7 +888,7 @@ AC_ARG_ENABLE(visibility-hidden,
 WARN=''
 if test x"$GCC" = xyes; then
 		WARN='-Wall -Wunused -Wmissing-declarations -Wpointer-arith -Wno-cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes'
-		CFLAGS="$CFLAGS -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wno-format-zero-length -Werror=c++-compat"
+		CFLAGS="$CFLAGS -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wno-format-zero-length -Wc++-compat"
 
 		# We require C99 with some GNU extensions, e.g. `linux` macro
 		CFLAGS="$CFLAGS -std=gnu99"
@@ -925,10 +925,6 @@ if test x"$GCC" = xyes; then
 		   WARN="$WARN -Wno-unused-function -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand"
 		   # We rely on zero length arrays in structs
 		   WARN="$WARN -Wno-zero-length-array"
-		   # Common warnings we have only fixed completely on OSX
-		   WARN="$WARN -Werror=unused-variable -Werror=missing-prototypes"
-		else
-		   WARN="$WARN -Werror=maybe-uninitalized"
 		fi
 else
 	# The Sun Forte compiler complains about inline functions that access static variables

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -693,6 +693,11 @@
       <_MonoCXXFLAGS Include="-Wl,--build-id=sha1" />
     </ItemGroup>
 
+    <!-- CI-specific build options -->
+    <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+      <_MonoConfigureParams Include="--enable-werror" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(MonoCrossDir)' != '' and ('$(TargetArchitecture)' == 'arm' Or '$(TargetArchitecture)' == 'arm64')">
       <_MonoConfigureParams Include="--host=$(_MonoTuple)" />
       <_MonoConfigureParams Include="--target=$(_MonoTuple)" />

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -694,7 +694,7 @@
     </ItemGroup>
 
     <!-- CI-specific build options -->
-    <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(TargetsOSX)' == 'true'">
       <_MonoConfigureParams Include="--enable-werror" />
     </ItemGroup>
 

--- a/src/mono/mono/metadata/w32socket-internals.h
+++ b/src/mono/mono/metadata/w32socket-internals.h
@@ -20,7 +20,7 @@
 #include <mono/utils/w32api.h>
 
 #ifndef HAVE_SOCKLEN_T
-#define socklen_t int
+#define socklen_t unsigned int
 #endif
 
 #ifndef HOST_WIN32
@@ -64,7 +64,7 @@ SOCKET
 mono_w32socket_accept (SOCKET s, struct sockaddr *addr, socklen_t *addrlen, gboolean blocking);
 
 int
-mono_w32socket_connect (SOCKET s, const struct sockaddr *name, int namelen, gboolean blocking);
+mono_w32socket_connect (SOCKET s, const struct sockaddr *name, socklen_t namelen, gboolean blocking);
 
 int
 mono_w32socket_recv (SOCKET s, char *buf, int len, int flags, gboolean blocking);

--- a/src/mono/mono/metadata/w32socket-internals.h
+++ b/src/mono/mono/metadata/w32socket-internals.h
@@ -20,7 +20,7 @@
 #include <mono/utils/w32api.h>
 
 #ifndef HAVE_SOCKLEN_T
-#define socklen_t unsigned int
+#define socklen_t int
 #endif
 
 #ifndef HOST_WIN32

--- a/src/mono/mono/metadata/w32socket-unix.c
+++ b/src/mono/mono/metadata/w32socket-unix.c
@@ -191,7 +191,7 @@ mono_w32socket_accept (SOCKET sock, struct sockaddr *addr, socklen_t *addrlen, g
 }
 
 int
-mono_w32socket_connect (SOCKET sock, const struct sockaddr *addr, int addrlen, gboolean blocking)
+mono_w32socket_connect (SOCKET sock, const struct sockaddr *addr, socklen_t addrlen, gboolean blocking)
 {
 	SocketHandle *sockethandle;
 	gint ret;

--- a/src/mono/mono/mini/helpers.c
+++ b/src/mono/mono/mini/helpers.c
@@ -124,10 +124,8 @@ mono_disassemble_code (MonoCompile *cfg, guint8 *code, int size, char *id)
 #ifdef HOST_WIN32
 	const char *tmp = g_get_tmp_dir ();
 #endif
-	char *objdump_args = g_getenv ("MONO_OBJDUMP_ARGS");
 	char *as_file;
 	char *o_file;
-	char *cmd;
 	int unused G_GNUC_UNUSED;
 
 #ifdef HOST_WIN32
@@ -255,9 +253,10 @@ mono_disassemble_code (MonoCompile *cfg, guint8 *code, int size, char *id)
 #endif
 
 #ifdef HAVE_SYSTEM
-	cmd = g_strdup_printf (ARCH_PREFIX AS_CMD " %s -o %s", as_file, o_file);
+	char *cmd = g_strdup_printf (ARCH_PREFIX AS_CMD " %s -o %s", as_file, o_file);
 	unused = system (cmd); 
 	g_free (cmd);
+	char *objdump_args = g_getenv ("MONO_OBJDUMP_ARGS");
 	if (!objdump_args)
 		objdump_args = g_strdup ("");
 

--- a/src/mono/mono/mini/simd-intrinsics-netcore.c
+++ b/src/mono/mono/mini/simd-intrinsics-netcore.c
@@ -28,6 +28,7 @@ mono_simd_intrinsics_init (void)
 #include "mono/utils/bsearch.h"
 #include <mono/metadata/abi-details.h>
 #include <mono/metadata/reflection-internals.h>
+#include <mono/utils/mono-hwcap.h>
 
 #if defined (MONO_ARCH_SIMD_INTRINSICS) && defined(ENABLE_NETCORE)
 
@@ -2177,13 +2178,10 @@ MONO_EMPTY_SOURCE_FILE (simd_intrinsics_netcore);
 
 
 #if defined(ENABLE_NETCORE) && defined(TARGET_AMD64)
-gboolean
-mono_cpuidex (int id, int sub_id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx);
-
 void
 ves_icall_System_Runtime_Intrinsics_X86_X86Base___cpuidex (int abcd[4], int function_id, int subfunction_id)
 {
-	mono_cpuidex (function_id, subfunction_id,
+	mono_hwcap_x86_call_cpuidex (function_id, subfunction_id,
 		&abcd [0], &abcd [1], &abcd [2], &abcd [3]);
 }
 #endif

--- a/src/mono/mono/utils/mono-hwcap-vars.h
+++ b/src/mono/mono/utils/mono-hwcap-vars.h
@@ -81,4 +81,7 @@ MONO_HWCAP_VAR(x86_has_lzcnt)
 MONO_HWCAP_VAR(x86_has_popcnt)
 MONO_HWCAP_VAR(x86_has_avx)
 
+gboolean
+mono_hwcap_x86_call_cpuidex (int id, int sub_id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx);
+
 #endif

--- a/src/mono/mono/utils/mono-hwcap-x86.c
+++ b/src/mono/mono/utils/mono-hwcap-x86.c
@@ -30,7 +30,7 @@
 #endif
 
 gboolean
-mono_cpuidex (int id, int sub_id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx)
+mono_hwcap_x86_call_cpuidex (int id, int sub_id, int *p_eax, int *p_ebx, int *p_ecx, int *p_edx)
 {
 #if defined(_MSC_VER)
 	int info [4];
@@ -111,7 +111,7 @@ mono_hwcap_arch_init (void)
 {
 	int eax, ebx, ecx, edx;
 
-	if (mono_cpuidex (1, 0, &eax, &ebx, &ecx, &edx)) {
+	if (mono_hwcap_x86_call_cpuidex (1, 0, &eax, &ebx, &ecx, &edx)) {
 		if (edx & (1 << 15)) {
 			mono_hwcap_x86_has_cmov = TRUE;
 
@@ -144,16 +144,16 @@ mono_hwcap_arch_init (void)
 			mono_hwcap_x86_has_avx = TRUE;
 	}
 
-	if (mono_cpuidex (0x80000000, 0, &eax, &ebx, &ecx, &edx)) {
+	if (mono_hwcap_x86_call_cpuidex (0x80000000, 0, &eax, &ebx, &ecx, &edx)) {
 		if ((unsigned int) eax >= 0x80000001 && ebx == 0x68747541 && ecx == 0x444D4163 && edx == 0x69746E65) {
-			if (mono_cpuidex (0x80000001, 0, &eax, &ebx, &ecx, &edx)) {
+			if (mono_hwcap_x86_call_cpuidex (0x80000001, 0, &eax, &ebx, &ecx, &edx)) {
 				if (ecx & (1 << 6))
 					mono_hwcap_x86_has_sse4a = TRUE;
 			}
 		}
 	}
 
-	if (mono_cpuidex (0x80000001, 0, &eax, &ebx, &ecx, &edx)) {
+	if (mono_hwcap_x86_call_cpuidex (0x80000001, 0, &eax, &ebx, &ecx, &edx)) {
 		if (ecx & (1 << 5))
 			mono_hwcap_x86_has_lzcnt = TRUE;
 	}


### PR DESCRIPTION
This PR:
* Enables `-Wc++-compat` on all platforms: we support building the runtime as C++, so this helps catch errors before they're found in CI and will help keep the netcore build C++-compatible
* Sets `-Werror` on netcore CI for OSX

It also fixes various warnings currently present in the build.

`-Werror` should probably be extended to cover all CI platforms eventually. Adding a new platform is as simple as adding to the line in mono.proj whitelisting platforms and fixing the warnings.

Not sure if there's a better way to handle the cpuidex function, but if we're using that from mini it should definitely be in a header somewhere.

Contributes to https://github.com/dotnet/runtime/issues/41357