### PR TITLE
[wasm] Mark System.Diagnostics.XmlWriterTraceListener APIs as unsupported on Browser

### DIFF
--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/ref/System.Diagnostics.TextWriterTraceListener.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/ref/System.Diagnostics.TextWriterTraceListener.cs
@@ -53,10 +53,15 @@ namespace System.Diagnostics
         public XmlWriterTraceListener(string? filename, string? name) { }
         public override void Close() { }
         public override void Fail(string? message, string? detailMessage) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override void TraceData(System.Diagnostics.TraceEventCache? eventCache, string source, System.Diagnostics.TraceEventType eventType, int id, object? data) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override void TraceData(System.Diagnostics.TraceEventCache? eventCache, string source, System.Diagnostics.TraceEventType eventType, int id, params object?[]? data) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override void TraceEvent(System.Diagnostics.TraceEventCache? eventCache, string source, System.Diagnostics.TraceEventType eventType, int id, string? message) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override void TraceEvent(System.Diagnostics.TraceEventCache? eventCache, string source, System.Diagnostics.TraceEventType eventType, int id, string format, params object?[]? args) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override void TraceTransfer(System.Diagnostics.TraceEventCache? eventCache, string source, int id, string? message, System.Guid relatedActivityId) { }
         public override void Write(string? message) { }
         public override void WriteLine(string? message) { }

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/XmlWriterTraceListener.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/XmlWriterTraceListener.cs
@@ -84,6 +84,7 @@ namespace System.Diagnostics
             }));
         }
 
+        [UnsupportedOSPlatform("browser")]
         public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string format, params object?[]? args)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, format, args, null, null))
@@ -94,6 +95,7 @@ namespace System.Diagnostics
             WriteFooter(eventCache);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, message, null, null, null))
@@ -104,6 +106,7 @@ namespace System.Diagnostics
             WriteFooter(eventCache);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public override void TraceData(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, object? data)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, null, null, data, null))
@@ -123,6 +126,7 @@ namespace System.Diagnostics
             WriteFooter(eventCache);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public override void TraceData(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, params object?[]? data)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, eventType, id, null, null, null, data))
@@ -186,6 +190,7 @@ namespace System.Diagnostics
             _strBldr = null;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public override void TraceTransfer(TraceEventCache? eventCache, string source, int id, string? message, Guid relatedActivityId)
         {
             if (Filter != null && !Filter.ShouldTrace(eventCache, source, TraceEventType.Transfer, id, message, null, null, null))


### PR DESCRIPTION
Contributes to #41087 

```
browser "M:System.Diagnostics.XmlWriterTraceListener.TraceData(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.Object)",System.Diagnostics,XmlWriterTraceListener,"TraceData(TraceEventCache, String, TraceEventType, Int32, Object)",3
browser "M:System.Diagnostics.XmlWriterTraceListener.TraceEvent(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.String,System.Object[])",System.Diagnostics,XmlWriterTraceListener,"TraceEvent(TraceEventCache, String, TraceEventType, Int32, String, Object[])",3
browser "M:System.Diagnostics.XmlWriterTraceListener.TraceData(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.Object[])",System.Diagnostics,XmlWriterTraceListener,"TraceData(TraceEventCache, String, TraceEventType, Int32, Object[])",3
browser "M:System.Diagnostics.XmlWriterTraceListener.TraceEvent(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.String)",System.Diagnostics,XmlWriterTraceListener,"TraceEvent(TraceEventCache, String, TraceEventType, Int32, String)",3
browser "M:System.Diagnostics.XmlWriterTraceListener.TraceTransfer(System.Diagnostics.TraceEventCache,System.String,System.Int32,System.String,System.Guid)",System.Diagnostics,XmlWriterTraceListener,"TraceTransfer(TraceEventCache, String, Int32, String, Guid)",3
```