### PR TITLE
[browser][wasm] Print message for invalid enum values

### DIFF
--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -39,7 +39,7 @@ EM_JS(MonoObject*, compile_function, (int snippet_ptr, int len, int *is_exceptio
 				+ 'Please use `return` statement to return a function.');
 		}
 		setValue (is_exception, 0, "i32");
-		return BINDING.js_to_mono_obj (func);	
+		return BINDING.js_to_mono_obj (func);
 	}
 	catch (e)
 	{
@@ -47,7 +47,7 @@ EM_JS(MonoObject*, compile_function, (int snippet_ptr, int len, int *is_exceptio
 		setValue (is_exception, 1, "i32");
 		if (res === null || res === undefined)
 			res = "unknown exception";
-		return BINDING.js_to_mono_obj (res);		
+		return BINDING.js_to_mono_obj (res);
 	}
 });
 
@@ -149,7 +149,7 @@ mono_wasm_unbox_enum (MonoObject *obj)
 {
 	if (!obj)
 		return 0;
-	
+
 	MonoType *type = mono_class_get_type (mono_object_get_class(obj));
 
 	void *ptr = mono_object_unbox (obj);
@@ -165,11 +165,13 @@ mono_wasm_unbox_enum (MonoObject *obj)
 		return *(int*)ptr;
 	case MONO_TYPE_U4:
 		return *(unsigned int*)ptr;
-	// WASM doesn't support returning longs to JS
-	// case MONO_TYPE_I8:
-	// case MONO_TYPE_U8:
+	// WASM doesn't support returning longs to JS i.e. JavaScript does not have a native 64-bit int
+	case MONO_TYPE_I8:
+	case MONO_TYPE_U8:
+		fprintf (stderr, "Invalid type %d to core mono_unbox_enum due to JavaScript not having a native 64-bit int.\n", mono_type_get_type(mono_type_get_underlying_type (type)));
+		return 0;
 	default:
-		printf ("Invalid type %d to mono_unbox_enum\n", mono_type_get_type(mono_type_get_underlying_type (type)));
+		fprintf (stderr, "Invalid type %d to mono_unbox_enum\n", mono_type_get_type(mono_type_get_underlying_type (type)));
 		return 0;
 	}
 }


### PR DESCRIPTION
Update bindings error message output when unboxing invalid enum values.

- When enum's are defined as long or ulong
- WASM doesn't support returning longs to JS i.e. JavaScript does not have a native 64-bit int

- Error message output: "Invalid type %d to core mono_unbox_enum due to JavaScript not having a native 64-bit int.\n"