### PR TITLE
[wasm] Mark System.IO.FileSystem.DriveInfo APIs as unsupported on Browser

### DIFF
--- a/src/libraries/System.IO.FileSystem.DriveInfo/ref/System.IO.FileSystem.DriveInfo.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/ref/System.IO.FileSystem.DriveInfo.cs
@@ -20,6 +20,7 @@ namespace System.IO
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string VolumeLabel { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public static System.IO.DriveInfo[] GetDrives() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
     }

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.UnixOrBrowser.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.UnixOrBrowser.cs
@@ -3,8 +3,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Security;
 using System.Runtime.Versioning;
+using System.Security;
 
 namespace System.IO
 {

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
@@ -5,8 +5,8 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Runtime.Versioning;
+using System.Text;
 
 namespace System.IO
 {

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 
 namespace System.IO
 {
@@ -19,6 +20,7 @@ namespace System.IO
             _name = NormalizeDriveName(driveName);
         }
 
+        [UnsupportedOSPlatform("browser")]
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();


### PR DESCRIPTION
Contributes to #41087 

```
browser "M:System.IO.DriveInfo.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.IO,DriveInfo,"System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo, StreamingContext)",0
windows M:System.IO.DriveInfo.set_VolumeLabel(System.String),System.IO,DriveInfo,set_VolumeLabel(String),0
```