### PR TITLE
improve test dynamic certificate generation

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -16,19 +16,16 @@ namespace System.Net.Security.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
-    public class SslStreamNetworkStreamTest : IDisposable
+    public class SslStreamNetworkStreamTest
     {
-        private readonly X509Certificate2 _serverCert;
-        private readonly X509Certificate2Collection _serverChain;
+        private static readonly X509Certificate2 _serverCert;
+        private static readonly X509Certificate2Collection _serverChain;
 
-        public SslStreamNetworkStreamTest()
+        static SslStreamNetworkStreamTest()
         {
-            (_serverCert, _serverChain) = TestHelper.GenerateCertificates("localhost", this.GetType().Name);
-        }
-
-        public void Dispose()
-        {
-            TestHelper.CleanupCertificates(this.GetType().Name);
+            string name = System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name.ToString();
+            TestHelper.CleanupCertificates(name);
+            (_serverCert, _serverChain) = TestHelper.GenerateCertificates("localhost", name);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -23,9 +23,8 @@ namespace System.Net.Security.Tests
 
         static SslStreamNetworkStreamTest()
         {
-            string name = System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name.ToString();
-            TestHelper.CleanupCertificates(name);
-            (_serverCert, _serverChain) = TestHelper.GenerateCertificates("localhost", name);
+            TestHelper.CleanupCertificates(nameof(SslStreamNetworkStreamTest));
+            (_serverCert, _serverChain) = TestHelper.GenerateCertificates("localhost", nameof(SslStreamNetworkStreamTest));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -7,6 +7,7 @@ using System.Net.Test.Common;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.X509Certificates.Tests.Common;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.Net.Security.Tests
@@ -107,7 +108,8 @@ namespace System.Net.Security.Tests
             }
             catch { };
         }
-        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, string? testName = null)
+
+        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, [CallerMemberName] string? testName = null)
         {
             if (PlatformDetection.IsWindows && testName != null)
             {


### PR DESCRIPTION
When submitting  #39818, I did not realized we would generate certificate chain for each test run. 
This will do it once per test class.