### PR TITLE
[wasm][debugger] Breakpoint stopping after it's removed

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -170,7 +170,6 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                 case "Debugger.enable":
                     {
-                        System.Console.WriteLine("recebi o Debugger.enable");
                         var resp = await SendCommand(id, method, args, token);
 
                         context.DebuggerId = resp.Value["debuggerId"]?.ToString();
@@ -854,7 +853,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     bp.State = BreakpointState.Disabled;
                 }
             }
-            breakpointRequest.Locations.Clear();
+            context.BreakpointRequests.Remove(bpid);
         }
 
         async Task SetBreakpoint(SessionId sessionId, DebugStore store, BreakpointRequest req, bool sendResolvedEvent, CancellationToken token)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Support.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Support.cs
@@ -852,6 +852,18 @@ namespace DebuggerTests
             return (null, res);
         }
 
+        internal async Task<Result> RemoveBreakpoint(string id)
+        {
+            var remove_bp = JObject.FromObject(new
+            {
+                breakpointId = id
+            });
+
+            var bp1_res = await ctx.cli.SendCommand("Debugger.removeBreakpoint", remove_bp, ctx.token);
+
+            return bp1_res;
+        }
+
         internal async Task<Result> SetBreakpoint(string url_key, int line, int column, bool expect_ok = true, bool use_regex = false)
         {
             var bp1_req = !use_regex ?

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Support.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Support.cs
@@ -852,16 +852,17 @@ namespace DebuggerTests
             return (null, res);
         }
 
-        internal async Task<Result> RemoveBreakpoint(string id)
+        internal async Task<Result> RemoveBreakpoint(string id, bool expect_ok = true)
         {
             var remove_bp = JObject.FromObject(new
             {
                 breakpointId = id
             });
 
-            var bp1_res = await ctx.cli.SendCommand("Debugger.removeBreakpoint", remove_bp, ctx.token);
+            var res = await ctx.cli.SendCommand("Debugger.removeBreakpoint", remove_bp, ctx.token);
+            Assert.True(expect_ok ? res.IsOk : res.IsErr);
 
-            return bp1_res;
+            return res;
         }
 
         internal async Task<Result> SetBreakpoint(string url_key, int line, int column, bool expect_ok = true, bool use_regex = false)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1538,23 +1538,79 @@ namespace DebuggerTests
 
                 var bp = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 10, 8);
                 var bp2 = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 12, 8);
-                var wait_res = await EvaluateAndCheck(
+                var pause_location = await EvaluateAndCheck(
                     "window.setTimeout(function() { invoke_add(); invoke_add()}, 1);",
                     "dotnet://debugger-test.dll/debugger-test.cs",  10, 8,
-                    "IntAdd",
-                    wait_for_event_fn: (pause_location) =>
-                    {   
-                        Assert.Equal("other", pause_location["reason"]?.Value<string>());
-                        Assert.Equal(bp.Value["breakpointId"]?.ToString(), pause_location["hitBreakpoints"]?[0]?.Value<string>());
-                        return Task.CompletedTask;
-                    }
-                );
-                var bp3 = await RemoveBreakpoint(bp.Value["breakpointId"]?.ToString());
+                    "IntAdd");
+
+                Assert.Equal("other", pause_location["reason"]?.Value<string>());
+                Assert.Equal(bp.Value["breakpointId"]?.ToString(), pause_location["hitBreakpoints"]?[0]?.Value<string>());
+
+                await RemoveBreakpoint(bp.Value["breakpointId"]?.ToString());
                 await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://debugger-test.dll/debugger-test.cs", 12, 8, "IntAdd");
                 await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://debugger-test.dll/debugger-test.cs", 12, 8, "IntAdd");
             });
         }
 
+        [Fact]
+        public async Task CreateGoodBreakpointAndHitAndRemoveTwice()
+        {
+            var insp = new Inspector();
+
+            //Collect events
+            var scripts = SubscribeToScripts(insp);
+
+            await Ready();
+            await insp.Ready(async (cli, token) =>
+            {
+                ctx = new DebugTestContext(cli, insp, token, scripts);
+
+                var bp = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 10, 8);
+                var bp2 = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 12, 8);
+                var pause_location = await EvaluateAndCheck(
+                    "window.setTimeout(function() { invoke_add(); invoke_add()}, 1);",
+                    "dotnet://debugger-test.dll/debugger-test.cs",  10, 8,
+                    "IntAdd");
+
+                Assert.Equal("other", pause_location["reason"]?.Value<string>());
+                Assert.Equal(bp.Value["breakpointId"]?.ToString(), pause_location["hitBreakpoints"]?[0]?.Value<string>());
+
+                await RemoveBreakpoint(bp.Value["breakpointId"]?.ToString());
+                await RemoveBreakpoint(bp.Value["breakpointId"]?.ToString());
+            });
+        }
+
+        [Fact]
+        public async Task CreateGoodBreakpointAndHitAndRemoveAndDontHitAndCreateAgainAndHit()
+        {
+            var insp = new Inspector();
+
+            //Collect events
+            var scripts = SubscribeToScripts(insp);
+
+            await Ready();
+            await insp.Ready(async (cli, token) =>
+            {
+                ctx = new DebugTestContext(cli, insp, token, scripts);
+
+                var bp = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 10, 8);
+                var bp2 = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 12, 8);
+                var pause_location = await EvaluateAndCheck(
+                    "window.setTimeout(function() { invoke_add(); invoke_add(); invoke_add(); invoke_add()}, 1);",
+                    "dotnet://debugger-test.dll/debugger-test.cs",  10, 8,
+                    "IntAdd");
+
+                Assert.Equal("other", pause_location["reason"]?.Value<string>());
+                Assert.Equal(bp.Value["breakpointId"]?.ToString(), pause_location["hitBreakpoints"]?[0]?.Value<string>());
+
+                await RemoveBreakpoint(bp.Value["breakpointId"]?.ToString());
+                await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://debugger-test.dll/debugger-test.cs", 12, 8, "IntAdd");
+                await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://debugger-test.dll/debugger-test.cs", 12, 8, "IntAdd");
+                bp = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 10, 8);
+                await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://debugger-test.dll/debugger-test.cs", 10, 8, "IntAdd");
+                
+            });
+        }
         //TODO add tests covering basic stepping behavior as step in/out/over
     }
 }


### PR DESCRIPTION
Remove unnecessary WriteLine.
Fixing after a breakpoint is removed and the page is refreshed the breakpoint was still stopping.
Trying to create a test.

Fixes #41447.