### PR TITLE
Suppress C5105 warning on build

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -444,7 +444,8 @@ if (MSVC)
 
   # Disable Warnings:
   # 4291: Delete not defined for new, c++ exception may cause leak.
-  add_compile_options(/wd4291)
+  # 5105: Windows SDK headers use 'defined' operator in some macros
+  add_compile_options(/wd4291 /wd5105)
 
   # Treat Warnings as Errors:
   # 4007: 'main' : must be __cdecl.


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/41886.

MSVC included with latest VS nightly performs stricter preprocessor conformance checks. These checks currently produce warnings on the Windows SDK header file _winbase.h_, which is failing our build. This PR suppresses this warning code so that we can continue to import this header file successfully.

This is only intended to be a temporary workaround to unblock development. We'll make a more permanent fix when we receive guidance from the MSVC or the Windows SDK team.