### PR TITLE
Enabling CA1416: Validate platform compatibility

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0-rc1.20413.9" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0-rc2.20451.1" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0-rc2.20451.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0-rc2.20458.2" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -64,6 +64,7 @@
       <Rule Id="CA1308" Action="None" />             <!-- Normalize strings to uppercase -->
       <Rule Id="CA1309" Action="None" />             <!-- Use ordinal stringcomparison -->
       <Rule Id="CA1401" Action="Warning" />          <!-- P/Invokes should not be visible -->
+      <Rule Id="CA1416" Action="Warning" />          <!-- Validate platform compatibility -->
       <Rule Id="CA1417" Action="Warning" />          <!-- Do not use 'OutAttribute' on string parameters for P/Invokes -->
       <Rule Id="CA1501" Action="None" />             <!-- Avoid excessive inheritance -->
       <Rule Id="CA1502" Action="None" />             <!-- Avoid excessive complexity -->

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -64,7 +64,6 @@
       <Rule Id="CA1308" Action="None" />             <!-- Normalize strings to uppercase -->
       <Rule Id="CA1309" Action="None" />             <!-- Use ordinal stringcomparison -->
       <Rule Id="CA1401" Action="Warning" />          <!-- P/Invokes should not be visible -->
-      <Rule Id="CA1416" Action="None" />             <!-- Validate platform compatibility; https://github.com/dotnet/runtime/issues/41354 -->
       <Rule Id="CA1417" Action="Warning" />          <!-- Do not use 'OutAttribute' on string parameters for P/Invokes -->
       <Rule Id="CA1501" Action="None" />             <!-- Avoid excessive inheritance -->
       <Rule Id="CA1502" Action="None" />             <!-- Avoid excessive complexity -->

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
@@ -57,7 +57,7 @@ internal static partial class Interop
                 fixed (int* pResult = &result)
                 {
 #if NETSTANDARD || NETCOREAPP
-                    Debug.Assert(OperatingSystem.IsWindows());
+                    Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 #endif
 
                     errorCode = Interop.NCrypt.NCryptGetProperty(

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
@@ -56,7 +56,9 @@ internal static partial class Interop
             {
                 fixed (int* pResult = &result)
                 {
+#if NETSTANDARD || NETCOREAPP
                     Debug.Assert(OperatingSystem.IsWindows());
+#endif
 
                     errorCode = Interop.NCrypt.NCryptGetProperty(
                         hObject,

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
+using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
 
 using Microsoft.Win32.SafeHandles;
 
@@ -17,6 +19,7 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.NCrypt, CharSet = CharSet.Unicode)]
         internal static extern unsafe ErrorCode NCryptSetProperty(SafeNCryptHandle hObject, string pszProperty, [In] void* pbInput, int cbInput, CngPropertyOptions dwFlags);
 
+        [SupportedOSPlatform("windows")]
         internal static ErrorCode NCryptGetByteProperty(SafeNCryptHandle hObject, string pszProperty, ref byte result, CngPropertyOptions options = CngPropertyOptions.None)
         {
             int cbResult;
@@ -53,6 +56,8 @@ internal static partial class Interop
             {
                 fixed (int* pResult = &result)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
+
                     errorCode = Interop.NCrypt.NCryptGetProperty(
                         hObject,
                         pszProperty,

--- a/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
@@ -57,6 +57,7 @@ namespace System.Net.Sockets
             {
                 unsafe
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     Debug.Assert(_socketHandle != null, "_socketHandle is null.");
 
                     ThreadPoolBoundHandle? boundHandle = _socketHandle.IOCPBoundHandle;

--- a/src/libraries/Common/src/System/Net/ContextAwareResult.Windows.cs
+++ b/src/libraries/Common/src/System/Net/ContextAwareResult.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
+using System.Diagnostics;
 using System.Security.Principal;
 
 namespace System.Net
@@ -13,6 +14,7 @@ namespace System.Net
         // Security: We need an assert for a call into WindowsIdentity.GetCurrent.
         private void SafeCaptureIdentity()
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             _windowsIdentity = WindowsIdentity.GetCurrent();
         }
 
@@ -20,6 +22,7 @@ namespace System.Net
         {
             if (_windowsIdentity != null)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 _windowsIdentity.Dispose();
                 _windowsIdentity = null;
             }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
@@ -164,6 +164,8 @@ namespace Microsoft.Extensions.Logging.EventLog
             }
         }
 
+#pragma warning disable CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
+
         private EventLogEntryType GetEventLogEntryType(LogLevel level)
         {
             switch (level)
@@ -181,5 +183,7 @@ namespace Microsoft.Extensions.Logging.EventLog
                     return EventLogEntryType.Information;
             }
         }
+
+#pragma warning restore CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Microsoft.Extensions.Logging.EventLog
@@ -164,10 +165,10 @@ namespace Microsoft.Extensions.Logging.EventLog
             }
         }
 
-#pragma warning disable CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
-
         private EventLogEntryType GetEventLogEntryType(LogLevel level)
         {
+            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
             switch (level)
             {
                 case LogLevel.Information:
@@ -183,7 +184,5 @@ namespace Microsoft.Extensions.Logging.EventLog
                     return EventLogEntryType.Information;
             }
         }
-
-#pragma warning restore CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLogger.cs
@@ -167,7 +167,9 @@ namespace Microsoft.Extensions.Logging.EventLog
 
         private EventLogEntryType GetEventLogEntryType(LogLevel level)
         {
+#if NETSTANDARD
             Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
 
             switch (level)
             {

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLoggerProvider.cs
@@ -55,7 +55,9 @@ namespace Microsoft.Extensions.Logging.EventLog
         {
             if (_settings.EventLog is WindowsEventLog windowsEventLog)
             {
+#if NETSTANDARD
                 Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
                 windowsEventLog.DiagnosticsEventLog.Dispose();
             }
         }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogLoggerProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Logging.EventLog
@@ -53,6 +55,7 @@ namespace Microsoft.Extensions.Logging.EventLog
         {
             if (_settings.EventLog is WindowsEventLog windowsEventLog)
             {
+                Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
                 windowsEventLog.DiagnosticsEventLog.Dispose();
             }
         }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
@@ -55,8 +55,9 @@ namespace Microsoft.Extensions.Logging.EventLog
                 defaultEventId = 1000;
             }
 
-
+#if NETSTANDARD
             Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
             return new WindowsEventLog(logName, machineName, sourceName) { DefaultEventId = defaultEventId };
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/EventLogSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
@@ -53,6 +55,8 @@ namespace Microsoft.Extensions.Logging.EventLog
                 defaultEventId = 1000;
             }
 
+
+            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             return new WindowsEventLog(logName, machineName, sourceName) { DefaultEventId = defaultEventId };
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +19,7 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging.Abstractions\src\Microsoft.Extensions.Logging.Abstractions.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Options\src\Microsoft.Extensions.Options.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Diagnostics.EventLog\src\System.Diagnostics.EventLog.csproj" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/WindowsEventLog.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/WindowsEventLog.cs
@@ -8,8 +8,7 @@ using System.Runtime.Versioning;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
-#pragma warning disable CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
-
+    [SupportedOSPlatform("windows")]
     internal class WindowsEventLog : IEventLog
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx
@@ -55,6 +54,4 @@ namespace Microsoft.Extensions.Logging.EventLog
             }
         }
     }
