### PR TITLE
Block casting to an interface marked ComInterfaceType.InterfaceIsIInspectable

### DIFF
--- a/src/coreclr/src/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/src/vm/runtimecallablewrapper.cpp
@@ -2633,6 +2633,11 @@ BOOL ComObject::SupportsInterface(OBJECTREF oref, MethodTable* pIntfTable)
     // Make sure the interface method table has been restored.
     pIntfTable->CheckRestore();
 
+    if (pIntfTable->GetComInterfaceType() == ifInspectable)
+    {
+        COMPlusThrow(kPlatformNotSupportedException, IDS_EE_NO_IINSPECTABLE);
+    }
+
     // Check to see if the static class definition indicates we implement the interface.
     MethodTable *pMT = oref->GetMethodTable();
     if (pMT->CanCastToInterface(pIntfTable))

--- a/src/tests/Interop/COM/NETClients/IInspectable/App.manifest
+++ b/src/tests/Interop/COM/NETClients/IInspectable/App.manifest
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity
+    type="win32" 
+    name="NetPrimitivesIDispatch"
+    version="1.0.0.0" />
+
+  <dependency>
+    <dependentAssembly>
+      <!-- RegFree COM -->
+      <assemblyIdentity
+          type="win32"
+          name="COMNativeServer.X"
+          version="1.0.0.0"/>
+    </dependentAssembly>
+  </dependency>
+
+</assembly>

--- a/src/tests/Interop/COM/NETClients/IInspectable/App.manifest
+++ b/src/tests/Interop/COM/NETClients/IInspectable/App.manifest
@@ -2,7 +2,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity
     type="win32" 
-    name="NetPrimitivesIDispatch"
+    name="NetPrimitivesIInspectable"
     version="1.0.0.0" />
 
   <dependency>

--- a/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
+++ b/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ApplicationManifest>App.manifest</ApplicationManifest>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
+    <!-- Test unsupported outside of windows -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="../../ServerContracts/Server.CoClasses.cs" />
+    <Compile Include="../../ServerContracts/Server.Contracts.cs" />
+    <Compile Include="../../ServerContracts/ServerGuids.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace NetClient
+{
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+
+    using TestLibrary;
+    using Server.Contract;
+    using Server.Contract.Servers;
+
+    class Program
+    {
+        static void Validate_IInspectable()
+        {
+            var server = (InspectableTesting)new InspectableTestingClass();
+            Assert.Throws<PlatformNotSupportedException>(() => _ = (IInspectableTesting2)server);
+        }
+
+        static int Main(string[] doNotUse)
+        {
+            // RegFree COM is not supported on Windows Nano
+            if (Utilities.IsWindowsNanoServer)
+            {
+                return 100;
+            }
+
+            try
+            {
+                Validate_IInspectable();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Test Failure: {e}");
+                return 101;
+            }
+
+            return 100;
+        }
+    }
+}

--- a/src/tests/Interop/COM/NativeServer/COMNativeServer.X.manifest
+++ b/src/tests/Interop/COM/NativeServer/COMNativeServer.X.manifest
@@ -51,6 +51,11 @@
   <comClass
     clsid="{66DB7882-E2B0-471D-92C7-B2B52A0EA535}"
     threadingModel="Both" />
+
+  <!-- InspectableTesting -->
+  <comClass
+    clsid="{CE137261-6F19-44F5-A449-EF963B3F987E}"
+    threadingModel="Both" />
 </file>
 
 </assembly>

