### PR TITLE
Revert #40641

### DIFF
--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -48,33 +48,36 @@ namespace System.IO.Enumeration
             // directory.
             else if ((directoryEntry.InodeType == Interop.Sys.NodeType.DT_LNK
                 || directoryEntry.InodeType == Interop.Sys.NodeType.DT_UNKNOWN)
-                && Interop.Sys.Stat(entry.FullPath, out Interop.Sys.FileStatus statInfo) >= 0)
+                && Interop.Sys.Stat(entry.FullPath, out Interop.Sys.FileStatus targetStatus) >= 0)
             {
                 // Symlink or unknown: Stat to it to see if we can resolve it to a directory.
-                isDirectory = FileStatus.IsDirectory(statInfo);
+                isDirectory = (targetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
             }
-
-            // Same idea as the directory check, just repeated for (and tweaked due to the nature of) symlinks.
-            int resultLStat = Interop.Sys.LStat(entry.FullPath, out Interop.Sys.FileStatus lstatInfo);
-
-            bool isReadOnly = resultLStat >= 0 && FileStatus.IsReadOnly(lstatInfo);
-
+            // Same idea as the directory check, just repeated for (and tweaked due to the
+            // nature of) symlinks.
             if (directoryEntry.InodeType == Interop.Sys.NodeType.DT_LNK)
             {
                 isSymlink = true;
             }
-            else if (resultLStat >= 0 && directoryEntry.InodeType == Interop.Sys.NodeType.DT_UNKNOWN)
+            else if ((directoryEntry.InodeType == Interop.Sys.NodeType.DT_UNKNOWN)
+                && (Interop.Sys.LStat(entry.FullPath, out Interop.Sys.FileStatus linkTargetStatus) >= 0))
             {
-                isSymlink = FileStatus.IsSymLink(lstatInfo);
+                isSymlink = (linkTargetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK;
             }
-
-            // If the filename starts with a period or has UF_HIDDEN flag set, it's hidden.
-            bool isHidden = directoryEntry.Name[0] == '.' || (resultLStat >= 0 && FileStatus.IsHidden(lstatInfo));
 
             entry._status = default;
             FileStatus.Initialize(ref entry._status, isDirectory);
 
-            FileAttributes attributes = FileStatus.GetAttributes(isReadOnly, isSymlink, isDirectory, isHidden);
+            FileAttributes attributes = default;
+            if (isSymlink)
+                attributes |= FileAttributes.ReparsePoint;
+            if (isDirectory)
+                attributes |= FileAttributes.Directory;
+            if (directoryEntry.Name[0] == '.')
+                attributes |= FileAttributes.Hidden;
+
+            if (attributes == default)
+                attributes = FileAttributes.Normal;
 
             entry._initialAttributes = attributes;
             return attributes;
@@ -140,12 +143,7 @@ namespace System.IO.Enumeration
         public DateTimeOffset LastAccessTimeUtc => _status.GetLastAccessTime(FullPath, continueOnError: true);
         public DateTimeOffset LastWriteTimeUtc => _status.GetLastWriteTime(FullPath, continueOnError: true);
         public bool IsDirectory => _status.InitiallyDirectory;
-        /// <summary>
-        /// Returns <see langword="true"/> if the file is hidden; <see langword="false" /> otherwise.
-        /// In Linux and OSX, a file can be marked hidden if the filename is prepended with a dot.
-        /// In Windows and OSX, a file can be hidden if the special hidden attribute is set. For example, via the <see cref="FileSystemInfo.Attributes" /> enum flag.
-        /// </summary>
-        public bool IsHidden => _directoryEntry.Name[0] == '.' || (_initialAttributes & FileAttributes.Hidden) != 0;
+        public bool IsHidden => _directoryEntry.Name[0] == '.';
 
         public FileSystemInfo ToFileSystemInfo()
         {

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -113,42 +113,18 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
-        public void IsHiddenAttribute_Windows_OSX()
+        public void IsHiddenAttribute()
         {
-            // Put a period in front to make it hidden on Unix
-            IsHiddenAttributeInternal(useDotPrefix: false, useHiddenFlag: true);
-
-        }
-
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void IsHiddenAttribute_Unix()
-        {
-            // Windows and MacOS hide a file by setting the hidden attribute
-            IsHiddenAttributeInternal(useDotPrefix: true, useHiddenFlag: false);
-        }
-
-        private void IsHiddenAttributeInternal(bool useDotPrefix, bool useHiddenFlag)
-        {
-            string prefix = useDotPrefix ? "." : "";
-
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
-
             FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
-            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, prefix + GetTestFileName()));
+
+            // Put a period in front to make it hidden on Unix
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, "." + GetTestFileName()));
 
             fileOne.Create().Dispose();
             fileTwo.Create().Dispose();
