### PR TITLE
Improve hashset intersect with dictionary keycollection

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -536,9 +536,10 @@ namespace System.Collections.Generic
                     return;
                 }
 
-                Type? otherType = other.GetType().GetGenericTypeDefinition();
+                Type? otherType = other.GetType();
+                otherType = otherType.IsGenericType ? otherType.GetGenericTypeDefinition() : null;
                 // For types supporting O(1) lookup, utilize the contains method for faster intersect.
-                if (otherType == typeof(Dictionary<,>.KeyCollection))
+                if (otherType != null && otherType == typeof(Dictionary<,>.KeyCollection))
                 {
                     IntersectWithCollection(otherAsCollection);
                     return;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -532,7 +532,15 @@ namespace System.Collections.Generic
                 // that other is a hashset using the same equality comparer.
                 if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
                 {
-                    IntersectWithHashSetWithSameComparer(otherAsSet);
+                    IntersectWithCollection(otherAsCollection);
+                    return;
+                }
+
+                Type? otherType = other.GetType().GetGenericTypeDefinition();
+                // For types supporting O(1) lookup, utilize the contains method for faster intersect.
+                if (otherType == typeof(Dictionary<,>.KeyCollection))
+                {
+                    IntersectWithCollection(otherAsCollection);
                     return;
                 }
             }
@@ -1266,10 +1274,10 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// If other is a hashset that uses same equality comparer, intersect is much faster
-        /// because we can use other's Contains
+        /// Intersect with type ICollection using Contains method. Use this only with
+        /// ICollection derived types having an O(1) implementation of Contains()
         /// </summary>
-        private void IntersectWithHashSetWithSameComparer(HashSet<T> other)
+        private void IntersectWithCollection(ICollection<T> other)
         {
             Entry[]? entries = _entries;
             for (int i = 0; i < _count; i++)


### PR DESCRIPTION
Helps #1854

Have added a check for detecting a `Dictionary.Keycollection` type. Here are the benchmarks:

3 trials done with minimum 100000 mutual elements. 

## Before:


``` ini

BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.7.20366.6
  [Host]     : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT
  Job-BLNDKK : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                               Method |     Mean |   Error |  StdDev |
|------------------------------------- |---------:|--------:|--------:|
|                 IntersectWithHashSet | 150.0 ms | 3.00 ms | 4.11 ms |
| IntersectWithDictionaryKeyCollection | 299.4 ms | 5.81 ms | 6.92 ms |
|                    IntersectWithList | 297.7 ms | 5.64 ms | 6.04 ms |


``` ini

BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.7.20366.6
  [Host]     : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT
  Job-CUGERE : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                               Method |     Mean |   Error |  StdDev |
|------------------------------------- |---------:|--------:|--------:|
|                 IntersectWithHashSet | 147.9 ms | 2.71 ms | 2.78 ms |
| IntersectWithDictionaryKeyCollection | 295.3 ms | 3.46 ms | 2.89 ms |
|                    IntersectWithList | 296.1 ms | 3.31 ms | 2.76 ms |

``` ini

BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.7.20366.6
  [Host]     : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT
  Job-XCMBEQ : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                               Method |     Mean |   Error |  StdDev |
|------------------------------------- |---------:|--------:|--------:|
|                 IntersectWithHashSet | 149.7 ms | 2.82 ms | 3.24 ms |
| IntersectWithDictionaryKeyCollection | 295.9 ms | 4.96 ms | 3.87 ms |
|                    IntersectWithList | 296.0 ms | 3.02 ms | 2.52 ms |

## After:

``` ini

BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.7.20366.6
  [Host]     : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT
  Job-PNETTD : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                               Method |     Mean |   Error |  StdDev |
|------------------------------------- |---------:|--------:|--------:|
|                 IntersectWithHashSet | 151.3 ms | 2.98 ms | 4.07 ms |
| IntersectWithDictionaryKeyCollection | 150.0 ms | 2.88 ms | 2.55 ms |
|                    IntersectWithList | 299.8 ms | 4.82 ms | 4.03 ms |
``` ini

BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.7.20366.6
  [Host]     : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT
  Job-QSRYRJ : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                               Method |     Mean |   Error |  StdDev |
|------------------------------------- |---------:|--------:|--------:|
|                 IntersectWithHashSet | 150.1 ms | 2.24 ms | 1.99 ms |
| IntersectWithDictionaryKeyCollection | 150.8 ms | 2.95 ms | 2.61 ms |
|                    IntersectWithList | 298.1 ms | 3.92 ms | 3.06 ms |
``` ini

BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.7.20366.6
  [Host]     : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT
  Job-GJJGUT : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 5.0.20.36411), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                               Method |     Mean |   Error |  StdDev |
|------------------------------------- |---------:|--------:|--------:|
|                 IntersectWithHashSet | 151.5 ms | 2.93 ms | 3.91 ms |
| IntersectWithDictionaryKeyCollection | 151.4 ms | 2.53 ms | 2.25 ms |
|                    IntersectWithList | 300.1 ms | 5.34 ms | 5.72 ms |

 <hr/> 

From the results, it can be concluded that it improves intersection performance by 50% when a `HashSet` intesect is done with a `Dictionary.KeyCollection`

Benchmark Code: https://github.com/shubhamranjan/dotnet-benchmarks/blob/master/dotnet-benchmarks/runtime/HashSetBenchmarks.cs
