### PR TITLE
Optimize the allocation and speed of ActivitySet/GetCustomProperty

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -80,7 +80,7 @@ namespace System.Diagnostics
         private LinkedList<KeyValuePair<string, string?>>? _baggage;
         private LinkedList<ActivityLink>? _links;
         private LinkedList<ActivityEvent>? _events;
-        private ConcurrentDictionary<string, object>? _customProperties;
+        private Dictionary<string, object>? _customProperties;
         private string? _displayName;
 
         /// <summary>
@@ -894,16 +894,19 @@ namespace System.Diagnostics
         {
             if (_customProperties == null)
             {
-                Interlocked.CompareExchange(ref _customProperties, new ConcurrentDictionary<string, object>(), null);
+                Interlocked.CompareExchange(ref _customProperties, new Dictionary<string, object>(), null);
             }
 
-            if (propertyValue == null)
+            lock (_customProperties)
             {
-                _customProperties.TryRemove(propertyName, out object _);
-            }
-            else
-            {
-                _customProperties[propertyName] = propertyValue!;
+                if (propertyValue == null)
+                {
+                    _customProperties.Remove(propertyName);
+                }
+                else
+                {
+                    _customProperties[propertyName] = propertyValue!;
+                }
             }
         }
 
@@ -921,7 +924,13 @@ namespace System.Diagnostics
                 return null;
             }
 
-            return _customProperties.TryGetValue(propertyName, out object? o) ? o! : null;
+            object? ret;
+            lock (_customProperties)
+            {
+                ret = _customProperties.TryGetValue(propertyName, out object? o) ? o! : null;
+            }
+
+            return ret;
         }
 
         internal static Activity CreateAndStart(ActivitySource source, string name, ActivityKind kind, string? parentId, ActivityContext parentContext,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39591

It has been reported the allocation when using `Activity.SetCustomProperty` is too much. This change enhance the allocation and also show enhancement in the speed perf too. 

## Before Change 

|          Method |       Mean |    Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |-----------:|---------:|----------:|-------:|------:|------:|----------:|
|  Using1Property |   278.0 ns |  9.67 ns |  28.52 ns | 0.2160 |     - |     - |     904 B |
|  Using3Property |   502.1 ns | 16.27 ns |  47.72 ns | 0.2384 |     - |     - |    1000 B |
|  Using5Property |   749.5 ns | 33.28 ns |  97.07 ns | 0.2613 |     - |     - |    1096 B |
| Using10Property | 1,235.8 ns | 46.23 ns | 133.37 ns | 0.3185 |     - |     - |    1336 B |
| Using20Property | 3,116.9 ns | 92.66 ns | 271.76 ns | 0.8545 |     - |     - |    3576 B |

## After Change 

|          Method |       Mean |    Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |-----------:|---------:|----------:|-------:|------:|------:|----------:|
|  Using1Property |   182.6 ns |  4.79 ns |  14.04 ns | 0.0937 |     - |     - |     392 B |
|  Using3Property |   356.9 ns | 10.38 ns |  30.12 ns | 0.0935 |     - |     - |     392 B |
|  Using5Property |   627.5 ns | 17.66 ns |  51.23 ns | 0.1526 |     - |     - |     640 B |
| Using10Property | 1,258.8 ns | 43.85 ns | 127.21 ns | 0.2785 |     - |     - |    1168 B |
| Using20Property | 2,419.1 ns | 78.58 ns | 219.05 ns | 0.5379 |     - |     - |    2256 B |