--- a/src/tests/Interop/COM/NativeServer/InspectableTesting.h
+++ b/src/tests/Interop/COM/NativeServer/InspectableTesting.h
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "Servers.h"
+
+class InspectableTesting : public UnknownImpl, public IInspectableTesting, public IInspectableTesting2
+{
+public: // IInspectableTesting2
+    DEF_FUNC(Add)(
+        /*[in]*/ int a,
+        /*[in]*/ int b,
+        /*[out] [retval] */ int* retVal)
+    {
+        *retVal = a + b;
+        return S_OK;
+    }
+
+public: // IInspectable
+    STDMETHOD(GetIids)( 
+        /* [out] */ ULONG *iidCount,
+        /* [size_is][size_is][out] */ IID **iids)
+    {
+        return E_NOTIMPL;
+    }
+        
+    STDMETHOD(GetRuntimeClassName)( 
+        /* [out] */ HSTRING *className)
+    {
+        className = nullptr;
+        return S_OK;
+    }
+    
+    STDMETHOD(GetTrustLevel)( 
+        /* [out] */ TrustLevel *trustLevel)
+    {
+        *trustLevel = TrustLevel::FullTrust;
+        return S_OK;
+    }
+
+public: // IUnknown
+    STDMETHOD(QueryInterface)(
+        /* [in] */ REFIID riid,
+        /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
+    {
+        return DoQueryInterface(riid, ppvObject, static_cast<IInspectableTesting *>(this), static_cast<IInspectableTesting2 *>(this), static_cast<IInspectable*>(this));
+    }
+
+    DEFINE_REF_COUNTING();
+};

--- a/src/tests/Interop/COM/NativeServer/Servers.cpp
+++ b/src/tests/Interop/COM/NativeServer/Servers.cpp
@@ -167,6 +167,7 @@ STDAPI DllRegisterServer(void)
     RETURN_IF_FAILED(RegisterClsid(__uuidof(EventTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(AggregationTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(ColorTesting), L"Both"));
+    RETURN_IF_FAILED(RegisterClsid(__uuidof(InspectableTesting), L"Both"));
 
     return S_OK;
 }
@@ -183,6 +184,7 @@ STDAPI DllUnregisterServer(void)
     RETURN_IF_FAILED(RemoveClsid(__uuidof(EventTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(AggregationTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(ColorTesting)));
+    RETURN_IF_FAILED(RemoveClsid(__uuidof(InspectableTesting)));
 
     return S_OK;
 }
@@ -215,6 +217,9 @@ STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Out_ LPVOID FA
 
     if (rclsid == __uuidof(LicenseTesting))
         return ClassFactoryLicense<LicenseTesting>::Create(riid, ppv);
+
+    if (rclsid == __uuidof(InspectableTesting))
+        return ClassFactoryBasic<InspectableTesting>::Create(riid, ppv);
 
     return CLASS_E_CLASSNOTAVAILABLE;
 }

--- a/src/tests/Interop/COM/NativeServer/Servers.h
+++ b/src/tests/Interop/COM/NativeServer/Servers.h
@@ -19,6 +19,7 @@ class DECLSPEC_UUID("4CEFE36D-F377-4B6E-8C34-819A8BB9CB04") AggregationTesting;
 class DECLSPEC_UUID("C222F472-DA5A-4FC6-9321-92F4F7053A65") ColorTesting;
 class DECLSPEC_UUID("66DB7882-E2B0-471D-92C7-B2B52A0EA535") LicenseTesting;
 class DECLSPEC_UUID("FAEF42AE-C1A4-419F-A912-B768AC2679EA") DefaultInterfaceTesting;
+class DECLSPEC_UUID("CE137261-6F19-44F5-A449-EF963B3F987E") InspectableTesting;
 
 #define CLSID_NumericTesting __uuidof(NumericTesting)
 #define CLSID_ArrayTesting __uuidof(ArrayTesting)
@@ -30,6 +31,7 @@ class DECLSPEC_UUID("FAEF42AE-C1A4-419F-A912-B768AC2679EA") DefaultInterfaceTest
 #define CLSID_ColorTesting __uuidof(ColorTesting)
 #define CLSID_LicenseTesting __uuidof(LicenseTesting)
 #define CLSID_DefaultInterfaceTesting __uuidof(DefaultInterfaceTesting)
+#define CLSID_InspectableTesting __uidof(InspectableTesting)
 
 #define IID_INumericTesting __uuidof(INumericTesting)
 #define IID_IArrayTesting __uuidof(IArrayTesting)
@@ -43,6 +45,8 @@ class DECLSPEC_UUID("FAEF42AE-C1A4-419F-A912-B768AC2679EA") DefaultInterfaceTest
 #define IID_ILicenseTesting __uuidof(ILicenseTesting)
 #define IID_IDefaultInterfaceTesting __uuidof(IDefaultInterfaceTesting)
 #define IID_IDefaultInterfaceTesting2 __uuidof(IDefaultInterfaceTesting2)
+#define IID_IInspectableTesting __uuidof(IInspectableTesting)
+#define IID_IInspectableTesting2 __uuidof(IInspectableTesting2)
 
 // Class used for COM activation when using CoreShim
 struct CoreShimComActivation
@@ -81,4 +85,5 @@ private:
     #include "AggregationTesting.h"
     #include "ColorTesting.h"
     #include "LicenseTesting.h"
+    #include "InspectableTesting.h"
 #endif

--- a/src/tests/Interop/COM/ServerContracts/Server.CoClasses.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.CoClasses.cs
@@ -207,6 +207,19 @@ namespace Server.Contract.Servers
     internal class ConsumeNETServerTestingClass
     {
     }
+
+    [ComImport]
+    [CoClass(typeof(InspectableTestingClass))]
+    [Guid("3021236a-2a9e-4a29-bf14-533842c55262")]
+    internal interface InspectableTesting : Server.Contract.IInspectableTesting
+    {
+    }
+
+    [ComImport]
+    [Guid(Server.Contract.Guids.InspectableTesting)]
+    internal class InspectableTestingClass
+    {
+    }
 }
 
 #pragma warning restore 618 // Must test deprecated features

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -324,6 +324,22 @@ namespace Server.Contract
         bool EqualByCCW(object obj);
         bool NotEqualByRCW(object obj);
     }
