### PR TITLE
[RyuJIT] Avoid emitting cdq/coq for a positive constant in rax for idiv

### DIFF
--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -788,7 +788,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* treeNode)
     genCopyRegIfNeeded(dividend, REG_RAX);
 
     // zero or sign extend rax to rdx
-    if (oper == GT_UMOD || oper == GT_UDIV)
+    if (oper == GT_UMOD || oper == GT_UDIV || (dividend->IsIntegralConst() && (dividend->AsIntConCommon()->IconValue() > 0)))
     {
         instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_EDX);
     }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -788,7 +788,8 @@ void CodeGen::genCodeForDivMod(GenTreeOp* treeNode)
     genCopyRegIfNeeded(dividend, REG_RAX);
 
     // zero or sign extend rax to rdx
-    if (oper == GT_UMOD || oper == GT_UDIV || (dividend->IsIntegralConst() && (dividend->AsIntConCommon()->IconValue() > 0)))
+    if (oper == GT_UMOD || oper == GT_UDIV ||
+        (dividend->IsIntegralConst() && (dividend->AsIntConCommon()->IconValue() > 0)))
     {
         instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_EDX);
     }


### PR DESCRIPTION
Avoid emitting cdq/cqo for sign extend from RAX to RDX if dividend is a positive constant - use XOR RDX, RDX instead. Just like LLVM does: https://godbolt.org/z/4G8c8n (we also do it today for UDIV and UMOD)
```csharp
long Test(long x) => 1000 / x;
```
#### Current codegen:
```asm
G_M27621_IG01:
       488BCA               mov      rcx, rdx
G_M27621_IG02:
       B8E8030000           mov      eax, 0x3E8
       4899                 cdq      
       48F7F9               idiv     rdx:rax, rcx
						;; bbWeight=1    PerfScore 69.25
G_M27621_IG03:
       C3                   ret
; Total bytes of code: 14
```
#### New codegen:
```asm
G_M27621_IG01:
       488BCA               mov      rcx, rdx
G_M27621_IG02:
       B8E8030000           mov      eax, 0x3E8
       33D2                 xor      rdx, rdx
       48F7F9               idiv     rdx:rax, rcx
						;; bbWeight=1    PerfScore 68.50   <---- smaller!
G_M27621_IG03:
       C3                   ret
; Total bytes of code: 14
```

#### Benchmark:
```csharp
[Benchmark]
public void Test()
{
    for (int i = 1; i < 1000; i++)
        Consume(1000 / i + 10000 % i); // the optimization affects both "/" and "%"
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void Consume(int x) { }
```
```
|        |     Mean |     Error |    StdDev |
|------- |---------:|----------:|----------:|
| master | 4.041 us | 0.0031 us | 0.0028 us |
|     PR | 3.830 us | 0.0028 us | 0.0026 us | ~5.5% faster (can be bigger if we do more independent div's = rely on rec. throughput)
```
(results are quite stable, Core i7 8700K (Coffee Lake), Windows 10)
/cc @dotnet/jit-contrib 

The fix doesn't improve/regress AMD since cdq/cqo is as fast as xor reg reg in terms of both latency and throughput(tested on `AMD Ryzen 7 3800X` (Zen2) and `AMD Ryzen 5 2600` (Zen1)).