### PR TITLE
Add HTTP Request/Response Headers/Content Start/Stop events

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -91,21 +91,51 @@ namespace System.Net.Http
         }
 
         [Event(7, Level = EventLevel.Informational)]
-        public void ResponseHeadersBegin()
+        public void RequestHeadersStart()
         {
             WriteEvent(eventId: 7);
         }
 
         [Event(8, Level = EventLevel.Informational)]
-        public void ResponseContentStart()
+        public void RequestHeadersStop()
         {
             WriteEvent(eventId: 8);
         }
 
         [Event(9, Level = EventLevel.Informational)]
-        public void ResponseContentStop()
+        public void RequestContentStart()
         {
             WriteEvent(eventId: 9);
+        }
+
+        [Event(10, Level = EventLevel.Informational)]
+        public void RequestContentStop(long contentLength)
+        {
+            WriteEvent(eventId: 10, contentLength);
+        }
+
+        [Event(11, Level = EventLevel.Informational)]
+        public void ResponseHeadersStart()
+        {
+            WriteEvent(eventId: 11);
+        }
+
+        [Event(12, Level = EventLevel.Informational)]
+        public void ResponseHeadersStop()
+        {
+            WriteEvent(eventId: 12);
+        }
+
+        [Event(13, Level = EventLevel.Informational)]
+        public void ResponseContentStart()
+        {
+            WriteEvent(eventId: 13);
+        }
+
+        [Event(14, Level = EventLevel.Informational)]
+        public void ResponseContentStop()
+        {
+            WriteEvent(eventId: 14);
         }
 
         [NonEvent]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
@@ -19,6 +19,8 @@ namespace System.Net.Http
 
             public override void Write(ReadOnlySpan<byte> buffer)
             {
+                BytesWritten += buffer.Length;
+
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
 
@@ -39,6 +41,8 @@ namespace System.Net.Http
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ignored)
             {
+                BytesWritten += buffer.Length;
+
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -17,6 +17,8 @@ namespace System.Net.Http
 
             public override void Write(ReadOnlySpan<byte> buffer)
             {
+                BytesWritten += buffer.Length;
+
                 // Have the connection write the data, skipping the buffer. Importantly, this will
                 // force a flush of anything already in the buffer, i.e. any remaining request headers
                 // that are still buffered.
@@ -27,6 +29,8 @@ namespace System.Net.Http
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ignored) // token ignored as it comes from SendAsync
             {
+                BytesWritten += buffer.Length;
+
                 // Have the connection write the data, skipping the buffer. Importantly, this will
                 // force a flush of anything already in the buffer, i.e. any remaining request headers
                 // that are still buffered.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1354,6 +1354,8 @@ namespace System.Net.Http
             ArrayBuffer headerBuffer = default;
             try
             {
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestHeadersStart();
+
                 // Serialize headers to a temporary buffer, and do as much work to prepare to send the headers as we can
                 // before taking the write lock.
                 headerBuffer = new ArrayBuffer(InitialConnectionBufferSize, usePool: true);
@@ -1434,6 +1436,9 @@ namespace System.Net.Http
 
                     return s.mustFlush || s.endStream;
                 }, cancellationToken).ConfigureAwait(false);
+
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestHeadersStop();
+
                 return http2Stream;
             }
             catch

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
@@ -12,6 +12,8 @@ namespace System.Net.Http
     {
         private abstract class HttpContentWriteStream : HttpContentStream
         {
+            public long BytesWritten { get; protected set; }
+
             public HttpContentWriteStream(HttpConnection connection) : base(connection) =>
                 Debug.Assert(connection != null);
 


### PR DESCRIPTION
- Removed (renamed) `ResponseHeadersBegin`
- Added `RequestHeadersStart`, `RequestHeadersStop`
- Added `RequestContentStart`, `RequestContentStop(long contentLength)`
- Added `ResponseHeadersStart`, `ResponseHeadersStop`