### PR TITLE
Bump emscripten version to 2.0.1

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -157,7 +157,7 @@ jobs:
       archType: wasm
       platform: Browser_wasm
       container:
-        image: ubuntu-18.04-webassembly-20200529220811-6a6da63
+        image: ubuntu-18.04-webassembly-20200827125937-9740252
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -62,8 +62,6 @@ jobs:
         - _subset: libs
         - _additionalBuildArguments: ''
         - ${{ parameters.variables }}
-        - ${{ if eq(parameters.osGroup, 'Browser') }}:
-          - EMSDK_PATH: /usr/local/emscripten
 
         # Tests only run for 'allConfiguration' and 'net48' build-jobs
         # If platform is in testBuildPlatforms we build tests as well.

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -68,8 +68,6 @@ jobs:
       - name: osOverride
         value: -os Android
     - ${{ if eq(parameters.osGroup, 'Browser') }}:
-      - name: EMSDK_PATH
-        value: /usr/local/emscripten
       - name: archType
         value: wasm
       - name: osOverride

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -25,7 +25,7 @@ all: build-native icu-data
 #  If EMSDK_PATH is not set by the caller, download and setup a local emsdk install.
 #
 
-EMSCRIPTEN_VERSION=1.39.16
+EMSCRIPTEN_VERSION=2.0.1
 EMSDK_LOCAL_PATH=emsdk
 EMCC=source $(EMSDK_PATH)/emsdk_env.sh && emcc
 
@@ -34,7 +34,7 @@ EMCC=source $(EMSDK_PATH)/emsdk_env.sh && emcc
 	git clone https://github.com/emscripten-core/emsdk.git $(EMSDK_LOCAL_PATH)
 	cd $(EMSDK_LOCAL_PATH) && git checkout $(EMSCRIPTEN_VERSION)
 	cd $(EMSDK_LOCAL_PATH) && ./emsdk install $(EMSCRIPTEN_VERSION)
-	cd $(EMSDK_LOCAL_PATH) && ./emsdk activate --embedded $(EMSCRIPTEN_VERSION)
+	cd $(EMSDK_LOCAL_PATH) && ./emsdk activate $(EMSCRIPTEN_VERSION)
 	touch $@
 
 ifeq ($(EMSDK_PATH),emsdk)


### PR DESCRIPTION
Updates the emscripten Docker container we use to build in CI. We no longer need to explicitly set `EMSDK_PATH` since the container already does it.
Also remove `--embedded` flag from `./emsdk activate` since it was deprecated and is now the default.