### PR TITLE
Exclude .a files from the runtime native files when packaging

### DIFF
--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -101,7 +101,8 @@
     <ItemGroup Condition="'$(PackageRID)' != ''">
       <LibrariesRuntimeFiles Condition="'%(IsNative)' != 'true'" TargetPath="runtimes/$(PackageRID)/lib/$(NetCoreAppCurrent)" />
       <LibrariesRuntimeFiles Condition="'%(IsNative)' == 'true'" TargetPath="$([System.String]::new('runtimes/$(PackageRID)/native/%(LibrariesRuntimeFiles.NativeSubDirectory)%(RecursiveDir)').TrimEnd('/'))" />
-      <ReferenceCopyLocalPaths Include="@(LibrariesRuntimeFiles)" />
+      <ReferenceCopyLocalPaths Include="@(LibrariesRuntimeFiles)" 
+          Condition="'%(LibrariesRuntimeFiles.Extension)' != '.a'"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
There's no use for the .a files in the shared framework or runtime pack, they just increase disk size.

Also not that we didn't include them in 3.1, so it's effectively a regression in 5.0.

This should fix #3447 