### PR TITLE
[release/5.0-rc2]Using .NET sdk properties to set FileVersion and Information Version

### DIFF
--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -12,8 +12,8 @@
   // --- The following custom attribute is added automatically, do not uncomment -------
   //  .custom instance void [CORE_ASSEMBLY]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [CORE_ASSEMBLY]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 02 00 00 00 00 00 )
 
-  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyFileVersionAttribute::.ctor(string) = ( 01 00 07 35 2E 30 2E 30 2E 30 00 00 )             // ...5.0.0.0..
-  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyInformationalVersionAttribute::.ctor(string) = ( 01 00 07 35 2E 30 2E 30 2E 30 00 00 )             // ...5.0.0.0..
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyFileVersionAttribute::.ctor(string) = FILE_VERSION
+  .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyInformationalVersionAttribute::.ctor(string) = INFORMATIONAL_VERSION
   .custom instance void [CORE_ASSEMBLY]System.Reflection.AssemblyTitleAttribute::.ctor(string) = ( 01 00 26 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..&System.Runtim
                                                                                               65 2E 43 6F 6D 70 69 6C 65 72 53 65 72 76 69 63   // e.CompilerServic
                                                                                               65 73 2E 55 6E 73 61 66 65 00 00 )                // es.Unsafe..

--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <Target Name="GenerateVersionFile"
-          DependsOnTargets="ResolveReferences"
+          DependsOnTargets="GetAssemblyVersion;ResolveReferences"
           Inputs="$(MSBuildAllProjects)"
           Outputs="'$(VersionFilePath)">
    <PropertyGroup>
@@ -51,6 +51,8 @@
 #define CORE_ASSEMBLY "$(CoreAssembly)"
 #define ASSEMBLY_VERSION "$(_AssemblyVersion)"
 #define CORE_ASSEMBLY_VERSION "$(_CoreAssemblyVersion)"
+#define FILE_VERSION "{string('$(FileVersion)')}"
+#define INFORMATIONAL_VERSION "{string('$(InformationalVersion)')}"
 $(ExtraMacros)
 // Metadata version: v4.0.30319
 .assembly extern CORE_ASSEMBLY


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/40895

GetFileVersionInfoEx which reads FILEVERSION of the VERSIONINFO resource On Windows.

 On Unix, we instead read the AssemblyFileVersionAttribute managed assembly attribute. 

For System.Runtime.CompilerServices.Unsafe, these 2 values donot match.

 We are hardcoding the value managed assembly attribute for this assembly.

 The PR resolves this issue by using already defined msbuild properties like FileVersion & InformationalVersion  which have the correct values

 