### PR TITLE
Modified #41008 without GetOverlappedResultEx

### DIFF
--- a/src/coreclr/src/vm/ipcstreamfactory.cpp
+++ b/src/coreclr/src/vm/ipcstreamfactory.cpp
@@ -318,7 +318,7 @@ IpcStream *IpcStreamFactory::GetNextAvailableStream(ErrorCallback callback)
                 {
                     case IpcStream::DiagnosticsIpc::PollEvents::HANGUP:
                         ((DiagnosticPort*)(rgIpcPollHandles[i].pUserData))->Reset(callback);
-                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - HUP :: Poll attempt: %d, connection %d hung up.\n", nPollAttempts, i);
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - HUP :: Poll attempt: %d, connection %d hung up. Connect is reset.\n", nPollAttempts, i);
                         pollTimeoutMs = s_pollTimeoutMinMs;
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::SIGNALED:
@@ -330,7 +330,8 @@ IpcStream *IpcStreamFactory::GetNextAvailableStream(ErrorCallback callback)
                         STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - SIG :: Poll attempt: %d, connection %d signalled.\n", nPollAttempts, i);
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::ERR:
-                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - ERR :: Poll attempt: %d, connection %d errored.\n", nPollAttempts, i);
+                        ((DiagnosticPort*)(rgIpcPollHandles[i].pUserData))->Reset(callback);
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - ERR :: Poll attempt: %d, connection %d errored. Connection is reset.\n", nPollAttempts, i);
                         fSawError = true;
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::NONE:


### PR DESCRIPTION
fixes #41217 

Same changes as #41008 but without using `GetOverlappedResultEx` which is only available in Windows 8 forward.  This modification does not change the behavior of the patch.

Below is the PR description from #41008.


---
fixes #41007

These changes are intended to be backported to 5.0-rc1 once merged into master.

As described in #41007, the runtime was treating `ERROR_BROKEN_PIPE` as a generic error rather than a hangup error.  These changes correct that misbehavior and reset the connection on generic errors in case additional errors have been missed.  Additionally, they simplify the logic of `IpcStream::{Read|Write}` to use `GetOverlappedResultEx` which directly takes a timeout rather than `GetOverlappedResult` followed by `WaitForSingleObject`.

CC @jander-msft @tommcdon

---

## Customer Impact

This currently impacts `dotnet-monitor` on Windows.

If a Connect Diagnostic Port on Windows doesn't call `DisconnectNamedPipe` before closing it will cause runtimes to be unable to connect to another Connect Diagnostic Port at the same address.  For example, `dotnet-monitor` currently does not call `DisconnectNamedPipe` before closing, so if a user restarts `dotnet-monitor` they won't see any apps show up if they connected before.

## Testing

I have tested these changes locally with `dotnet-monitor` both under a debugger and without the debugger.  These fix the observed issue.  I did not add an individual test for this scenario, but one could be created.

## Risk

This is a low risk patch.  It simply improves the error handling and corrects a misbehavior.