### PR TITLE
eng/build.sh - support for Android version of bash+devfs limititation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ dlldata.c
 *.tmp
 *.tmp_proj
 *.log
+*.tdrec
 *.vspscc
 *.vssscc
 .builds
@@ -191,6 +192,10 @@ Generated_Code/
 # because we have git ;-)
 _UpgradeReport_Files/
 Backup*/
+*.1[45]*.bak
+*.1[45]*.mod
+*~
+*~[0-9]*~
 UpgradeLog*.XML
 UpgradeLog*.htm
 


### PR DESCRIPTION
Unfortunately, '/dev/fd' is not available on Android, despite which Bash tries to  open temporary pipes there for process substitution (for comparing passed-in args with build actions). This change uses a single pipeline and adds an array that holds the normalized action arguments passed in (userActions e.g. ("-b" "--rebuild")).

I also added a "friendly" error message when arch is not passed in,so that it will give some guidance instead of failing with "use of unset variable '$arch'" on the following line.