### PR TITLE
[mono] Set t_currentThread in InitializeCurrentThread

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -321,9 +321,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Thread InitializeCurrentThread()
         {
-            Thread? thread = null;
-            InitializeCurrentThread_icall(ref thread);
-            return thread;
+            InitializeCurrentThread_icall(ref t_currentThread);
+            return t_currentThread;
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
In order to avoid the static Thread initialization (System.Thread.CurrentThread inits a static field) see https://github.com/dotnet/runtime/pull/41360

Benchmark:
```csharp
[Benchmark]
public int CurrentThreadId() => Environment.CurrentManagedThreadId;
```

Mono JIT (benchmarked on a slow machine):
```
       |          Method |     Mean |     Error |    StdDev |
       |---------------- |---------:|----------:|----------:|
master | CurrentThreadId | 7.191 ns | 0.0128 ns | 0.0107 ns |
PR     | CurrentThreadId | 5.034 ns | 0.0395 ns | 0.0350 ns |
```