-
-            if (useHiddenFlag)
-            {
-                fileTwo.Attributes |= FileAttributes.Hidden;
-            }
-
-            FileInfo fileCheck = new FileInfo(fileTwo.FullName);
-            Assert.Equal(fileTwo.Attributes, fileCheck.Attributes);
+            if (PlatformDetection.IsWindows)
+                fileTwo.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
 
             IEnumerable<string> enumerable = new FileSystemEnumerable<string>(
                 testDirectory.FullName,
@@ -156,30 +132,6 @@ namespace System.IO.Tests.Enumeration
                 new EnumerationOptions() { AttributesToSkip = 0 })
             {
                 ShouldIncludePredicate = (ref FileSystemEntry entry) => entry.IsHidden
-            };
-
-            Assert.Equal(new string[] { fileTwo.FullName }, enumerable);
-        }
-
-        [Fact]
-        public void IsReadOnlyAttribute()
-        {
-            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
-
-            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
-            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
-
-            fileOne.Create().Dispose();
-            fileTwo.Create().Dispose();
-
-            fileTwo.Attributes |= FileAttributes.ReadOnly;
-
-            IEnumerable<string> enumerable = new FileSystemEnumerable<string>(
-                 testDirectory.FullName,
-                 (ref FileSystemEntry entry) => entry.ToFullPath(),
-                 new EnumerationOptions() { AttributesToSkip = 0 })
-            {
-                ShouldIncludePredicate = (ref FileSystemEntry entry) => (entry.Attributes & FileAttributes.ReadOnly) != 0
             };
 
             Assert.Equal(new string[] { fileTwo.FullName }, enumerable);

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/SkipAttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/SkipAttributeTests.cs
@@ -21,42 +21,25 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
-        public void SkippingHiddenFiles_Windows_OSX()
-        {
-            SkippingHiddenFilesInternal(useDotPrefix: false, useHiddenFlag: true);
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void SkippingHiddenFiles_Unix()
-        {
-            SkippingHiddenFilesInternal(useDotPrefix: true, useHiddenFlag: false);
-        }
-
-        private void SkippingHiddenFilesInternal(bool useDotPrefix, bool useHiddenFlag)
+        public void SkippingHiddenFiles()
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
             DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Combine(testDirectory.FullName, GetTestFileName()));
-
             FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
-            FileInfo fileThree = new FileInfo(Path.Combine(testSubdirectory.FullName, GetTestFileName()));
 
-            // Put a period in front of files two and four to make them hidden on Unix
-            string prefix = useDotPrefix ? "." : "";
-            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, prefix + GetTestFileName()));
-            FileInfo fileFour = new FileInfo(Path.Combine(testSubdirectory.FullName, prefix + GetTestFileName()));
+            // Put a period in front to make it hidden on Unix
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, "." + GetTestFileName()));
+            FileInfo fileThree = new FileInfo(Path.Combine(testSubdirectory.FullName, GetTestFileName()));
+            FileInfo fileFour = new FileInfo(Path.Combine(testSubdirectory.FullName, "." + GetTestFileName()));
 
             fileOne.Create().Dispose();
             fileTwo.Create().Dispose();
+            if (PlatformDetection.IsWindows)
+                fileTwo.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
             fileThree.Create().Dispose();
             fileFour.Create().Dispose();
-
-            if (useHiddenFlag)
-            {
-                fileTwo.Attributes |= FileAttributes.Hidden;
-                fileFour.Attributes |= FileAttributes.Hidden;
-            }
+            if (PlatformDetection.IsWindows)
+                fileFour.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
 
             // Default EnumerationOptions is to skip hidden
             string[] paths = GetPaths(testDirectory.FullName, new EnumerationOptions());


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/41739

Reverts PR #40641 - "Ensure FileStatus and FileSystemEntry Hidden and ReadOnly attributes are retrieved the same way" which introduced a perf regression on Unix in `Directory.EnumerateFiles`.