### PR TITLE
Fix neutral source flag in standalone MSIL component assemblies

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Internal.IL;
 using Internal.IL.Stubs;
 using Internal.JitInterface;
+using Internal.ReadyToRunConstants;
 using Internal.TypeSystem;
 
 using ILCompiler.DependencyAnalysis;
@@ -328,6 +329,15 @@ namespace ILCompiler
 
             Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
 
+            ReadyToRunFlags flags =
+                ReadyToRunFlags.READYTORUN_FLAG_Component |
+                ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs;
+
+            if (inputModule.IsPlatformNeutral)
+            {
+                flags |= ReadyToRunFlags.READYTORUN_FLAG_PlatformNeutralSource;
+            }
+
             CopiedCorHeaderNode copiedCorHeader = new CopiedCorHeaderNode(inputModule);
             DebugDirectoryNode debugDirectory = new DebugDirectoryNode(inputModule, outputFile);
             NodeFactory componentFactory = new NodeFactory(
@@ -337,8 +347,7 @@ namespace ILCompiler
                 copiedCorHeader,
                 debugDirectory,
                 win32Resources: new Win32Resources.ResourceData(inputModule),
-                Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_Component |
-                Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs);
+                flags);
 
             IComparer<DependencyNodeCore<NodeFactory>> comparer = new SortableDependencyNode.ObjectNodeComparer(new CompilerComparer());
             DependencyAnalyzerBase<NodeFactory> componentGraph = new DependencyAnalyzer<NoLogStrategy<NodeFactory>, NodeFactory>(componentFactory, comparer);

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -926,12 +926,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests/*">
             <Issue>https://github.com/dotnet/runtime/issues/34905</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.ResolutionFlow/*">
-            <Issue>https://github.com/dotnet/runtime/issues/38290</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.Basic/*">
-            <Issue>https://github.com/dotnet/runtime/issues/38290</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- runtest.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -926,6 +926,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests/*">
             <Issue>https://github.com/dotnet/runtime/issues/34905</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.Basic/*">
+            <Issue>https://github.com/dotnet/runtime/issues/38290</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- runtest.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.


### PR DESCRIPTION
In composite build mode, we copy the input assemblies to output,
injecting the component R2R headers into them. This process was
missing the logic to set up the READYTORUN_FLAG_PLATFORM_NEUTRAL_SOURCE
flag, causing subsequent AssemblyName mismatches. At this point
I don't plan to back-propagate the change to .NET 5 as Crossgen2
is not yet generally available and this fixes just a corner case in it.

Partially addresses: https://github.com/dotnet/runtime/issues/38290
(Two tests are blocked on the same bug but they are failing for
different reasons. I already have a local fix for the second bug so
for now I'm just keeping the bug open and I'll close it in the second PR.)

Thanks

Tomas

/cc: @dotnet/crossgen-contrib 