### PR TITLE
Disable the Platform Compat Analyzer until #41354 is fixed

### DIFF
--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -64,6 +64,7 @@
       <Rule Id="CA1308" Action="None" />             <!-- Normalize strings to uppercase -->
       <Rule Id="CA1309" Action="None" />             <!-- Use ordinal stringcomparison -->
       <Rule Id="CA1401" Action="Warning" />          <!-- P/Invokes should not be visible -->
+      <Rule Id="CA1416" Action="None" />             <!-- Validate platform compatibility; https://github.com/dotnet/runtime/issues/41354 -->
       <Rule Id="CA1417" Action="Warning" />          <!-- Do not use 'OutAttribute' on string parameters for P/Invokes -->
       <Rule Id="CA1501" Action="None" />             <!-- Avoid excessive inheritance -->
       <Rule Id="CA1502" Action="None" />             <!-- Avoid excessive complexity -->


### PR DESCRIPTION
We intend to merge the [Platform Compatibility Analyzer](https://github.com/dotnet/roslyn-analyzers/pull/3917) into the .NET 5.0 RC1 SDK.  When the updated version of the `NetAnalyzers` package is taken into the `dotnet/runtime` repo that contains this analyzer, it will introduce build warnings.  Those build warnings surface because:

* The Runtime repo applies `[SupportedOSPlatform]` and `[UnsupportedOSPlatform]` attributes to many APIs now
* We began applying those attributes before having the analyzer merged in because we wanted to have those attributes in place for the RC1 release
* There are cases, specifically around our multi-targeting, where we will need to either apply further annotations or utilize guard methods around calls to the platform-specific APIs

Because these warnings will occur, we are going to disable the analyzer in the `dotnet/runtime` repo before merging it into the SDK.  Before we ship .NET 5.0 RC2 though, we want to re-enable the analyzer and address all of the warnings introduced. #41354 tracks that work.