### PR TITLE
[release/5.0] HTTP/3 interop fixes

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/Mock/MockConnection.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/Mock/MockConnection.cs
@@ -14,7 +14,7 @@ namespace System.Net.Quic.Implementations.Mock
     {
         private readonly bool _isClient;
         private bool _disposed;
-        private IPEndPoint? _remoteEndPoint;
+        private EndPoint? _remoteEndPoint;
         private IPEndPoint? _localEndPoint;
         private object _syncObject = new object();
         private Socket? _socket;
@@ -24,7 +24,7 @@ namespace System.Net.Quic.Implementations.Mock
         private long _nextOutboundUnidirectionalStream;
 
         // Constructor for outbound connections
-        internal MockConnection(IPEndPoint? remoteEndPoint, SslClientAuthenticationOptions? sslClientAuthenticationOptions, IPEndPoint? localEndPoint = null)
+        internal MockConnection(EndPoint? remoteEndPoint, SslClientAuthenticationOptions? sslClientAuthenticationOptions, IPEndPoint? localEndPoint = null)
         {
             _remoteEndPoint = remoteEndPoint;
             _localEndPoint = localEndPoint;
@@ -59,7 +59,7 @@ namespace System.Net.Quic.Implementations.Mock
 
         internal override IPEndPoint LocalEndPoint => new IPEndPoint(_localEndPoint!.Address, _localEndPoint.Port);
 
-        internal override IPEndPoint RemoteEndPoint => new IPEndPoint(_remoteEndPoint!.Address, _remoteEndPoint.Port);
+        internal override EndPoint RemoteEndPoint => _remoteEndPoint!;
 
         internal override SslApplicationProtocol NegotiatedApplicationProtocol => throw new NotImplementedException();
 

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicSession.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicSession.cs
@@ -1,5 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.Net.Security;
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
@@ -21,7 +23,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         {
             if (!_opened)
             {
-                OpenSession(options.ClientAuthenticationOptions!.ApplicationProtocols![0].Protocol.ToArray(),
+                OpenSession(options.ClientAuthenticationOptions!.ApplicationProtocols!,
                     (ushort)options.MaxBidirectionalStreams,
                     (ushort)options.MaxUnidirectionalStreams);
             }
@@ -36,7 +38,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             return connectionPtr;
         }
 
-        private void OpenSession(byte[] alpn, ushort bidirectionalStreamCount, ushort undirectionalStreamCount)
+        private void OpenSession(List<SslApplicationProtocol> alpn, ushort bidirectionalStreamCount, ushort undirectionalStreamCount)
         {
             _opened = true;
             _nativeObjPtr = MsQuicApi.Api.SessionOpen(alpn);
@@ -49,7 +51,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         {
             if (!_opened)
             {
-                OpenSession(options.ServerAuthenticationOptions!.ApplicationProtocols![0].Protocol.ToArray(),
+                OpenSession(options.ServerAuthenticationOptions!.ApplicationProtocols!,
                                     (ushort)options.MaxBidirectionalStreams,
                                     (ushort)options.MaxUnidirectionalStreams);
             }

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/QuicExceptionHelpers.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/QuicExceptionHelpers.cs
@@ -10,8 +10,13 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         {
             if (!MsQuicStatusHelper.SuccessfulStatusCode(status))
             {
-                throw new QuicException($"{message} Error Code: {MsQuicStatusCodes.GetError(status)}");
+                throw CreateExceptionForHResult(status, message, innerException);
             }
+        }
+
+        internal static Exception CreateExceptionForHResult(uint status, string? message = null, Exception? innerException = null)
+        {
+            return new QuicException($"{message} Error Code: {MsQuicStatusCodes.GetError(status)}", innerException);
         }
     }
 }

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -225,6 +225,11 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new InvalidOperationException("Reading is not allowed on stream.");
             }
 
+            if (NetEventSource.IsEnabled)
+            {
+                NetEventSource.Info(this, $"[{GetHashCode()}] reading into Memory of '{destination.Length}' bytes.");
+            }
+
             lock (_sync)
             {
                 if (_readState == ReadState.ReadsCompleted)
@@ -474,6 +479,11 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private uint HandleEvent(ref StreamEvent evt)
         {
+            if (NetEventSource.IsEnabled)
+            {
+                NetEventSource.Info(this, $"[{GetHashCode()}] handling event '{evt.Type}'.");
+            }
+
             uint status = MsQuicStatusCodes.Success;
 
             try

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/QuicConnectionProvider.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/QuicConnectionProvider.cs
@@ -12,7 +12,7 @@ namespace System.Net.Quic.Implementations
 
         internal abstract IPEndPoint LocalEndPoint { get; }
 
-        internal abstract IPEndPoint RemoteEndPoint { get; }
+        internal abstract EndPoint RemoteEndPoint { get; }
 
         internal abstract ValueTask ConnectAsync(CancellationToken cancellationToken = default);
 

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Interop/MsQuicStatusCodes.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Interop/MsQuicStatusCodes.cs
@@ -26,13 +26,16 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             internal const uint HandshakeFailure = 0x80410000;
             internal const uint Aborted = 0x80004004;
             internal const uint AddressInUse = 0x80072740;
-            internal const uint ConnectionTimeout = 0x800704CF;
-            internal const uint ConnectionIdle = 0x800704D4;
-            internal const uint InternalError = 0x80004005;
-            internal const uint ServerBusy = 0x800704C9;
-            internal const uint ProtocolError = 0x800704CD;
+            internal const uint ConnectionTimeout = 0x80410006;
+            internal const uint ConnectionIdle = 0x80410005;
             internal const uint HostUnreachable = 0x800704D0;
+            internal const uint InternalError = 0x80410003;
+            internal const uint ConnectionRefused = 0x800704C9;
+            internal const uint ProtocolError = 0x80410004;
             internal const uint VerNegError = 0x80410001;
+            internal const uint TlsError = 0x80072B18;
+            internal const uint UserCanceled = 0x80410002;
+            internal const uint AlpnNegotiationFailure = 0x80410007;
 
             // TODO return better error messages here.
             public static string GetError(uint status)
@@ -53,11 +56,15 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     AddressInUse => "ADDRESS_IN_USE",
                     ConnectionTimeout => "CONNECTION_TIMEOUT",
                     ConnectionIdle => "CONNECTION_IDLE",
+                    HostUnreachable => "UNREACHABLE",
                     InternalError => "INTERNAL_ERROR",
-                    ServerBusy => "SERVER_BUSY",
+                    ConnectionRefused => "CONNECTION_REFUSED",
                     ProtocolError => "PROTOCOL_ERROR",
                     VerNegError => "VER_NEG_ERROR",
-                    _ => status.ToString()
+                    TlsError => "TLS_ERROR",
+                    UserCanceled => "USER_CANCELED",
+                    AlpnNegotiationFailure => "ALPN_NEG_FAILURE",
+                    _ => $"0x{status:X8}"
                 };
             }
         }
@@ -79,9 +86,15 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             internal const uint ConnectionTimeout = 110;
             internal const uint ConnectionIdle = 200000011;
             internal const uint InternalError = 200000012;
-            internal const uint ServerBusy = 200000007;
+            internal const uint ConnectionRefused = 200000007;
             internal const uint ProtocolError = 200000013;
             internal const uint VerNegError = 200000014;
+            internal const uint EpollError = 200000015;
+            internal const uint DnsResolutionError = 200000016;
+            internal const uint SocketError = 200000017;
+            internal const uint TlsError = 200000018;
+            internal const uint UserCanceled = 200000019;
+            internal const uint AlpnNegotiationFailure = 200000020;
 
             // TODO return better error messages here.
             public static string GetError(uint status)
@@ -103,10 +116,16 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     ConnectionTimeout => "CONNECTION_TIMEOUT",
                     ConnectionIdle => "CONNECTION_IDLE",
                     InternalError => "INTERNAL_ERROR",
-                    ServerBusy => "SERVER_BUSY",
+                    ConnectionRefused => "CONNECTION_REFUSED",
                     ProtocolError => "PROTOCOL_ERROR",
                     VerNegError => "VER_NEG_ERROR",
-                    _ => status.ToString()
+                    EpollError => "EPOLL_ERROR",
+                    DnsResolutionError => "DNS_RESOLUTION_ERROR",
+                    SocketError => "SOCKET_ERROR",
+                    TlsError => "TLS_ERROR",
+                    UserCanceled => "USER_CANCELED",
+                    AlpnNegotiationFailure => "ALPN_NEG_FAILURE",
+                    _ => $"0x{status:X8}"
                 };
             }
         }

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/QuicClientConnectionOptions.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/QuicClientConnectionOptions.cs
@@ -24,7 +24,7 @@ namespace System.Net.Quic
         /// <summary>
         /// The endpoint to connect to.
         /// </summary>
