### PR TITLE
[wasm][browser] Fix System.IO.FileSystem failing tests requiring nanosecond/millisecond granularity

### DIFF
--- a/src/libraries/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/libraries/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation"/>
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/libraries/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -49,7 +49,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation"/>
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -16,9 +16,10 @@ namespace System.IO.Tests
         private static string driveFormat = PlatformDetection.IsInAppContainer ? string.Empty : new DriveInfo(Path.GetTempPath()).DriveFormat;
 
         protected static bool isHFS => driveFormat != null && driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
-        protected static bool isNotHFS => !isHFS;
-
         protected static bool isBrowser => PlatformDetection.IsBrowser;
+
+        protected static bool isHFSOrBrowser => isBrowser || isHFS;
+        protected static bool isNotHFSOrBrowser => !isHFSOrBrowser;
 
         protected abstract T GetExistingItem();
         protected abstract T GetMissingItem();
@@ -79,8 +80,7 @@ namespace System.IO.Tests
             ValidateSetTimes(item, beforeTime, afterTime);
         }
 
-        [ConditionalFact(nameof(isNotHFS))] // OSX HFS driver format does not support millisec granularity
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40530", TestPlatforms.Browser)]
+        [ConditionalFact(nameof(isNotHFSOrBrowser))] // OSX HFS driver format and Browser platform do not support millisec granularity
         public void TimesIncludeMillisecondPart()
         {
             T item = GetExistingItem();
@@ -112,11 +112,11 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact(nameof(isHFS))]
-        public void TimesIncludeMillisecondPart_HFS()
+        [ConditionalFact(nameof(isHFSOrBrowser))]
+        public void TimesIncludeMillisecondPart_HFSOrBrowser()
         {
             T item = GetExistingItem();
-            // OSX HFS driver format does not support millisec granularity
+            // OSX HFS driver format and Browser do not support millisec granularity
             Assert.All(TimeFunctions(), (function) =>
             {
                 DateTime time = function.Getter(item);

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -17,8 +17,8 @@ namespace System.IO.Tests
 
         protected static bool isHFS => driveFormat != null && driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
 
-        protected static bool WithMillisecondResolution => PlatformDetection.IsBrowser || isHFS;
-        protected static bool WithoutMillisecondResolution => !WithMillisecondResolution;
+        protected static bool LowTemporalResolution => PlatformDetection.IsBrowser || isHFS;
+        protected static bool HighTemporalResolution => !LowTemporalResolution;
 
         protected abstract T GetExistingItem();
         protected abstract T GetMissingItem();
@@ -51,7 +51,7 @@ namespace System.IO.Tests
             {
                 // Checking that milliseconds are not dropped after setter.
                 // Emscripten drops milliseconds in Browser
-                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, (WithMillisecondResolution) ? 0 : 321, function.Kind);
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, LowTemporalResolution ? 0 : 321, function.Kind);
                 function.Setter(item, dt);
                 DateTime result = function.Getter(item);
                 Assert.Equal(dt, result);
@@ -79,7 +79,7 @@ namespace System.IO.Tests
             ValidateSetTimes(item, beforeTime, afterTime);
         }
 
-        [ConditionalFact(nameof(WithoutMillisecondResolution))] // OSX HFS driver format and Browser platform do not support millisec granularity
+        [ConditionalFact(nameof(HighTemporalResolution))] // OSX HFS driver format and Browser platform do not support millisec granularity
         public void TimesIncludeMillisecondPart()
         {
             T item = GetExistingItem();
@@ -111,8 +111,8 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact(nameof(WithMillisecondResolution))]
-        public void TimesIncludeMillisecondPart_HFSOrBrowser()
+        [ConditionalFact(nameof(LowTemporalResolution))]
+        public void TimesIncludeMillisecondPart_LowTempRes()
         {
             T item = GetExistingItem();
             // OSX HFS driver format and Browser do not support millisec granularity

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -16,10 +16,9 @@ namespace System.IO.Tests
         private static string driveFormat = PlatformDetection.IsInAppContainer ? string.Empty : new DriveInfo(Path.GetTempPath()).DriveFormat;
 
         protected static bool isHFS => driveFormat != null && driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
-        protected static bool isBrowser => PlatformDetection.IsBrowser;
 
-        protected static bool isHFSOrBrowser => isBrowser || isHFS;
-        protected static bool isNotHFSOrBrowser => !isHFSOrBrowser;
+        protected static bool WithMillisecondResolution => PlatformDetection.IsBrowser || isHFS;
+        protected static bool WithoutMillisecondResolution => !WithMillisecondResolution;
 
         protected abstract T GetExistingItem();
         protected abstract T GetMissingItem();
@@ -52,7 +51,7 @@ namespace System.IO.Tests
             {
                 // Checking that milliseconds are not dropped after setter.
                 // Emscripten drops milliseconds in Browser
-                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, (isHFS || isBrowser) ? 0 : 321, function.Kind);
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, (WithMillisecondResolution) ? 0 : 321, function.Kind);
                 function.Setter(item, dt);
                 DateTime result = function.Getter(item);
                 Assert.Equal(dt, result);
@@ -80,7 +79,7 @@ namespace System.IO.Tests
             ValidateSetTimes(item, beforeTime, afterTime);
         }
 
