### PR TITLE
Add COMPlus env var comment docs

### DIFF
--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -8,6 +8,17 @@
 // Unified method of accessing configuration values from environment variables,
 // registry and config file.
 //
+// Given any config knob below that looks like this example:
+//    RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_LogEnable, W("LogEnable"), "Turns on the traditional CLR log.")
+//                                                                  ---------
+//                                                                     |
+//                                                 --------------------
+//                                                 |
+//                                                 V
+// You can set an environment variable COMPlus_LogEnable=1 to enable it.
+//
+// See below for more details
+//
 //*****************************************************************************
 
 // IMPORTANT: Before adding a new config value, please read up on naming conventions (see


### PR DESCRIPTION
We lost our docs at some point, but the key detail is that prepending COMPlus_ to the knob name is the environment variable you need to set. Hoisting that fact right to the top of the file so that people who come looking can find it.

@sdmaclea - does this do the trick? Feel free to change the text if it would make it more helpful in the future.