### PR TITLE
Use dynamic port for BrowserDebugHost process

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
@@ -31,7 +31,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 {
                     config.AddCommandLine(args);
                 })
-                .UseUrls("http://localhost:9300")
+                .UseUrls("http://127.0.0.1:0")
                 .Build();
 
             host.Run();


### PR DESCRIPTION
The `BrowserDebugHost` currently launches at a fixed port (9300). This can cause issues if a user is:

(a) attempting to debug multiple Blazor WASM applications at the same time
(b) has another process running on port 9300 on their machine

Sidenote: I haven't been able to track down where the BrowserDebugHost is used in the testing infrastructure. There are some [mocked responses](https://github.com/dotnet/runtime/blob/master/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessStartup.cs#L59-L68) which seem to assume that it runs on port 9300, although I'm not sure if the test infrastructure actually issues a request to that endpoint.