-        [ConditionalFact(nameof(isNotHFSOrBrowser))] // OSX HFS driver format and Browser platform do not support millisec granularity
+        [ConditionalFact(nameof(WithoutMillisecondResolution))] // OSX HFS driver format and Browser platform do not support millisec granularity
         public void TimesIncludeMillisecondPart()
         {
             T item = GetExistingItem();
@@ -112,7 +111,7 @@ namespace System.IO.Tests
             });
         }
 
-        [ConditionalFact(nameof(isHFSOrBrowser))]
+        [ConditionalFact(nameof(WithMillisecondResolution))]
         public void TimesIncludeMillisecondPart_HFSOrBrowser()
         {
             T item = GetExistingItem();

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -18,6 +18,8 @@ namespace System.IO.Tests
         protected static bool isHFS => driveFormat != null && driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase);
         protected static bool isNotHFS => !isHFS;
 
+        protected static bool isBrowser => PlatformDetection.IsBrowser;
+
         protected abstract T GetExistingItem();
         protected abstract T GetMissingItem();
 
@@ -41,7 +43,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40528", TestPlatforms.Browser)]
         public void SettingUpdatesProperties()
         {
             T item = GetExistingItem();
@@ -49,7 +50,8 @@ namespace System.IO.Tests
             Assert.All(TimeFunctions(requiresRoundtripping: true), (function) =>
             {
                 // Checking that milliseconds are not dropped after setter.
-                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, isHFS ? 0 : 321, function.Kind);
+                // Emscripten drops milliseconds in Browser
+                DateTime dt = new DateTime(2014, 12, 1, 12, 3, 3, (isHFS || isBrowser) ? 0 : 321, function.Kind);
                 function.Setter(item, dt);
                 DateTime result = function.Getter(item);
                 Assert.Equal(dt, result);

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -134,7 +134,7 @@ namespace System.IO.Tests
             Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
         }
 
-        [ConditionalFact(nameof(WithoutMillisecondResolution))] // OSX HFS driver format/Browser Platform do not support nanosecond granularity.
+        [ConditionalFact(nameof(HighTemporalResolution))] // OSX HFS driver format/Browser Platform do not support nanosecond granularity.
         public void SetUptoNanoseconds()
         {
             string file = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -134,8 +134,7 @@ namespace System.IO.Tests
             Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
         }
 
-        [ConditionalFact(nameof(isNotHFS))] // OSX HFS driver format does not support nanosecond granularity.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40532", TestPlatforms.Browser)]
+        [ConditionalFact(nameof(isNotHFSOrBrowser))] // OSX HFS driver format/Browser Platform do not support nanosecond granularity.
         public void SetUptoNanoseconds()
         {
             string file = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -134,7 +134,7 @@ namespace System.IO.Tests
             Assert.True(firstFileTicks <= secondFileTicks, $"First File Ticks\t{firstFileTicks}\nSecond File Ticks\t{secondFileTicks}");
         }
 
-        [ConditionalFact(nameof(isNotHFSOrBrowser))] // OSX HFS driver format/Browser Platform do not support nanosecond granularity.
+        [ConditionalFact(nameof(WithoutMillisecondResolution))] // OSX HFS driver format/Browser Platform do not support nanosecond granularity.
         public void SetUptoNanoseconds()
         {
             string file = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -103,8 +103,7 @@ namespace System.IO.Tests
                 DateTimeKind.Utc);
         }
 
-        [ConditionalFact(nameof(isNotHFS))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40530", TestPlatforms.Browser)]
+        [ConditionalFact(nameof(isNotHFSOrBrowser))]
         public void CopyToMillisecondPresent()
         {
             FileInfo input = GetNonZeroMilliseconds();
@@ -118,8 +117,7 @@ namespace System.IO.Tests
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(isNotHFS))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40530", TestPlatforms.Browser)]
+        [ConditionalFact(nameof(isNotHFSOrBrowser))]
         public void CopyToNanosecondsPresent()
         {
             FileInfo input = GetNonZeroNanoseconds();
@@ -135,8 +133,8 @@ namespace System.IO.Tests
             Assert.True(HasNonZeroNanoseconds(output.LastWriteTime));
         }
 
-        [ConditionalFact(nameof(isHFS))]
-        public void CopyToNanosecondsPresent_HFS()
+        [ConditionalFact(nameof(isHFSOrBrowser))]
+        public void CopyToNanosecondsPresent_HFSOrBrowser()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();
@@ -149,8 +147,8 @@ namespace System.IO.Tests
             Assert.False(HasNonZeroNanoseconds(output.LastWriteTime));
         }
 
-        [ConditionalFact(nameof(isHFS))]
-        public void MoveToMillisecondPresent_HFS()
+        [ConditionalFact(nameof(isHFSOrBrowser))]
+        public void MoveToMillisecondPresent_HFSOrBrowser()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();
@@ -161,8 +159,7 @@ namespace System.IO.Tests
             Assert.Equal(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(isNotHFS))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40530", TestPlatforms.Browser)]
