### PR TITLE
Disable LoadAsync_CancelDuringLoad_CompletesAsCanceled test on mono

### DIFF
--- a/src/libraries/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
+++ b/src/libraries/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
@@ -462,7 +462,7 @@ namespace System.Media.Test
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/41676", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/41676", TestRuntimes.Mono)]
         public async Task LoadAsync_CancelDuringLoad_CompletesAsCanceled(int cancellationCause)
         {
             var tcs = new TaskCompletionSource<AsyncCompletedEventArgs>();

--- a/src/libraries/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
+++ b/src/libraries/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
@@ -462,6 +462,7 @@ namespace System.Media.Test
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/41676", TestPlatforms.Browser)]
         public async Task LoadAsync_CancelDuringLoad_CompletesAsCanceled(int cancellationCause)
         {
             var tcs = new TaskCompletionSource<AsyncCompletedEventArgs>();


### PR DESCRIPTION
Relates to: https://github.com/dotnet/runtime/issues/41676

I just hit this on another PR, let's disable to get cleaner CI builds.