### PR TITLE
Switch Markup property to XmlNode?[]? to reflect it can contain null elements

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/Parser.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/Parser.cs
@@ -243,10 +243,10 @@ namespace System.Xml.Schema
                     {
                         Debug.Assert(_parentNode != null);
                         XmlNodeList list = _parentNode.ChildNodes;
-                        XmlNode[] markup = new XmlNode[list.Count];
+                        XmlNode?[] markup = new XmlNode[list.Count];
                         for (int i = 0; i < list.Count; i++)
                         {
-                            markup[i] = list[i]!;
+                            markup[i] = list[i];
                         }
 
                         _builder!.ProcessMarkup(markup);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaBuilder.cs
@@ -8,7 +8,7 @@ namespace System.Xml.Schema
         internal abstract bool ProcessElement(string prefix, string name, string ns);
         internal abstract void ProcessAttribute(string prefix, string name, string ns, string value);
         internal abstract bool IsContentParsed();
-        internal abstract void ProcessMarkup(XmlNode[] markup);
+        internal abstract void ProcessMarkup(XmlNode?[] markup);
         internal abstract void ProcessCData(string value);
         internal abstract void StartChildren();
         internal abstract void EndChildren();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
@@ -561,7 +561,7 @@ namespace System.Xml.Schema
             return true;
         }
 
-        internal override void ProcessMarkup(XmlNode[] markup)
+        internal override void ProcessMarkup(XmlNode?[] markup)
         {
             throw new InvalidOperationException(SR.Xml_InvalidOperation); // should never be called
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAppInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAppInfo.cs
@@ -9,7 +9,7 @@ namespace System.Xml.Schema
     public class XmlSchemaAppInfo : XmlSchemaObject
     {
         private string? _source;
-        private XmlNode[]? _markup;
+        private XmlNode?[]? _markup;
 
         [XmlAttribute("source", DataType = "anyURI")]
         public string? Source
@@ -19,7 +19,7 @@ namespace System.Xml.Schema
         }
 
         [XmlText, XmlAnyElement]
-        public XmlNode[]? Markup
+        public XmlNode?[]? Markup
         {
             get { return _markup; }
             set { _markup = value; }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDocumentation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDocumentation.cs
@@ -12,7 +12,7 @@ namespace System.Xml.Schema
     {
         private string? _source;
         private string? _language;
-        private XmlNode[]? _markup;
+        private XmlNode?[]? _markup;
         private static readonly XmlSchemaSimpleType s_languageType = DatatypeImplementation.GetSimpleTypeFromXsdType(new XmlQualifiedName("language", XmlReservedNs.NsXs))!;
 
         [XmlAttribute("source", DataType = "anyURI")]
@@ -31,7 +31,7 @@ namespace System.Xml.Schema
         }
 
         [XmlText, XmlAnyElement]
-        public XmlNode[]? Markup
+        public XmlNode?[]? Markup
         {
             get { return _markup; }
             set { _markup = value; }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
@@ -675,7 +675,7 @@ namespace System.Xml.Schema
         private XmlSchemaAppInfo? _appInfo;
         private XmlSchemaDocumentation? _documentation;
         private XmlSchemaFacet? _facet;
-        private XmlNode[]? _markup;
+        private XmlNode?[]? _markup;
         private XmlSchemaRedefine? _redefine;
 
         private readonly ValidationEventHandler? _validationEventHandler;
@@ -778,7 +778,7 @@ namespace System.Xml.Schema
             return _currentEntry.ParseContent;
         }
 
-        internal override void ProcessMarkup(XmlNode[] markup)
+        internal override void ProcessMarkup(XmlNode?[] markup)
         {
             _markup = markup;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SchemaObjectWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SchemaObjectWriter.cs
@@ -523,12 +523,12 @@ namespace System.Xml.Serialization
 
             WriteAttribute(@"source", @"", ((string?)o.@Source));
             WriteAttribute(@"lang", @"http://www.w3.org/XML/1998/namespace", ((string?)o.@Language));
-            XmlNode[]? a = (XmlNode[]?)o.@Markup;
+            XmlNode?[]? a = (XmlNode?[]?)o.@Markup;
             if (a != null)
             {
                 for (int ia = 0; ia < a.Length; ia++)
                 {
-                    XmlNode ai = (XmlNode)a[ia];
+                    XmlNode ai = (XmlNode)a[ia]!;
                     WriteStartElement("node");
                     WriteAttribute("xml", "", ai.OuterXml);
                 }
@@ -542,12 +542,12 @@ namespace System.Xml.Serialization
             WriteStartElement("appinfo");
 
             WriteAttribute("source", "", o.Source);
-            XmlNode[]? a = (XmlNode[]?)o.@Markup;
+            XmlNode?[]? a = (XmlNode?[]?)o.@Markup;
             if (a != null)
             {
                 for (int ia = 0; ia < a.Length; ia++)
                 {
-                    XmlNode ai = (XmlNode)a[ia];
+                    XmlNode ai = (XmlNode)a[ia]!;
                     WriteStartElement("node");
                     WriteAttribute("xml", "", ai.OuterXml);
                 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaImporter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSchemaImporter.cs
@@ -1485,10 +1485,10 @@ namespace System.Xml.Serialization
             {
                 if (o is XmlSchemaAppInfo)
                 {
-                    XmlNode[]? nodes = ((XmlSchemaAppInfo)o).Markup;
+                    XmlNode?[]? nodes = ((XmlSchemaAppInfo)o).Markup;
                     if (nodes != null && nodes.Length > 0)
                     {
-                        foreach (XmlNode node in nodes)
+                        foreach (XmlNode? node in nodes)
                         {
                             if (node is XmlElement)
                             {

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -1534,7 +1534,7 @@ namespace System.Xml.Schema
         public XmlSchemaAppInfo() { }
         [System.Xml.Serialization.XmlAnyElementAttribute]
         [System.Xml.Serialization.XmlTextAttribute]
-        public System.Xml.XmlNode[]? Markup { get { throw null; } set { } }
+        public System.Xml.XmlNode?[]? Markup { get { throw null; } set { } }
         [System.Xml.Serialization.XmlAttributeAttribute("source", DataType="anyURI")]
         public string? Source { get { throw null; } set { } }
     }
@@ -1791,7 +1791,7 @@ namespace System.Xml.Schema
         public string? Language { get { throw null; } set { } }
         [System.Xml.Serialization.XmlAnyElementAttribute]
         [System.Xml.Serialization.XmlTextAttribute]
-        public System.Xml.XmlNode[]? Markup { get { throw null; } set { } }
+        public System.Xml.XmlNode?[]? Markup { get { throw null; } set { } }
         [System.Xml.Serialization.XmlAttributeAttribute("source", DataType="anyURI")]
         public string? Source { get { throw null; } set { } }
     }


### PR DESCRIPTION
Switches `Markup` property from `XmlNode[]?` to `XmlNode?[]?` in `XmlSchemaAppInfo` and `XmlSchemaDocumentation`.