### PR TITLE
Fix argument name in CompareInfo.IsPrefix (suffix -> prefix)

### DIFF
--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6063,7 +6063,7 @@ namespace System.Globalization
         public int IndexOf(string source, string value, int startIndex, int count) { throw null; }
         public int IndexOf(string source, string value, int startIndex, int count, System.Globalization.CompareOptions options) { throw null; }
         public bool IsPrefix(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> prefix, System.Globalization.CompareOptions options = System.Globalization.CompareOptions.None) { throw null; }
-        public bool IsPrefix(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> suffix, System.Globalization.CompareOptions options, out int matchLength) { throw null; }
+        public bool IsPrefix(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> prefix, System.Globalization.CompareOptions options, out int matchLength) { throw null; }
         public bool IsPrefix(string source, string prefix) { throw null; }
         public bool IsPrefix(string source, string prefix, System.Globalization.CompareOptions options) { throw null; }
         public static bool IsSortable(char ch) { throw null; }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/41802

Fixes argument name in CompareInfo.IsPrefix which should be called `prefix` instead of `suffix` (implementation calls it correctly).

This seems to [have been introduced recently](https://github.com/dotnet/runtime/pull/40752/files#diff-1d02aa10f6540e37197ff9f090ca1d9eR6062) so we still got time to fix it