### PR TITLE
Fix exception mapping during expect 100 cancellation.

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -745,14 +745,10 @@ namespace System.Net.Http
                                 sendRequestContentTask.GetAwaiter().GetResult();
                             }
                         }
-                        catch (Exception ex)
+                        // Map the exception the same way as we normally do.
+                        catch (Exception ex) when (MapSendException(ex, cancellationToken, out Exception mappedEx))
                         {
-                            // Map the exception the same way as we normally do.
-                            if (MapSendException(ex, cancellationToken, out Exception mappedEx))
-                            {
-                                throw mappedEx;
-                            }
-                            throw;
+                            throw mappedEx;
                         }
                     }
                     LogExceptions(sendRequestContentTask);


### PR DESCRIPTION
Discovered during HTTP stress tests for HTTP 1.1
The exception from [`sendRequestContentTask`](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L740) was thrown as-is instead of being mapped as any other exception (e.g. being wrapped in [`OperationCanceledException`](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L767) when task was cancelled)

Stress failure: https://dev.azure.com/dnceng/public/_build/results?buildId=796633&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=8030b67c-413b-5f79-b1fb-b1ba3f08bc47&l=1235

The related code block has been introduced in 5.0 (#38774) and this is a regression from 3.1: a different type of exception is thrown for cancellation than `TaskCancelledException`.


Contributes to #40388