### PR TITLE
Fixed stress test pipeline and other issues.

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -34,22 +34,26 @@ jobs:
   - checkout: self
     clean: true
     fetchDepth: 5
-  
+
   - bash: |
       $(dockerfilesFolder)/build-docker-sdk.sh -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+    name: buildRuntime
     displayName: Build CLR and Libraries
-  
+
   - bash: |
-      exit 1
       $(httpStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+    name: buildStress
     displayName: Build HttpStress
-  
+
   - bash: |
       cd '$(httpStressProject)'
       export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 2.0"
       export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 2.0"
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 2.0
+    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
   - bash: |
       cd '$(httpStressProject)'
@@ -57,39 +61,39 @@ jobs:
       export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 1.1"
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 1.1
-    condition: succeededOrFailed()
+    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
-- job: windows
-  displayName: Docker NanoServer
-  timeoutInMinutes: 120
-  pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Server.Amd64.VS2019.Open
-
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    lfs: false
-  
-  - powershell: |
-      $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
-    displayName: Build CLR and Libraries
-  
-  - powershell: |
-      $(httpStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
-    displayName: Build HttpStress
-  
-  - powershell: |
-      cd '$(httpStressProject)'
-      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
-      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 2.0"
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP 2.0
-  
-  - powershell: |
-      cd '$(httpStressProject)'
-      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 1.1"
-      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 1.1"
-      docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP 1.1
+#- job: windows
+#  displayName: Docker NanoServer
+#  timeoutInMinutes: 120
+#  pool:
+#    name: NetCorePublic-Pool
+#    queue: BuildPool.Server.Amd64.VS2019.Open
+#
+#  steps:
+#  - checkout: self
+#    clean: true
+#    fetchDepth: 5
+#    lfs: false
+#
+#  - powershell: |
+#      $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+#    displayName: Build CLR and Libraries
+#
+#  - powershell: |
+#      $(httpStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+#    displayName: Build HttpStress
+#
+#  - powershell: |
+#      cd '$(httpStressProject)'
+#      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
+#      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 2.0"
+#      docker-compose up --abort-on-container-exit --no-color
+#    displayName: Run HttpStress - HTTP 2.0
+#
+#  - powershell: |
+#      cd '$(httpStressProject)'
+#      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 1.1"
+#      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 1.1"
+#      docker-compose up --abort-on-container-exit --no-color
+#    displayName: Run HttpStress - HTTP 1.1

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -63,37 +63,43 @@ jobs:
     displayName: Run HttpStress - HTTP 1.1
     condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
-#- job: windows
-#  displayName: Docker NanoServer
-#  timeoutInMinutes: 120
-#  pool:
-#    name: NetCorePublic-Pool
-#    queue: BuildPool.Server.Amd64.VS2019.Open
-#
-#  steps:
-#  - checkout: self
-#    clean: true
-#    fetchDepth: 5
-#    lfs: false
-#
-#  - powershell: |
-#      $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
-#    displayName: Build CLR and Libraries
-#
-#  - powershell: |
-#      $(httpStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
-#    displayName: Build HttpStress
-#
-#  - powershell: |
-#      cd '$(httpStressProject)'
-#      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
-#      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 2.0"
-#      docker-compose up --abort-on-container-exit --no-color
-#    displayName: Run HttpStress - HTTP 2.0
-#
-#  - powershell: |
-#      cd '$(httpStressProject)'
-#      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 1.1"
-#      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 1.1"
-#      docker-compose up --abort-on-container-exit --no-color
-#    displayName: Run HttpStress - HTTP 1.1
+- job: windows
+  displayName: Docker NanoServer
+  timeoutInMinutes: 120
+  pool:
+    name: NetCorePublic-Pool
+    queue: BuildPool.Server.Amd64.VS2019.Open
+
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 5
+    lfs: false
+
+  - powershell: |
+      $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
+      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+    name: buildRuntime
+    displayName: Build CLR and Libraries
+
+  - powershell: |
+      $(httpStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
+      echo "##vso[task.setvariable variable=succeeded;isOutput=true]true"
+    name: buildStress
+    displayName: Build HttpStress
+
+  - powershell: |
+      cd '$(httpStressProject)'
+      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
+      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 2.0"
+      docker-compose up --abort-on-container-exit --no-color
+    displayName: Run HttpStress - HTTP 2.0
+    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
+
+  - powershell: |
+      cd '$(httpStressProject)'
+      $env:HTTPSTRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 1.1"
+      $env:HTTPSTRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 1.1"
+      docker-compose up --abort-on-container-exit --no-color
+    displayName: Run HttpStress - HTTP 1.1
+    condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -48,7 +48,7 @@ jobs:
       export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 2.0"
       export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 2.0"
       docker-compose up --abort-on-container-exit --no-color
-    displayName: Run HttpStress - HTTP/2
+    displayName: Run HttpStress - HTTP 2.0
 
   - bash: |
       cd '$(httpStressProject)'

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -40,6 +40,7 @@ jobs:
     displayName: Build CLR and Libraries
   
   - bash: |
+      exit 1
       $(httpStressProject)/run-docker-compose.sh -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
     displayName: Build HttpStress
   
@@ -56,6 +57,7 @@ jobs:
       export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 1.1"
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 1.1
+    condition: succeededOrFailed()
 
 - job: windows
   displayName: Docker NanoServer

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -466,7 +466,7 @@ namespace HttpStress
 
         private class StructuralEqualityComparer<T> : IEqualityComparer<T> where T : IStructuralEquatable
         {
-            public bool Equals([AllowNull] T left, [AllowNull] T right) => left != null && left.Equals(right, StructuralComparisons.StructuralEqualityComparer);
+            public bool Equals(T? left, T? right) => left != null && left.Equals(right, StructuralComparisons.StructuralEqualityComparer);
             public int GetHashCode([DisallowNull] T value) => value.GetHashCode(StructuralComparisons.StructuralEqualityComparer);
         }
     }

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -185,7 +185,7 @@ namespace HttpStress
                     }
                     catch (Exception e)
                     {
-                        _aggregator.RecordFailure(e, opIndex, stopwatch.Elapsed, taskNum: taskNum, iteration: i);
+                        _aggregator.RecordFailure(e, opIndex, stopwatch.Elapsed, requestContext.IsCancellationRequested, taskNum: taskNum, iteration: i);
                     }
                 }
 
