### PR TITLE
[wasm] Fix csproj that was using System.Runtime.InteropServices.JavaScript.dll

### DIFF
--- a/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
@@ -36,7 +36,7 @@
     </ItemGroup>
     <WasmAppBuilder
       AppDir="$(AppDir)"
-      ExtraAssemblies="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)\System.Runtime.InteropServices.JavaScript.dll"
+      ExtraAssemblies="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)\System.Private.Runtime.InteropServices.JavaScript.dll"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
       MainAssembly="bin\WasmSample.dll"
       MainJS="runtime.js"


### PR DESCRIPTION
Fix wasm sample after that was broken after this PR: https://github.com/dotnet/runtime/pull/40478