+        [ConditionalFact(nameof(isNotHFSOrBrowser))]
         public void MoveToMillisecondPresent()
         {
             FileInfo input = GetNonZeroMilliseconds();
@@ -173,8 +170,8 @@ namespace System.IO.Tests
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(isHFS))]
-        public void CopyToMillisecondPresent_HFS()
+        [ConditionalFact(nameof(isHFSOrBrowser))]
+        public void CopyToMillisecondPresent_HFSOrBrowser()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -103,7 +103,7 @@ namespace System.IO.Tests
                 DateTimeKind.Utc);
         }
 
-        [ConditionalFact(nameof(WithoutMillisecondResolution))]
+        [ConditionalFact(nameof(HighTemporalResolution))]
         public void CopyToMillisecondPresent()
         {
             FileInfo input = GetNonZeroMilliseconds();
@@ -117,7 +117,7 @@ namespace System.IO.Tests
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(WithoutMillisecondResolution))]
+        [ConditionalFact(nameof(HighTemporalResolution))]
         public void CopyToNanosecondsPresent()
         {
             FileInfo input = GetNonZeroNanoseconds();
@@ -133,8 +133,8 @@ namespace System.IO.Tests
             Assert.True(HasNonZeroNanoseconds(output.LastWriteTime));
         }
 
-        [ConditionalFact(nameof(WithMillisecondResolution))]
-        public void CopyToNanosecondsPresent_HFSOrBrowser()
+        [ConditionalFact(nameof(LowTemporalResolution))]
+        public void CopyToNanosecondsPresent_LowTempRes()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();
@@ -147,8 +147,8 @@ namespace System.IO.Tests
             Assert.False(HasNonZeroNanoseconds(output.LastWriteTime));
         }
 
-        [ConditionalFact(nameof(WithMillisecondResolution))]
-        public void MoveToMillisecondPresent_HFSOrBrowser()
+        [ConditionalFact(nameof(LowTemporalResolution))]
+        public void MoveToMillisecondPresent_LowTempRes()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();
@@ -159,7 +159,7 @@ namespace System.IO.Tests
             Assert.Equal(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(WithoutMillisecondResolution))]
+        [ConditionalFact(nameof(HighTemporalResolution))]
         public void MoveToMillisecondPresent()
         {
             FileInfo input = GetNonZeroMilliseconds();
@@ -170,8 +170,8 @@ namespace System.IO.Tests
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(WithMillisecondResolution))]
-        public void CopyToMillisecondPresent_HFSOrBrowser()
+        [ConditionalFact(nameof(LowTemporalResolution))]
+        public void CopyToMillisecondPresent_LowTempRes()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
             input.Create().Dispose();

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -103,7 +103,7 @@ namespace System.IO.Tests
                 DateTimeKind.Utc);
         }
 
-        [ConditionalFact(nameof(isNotHFSOrBrowser))]
+        [ConditionalFact(nameof(WithoutMillisecondResolution))]
         public void CopyToMillisecondPresent()
         {
             FileInfo input = GetNonZeroMilliseconds();
@@ -117,7 +117,7 @@ namespace System.IO.Tests
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(isNotHFSOrBrowser))]
+        [ConditionalFact(nameof(WithoutMillisecondResolution))]
         public void CopyToNanosecondsPresent()
         {
             FileInfo input = GetNonZeroNanoseconds();
@@ -133,7 +133,7 @@ namespace System.IO.Tests
             Assert.True(HasNonZeroNanoseconds(output.LastWriteTime));
         }
 
-        [ConditionalFact(nameof(isHFSOrBrowser))]
+        [ConditionalFact(nameof(WithMillisecondResolution))]
         public void CopyToNanosecondsPresent_HFSOrBrowser()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
@@ -147,7 +147,7 @@ namespace System.IO.Tests
             Assert.False(HasNonZeroNanoseconds(output.LastWriteTime));
         }
 
-        [ConditionalFact(nameof(isHFSOrBrowser))]
+        [ConditionalFact(nameof(WithMillisecondResolution))]
         public void MoveToMillisecondPresent_HFSOrBrowser()
         {
             FileInfo input = new FileInfo(GetTestFilePath());
@@ -159,7 +159,7 @@ namespace System.IO.Tests
             Assert.Equal(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(isNotHFSOrBrowser))]
+        [ConditionalFact(nameof(WithoutMillisecondResolution))]
         public void MoveToMillisecondPresent()
         {
             FileInfo input = GetNonZeroMilliseconds();
@@ -170,7 +170,7 @@ namespace System.IO.Tests
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
-        [ConditionalFact(nameof(isHFSOrBrowser))]
+        [ConditionalFact(nameof(WithMillisecondResolution))]
         public void CopyToMillisecondPresent_HFSOrBrowser()
         {
             FileInfo input = new FileInfo(GetTestFilePath());


### PR DESCRIPTION
- Emscripten does not support ms granularity so I included a switch for Browser
- Emscripten takes maximum of utime and atime so I set utime and atime together for Browserx

Fix #40528, #40532, #40530