### PR TITLE
Search libgdiplus in /usr/local/lib on macOS

### DIFF
--- a/src/coreclr/src/pal/src/loader/module.cpp
+++ b/src/coreclr/src/pal/src/loader/module.cpp
@@ -67,13 +67,6 @@ using namespace CorUnix;
 /* get the full name of a module if available, and the short name otherwise*/
 #define MODNAME(x) ((x)->lib_name)
 
-/* Which path should FindLibrary search? */
-#if defined(__APPLE__)
-#define LIBSEARCHPATH "DYLD_LIBRARY_PATH"
-#else
-#define LIBSEARCHPATH "LD_LIBRARY_PATH"
-#endif
-
 #define LIBC_NAME_WITHOUT_EXTENSION "libc"
 
 /* static variables ***********************************************************/

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -33,7 +33,10 @@ namespace System.Drawing
                 IntPtr lib = IntPtr.Zero;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    NativeLibrary.TryLoad("libgdiplus.dylib", assembly, default, out lib);
+                    if (!NativeLibrary.TryLoad("libgdiplus.dylib", assembly, default, out lib))
+                    {
+                        NativeLibrary.TryLoad("/usr/local/lib/libgdiplus.dylib", assembly, default, out lib);
+                    }
                 }
                 else
                 {
@@ -43,7 +46,7 @@ namespace System.Drawing
                     // the name suffixed with ".0".
                     if (!NativeLibrary.TryLoad("libgdiplus.so", assembly, default, out lib))
                     {
-                         NativeLibrary.TryLoad("libgdiplus.so.0", assembly, default, out lib);
+                        NativeLibrary.TryLoad("libgdiplus.so.0", assembly, default, out lib);
                     }
                 }
 
@@ -403,7 +406,7 @@ namespace System.Drawing
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetPostScriptGraphicsContext(
-                [MarshalAs(UnmanagedType.LPStr)]string filename,
+                [MarshalAs(UnmanagedType.LPStr)] string filename,
                 int width, int height, double dpix, double dpiy, ref IntPtr graphics);
 
             [DllImport(LibraryName, ExactSpelling = true)]


### PR DESCRIPTION
With Apple's Hardened Runtime, `/usr/local/lib` is not searched for
`dlopen(3)` calls.

Today, some brew packages, such as `mono-libgdiplus` (used by
System.Drawing) are installed in `/usr/local/lib`. This causes
`DllNotFoundException` and user is supposed to either:

1. manually create a symlink to `/usr/local/lib/libgdiplus.dylib`.
2. export `LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH` or
  `DYLD_FALLBACK_LIBRARY_PATH` to `/usr/local/lib`.
3. remove signature from dotnet binary:
  `sudo codesign --remove-signature $(command -v dotnet)`

This patch adds a fallback lookup for libgdiplus.dylib, to avoid
workaround on macOS (as it is done for Linux: `libgdiplus.so` falls
back to `libgdiplus.so.0`).

Also removed `LIBSEARCHPATH` which is unused since 8d5e610.

cc @janvorli