### PR TITLE
[release/5.0] Leftover Utf8String defines are causing ILLinker warnings

### DIFF
--- a/src/coreclr/src/vm/corelib.h
+++ b/src/coreclr/src/vm/corelib.h
@@ -318,9 +318,12 @@ DEFINE_CLASS(ENCODING,              Text,                   Encoding)
 
 DEFINE_CLASS(RUNE,                  Text,                   Rune)
 
-#ifdef FEATURE_UTF8STRING
-DEFINE_CLASS(CHAR8,                 System,                 Char8)
-#endif // FEATURE_UTF8STRING
+// https://github.com/dotnet/runtime/issues/41654 - having DEFINE_CLASS (even under #ifdef) causes an entry
+// in System.Private.CoreLib's ILLink.Descriptor.xml which causes warnings
+// Use /// comments because CreateRuntimeRootILLinkDescriptorFile will still match `// DEFINE_CLASS`
+/// #ifdef FEATURE_UTF8STRING
+/// DEFINE_CLASS(CHAR8,                 System,                 Char8)
+/// #endif // FEATURE_UTF8STRING
 
 DEFINE_CLASS(ENUM,                  System,                 Enum)
 
@@ -849,16 +852,19 @@ DEFINE_METHOD(STRING,               WCSLEN,                 wcslen,             
 DEFINE_METHOD(STRING,               STRLEN,                 strlen,                     SM_PtrByte_RetInt)
 DEFINE_PROPERTY(STRING,             LENGTH,                 Length,                     Int)
 
-#ifdef FEATURE_UTF8STRING
-DEFINE_CLASS(UTF8_STRING,           System,                 Utf8String)
-DEFINE_METHOD(UTF8_STRING,          CTORF_READONLYSPANOFBYTE,Ctor,                      IM_ReadOnlySpanOfByte_RetUtf8Str)
-DEFINE_METHOD(UTF8_STRING,          CTORF_READONLYSPANOFCHAR,Ctor,                      IM_ReadOnlySpanOfChar_RetUtf8Str)
-DEFINE_METHOD(UTF8_STRING,          CTORF_BYTEARRAY_START_LEN,Ctor,                     IM_ArrByte_Int_Int_RetUtf8Str)
-DEFINE_METHOD(UTF8_STRING,          CTORF_BYTEPTR,           Ctor,                      IM_PtrByte_RetUtf8Str)
-DEFINE_METHOD(UTF8_STRING,          CTORF_CHARARRAY_START_LEN,Ctor,                     IM_ArrChar_Int_Int_RetUtf8Str)
-DEFINE_METHOD(UTF8_STRING,          CTORF_CHARPTR,           Ctor,                      IM_PtrChar_RetUtf8Str)
-DEFINE_METHOD(UTF8_STRING,          CTORF_STRING,            Ctor,                      IM_String_RetUtf8Str)
-#endif // FEATURE_UTF8STRING
+// https://github.com/dotnet/runtime/issues/41654 - having DEFINE_CLASS (even under #ifdef) causes an entry
+// in System.Private.CoreLib's ILLink.Descriptor.xml which causes warnings.
+// Use /// comments because CreateRuntimeRootILLinkDescriptorFile will still match `// DEFINE_CLASS`
+/// #ifdef FEATURE_UTF8STRING
+/// DEFINE_CLASS(UTF8_STRING,           System,                 Utf8String)
+/// DEFINE_METHOD(UTF8_STRING,          CTORF_READONLYSPANOFBYTE,Ctor,                      IM_ReadOnlySpanOfByte_RetUtf8Str)
+/// DEFINE_METHOD(UTF8_STRING,          CTORF_READONLYSPANOFCHAR,Ctor,                      IM_ReadOnlySpanOfChar_RetUtf8Str)
+/// DEFINE_METHOD(UTF8_STRING,          CTORF_BYTEARRAY_START_LEN,Ctor,                     IM_ArrByte_Int_Int_RetUtf8Str)
+/// DEFINE_METHOD(UTF8_STRING,          CTORF_BYTEPTR,           Ctor,                      IM_PtrByte_RetUtf8Str)
+/// DEFINE_METHOD(UTF8_STRING,          CTORF_CHARARRAY_START_LEN,Ctor,                     IM_ArrChar_Int_Int_RetUtf8Str)
+/// DEFINE_METHOD(UTF8_STRING,          CTORF_CHARPTR,           Ctor,                      IM_PtrChar_RetUtf8Str)
+/// DEFINE_METHOD(UTF8_STRING,          CTORF_STRING,            Ctor,                      IM_String_RetUtf8Str)
+/// #endif // FEATURE_UTF8STRING
 
 DEFINE_CLASS(STRING_BUILDER,        Text,                   StringBuilder)
 DEFINE_PROPERTY(STRING_BUILDER,     LENGTH,                 Length,                     Int)


### PR DESCRIPTION
The CreateRuntimeRootILLinkDescriptorFile task, which generates most of S.P.CoreLib's ILLink.Descriptor file for coreclr, doesn't respect #ifdefs. So even though FEATURE_UTF8STRING is disabled in the release/5.0 branch, it is still generating entries for Char8 and Utf8String. But since these managed types do not exist in the release/5.0 branch, the ILLinker is raising warnings.

To fix this, comment the DEFINE_CLASS entries out of the header file.

Fix #41654

## Customer Impact

This fixes #41654. If anyone tries to link a coreclr application (console, asp.net, winforms, etc) they are getting warnings that they cannot fix.

## Testing

I verified that linking with the new System.Private.CoreLib is no longer producing warnings by default.

## Risk

Low - I commented out code that is already behind a `#ifdef` that is turned off.

### Notes

I chose to go the surgical route of removing these from the .h file instead of the full blown route of removing the all the `FEATURE_UTF8STRING` code because it is a safer change to make at this point in 5.0.