-
-#pragma warning restore CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
 }

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/WindowsEventLog.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/WindowsEventLog.cs
@@ -4,9 +4,12 @@
 using System;
 using System.Diagnostics;
 using System.Security;
+using System.Runtime.Versioning;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
+#pragma warning disable CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
+
     internal class WindowsEventLog : IEventLog
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx
@@ -52,4 +55,6 @@ namespace Microsoft.Extensions.Logging.EventLog
             }
         }
     }
+
+#pragma warning restore CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -657,6 +657,7 @@ namespace System.Drawing
                     }
                     finally
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
                         Marshal.ReleaseComObject(picture);
                     }
                 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -657,7 +657,7 @@ namespace System.Drawing
                     }
                     finally
                     {
-                        Debug.Assert(OperatingSystem.IsWindows());
+                        Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
                         Marshal.ReleaseComObject(picture);
                     }
                 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Internal/SystemColorTracker.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Internal/SystemColorTracker.cs
@@ -39,6 +39,7 @@ namespace System.Drawing.Internal
 
                 if (!addedTracker)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     addedTracker = true;
                     SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(OnUserPreferenceChanged);
                 }
@@ -131,6 +132,7 @@ namespace System.Drawing.Internal
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
 
             // Update pens and brushes
             if (e.Category == UserPreferenceCategory.Color)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Internal/SystemColorTracker.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Internal/SystemColorTracker.cs
