### PR TITLE
[release/5.0] Bump emscripten version to 2.0.1 

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>cfe95a23647c7de1fe1a349343115bd7720d6949</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20425.3">
+    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20428.3">
       <Uri>https://github.com/dotnet/icu</Uri>
-      <Sha>ba56d3de3dd497dc33b5c92fe27a0236f7f1ca41</Sha>
+      <Sha>3d5575cc9b110fd9e73ca77d75bf7a9c13e4fa86</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -147,7 +147,7 @@
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>5.0.0-rc.1.20420.3</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->
-    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20425.3</MicrosoftNETCoreRuntimeICUTransportVersion>
+    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20428.3</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -157,7 +157,7 @@ jobs:
       archType: wasm
       platform: Browser_wasm
       container:
-        image: ubuntu-18.04-webassembly-20200529220811-6a6da63
+        image: ubuntu-18.04-webassembly-20200827125937-9740252
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -62,8 +62,6 @@ jobs:
         - _subset: libs
         - _additionalBuildArguments: ''
         - ${{ parameters.variables }}
-        - ${{ if eq(parameters.osGroup, 'Browser') }}:
-          - EMSDK_PATH: /usr/local/emscripten
 
         # Tests only run for 'allConfiguration' and 'net48' build-jobs
         # If platform is in testBuildPlatforms we build tests as well.

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -68,8 +68,6 @@ jobs:
       - name: osOverride
         value: -os Android
     - ${{ if eq(parameters.osGroup, 'Browser') }}:
-      - name: EMSDK_PATH
-        value: /usr/local/emscripten
       - name: archType
         value: wasm
       - name: osOverride

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -25,7 +25,7 @@ all: build-native icu-data
 #  If EMSDK_PATH is not set by the caller, download and setup a local emsdk install.
 #
 
-EMSCRIPTEN_VERSION=1.39.16
+EMSCRIPTEN_VERSION=2.0.1
 EMSDK_LOCAL_PATH=emsdk
 EMCC=source $(EMSDK_PATH)/emsdk_env.sh && emcc
 
@@ -34,7 +34,7 @@ EMCC=source $(EMSDK_PATH)/emsdk_env.sh && emcc
 	git clone https://github.com/emscripten-core/emsdk.git $(EMSDK_LOCAL_PATH)
 	cd $(EMSDK_LOCAL_PATH) && git checkout $(EMSCRIPTEN_VERSION)
 	cd $(EMSDK_LOCAL_PATH) && ./emsdk install $(EMSCRIPTEN_VERSION)
-	cd $(EMSDK_LOCAL_PATH) && ./emsdk activate --embedded $(EMSCRIPTEN_VERSION)
+	cd $(EMSDK_LOCAL_PATH) && ./emsdk activate $(EMSCRIPTEN_VERSION)
 	touch $@
 
 ifeq ($(EMSDK_PATH),emsdk)


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/41509 to release/5.0

## Customer Impact

None, this updates the build toolchain.

## Testing

It's been tested manually and on CI in master.

## Risk

Low.