### PR TITLE
[release/5.0-rc2] Enable runtime closure verification

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,9 +62,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4be47e467013f8a07a1ed7b6e49e39c8150bde54</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.20431.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.20452.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4be47e467013f8a07a1ed7b6e49e39c8150bde54</Sha>
+      <Sha>3d3bc7c7181b6f1b4a930ef0c88a388765379c77</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20200806.6">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/global.json
+++ b/global.json
@@ -14,7 +14,7 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20431.1",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20431.1",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20431.1",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20452.6",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20431.1",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20359.4",

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -161,10 +161,20 @@
     </ItemGroup>
 
     <Message Importance="High" Text="Verifying closure of $(Id) %(ClosureFile.FileSet) assemblies" />
+
+    <PropertyGroup>
+      <_DependencyGraphFilePath>$(PackageReportDir)$(Id)$(NuspecSuffix)-%(ClosureFile.FileSet).dgml</_DependencyGraphFilePath>
+      <_DependencyGraphDir>$([System.IO.Path]::GetDirectoryName($(_DependencyGraphFilePath)))</_DependencyGraphDir>
+    </PropertyGroup>
+
+    <!-- Ensure directory for dependency graph file exists. -->
+    <MakeDir Condition="!Exists('$(_DependencyGraphDir')"
+             Directories="$(_DependencyGraphDir)" />
+
     <VerifyClosure
       Sources="@(_closureFileFiltered)"
       IgnoredReferences="@(IgnoredReference)"
-      DependencyGraphFilePath="$(PackageReportDir)$(Id)$(NuspecSuffix)-%(ClosureFile.FileSet).dgml" />
+      DependencyGraphFilePath="$(_DependencyGraphFilePath)" />
   </Target>
 
   <!--

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -146,35 +146,12 @@
   </Target>
 
   <!--
-    Overriding VerifyClosure target to enable closure validation without other validations.
+    Ensures package reports dir exists, to work around the issue in VerifyClosure task:
+    https://github.com/dotnet/arcade/issues/6090
+    Remove this target, once the issue is fixed.
   -->
-  <Target Name="VerifyClosure"
-          DependsOnTargets="GetClosureFiles"
-          Condition="'$(SkipValidatePackage)' != 'true' or '$(ShouldVerifyClosure)' == 'true'"
-          Inputs="%(ClosureFile.FileSet)"
-          Outputs="batching-on-FileSet-metadata">
-    <ItemGroup>
-      <_closureFileNames Include="@(ClosureFile->'%(FileName)')" Original="%(Identity)" />
-
-      <_closureFileNamesFiltered Include="@(_closureFileNames)" Exclude="@(ExcludeFromClosure)"/>
-      <_closureFileFiltered Include="@(_closureFileNamesFiltered->'%(Original)')"/>
-    </ItemGroup>
-
-    <Message Importance="High" Text="Verifying closure of $(Id) %(ClosureFile.FileSet) assemblies" />
-
-    <PropertyGroup>
-      <_DependencyGraphFilePath>$(PackageReportDir)$(Id)$(NuspecSuffix)-%(ClosureFile.FileSet).dgml</_DependencyGraphFilePath>
-      <_DependencyGraphDir>$([System.IO.Path]::GetDirectoryName($(_DependencyGraphFilePath)))</_DependencyGraphDir>
-    </PropertyGroup>
-
-    <!-- Ensure directory for dependency graph file exists. -->
-    <MakeDir Condition="!Exists('$(_DependencyGraphDir')"
-             Directories="$(_DependencyGraphDir)" />
-
-    <VerifyClosure
-      Sources="@(_closureFileFiltered)"
-      IgnoredReferences="@(IgnoredReference)"
-      DependencyGraphFilePath="$(_DependencyGraphFilePath)" />
+  <Target Name="EnsureDepenedencyGraphDir" BeforeTargets="VerifyClosure">
+    <MakeDir Directories="$(PackageReportDir)" />
   </Target>
 
   <!--

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -146,6 +146,28 @@
   </Target>
 
   <!--
