### PR TITLE
mono.proj: properly pass -mmacosx-version-min to CFLAGS for OSX

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -87,6 +87,12 @@
       <_MonoCXXFLAGS Include="-g" />
     </ItemGroup>
 
+    <!-- OSX specific options -->
+    <ItemGroup Condition="'$(TargetOS)' == 'OSX'">
+      <_MonoCFLAGS Include="-mmacosx-version-min=$(macOSVersionMin)" />
+      <_MonoCXXFLAGS Include="-mmacosx-version-min=$(macOSVersionMin)" />
+    </ItemGroup>
+
     <!-- We build LLVM bits for x64 Linux without C++11 ABI (CentOS 7 has libstdc++ < 5.1) -->
     <ItemGroup Condition="'$(TargetOS)' == 'Linux' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' != 'true'">
       <_MonoCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=0" />


### PR DESCRIPTION
Noticed we were missing this while looking at another PR.