### PR TITLE
Exclude Fannkuch_9 test on ARM

### DIFF
--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -54,6 +54,11 @@ if ($Internal) {
     $HelixSourcePrefix = "official"
 }
 
+if($Architecture -eq "arm64")
+{
+    $ExtraBenchmarkDotNetArguments = "--exclusion-filter *FannkuchRedux_9.FannkuchRedux_9*"
+}
+
 if($MonoInterpreter)
 {
     $ExtraBenchmarkDotNetArguments = "--category-exclusion-filter NoInterpreter"

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -189,6 +189,7 @@ if [[ "$internal" == true ]]; then
     
     if [[ "$architecture" = "arm64" ]]; then
         queue=Ubuntu.1804.Arm64.Perf
+        extra_benchmark_dotnet_arguments="--exclusion-filter *FannkuchRedux_9.FannkuchRedux_9*"
     else
         queue=Ubuntu.1804.Amd64.Tiger.Perf
     fi


### PR DESCRIPTION
I have filed this issue, https://github.com/dotnet/performance/issues/1483, to track investigating this test, but for now I want to turn this test off, so that we can get results.