### PR TITLE
Microsoft.Extensions.Internal.Transport and System.Numerics.tensors are not stable shipping packages

### DIFF
--- a/src/libraries/System.Numerics.Tensors/Directory.Build.props
+++ b/src/libraries/System.Numerics.Tensors/Directory.Build.props
@@ -2,8 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <!-- This is a preview package. Do not mark as stable. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <IsShippingAssembly>false</IsShippingAssembly>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 </Project>

--- a/src/libraries/pkg/Microsoft.Extensions.Internal.Transport/Microsoft.Extensions.Internal.Transport.pkgproj
+++ b/src/libraries/pkg/Microsoft.Extensions.Internal.Transport/Microsoft.Extensions.Internal.Transport.pkgproj
@@ -4,6 +4,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
     <HarvestStablePackage>false</HarvestStablePackage>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
   <ItemGroup>
     <_libDocs Include="$(ASPNETCoreAppPackageRuntimePath)\*.xml" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/41560