### PR TITLE
Implement ExportSubjectPublicKeyInfo on ECDHPublicKey

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDhKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDhKeyFileTests.cs
@@ -40,5 +40,12 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         protected override void Exercise(ECDiffieHellman key) => key.Exercise();
+
+        protected override Func<ECDiffieHellman, byte[]> PublicKeyWriteArrayFunc { get; } =
+            key => key.PublicKey.ExportSubjectPublicKeyInfo();
+
+        protected override WriteKeyToSpanFunc PublicKeyWriteSpanFunc { get; } =
+            (ECDiffieHellman key, Span<byte> destination, out int bytesWritten) =>
+                key.PublicKey.TryExportSubjectPublicKeyInfo(destination, out bytesWritten);
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.cs
@@ -111,6 +111,18 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             }
         }
 
+        [Fact]
+        public static void PublicKey_TryExportSubjectPublicKeyInfo_TooSmall()
+        {
+            using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
+            using (ECDiffieHellmanPublicKey publicKey = ecdh.PublicKey)
+            {
+                Span<byte> destination = stackalloc byte[1];
+                Assert.False(publicKey.TryExportSubjectPublicKeyInfo(destination, out int written));
+                Assert.Equal(0, written);
+            }
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -308,8 +308,10 @@ namespace System.Security.Cryptography
         protected virtual void Dispose(bool disposing) { }
         public virtual System.Security.Cryptography.ECParameters ExportExplicitParameters() { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportParameters() { throw null; }
+        public virtual byte[] ExportSubjectPublicKeyInfo() { throw null; }
         public virtual byte[] ToByteArray() { throw null; }
         public virtual string ToXmlString() { throw null; }
+        public virtual bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public abstract partial class ECDsa : System.Security.Cryptography.AsymmetricAlgorithm
     {

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.ExportParameters.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.ExportParameters.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Formats.Asn1;
+
 namespace System.Security.Cryptography
 {
     /// <summary>
@@ -26,6 +28,20 @@ namespace System.Security.Cryptography
         public virtual ECParameters ExportExplicitParameters()
         {
             throw new NotSupportedException(SR.NotSupported_SubclassOverride);
+        }
+
+        public virtual bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten)
+        {
+            ECParameters ecParameters = ExportParameters();
+            AsnWriter writer = EccKeyFormatHelper.WriteSubjectPublicKeyInfo(ecParameters);
+            return writer.TryEncode(destination, out bytesWritten);
+        }
+
+        public virtual byte[] ExportSubjectPublicKeyInfo()
+        {
+            ECParameters ecParameters = ExportParameters();
+            AsnWriter writer = EccKeyFormatHelper.WriteSubjectPublicKeyInfo(ecParameters);
+            return writer.Encode();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.ExportParameters.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanPublicKey.ExportParameters.cs
@@ -30,6 +30,23 @@ namespace System.Security.Cryptography
             throw new NotSupportedException(SR.NotSupported_SubclassOverride);
         }
 
+        /// <summary>
+        /// Attempts to export the current key in the X.509 SubjectPublicKeyInfo format.
+        /// </summary>
+        /// <param name="destination">The byte span to receive the X.509 SubjectPublicKeyInfo data.</param>
+        /// <param name="bytesWritten">
+        /// When this method returns, contains a value that indicates the number of bytes written to <paramref name="destination" />.
+        /// This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> is big enough to receive the output;
+        ///   otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="NotSupportedException">
+        /// The member <see cref="ExportParameters" /> has not been overridden in a derived class.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        /// <exception cref="CryptographicException">The key is invalid and could not be exported.</exception>
         public virtual bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten)
         {
             ECParameters ecParameters = ExportParameters();
@@ -37,6 +54,17 @@ namespace System.Security.Cryptography
             return writer.TryEncode(destination, out bytesWritten);
         }
 
+        /// <summary>
+        /// Exports the current key in the X.509 SubjectPublicKeyInfo format.
+        /// </summary>
+        /// <returns>
+        /// A byte array containing the X.509 SubjectPublicKeyInfo representation of this key.
+        /// </returns>
+        /// <exception cref="NotSupportedException">
+        /// The member <see cref="ExportParameters" /> has not been overridden in a derived class.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        /// <exception cref="CryptographicException">The key is invalid and could not be exported.</exception>
         public virtual byte[] ExportSubjectPublicKeyInfo()
         {
             ECParameters ecParameters = ExportParameters();


### PR DESCRIPTION
This implements ExportSubjectPublicKeyInfo on ECDiffieHellmanPublicKey.

The original API design indicated that we should throw not supported and let derived classes implement this, but I think the implementation can be done reasonably in the abstract class.

Closes #587