### PR TITLE
Mark System.Diagnostics.FileVersionInfo as unsupported on Browser

### DIFF
--- a/src/libraries/System.Diagnostics.FileVersionInfo/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Contributes to #41087 

All the public APIs are to be marked as unsupported, so it is marked at the assembly level.

```
M:System.Diagnostics.FileVersionInfo.get_IsSpecialBuild,System.Diagnostics,FileVersionInfo,get_IsSpecialBuild(),0
M:System.Diagnostics.FileVersionInfo.get_FileName,System.Diagnostics,FileVersionInfo,get_FileName(),0
M:System.Diagnostics.FileVersionInfo.get_FileDescription,System.Diagnostics,FileVersionInfo,get_FileDescription(),0
M:System.Diagnostics.FileVersionInfo.get_OriginalFilename,System.Diagnostics,FileVersionInfo,get_OriginalFilename(),0
M:System.Diagnostics.FileVersionInfo.get_Language,System.Diagnostics,FileVersionInfo,get_Language(),0
M:System.Diagnostics.FileVersionInfo.get_LegalTrademarks,System.Diagnostics,FileVersionInfo,get_LegalTrademarks(),0
M:System.Diagnostics.FileVersionInfo.get_SpecialBuild,System.Diagnostics,FileVersionInfo,get_SpecialBuild(),0
M:System.Diagnostics.FileVersionInfo.get_ProductBuildPart,System.Diagnostics,FileVersionInfo,get_ProductBuildPart(),0
M:System.Diagnostics.FileVersionInfo.get_FileVersion,System.Diagnostics,FileVersionInfo,get_FileVersion(),0
M:System.Diagnostics.FileVersionInfo.get_ProductPrivatePart,System.Diagnostics,FileVersionInfo,get_ProductPrivatePart(),0
M:System.Diagnostics.FileVersionInfo.get_PrivateBuild,System.Diagnostics,FileVersionInfo,get_PrivateBuild(),0
M:System.Diagnostics.FileVersionInfo.get_FilePrivatePart,System.Diagnostics,FileVersionInfo,get_FilePrivatePart(),0
M:System.Diagnostics.FileVersionInfo.get_LegalCopyright,System.Diagnostics,FileVersionInfo,get_LegalCopyright(),0
M:System.Diagnostics.FileVersionInfo.get_FileBuildPart,System.Diagnostics,FileVersionInfo,get_FileBuildPart(),0
M:System.Diagnostics.FileVersionInfo.ToString,System.Diagnostics,FileVersionInfo,ToString(),0
M:System.Diagnostics.FileVersionInfo.get_IsDebug,System.Diagnostics,FileVersionInfo,get_IsDebug(),0
M:System.Diagnostics.FileVersionInfo.GetVersionInfo(System.String),System.Diagnostics,FileVersionInfo,GetVersionInfo(String),0
M:System.Diagnostics.FileVersionInfo.get_ProductMajorPart,System.Diagnostics,FileVersionInfo,get_ProductMajorPart(),0
M:System.Diagnostics.FileVersionInfo.get_ProductName,System.Diagnostics,FileVersionInfo,get_ProductName(),0
M:System.Diagnostics.FileVersionInfo.get_InternalName,System.Diagnostics,FileVersionInfo,get_InternalName(),0
M:System.Diagnostics.FileVersionInfo.get_FileMinorPart,System.Diagnostics,FileVersionInfo,get_FileMinorPart(),0
M:System.Diagnostics.FileVersionInfo.get_IsPrivateBuild,System.Diagnostics,FileVersionInfo,get_IsPrivateBuild(),0
M:System.Diagnostics.FileVersionInfo.get_FileMajorPart,System.Diagnostics,FileVersionInfo,get_FileMajorPart(),0
M:System.Diagnostics.FileVersionInfo.get_ProductVersion,System.Diagnostics,FileVersionInfo,get_ProductVersion(),0
M:System.Diagnostics.FileVersionInfo.get_Comments,System.Diagnostics,FileVersionInfo,get_Comments(),0
M:System.Diagnostics.FileVersionInfo.get_IsPatched,System.Diagnostics,FileVersionInfo,get_IsPatched(),0
M:System.Diagnostics.FileVersionInfo.get_CompanyName,System.Diagnostics,FileVersionInfo,get_CompanyName(),0
M:System.Diagnostics.FileVersionInfo.get_ProductMinorPart,System.Diagnostics,FileVersionInfo,get_ProductMinorPart(),0
M:System.Diagnostics.FileVersionInfo.get_IsPreRelease,System.Diagnostics,FileVersionInfo,get_IsPreRelease(),0
```