### PR TITLE
Fix Crossgen2 package by using the proper UCRT version

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -396,7 +396,7 @@ set _C=
 set /p PYTHON=<%TEMP%\pythonlocation.txt
 
 if NOT DEFINED PYTHON (
-    echo %__ErrMsgPrefix%%__MsgPrefix%Error: Could not find a python installation
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: Could not find a Python installation.
     goto ExitWithError
 )
 
@@ -550,17 +550,17 @@ if %__BuildNative% EQU 1 (
 
     if /i "%__BuildArch%" == "arm64" goto SkipCopyUcrt
 
-    set "__UCRTDir=%UniversalCRTSDKDIR%Redist\ucrt\DLLs\%__BuildArch%\"
-    if not exist "!__UCRTDir!" set "__UCRTDir=%UniversalCRTSDKDIR%Redist\%UCRTVersion%\ucrt\DLLs\%__BuildArch%\"
-    if not exist "!__UCRTDir!" (
-        echo %__ErrMsgPrefix%%__MsgPrefix%Error: Please install the Redistributable Universal C Runtime.
+    if not defined UCRTVersion (
+        echo %__ErrMsgPrefix%%__MsgPrefix%Error: Please install Windows 10 SDK.
         goto ExitWithError
     )
+
+    set "__UCRTDir=%UniversalCRTSdkDir%Redist\%UCRTVersion%\ucrt\DLLs\%__BuildArch%\"
 
     xcopy /Y/I/E/D/F "!__UCRTDir!*.dll" "%__BinDir%\Redist\ucrt\DLLs\%__BuildArch%"
     if not !errorlevel! == 0 (
         set __exitCode=!errorlevel!
-        echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to copy the CRT to the output.
+        echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to copy the Universal CRT to the artifacts directory.
         goto ExitWithCode
     )
 


### PR DESCRIPTION
Change #40642 switched to use the 'versionless' UCRT (16299) instead of the latest UCRT installed on the computer.  That broke Crossgen2 package due to `api-ms-win-core-console-l1-2-0.dll` file being missed in the package but still listed in `crossgen2.deps.json` file.  Note that building the repo requires Windows 10 SDK version 10.0.18362 or newer.  In particular, `ConsolePal.Windows.cs` uses `PeekConsoleInputW`, which needs `api-ms-win-core-console-l1-2-0.dll`.  Therefore using the 'versionless' UCRT seems incorrect.  Please also see @hoyosjs's comment here: https://github.com/dotnet/sdk/issues/13279#issuecomment-686236880.