### PR TITLE
Add docs link to editing-and-debugging

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -40,6 +40,10 @@ On Unix like systems, arguments can be passed in with a single `-` or double hyp
 The repository currently consists of different major parts: the runtimes, the libraries, and the installer.
 To build just one part you use the root build script (build.cmd/sh), and you add the `-subset` flag.
 
+## Editing and Debugging
+
+For instructions on how to edit code and debug your changes, see [Editing and Debugging](editing-and-debugging.md).
+
 ## Configurations
 
 You may need to build the tree in a combination of configurations. This section explains why.

--- a/docs/workflow/editing-and-debugging.md
+++ b/docs/workflow/editing-and-debugging.md
@@ -31,7 +31,7 @@ what are in the repository. In particular
 Thus opening one of these two solution files (double clicking on them in Explorer) is typically all you need
 to do most editing.
 
-Notice that the CoreCLR solution is under the 'bin' directory.  This is because it is created as part of the build.
+Notice that the CoreCLR solution is under the `artifacts` directory.  This is because it is created as part of the build.
 Thus you can only launch this solution after you have built at least once.
 
 * See [Debugging CoreCLR](debugging/coreclr/debugging.md)


### PR DESCRIPTION
We were missing a link to the Editing and Debugging doc from the main workflow doc.