### PR TITLE
Mark System.Net.WebSockets.ClientWebSocketOptions APIs as unsupported on Browser

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/Directory.Build.props
+++ b/src/libraries/System.Net.WebSockets.Client/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.WebSockets.Client/ref/System.Net.WebSockets.Client.cs
+++ b/src/libraries/System.Net.WebSockets.Client/ref/System.Net.WebSockets.Client.cs
@@ -27,16 +27,26 @@ namespace System.Net.WebSockets
     public sealed partial class ClientWebSocketOptions
     {
         internal ClientWebSocketOptions() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.CookieContainer? Cookies { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.TimeSpan KeepAliveInterval { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.IWebProxy? Proxy { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.Security.RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseDefaultCredentials { get { throw null; } set { } }
         public void AddSubProtocol(string subProtocol) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize, System.ArraySegment<byte> buffer) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void SetRequestHeader(string headerName, string? headerValue) { }
     }
 }

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/ClientWebSocketOptions.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/ClientWebSocketOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.WebSockets
@@ -17,42 +18,49 @@ namespace System.Net.WebSockets
 
         #region HTTP Settings
 
+        [UnsupportedOSPlatform("browser")]
         // Note that some headers are restricted like Host.
         public void SetRequestHeader(string headerName, string headerValue)
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseDefaultCredentials
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.ICredentials Credentials
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.IWebProxy Proxy
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public X509CertificateCollection ClientCertificates
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.Security.RemoteCertificateValidationCallback RemoteCertificateValidationCallback
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.CookieContainer Cookies
         {
             get => throw new PlatformNotSupportedException();
@@ -85,17 +93,20 @@ namespace System.Net.WebSockets
 
         internal List<string> RequestedSubProtocols => _requestedSubProtocols ??= new List<string>();
 
+        [UnsupportedOSPlatform("browser")]
         public TimeSpan KeepAliveInterval
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize)
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize, ArraySegment<byte> buffer)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
@@ -29,6 +29,7 @@ namespace System.Net.WebSockets
 
         #region HTTP Settings
 
+        [UnsupportedOSPlatform("browser")]
         // Note that some headers are restricted like Host.
         public void SetRequestHeader(string headerName, string? headerValue)
         {
@@ -42,6 +43,7 @@ namespace System.Net.WebSockets
 
         internal List<string> RequestedSubProtocols => _requestedSubProtocols ??= new List<string>();
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseDefaultCredentials
         {
             get => _useDefaultCredentials;
@@ -52,6 +54,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public ICredentials? Credentials
         {
             get => _credentials;
@@ -62,6 +65,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public IWebProxy? Proxy
         {
             get => _proxy;
@@ -72,6 +76,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public X509CertificateCollection ClientCertificates
         {
             get => _clientCertificates ??= new X509CertificateCollection();
@@ -82,6 +87,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback
         {
             get => _remoteCertificateValidationCallback;
@@ -92,6 +98,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public CookieContainer? Cookies
         {
             get => _cookies;
@@ -123,6 +130,7 @@ namespace System.Net.WebSockets
             subprotocols.Add(subProtocol);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public TimeSpan KeepAliveInterval
         {
             get => _keepAliveInterval;
@@ -142,6 +150,7 @@ namespace System.Net.WebSockets
         internal int ReceiveBufferSize => _receiveBufferSize;
         internal ArraySegment<byte>? Buffer => _buffer;
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize)
         {
             ThrowIfReadOnly();
@@ -159,6 +168,7 @@ namespace System.Net.WebSockets
             _buffer = null;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize, ArraySegment<byte> buffer)
         {
             ThrowIfReadOnly();

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Security;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/41087.

Almost all public APIs (besides `void AddSubProtocol(string subProtocol)`) in `System.Net.WebSockets.ClientWebSocketOptions` throw PNSE on Browser.

DocID |Namespace| Type | Member | Nesting |
-- | -- | -- | -- | --
M:System.Net.WebSockets.ClientWebSocketOptions.get_Proxy | System.Net.WebSockets | ClientWebSocketOptions | get_Proxy() | 0
M:System.Net.WebSockets.ClientWebSocketOptions.set_Cookies(System.Net.CookieContainer) | System.Net.WebSockets | ClientWebSocketOptions | set_Cookies(CookieContainer) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.set_UseDefaultCredentials(System.Boolean) | System.Net.WebSockets | ClientWebSocketOptions | set_UseDefaultCredentials(Boolean) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.get_Credentials | System.Net.WebSockets | ClientWebSocketOptions | get_Credentials() | 0
M:System.Net.WebSockets.ClientWebSocketOptions.SetRequestHeader(System.String,System.String) | System.Net.WebSockets | ClientWebSocketOptions | SetRequestHeader(String, String) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.get_ClientCertificates | System.Net.WebSockets | ClientWebSocketOptions | get_ClientCertificates() | 0
M:System.Net.WebSockets.ClientWebSocketOptions.SetBuffer(System.Int32,System.Int32) | System.Net.WebSockets | ClientWebSocketOptions | SetBuffer(Int32, Int32) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.get_RemoteCertificateValidationCallback | System.Net.WebSockets | ClientWebSocketOptions | get_RemoteCertificateValidationCallback() | 0
M:System.Net.WebSockets.ClientWebSocketOptions.get_Cookies | System.Net.WebSockets | ClientWebSocketOptions | get_Cookies() | 0
M:System.Net.WebSockets.ClientWebSocketOptions.set_RemoteCertificateValidationCallback(System.Net.Security.RemoteCertificateValidationCallback) | System.Net.WebSockets | ClientWebSocketOptions | set_RemoteCertificateValidationCallback(RemoteCertificateValidationCallback) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.set_KeepAliveInterval(System.TimeSpan) | System.Net.WebSockets | ClientWebSocketOptions | set_KeepAliveInterval(TimeSpan) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.get_UseDefaultCredentials | System.Net.WebSockets | ClientWebSocketOptions | get_UseDefaultCredentials() | 0
M:System.Net.WebSockets.ClientWebSocketOptions.SetBuffer(System.Int32,System.Int32,System.ArraySegment{System.Byte}) | System.Net.WebSockets | ClientWebSocketOptions | SetBuffer(Int32, Int32, ArraySegment<Byte>) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.set_Proxy(System.Net.IWebProxy) | System.Net.WebSockets | ClientWebSocketOptions | set_Proxy(IWebProxy) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.set_Credentials(System.Net.ICredentials) | System.Net.WebSockets | ClientWebSocketOptions | set_Credentials(ICredentials) | 0
M:System.Net.WebSockets.ClientWebSocketOptions.get_KeepAliveInterval | System.Net.WebSockets | ClientWebSocketOptions | get_KeepAliveInterval() | 0
M:System.Net.WebSockets.ClientWebSocketOptions.set_ClientCertificates(System.Security.Cryptography.X509Certificates.X509CertificateCollection) | System.Net.WebSockets | ClientWebSocketOptions | set_ClientCertificates(X509CertificateCollection) | 0