-        public IPEndPoint? RemoteEndPoint { get; set; }
+        public EndPoint? RemoteEndPoint { get; set; }
 
         /// <summary>
         /// Limit on the number of bidirectional streams the peer connection can create

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/QuicConnection.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/QuicConnection.cs
@@ -22,13 +22,13 @@ namespace System.Net.Quic
         /// <param name="remoteEndPoint">The remote endpoint to connect to.</param>
         /// <param name="sslClientAuthenticationOptions">TLS options</param>
         /// <param name="localEndPoint">The local endpoint to connect from.</param>
-        public QuicConnection(IPEndPoint remoteEndPoint, SslClientAuthenticationOptions? sslClientAuthenticationOptions, IPEndPoint? localEndPoint = null)
+        public QuicConnection(EndPoint remoteEndPoint, SslClientAuthenticationOptions? sslClientAuthenticationOptions, IPEndPoint? localEndPoint = null)
             : this(QuicImplementationProviders.Default, remoteEndPoint, sslClientAuthenticationOptions, localEndPoint)
         {
         }
 
         // !!! TEMPORARY: Remove "implementationProvider" before shipping
-        public QuicConnection(QuicImplementationProvider implementationProvider, IPEndPoint remoteEndPoint, SslClientAuthenticationOptions? sslClientAuthenticationOptions, IPEndPoint? localEndPoint = null)
+        public QuicConnection(QuicImplementationProvider implementationProvider, EndPoint remoteEndPoint, SslClientAuthenticationOptions? sslClientAuthenticationOptions, IPEndPoint? localEndPoint = null)
             : this(implementationProvider, new QuicClientConnectionOptions() { RemoteEndPoint = remoteEndPoint, ClientAuthenticationOptions = sslClientAuthenticationOptions, LocalEndPoint = localEndPoint })
         {
         }
