### PR TITLE
Change Environment.CurrentManagedThreadId back to FCall

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
@@ -11,7 +11,11 @@ namespace System
 {
     public static partial class Environment
     {
-        public static int CurrentManagedThreadId => Thread.CurrentThread.ManagedThreadId;
+        public static extern int CurrentManagedThreadId
+        {
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            get;
+        }
 
         // Terminates this process with the given exit code.
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]

--- a/src/coreclr/src/vm/ecalllist.h
+++ b/src/coreclr/src/vm/ecalllist.h
@@ -155,6 +155,7 @@ FCFuncStart(gDateTimeFuncs)
 FCFuncEnd()
 
 FCFuncStart(gEnvironmentFuncs)
+    FCFuncElement("get_CurrentManagedThreadId", JIT_GetCurrentManagedThreadId)
     FCFuncElement("get_TickCount", SystemNative::GetTickCount)
     FCFuncElement("get_TickCount64", SystemNative::GetTickCount64)
     QCFuncElement("_Exit", SystemNative::Exit)

--- a/src/coreclr/src/vm/jithelpers.cpp
+++ b/src/coreclr/src/vm/jithelpers.cpp
@@ -4932,7 +4932,7 @@ HCIMPLEND
 
 
 
-HCIMPL0(INT32, JIT_GetCurrentManagedThreadId)
+FCIMPL0(INT32, JIT_GetCurrentManagedThreadId)
 {
     FCALL_CONTRACT;
 
@@ -4941,7 +4941,7 @@ HCIMPL0(INT32, JIT_GetCurrentManagedThreadId)
     Thread * pThread = GetThread();
     return pThread->GetThreadId();
 }
-HCIMPLEND
+FCIMPLEND
 
 
 /*********************************************************************/

--- a/src/coreclr/src/vm/jitinterface.h
+++ b/src/coreclr/src/vm/jitinterface.h
@@ -225,9 +225,8 @@ EXTERN_C FCDECL2(void*, JIT_GetSharedGCStaticBase_Helper, DomainLocalModule *pLo
 
 EXTERN_C void DoJITFailFast ();
 EXTERN_C FCDECL0(void, JIT_FailFast);
-extern FCDECL3(void, JIT_ThrowAccessException, RuntimeExceptionKind, CORINFO_METHOD_HANDLE caller, void * callee);
 
-FCDECL1(void*, JIT_SafeReturnableByref, void* byref);
+FCDECL0(int, JIT_GetCurrentManagedThreadId);
 
 #if !defined(FEATURE_USE_ASM_GC_WRITE_BARRIERS) && defined(FEATURE_COUNT_GC_WRITE_BARRIERS)
 // Extra argument for the classification of the checked barriers.


### PR DESCRIPTION
This was deoptimized in early .NET Core days when Environment did not live in CoreLib. Gives same perf gain as https://github.com/dotnet/runtime/pull/41213#issuecomment-678692016