### PR TITLE
[wasm][debugger] Show actual data for boxed values

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -829,40 +829,24 @@ read_enum_value (const char *mem, int type)
 	return 0;
 }
 
-static MonoClassField*
-nullable_class_get_value_field (MonoClass *klass)
-{
-	mono_class_setup_fields (klass);
-	g_assert (m_class_is_fields_inited (klass));
-
-	MonoClassField *klass_fields = m_class_get_fields (klass);
-	return &klass_fields [1];
-}
-
-static MonoClassField*
-nullable_class_get_has_value_field (MonoClass *klass)
-{
-	mono_class_setup_fields (klass);
-	g_assert (m_class_is_fields_inited (klass));
-
-	MonoClassField *klass_fields = m_class_get_fields (klass);
-	return &klass_fields [0];
-}
-
 static gpointer
 nullable_get_has_value_field_addr (guint8 *nullable, MonoClass *klass)
 {
-	MonoClassField *has_value_field = nullable_class_get_has_value_field (klass);
+	mono_class_setup_fields (klass);
+	g_assert (m_class_is_fields_inited (klass));
 
-	return mono_vtype_get_field_addr (nullable, has_value_field);
+	MonoClassField *klass_fields = m_class_get_fields (klass);
+	return mono_vtype_get_field_addr (nullable, &klass_fields[0]);
 }
 
 static gpointer
 nullable_get_value_field_addr (guint8 *nullable, MonoClass *klass)
 {
-	MonoClassField *has_value_field = nullable_class_get_value_field (klass);
+	mono_class_setup_fields (klass);
+	g_assert (m_class_is_fields_inited (klass));
 
-	return mono_vtype_get_field_addr (nullable, has_value_field);
+	MonoClassField *klass_fields = m_class_get_fields (klass);
+	return mono_vtype_get_field_addr (nullable, &klass_fields[1]);
 }
 
 static gboolean
@@ -948,7 +932,7 @@ describe_value(MonoType * type, gpointer addr, int gpflags)
 					g_free (class_name);
 					break;
 				} else {
-					gpointer value_addr = nullable_get_value_field_addr(addr, klass);
+					gpointer value_addr = nullable_get_value_field_addr (addr, klass);
 					return describe_value(targ, value_addr, gpflags);
 				}
 			}

--- a/src/mono/wasm/debugger/tests/debugger-get-properties-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-get-properties-test.cs
@@ -17,7 +17,7 @@ namespace DebuggerTests.GetPropertiesTests
     }
 
     public interface IName : IFirstName, ILastName
-    {}
+    { }
 
     public class BaseBaseClass
     {
@@ -91,20 +91,20 @@ namespace DebuggerTests.GetPropertiesTests
 
         public static void run()
         {
-            new DerivedClass().InstanceMethod ();
-            new DerivedClass().InstanceMethodAsync ().Wait();
+            new DerivedClass().InstanceMethod();
+            new DerivedClass().InstanceMethodAsync().Wait();
         }
 
         public string GetStringField() => _stringField;
 
         public void InstanceMethod()
         {
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
         }
 
         public async Task InstanceMethodAsync()
         {
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
             await Task.CompletedTask;
         }
     }
@@ -138,20 +138,20 @@ namespace DebuggerTests.GetPropertiesTests
 
         public static void run()
         {
-            new CloneableStruct(3).InstanceMethod ();
-            new CloneableStruct(3).InstanceMethodAsync ().Wait();
+            new CloneableStruct(3).InstanceMethod();
+            new CloneableStruct(3).InstanceMethodAsync().Wait();
         }
 
         public string GetStringField() => _stringField;
 
         public void InstanceMethod()
         {
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
         }
 
         public async Task InstanceMethodAsync()
         {
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
             await Task.CompletedTask;
         }
     }
@@ -174,13 +174,13 @@ namespace DebuggerTests.GetPropertiesTests
         public static void TestNestedStructStatic()
         {
             var ns = new NestedStruct(3);
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
         }
 
         public static async Task TestNestedStructStaticAsync()
         {
             var ns = new NestedStruct(3);
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
             await Task.CompletedTask;
         }
     }
@@ -200,7 +200,7 @@ namespace DebuggerTests.GetPropertiesTests
         public static void run()
         {
             var obj = new DerivedClassForJSTest();
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
         }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-nullable-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-nullable-test.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace DebuggerTests
