### PR TITLE
[WIP] Synchronize the update to heap_segment_committed and heap_segment_used with allocation

### DIFF
--- a/src/coreclr/src/gc/gcpriv.h
+++ b/src/coreclr/src/gc/gcpriv.h
@@ -1708,7 +1708,7 @@ protected:
     PER_HEAP
     size_t decommit_ephemeral_segment_pages_step ();
     PER_HEAP
-    size_t decommit_heap_segment_pages_worker (heap_segment* seg, uint8_t *new_committed);
+    size_t decommit_heap_segment_pages_worker (heap_segment* seg, uint8_t *new_committed, bool synchronized);
     PER_HEAP_ISOLATED
     bool decommit_step ();
     PER_HEAP


### PR DESCRIPTION
As of https://github.com/dotnet/runtime/pull/35896, `decommit_heap_segment_pages` could be called outside of the GC pause. This function modifies `heap_segment.used`, which is also read by `adjust_limit_clr`, called by allocation.

Before the change, these operations are not synchronized, leading to the possibility of a race condition.