### PR TITLE
Fix cross-OS DAC metadata locator interface callback

### DIFF
--- a/src/coreclr/src/debug/di/module.cpp
+++ b/src/coreclr/src/debug/di/module.cpp
@@ -869,7 +869,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
                                                 DWORD dwOpenFlags,
                                                 bool validateFileInfo)
 {
-#ifdef TARGET_UNIX
+#ifdef HOST_UNIX
     // UNIXTODO: Some intricate details of file mapping don't work on Linux as on Windows.
     // We have to revisit this and try to fix it for POSIX system.
     return E_FAIL;


### PR DESCRIPTION
This fixes the  cross-OS DBI for debugging Linux on Windows. VS ran into this bug in their Linux coredump support.  The metadata locator callback in DBI isn't be called (ifdef'ed out) so the debugger (VS) can't provide the missing metadata for the dump.

Issue: https://github.com/dotnet/runtime/issues/41034