### PR TITLE
[wasm] Mark System.Data.Common APIs as unsupported on Browser

### DIFF
--- a/src/libraries/System.Data.Common/Directory.Build.props
+++ b/src/libraries/System.Data.Common/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -2768,6 +2768,7 @@ namespace System.Data.SqlTypes
         public long Read(long offset, byte[] buffer, int offsetInBuffer, int count) { throw null; }
         public void SetLength(long value) { }
         public void SetNull() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         System.Xml.Schema.XmlSchema? System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
         void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader r) { }

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -2115,6 +2115,7 @@ namespace System.Data.Common
         protected virtual void InitializeBatching() { }
         protected virtual void OnRowUpdated(System.Data.Common.RowUpdatedEventArgs value) { }
         protected virtual void OnRowUpdating(System.Data.Common.RowUpdatingEventArgs value) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         object System.ICloneable.Clone() { throw null; }
         protected virtual void TerminateBatching() { }
         public int Update(System.Data.DataRow[] dataRows) { throw null; }

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -2795,6 +2795,7 @@ namespace System.Data.SqlTypes
         public long Read(long offset, char[] buffer, int offsetInBuffer, int count) { throw null; }
         public void SetLength(long value) { }
         public void SetNull() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         System.Xml.Schema.XmlSchema? System.Xml.Serialization.IXmlSerializable.GetSchema() { throw null; }
         void System.Xml.Serialization.IXmlSerializable.ReadXml(System.Xml.XmlReader r) { }

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -485,6 +485,7 @@ namespace System.Data
     {
         public DataSet() { }
         protected DataSet(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         protected DataSet(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context, bool ConstructSchema) { }
         public DataSet(string dataSetName) { }
         [System.ComponentModel.DefaultValueAttribute(false)]
@@ -538,6 +539,7 @@ namespace System.Data
         public System.Data.DataSet? GetChanges() { throw null; }
         public System.Data.DataSet? GetChanges(System.Data.DataRowState rowStates) { throw null; }
         public static System.Xml.Schema.XmlSchemaComplexType GetDataSetSchema(System.Xml.Schema.XmlSchemaSet? schemaSet) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected virtual System.Xml.Schema.XmlSchema? GetSchemaSerializable() { throw null; }
         protected void GetSerializationData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataAdapter.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataAdapter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data.ProviderBase;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
 
 namespace System.Data.Common
 {
@@ -231,6 +232,7 @@ namespace System.Data.Common
             throw ADP.NotSupported();
         }
 
+        [UnsupportedOSPlatform("browser")]
         object ICloneable.Clone()
         {
 #pragma warning disable 618 // ignore obsolete warning about CloneInternals

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
 using System.Xml;
@@ -227,6 +228,7 @@ namespace System.Data
         {
         }
 
+        [UnsupportedOSPlatform("browser")]
         protected DataSet(SerializationInfo info, StreamingContext context, bool ConstructSchema) : this()
         {
             SerializationFormat remotingFormat = SerializationFormat.Xml;
@@ -263,6 +265,7 @@ namespace System.Data
             DeserializeDataSet(info, context, remotingFormat, schemaSerializationMode);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             SerializationFormat remotingFormat = RemotingFormat;

--- a/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLBytes.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLBytes.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 namespace System.Data.SqlTypes
 {
@@ -551,6 +552,7 @@ namespace System.Data.SqlTypes
 
         // State information is not saved. The current state is converted to Buffer and only the underlying
         // array is serialized, except for Null, in which case this state is kept.
+        [UnsupportedOSPlatform("browser")]
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLChars.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLChars.cs
@@ -9,6 +9,7 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 namespace System.Data.SqlTypes
 {
@@ -535,6 +536,7 @@ namespace System.Data.SqlTypes
 
         // State information is not saved. The current state is converted to Buffer and only the underlying
         // array is serialized, except for Null, in which case this state is kept.
+        [UnsupportedOSPlatform("browser")]
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLChars.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLChars.cs
@@ -4,12 +4,12 @@
 using System.IO;
 using System.Diagnostics;
 using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
-using System.Runtime.Serialization;
-using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 
 namespace System.Data.SqlTypes
 {


### PR DESCRIPTION
Contributes to #41087 

```
browser "M:System.Data.DataSet.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.Data,DataSet,"GetObjectData(SerializationInfo, StreamingContext)",2
browser "M:System.Data.DataSet.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext,System.Boolean)",System.Data,DataSet,".ctor(SerializationInfo, StreamingContext, Boolean)",3
browser "M:System.Data.SqlTypes.SqlChars.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.Data.SqlTypes,SqlChars,"System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo, StreamingContext)",0
browser "M:System.Data.SqlTypes.SqlBytes.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.Data.SqlTypes,SqlBytes,"System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo, StreamingContext)",0
obsolete M:System.Data.Common.DataAdapter.CloneInternals,System.Data.Common,DataAdapter,CloneInternals(),1
browser M:System.Data.Common.DbDataAdapter.System#ICloneable#Clone,System.Data.Common,DbDataAdapter,System.ICloneable.Clone(),2
```