### PR TITLE
Fix NRE introduced in FileSystemWatcher during nullability annotations

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -390,6 +390,7 @@ namespace System.IO
                     // of the world, but there's little that can be done about that.)
                     if (directoryEntry.Parent != parent)
                     {
+                        // Work around https://github.com/dotnet/csharplang/issues/3393 preventing Parent?.Children!. from behaving as expected
                         if (directoryEntry.Parent != null)
                         {
                             directoryEntry.Parent.Children!.Remove(directoryEntry);
@@ -447,6 +448,7 @@ namespace System.IO
                 Debug.Assert (_includeSubdirectories);
                 lock (SyncObj)
                 {
+                    // Work around https://github.com/dotnet/csharplang/issues/3393 preventing Parent?.Children!. from behaving as expected
                     if (directoryEntry.Parent != null)
                     {
                         directoryEntry.Parent.Children!.Remove(directoryEntry);

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -390,7 +390,11 @@ namespace System.IO
                     // of the world, but there's little that can be done about that.)
                     if (directoryEntry.Parent != parent)
                     {
-                        directoryEntry.Parent?.Children!.Remove (directoryEntry);
+                        if (directoryEntry.Parent != null)
+                        {
+                            directoryEntry.Parent.Children!.Remove(directoryEntry);
+                        }
+
                         directoryEntry.Parent = parent;
                         if (parent != null)
                         {
@@ -443,7 +447,11 @@ namespace System.IO
                 Debug.Assert (_includeSubdirectories);
                 lock (SyncObj)
                 {
-                    directoryEntry.Parent?.Children!.Remove(directoryEntry);
+                    if (directoryEntry.Parent != null)
+                    {
+                        directoryEntry.Parent.Children!.Remove(directoryEntry);
+                    }
+
                     RemoveWatchedDirectoryUnlocked (directoryEntry, removeInotify);
                 }
             }


### PR DESCRIPTION
While annotating https://github.com/dotnet/runtime/pull/41261 I've introduced a product bug which luckily got caught by tests. It is weird compiler behavior (https://github.com/dotnet/csharplang/issues/3393) which changes `?.` precedence when adding `!`, see i.e.:
https://sharplab.io/#v2:EYLgtghgzgLgpgJwDQBMQGoA+ABATARgFgAoEvAZgAIBvEy+y7fANkYBZKAFCGAC3wAUAYXyUADgEoadBrIBuEBJQB2EMHEoBecQH4AdENx6AcmrgBuGbPpMAnANXqJl4rIC+Vyp6atsHbny4wqKS0q7W9ApKjhraYvqGAIQmZi4RNvj2Mc6eHsR5ZLiUIiS04TZUhsVF1JQA5nAw5pRQjc15BcR41aXeVEwADJSm6jT1bS1tHUA

I've done quick search in our code if we've introduced similar errors elsewhere and found only this.

Note: **this is fixing a regression** introduced by https://github.com/dotnet/runtime/commit/e59c9260eb78bbf093d8081a3b8a1ecc0132d70f#diff-ab050074db1f148b9d552c569a7899b7R398.