### PR TITLE
[wasm][debugger] Make sure `System.Private.CoreLib.dll` is in sync with

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -117,12 +117,12 @@ icu-data:
 
 runtime:
 	EMSDK_PATH=$(TOP)/src/mono/wasm/emsdk $(TOP)/build.sh --subset mono --arch wasm --os Browser -c $(CONFIG) /p:ContinueOnError=false  /p:StopOnFirstFailure=true
-	cp $(TOP)/artifacts/bin/mono/Browser.wasm.$(CONFIG)/IL/System.Private.CoreLib.dll $(TOP)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/$(CONFIG)/runtimes/browser-wasm/native/
+	cp $(TOP)/artifacts/bin/mono/Browser.wasm.$(CONFIG)/IL/System.Private.CoreLib.* $(TOP)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/$(CONFIG)/runtimes/browser-wasm/native/
 	$(MAKE) build
 
 corlib:
 	EMSDK_PATH=$(TOP)/src/mono/wasm/emsdk $(TOP)/build.sh --subset mono.corelib --arch wasm --os Browser -c $(CONFIG)
-	cp $(TOP)/artifacts/bin/mono/Browser.wasm.$(CONFIG)/IL/System.Private.CoreLib.dll $(TOP)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/$(CONFIG)/runtimes/browser-wasm/native/
+	cp $(TOP)/artifacts/bin/mono/Browser.wasm.$(CONFIG)/IL/System.Private.CoreLib.* $(TOP)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/$(CONFIG)/runtimes/browser-wasm/native/
 
 build-all:
 	EMSDK_PATH=$(TOP)/src/mono/wasm/emsdk $(TOP)/build.sh --subset mono+libs --arch wasm --os Browser -c $(CONFIG)


### PR DESCRIPTION
.. it's pdb. Running debugger-tests, I saw lot of messages like:

`CWL: : /Users/radical/dev/runtime/src/mono/mono/metadata/debug-mono-ppdb.c:230 <disabled>`

.. which is trying to print:
`CWL: Symbol file data-0x1c38008 doesn't match image System.Private.CoreLib.dll`

And indeed the dll is out of sync with it's pdb. We need to copy the pdb
too.