### PR TITLE
Prevent invoking property 'init' method

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -841,7 +841,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             {
                 case ExpressionKind.Property:
                     ExprProperty prop = (ExprProperty)expr;
-                    Debug.Assert(!prop.MethWithTypeSet);
+                    Debug.Assert(!prop.MethWithTypeSet || ExprProperty.HasIsExternalInitModifier(prop.MethWithTypeSet));
                     // Assigning to a property without a setter.
                     // If we have
                     // bool? b = true; (bool)b = false;

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
@@ -49,7 +49,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         internal static bool HasIsExternalInitModifier(MethWithType mwtSet)
         {
             var types = (mwtSet.Meth()?.AssociatedMemberInfo as MethodInfo)?.ReturnParameter.GetRequiredCustomModifiers();
-            return (types != null) && types.Any(type => type.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+            return types != null &&
+                types.Any(type => type.Name == "IsExternalInit" && !type.IsNested && type.Namespace == "System.Runtime.CompilerServices");
         }
     }
 }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
+using System.Reflection;
+
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
     internal sealed class ExprProperty : ExprWithArgs
@@ -28,7 +31,10 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             if (mwtSet != null)
             {
                 MethWithTypeSet = mwtSet;
-                Flags = EXPRFLAG.EXF_LVALUE;
+                if (!HasIsExternalInitModifier(mwtSet))
+                {
+                    Flags = EXPRFLAG.EXF_LVALUE;
+                }
             }
         }
 
@@ -39,5 +45,11 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public MethWithType MethWithTypeSet { get; }
 
         public override SymWithType GetSymWithType() => PropWithTypeSlot;
+
+        internal static bool HasIsExternalInitModifier(MethWithType mwtSet)
+        {
+            var types = (mwtSet.Meth().AssociatedMemberInfo as MethodInfo)?.ReturnParameter.GetRequiredCustomModifiers();
+            return (types != null) && types.Any(type => type.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+        }
     }
 }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/Property.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         internal static bool HasIsExternalInitModifier(MethWithType mwtSet)
         {
-            var types = (mwtSet.Meth().AssociatedMemberInfo as MethodInfo)?.ReturnParameter.GetRequiredCustomModifiers();
+            var types = (mwtSet.Meth()?.AssociatedMemberInfo as MethodInfo)?.ReturnParameter.GetRequiredCustomModifiers();
             return (types != null) && types.Any(type => type.FullName == "System.Runtime.CompilerServices.IsExternalInit");
         }
     }

--- a/src/libraries/Microsoft.CSharp/tests/BindingErrors.cs
+++ b/src/libraries/Microsoft.CSharp/tests/BindingErrors.cs
@@ -577,6 +577,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void InitOnlyProperty_Set()
         {
             dynamic d = new InitOnlyProperty();
@@ -591,18 +592,21 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void InitOnlyProperty_SetInConstructor()
         {
             Assert.Throws<RuntimeBinderException>(() => new InitOnlyProperty(1));
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void InitOnlyProperty_SetInInitAccessor()
         {
             Assert.Throws<RuntimeBinderException>(() => new InitOnlyProperty() { Q = 1 });
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void InitOnlyProperty_Increment()
         {
             dynamic d = new InitOnlyProperty();
@@ -610,6 +614,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void InitOnlyProperty_CompoundAssignment()
         {
             dynamic d = new InitOnlyProperty();

--- a/src/libraries/Microsoft.CSharp/tests/BindingErrors.cs
+++ b/src/libraries/Microsoft.CSharp/tests/BindingErrors.cs
@@ -560,5 +560,60 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             char c = d.get_Chars(2);
             Assert.Equal('c', c);
         }
+
+        private sealed class InitOnlyProperty
+        {
+            public InitOnlyProperty() { }
+            public InitOnlyProperty(int value)
+            {
+                ((dynamic)this).P = value;
+            }
+            public int P { get; init; }
+            public int Q
+            {
+                get { return P; }
+                init { ((dynamic)this).P = value; }
+            }
+        }
+
+        [Fact]
+        public void InitOnlyProperty_Set()
+        {
+            dynamic d = new InitOnlyProperty();
+            Assert.Throws<RuntimeBinderException>(() => d.P = 1);
+        }
+
+        [Fact]
+        public void InitOnlyProperty_SetAccessor()
+        {
+            dynamic d = new InitOnlyProperty();
+            Assert.Throws<RuntimeBinderException>(() => d.set_P(1));
+        }
+
+        [Fact]
+        public void InitOnlyProperty_SetInConstructor()
+        {
+            Assert.Throws<RuntimeBinderException>(() => new InitOnlyProperty(1));
+        }
+
+        [Fact]
+        public void InitOnlyProperty_SetInInitAccessor()
+        {
+            Assert.Throws<RuntimeBinderException>(() => new InitOnlyProperty() { Q = 1 });
+        }
+
+        [Fact]
+        public void InitOnlyProperty_Increment()
+        {
+            dynamic d = new InitOnlyProperty();
+            Assert.Throws<RuntimeBinderException>(() => d.P++);
+        }
+
+        [Fact]
+        public void InitOnlyProperty_CompoundAssignment()
+        {
+            dynamic d = new InitOnlyProperty();
+            Assert.Throws<RuntimeBinderException>(() => d.P += 1);
+        }
     }
 }

--- a/src/libraries/Microsoft.CSharp/tests/IsExternalInit.cs
+++ b/src/libraries/Microsoft.CSharp/tests/IsExternalInit.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    public sealed class IsExternalInit
+    {
+    }
+}

--- a/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="IntegerBinaryOperationTests.cs" />
     <Compile Include="IntegerUnaryOperationTests.cs" />
     <Compile Include="IsEventTests.cs" />
+    <Compile Include="IsExternalInit.cs" />
     <Compile Include="NamedArgumentTests.cs" />
     <Compile Include="NullableEnumUnaryOperationTest.cs" />
     <Compile Include="RuntimeBinderExceptionTests.cs" />


### PR DESCRIPTION
Prevent invoking a property setter in the dynamic binder if the setter has a `System.Runtime.CompilerServices.IsExternalInit` modifier.

Fixes #40118.