### PR TITLE
hold ref to temp keychain on OSX to avoid premature cleanup

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.Pkcs12.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.Pkcs12.cs
@@ -11,7 +11,7 @@ namespace Internal.Cryptography.Pal
 {
     internal sealed partial class AppleCertificatePal : ICertificatePal
     {
-        private static ICertificatePal ImportPkcs12(
+        private static AppleCertificatePal ImportPkcs12(
             ReadOnlySpan<byte> rawData,
             SafePasswordHandle password,
             bool exportable,
@@ -57,7 +57,7 @@ namespace Internal.Cryptography.Pal
             }
         }
 
-        internal static ICertificatePal ImportPkcs12NonExportable(
+        internal static AppleCertificatePal ImportPkcs12NonExportable(
             AppleCertificatePal cert,
             SafeSecKeyRefHandle privateKey,
             SafePasswordHandle password,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.Apple;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography.Pal
@@ -20,6 +21,7 @@ namespace Internal.Cryptography.Pal
         private SafeSecCertificateHandle _certHandle;
         private CertificateData _certData;
         private bool _readCertData;
+        private SafeKeychainHandle? _tempKeychain;
 
         public static ICertificatePal? FromHandle(IntPtr handle)
         {
@@ -109,7 +111,20 @@ namespace Internal.Cryptography.Pal
 
                 using (keychain)
                 {
-                    return ImportPkcs12(rawData, password, exportable, keychain);
+                    var  ret = ImportPkcs12(rawData, password, exportable, keychain);
+                    if (!persist)
+                    {
+                        // If we used temporary keychain we need to prevent deletion.
+                        // on 10.15+ if keychain is unlinked, certain certificate operations may fail.
+                        bool success = false;
+                        keychain.DangerousAddRef(ref success);
+                        if (success)
+                        {
+                            ((AppleCertificatePal)ret)._tempKeychain = keychain;
+                        }
+                    }
+
+                    return ret;
                 }
             }
 
@@ -165,6 +180,12 @@ namespace Internal.Cryptography.Pal
 
             _certHandle = null!;
             _identityHandle = null;
+
+            SafeKeychainHandle? tempKeychain = Interlocked.Exchange(ref _tempKeychain, null);
+            if (tempKeychain != null)
+            {
+                tempKeychain.Dispose();
+            }
         }
 
         internal SafeSecCertificateHandle CertificateHandle => _certHandle;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -111,7 +111,7 @@ namespace Internal.Cryptography.Pal
 
                 using (keychain)
                 {
-                    var  ret = ImportPkcs12(rawData, password, exportable, keychain);
+                    AppleCertificatePal ret = ImportPkcs12(rawData, password, exportable, keychain);
                     if (!persist)
                     {
                         // If we used temporary keychain we need to prevent deletion.
@@ -120,7 +120,7 @@ namespace Internal.Cryptography.Pal
                         keychain.DangerousAddRef(ref success);
                         if (success)
                         {
-                            ((AppleCertificatePal)ret)._tempKeychain = keychain;
+                            ret._tempKeychain = keychain;
                         }
                     }
 


### PR DESCRIPTION
This is fix for issue originally reported on macOS 11.0 when we fail to add certificates to a store. 
The root cause if fact that when importing, we put certificate and key to temporary keyChain and that can be deleted before we use the bits. This used to work with 3.1 but it is failing now on Catalina+. 

The fix is to grab reference when temporary keychain is used to make sure keychain file stays around. 
Since the chain can now linger longer, all the changes in `CreateTemporaryKeychain` are to ensure we have better one time encryption password. Technically, that is not needed to avoid the issue.

As far as testing, this is little bit tricky. We already have tests that would expose the behavior.
However, the X509StoreMutableTests are guarded by PermissionsAllowStoreWrite.
With the bug adding to store fails and the tests therefore do not run.
I think improving detection of SSH with combination of kPOSIXErrorBase may be long term fix. 
Alternatively, we can create new Keychain for the test so it is always writable independently of the the default one. 
For now, I verified that the tests run again when keychain is unlocked and the repro code runs on 10.15 & 11.0 


fixes #39603
