### PR TITLE
[wasm] Mark System.Threading.ThreadPoolBoundHandle unsupported on Browser

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.PlatformNotSupported.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Threading
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class ThreadPoolBoundHandle : IDisposable
     {
         public SafeHandle Handle => null!;

--- a/src/libraries/System.Threading.Overlapped/Directory.Build.props
+++ b/src/libraries/System.Threading.Overlapped/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
     <IsWindowsSpecific>true</IsWindowsSpecific>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
+++ b/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
@@ -50,6 +50,7 @@ namespace System.Threading
         public void Dispose() { }
         ~PreAllocatedOverlapped() { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class ThreadPoolBoundHandle : System.IDisposable
     {
         internal ThreadPoolBoundHandle() { }


### PR DESCRIPTION
Contributes to #41087 

```
M:System.Threading.ThreadPoolBoundHandle.BindHandle(System.Runtime.InteropServices.SafeHandle),System.Threading,ThreadPoolBoundHandle,BindHandle(SafeHandle),0
M:System.Threading.ThreadPoolBoundHandle.AllocateNativeOverlapped(System.Threading.PreAllocatedOverlapped),System.Threading,ThreadPoolBoundHandle,AllocateNativeOverlapped(PreAllocatedOverlapped),0
M:System.Threading.ThreadPoolBoundHandle.GetNativeOverlappedState(System.Threading.NativeOverlapped*),System.Threading,ThreadPoolBoundHandle,GetNativeOverlappedState(NativeOverlapped*),0
M:System.Threading.ThreadPoolBoundHandle.FreeNativeOverlapped(System.Threading.NativeOverlapped*),System.Threading,ThreadPoolBoundHandle,FreeNativeOverlapped(NativeOverlapped*),0
"M:System.Threading.ThreadPoolBoundHandle.AllocateNativeOverlapped(System.Threading.IOCompletionCallback,System.Object,System.Object)",System.Threading,ThreadPoolBoundHandle,"AllocateNativeOverlapped(IOCompletionCallback, Object, Object)",0
```

Though `Dispose()` and `Handle` were not on the list to mark as unsupported, mark the entire `ThreadPoolBoundHandle` class as unsupported because the source file `ThreadPoolBoundHandle.PlatformNotSupported.cs` suggests PNSE. 