### PR TITLE
Include CrossOs diagnostic assets for signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -104,6 +104,11 @@
       <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
       <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
 
+      <!-- The cross OS diagnostics symbol packages need to be signed as they are the only packages
+      that have a specific version of assets that are only meant to be indexed in symbol servers.
+      Since only *symbols.nupkg get indexed, and Core-Setup doesn't produce these, we need to glob them for signing. -->
+      <ItemsToSign Include="$(DownloadDirectory)**\*CrossOsDiag*" />
+
       <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
       <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
     </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -106,7 +106,7 @@
 
       <!-- The cross OS diagnostics symbol packages need to be signed as they are the only packages
       that have a specific version of assets that are only meant to be indexed in symbol servers.
-      Since only *symbols.nupkg get indexed, and Core-Setup doesn't produce these, we need to glob them for signing. -->
+      Since only *symbols.nupkg get indexed, and installer doesn't produce these, we need to glob them for signing. -->
       <ItemsToSign Include="$(DownloadDirectory)**\*CrossOsDiag*" />
 
       <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -107,7 +107,7 @@
       <!-- The cross OS diagnostics symbol packages need to be signed as they are the only packages
       that have a specific version of assets that are only meant to be indexed in symbol servers.
       Since only *symbols.nupkg get indexed, and installer doesn't produce these, we need to glob them for signing. -->
-      <ItemsToSign Include="$(DownloadDirectory)**\*CrossOsDiag*" />
+      <ItemsToSign Include="$(DownloadDirectory)**\*CrossOsDiag*.symbols.nupkg" />
 
       <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
       <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />


### PR DESCRIPTION
These assets were not getting signed. Usually we need this signed as we need to run this is trusted scenarios.