### PR TITLE
[Wasm] Reduce max length on browser for ToArrayShouldWorkWithSpecialLengthLazyEnumerables Linq test

### DIFF
--- a/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <DefineConstants Condition="'$(TargetOS)' == 'Browser'">$(DefineConstants);OUTERLOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AggregateTests.cs" />

--- a/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
-    <DefineConstants Condition="'$(TargetOS)' == 'Browser'">$(DefineConstants);OUTERLOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AggregateTests.cs" />

--- a/src/libraries/System.Linq/tests/ToArrayTests.cs
+++ b/src/libraries/System.Linq/tests/ToArrayTests.cs
@@ -331,7 +331,6 @@ namespace System.Linq.Tests
         }
 
         [Theory]
-        [OuterLoop] // Prone to long runs on wasm, which may result in tests timing out.
         [MemberData(nameof(ToArrayShouldWorkWithSpecialLengthLazyEnumerables_MemberData))]
         public void ToArrayShouldWorkWithSpecialLengthLazyEnumerables(int length)
         {
@@ -372,7 +371,7 @@ namespace System.Linq.Tests
         public static IEnumerable<object[]> ToArrayShouldWorkWithSpecialLengthLazyEnumerables_MemberData()
         {
             // Return array sizes that should be small enough not to OOM
-            const int MaxPower = 18;
+            int MaxPower = PlatformDetection.IsBrowser ? 15 : 18;
             yield return new object[] { 1 };
             yield return new object[] { 2 };
             for (int i = 2; i <= MaxPower; i++)

--- a/src/libraries/System.Linq/tests/ToArrayTests.cs
+++ b/src/libraries/System.Linq/tests/ToArrayTests.cs
@@ -331,6 +331,9 @@ namespace System.Linq.Tests
         }
 
         [Theory]
+#if OUTERLOOP
+        [OuterLoop("Prone to long runs on wasm, which may result in tests timing out.")]
+#endif
         [MemberData(nameof(ToArrayShouldWorkWithSpecialLengthLazyEnumerables_MemberData))]
         public void ToArrayShouldWorkWithSpecialLengthLazyEnumerables(int length)
         {

--- a/src/libraries/System.Linq/tests/ToArrayTests.cs
+++ b/src/libraries/System.Linq/tests/ToArrayTests.cs
@@ -331,9 +331,7 @@ namespace System.Linq.Tests
         }
 
         [Theory]
-#if OUTERLOOP
-        [OuterLoop("Prone to long runs on wasm, which may result in tests timing out.")]
-#endif
+        [OuterLoop] // Prone to long runs on wasm, which may result in tests timing out.
         [MemberData(nameof(ToArrayShouldWorkWithSpecialLengthLazyEnumerables_MemberData))]
         public void ToArrayShouldWorkWithSpecialLengthLazyEnumerables(int length)
         {


### PR DESCRIPTION
Addresses the occasional timeouts in System.Linq tests.  

The last 3-4 iterations of ToArrayShouldWorkWithSpecialLengthLazyEnumerables take between 20 - 56 seconds each and likely trigger longer GC runs.

Fixes https://github.com/dotnet/runtime/issues/41114