### PR TITLE
char.IsAscii xml doc comments

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -74,7 +74,7 @@ namespace System
         // Return true for all characters below or equal U+007f, which is ASCII.
 
         /// <summary>
-        /// Returns <see langword="true"/> iff <paramref name="c"/> is an ASCII
+        /// Returns <see langword="true"/> if <paramref name="c"/> is an ASCII
         /// character ([ U+0000..U+007F ]).
         /// </summary>
         /// <remarks>

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -72,6 +72,14 @@ namespace System
         private static bool IsLatin1(char c) => (uint)c < (uint)Latin1CharInfo.Length;
 
         // Return true for all characters below or equal U+007f, which is ASCII.
+
+        /// <summary>
+        /// Returns <see langword="true"/> iff <paramref name="c"/> is an ASCII
+        /// character ([ U+0000..U+007F ]).
+        /// </summary>
+        /// <remarks>
+        /// Per http://www.unicode.org/glossary/#ASCII, ASCII is only U+0000..U+007F.
+        /// </remarks>
         public static bool IsAscii(char c) => (uint)c <= '\x007f';
 
         // Return the Unicode category for Unicode character <= 0x00ff.


### PR DESCRIPTION
Cf. https://github.com/dotnet/runtime/issues/40936#issuecomment-684523158

I based the text on https://github.com/dotnet/runtime/blob/2d463ee3d6c128f4bfa36d70e46bb023c7b59f38/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeUtility.cs#L120 (to be consistent).

/cc: @danmosemsft 