### PR TITLE
Fix infinite recursion in configuration manager

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
@@ -725,7 +725,9 @@ namespace System.Configuration
                     }
                 }
 
-                object temp = base[propertyName];
+                // we query the value first so that we initialize all values from value providers and so that we don't end up
+                // on an infinite recursion when calling Properties[propertyName] as that calls this.
+                object _ = base[propertyName];
                 SettingsProperty setting = Properties[propertyName];
                 SettingsProvider provider = setting != null ? setting.Provider : null;
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
@@ -725,6 +725,7 @@ namespace System.Configuration
                     }
                 }
 
+                object temp = base[propertyName];
                 SettingsProperty setting = Properties[propertyName];
                 SettingsProvider provider = setting != null ? setting.Provider : null;
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
@@ -727,7 +727,7 @@ namespace System.Configuration
 
                 // we query the value first so that we initialize all values from value providers and so that we don't end up
                 // on an infinite recursion when calling Properties[propertyName] as that calls this.
-                object _ = base[propertyName];
+                _ = base[propertyName];
                 SettingsProperty setting = Properties[propertyName];
                 SettingsProvider provider = setting != null ? setting.Provider : null;
 


### PR DESCRIPTION
This was introduced by: https://github.com/dotnet/runtime/pull/40583
Fixes: https://github.com/dotnet/runtime/issues/41496

I confirmed that the test I'm adding if we remove this property I get a repro of the infinite recursion.