### PR TITLE
Reset all Uri fields when reusing an instance

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -504,6 +504,7 @@ namespace System
             _flags = Flags.Zero;
             _info = null!;
             _syntax = null!;
+            _originalUnicodeString = null!;
             // If not resolved, we reparse modified Uri string and populate Uri internal data.
             CreateThis(relativeUri, dontEscape, UriKind.Absolute);
         }
@@ -550,6 +551,7 @@ namespace System
             _flags = Flags.Zero;
             _info = null!;
             _syntax = null!;
+            _originalUnicodeString = null!;
             CreateThis(newUriString, dontEscape, UriKind.Absolute);
             DebugSetLeftCtor();
         }

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -26,6 +26,8 @@ namespace System
 
             _string = uri ?? string.Empty;
 
+            Debug.Assert(_originalUnicodeString is null && _info is null && _syntax is null && _flags == Flags.Zero);
+
             if (dontEscape)
                 _flags |= Flags.UserEscaped;
 

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -710,6 +710,23 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        public static void Uri_CombineUsesNewUriString()
+        {
+            // Tests that internal Uri fields were properly reset during a Combine operation
+            // Otherwise, the wrong Uri string would be used if the relative Uri contains non-ascii characters
+            // This will only affect parsers without the IriParsing flag - only custom parsers
+            UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "combine-scheme", -1);
+
+            const string RelativeUriString = "/relative/uri/with/non/ascii/\u00FC";
+
+            var absoluteUri = new Uri("combine-scheme://foo", UriKind.Absolute);
+            var relativeUri = new Uri(RelativeUriString, UriKind.Relative);
+
+            new Uri(absoluteUri, relativeUri);
+            new Uri(absoluteUri, RelativeUriString);
+        }
+
+        [Fact]
         public static void Uri_CachesIdnHost()
         {
             var uri = new Uri("https://\u00FCnicode/foo");

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -717,13 +717,15 @@ namespace System.PrivateUri.Tests
             // This will only affect parsers without the IriParsing flag - only custom parsers
             UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "combine-scheme", -1);
 
+            const string BaseUriString = "combine-scheme://foo";
             const string RelativeUriString = "/relative/uri/with/non/ascii/\u00FC";
+            const string Combined = BaseUriString + "/relative/uri/with/non/ascii/%C3%BC";
 
-            var absoluteUri = new Uri("combine-scheme://foo", UriKind.Absolute);
+            var baseUri = new Uri(BaseUriString, UriKind.Absolute);
             var relativeUri = new Uri(RelativeUriString, UriKind.Relative);
 
-            new Uri(absoluteUri, relativeUri);
-            new Uri(absoluteUri, RelativeUriString);
+            Assert.Equal(Combined, new Uri(baseUri, relativeUri).AbsoluteUri);
+            Assert.Equal(Combined, new Uri(baseUri, RelativeUriString).AbsoluteUri);
         }
 
         [Fact]


### PR DESCRIPTION
Simplifying `OriginalString` to `_originalUnicodeString ?? _string` in #33044 introduced a bug affecting the `new Uri(baseUri, relativeUri)` combine operations.

The bug can be hit if:
1. The `relativeUri` contains non-ascii characters
1. The `baseUri` uses a custom (not built-in scheme) - in this case `pack`
1. A custom `UriParser` is registered for that scheme
1. That parser is a "Simple parser" - a `GenericUriParser`, and it is set up without the `GenericUriParserOptions.IriParsing` flag

The cause is that when combining the Uris, the Uri instance gets reused, but not all internal fields are reset. As `_originalUnicodeString` was not being reset, it changed the output of `OriginalString` when reused. This led to the relative Uri being used in the parsing logic instead of the constructed combined Uri.

This does not affect built-in schemes / custom parsers with the `IriParsing` flag, as `_originalUnicodeString` will be properly set during parsing (the old value won't sneak through).

Fixes #41177