### PR TITLE
Made char.IsAscii public

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -69,16 +69,16 @@ namespace System
         };
 
         // Return true for all characters below or equal U+00ff, which is ASCII + Latin-1 Supplement.
-        private static bool IsLatin1(char ch) => (uint)ch < (uint)Latin1CharInfo.Length;
+        private static bool IsLatin1(char c) => (uint)c < (uint)Latin1CharInfo.Length;
 
         // Return true for all characters below or equal U+007f, which is ASCII.
-        private static bool IsAscii(char ch) => (uint)ch <= '\x007f';
+        public static bool IsAscii(char c) => (uint)c <= '\x007f';
 
         // Return the Unicode category for Unicode character <= 0x00ff.
-        private static UnicodeCategory GetLatin1UnicodeCategory(char ch)
+        private static UnicodeCategory GetLatin1UnicodeCategory(char c)
         {
-            Debug.Assert(IsLatin1(ch), "char.GetLatin1UnicodeCategory(): ch should be <= 00ff");
-            return (UnicodeCategory)(Latin1CharInfo[ch] & UnicodeCategoryMask);
+            Debug.Assert(IsLatin1(c), "char.GetLatin1UnicodeCategory(): c should be <= 00ff");
+            return (UnicodeCategory)(Latin1CharInfo[c] & UnicodeCategoryMask);
         }
 
         //

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -728,6 +728,7 @@ namespace System
         private readonly char _dummyPrimitive;
         public const char MaxValue = '\uFFFF';
         public const char MinValue = '\0';
+        public static bool IsAscii(System.Char c) { throw null; }
         public int CompareTo(System.Char value) { throw null; }
         public int CompareTo(object? value) { throw null; }
         public static string ConvertFromUtf32(int utf32) { throw null; }

--- a/src/libraries/System.Runtime/tests/System/CharTests.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.cs
@@ -200,6 +200,15 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void IsAscii_Char()
+        {
+            Assert.True(char.IsAscii(char.MinValue));
+            Assert.True(char.IsAscii('\x007f'));
+            Assert.False(char.IsAscii('\x0080'));
+            Assert.False(char.IsAscii(char.MaxValue));
+        }
+
+        [Fact]
         public static void IsControl_Char()
         {
             foreach (char c in GetTestChars(UnicodeCategory.Control))


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/40936

Also normalized parameters of other method to `c` (instead of `ch`, only two others).

/cc: @GrabYourPitchforks 