### PR TITLE
[release/5.0] Fix issue 41311 - Assert failure ephemeral_heap_segment->saved_committed == heap_segment_committed

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -5703,6 +5703,7 @@ void gc_heap::gc_thread_function ()
             END_TIMING(suspend_ee_during_log);
 
             proceed_with_gc_p = TRUE;
+            gradual_decommit_in_progress_p = FALSE;
 
             if (!should_proceed_with_gc())
             {
@@ -11504,6 +11505,15 @@ BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address, bool*
 
         assert (heap_segment_committed (seg) <= heap_segment_reserved (seg));
         assert (high_address <= heap_segment_committed (seg));
+
+#ifdef MULTIPLE_HEAPS
+        // we should never increase committed beyond decommit target when gradual
+        // decommit is in progress - if we do, this means commit and decommit are
+        // going on at the same time.
+        assert (!gradual_decommit_in_progress_p ||
+                (seg != ephemeral_heap_segment) ||
+                (heap_segment_committed (seg) <= heap_segment_decommit_target (seg)));
+#endif // MULTIPLE_HEAPS
     }
 
     return !!ret;
@@ -32456,7 +32466,7 @@ void gc_heap::trim_youngest_desired_low_memory()
 
 void gc_heap::decommit_ephemeral_segment_pages()
 {
-    if (settings.concurrent || use_large_pages_p)
+    if (settings.concurrent || use_large_pages_p || (settings.pause_mode == pause_no_gc))
     {
         return;
     }
@@ -32495,7 +32505,7 @@ void gc_heap::decommit_ephemeral_segment_pages()
         decommit_target += target_decrease * 2 / 3;
     }
 
-    heap_segment_decommit_target(ephemeral_heap_segment) = decommit_target;
+    heap_segment_decommit_target (ephemeral_heap_segment) = decommit_target;
 
 #ifdef MULTIPLE_HEAPS
     if (decommit_target < heap_segment_committed (ephemeral_heap_segment))


### PR DESCRIPTION
Backport of #41441 to release/5.0

/cc @PeterSolMS 

Customer Impact
 This bug could cause AVs when customers are using no GC regions with Server GC.

Testing
 Test case failing with assert now succeeds, CI testing.
 
Risk
 Low - changes should only affect no GC regions.

Doing this backport PR by hand because of issues with commit history.