### PR TITLE
Exclude Mono.Cecil assemblies from signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -111,6 +111,9 @@
     <ItemGroup>
       <!-- External files -->
       <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
+      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Mono.Cecil'))" />
+      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Mono.Cecil.Pdb'))" />
+      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Mono.Cecil.Rocks'))" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We're just shipping them in the Microsoft.NETCore.BrowserDebugHost.Transport package.