### PR TITLE
Console.Unix: fix window size not always being invalidated

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1357,6 +1357,9 @@ namespace System
 
         private static void CheckTerminalSettingsInvalidated()
         {
+            // Register for signals that invalidate cached values.
+            EnsureConsoleInitialized();
+
             bool invalidateSettings = Interlocked.CompareExchange(ref s_invalidateCachedSettings, 0, 1) == 1;
             if (invalidateSettings)
             {


### PR DESCRIPTION
Ensure signal handlers are setup to invalidate cached values for window size.

Fixes https://github.com/dotnet/runtime/issues/41274

This a regression caused by the caching added in 3.0 https://github.com/dotnet/corefx/pull/36049

cc @stephentoub @eiriktsarpalis @zeroskyx 