@@ -39,7 +39,7 @@ namespace System.Drawing.Internal
 
                 if (!addedTracker)
                 {
-                    Debug.Assert(OperatingSystem.IsWindows());
+                    Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
                     addedTracker = true;
                     SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(OnUserPreferenceChanged);
                 }
@@ -132,7 +132,7 @@ namespace System.Drawing.Internal
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
-            Debug.Assert(OperatingSystem.IsWindows());
+            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
             // Update pens and brushes
             if (e.Category == UserPreferenceCategory.Color)

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.Win32.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.Win32.cs
@@ -4,6 +4,7 @@
 using Microsoft.Win32;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.IO.Ports
 {
@@ -18,7 +19,7 @@ namespace System.IO.Ports
             //
             // QueryDosDevice involves finding any ports that map to \Device\Serialx (call with null to get all, then iterate to get the actual device name)
 
-#pragma warning disable CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
+            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
             using (RegistryKey serialKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM"))
             {
@@ -33,8 +34,6 @@ namespace System.IO.Ports
                     return result;
                 }
             }
-
-#pragma warning restore CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
 
             return Array.Empty<string>();
         }

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.Win32.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.Win32.cs
@@ -19,7 +19,9 @@ namespace System.IO.Ports
             //
             // QueryDosDevice involves finding any ports that map to \Device\Serialx (call with null to get all, then iterate to get the actual device name)
 