+    Overriding VerifyClosure target to enable closure validation without other validations.
+  -->
+  <Target Name="VerifyClosure"
+          DependsOnTargets="GetClosureFiles"
+          Condition="'$(SkipValidatePackage)' != 'true' or '$(ShouldVerifyClosure)' == 'true'"
+          Inputs="%(ClosureFile.FileSet)"
+          Outputs="batching-on-FileSet-metadata">
+    <ItemGroup>
+      <_closureFileNames Include="@(ClosureFile->'%(FileName)')" Original="%(Identity)" />
+
+      <_closureFileNamesFiltered Include="@(_closureFileNames)" Exclude="@(ExcludeFromClosure)"/>
+      <_closureFileFiltered Include="@(_closureFileNamesFiltered->'%(Original)')"/>
+    </ItemGroup>
+
+    <Message Importance="High" Text="Verifying closure of $(Id) %(ClosureFile.FileSet) assemblies" />
+    <VerifyClosure
+      Sources="@(_closureFileFiltered)"
+      IgnoredReferences="@(IgnoredReference)"
+      DependencyGraphFilePath="$(PackageReportDir)$(Id)$(NuspecSuffix)-%(ClosureFile.FileSet).dgml" />
+  </Target>
+
+  <!--
     Finds symbol files and injects them into the package build.
   -->
   <Target Name="GetSymbolPackageFiles"

--- a/src/installer/pkg/projects/netcoreapp/pkg/legacy/Microsoft.NETCore.App.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/legacy/Microsoft.NETCore.App.pkgproj
@@ -14,9 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- netstandard will have cycles because OOB packages target netstandard and are used in netstandard closure,
-       We do ensure that netstandard inside the shared framework has no cycles, but we permit them in packages in order to allow for simpler netstandard-based builds.-->
-    <IgnoredReference Include="netstandard" />
     <!-- windows.winmd is not part of the framework -->
     <IgnoredReference Include="Windows" />
 

--- a/src/installer/pkg/projects/netcoreapp/pkg/legacy/Microsoft.NETCore.App.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/legacy/Microsoft.NETCore.App.pkgproj
@@ -7,8 +7,31 @@
     -->
     <BuildLineupPackage>false</BuildLineupPackage>
 
+    <ShouldVerifyClosure>true</ShouldVerifyClosure>
+
     <FrameworkListTargetPath>data/</FrameworkListTargetPath>
     <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- netstandard will have cycles because OOB packages target netstandard and are used in netstandard closure,
+       We do ensure that netstandard inside the shared framework has no cycles, but we permit them in packages in order to allow for simpler netstandard-based builds.-->
+    <IgnoredReference Include="netstandard" />
+    <!-- windows.winmd is not part of the framework -->
+    <IgnoredReference Include="Windows" />
+
+    <!-- Exclude shims from the closure verification -->
+    <ExcludeFromClosure Include="mscorlib" />
+    <ExcludeFromClosure Include="System" />
+    <ExcludeFromClosure Include="System.Configuration" />
+    <ExcludeFromClosure Include="System.Core" />
+    <ExcludeFromClosure Include="System.Data" />
+    <ExcludeFromClosure Include="System.Drawing" />
+    <ExcludeFromClosure Include="System.Net" />
+    <ExcludeFromClosure Include="System.Security" />
+    <ExcludeFromClosure Include="System.ServiceModel.Web" />
+    <ExcludeFromClosure Include="System.ServiceProcess" />
+    <ExcludeFromClosure Include="System.Transactions" />
+    <ExcludeFromClosure Include="WindowsBase" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/31805

Backport of: https://github.com/dotnet/runtime/pull/41698

This fix is needed to ensure we don’t miss any dependencies in our shipping runtime packages.