### PR TITLE
Modify condition to match message:

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -135,7 +135,7 @@ namespace System.Net.Http
             get => _settings._maxAutomaticRedirections;
             set
             {
-                if (value < 1)
+                if (value <= 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, SR.Format(SR.net_http_value_must_be_greater_than, 0));
                 }


### PR DESCRIPTION
- Since we are throwing: `net_http_value_must_be_greater_than, 0` it makes more sense to use the same value in the condition.

Close: https://github.com/dotnet/runtime/issues/41932