### PR TITLE
[release/5.0] Update ICU

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>cfe95a23647c7de1fe1a349343115bd7720d6949</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20428.3">
+    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20451.2">
       <Uri>https://github.com/dotnet/icu</Uri>
-      <Sha>3d5575cc9b110fd9e73ca77d75bf7a9c13e4fa86</Sha>
+      <Sha>ed7daa0d0a29de51ecaacf8e7820adf59a3bac1f</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -147,7 +147,7 @@
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>5.0.0-rc.1.20420.3</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->
-    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20428.3</MicrosoftNETCoreRuntimeICUTransportVersion>
+    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20451.2</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -196,34 +196,34 @@ namespace System.Globalization.Tests
 
         public static IEnumerable<object[]> RegionInfo_TestData()
         {
-            yield return new object[] { 0x409, 244, "US Dollar", "US Dollar", "\u0055\u0053\u0020\u0044\u006f\u006c\u006c\u0061\u0072", "USA", "USA" };
-            yield return new object[] { 0x411, 122, "Japanese Yen", "Japanese Yen", PlatformDetection.IsNlsGlobalization ? "\u5186" : "\u65e5\u672c\u5186", "JPN", "JPN" };
-            yield return new object[] { 0x804, 45, "Chinese Yuan", "PRC Yuan Renminbi", "\u4eba\u6c11\u5e01", "CHN", "CHN" };
-            yield return new object[] { 0x401, 205, "Saudi Riyal", "Saudi Riyal", PlatformDetection.IsNlsGlobalization ?
+            yield return new object[] { 0x409, 244, "US Dollar", "USD", "US Dollar", "\u0055\u0053\u0020\u0044\u006f\u006c\u006c\u0061\u0072", "USA", "USA" };
+            yield return new object[] { 0x411, 122, "Japanese Yen", "JPY", "Japanese Yen", PlatformDetection.IsNlsGlobalization ? "\u5186" : "\u65e5\u672c\u5186", "JPN", "JPN" };
+            yield return new object[] { 0x804, 45, "Chinese Yuan", "CNH", "PRC Yuan Renminbi", "\u4eba\u6c11\u5e01", "CHN", "CHN" };
+            yield return new object[] { 0x401, 205, "Saudi Riyal", "SAR", "Saudi Riyal", PlatformDetection.IsNlsGlobalization ?
                                                     "\u0631\u064a\u0627\u0644\u00a0\u0633\u0639\u0648\u062f\u064a" :
                                                     "\u0631\u064a\u0627\u0644\u0020\u0633\u0639\u0648\u062f\u064a",
                                                     "SAU", "SAU" };
-            yield return new object[] { 0x412, 134, "South Korean Won", "Korean Won", PlatformDetection.IsNlsGlobalization ? "\uc6d0" : "\ub300\ud55c\ubbfc\uad6d\u0020\uc6d0", "KOR", "KOR" };
-            yield return new object[] { 0x40d, 117, "Israeli New Shekel", "Israeli New Sheqel",
+            yield return new object[] { 0x412, 134, "South Korean Won", "KRW", "Korean Won", PlatformDetection.IsNlsGlobalization ? "\uc6d0" : "\ub300\ud55c\ubbfc\uad6d\u0020\uc6d0", "KOR", "KOR" };
+            yield return new object[] { 0x40d, 117, "Israeli New Shekel", "ILS", "Israeli New Sheqel",
                                                     PlatformDetection.IsNlsGlobalization || PlatformDetection.ICUVersion.Major >= 58 ? "\u05e9\u05e7\u05dc\u0020\u05d7\u05d3\u05e9" : "\u05e9\u05f4\u05d7", "ISR", "ISR" };
         }
 
         [Theory]
         [MemberData(nameof(RegionInfo_TestData))]
-        public void MiscTest(int lcid, int geoId, string currencyEnglishName, string alternativeCurrencyEnglishName, string currencyNativeName, string threeLetterISORegionName, string threeLetterWindowsRegionName)
+        public void MiscTest(int lcid, int geoId, string currencyEnglishName, string currencyShortName, string alternativeCurrencyEnglishName, string currencyNativeName, string threeLetterISORegionName, string threeLetterWindowsRegionName)
         {
             RegionInfo ri = new RegionInfo(lcid); // create it with lcid
             Assert.Equal(geoId, ri.GeoId);
-            Assert.True(currencyEnglishName.Equals(ri.CurrencyEnglishName) ||
-                        alternativeCurrencyEnglishName.Equals(ri.CurrencyEnglishName), "Wrong currency English Name");
 
             if (PlatformDetection.IsBrowser)
             {
-                // Browser's ICU doesn't support CurrencyNativeName
-                Assert.Equal(currencyEnglishName, ri.CurrencyNativeName);
+                Assert.Equal(currencyShortName, currencyEnglishName);
+                Assert.Equal(currencyShortName, ri.CurrencyNativeName);
             }
             else
             {
+                Assert.True(currencyEnglishName.Equals(ri.CurrencyEnglishName) ||
+                            alternativeCurrencyEnglishName.Equals(ri.CurrencyEnglishName), "Wrong currency English Name");
                 Assert.Equal(currencyNativeName, ri.CurrencyNativeName);
             }
             Assert.Equal(threeLetterISORegionName, ri.ThreeLetterISORegionName);

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -217,7 +217,7 @@ namespace System.Globalization.Tests
 
             if (PlatformDetection.IsBrowser)
             {
-                Assert.Equal(currencyShortName, currencyEnglishName);
+                Assert.Equal(currencyShortName, ri.CurrencyEnglishName);
                 Assert.Equal(currencyShortName, ri.CurrencyNativeName);
             }
             else

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -181,14 +181,7 @@ namespace System.Globalization.Tests
         public void CurrencySymbol()
         {
             Assert.Equal("$", new RegionInfo("en-US").CurrencySymbol);
-            if (PlatformDetection.IsNotBrowser)
-            {
-                Assert.Contains(new RegionInfo("zh-CN").CurrencySymbol, new string[] { "\u00A5", "\uffe5" });
-            }
-            else
-            {
-                Assert.Equal("CN¥", new RegionInfo("zh-CN").CurrencySymbol);
-            }
+            Assert.Contains(new RegionInfo("zh-CN").CurrencySymbol, new string[] { "\u00A5", "\uffe5" });
         }
 
         [Theory]

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -198,7 +198,7 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { 0x409, 244, "US Dollar", "USD", "US Dollar", "\u0055\u0053\u0020\u0044\u006f\u006c\u006c\u0061\u0072", "USA", "USA" };
             yield return new object[] { 0x411, 122, "Japanese Yen", "JPY", "Japanese Yen", PlatformDetection.IsNlsGlobalization ? "\u5186" : "\u65e5\u672c\u5186", "JPN", "JPN" };
-            yield return new object[] { 0x804, 45, "Chinese Yuan", "CNH", "PRC Yuan Renminbi", "\u4eba\u6c11\u5e01", "CHN", "CHN" };
+            yield return new object[] { 0x804, 45, "Chinese Yuan", "CNY", "PRC Yuan Renminbi", "\u4eba\u6c11\u5e01", "CHN", "CHN" };
             yield return new object[] { 0x401, 205, "Saudi Riyal", "SAR", "Saudi Riyal", PlatformDetection.IsNlsGlobalization ?
                                                     "\u0631\u064a\u0627\u0644\u00a0\u0633\u0639\u0648\u062f\u064a" :
                                                     "\u0631\u064a\u0627\u0644\u0020\u0633\u0639\u0648\u062f\u064a",


### PR DESCRIPTION
## Customer Impact
Without this fix, customer will see 3-letter abbriviations instead of currency symbols for some cultures, e.g.:
```csharp
Console.WriteLine(10000.ToString("C", new CultureInfo("en-US")));
Console.WriteLine(10000.ToString("C", new CultureInfo("en-CA")));
Console.WriteLine(10000.ToString("C", new CultureInfo("ru-RU")));
```
Current output:
```
$10,000.00
CAD10,000.00
10 000,00 RUB
```
Output with updated ICU data (this fix):
```
$10,000.00
$10,000.00
10 000,00 ₽
```
ICU update only updates static data and doesn't change code, see https://github.com/dotnet/icu/pull/31
## Testing
System.Globalization.* tests + local testing.

## Risk
Low.