### PR TITLE
Bundle assemblies at 4K for linux arm64

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -29,24 +29,6 @@ namespace Microsoft.NET.HostModel.Bundle
         readonly TargetInfo Target;
         readonly BundleOptions Options;
 
-        // Temporary overload to avoid breaking the SDK build.
-        // This can be removed once the SDK is updated to call the other overload.
-        public Bundler(string hostName,
-                       string outputDir,
-                       BundleOptions options,
-                       OSPlatform? targetOS,
-                       Version targetFrameworkVersion,
-                       bool diagnosticOutput)
-            : this(hostName,
-                   outputDir,
-                   options,
-                   targetOS,
-                   null,
-                   targetFrameworkVersion,
-                   diagnosticOutput)
-        {
-        }
-
         public Bundler(string hostName,
                        string outputDir,
                        BundleOptions options = BundleOptions.None,

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
@@ -52,8 +52,9 @@ namespace Microsoft.NET.HostModel.Bundle
 
             if (IsLinux && Arch == Architecture.Arm64)
             {
-                // On ARM64, we use adrp; add instructions to encode pointers in the instruction stream.
-                // Adrp computes a page-relative offset, and these don't get fixed up, so we keep assemblies page-aligned.
+                // We align assemblies in the bundle at 4K so that we can use mmap on Linux without changing the page alignment of ARM64 R2R code.
+                // This is only necessary for R2R assemblies, but we do it for all assemblies for simplicity.
+                // See https://github.com/dotnet/runtime/issues/41832.
                 AssemblyAlignment = 4096;
             }
             else

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
@@ -78,7 +78,8 @@ namespace Microsoft.NET.HostModel.Bundle
         public override string ToString()
         {
             string os = IsWindows ? "win" : IsLinux ? "linux" : "osx";
-            return $"OS: {os} FrameworkVersion: {FrameworkVersion}";
+            string arch = Arch.ToString().ToLowerInvariant();
+            return $"OS: {os} Arch: {arch} FrameworkVersion: {FrameworkVersion}";
         }
 
         static OSPlatform HostOS => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? OSPlatform.Linux :

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
@@ -14,8 +14,10 @@ namespace Microsoft.NET.HostModel.Bundle
     /// 
     /// Currently the TargetInfo only tracks:
     ///   - the target operating system
-    ///   - The target framework
-    /// If necessary, the target architecture may be tracked in future.
+    ///   - the target architecture
+    ///   - the target framework
+    ///   - the default options for this target
+    ///   - the assembly alignment for this target
     /// </summary>
 
     public class TargetInfo

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Linq;
 using System.Xml.Linq;
 
 namespace BundleTests.Helpers
@@ -100,7 +99,7 @@ namespace BundleTests.Helpers
 
         public static OSPlatform GetTargetOS(string runtimeIdentifier)
         {
-            return runtimeIdentifier.Split('-').First() switch {
+            return runtimeIdentifier.Split('-')[0] switch {
                 "win" => OSPlatform.Windows,
                 "osx" => OSPlatform.OSX,
                 "linux" => OSPlatform.Linux,
@@ -110,13 +109,11 @@ namespace BundleTests.Helpers
 
         public static Architecture GetTargetArch(string runtimeIdentifier)
         {
-            return runtimeIdentifier.Split('-').Last() switch {
-                "x64" => Architecture.X64,
-                "x86" => Architecture.X86,
-                "arm64" => Architecture.Arm64,
-                "arm" => Architecture.Arm,
-                _ => throw new ArgumentException(nameof (runtimeIdentifier))
-            };
+            return runtimeIdentifier.EndsWith("-x64") || runtimeIdentifier.Contains("-x64-") ? Architecture.X64 :
+                   runtimeIdentifier.EndsWith("-x86") || runtimeIdentifier.Contains("-x86-") ? Architecture.X86 :
+                   runtimeIdentifier.EndsWith("-arm64") || runtimeIdentifier.Contains("-arm64-") ? Architecture.Arm64 :
+                   runtimeIdentifier.EndsWith("-arm") || runtimeIdentifier.Contains("-arm-") ? Architecture.Arm :
+                   throw new ArgumentException(nameof (runtimeIdentifier));
         }
 
         /// Generate a bundle containind the (embeddable) files in sourceDir

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -32,7 +32,9 @@ namespace Microsoft.NET.HostModel.Tests
 
             var hostName = BundleHelper.GetHostName(fixture);
             var bundleDir = BundleHelper.GetBundleDir(fixture);
-            Bundler bundler = new Bundler(hostName, bundleDir.FullName);
+            var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
+            var targetArch = BundleHelper.GetTargetArch(fixture.CurrentRid);
+            Bundler bundler = new Bundler(hostName, bundleDir.FullName, targetOS: targetOS, targetArch: targetArch);
 
             FileSpec[][] invalidSpecs =
             {
@@ -55,13 +57,15 @@ namespace Microsoft.NET.HostModel.Tests
             var hostName = BundleHelper.GetHostName(fixture);
             var appName = Path.GetFileNameWithoutExtension(hostName);
             var bundleDir = BundleHelper.GetBundleDir(fixture);
+            var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
+            var targetArch = BundleHelper.GetTargetArch(fixture.CurrentRid);
 
             // Generate a file specification without the apphost
             var fileSpecs = new List<FileSpec>();
             string[] files = { $"{appName}.dll", $"{appName}.deps.json", $"{appName}.runtimeconfig.json" };
             Array.ForEach(files, x => fileSpecs.Add(new FileSpec(x, x)));
 
-            Bundler bundler = new Bundler(hostName, bundleDir.FullName);
+            Bundler bundler = new Bundler(hostName, bundleDir.FullName, targetOS: targetOS, targetArch: targetArch);
 
             Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs));
         }
@@ -73,6 +77,8 @@ namespace Microsoft.NET.HostModel.Tests
 
             var hostName = BundleHelper.GetHostName(fixture);
             var bundleDir = BundleHelper.GetBundleDir(fixture);
+            var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
+            var targetArch = BundleHelper.GetTargetArch(fixture.CurrentRid);
 
             // Generate a file specification with duplicate entries
             var fileSpecs = new List<FileSpec>();
@@ -80,7 +86,7 @@ namespace Microsoft.NET.HostModel.Tests
             fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
             fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
 
-            Bundler bundler = new Bundler(hostName, bundleDir.FullName);
+            Bundler bundler = new Bundler(hostName, bundleDir.FullName, targetOS: targetOS, targetArch: targetArch);
             Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs));
         }
 
