### PR TITLE
MemoryMarshal.ToEnumerable cache span

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -350,8 +350,9 @@ namespace System.Runtime.InteropServices
         /// <returns>An <see cref="IEnumerable{T}"/> view of the given <paramref name="memory" /></returns>
         public static IEnumerable<T> ToEnumerable<T>(ReadOnlyMemory<T> memory)
         {
-            for (int i = 0; i < memory.Length; i++)
-                yield return memory.Span[i];
+            ReadOnlySpan<T> span = memory.Span;
+            for (int i = 0; i < span.Length; i++)
+                yield return span[i];
         }
 
         /// <summary>Attempts to get the underlying <see cref="string"/> from a <see cref="ReadOnlyMemory{T}"/>.</summary>


### PR DESCRIPTION
MemoryMarshal.ToEnumerable cache span

```
public static IEnumerable<T> ToEnumerable<T>(ReadOnlyMemory<T> memory)
{
	for (int i = 0; i < memory.Length; i++)
		yield return memory.Span[i];
}
```
```
public unsafe ReadOnlySpan<T> Span
{
	[MethodImpl(MethodImplOptions.AggressiveInlining)]
	get
	{
		ref T refToReturn = ref Unsafe.NullRef<T>();
		int lengthOfUnderlyingSpan = 0;

		// Copy this field into a local so that it can't change out from under us mid-operation.

		object? tmpObject = _object;
		if (tmpObject != null)
		{
			if (typeof(T) == typeof(char) && tmpObject.GetType() == typeof(string))
			{
				// Special-case string since it's the most common for ROM<char>.

				refToReturn = ref Unsafe.As<char, T>(ref Unsafe.As<string>(tmpObject).GetRawStringData());
				lengthOfUnderlyingSpan = Unsafe.As<string>(tmpObject).Length;
...
```

ReadOnlyMemory<T>.Span getter is not pure, it does some type checks, allocations, etc. In this loop scenario asking to construct a span to use it once and discard it immediately after is an overkill. Since we're dealing with read-only memory, we can safely cache span for reuse.