### PR TITLE
Switch text param to nullable in WriteProcessingInstructionAsync

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckWriter.cs
@@ -432,7 +432,7 @@ namespace System.Xml
             return task;
         }
 
-        public override Task WriteProcessingInstructionAsync(string name, string text)
+        public override Task WriteProcessingInstructionAsync(string name, string? text)
         {
             CheckAsync();
             var task = _coreWriter.WriteProcessingInstructionAsync(name, text);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriterAsync.cs
@@ -137,7 +137,7 @@ namespace System.Xml
             return writer.WriteCommentAsync(text);
         }
 
-        public override Task WriteProcessingInstructionAsync(string name, string text)
+        public override Task WriteProcessingInstructionAsync(string name, string? text)
         {
             if (_checkNames)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
@@ -807,7 +807,7 @@ namespace System.Xml
             }
         }
 
-        public override async Task WriteProcessingInstructionAsync(string name, string text)
+        public override async Task WriteProcessingInstructionAsync(string name, string? text)
         {
             try
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWrappingWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWrappingWriterAsync.cs
@@ -68,7 +68,7 @@ namespace System.Xml
             return writer.WriteCommentAsync(text);
         }
 
-        public override Task WriteProcessingInstructionAsync(string name, string text)
+        public override Task WriteProcessingInstructionAsync(string name, string? text)
         {
             return writer.WriteProcessingInstructionAsync(name, text);
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
@@ -120,7 +120,7 @@ namespace System.Xml
 
         // Writes out a processing instruction with a space between the name and text as follows: <?name text?>
 
-        public virtual Task WriteProcessingInstructionAsync(string name, string text)
+        public virtual Task WriteProcessingInstructionAsync(string name, string? text)
         {
             throw new NotImplementedException();
         }

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -1288,7 +1288,7 @@ namespace System.Xml
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task WriteNodeAsync(System.Xml.XPath.XPathNavigator navigator, bool defattr) { throw null; }
         public abstract void WriteProcessingInstruction(string name, string? text);
-        public virtual System.Threading.Tasks.Task WriteProcessingInstructionAsync(string name, string text) { throw null; }
+        public virtual System.Threading.Tasks.Task WriteProcessingInstructionAsync(string name, string? text) { throw null; }
         public virtual void WriteQualifiedName(string localName, string? ns) { }
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual System.Threading.Tasks.Task WriteQualifiedNameAsync(string localName, string? ns) { throw null; }


### PR DESCRIPTION
In order to match with the nullability of the sync method.