@@ -50,7 +50,7 @@ namespace System.Net.Quic
 
         public IPEndPoint LocalEndPoint => _provider.LocalEndPoint;
 
-        public IPEndPoint RemoteEndPoint => _provider.RemoteEndPoint;
+        public EndPoint RemoteEndPoint => _provider.RemoteEndPoint;
 
         public SslApplicationProtocol NegotiatedApplicationProtocol => _provider.NegotiatedApplicationProtocol;
 

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/QuicException.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/QuicException.cs
@@ -1,12 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 namespace System.Net.Quic
 {
     internal class QuicException : Exception
     {
-        public QuicException(string message)
-            : base (message)
+        public QuicException(string? message)
+            : base(message)
+        {
+        }
+        public QuicException(string? message, Exception? innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
@@ -28,7 +28,7 @@ namespace System.Net.Test.Common
             var sslOpts = new SslServerAuthenticationOptions
             {
                 EnabledSslProtocols = options.SslProtocols,
-                ApplicationProtocols = new List<SslApplicationProtocol> { new SslApplicationProtocol("h3") },
+                ApplicationProtocols = new List<SslApplicationProtocol> { new SslApplicationProtocol("h3-29") },
                 //ServerCertificate = _cert,
                 ClientCertificateRequired = false
             };

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -17,7 +17,7 @@ namespace System.Net.Http
     {
         // TODO: once HTTP/3 is standardized, create APIs for these.
         public static readonly Version HttpVersion30 = new Version(3, 0);
-        public static readonly SslApplicationProtocol Http3ApplicationProtocol = new SslApplicationProtocol("h3");
+        public static readonly SslApplicationProtocol Http3ApplicationProtocol = new SslApplicationProtocol("h3-29");
 
         /// <summary>
         /// If we receive a settings frame larger than this, tear down the connection with an error.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -743,6 +743,11 @@ namespace System.Net.Http
 
                 _recvBuffer.Discard(bytesRead);
 
+                if (NetEventSource.IsEnabled)
+                {
+                    Trace($"Received frame {frameType} of length {payloadLength}.");
+                }
+
                 switch ((Http3FrameType)frameType)
                 {
                     case Http3FrameType.Headers:

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -826,7 +826,7 @@ namespace System.Net.Http
                 QuicConnection quicConnection;
                 try
                 {
-                    quicConnection = await ConnectHelper.ConnectQuicAsync(authority.IdnHost, authority.Port, _sslOptionsHttp3, cancellationToken).ConfigureAwait(false);
+                    quicConnection = await ConnectHelper.ConnectQuicAsync(new DnsEndPoint(authority.IdnHost, authority.Port), _sslOptionsHttp3, cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -21,10 +21,33 @@ namespace System.Net.Http.Functional.Tests
     {
         protected override Version UseVersion => HttpVersion30;
 
-        public static bool SupportsAlpn => PlatformDetection.SupportsAlpn;
-
         public HttpClientHandlerTest_Http3(ITestOutputHelper output) : base(output)
         {
+        }
+
+        /// <summary>
+        /// These are public interop test servers for various QUIC and HTTP/3 implementations,
+        /// taken from https://github.com/quicwg/base-drafts/wiki/Implementations
+        /// </summary>
+        [OuterLoop]
+        [Theory]
+        [InlineData("https://quic.rocks:4433/")] // Chromium
+        [InlineData("https://www.litespeedtech.com/")] // LiteSpeed
+        [InlineData("https://quic.tech:8443/")] // Cloudflare
+        public async Task Public_Interop_Success(string uri)
+        {
+            using HttpClient client = CreateHttpClient();
+            using HttpRequestMessage request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri(uri, UriKind.Absolute),
+                Version = HttpVersion30,
+                VersionPolicy = HttpVersionPolicy.RequestVersionExact
+            };
+            using HttpResponseMessage response = await client.SendAsync(request).TimeoutAfter(20_000);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(3, response.Version.Major);
         }
     }
 }


### PR DESCRIPTION
Ports #41298 to 5.0.

Fixes critical issues discovered during interop testing against various H3 servers.

Tested locally; CI does not yet support QUIC.

- Support DNS-based quic connections -- required for SNI, which is used in TLS auth.
- Support multiple ALPN values -- used to negotiate protocols, as we support multiple draft versions.
- Update H3 ALPN from "h3" to "h3-29", which is what the RFC requires for implementations of the draft.
- Fixes error codes in msquic P/invoke, so we report correct errors in exceptions.

Risks:

Minimal; this code is 100% behind an experimental feature flag.

CC @karelz @danmosemsft 