### PR TITLE
[wasm] Mark System.Threading.Thread APIs unsupported on Browser

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CompressedStack.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CompressedStack.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 
 namespace System.Threading
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -189,7 +189,7 @@ namespace System.Threading
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);
         }
 
-        [UnsupportedOSPlatform("browser")]
+        [Obsolete("Thread.ResetAbort is not supported and throws PlatformNotSupportedException.")]
         public static void ResetAbort()
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -131,7 +131,6 @@ namespace System.Threading
 
         public static IPrincipal? CurrentPrincipal
         {
-            [UnsupportedOSPlatform("browser")]
             get
             {
                 IPrincipal? principal = s_asyncLocalPrincipal?.Value;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -131,6 +131,7 @@ namespace System.Threading
 
         public static IPrincipal? CurrentPrincipal
         {
+            [UnsupportedOSPlatform("browser")]
             get
             {
                 IPrincipal? principal = s_asyncLocalPrincipal?.Value;
@@ -189,6 +190,7 @@ namespace System.Threading
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static void ResetAbort()
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);

--- a/src/libraries/System.Threading.Thread/Directory.Build.props
+++ b/src/libraries/System.Threading.Thread/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -39,7 +39,7 @@ namespace System.Threading
         [System.ObsoleteAttribute("The ApartmentState property has been deprecated.  Use GetApartmentState, SetApartmentState or TrySetApartmentState instead.", false)]
         public System.Threading.ApartmentState ApartmentState { get { throw null; } set { } }
         public System.Globalization.CultureInfo CurrentCulture { get { throw null; } set { } }
-        public static System.Security.Principal.IPrincipal? CurrentPrincipal { get { throw null; } set { } }
+        public static System.Security.Principal.IPrincipal? CurrentPrincipal { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] get { throw null; } set { } }
         public static System.Threading.Thread CurrentThread { get { throw null; } }
         public System.Globalization.CultureInfo CurrentUICulture { get { throw null; } set { } }
         public System.Threading.ExecutionContext? ExecutionContext { get { throw null; } }
@@ -77,6 +77,7 @@ namespace System.Threading
         public bool Join(int millisecondsTimeout) { throw null; }
         public bool Join(System.TimeSpan timeout) { throw null; }
         public static void MemoryBarrier() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static void ResetAbort() { }
         [System.ObsoleteAttribute("Thread.Resume has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
         public void Resume() { }

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -39,7 +39,7 @@ namespace System.Threading
         [System.ObsoleteAttribute("The ApartmentState property has been deprecated.  Use GetApartmentState, SetApartmentState or TrySetApartmentState instead.", false)]
         public System.Threading.ApartmentState ApartmentState { get { throw null; } set { } }
         public System.Globalization.CultureInfo CurrentCulture { get { throw null; } set { } }
-        public static System.Security.Principal.IPrincipal? CurrentPrincipal { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] get { throw null; } set { } }
+        public static System.Security.Principal.IPrincipal? CurrentPrincipal { get { throw null; } set { } }
         public static System.Threading.Thread CurrentThread { get { throw null; } }
         public System.Globalization.CultureInfo CurrentUICulture { get { throw null; } set { } }
         public System.Threading.ExecutionContext? ExecutionContext { get { throw null; } }

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -77,7 +77,7 @@ namespace System.Threading
         public bool Join(int millisecondsTimeout) { throw null; }
         public bool Join(System.TimeSpan timeout) { throw null; }
         public static void MemoryBarrier() { }
-        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+        [System.ObsoleteAttribute("Thread.ResetAbort is not supported and throws PlatformNotSupportedException.")]
         public static void ResetAbort() { }
         [System.ObsoleteAttribute("Thread.Resume has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
         public void Resume() { }


### PR DESCRIPTION
Contributes to #41087 

```
M:System.Threading.Thread.Abort(System.Object),System.Threading,Thread,Abort(Object),0
M:System.Threading.Thread.ResetAbort,System.Threading,Thread,ResetAbort(),0
M:System.Threading.Thread.get_CurrentPrincipal,System.Threading,Thread,get_CurrentPrincipal(),1
M:System.Threading.Thread.Suspend,System.Threading,Thread,Suspend(),0
M:System.Threading.Thread.SetApartmentState(System.Threading.ApartmentState),System.Threading,Thread,SetApartmentState(ApartmentState),0
M:System.Threading.Thread.Abort,System.Threading,Thread,Abort(),0
M:System.Threading.Thread.Resume,System.Threading,Thread,Resume(),0
"M:System.Threading.CompressedStack.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System.Threading,CompressedStack,"GetObjectData(SerializationInfo, StreamingContext)",0
```

Omitted CompressedStack because it pertains to Serialization infrastructure.
SetApartmentState is windows specific
Abort, Suspend, Resume are obsolete