### PR TITLE
[iOS] Make Environment.GetFolderPathCore Xamarin.iOS compatible

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
@@ -78,7 +78,7 @@ namespace System
                     return CombineSearchPath(NSSearchPathDirectory.NSLibraryDirectory, "Favorites");
 
                 case SpecialFolder.ProgramFiles:
-                    return "/Applications";
+                    return Interop.Sys.SearchPath(NSSearchPathDirectory.NSApplicationDirectory);
 
                 case SpecialFolder.InternetCache:
                     return Interop.Sys.SearchPath(NSSearchPathDirectory.NSCachesDirectory);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
@@ -54,19 +54,19 @@ namespace System
 
                 case SpecialFolder.Desktop:
                 case SpecialFolder.DesktopDirectory:
-                    return Interop.Sys.SearchPath(NSSearchPathDirectory.NSDesktopDirectory);
+                    return Path.Combine(GetFolderPathCore(SpecialFolder.Personal, SpecialFolderOption.None), "Desktop");
 
                 case SpecialFolder.MyMusic:
-                    return Interop.Sys.SearchPath(NSSearchPathDirectory.NSMusicDirectory);
+                    return Path.Combine(GetFolderPathCore(SpecialFolder.Personal, SpecialFolderOption.None), "Music");
 
                 case SpecialFolder.MyPictures:
-                    return Interop.Sys.SearchPath(NSSearchPathDirectory.NSPicturesDirectory);
+                    return Path.Combine(GetFolderPathCore(SpecialFolder.Personal, SpecialFolderOption.None), "Pictures");
 
                 case SpecialFolder.Templates:
                     return CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, "Templates");
 
                 case SpecialFolder.MyVideos:
-                    return Interop.Sys.SearchPath(NSSearchPathDirectory.NSMoviesDirectory);
+                    return Path.Combine(GetFolderPathCore(SpecialFolder.Personal, SpecialFolderOption.None), "Videos");
 
                 case SpecialFolder.CommonTemplates:
                     return "/usr/share/templates";
@@ -78,7 +78,7 @@ namespace System
                     return CombineSearchPath(NSSearchPathDirectory.NSLibraryDirectory, "Favorites");
 
                 case SpecialFolder.ProgramFiles:
-                    return Interop.Sys.SearchPath(NSSearchPathDirectory.NSApplicationDirectory);
+                    return "/Applications";
 
                 case SpecialFolder.InternetCache:
                     return Interop.Sys.SearchPath(NSSearchPathDirectory.NSCachesDirectory);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/41383

XI current implementation: https://github.com/mono/mono/blob/master/mcs/class/corlib/System/Environment.iOS.cs