### PR TITLE
Fix palsuite build

### DIFF
--- a/src/coreclr/src/pal/inc/pal.h
+++ b/src/coreclr/src/pal/inc/pal.h
@@ -376,7 +376,7 @@ PALIMPORT
 DWORD
 PALAPI
 PAL_InitializeCoreCLR(
-    const char *szExePath, bool runningInExe);
+    const char *szExePath, BOOL runningInExe);
 
 /// <summary>
 /// This function shuts down PAL WITHOUT exiting the current process.

--- a/src/coreclr/src/pal/src/init/pal.cpp
+++ b/src/coreclr/src/pal/src/init/pal.cpp
@@ -796,7 +796,7 @@ Return:
 --*/
 PAL_ERROR
 PALAPI
-PAL_InitializeCoreCLR(const char *szExePath, bool runningInExe)
+PAL_InitializeCoreCLR(const char *szExePath, BOOL runningInExe)
 {
     g_running_in_exe = runningInExe;
 

--- a/src/coreclr/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
+++ b/src/coreclr/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
@@ -19,7 +19,7 @@ set(EXPORTS_FILE1 ${CMAKE_CURRENT_BINARY_DIR}/dlltest1.exports)
 generate_exports_file(${DEF_SOURCES1} ${EXPORTS_FILE1})
 
 if(CLR_CMAKE_HOST_UNIX)
-  set_exports_linker_option(${EXPORTS_FILE})
+  set_exports_linker_option(${EXPORTS_FILE1})
 endif(CLR_CMAKE_HOST_UNIX)
 
 set(DLL1SOURCES dlltest1.cpp)


### PR DESCRIPTION
Error 1
```sh
   CMake Error at src/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt:22 (set_exports_linker_option):
    set_exports_linker_option Function invoked with incorrect arguments for
    function named: set_exports_linker_option
```
Error 2
```sh
  [ 23%] Building CXX object src/vm/wks/CMakeFiles/cee_wks_core.dir/__/debugdebugger.cpp.o
  In file included from /Users/am11/projects/runtime_base/src/coreclr/src/pal/tests/palsuite/c_runtime/acosf/test1/test1.c:17:
  In file included from /Users/am11/projects/runtime_base/src/coreclr/src/pal/tests/palsuite/common/palsuite.h:24:
  /Users/am11/projects/runtime_base/src/coreclr/src/pal/inc/pal.h:379:28: error: unknown type name 'bool'
      const char *szExePath, bool runningInExe);
                             ^
  1 error generated.
```
cc @janvorli 