+#if NETSTANDARD
             Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
 
             using (RegistryKey serialKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM"))
             {

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.Win32.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.Win32.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Win32;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace System.IO.Ports
 {
@@ -17,6 +18,8 @@ namespace System.IO.Ports
             //
             // QueryDosDevice involves finding any ports that map to \Device\Serialx (call with null to get all, then iterate to get the actual device name)
 
+#pragma warning disable CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
+
             using (RegistryKey serialKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM"))
             {
                 if (serialKey != null)
@@ -30,6 +33,8 @@ namespace System.IO.Ports
                     return result;
                 }
             }
+
+#pragma warning restore CA1416 // Debug.Assert(OperatingSystem.IsWindows()) is not available
 
             return Array.Empty<string>();
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -50,6 +50,7 @@ namespace System.Net.Sockets
 
             unsafe
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 NativeOverlapped* overlapped = boundHandle.AllocateNativeOverlapped(s_ioCallback, this, objectsToPin);
                 _nativeOverlapped = new SafeNativeOverlapped(s.SafeHandle, overlapped);
             }
@@ -59,6 +60,7 @@ namespace System.Net.Sockets
 
         private static unsafe void CompletionPortCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             BaseOverlappedAsyncResult asyncResult = (BaseOverlappedAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
 
             if (asyncResult.InternalPeekCompleted)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
@@ -48,6 +48,7 @@ namespace System.Net.Sockets
 
                     try
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
                         // The handle (this) may have been already released:
                         // E.g.: The socket has been disposed in the main thread. A completion callback may
                         //       attempt starting another operation.
@@ -105,6 +106,7 @@ namespace System.Net.Sockets
             // ThreadPoolBoundHandle allows FreeNativeOverlapped even after it has been disposed.
             if (_iocpBoundHandle != null)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 _iocpBoundHandle.Dispose();
             }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -1223,10 +1223,8 @@ namespace System.Net.Sockets
 
         private static readonly unsafe IOCompletionCallback s_completionPortCallback = delegate (uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
-#pragma warning disable CA1416 // https://github.com/dotnet/roslyn-analyzers/issues/4090
             Debug.Assert(OperatingSystem.IsWindows());
             var saeaBox = (StrongBox<SocketAsyncEventArgs>)(ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!);
-#pragma warning restore CA1416 // https://github.com/dotnet/roslyn-analyzers/issues/4090
 
             Debug.Assert(saeaBox.Value != null);
             SocketAsyncEventArgs saea = saeaBox.Value;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -56,6 +56,7 @@ namespace System.Net.Sockets
             bool suppressFlow = !ExecutionContext.IsFlowSuppressed();
             try
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 if (suppressFlow) ExecutionContext.SuppressFlow();
                 _preAllocatedOverlapped = new PreAllocatedOverlapped(s_completionPortCallback, _strongThisRef, null);
             }
@@ -75,6 +76,7 @@ namespace System.Net.Sockets
 
         private unsafe NativeOverlapped* AllocateNativeOverlapped()
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             Debug.Assert(_operating == InProgress, $"Expected {nameof(_operating)} == {nameof(InProgress)}, got {_operating}");
             Debug.Assert(_currentSocket != null, "_currentSocket is null");
             Debug.Assert(_currentSocket.SafeHandle != null, "_currentSocket.SafeHandle is null");
@@ -86,6 +88,7 @@ namespace System.Net.Sockets
 
         private unsafe void FreeNativeOverlapped(NativeOverlapped* overlapped)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             Debug.Assert(overlapped != null, "overlapped is null");
             Debug.Assert(_operating == InProgress, $"Expected _operating == InProgress, got {_operating}");
             Debug.Assert(_currentSocket != null, "_currentSocket is null");
@@ -904,6 +907,7 @@ namespace System.Net.Sockets
             // any pinned buffers.
             if (_preAllocatedOverlapped != null)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 _preAllocatedOverlapped.Dispose();
                 _preAllocatedOverlapped = null!;
             }
@@ -1219,7 +1223,11 @@ namespace System.Net.Sockets
 
         private static readonly unsafe IOCompletionCallback s_completionPortCallback = delegate (uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
-            var saeaBox = (StrongBox<SocketAsyncEventArgs>)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
+#pragma warning disable CA1416 // https://github.com/dotnet/roslyn-analyzers/issues/4090
+            Debug.Assert(OperatingSystem.IsWindows());
+            var saeaBox = (StrongBox<SocketAsyncEventArgs>)(ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!);
+#pragma warning restore CA1416 // https://github.com/dotnet/roslyn-analyzers/issues/4090
+
             Debug.Assert(saeaBox.Value != null);
             SocketAsyncEventArgs saea = saeaBox.Value;
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
@@ -129,6 +129,10 @@ namespace Internal.Cryptography.Pal.Windows
 
                 if (keySpec == CryptKeySpec.CERT_NCRYPT_KEY_SPEC)
                 {
+#if NET5_0
+                    Debug.Assert(OperatingSystem.IsWindows());
+#endif
+
                     using (SafeNCryptKeyHandle keyHandle = new SafeNCryptKeyHandle(handle.DangerousGetHandle(), handle))
                     {
                         CngKeyHandleOpenOptions options = CngKeyHandleOpenOptions.None;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
@@ -129,8 +129,8 @@ namespace Internal.Cryptography.Pal.Windows
 
                 if (keySpec == CryptKeySpec.CERT_NCRYPT_KEY_SPEC)
                 {
-#if NET5_0
-                    Debug.Assert(OperatingSystem.IsWindows());
+#if NETSTANDARD || NETCOREAPP
+                    Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 #endif
 
                     using (SafeNCryptKeyHandle keyHandle = new SafeNCryptKeyHandle(handle.DangerousGetHandle(), handle))


### PR DESCRIPTION
This enables CA1416: Validate platform compatibility. Most scenarios are handled by adding `Debug.Assert(OperatingSystem.IsWindows());`. This was done because most code paths also have a Unix version in a separate `*.Unix.cs` file and the files are already limited to running on Windows only via the build system.

There is one place that is bypassed via `#pragma warning disable` due to: https://github.com/dotnet/roslyn-analyzers/issues/4090 
There are likewise a couple places that were bypassed as they only build netstandard versions of the respective binaries and so `OperatingSystem.IsWindows` was not available.