### PR TITLE
Add sleep in hijacking test

### DIFF
--- a/src/tests/JIT/Methodical/tailcall_v4/hijacking.il
+++ b/src/tests/JIT/Methodical/tailcall_v4/hijacking.il
@@ -219,6 +219,8 @@
     IL_000f:  conv.i8
     IL_0010:  add
     IL_0011:  stfld      int64 Repro::gc
+              ldc.i4.1
+              call       void [System.Threading.Thread]System.Threading.Thread::Sleep(int32)
     IL_0016:  ldarg.0
     IL_0017:  volatile.
     IL_0019:  ldfld      bool modreq([System.Runtime]System.Runtime.CompilerServices.IsVolatile) Repro::stop


### PR DESCRIPTION
Calling GC.Collect in a tight loop is unnecessary for the test and
causing timeouts in CI.

Fixes #40916

I have verified that this test still catches the regression if the following is commented:
https://github.com/dotnet/runtime/blob/ff4f37fa33160095468275df25ae434d1df46847/src/coreclr/src/vm/threads.h#L4124-L4129