### PR TITLE
Add initial release testing for outerloop and jitstress pipelines

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - master
+    - release/*.*
   paths:
     include:
     - '*'

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -9,8 +9,8 @@ schedules:
     include:
     - master
   always: true
-- cron: "0 4 * * 2,4,6"
-  displayName: Tue, Thu, Sat at 8:00 PM (UTC-8:00)
+- cron: "0 4 * * 0,2,4,6"
+  displayName: Sun, Tue, Thu, Sat at 8:00 PM (UTC-8:00)
   branches:
     include:
     - release/*.*

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -3,11 +3,17 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 4 * * *"
-  displayName: Mon through Sun at 8:00 PM (UTC-8:00)
+- cron: "0 4 * * 1,3,5"
+  displayName: Mon, Wed, Fri at 8:00 PM (UTC-8:00)
   branches:
     include:
     - master
+  always: true
+- cron: "0 4 * * 2,4,6"
+  displayName: Tue, Thu, Sat at 8:00 PM (UTC-8:00)
+  branches:
+    include:
+    - release/*.*
   always: true
 
 jobs:

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -3,8 +3,8 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 7 * * 2,4,6"
-  displayName: Tue, Thu, Sat at 11:00 PM (UTC-8:00)
+- cron: "0 7 * * 0,2,4,6"
+  displayName: Sun, Tue, Thu, Sat at 11:00 PM (UTC-8:00)
   branches:
     include:
     - master

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -3,11 +3,17 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 7 * * *"
-  displayName: Mon through Sun at 11:00 PM (UTC-8:00)
+- cron: "0 7 * * 2,4,6"
+  displayName: Tue, Thu, Sat at 11:00 PM (UTC-8:00)
   branches:
     include:
     - master
+  always: true
+- cron: "0 7 * * 1,3,5"
+  displayName: Mon, Wed, Fri at 11:00 PM (UTC-8:00)
+  branches:
+    include:
+    - release/*.*
   always: true
 
 jobs:


### PR DESCRIPTION
I have fixed the CoreCLR outerloop pipeline to include the release
branches. For jitstress and libraries_jitstress I have split the
schedules to run every other day for master vs. release as with
the growing number of Mono runs there's not much space for maneuver
w.r.t. allocating new lab HW.

Fixes: https://github.com/dotnet/runtime/issues/41841

Thanks

Tomas

P.S. There's not much I can do about validating that the updated
schedules actually work apart from just running the pipeline on the
PR to at least verify that the YAML is syntactically correct.

/cc: @dotnet/runtime-infrastructure 