### PR TITLE
[debugger][wasm] Fix exception on _filter_automatic_properties

### DIFF
--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -386,6 +386,10 @@ var MonoSupportLib = {
 
 			for (var i in props) {
 				var p = props [i];
+
+				if (p.name == null)
+					continue;
+					
 				if (p.name in names_found)
 					continue;
 


### PR DESCRIPTION
Fixing exception found while testing locally Blazor with .net 5.0.
I executed the StandaloneApp and put a breakpoint on `counter++`, when it breaks I tried to walk thought the stack and when I click on `InvokeAsync` from `EventCallback.cs` this exception was threw. 