### PR TITLE
Disable System.Xml.Tests.AsyncReaderLateInitTests.InitializationWithUriOnNonAsyncReaderTrows test on Browser WASM due to PNSE

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -86,8 +86,8 @@ namespace System.Xml.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
-        public static void InitializationWithUriOnNonAsyncReaderTrows()
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
+        public static void InitializationWithUriOnNonAsyncReaderThrows()
         {
             Assert.Throws<System.Net.Http.HttpRequestException>(() => XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = false }));
         }


### PR DESCRIPTION
During the Wasm testing in Chromium happening in https://github.com/dotnet/runtime/pull/40786, yet another occurrence of `typeof(System.PlatformNotSupportedException): Cannot wait on monitors on this runtime.` has been uncovered.  
This PR just disables the failing test using `PlatformDetection.IsThreadingSupported` feature detection and fixes a typo in the test naming.

Fixes https://github.com/dotnet/runtime/issues/41163.
