### PR TITLE
Add netcoreapp build of System.Formats.Asn1

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System.Formats.Asn1.csproj
+++ b/src/libraries/System.Formats.Asn1/src/System.Formats.Asn1.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>
+    <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
@@ -46,10 +47,26 @@
     <Compile Include="System\Formats\Asn1\TagClass.cs" />
     <Compile Include="System\Formats\Asn1\UniversalTagNumber.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+      <ItemGroup>
+        <Reference Include="System.Buffers" />
+        <Reference Include="System.Collections" />
+        <Reference Include="System.Memory" />
+        <Reference Include="System.Runtime" />
+        <Reference Include="System.Runtime.InteropServices" />
+        <Reference Include="System.Runtime.Numerics" />
+        <Reference Include="System.Security.Cryptography.Primitives" />
+        <Reference Include="System.Text.Encoding.Extensions" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+        <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Numerics" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" Condition="'$(TargetFramework)' == 'net461'" />

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -730,7 +730,9 @@ namespace System.Formats.Asn1
 
             public void Dispose()
             {
-                if (_writer == null || _writer._nestingStack.Count == 0)
+                Debug.Assert(_writer == null || _writer._nestingStack != null);
+
+                if (_writer == null || _writer._nestingStack!.Count == 0)
                 {
                     return;
                 }


### PR DESCRIPTION
This avoids the library causing a cyclic dependency in generating netstandard.dll.

The netcoreapp version is not included in the NuGet package,
following the pattern of
  * System.Text.Json
  * System.Collections.Immutable
  * System.Reflection.Metadata

Contributes to #41106 (also requires a 5.0 fix).