### PR TITLE
Mark `sizeValue` in `impRuntimeLookupToTree` as non faulting.

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -2223,6 +2223,7 @@ GenTree* Compiler::impRuntimeLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken
         GenTreeIntCon* sizeOffset      = gtNewIconNode(pRuntimeLookup->sizeOffset, TYP_I_IMPL);
         GenTree*       sizeValueOffset = gtNewOperNode(GT_ADD, TYP_I_IMPL, lastIndOfTree, sizeOffset);
         GenTree*       sizeValue       = gtNewOperNode(GT_IND, TYP_I_IMPL, sizeValueOffset);
+        sizeValue->gtFlags |= GTF_IND_NONFAULTING;
 
         // sizeCheck fails if sizeValue < pRuntimeLookup->offsets[i]
         GenTree* offsetValue = gtNewIconNode(pRuntimeLookup->offsets[pRuntimeLookup->indirections - 1], TYP_I_IMPL);


### PR DESCRIPTION
The address of the ind can't be null because it is a prejited location.

However, the value of the indirection could be different, so should not mark it as an invariant.

Fixes https://github.com/dotnet/runtime/issues/40856.

My local results:
```
| Method |        Job |                   Toolchain | Size |     Mean |   Error |  StdDev |   Median |      Min |      Max | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |----------- |---------------------------- |----- |---------:|--------:|--------:|---------:|---------:|---------:|------:|------:|------:|------:|----------:|
|   Span | Job-VVNWWU | \Core_Root_base\CoreRun.exe |  512 | 325.9 ns | 2.55 ns | 1.99 ns | 325.2 ns | 324.1 ns | 330.6 ns |  1.00 |     - |     - |     - |         - |
|   Span | Job-JRPKOX | \Core_Root_diff\CoreRun.exe |  512 | 266.7 ns | 2.22 ns | 2.08 ns | 265.8 ns | 264.3 ns | 269.9 ns |  0.82 |     - |     - |     - |         - |
```

so it gives us 22% back.


Update:
0 crossgen diffs,
small pmi diffs:
```
Beginning PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies
Completed PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies in 285.68s
Diffs (if any) can be viewed by comparing: D:\Sergey\diffs\dasmset_2\base D:\Sergey\diffs\dasmset_2\diff
Analyzing CodeSize diffs...
Found 17 files with textual diffs.
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -670 (-0.001% of base)
Top method improvements (percentages):
         -16 (-7.805% of base) : System.Text.Json.dasm - <ReadAsync>d__20`1:SetStateMachine(IAsyncStateMachine):this (7 methods)
         -11 (-5.446% of base) : System.Private.CoreLib.dasm - Table:Insert(__Canon,__Canon):this
         -13 (-4.962% of base) : System.Collections.Immutable.dasm - ImmutableInterlocked:AddOrUpdate(byref,__Canon,Func`2,Func`3):long
         -37 (-3.678% of base) : System.Linq.Expressions.dasm - UpdateDelegates:UpdateAndExecuteVoid1(CallSite,__Canon)
         -37 (-3.561% of base) : System.Linq.Expressions.dasm - UpdateDelegates:UpdateAndExecute1(CallSite,__Canon):long
         -37 (-3.468% of base) : System.Linq.Expressions.dasm - UpdateDelegates:UpdateAndExecuteVoid2(CallSite,__Canon,long)
         -11 (-3.385% of base) : System.Collections.Immutable.dasm - FallbackWrapper`1:.ctor(IEnumerable`1):this (7 methods)
34 total methods with Code Size differences (34 improved, 0 regressed), 259449 unchanged.
```
