### PR TITLE
[runtime] Allocate code memory using MAP_JIT on apple silicon, patching code randomly crashes without it.

### DIFF
--- a/src/mono/mono/utils/mono-mmap.c
+++ b/src/mono/mono/utils/mono-mmap.c
@@ -305,6 +305,9 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 		}
 		if ((flags & MONO_MMAP_JIT) && (use_mmap_jit || is_hardened_runtime == 1))
 			mflags |= MAP_JIT;
+		/* Patching code on apple silicon seems to cause random crashes without this flag */
+		if (__builtin_available (macOS 11, *))
+			mflags |= MAP_JIT;
 	}
 #endif
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20342,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>