### PR TITLE
[interp] Add basic block support

### DIFF
--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -12,7 +12,8 @@
 
 #define INTERP_LOCAL_FLAG_DEAD 1
 
-typedef struct InterpInst InterpInst;
+typedef struct _InterpInst InterpInst;
+typedef struct _InterpBasicBlock InterpBasicBlock;
 
 typedef struct
 {
@@ -50,26 +51,52 @@ typedef struct
 	InterpInst *ins;
 } StackContentInfo;
 
-struct InterpInst {
+struct _InterpInst {
 	guint16 opcode;
 	InterpInst *next, *prev;
 	// If this is -1, this instruction is not logically associated with an IL offset, it is
 	// part of the IL instruction associated with the previous interp instruction.
 	int il_offset;
 	guint32 flags;
+	// This union serves the same purpose as the data array. The difference is that
+	// the data array maps exactly to the final representation of the instruction.
+	// FIXME We should consider using a separate higher level IR, that is also easier
+	// to use for various optimizations.
+	union {
+		InterpBasicBlock *target_bb;
+		InterpBasicBlock **target_bb_table;
+	} info;
 	guint16 data [MONO_ZERO_LEN_ARRAY];
 };
 
-typedef struct {
+struct _InterpBasicBlock {
 	guint8 *ip;
-	GSList *preds;
 	GSList *seq_points;
 	SeqPoint *last_seq_point;
+
+	InterpInst *first_ins, *last_ins;
+	/* Next bb in IL order */
+	InterpBasicBlock *next_bb;
+
+	gint16 in_count;
+	InterpBasicBlock **in_bb;
+	gint16 out_count;
+	InterpBasicBlock **out_bb;
+
+	int native_offset;
+
+	/*
+	 * The state of the stack when entering this basic block. By default, the stack height is
+	 * -1, which means it inherits the stack state from the previous instruction, in IL order
+	 */
+	int stack_height;
+	StackInfo *stack_state;
+	int vt_stack_size;
 
 	// This will hold a list of last sequence points of incoming basic blocks
 	SeqPoint **pred_seq_points;
 	guint num_pred_seq_points;
-} InterpBasicBlock;
+};
 
 typedef enum {
 	RELOC_SHORT_BRANCH,
@@ -81,8 +108,7 @@ typedef struct {
 	RelocType type;
 	/* In the interpreter IR */
 	int offset;
-	/* In the IL code */
-	int target;
+	InterpBasicBlock *target_bb;
 } Reloc;
 
 typedef struct {
@@ -106,10 +132,6 @@ typedef struct
 	int code_size;
 	int *in_offsets;
 	int current_il_offset;
-	StackInfo **stack_state;
-	int *stack_height;
-	int *vt_stack_size;
-	unsigned char *is_bb_start;
 	unsigned short *new_code;
 	unsigned short *new_code_end;
 	unsigned int max_code_size;
@@ -136,7 +158,7 @@ typedef struct
 	gboolean gen_sdb_seq_points;
 	GPtrArray *seq_points;
 	InterpBasicBlock **offset_to_bb;
-	InterpBasicBlock *entry_bb;
+	InterpBasicBlock *entry_bb, *cbb;
 	MonoMemPool     *mempool;
 	GList *basic_blocks;
 	GPtrArray *relocs;
@@ -145,6 +167,7 @@ typedef struct
 	gboolean prof_coverage;
 	MonoProfilerCoverageInfo *coverage_info;
 	GList *dont_inline;
+	int inline_depth;
 	int has_localloc : 1;
 } TransformData;
 

--- a/src/mono/mono/mini/interp/whitebox.c
+++ b/src/mono/mono/mini/interp/whitebox.c
@@ -167,9 +167,7 @@ transform_method (MonoDomain *domain, MonoImage *image, TestItem *ti)
 	td->verbose_level = determine_verbose_level (td);
 	td->mempool = mp;
 	td->rtm = rtm;
-	td->stack_height = (int*)g_malloc(header->code_size * sizeof(int));
 	td->clause_indexes = (int*)g_malloc (header->code_size * sizeof (int));
-	td->is_bb_start = (guint8*)g_malloc0(header->code_size);
 	td->data_items = NULL;
 	td->data_hash = g_hash_table_new (NULL, NULL);
 	/* TODO: init more fields of `td` */

--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -697,7 +697,7 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 		break;
 	case OP_IL_SEQ_POINT:
 	case OP_SEQ_POINT:
-		g_string_append_printf (sbuf, " il: 0x%x%s", (int)ins->inst_imm, ins->flags & MONO_INST_NONEMPTY_STACK ? ", nonempty-stack" : "");
+		g_string_append_printf (sbuf, "%s il: 0x%x%s", (ins->flags & MONO_INST_SINGLE_STEP_LOC) ? " intr" : "", (int)ins->inst_imm, ins->flags & MONO_INST_NONEMPTY_STACK ? ", nonempty-stack" : "");
 		break;
 	case OP_COND_EXC_EQ:
 	case OP_COND_EXC_GE:


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20328,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This PR makes basic blocks a fundamental part of the code generation machinery. Before this change, there wasn't really any notion of basic blocks, there was a single list of instructions. With this change, we emit instructions inside basic blocks which are linked together. These basic blocks are iterated one at a time when doing optimization passes or emitting the final code. Currently, the origin of all basic blocks is IL code (they originate from branch targets and exception clauses) and we might never support creation of additional bblocks (since we could just create more complex instructions, which would also result in faster code). The bblocks will be emitted in the final code in the same order as they appear in IL code. This order is maintained through `next_bb` link.

Since the list of bblocks was completely changed, some fixes were required for debugging support. Some tests seemed to pass by chance, since we didn't emit MINT_SDB_INTR_LOC in the same locations as jit. There are probably still some discrepancies there.

This PR enables inlining of methods with multiple basic blocks. Currently, this might regress performance because we don't merge some basic blocks that we could (for method start), reducing benefits from cprop passes operating on single basic blocks. We will soon add a pass that traverses the list of basic blocks which eliminates dead basic blocks, merging any adjacent ones. 