+
+    [ComVisible(true)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("3021236a-2a9e-4a29-bf14-533842c55262")]
+    internal interface IInspectableTesting
+    {
+        int Add(int i, int j);
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIInspectable)]
+    [Guid("e9e1ccf9-8e93-4850-ac1c-a71692cb68c5")]
+    internal interface IInspectableTesting2
+    {
+        int Add(int i, int j);
+    }
 }
 
 #pragma warning restore 618 // Must test deprecated features

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -330,7 +330,6 @@ namespace Server.Contract
     [Guid("3021236a-2a9e-4a29-bf14-533842c55262")]
     internal interface IInspectableTesting
     {
-        int Add(int i, int j);
     }
 
     [ComImport]

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -4,6 +4,7 @@
 #pragma pack(push, 8)
 
 #include <comdef.h>
+#include <inspectable.h>
 
 struct HFA_4
 {
@@ -484,6 +485,17 @@ struct __declspec(uuid("9B3CE792-F063-427D-B48E-4354094BF7A0"))
 IDefaultInterfaceTesting2 : IUnknown
 {
     // Empty
+};
+
+struct __declspec(uuid("3021236a-2a9e-4a29-bf14-533842c55262"))
+IInspectableTesting : IUnknown
+{
+};
+
+struct __declspec(uuid("e9e1ccf9-8e93-4850-ac1c-a71692cb68c5"))
+IInspectableTesting2 : IInspectable
+{
+    virtual HRESULT STDMETHODCALLTYPE Add(_In_ int i, _In_ int j, _Out_ _Ret_ int* retVal) = 0;
 };
 
 #pragma pack(pop)

--- a/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
+++ b/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
@@ -19,5 +19,6 @@ namespace Server.Contract
         public const string LicenseTesting = "66DB7882-E2B0-471D-92C7-B2B52A0EA535";
         public const string DefaultInterfaceTesting = "FAEF42AE-C1A4-419F-A912-B768AC2679EA";
         public const string ConsumeNETServerTesting = "DE4ACF53-5957-4D31-8BE2-EA6C80683246";
+        public const string InspectableTesting = "CE137261-6F19-44F5-A449-EF963B3F987E";
     }
 }


### PR DESCRIPTION
During the cast path, nothing checks if an interface is an IInspectable interface. This PR adds that check to ensure that we block usage of ComInterfaceType.InterfaceIsIInspectable now that WinRT support is removed.

Fixes #41621 