### PR TITLE
Optimize Half.Equals

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -424,12 +424,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Half other)
         {
-            if (_value == other._value)
-            {
-                return true;
-            }
-
-            return AreZero(this, other)
+            return _value == other._value
+                || AreZero(this, other)
                 || (IsNaN(this) && IsNaN(other));
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -422,11 +422,13 @@ namespace System
         /// </summary>
         public bool Equals(Half other)
         {
-            if (this == other)
+            if (_value == other._value)
             {
                 return true;
             }
-            return IsNaN(this) && IsNaN(other);
+
+            return AreZero(this, other)
+                || (IsNaN(this) && IsNaN(other));
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace System
@@ -420,6 +421,7 @@ namespace System
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified <paramref name="other"/> value.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Half other)
         {
             if (_value == other._value)

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace System
@@ -421,7 +420,6 @@ namespace System
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified <paramref name="other"/> value.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Half other)
         {
             return _value == other._value


### PR DESCRIPTION
Fixes #41329

Benchmark:
(See full benchmark at https://github.com/dotnet/runtime/issues/41329#issuecomment-683307793)

| Method |        Job |  left |  right |      Mean |     Error |    StdDev | Ratio | RatioSD | Code Size |
|------- |----------- |--------------------------- |------ |------- |----------:|----------:|----------:|------:|--------:|
|  Equal | PR |     0 |     -0 | 0.4526 ns | 0.0127 ns | 0.0112 ns |  1.00 |    0.00 |      75 B |
|  Equal | master |     0 |     -0 | 1.8901 ns | 0.0135 ns | 0.0126 ns |  4.18 |    0.12 |     156 B |
|        |            |                            |       |        |           |           |           |       |         |           |
|  Equal | PR | 65500 | -65500 | 0.6604 ns | 0.0088 ns | 0.0082 ns |  1.00 |    0.00 |      75 B |
|  Equal | master | 65500 | -65500 | 1.6911 ns | 0.0131 ns | 0.0116 ns |  2.56 |    0.03 |     156 B |
|        |            |                            |       |        |           |           |           |       |         |           |
|  Equal | PR | 65500 |      0 | 0.6683 ns | 0.0042 ns | 0.0038 ns |  1.00 |    0.00 |      75 B |
|  Equal | master | 65500 |      0 | 1.6832 ns | 0.0076 ns | 0.0068 ns |  2.52 |    0.02 |     156 B |
|        |            |                            |       |        |           |           |           |       |         |           |
|  Equal | PR | 65500 |  65500 | 0.2071 ns | 0.0095 ns | 0.0089 ns |  1.00 |    0.00 |      75 B |
|  Equal | master | 65500 |  65500 | 2.2191 ns | 0.0173 ns | 0.0162 ns | 10.73 |    0.43 |     156 B |
|        |            |                            |       |        |           |           |           |       |         |           |
|  Equal | PR | 65500 |    NaN | 0.6647 ns | 0.0081 ns | 0.0076 ns |  1.00 |    0.00 |      75 B |
|  Equal | master | 65500 |    NaN | 1.4638 ns | 0.0015 ns | 0.0014 ns |  2.20 |    0.02 |     156 B |
|        |            |                            |       |        |           |           |           |       |         |           |
|  Equal | PR |   NaN |      0 | 0.4603 ns | 0.0009 ns | 0.0008 ns |  1.00 |    0.00 |      75 B |
|  Equal | master |   NaN |      0 | 2.4231 ns | 0.0039 ns | 0.0036 ns |  5.26 |    0.01 |     156 B |
|        |            |                            |       |        |           |           |           |       |         |           |
|  Equal | PR |   NaN |    NaN | 0.2098 ns | 0.0017 ns | 0.0016 ns |  1.00 |    0.00 |      75 B |
|  Equal | PR |   NaN |    NaN | 0.4320 ns | 0.0041 ns | 0.0038 ns |  2.06 |    0.02 |      75 B |
|  Equal | master |   NaN |    NaN | 2.4281 ns | 0.0078 ns | 0.0069 ns | 11.58 |    0.09 |     156 B |
|  Equal | master |   NaN |    NaN | 2.0738 ns | 0.0086 ns | 0.0076 ns |  9.89 |    0.09 |     156 B |

### Further question

Should we apply more `AggressiveInlineing` on `Half` members?
If we've get hardware acceleration, the implementation should change massively, and can be considered later.
Should call size bloat be considered?