### PR TITLE
[wasm] Mark System.Threading APIs as unsupported on Browser

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/AutoResetEvent.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/AutoResetEvent.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Threading
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class AutoResetEvent : EventWaitHandle
     {
         public AutoResetEvent(bool initialState) : base(initialState, EventResetMode.AutoReset) { }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
@@ -8,6 +8,7 @@ using System.Runtime.Versioning;
 
 namespace System.Threading
 {
+    [UnsupportedOSPlatform("browser")]
     public partial class EventWaitHandle : WaitHandle
     {
         public EventWaitHandle(bool initialState, EventResetMode mode) :

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEvent.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEvent.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Threading
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class ManualResetEvent : EventWaitHandle
     {
         public ManualResetEvent(bool initialState) : base(initialState, EventResetMode.ManualReset) { }

--- a/src/libraries/System.Threading/Directory.Build.props
+++ b/src/libraries/System.Threading/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Threading/ref/System.Threading.cs
+++ b/src/libraries/System.Threading/ref/System.Threading.cs
@@ -46,6 +46,7 @@ namespace System.Threading
         [System.Diagnostics.CodeAnalysis.MaybeNullAttribute]
         public T Value { get { throw null; } set { } }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class AutoResetEvent : System.Threading.EventWaitHandle
     {
         public AutoResetEvent(bool initialState) : base (default(bool), default(System.Threading.EventResetMode)) { }
@@ -108,6 +109,7 @@ namespace System.Threading
         AutoReset = 0,
         ManualReset = 1,
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class EventWaitHandle : System.Threading.WaitHandle
     {
         public EventWaitHandle(bool initialState, System.Threading.EventResetMode mode) { }
@@ -242,6 +244,7 @@ namespace System.Threading
         NoRecursion = 0,
         SupportsRecursion = 1,
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class ManualResetEvent : System.Threading.EventWaitHandle
     {
         public ManualResetEvent(bool initialState) : base (default(bool), default(System.Threading.EventResetMode)) { }


### PR DESCRIPTION
Contributes towards #41087 

```
"M:System.Threading.EventWaitHandle.#ctor(System.Boolean,System.Threading.EventResetMode)",System.Threading,EventWaitHandle,".ctor(Boolean, EventResetMode)",2
"M:System.Threading.EventWaitHandle.TryOpenExisting(System.String,System.Threading.EventWaitHandle@)",System.Threading,EventWaitHandle,"TryOpenExisting(String, EventWaitHandle)",1
"M:System.Threading.EventWaitHandle.#ctor(System.Boolean,System.Threading.EventResetMode,System.String)",System.Threading,EventWaitHandle,".ctor(Boolean, EventResetMode, String)",2
"M:System.Threading.EventWaitHandle.#ctor(System.Boolean,System.Threading.EventResetMode,System.String,System.Boolean@)",System.Threading,EventWaitHandle,".ctor(Boolean, EventResetMode, String, Boolean)",1
M:System.Threading.EventWaitHandle.OpenExisting(System.String),System.Threading,EventWaitHandle,OpenExisting(String),1
M:System.Threading.AutoResetEvent.#ctor(System.Boolean),System.Threading,AutoResetEvent,.ctor(Boolean),3
"M:System.Threading.ExecutionContext.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.Threading,ExecutionContext,"GetObjectData(SerializationInfo, StreamingContext)",0
M:System.Threading.ManualResetEvent.#ctor(System.Boolean),System.Threading,ManualResetEvent,.ctor(Boolean),3
```

Marked EventWaitHandle, AutoResetEvent, and ManualResetEvent at class level
Omitted ExecutionContext.GetObjectData as it pertains to Serialization infrastructure