### PR TITLE
Fix null check in S.Diagnostics.Contract regressed by nullability annotations

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
@@ -628,8 +628,7 @@ namespace System.Diagnostics.Contracts
             Assembly? probablyNotRewritten = null;
             for (int i = 0; i < stack.FrameCount; i++)
             {
-                MethodBase stackMethod = stack.GetFrame(i)!.GetMethod();
-                Assembly? caller = (stackMethod != null) ? stackMethod.DeclaringType!.Assembly : null;
+                Assembly? caller = stack.GetFrame(i)!.GetMethod()?.DeclaringType?.Assembly;
                 if (caller != null && caller != thisAssembly)
                 {
                     probablyNotRewritten = caller;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
@@ -628,7 +628,8 @@ namespace System.Diagnostics.Contracts
             Assembly? probablyNotRewritten = null;
             for (int i = 0; i < stack.FrameCount; i++)
             {
-                Assembly? caller = stack.GetFrame(i)!.GetMethod()?.DeclaringType!.Assembly;
+                MethodBase stackMethod = stack.GetFrame(i)!.GetMethod();
+                Assembly? caller = (stackMethod != null) ? stackMethod.DeclaringType!.Assembly : null;
                 if (caller != null && caller != thisAssembly)
                 {
                     probablyNotRewritten = caller;


### PR DESCRIPTION
While annotating https://github.com/dotnet/runtime/pull/41261 I've introduced a product bug which luckily got caught by tests. It is weird compiler behavior (https://github.com/dotnet/csharplang/issues/3393) which changes `?.` precedence when adding `!`, see i.e.:
https://sharplab.io/#v2:EYLgtghgzgLgpgJwDQBMQGoA+ABATARgFgAoEvAZgAIBvEy+y7fANkYBZKAFCGAC3wAUAYXyUADgEoadBrIBuEBJQB2EMHEoBecQH4AdENx6AcmrgBuGbPpMAnANXqJl4rIC+Vyp6atsHbny4wqKS0q7W9ApKjhraYvqGAIQmZi4RNvj2Mc6eHsR5ZLiUIiS04TZUhsVF1JQA5nAw5pRQjc15BcR41aXeVEwADJSm6jT1bS1tHUA

Note: **this is fixing a regression** introduced by https://github.com/dotnet/runtime/commit/a8b7c2204e167cff2068ff9a72d4238469f70c4b#diff-918e20adb7bd65c2e6e73caa106465d6R658