### PR TITLE
Handle name constraint errors from chain building.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -169,6 +169,8 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         *pStatus |= PAL_X509ChainPartialChain;
     else if (CFEqual(keyString, CFSTR("CriticalExtensions")))
         *pStatus |= PAL_X509ChainHasNotSupportedCriticalExtension;
+    else if (CFEqual(keyString, CFSTR("NameConstraints")))
+        *pStatus |= PAL_X509ChainInvalidNameConstraints;
     else if (CFEqual(keyString, CFSTR("UnparseableExtension")))
     {
         // 10.15 introduced new status code value which is not reported by Windows. Ignoring for now.

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -1058,6 +1058,18 @@ namespace Internal.Cryptography.Pal
                 case Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
                     return X509ChainStatusFlags.HasNotSupportedCriticalExtension;
 
+                case Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_PERMITTED_VIOLATION:
+                    return X509ChainStatusFlags.HasNotPermittedNameConstraint;
+
+                case Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_EXCLUDED_VIOLATION:
+                    return X509ChainStatusFlags.HasExcludedNameConstraint;
+
+                case Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_SUBTREE_MINMAX:
+                    return X509ChainStatusFlags.HasNotSupportedNameConstraint;
+
+                case Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_UNSUPPORTED_NAME_SYNTAX:
+                    return X509ChainStatusFlags.InvalidNameConstraints;
+
                 case Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_CERT_CHAIN_TOO_LONG:
                     throw new CryptographicException();
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -524,7 +524,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     X509ChainStatusFlags.HasNotSupportedNameConstraint |
                     X509ChainStatusFlags.InvalidNameConstraints;
 
-                if ((flags & AnyNameConstraintFlags) > 0)
+                if ((flags & AnyNameConstraintFlags) != 0)
                 {
                     flags &= ~AnyNameConstraintFlags;
                     flags |= X509ChainStatusFlags.InvalidNameConstraints;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Runtime.InteropServices;
 using Test.Cryptography;
 using Xunit;
 
@@ -447,6 +448,139 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.False(chain.Build(endEntityCert));
                 Assert.Equal(1, chain.ChainElements.Count);
                 Assert.Equal(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
+            }
+        }
+
+        [Fact]
+        public static void NameConstraintViolation_PermittedTree_Dns()
+        {
+            SubjectAlternativeNameBuilder builder = new SubjectAlternativeNameBuilder();
+            builder.AddDnsName("microsoft.com");
+
+            // permitted DNS name constraint for .example.com
+            string nameConstraints = "3012A010300E820C2E6578616D706C652E636F6D";
+
+            TestNameConstrainedChain(nameConstraints, builder, (bool result, X509Chain chain) => {
+                Assert.False(result, "chain.Build");
+                Assert.Equal(PlatformNameConstraints(X509ChainStatusFlags.HasNotPermittedNameConstraint), chain.AllStatusFlags());
+            });
+        }
+
+        [Fact]
+        public static void NameConstraintViolation_ExcludedTree_Dns()
+        {
+            SubjectAlternativeNameBuilder builder = new SubjectAlternativeNameBuilder();
+            builder.AddDnsName("www.example.com");
+
+            // excluded DNS name constraint for example.com.
+            string nameConstraints = "3012A110300E820C2E6578616D706C652E636F6D";
+
+            TestNameConstrainedChain(nameConstraints, builder, (bool result, X509Chain chain) => {
+                Assert.False(result, "chain.Build");
+                Assert.Equal(PlatformNameConstraints(X509ChainStatusFlags.HasExcludedNameConstraint), chain.AllStatusFlags());
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.OSX)] // macOS appears to just completely ignore min/max.
+        public static void NameConstraintViolation_PermittedTree_HasMin()
+        {
+            SubjectAlternativeNameBuilder builder = new SubjectAlternativeNameBuilder();
+            builder.AddDnsName("example.com");
+
+            // permitted DNS name constraint for example.com with a MIN of 9.
+            string nameConstraints = "3015A0133011820C2E6578616D706C652E636F6D800109";
+
+            TestNameConstrainedChain(nameConstraints, builder, (bool result, X509Chain chain) => {
+                Assert.False(result, "chain.Build");
+                Assert.Equal(PlatformNameConstraints(X509ChainStatusFlags.HasNotSupportedNameConstraint), chain.AllStatusFlags());
+            });
+        }
+
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.Windows)] // Windows seems to skip over nonsense GeneralNames.
+        public static void NameConstraintViolation_InvalidGeneralNames()
+        {
+            SubjectAlternativeNameBuilder builder = new SubjectAlternativeNameBuilder();
+            builder.AddEmailAddress("///");
+
+            // permitted RFC822 name constraint with GeneralName of ///.
+            string nameConstraints = "3009A007300581032F2F2F";
+
+            TestNameConstrainedChain(nameConstraints, builder, (bool result, X509Chain chain) => {
+                Assert.False(result, "chain.Build");
+                Assert.Equal(PlatformNameConstraints(X509ChainStatusFlags.InvalidNameConstraints), chain.AllStatusFlags());
+            });
+        }
+
+        private static X509ChainStatusFlags PlatformNameConstraints(X509ChainStatusFlags flags)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                const X509ChainStatusFlags AnyNameConstraintFlags =
+                    X509ChainStatusFlags.HasExcludedNameConstraint |
+                    X509ChainStatusFlags.HasNotDefinedNameConstraint |
+                    X509ChainStatusFlags.HasNotPermittedNameConstraint |
+                    X509ChainStatusFlags.HasNotSupportedNameConstraint |
+                    X509ChainStatusFlags.InvalidNameConstraints;
+
+                if ((flags & AnyNameConstraintFlags) > 0)
+                {
+                    flags &= ~AnyNameConstraintFlags;
+                    flags |= X509ChainStatusFlags.InvalidNameConstraints;
+                }
+            }
+
+            return flags;
+        }
+
+        private static void TestNameConstrainedChain(
+            string intermediateNameConstraints,
+            SubjectAlternativeNameBuilder endEntitySanBuilder,
+            Action<bool, X509Chain> body)
+        {
+            X509Extension[] endEntityExtensions = new [] {
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: false,
+                    hasPathLengthConstraint: false,
+                    pathLengthConstraint: 0,
+                    critical: true),
+                endEntitySanBuilder.Build()
+            };
+
+            X509Extension[] intermediateExtensions = new [] {
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: true,
+                    hasPathLengthConstraint: false,
+                    pathLengthConstraint: 0,
+                    critical: true),
+                new X509Extension(
+                    "2.5.29.30",
+                    intermediateNameConstraints.HexToByteArray(),
+                    critical: true)
+            };
+
+            TestDataGenerator.MakeTestChain3(
+                out X509Certificate2 endEntityCert,
+                out X509Certificate2 intermediateCert,
+                out X509Certificate2 rootCert,
+                intermediateExtensions: intermediateExtensions,
+                endEntityExtensions: endEntityExtensions);
+
+            using (endEntityCert)
+            using (intermediateCert)
+            using (rootCert)
+            using (ChainHolder chainHolder = new ChainHolder())
+            {
+                X509Chain chain = chainHolder.Chain;
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.VerificationTime = endEntityCert.NotBefore.AddSeconds(1);
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+
+                bool result = chain.Build(endEntityCert);
+                body(result, chain);
             }
         }
 


### PR DESCRIPTION
Map Linux name constraint status codes to the appropriate
X509ChainStatusFlags.

macOS does not have a unique status for different types of name
constraint violations like Linux and Windows do. Map this to
InvalidNameConstraint.

Fixes #41748 