### PR TITLE
Fix parent assembly for standalone components in Crossgen2 build

### DIFF
--- a/src/coreclr/src/vm/nativeimage.cpp
+++ b/src/coreclr/src/vm/nativeimage.cpp
@@ -224,12 +224,12 @@ NativeImage *NativeImage::Open(
 #endif
 
 #ifndef DACCESS_COMPILE
-Assembly *NativeImage::LoadManifestAssembly(uint32_t rowid)
+Assembly *NativeImage::LoadManifestAssembly(uint32_t rowid, DomainAssembly *pParentAssembly)
 {
     STANDARD_VM_CONTRACT;
 
     AssemblySpec spec;
-    spec.InitializeSpec(TokenFromRid(rowid, mdtAssemblyRef), m_pManifestMetadata, NULL);
+    spec.InitializeSpec(TokenFromRid(rowid, mdtAssemblyRef), m_pManifestMetadata, pParentAssembly);
     return spec.LoadAssembly(FILE_LOADED);
 }
 #endif

--- a/src/coreclr/src/vm/nativeimage.h
+++ b/src/coreclr/src/vm/nativeimage.h
@@ -118,7 +118,7 @@ public:
     PTR_Assembly *GetManifestMetadataAssemblyRefMap() { return m_pNativeMetadataAssemblyRefMap; }
     AssemblyLoadContext *GetAssemblyLoadContext() const { return m_pAssemblyLoadContext; }
 
-    Assembly *LoadManifestAssembly(uint32_t rowid);
+    Assembly *LoadManifestAssembly(uint32_t rowid, DomainAssembly *pParentAssembly);
     
     PTR_READYTORUN_CORE_HEADER GetComponentAssemblyHeader(LPCUTF8 assemblySimpleName);
     

--- a/src/coreclr/src/vm/zapsig.cpp
+++ b/src/coreclr/src/vm/zapsig.cpp
@@ -647,17 +647,17 @@ Module *ZapSig::DecodeModuleFromIndex(Module *fromModule,
 
         if(pAssembly == NULL)
         {
+            DomainAssembly *pParentAssembly = fromModule->GetDomainAssembly();
             if (nativeImage != NULL)
             {
-                pAssembly = nativeImage->LoadManifestAssembly(index);
+                pAssembly = nativeImage->LoadManifestAssembly(index, pParentAssembly);
             }
             else
             {
                 AssemblySpec spec;
                 spec.InitializeSpec(TokenFromRid(index, mdtAssemblyRef),
                                 fromModule->GetNativeAssemblyImport(),
-                                NULL);
-                spec.SetParentAssembly(fromModule->GetDomainAssembly());
+                                pParentAssembly);
                 pAssembly = spec.LoadAssembly(FILE_LOADED);
             }
             fromModule->SetNativeMetadataAssemblyRefInCache(index, pAssembly);

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -926,9 +926,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests/*">
             <Issue>https://github.com/dotnet/runtime/issues/34905</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.Basic/*">
-            <Issue>https://github.com/dotnet/runtime/issues/38290</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- runtest.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/38290

(finally, the issue was originally also tracking the bug in ResolutionFlow
I just fixed with https://github.com/dotnet/runtime/pull/41764)

/cc: @dotnet/crossgen-contrib 