### PR TITLE
Fix half equality method

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -57,7 +57,7 @@ namespace System
 
         // Well-defined and commonly used values
 
-        public static Half Epsilon =>  new Half(EpsilonBits);                        //  5.9604645E-08
+        public static Half Epsilon => new Half(EpsilonBits);                        //  5.9604645E-08
 
         public static Half PositiveInfinity => new Half(PositiveInfinityBits);      //  1.0 / 0.0;
 
@@ -151,12 +151,19 @@ namespace System
 
         public static bool operator ==(Half left, Half right)
         {
-            return left.Equals(right);
+            if (IsNaN(left) || IsNaN(right))
+            {
+                // IEEE defines that NaN is not equal to anything, including itself.
+                return false;
+            }
+
+            // IEEE defines that positive and negative zero are equivalent.
+            return (left._value == right._value) || AreZero(left, right);
         }
 
         public static bool operator !=(Half left, Half right)
         {
-            return !(left.Equals(right));
+            return !(left == right);
         }
 
         /// <summary>Determines whether the specified value is finite (zero, subnormal, or normal).</summary>
@@ -415,14 +422,11 @@ namespace System
         /// </summary>
         public bool Equals(Half other)
         {
-            if (IsNaN(this) || IsNaN(other))
+            if (this == other)
             {
-                // IEEE defines that NaN is not equal to anything, including itself.
-                return false;
+                return true;
             }
-
-            // IEEE defines that positive and negative zero are equivalent.
-            return (_value == other._value) || AreZero(this, other);
+            return IsNaN(this) && IsNaN(other);
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime/tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.cs
@@ -335,7 +335,7 @@ namespace System.Tests
             yield return new object[] { Half.MaxValue, Half.MaxValue, true };
             yield return new object[] { Half.MaxValue, Half.MinValue, false };
             yield return new object[] { Half.MaxValue, UInt16BitsToHalf(0x0000), false };
-            yield return new object[] { Half.NaN, Half.NaN, false };
+            yield return new object[] { Half.NaN, Half.NaN, true };
             yield return new object[] { Half.MaxValue, 789.0f, false };
             yield return new object[] { Half.MaxValue, "789", false };
         }
@@ -931,6 +931,14 @@ namespace System.Tests
         {
             float f = (float)half;
             Assert.Equal(f, verify, precision: 1);
+        }
+
+        [Fact]
+        public static void EqualityMethodAndOperator()
+        {
+            Assert.True(Half.NaN.Equals(Half.NaN));
+            Assert.False(Half.NaN == Half.NaN);
+            Assert.Equal(Half.NaN, Half.NaN);
         }
     }
 }


### PR DESCRIPTION
Fixes #41258 

The implementation may not be fully optimal, but I copied the semantics from `double`.
Relevant test added.