### PR TITLE
Add managed Marshal.AllocBSTRByteLen()

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -250,9 +250,6 @@
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.HandleTypes.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.HandleTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\OleAut32\Interop.SysAllocStringByteLen.cs">
-      <Link>Common\Interop\Windows\OleAut32\Interop.SysAllocStringByteLen.cs</Link>
-    </Compile>
   </ItemGroup>
   <!-- These classes are only used for FeatureCominterop, but they are referenced by tests
        in order to allow tests to be built on all platforms, these classes are included for all

--- a/src/coreclr/src/System.Private.CoreLib/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/Interop/Unix/Interop.Libraries.cs
@@ -8,6 +8,5 @@ internal static partial class Interop
     internal static partial class Libraries
     {
         internal const string Kernel32 = RuntimeHelpers.QCall;
-        internal const string OleAut32 = RuntimeHelpers.QCall;
     }
 }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -487,7 +487,7 @@ namespace System.StubHelpers
                 bytes = AnsiCharMarshaler.DoAnsiConversion(strManaged, 0 != (flags & 0xFF), 0 != (flags >> 8), out nb);
             }
 
-            var length = (uint)nb;
+            uint length = (uint)nb;
             IntPtr bstr = Marshal.AllocBSTRByteLen(length);
             fixed (byte* firstByte = bytes)
             {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -333,14 +333,9 @@ namespace System.StubHelpers
                 }
                 else
                 {
-                    // If not provided, allocate the buffer using SysAllocStringByteLen so
+                    // If not provided, allocate the buffer using Marshal.AllocBSTRByteLen so
                     // that odd-sized strings will be handled as well.
-                    ptrToFirstChar = (byte*)Interop.OleAut32.SysAllocStringByteLen(null, lengthInBytes);
-
-                    if (ptrToFirstChar == null)
-                    {
-                        throw new OutOfMemoryException();
-                    }
+                    ptrToFirstChar = (byte*)Marshal.AllocBSTRByteLen(lengthInBytes);
                 }
 
                 // copy characters from the managed string
@@ -477,7 +472,7 @@ namespace System.StubHelpers
 
     internal static class AnsiBSTRMarshaler
     {
-        internal static IntPtr ConvertToNative(int flags, string strManaged)
+        internal static unsafe IntPtr ConvertToNative(int flags, string strManaged)
         {
             if (null == strManaged)
             {
@@ -492,7 +487,13 @@ namespace System.StubHelpers
                 bytes = AnsiCharMarshaler.DoAnsiConversion(strManaged, 0 != (flags & 0xFF), 0 != (flags >> 8), out nb);
             }
 
-            return Interop.OleAut32.SysAllocStringByteLen(bytes, (uint)nb);
+            var length = (uint)nb;
+            IntPtr bstr = Marshal.AllocBSTRByteLen(length);
+            fixed (byte* firstByte = bytes)
+            {
+                Buffer.Memmove((byte*)bstr, firstByte, length);
+            }
+            return bstr;
         }
 
         internal static unsafe string? ConvertToManaged(IntPtr bstr)

--- a/src/coreclr/src/vm/ecalllist.h
+++ b/src/coreclr/src/vm/ecalllist.h
@@ -1068,9 +1068,6 @@ FCFuncStart(gPalKernel32Funcs)
     QCFuncElement("SetEvent", SetEvent)
     QCFuncElement("WriteFile", WriteFile)
 FCFuncEnd()
-FCFuncStart(gPalOleAut32Funcs)
-    QCFuncElement("SysAllocStringByteLen", SysAllocStringByteLen)
-FCFuncEnd()
 #endif
 
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
@@ -1182,9 +1179,6 @@ FCClassElement("OAVariantLib", "Microsoft.Win32", gOAVariantFuncs)
 FCClassElement("Object", "System", gObjectFuncs)
 #ifdef FEATURE_COMINTEROP
 FCClassElement("ObjectMarshaler", "System.StubHelpers", gObjectMarshalerFuncs)
-#endif
-#ifdef TARGET_UNIX
-FCClassElement("OleAut32", "", gPalOleAut32Funcs)
 #endif
 FCClassElement("OverlappedData", "System.Threading", gOverlappedFuncs)
 

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1518,6 +1518,9 @@
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Interop\Windows\OleAut32\Interop.SysAllocStringByteLen.cs">
+      <Link>Common\Interop\Windows\OleAut32\Interop.SysAllocStringByteLen.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SYSTEM_INFO.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SYSTEM_INFO.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Unix.cs
@@ -154,6 +154,33 @@ namespace System.Runtime.InteropServices
             return s;
         }
 
+        internal static unsafe IntPtr AllocBSTRByteLen(uint length)
+        {
+            // SysAllocString on Windows aligns the memory block size up
+            const nuint WIN32_ALLOC_ALIGN = 15;
+
+            ulong cbNative = (ulong)(uint)length + (uint)sizeof(IntPtr) + (uint)sizeof(char) + WIN32_ALLOC_ALIGN;
+            if (cbNative > uint.MaxValue)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            IntPtr p = Interop.Sys.MemAlloc((nuint)cbNative & ~WIN32_ALLOC_ALIGN);
+            if (p == IntPtr.Zero)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            IntPtr s = p + sizeof(IntPtr);
+            *(((uint*)s) - 1) = (uint)length;
+
+            // NULL-terminate with both a narrow and wide zero.
+            *(byte*)((byte*)s + length) = (byte)'\0';
+            *(short*)((byte*)s + ((length + 1) & ~1)) = 0;
+
+            return s;
+        }
+
         public static unsafe void FreeBSTR(IntPtr ptr)
         {
             if (ptr != IntPtr.Zero)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Windows.cs
@@ -200,6 +200,16 @@ namespace System.Runtime.InteropServices
             return bstr;
         }
 
+        internal static unsafe IntPtr AllocBSTRByteLen(uint length)
+        {
+            IntPtr bstr = Interop.OleAut32.SysAllocStringByteLen(null, length);
+            if (bstr == IntPtr.Zero)
+            {
+                throw new OutOfMemoryException();
+            }
+            return bstr;
+        }
+
         public static void FreeBSTR(IntPtr ptr)
         {
             if (!IsNullOrWin32Atom(ptr))


### PR DESCRIPTION
Remove a call from managed stub to PAL for `SysAllocStringByteLen` during marshalling and delete `OleAut32` library interop on Unix.

`BSTR::SysAllocStringByteLen` is still used by `olevariant.cpp`, so native implementation is not removed as part of this PR.