### PR TITLE
[release/5.0] Http telemetry changes backport

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -91,21 +91,51 @@ namespace System.Net.Http
         }
 
         [Event(7, Level = EventLevel.Informational)]
-        public void ResponseHeadersBegin()
+        public void RequestHeadersStart()
         {
             WriteEvent(eventId: 7);
         }
 
         [Event(8, Level = EventLevel.Informational)]
-        public void ResponseContentStart()
+        public void RequestHeadersStop()
         {
             WriteEvent(eventId: 8);
         }
 
         [Event(9, Level = EventLevel.Informational)]
-        public void ResponseContentStop()
+        public void RequestContentStart()
         {
             WriteEvent(eventId: 9);
+        }
+
+        [Event(10, Level = EventLevel.Informational)]
+        public void RequestContentStop(long contentLength)
+        {
+            WriteEvent(eventId: 10, contentLength);
+        }
+
+        [Event(11, Level = EventLevel.Informational)]
+        public void ResponseHeadersStart()
+        {
+            WriteEvent(eventId: 11);
+        }
+
+        [Event(12, Level = EventLevel.Informational)]
+        public void ResponseHeadersStop()
+        {
+            WriteEvent(eventId: 12);
+        }
+
+        [Event(13, Level = EventLevel.Informational)]
+        public void ResponseContentStart()
+        {
+            WriteEvent(eventId: 13);
+        }
+
+        [Event(14, Level = EventLevel.Informational)]
+        public void ResponseContentStop()
+        {
+            WriteEvent(eventId: 14);
         }
 
         [NonEvent]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
@@ -19,6 +19,8 @@ namespace System.Net.Http
 
             public override void Write(ReadOnlySpan<byte> buffer)
             {
+                BytesWritten += buffer.Length;
+
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
 
@@ -39,6 +41,8 @@ namespace System.Net.Http
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ignored)
             {
+                BytesWritten += buffer.Length;
+
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -17,6 +17,8 @@ namespace System.Net.Http
 
             public override void Write(ReadOnlySpan<byte> buffer)
             {
+                BytesWritten += buffer.Length;
+
                 // Have the connection write the data, skipping the buffer. Importantly, this will
                 // force a flush of anything already in the buffer, i.e. any remaining request headers
                 // that are still buffered.
@@ -27,6 +29,8 @@ namespace System.Net.Http
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ignored) // token ignored as it comes from SendAsync
             {
+                BytesWritten += buffer.Length;
+
                 // Have the connection write the data, skipping the buffer. Importantly, this will
                 // force a flush of anything already in the buffer, i.e. any remaining request headers
                 // that are still buffered.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1354,6 +1354,8 @@ namespace System.Net.Http
             ArrayBuffer headerBuffer = default;
             try
             {
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestHeadersStart();
+
                 // Serialize headers to a temporary buffer, and do as much work to prepare to send the headers as we can
                 // before taking the write lock.
                 headerBuffer = new ArrayBuffer(InitialConnectionBufferSize, usePool: true);
@@ -1434,6 +1436,9 @@ namespace System.Net.Http
 
                     return s.mustFlush || s.endStream;
                 }, cancellationToken).ConfigureAwait(false);
+
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestHeadersStop();
+
                 return http2Stream;
             }
             catch

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -351,12 +351,6 @@ namespace System.Net.Http
                     w.Dispose();
                     _creditWaiter = null;
                 }
-
-                if (HttpTelemetry.Log.IsEnabled())
-                {
-                    bool aborted = _requestCompletionState == StreamCompletionState.Failed || _responseCompletionState == StreamCompletionState.Failed;
-                    _request.OnStopped(aborted);
-                }
             }
 
             private void Cancel()
@@ -391,8 +385,6 @@ namespace System.Net.Http
                 {
                     _waitSource.SetResult(true);
                 }
-
-                if (HttpTelemetry.Log.IsEnabled()) _request.OnAborted();
             }
 
             // Returns whether the waiter should be signalled or not.
@@ -1154,10 +1146,6 @@ namespace System.Net.Http
                 if (!fullyConsumed)
                 {
                     Cancel();
-                }
-                else
-                {
-                    _request.OnStopped();
                 }
 
                 _responseBuffer.Dispose();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -120,8 +120,6 @@ namespace System.Net.Http
 
                 _pool.DecrementConnectionCount();
 