+{
+    public class NullableTests
+    {
+        public static void TestNullableLocal ()
+        {
+            int? n_int = 5;
+            int? n_int_null = null;
+
+            DateTime? n_dt = new DateTime(2310, 1, 2, 3, 4, 5);
+            DateTime? n_dt_null = null;
+
+            ValueTypesTest.GenericStruct<int>? n_gs = new ValueTypesTest.GenericStruct<int> { StringField = "n_gs#StringField" };
+            ValueTypesTest.GenericStruct<int>? n_gs_null = null;
+
+            Console.WriteLine ($"break here");
+        }
+
+        public static async Task TestNullableLocalAsync ()
+        {
+            int? n_int = 5;
+            int? n_int_null = null;
+
+            DateTime? n_dt = new DateTime(2310, 1, 2, 3, 4, 5);
+            DateTime? n_dt_null = null;
+
+            ValueTypesTest.GenericStruct<int>? n_gs = new ValueTypesTest.GenericStruct<int> { StringField = "n_gs#StringField" };
+            ValueTypesTest.GenericStruct<int>? n_gs_null = null;
+
+            Console.WriteLine ($"break here");
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-nullable-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-nullable-test.cs
@@ -8,7 +8,7 @@ namespace DebuggerTests
 {
     public class NullableTests
     {
-        public static void TestNullableLocal ()
+        public static void TestNullableLocal()
         {
             int? n_int = 5;
             int? n_int_null = null;
@@ -19,10 +19,10 @@ namespace DebuggerTests
             ValueTypesTest.GenericStruct<int>? n_gs = new ValueTypesTest.GenericStruct<int> { StringField = "n_gs#StringField" };
             ValueTypesTest.GenericStruct<int>? n_gs_null = null;
 
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
         }
 
-        public static async Task TestNullableLocalAsync ()
+        public static async Task TestNullableLocalAsync()
         {
             int? n_int = 5;
             int? n_int_null = null;
@@ -33,7 +33,7 @@ namespace DebuggerTests
             ValueTypesTest.GenericStruct<int>? n_gs = new ValueTypesTest.GenericStruct<int> { StringField = "n_gs#StringField" };
             ValueTypesTest.GenericStruct<int>? n_gs_null = null;
 
-            Console.WriteLine ($"break here");
+            Console.WriteLine($"break here");
             await Task.CompletedTask;
         }
     }

--- a/src/mono/wasm/debugger/tests/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-
+using System.Threading.Tasks;
 public partial class Math
 { //Only append content to this class as the test suite depends on line info
     public static int IntAdd(int a, int b)
@@ -285,7 +285,7 @@ public partial class Math
     public delegate void DelegateWithVoidReturn(GenericStruct<int[]> gs);
     public static void DelegateTargetWithVoidReturn(GenericStruct<int[]> gs) { }
 
-    delegate GenericStruct<bool[]> DelegateForSignatureTest(Math m, GenericStruct<GenericStruct<int[]>> gs);
+    public delegate GenericStruct<bool[]> DelegateForSignatureTest(Math m, GenericStruct<GenericStruct<int[]>> gs);
     static bool DelegateTargetForNestedFunc<T>(T arg) => true;
 
     public struct SimpleStruct
@@ -339,4 +339,47 @@ public class DebuggerTest
     }
 
     static void locals_inner() { }
+
+    public static void BoxingTest()
+    {
+        int? n_i = 5;
+        object o_i = n_i.Value;
+        object o_n_i = n_i;
+
+        object o_s = "foobar";
+        object o_obj = new Math();
+        DebuggerTests.ValueTypesTest.GenericStruct<int>? n_gs = new DebuggerTests.ValueTypesTest.GenericStruct<int> { StringField = "n_gs#StringField" };
+        object o_gs = n_gs.Value;
+        object o_n_gs = n_gs;
+
+        DateTime? n_dt = new DateTime(2310, 1, 2, 3, 4, 5);
+        object o_dt = n_dt.Value;
+        object o_n_dt = n_dt;
+        object o_null = null;
+        object o_ia = new int[] {918, 58971};
+
+        Console.WriteLine ($"break here");
+    }
+
+    public static async Task BoxingTestAsync()
+    {
+        int? n_i = 5;
+        object o_i = n_i.Value;
+        object o_n_i = n_i;
+
+        object o_s = "foobar";
+        object o_obj = new Math();
+        DebuggerTests.ValueTypesTest.GenericStruct<int>? n_gs = new DebuggerTests.ValueTypesTest.GenericStruct<int> { StringField = "n_gs#StringField" };
+        object o_gs = n_gs.Value;
+        object o_n_gs = n_gs;
+
+        DateTime? n_dt = new DateTime(2310, 1, 2, 3, 4, 5);
+        object o_dt = n_dt.Value;
+        object o_n_dt = n_dt;
+        object o_null = null;
+        object o_ia = new int[] {918, 58971};
+
+        Console.WriteLine ($"break here");
+        await Task.CompletedTask;
+    }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test.cs
@@ -316,7 +316,7 @@ public partial class Math
             str_spaces,
             str_esc
         };
-        Console.WriteLine ($"break here");
+        Console.WriteLine($"break here");
     }
 
 }


### PR DESCRIPTION
Eg. `object o = "foobar"`

This will show the string `"foobar"`, instead of an object, in the
debugger.

Fixes https://github.com/dotnet/runtime/issues/41846