### PR TITLE
[mono] Fix Android and iOS samples

### DIFF
--- a/src/mono/netcore/sample/Android/Makefile
+++ b/src/mono/netcore/sample/Android/Makefile
@@ -12,7 +12,7 @@ runtimepack:
 
 run: clean appbuilder
 	$(DOTNET) publish -c $(MONO_CONFIG) -r android-$(MONO_ARCH) \
-	/p:Platform=$(MONO_ARCH) /p:DeployAndRun=true
+	/p:Platform=$(MONO_ARCH) /p:DeployAndRun=true /p:TargetArchitecture=$(MONO_ARCH)
 
 clean:
 	rm -rf bin

--- a/src/mono/netcore/sample/Android/Makefile
+++ b/src/mono/netcore/sample/Android/Makefile
@@ -12,7 +12,7 @@ runtimepack:
 
 run: clean appbuilder
 	$(DOTNET) publish -c $(MONO_CONFIG) -r android-$(MONO_ARCH) \
-	/p:Platform=$(MONO_ARCH) /p:DeployAndRun=true /p:TargetArchitecture=$(MONO_ARCH)
+	/p:TargetArchitecture=$(MONO_ARCH) /p:DeployAndRun=true
 
 clean:
 	rm -rf bin

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -9,6 +9,7 @@
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <PublishTrimmed>true</PublishTrimmed>
     <_TrimmerDefaultAction>link</_TrimmerDefaultAction>
+    <InvariantGlobalization>true</InvariantGlobalization> <!-- workaround for https://github.com/dotnet/runtime/issues/41866 -->
   </PropertyGroup>
 
   <!-- Redirect 'dotnet publish' to in-tree runtime pack -->

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -11,13 +11,14 @@
     <PublishTrimmed>true</PublishTrimmed>
     <_TrimmerDefaultAction>link</_TrimmerDefaultAction>
     <Optimized Condition="'$(Configuration)' == 'Release'">True</Optimized>
+    <InvariantGlobalization>true</InvariantGlobalization> <!-- workaround for https://github.com/dotnet/runtime/issues/41866 -->
   </PropertyGroup>
 
   <!-- Redirect 'dotnet publish' to in-tree runtime pack -->
   <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <RuntimePack>
-        <PackageDirectory>$(ArtifactBinDir)microsoft.netcore.app.runtime.ios-$(TargetArchitecture)\$(Configuration)</PackageDirectory>
+        <PackageDirectory>$(ArtifactsBinDir)microsoft.netcore.app.runtime.ios-$(TargetArchitecture)\$(Configuration)</PackageDirectory>
       </RuntimePack>
     </ItemGroup>
     <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />


### PR DESCRIPTION
Fixes broken samples for Android and iOS.
`InvariantGlobalization` fixes the issue described in https://github.com/dotnet/runtime/issues/41866 because otherwise ILLink fails on Interop.Globalization.EnumCalendarInfo (with a function pointer).