### PR TITLE
Start stopwatch immediately before sending http request

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Extensions.Http.Logging
             {
                 throw new ArgumentNullException(nameof(request));
             }
-
             
             Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? _shouldNotRedactHeaderValue;
 

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -50,13 +50,13 @@ namespace Microsoft.Extensions.Http.Logging
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var stopwatch = ValueStopwatch.StartNew();
-
+            
             Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? _shouldNotRedactHeaderValue;
 
             // Not using a scope here because we always expect this to be at the end of the pipeline, thus there's
             // not really anything to surround.
             Log.RequestStart(_logger, request, shouldRedactHeaderValue);
+            var stopwatch = ValueStopwatch.StartNew();
             HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             Log.RequestEnd(_logger, response, stopwatch.GetElapsedTime(), shouldRedactHeaderValue);
 

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Http.Logging
             {
                 throw new ArgumentNullException(nameof(request));
             }
-            
+
             Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? _shouldNotRedactHeaderValue;
 
             // Not using a scope here because we always expect this to be at the end of the pipeline, thus there's


### PR DESCRIPTION
This is a minor change regarding `Microsoft.Extensions.Http.LoggingHttpMessageHandler`. 
When measuring HTTP request time, the measured duration includes both logging the request and actually sending it.

Although I suppose logging duration is insignificant compared to request duration, I thought it would still be more correct and accurate to start the stop watch immediately before sending an HTTP request.

Please feel free to ignore this if you think it's not worth it.