-                if (HttpTelemetry.Log.IsEnabled()) _currentRequest?.OnAborted();
-
                 if (disposing)
                 {
                     GC.SuppressFinalize(this);
@@ -1871,8 +1869,6 @@ namespace System.Net.Http
         {
             Debug.Assert(_currentRequest != null, "Expected the connection to be associated with a request.");
             Debug.Assert(_writeOffset == 0, "Everything in write buffer should have been flushed.");
-
-            if (HttpTelemetry.Log.IsEnabled()) _currentRequest.OnStopped();
 
             // Disassociate the connection from a request.
             _currentRequest = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
@@ -12,6 +12,8 @@ namespace System.Net.Http
     {
         private abstract class HttpContentWriteStream : HttpContentStream
         {
+            public long BytesWritten { get; protected set; }
+
             public HttpContentWriteStream(HttpConnection connection) : base(connection) =>
                 Debug.Assert(connection != null);
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -327,12 +327,12 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public void GetAsync_CustomException_Synchronous_ThrowsException()
+        public async Task GetAsync_CustomException_Synchronous_ThrowsException()
         {
             var e = new FormatException();
             using (var client = new HttpClient(new CustomResponseHandler((r, c) => { throw e; })))
             {
-                FormatException thrown = Assert.Throws<FormatException>(() => { client.GetAsync(CreateFakeUri()); });
+                FormatException thrown = await Assert.ThrowsAsync<FormatException>(() => client.GetAsync(CreateFakeUri()));
                 Assert.Same(e, thrown);
             }
         }

--- a/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
@@ -9,8 +9,14 @@ namespace System.Net.Http
 
         public bool IsEnabled() => false;
 
+        public void RequestStart(HttpRequestMessage request) { }
+
         public void RequestStop() { }
 
-        public void RequestAborted() { }
+        public void RequestFailed() { }
+
+        public void ResponseContentStart() { }
+
+        public void ResponseContentStop() { }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetSecurityTelemetry.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetSecurityTelemetry.cs
@@ -133,7 +133,7 @@ namespace System.Net.Security
         }
 
         [Event(2, Level = EventLevel.Informational)]
-        private void HandshakeStop(string protocol)
+        private void HandshakeStop(SslProtocols protocol)
         {
             if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
@@ -159,7 +159,7 @@ namespace System.Net.Security
                 HandshakeFailed(isServer, stopwatch.GetElapsedTime().TotalMilliseconds, exceptionMessage);
             }
 
-            HandshakeStop(protocol: string.Empty);
+            HandshakeStop(SslProtocols.None);
         }
 
         [NonEvent]
@@ -206,10 +206,7 @@ namespace System.Net.Security
             handshakeDurationCounter?.WriteMetric(duration);
             _handshakeDurationCounter!.WriteMetric(duration);
 
-            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
-            {
-                HandshakeStop(protocol.ToString());
-            }
+            HandshakeStop(protocol);
         }
 
         [NonEvent]
@@ -268,6 +265,21 @@ namespace System.Net.Security
 
                     WriteEventCore(eventId, NumEventDatas, descrs);
                 }
+            }
+        }
+
+        [NonEvent]
+        private unsafe void WriteEvent(int eventId, SslProtocols arg1)
+        {
+            if (IsEnabled())
+            {
+                var data = new EventData
+                {
+                    DataPointer = (IntPtr)(&arg1),
+                    Size = sizeof(SslProtocols)
+                };
+
+                WriteEventCore(eventId, eventDataCount: 1, &data);
             }
         }
 


### PR DESCRIPTION
Joint changes of 3 related PRs: #41527, #41022, #41590 (they depend on each other, therefore they are merged in the port)

## Customer Impact

Http telemetry: Request Start/Stop events don't properly correlate, which makes the end-to-end tracing impossible to use.
#41022 fixed that issue by moving the relevant telemetry instrumentation into `HttpClient` & `HttpMessageInvoker`.

The PR also adds more events that can provide more fine-grained insight into the lifetime of requests -- result of end-to-end validation and comparison with other stack:
- `RequestHeadersStart/Stop`
- `RequestContentStart/Stop`
- `ResponseHeadersStart/Stop`
- `ResponseContentStart/Stop`

`RequestAborted` event and counter were renamed to `RequestFailed` to align with naming of other `*Failed` events and to reflect their real purpose -- i.e. `RequestFailed` includes also non-successful HTTP response status codes (not quite an abort of request).

The PR further merges several event patterns together into parameterized HTTP version to avoid duplication (motivated by end-to-end validation feedback), for example:
`Http11ConnectionEstablished` and `Http20ConnectionEstablished` are merged into `ConnectionEstablished(version)`.

## Testing

- Added a significant amount of testing to ensure the proper events and counters are emitted as part of this change.
- There are a lot of existing tests covering `HttpClient` behavior in CI.
- End-to-end manual validation in PerfView and using in-proc `EventListener`.

## Risk

- **Small** - There is minimal impact on non-Telemetry code path, because the change just shifts around code in `HttpClient`, but the changes are mostly copy/paste indentation changes (scope changes like including code in `try-catch` block, etc.).
- Telemetry code paths are brand new - added during 5.0 (end of June), not yet consumed by any customers (beyond potentially early experimentation)