### PR TITLE
[release/5.0] Fix issue 41413

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -37853,15 +37853,26 @@ size_t GCHeap::ApproxTotalBytesInUse(BOOL small_heap_only)
     size_t totsize = 0;
     enter_spin_lock (&pGenGCHeap->gc_lock);
 
-    heap_segment* eph_seg = generation_allocation_segment (pGenGCHeap->generation_of (0));
-    // Get small block heap size info
-    totsize = (pGenGCHeap->alloc_allocated - heap_segment_mem (eph_seg));
-    heap_segment* seg1 = generation_start_segment (pGenGCHeap->generation_of (max_generation));
-    while (seg1 != eph_seg)
+    // the complication with the following code is that background GC may
+    // remove the ephemeral segment while we are iterating
+    // if so, we retry a couple times and ultimately may report a slightly wrong result
+    for (int tries = 1; tries <= 3; tries++)
     {
-        totsize += heap_segment_allocated (seg1) -
-            heap_segment_mem (seg1);
-        seg1 = heap_segment_next (seg1);
+        heap_segment* eph_seg = generation_allocation_segment (pGenGCHeap->generation_of (0));
+        // Get small block heap size info
+        totsize = (pGenGCHeap->alloc_allocated - heap_segment_mem (eph_seg));
+        heap_segment* seg1 = generation_start_segment (pGenGCHeap->generation_of (max_generation));
+        while ((seg1 != eph_seg) && (seg1 != nullptr) && (seg1 != pGenGCHeap->freeable_soh_segment))
+        {
+            if (!heap_segment_decommitted_p (seg1))
+            {
+                totsize += heap_segment_allocated (seg1) -
+                    heap_segment_mem (seg1);
+            }
+            seg1 = heap_segment_next (seg1);
+        }
+        if (seg1 == eph_seg)
+            break;
     }
 
     //discount the fragmentation


### PR DESCRIPTION
Backport of #41445 to release/5.0

/cc @PeterSolMS

Customer Impact
 This fixes a rare AV when GC.GetTotalMemory executes at the same time as background GC deletes the ephemeral segment.

Testing
 Repro case supplied by Chris Ahna now executes without crashing, CI tests.

Risk
 Low - the change is small and fixes the rare AV.

Doing this backport PR by hand because of issues with commit history.