@@ -90,6 +96,8 @@ namespace Microsoft.NET.HostModel.Tests
             var fixture = sharedTestState.TestFixture.Copy();
             var publishPath = BundleHelper.GetPublishPath(fixture);
             var bundleDir = BundleHelper.GetBundleDir(fixture);
+            var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
+            var targetArch = BundleHelper.GetTargetArch(fixture.CurrentRid);
 
             // Rename the host from "StandaloneApp" to "Stand.Alone.App" to check that baseName computation
             // (and consequently deps.json and runtimeconfig.json name computations) in the bundler
@@ -110,7 +118,7 @@ namespace Microsoft.NET.HostModel.Tests
             var depsJson = newBaseName + ".deps.json";
             var runtimeconfigJson = newBaseName + ".runtimeconfig.json";
 
-            var bundler = new Bundler(hostName, bundleDir.FullName);
+            var bundler = new Bundler(hostName, bundleDir.FullName, targetOS: targetOS, targetArch: targetArch);
             BundleHelper.GenerateBundle(bundler, publishPath, bundleDir.FullName);
 
             string[] jsonFiles = { depsJson, runtimeconfigJson };
@@ -196,9 +204,11 @@ namespace Microsoft.NET.HostModel.Tests
         {
             var fixture = sharedTestState.TestFixture.Copy();
             var bundler = BundleHelper.Bundle(fixture);
-
+            var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
+            var targetArch = BundleHelper.GetTargetArch(fixture.CurrentRid);
+            var alignment = (targetOS == OSPlatform.Linux && targetArch == Architecture.Arm64) ? 4096 : 16;
             bundler.BundleManifest.Files.ForEach(file => 
-                Assert.True((file.Type != FileType.Assembly) || (file.Offset % Bundler.AssemblyAlignment == 0)));
+                Assert.True((file.Type != FileType.Assembly) || (file.Offset % alignment == 0)));
         }
 
         [Fact]


### PR DESCRIPTION
On ARM64 Linux, single-file apps were segfaulting because of an incorrect address computed in R2R code. See https://github.com/dotnet/runtime/issues/41832 for details about the issue.

This is a temporary fix that uses 4K offsets within the bundle. This will preserve the page alignment when we mmap assemblies, working around the lack of fixups for `adrp`; `add` instruction sequences.

I've confirmed that the fix, together with these SDK changes, produces a functional single-file app on Linux ARM64: https://github.com/sbomer/sdk/commit/19998e630c7aeb46e19898d4c2fb9b8df57a6ee7. I will make the SDK changes in the rc2 branch after this fix is ported and flows to the SDK.
