### PR TITLE
Marking Matrix3x2, Matrix4x4, Plane, and Quaternion as Intrinsic

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace System.Numerics
 {
     /// <summary>
     /// A structure encapsulating a 3x2 matrix.
     /// </summary>
+    [Intrinsic]
     public struct Matrix3x2 : IEquatable<Matrix3x2>
     {
         private const float RotationEpsilon = 0.001f * MathF.PI / 180f;     // 0.1% of a degree

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -14,7 +14,7 @@ namespace System.Numerics
     /// <summary>
     /// A structure encapsulating a 4x4 matrix.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [Intrinsic]
     public struct Matrix4x4 : IEquatable<Matrix4x4>
     {
         private const float BillboardEpsilon = 1e-4f;

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Plane.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Plane.cs
@@ -9,6 +9,7 @@ namespace System.Numerics
     /// <summary>
     /// A structure encapsulating a 3D Plane
     /// </summary>
+    [Intrinsic]
     public struct Plane : IEquatable<Plane>
     {
         private const float NormalizeEpsilon = 1.192092896e-07f; // smallest such that 1.0+NormalizeEpsilon != 1.0

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Quaternion.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Quaternion.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace System.Numerics
 {
@@ -9,6 +10,7 @@ namespace System.Numerics
     /// A structure encapsulating a four-dimensional vector (x,y,z,w),
     /// which is used to efficiently rotate an object about the (x,y,z) vector by the angle theta, where w = cos(theta/2).
     /// </summary>
+    [Intrinsic]
     public struct Quaternion : IEquatable<Quaternion>
     {
         private const float SlerpEpsilon = 1e-6f;


### PR DESCRIPTION
This resolves #41738 by marking `Matrix3x2`, `Matrix4x4`, `Plane`, and `Quaternion` as intrinsic causing the `JitInlineSIMDMultipler` to be applied as it was for .NET Core 3.1