@@ -222,12 +222,12 @@ namespace HttpStress
             // Representative error text of stress failure
             public string ErrorText { get; }
             // Operation id => failure timestamps
-            public Dictionary<int, List<(DateTime timestamp, TimeSpan duration)>> Failures { get; }
+            public Dictionary<int, List<(DateTime timestamp, TimeSpan duration, bool isCancelled)>> Failures { get; }
 
             public StressFailureType(string errorText)
             {
                 ErrorText = errorText;
-                Failures = new Dictionary<int, List<(DateTime timestamp, TimeSpan duration)>>();
+                Failures = new Dictionary<int, List<(DateTime timestamp, TimeSpan duration, bool isCancelled)>>();
             }
 
             public int FailureCount => Failures.Values.Select(x => x.Count).Sum();
@@ -272,7 +272,7 @@ namespace HttpStress
                 _latencies.Add(elapsed.TotalMilliseconds);
             }
 
-            public void RecordFailure(Exception exn, int operationIndex, TimeSpan elapsed, int taskNum, long iteration)
+            public void RecordFailure(Exception exn, int operationIndex, TimeSpan elapsed, bool isCancelled, int taskNum, long iteration)
             {
                 DateTime timestamp = DateTime.Now;
                 
@@ -293,13 +293,13 @@ namespace HttpStress
 
                     lock (failureType)
                     {
-                        if(!failureType.Failures.TryGetValue(operationIndex, out List<(DateTime timestamp, TimeSpan duration)>? timestamps))
+                        if(!failureType.Failures.TryGetValue(operationIndex, out List<(DateTime timestamp, TimeSpan duration, bool isCancelled)>? details))
                         {
-                            timestamps = new List<(DateTime timestamp, TimeSpan duration)>();
-                            failureType.Failures.Add(operationIndex, timestamps);
+                            details = new List<(DateTime timestamp, TimeSpan duration, bool isCancelled)>();
+                            failureType.Failures.Add(operationIndex, details);
                         }
 
-                        timestamps.Add((timestamp, elapsed));
+                        details.Add((timestamp, elapsed, isCancelled));
                     }
 
                     (Type exception, string message, string callSite)[] ClassifyFailure(Exception exn)
@@ -439,7 +439,7 @@ namespace HttpStress
                     Console.WriteLine(failure.ErrorText);
                     Console.WriteLine();
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    foreach (KeyValuePair<int, List<(DateTime timestamp, TimeSpan duration)>> operation in failure.Failures)
+                    foreach (KeyValuePair<int, List<(DateTime timestamp, TimeSpan duration, bool isCancelled)>> operation in failure.Failures)
                     {
                         Console.ForegroundColor = ConsoleColor.Cyan;
                         Console.Write($"\t{_operationNames[operation.Key].PadRight(30)}");
@@ -448,7 +448,7 @@ namespace HttpStress
                         Console.Write("Fail: ");
                         Console.ResetColor();
                         Console.Write(operation.Value.Count);
-                        Console.WriteLine($"\tTimestamps: {string.Join(", ", operation.Value.Select(x => $"{x.timestamp:HH:mm:ss.fffffff} in {x.duration}"))}");
+                        Console.WriteLine($"\t{string.Join(", ", operation.Value.Select(x => $"Timestamps: {x.timestamp:HH:mm:ss.fffffff}, Duration: {x.duration}, Cancelled: {x.isCancelled}"))}");
                     }
 
                     Console.ForegroundColor = ConsoleColor.Cyan;

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Utils/ErrorAggregator.cs
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Utils/ErrorAggregator.cs
@@ -113,7 +113,7 @@ namespace SslStress.Utils
 
         private class StructuralEqualityComparer<T> : IEqualityComparer<T> where T : IStructuralEquatable
         {
-            public bool Equals([AllowNull] T left, [AllowNull] T right) => left != null && left.Equals(right, StructuralComparisons.StructuralEqualityComparer);
+            public bool Equals(T? left, T? right) => left != null && left.Equals(right, StructuralComparisons.StructuralEqualityComparer);
             public int GetHashCode([DisallowNull] T value) => value.GetHashCode(StructuralComparisons.StructuralEqualityComparer);
         }
     }


### PR DESCRIPTION
Addresses multiple issues with HTTP stress:
- HTTP 1.1 won't run at all if HTTP 2.0 failed
  - Adding conditions that ensure that the step won't run only if build failed, not the previous stress run step.
- Pipeline naming inconsistencies
- Parameter nullability inspired by https://github.com/dotnet/runtime/pull/41321#pullrequestreview-477694852
  - Leaving `[DisallowNull]` in since that's the way it is in the interface: https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IEqualityComparer.cs#L14
- The final report will log if the failed run has been intentionally cancelled, to improve investigation of existing H/2 failures.