### PR TITLE
rework UseCallback_BadCertificate_ExpectedPolicyErrors test to use Loopback server to avoid external dependency

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.IO;
 using System.Net.Sockets;
 
@@ -93,6 +94,7 @@ namespace System.Net.Test.Common
     {
         public IPAddress Address { get; set; } = IPAddress.Loopback;
         public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback();
+        public X509Certificate2 Certificate { get; set; }
         public SslProtocols SslProtocols { get; set; } =
 #if !NETSTANDARD2_0 && !NETFRAMEWORK
                 SslProtocols.Tls13 |

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -387,12 +387,9 @@ namespace System.Net.Http.Functional.Tests
 
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Get, url);
-                    request.Headers.Add("Host", certificate.GetNameInfo(X509NameType.SimpleName, false));
-
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         server.AcceptConnectionSendResponseAndCloseAsync(),
-                        client.SendAsync(request));
+                        client.GetAsync($"https://{certificate.GetNameInfo(X509NameType.SimpleName, false)}:{url.Port}/"));
                 }, options);
 
                 Assert.True(callbackCalled);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -310,7 +310,6 @@ namespace System.Net.Http.Functional.Tests
         public static readonly object[][] CertificateValidationServersAndExpectedPolicies =
         {
             new object[] { Configuration.Http.ExpiredCertRemoteServer, SslPolicyErrors.RemoteCertificateChainErrors },
-            new object[] { Configuration.Http.SelfSignedCertRemoteServer, SslPolicyErrors.RemoteCertificateChainErrors },
             new object[] { Configuration.Http.WrongHostNameCertRemoteServer , SslPolicyErrors.RemoteCertificateNameMismatch},
         };
 
@@ -362,6 +361,41 @@ namespace System.Net.Http.Functional.Tests
             {
                 // Testing on old Windows versions can hit https://github.com/dotnet/runtime/issues/17005
                 // Ignore SEC_E_BUFFER_TOO_SMALL error on such cases.
+            }
+        }
+
+        [Fact]
+        public async Task UseCallback_SelfSignedCertificate_ExpectedPolicyErrors()
+        {
+            using (HttpClientHandler handler = CreateHttpClientHandler())
+            using (HttpClient client = CreateHttpClient(handler))
+            {
+                bool callbackCalled = false;
+                X509Certificate2 certificate = TestHelper.CreateServerSelfSignedCertificate();
+
+                handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
+                {
+                    callbackCalled = true;
+                    Assert.NotNull(request);
+                    Assert.NotNull(cert);
+                    Assert.NotNull(chain);
+                    Assert.Equal(SslPolicyErrors.RemoteCertificateChainErrors, errors);
+                    return true;
+                };
+
+                var options = new LoopbackServer.Options { UseSsl = true, Certificate = certificate };
+
+                await LoopbackServer.CreateServerAsync(async (server, url) =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.Add("Host", certificate.GetNameInfo(X509NameType.SimpleName, false));
+
+                    await TestHelper.WhenAllCompletedOrAnyFailed(
+                        server.AcceptConnectionSendResponseAndCloseAsync(),
+                        client.SendAsync(request));
+                }, options);
+
+                Assert.True(callbackCalled);
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -379,7 +379,6 @@ namespace System.Net.Test.Common
             public string Domain { get; set; }
             public string Password { get; set; }
             public bool IsProxy { get; set; } = false;
-            public X509Certificate2 Certificate { get; set; }
 
             public Options()
             {

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -379,6 +379,7 @@ namespace System.Net.Test.Common
             public string Domain { get; set; }
             public string Password { get; set; }
             public bool IsProxy { get; set; } = false;
+            public X509Certificate2 Certificate { get; set; }
 
             public Options()
             {
@@ -424,7 +425,7 @@ namespace System.Net.Test.Common
                 if (httpOptions.UseSsl)
                 {
                     var sslStream = new SslStream(stream, false, delegate { return true; });
-                    using (X509Certificate2 cert = Configuration.Certificates.GetServerCertificate())
+                    using (X509Certificate2 cert = httpOptions.Certificate ?? Configuration.Certificates.GetServerCertificate())
                     {
                         await sslStream.AuthenticateAsServerAsync(
                             cert,


### PR DESCRIPTION
The test is currently failing because new certificate on badssl.com does not have EKU so our validation throws in unexpected RemoteCertificateNameMismatch.
With this change we use loopback with certificate we can control. Since there is no external dependency, new test its no longer Outerloop. 

fixes #41381
