### PR TITLE
free existingTrust when verifying certificate name on macOS

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -449,7 +449,6 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
                 osStatus = SecTrustEvaluate(trust, &trustResult);
             }
         }
-
 #pragma clang diagnostic pop
 
         if (osStatus == noErr && trustResult != kSecTrustResultUnspecified && trustResult != kSecTrustResultProceed)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -449,6 +449,7 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
                 osStatus = SecTrustEvaluate(trust, &trustResult);
             }
         }
+
 #pragma clang diagnostic pop
 
         if (osStatus == noErr && trustResult != kSecTrustResultUnspecified && trustResult != kSecTrustResultProceed)
@@ -512,6 +513,9 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
 
     if (anchors != NULL)
         CFRelease(anchors);
+
+    if (existingTrust != NULL)
+        CFRelease(existingTrust);
 
     CFRelease(sslPolicy);
     return ret;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -392,6 +392,7 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
     if (anchors == NULL)
     {
         CFRelease(certs);
+        CFRelease(existingTrust);
         return -6;
     }
 


### PR DESCRIPTION
I put that off since native C code also showed memory grow. However, the `leaks` utility showed no leak with native app (probably some memory still referenced or memory fragmentation) but it was showing for the c# repro code:
```
Process 47514: 44 leaks for 6528 total leaked bytes.

STACK OF 1 INSTANCE OF 'ROOT LEAK: <SecTrust>':
43  libdyld.dylib                      0x7fff7047dcc9 start + 1
42  sslLeak                               0x10155de5f main + 143
41  sslLeak                               0x10155db57 exe_start(int, char const**) + 1831
40  libhostfxr.dylib                      0x1016ae82a hostfxr_main_startupinfo + 138
39  libhostfxr.dylib                      0x1016b0e43 fx_muxer_t::execute(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int, char const**, host_startup_info_t const&, char*, int, int*) + 611
38  libhostfxr.dylib                      0x1016b1cdb fx_muxer_t::handle_exec_host_command(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, host_startup_info_t const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::unordered_map<known_options, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >, known_options_hash, std::__1::equal_to<known_options>, std::__1::allocator<std::__1::pair<known_options const, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > > > > const&, int, char const**, int, host_mode_t, char*, int, int*) + 1259
37  libhostpolicy.dylib                   0x10171e79f corehost_main + 303
36  libhostpolicy.dylib                   0x10171d653 run_app_for_context(hostpolicy_context_t const&, int, char const**) + 1443
35  libcoreclr.dylib                      0x1017b54a2 coreclr_execute_assembly + 242
34  libcoreclr.dylib                      0x101876a5d CorHost2::ExecuteAssembly(unsigned int, char16_t const*, int, char16_t const**, unsigned int*) + 509
33  libcoreclr.dylib                      0x101833ab3 Assembly::ExecuteMainMethod(PtrArray**, int) + 387
32  libcoreclr.dylib                      0x1018337aa RunMain(MethodDesc*, short, int*, PtrArray**) + 714
31  libcoreclr.dylib                      0x10195b57f MethodDescCallSite::CallTargetWorker(unsigned long const*, unsigned long*, int) + 1519
30  libcoreclr.dylib                      0x101afed87 CallDescrWorkerInternal + 124
29  ???                                   0x1105c02fd 0x7fffffffffffffff + 9223372041424208638
28  ???                                   0x1105cb95f 0x7fffffffffffffff + 9223372041424255328
27  ???                                   0x110abd359 0x7fffffffffffffff + 9223372041429439322
26  ???                                   0x110abd3c5 0x7fffffffffffffff + 9223372041429439430
25  ???                                   0x110abf769 0x7fffffffffffffff + 9223372041429448554
24  ???                                   0x110ac1128 0x7fffffffffffffff + 9223372041429455145
23  ???                                   0x1105d423b 0x7fffffffffffffff + 9223372041424290364
22  ???                                   0x1105d46e4 0x7fffffffffffffff + 9223372041424291557
21  ???                                   0x110ae4416 0x7fffffffffffffff + 9223372041429599255
20  ???                                   0x110ac14e0 0x7fffffffffffffff + 9223372041429456097
19  ???                                   0x1105d865f 0x7fffffffffffffff + 9223372041424307808
18  ???                                   0x1105d8704 0x7fffffffffffffff + 9223372041424307973
17  ???                                   0x110ae825f 0x7fffffffffffffff + 9223372041429615200
16  ???                                   0x110abfac2 0x7fffffffffffffff + 9223372041429449411
15  ???                                   0x110ac843a 0x7fffffffffffffff + 9223372041429484603
14  ???                                   0x110ac87e5 0x7fffffffffffffff + 9223372041429485542
13  ???                                   0x110ae2a26 0x7fffffffffffffff + 9223372041429592615
12  ???                                   0x110ae2b43 0x7fffffffffffffff + 9223372041429592900
11  ???                                   0x1105d7193 0x7fffffffffffffff + 9223372041424302484
10  libSystem.Security.Cryptography.Native.Apple.dylib        0x1015b40ec AppleCryptoNative_SslHandshake + 44  pal_ssl.c:262
9   com.apple.security                 0x7fff42da5909 SSLHandshake + 185
8   com.apple.security                 0x7fff42da5a29 SSLHandshakeProceed + 185
7   libcoretls.dylib                   0x7fff6dabb999 tls_handshake_process + 85
6   libcoretls.dylib                   0x7fff6dabc0eb SSLProcessHandshakeRecordInner + 219
5   com.apple.security                 0x7fff42fc5dac tls_verify_peer_cert + 71
4   com.apple.security                 0x7fff42fc5cff sslCreateSecTrust + 47
3   libcoretls_cfhelpers.dylib         0x7fff6dace23e tls_helper_create_peer_trust + 222
2   com.apple.security                 0x7fff42d78f43 SecTrustCreateWithCertificates + 918
1   com.apple.CoreFoundation           0x7fff36402663 _CFRuntimeCreateInstance + 597
0   libsystem_malloc.dylib             0x7fff70633d9e malloc_zone_malloc + 140
====
    44 (6.38K) ROOT LEAK: <SecTrust 0x7fd436448c80> [144]
       12 (2.67K) <NSMutableArray 0x7fd436434480> [48]  item count: 1
          11 (2.62K) <NSMutableArray (Storage) 0x7fd43642fb10> [16]
             10 (2.61K) <SecCertificate 0x7fd4364273e0> [624]
                5 (1.00K) <SecCertificate 0x7fd436422220> [592]
                   1 (320 bytes) <Security::CssmClient::CLImpl 0x7fd436435ac0> [320]
                   2 (80 bytes) 0x7fd4364380a0 [64]
                      1 (16 bytes) 0x7fd436422470 [16]
                   1 (32 bytes) 0x7fd436421bb0 [32]
                1 (752 bytes) <CFData 0x7fd43641c0c0> [752]  inline content length 688: 0x308202AC30820194020900CB59CEBDCC509348300D06092A864886F70D01010B050..."
                1 (96 bytes) <CFData 0x7fd43641bee0> [96]  inline content length 18: 0x3110300E06035504030C0 "Furtojc"
                1 (96 bytes) <CFData 0x7fd43641e750> [96]  inline content length 30: 0x311C301A06035504030C1 "*.azurewebsites.net"
                1 (80 bytes) <CFData 0x7fd436427a40> [80]  inline content length 9: 0x00CB59CEBDCC509348
       6 (1.83K) <NSMutableArray 0x7fd42650a4e0> [48]  item count: 1
          5 (1.78K) <NSMutableArray (Storage) 0x7fd42650a620> [16]
             4 (1.77K) <SecCertificate 0x7fd42780a000> [1536]
                1 (96 bytes) <CFData 0x7fd42650a560> [96]  inline content length 18: 0x3110300E06035504030C0 "Furtojc"
                1 (96 bytes) <CFData 0x7fd42650a5c0> [96]  inline content length 30: 0x311C301A06035504030C1 "*.azurewebsites.net"
                1 (80 bytes) <CFData 0x7fd42650a510> [80]  inline content length 9: 0x00CB59CEBDCC509348
       15 (1.11K) <NSArray 0x7fd436442180> [16]
          14 (1.09K) __strong _object --> <SecPolicy 0x7fd436444da0> [48]
             13 (1.05K) <NSMutableDictionary 0x7fd43644bdf0> [32]  item count: 16
                12 (1.02K) <NSMutableDictionary (Storage) 0x7fd436439170> [368]
                   7 (480 bytes) <NSMutableArray 0x7fd436415660> [48]  item count: 5
                      6 (432 bytes) <NSMutableArray (Storage) 0x7fd43641a120> [48]
                         1 (80 bytes) <CFData 0x7fd436424720> [80]  inline content length 9: 0x6086480186F8420401
                         1 (80 bytes) <CFData 0x7fd436434010> [80]  inline content length 4: 0x551D2500
                         1 (80 bytes) <CFData 0x7fd436434510> [80]  inline content length 8: 0x2B06010505070301
                         1 (80 bytes) <CFData 0x7fd436443550> [80]  inline content length 10: 0x2B0601040182370A0303
                         1 (64 bytes) <CFData 0x7fd436439900> [64]  content length 0
                   2 (80 bytes) <NSMutableArray 0x7fd4364220f0> [48]  item count: 4
                      1 (32 bytes) <NSMutableArray (Storage) 0x7fd43644bb60> [32]
                   1 (64 bytes) <NSDictionary 0x7fd436427650> [64]  item count: 2
                   1 (48 bytes) <CFString 0x7fd43641f660> [48]  length: 16  "mytestdomain.com"
       8 (432 bytes) 0x7fd426509f20 [64]
          7 (368 bytes) 0x7fd42650a050 [48]
             6 (320 bytes) 0x7fd426509f60 [80]
                4 (208 bytes) 0x7fd426509fb0 [32]
                   1 (64 bytes) 0x7fd426509fd0 [64]
                   1 (64 bytes) 0x7fd42650a010 [64]
                   1 (48 bytes) 0x7fd4265090e0 [48]
                1 (32 bytes) 0x7fd426509c30 [32]
       1 (128 bytes) <OS_dispatch_queue_serial 0x7fd436425900> [128]  "trust" (from Security)
       1 (80 bytes) 0x7fd42650a110 [80]
``` 

after some digging I realized we are not freeing memory allocated by `SSLCopyPeerTrust()`.
With the change, the repro code no longer shows leak with `leaks` utility.  

fixes #34080

contributes to #37318. I'm hesitant to resolve it since there seems to be more issues with holding references to interesting objects.
