### PR TITLE
Fix comments calling surrogate halves low surrogates

### DIFF
--- a/src/coreclr/src/pal/src/locale/utf8.cpp
+++ b/src/coreclr/src/pal/src/locale/utf8.cpp
@@ -51,7 +51,7 @@ struct Char
         return (c & 0xFC00) == CharUnicodeInfo::LOW_SURROGATE_START;
     }
 
-    // Test if the wide character is a low surrogate
+    // Test if the wide character is a surrogate half
     static bool IsSurrogate(const WCHAR c)
     {
         return (c & 0xF800) == CharUnicodeInfo::HIGH_SURROGATE_START;
@@ -69,7 +69,7 @@ struct Char
         return IsLowSurrogate(s[index]);
     }
 
-    // Test if the wide character is a low surrogate
+    // Test if the wide character is a surrogate half
     static bool IsSurrogate(const WCHAR* s, int index)
     {
         return IsSurrogate(s[index]);


### PR DESCRIPTION
I think these comments were copied and pasted and someone forgot to modify them.