### PR TITLE
[release/5.0] Backport Browser Unsupported Attribute Changes

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Threading
 {
@@ -159,6 +160,7 @@ namespace System.Threading
         private static extern bool UnregisterWaitNative(IntPtr handle, SafeHandle? waitObject);
     }
 
+    [UnsupportedOSPlatform("browser")]
     public sealed class RegisteredWaitHandle : MarshalByRefObject
     {
         private readonly RegisteredWaitHandleSafe internalRegisteredWait;
@@ -352,6 +354,7 @@ namespace System.Threading
             return BindIOCompletionCallbackNative(osHandle);
         }
 
+        [SupportedOSPlatform("windows")]
         public static bool BindHandle(SafeHandle osHandle)
         {
             if (osHandle == null)

--- a/src/libraries/System.ComponentModel.TypeConverter/Directory.Build.props
+++ b/src/libraries/System.ComponentModel.TypeConverter/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -687,7 +687,9 @@ namespace System.ComponentModel
         internal LicenseManager() { }
         public static System.ComponentModel.LicenseContext CurrentContext { get { throw null; } set { } }
         public static System.ComponentModel.LicenseUsageMode UsageMode { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static object CreateWithContext(System.Type type, System.ComponentModel.LicenseContext creationContext) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static object CreateWithContext(System.Type type, System.ComponentModel.LicenseContext creationContext, object[] args) { throw null; }
         public static bool IsLicensed(System.Type type) { throw null; }
         public static bool IsValid(System.Type type) { throw null; }
@@ -868,6 +870,7 @@ namespace System.ComponentModel
         public bool Add(string input, out int testPosition, out System.ComponentModel.MaskedTextResultHint resultHint) { throw null; }
         public void Clear() { }
         public void Clear(out System.ComponentModel.MaskedTextResultHint resultHint) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public object Clone() { throw null; }
         public int FindAssignedEditPositionFrom(int position, bool direction) { throw null; }
         public int FindAssignedEditPositionInRange(int startPosition, int endPosition, bool direction) { throw null; }
@@ -1305,6 +1308,7 @@ namespace System.ComponentModel
     {
         protected TypeDescriptionProvider() { }
         protected TypeDescriptionProvider(System.ComponentModel.TypeDescriptionProvider parent) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public virtual object CreateInstance(System.IServiceProvider provider, System.Type objectType, System.Type[] argTypes, object[] args) { throw null; }
         public virtual System.Collections.IDictionary GetCache(object instance) { throw null; }
         public virtual System.ComponentModel.ICustomTypeDescriptor GetExtendedTypeDescriptor(object instance) { throw null; }
@@ -1347,6 +1351,7 @@ namespace System.ComponentModel
         public static System.ComponentModel.Design.IDesigner CreateDesigner(System.ComponentModel.IComponent component, System.Type designerBaseType) { throw null; }
         public static System.ComponentModel.EventDescriptor CreateEvent(System.Type componentType, System.ComponentModel.EventDescriptor oldEventDescriptor, params System.Attribute[] attributes) { throw null; }
         public static System.ComponentModel.EventDescriptor CreateEvent(System.Type componentType, string name, System.Type type, params System.Attribute[] attributes) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static object CreateInstance(System.IServiceProvider provider, System.Type objectType, System.Type[] argTypes, object[] args) { throw null; }
         public static System.ComponentModel.PropertyDescriptor CreateProperty(System.Type componentType, System.ComponentModel.PropertyDescriptor oldPropertyDescriptor, params System.Attribute[] attributes) { throw null; }
         public static System.ComponentModel.PropertyDescriptor CreateProperty(System.Type componentType, string name, System.Type type, params System.Attribute[] attributes) { throw null; }
@@ -2217,6 +2222,7 @@ namespace System.Security.Authentication.ExtendedProtection
     {
         public ExtendedProtectionPolicyTypeConverter() { }
         public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { throw null; }
     }
 }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace System.ComponentModel
@@ -116,6 +117,7 @@ namespace System.ComponentModel
         /// creationContext
         /// as the context in which the licensed instance can be used.
         /// </summary>
+        [UnsupportedOSPlatform("browser")]
         public static object CreateWithContext(Type type, LicenseContext creationContext)
         {
             return CreateWithContext(type, creationContext, Array.Empty<object>());
@@ -126,6 +128,7 @@ namespace System.ComponentModel
         /// specified arguments, using creationContext as the context in which the licensed
         /// instance can be used.
         /// </summary>
+        [UnsupportedOSPlatform("browser")]
         public static object CreateWithContext(Type type, LicenseContext creationContext, object[] args)
         {
             object created = null;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.Versioning;
 using System.Text;
 
 namespace System.ComponentModel
@@ -467,6 +468,7 @@ namespace System.ComponentModel
         /// Derived classes can override this method and call base.Clone to get proper cloning semantics but must
         /// implement the full-parameter constructor (passing parameters to the base constructor as well).
         /// </summary>
+        [UnsupportedOSPlatform("browser")]
         public object Clone()
         {
             MaskedTextProvider clonedProvider;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Runtime.Versioning;
 
 namespace System.ComponentModel
 {
@@ -49,6 +50,7 @@ namespace System.ComponentModel
         /// parent provider was passed. If a parent provider was passed, this
         /// method will invoke the parent provider's CreateInstance method.
         /// </summary>
+        [UnsupportedOSPlatform("browser")]
         public virtual object CreateInstance(IServiceProvider provider, Type objectType, Type[] argTypes, object[] args)
         {
             if (_parent != null)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace System.ComponentModel
@@ -428,6 +429,7 @@ namespace System.ComponentModel
         /// a TypeDescriptionProvider object that is associated with the given
         /// data type. If it finds one, it will delegate the call to that object.
         /// </summary>
+        [UnsupportedOSPlatform("browser")]
         public static object CreateInstance(IServiceProvider provider, Type objectType, Type[] argTypes, object[] args)
         {
             if (objectType == null)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTypeConverter.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.Versioning;
 
 namespace System.Security.Authentication.ExtendedProtection
 {
@@ -16,6 +17,7 @@ namespace System.Security.Authentication.ExtendedProtection
             return destinationType == typeof(InstanceDescriptor) || base.CanConvertTo(context, destinationType);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             if (destinationType == typeof(InstanceDescriptor))

--- a/src/libraries/System.Console/ref/System.Console.cs
+++ b/src/libraries/System.Console/ref/System.Console.cs
@@ -8,40 +8,52 @@ namespace System
 {
     public static partial class Console
     {
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.ConsoleColor BackgroundColor { get { throw null; } set { } }
-        public static int BufferHeight { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
-        public static int BufferWidth { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        public static int BufferHeight { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        public static int BufferWidth { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static bool CapsLock { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static int CursorLeft { get { throw null; } set { } }
-        public static int CursorSize { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        public static int CursorSize { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static int CursorTop { get { throw null; } set { } }
-        public static bool CursorVisible { [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] get { throw null; } set { } }
+        public static bool CursorVisible { [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] get { throw null; } [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] set { } }
         public static System.IO.TextWriter Error { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.ConsoleColor ForegroundColor { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.TextReader In { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Text.Encoding InputEncoding { get { throw null; } set { } }
         public static bool IsErrorRedirected { get { throw null; } }
         public static bool IsInputRedirected { get { throw null; } }
         public static bool IsOutputRedirected { get { throw null; } }
         public static bool KeyAvailable { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static int LargestWindowHeight { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static int LargestWindowWidth { get { throw null; } }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static bool NumberLock { get { throw null; } }
         public static System.IO.TextWriter Out { get { throw null; } }
         public static System.Text.Encoding OutputEncoding { get { throw null; } set { } }
-        public static string Title { [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] get { throw null; } set { } }
+        public static string Title { [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] get { throw null; } [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static bool TreatControlCAsInput { get { throw null; } set { } }
-        public static int WindowHeight { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        public static int WindowHeight { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public static int WindowLeft { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public static int WindowTop { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
-        public static int WindowWidth { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        public static int WindowWidth { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static event System.ConsoleCancelEventHandler? CancelKeyPress { add { } remove { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static void Beep() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static void Beep(int frequency, int duration) { }
         public static void Clear() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static (int Left, int Top) GetCursorPosition() { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop) { }
@@ -49,19 +61,28 @@ namespace System
         public static void MoveBufferArea(int sourceLeft, int sourceTop, int sourceWidth, int sourceHeight, int targetLeft, int targetTop, char sourceChar, System.ConsoleColor sourceForeColor, System.ConsoleColor sourceBackColor) { }
         public static System.IO.Stream OpenStandardError() { throw null; }
         public static System.IO.Stream OpenStandardError(int bufferSize) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.Stream OpenStandardInput() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.Stream OpenStandardInput(int bufferSize) { throw null; }
         public static System.IO.Stream OpenStandardOutput() { throw null; }
         public static System.IO.Stream OpenStandardOutput(int bufferSize) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static int Read() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.ConsoleKeyInfo ReadKey() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.ConsoleKeyInfo ReadKey(bool intercept) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static string? ReadLine() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static void ResetColor() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static void SetBufferSize(int width, int height) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static void SetCursorPosition(int left, int top) { }
         public static void SetError(System.IO.TextWriter newError) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static void SetIn(System.IO.TextReader newIn) { }
         public static void SetOut(System.IO.TextWriter newOut) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]

--- a/src/libraries/System.Console/src/System/Console.cs
+++ b/src/libraries/System.Console/src/System/Console.cs
@@ -33,6 +33,7 @@ namespace System
         private static ConsoleCancelEventHandler? s_cancelCallbacks;
         private static ConsolePal.ControlCHandlerRegistrar? s_registrar;
 
+        [UnsupportedOSPlatform("browser")]
         public static TextReader In
         {
             get
@@ -56,6 +57,7 @@ namespace System
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static Encoding InputEncoding
         {
             get
@@ -152,11 +154,13 @@ namespace System
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static ConsoleKeyInfo ReadKey()
         {
             return ConsolePal.ReadKey(false);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static ConsoleKeyInfo ReadKey(bool intercept)
         {
             return ConsolePal.ReadKey(intercept);
@@ -276,6 +280,7 @@ namespace System
 
         public static int CursorSize
         {
+            [UnsupportedOSPlatform("browser")]
             get { return ConsolePal.CursorSize; }
             [SupportedOSPlatform("windows")]
             set { ConsolePal.CursorSize = value; }
@@ -295,18 +300,21 @@ namespace System
 
         internal const ConsoleColor UnknownColor = (ConsoleColor)(-1);
 
+        [UnsupportedOSPlatform("browser")]
         public static ConsoleColor BackgroundColor
         {
             get { return ConsolePal.BackgroundColor; }
             set { ConsolePal.BackgroundColor = value; }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static ConsoleColor ForegroundColor
         {
             get { return ConsolePal.ForegroundColor; }
             set { ConsolePal.ForegroundColor = value; }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static void ResetColor()
         {
             ConsolePal.ResetColor();
@@ -314,6 +322,7 @@ namespace System
 
         public static int BufferWidth
         {
+            [UnsupportedOSPlatform("browser")]
             get { return ConsolePal.BufferWidth; }
             [SupportedOSPlatform("windows")]
             set { ConsolePal.BufferWidth = value; }
@@ -321,6 +330,7 @@ namespace System
 
         public static int BufferHeight
         {
+            [UnsupportedOSPlatform("browser")]
             get { return ConsolePal.BufferHeight; }
             [SupportedOSPlatform("windows")]
             set { ConsolePal.BufferHeight = value; }
@@ -348,6 +358,7 @@ namespace System
 
         public static int WindowWidth
         {
+            [UnsupportedOSPlatform("browser")]
             get { return ConsolePal.WindowWidth; }
             [SupportedOSPlatform("windows")]
             set { ConsolePal.WindowWidth = value; }
@@ -355,6 +366,7 @@ namespace System
 
         public static int WindowHeight
         {
+            [UnsupportedOSPlatform("browser")]
             get { return ConsolePal.WindowHeight; }
             [SupportedOSPlatform("windows")]
             set { ConsolePal.WindowHeight = value; }
@@ -372,11 +384,13 @@ namespace System
             ConsolePal.SetWindowSize(width, height);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static int LargestWindowWidth
         {
             get { return ConsolePal.LargestWindowWidth; }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static int LargestWindowHeight
         {
             get { return ConsolePal.LargestWindowHeight; }
@@ -386,15 +400,18 @@ namespace System
         {
             [SupportedOSPlatform("windows")]
             get { return ConsolePal.CursorVisible; }
+            [UnsupportedOSPlatform("browser")]
             set { ConsolePal.CursorVisible = value; }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static int CursorLeft
         {
             get { return ConsolePal.GetCursorPosition().Left; }
             set { SetCursorPosition(value, CursorTop); }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static int CursorTop
         {
             get { return ConsolePal.GetCursorPosition().Top; }
@@ -406,6 +423,7 @@ namespace System
         /// <remarks>
         /// Columns are numbered from left to right starting at 0. Rows are numbered from top to bottom starting at 0.
         /// </remarks>
+        [UnsupportedOSPlatform("browser")]
         public static (int Left, int Top) GetCursorPosition()
         {
             return ConsolePal.GetCursorPosition();
@@ -415,12 +433,14 @@ namespace System
         {
             [SupportedOSPlatform("windows")]
             get { return ConsolePal.Title; }
+            [UnsupportedOSPlatform("browser")]
             set
             {
                 ConsolePal.Title = value ?? throw new ArgumentNullException(nameof(value));
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static void Beep()
         {
             ConsolePal.Beep();
@@ -449,6 +469,7 @@ namespace System
             ConsolePal.Clear();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static void SetCursorPosition(int left, int top)
         {
             // Basic argument validation.  The PAL implementation may provide further validation.
@@ -460,6 +481,7 @@ namespace System
             ConsolePal.SetCursorPosition(left, top);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static event ConsoleCancelEventHandler? CancelKeyPress
         {
             add
@@ -493,17 +515,20 @@ namespace System
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static bool TreatControlCAsInput
         {
             get { return ConsolePal.TreatControlCAsInput; }
             set { ConsolePal.TreatControlCAsInput = value; }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static Stream OpenStandardInput()
         {
             return ConsolePal.OpenStandardInput();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static Stream OpenStandardInput(int bufferSize)
         {
             // bufferSize is ignored, other than in argument validation, even in the .NET Framework
@@ -544,6 +569,7 @@ namespace System
             return OpenStandardError();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static void SetIn(TextReader newIn)
         {
             CheckNonNull(newIn, nameof(newIn));
@@ -590,12 +616,14 @@ namespace System
         // the inlined console writelines from them.
         //
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        [UnsupportedOSPlatform("browser")]
         public static int Read()
         {
             return In.Read();
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        [UnsupportedOSPlatform("browser")]
         public static string? ReadLine()
         {
             return In.ReadLine();

--- a/src/libraries/System.Diagnostics.FileVersionInfo/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Process/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.Process/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.Compression.Brotli/Directory.Build.props
+++ b/src/libraries/System.IO.Compression.Brotli/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.FileSystem.Watcher/Directory.Build.props
+++ b/src/libraries/System.IO.FileSystem.Watcher/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.IsolatedStorage/Directory.Build.props
+++ b/src/libraries/System.IO.IsolatedStorage/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Mail/Directory.Build.props
+++ b/src/libraries/System.Net.Mail/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.NameResolution/Directory.Build.props
+++ b/src/libraries/System.Net.NameResolution/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.NetworkInformation/Directory.Build.props
+++ b/src/libraries/System.Net.NetworkInformation/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Ping/Directory.Build.props
+++ b/src/libraries/System.Net.Ping/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Requests/Directory.Build.props
+++ b/src/libraries/System.Net.Requests/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Security/Directory.Build.props
+++ b/src/libraries/System.Net.Security/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/Directory.Build.props
+++ b/src/libraries/System.Net.Sockets/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.WebClient/Directory.Build.props
+++ b/src/libraries/System.Net.WebClient/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.WebSockets.Client/Directory.Build.props
+++ b/src/libraries/System.Net.WebSockets.Client/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.WebSockets.Client/ref/System.Net.WebSockets.Client.cs
+++ b/src/libraries/System.Net.WebSockets.Client/ref/System.Net.WebSockets.Client.cs
@@ -27,16 +27,26 @@ namespace System.Net.WebSockets
     public sealed partial class ClientWebSocketOptions
     {
         internal ClientWebSocketOptions() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.CookieContainer? Cookies { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.TimeSpan KeepAliveInterval { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.IWebProxy? Proxy { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.Security.RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseDefaultCredentials { get { throw null; } set { } }
         public void AddSubProtocol(string subProtocol) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize, System.ArraySegment<byte> buffer) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void SetRequestHeader(string headerName, string? headerValue) { }
     }
 }

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/ClientWebSocketOptions.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/ClientWebSocketOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.WebSockets
@@ -17,42 +18,49 @@ namespace System.Net.WebSockets
 
         #region HTTP Settings
 
+        [UnsupportedOSPlatform("browser")]
         // Note that some headers are restricted like Host.
         public void SetRequestHeader(string headerName, string headerValue)
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseDefaultCredentials
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.ICredentials Credentials
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.IWebProxy Proxy
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public X509CertificateCollection ClientCertificates
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.Security.RemoteCertificateValidationCallback RemoteCertificateValidationCallback
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public System.Net.CookieContainer Cookies
         {
             get => throw new PlatformNotSupportedException();
@@ -85,17 +93,20 @@ namespace System.Net.WebSockets
 
         internal List<string> RequestedSubProtocols => _requestedSubProtocols ??= new List<string>();
 
+        [UnsupportedOSPlatform("browser")]
         public TimeSpan KeepAliveInterval
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize)
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize, ArraySegment<byte> buffer)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Security;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
@@ -29,6 +30,7 @@ namespace System.Net.WebSockets
 
         #region HTTP Settings
 
+        [UnsupportedOSPlatform("browser")]
         // Note that some headers are restricted like Host.
         public void SetRequestHeader(string headerName, string? headerValue)
         {
@@ -42,6 +44,7 @@ namespace System.Net.WebSockets
 
         internal List<string> RequestedSubProtocols => _requestedSubProtocols ??= new List<string>();
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseDefaultCredentials
         {
             get => _useDefaultCredentials;
@@ -52,6 +55,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public ICredentials? Credentials
         {
             get => _credentials;
@@ -62,6 +66,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public IWebProxy? Proxy
         {
             get => _proxy;
@@ -72,6 +77,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public X509CertificateCollection ClientCertificates
         {
             get => _clientCertificates ??= new X509CertificateCollection();
@@ -82,6 +88,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback
         {
             get => _remoteCertificateValidationCallback;
@@ -92,6 +99,7 @@ namespace System.Net.WebSockets
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public CookieContainer? Cookies
         {
             get => _cookies;
@@ -123,6 +131,7 @@ namespace System.Net.WebSockets
             subprotocols.Add(subProtocol);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public TimeSpan KeepAliveInterval
         {
             get => _keepAliveInterval;
@@ -142,6 +151,7 @@ namespace System.Net.WebSockets
         internal int ReceiveBufferSize => _receiveBufferSize;
         internal ArraySegment<byte>? Buffer => _buffer;
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize)
         {
             ThrowIfReadOnly();
@@ -159,6 +169,7 @@ namespace System.Net.WebSockets
             _buffer = null;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void SetBuffer(int receiveBufferSize, int sendBufferSize, ArraySegment<byte> buffer)
         {
             ThrowIfReadOnly();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Microsoft.Win32.SafeHandles;
+using System.Runtime.Versioning;
 
 namespace System.Threading
 {
@@ -13,6 +14,7 @@ namespace System.Threading
     /// <summary>
     /// An object representing the registration of a <see cref="WaitHandle"/> via <see cref="ThreadPool.RegisterWaitForSingleObject"/>.
     /// </summary>
+    [UnsupportedOSPlatform("browser")]
     public sealed class RegisteredWaitHandle : MarshalByRefObject
     {
         internal RegisteredWaitHandle(WaitHandle waitHandle, _ThreadPoolWaitOrTimerCallback callbackHelper,

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -17,6 +17,7 @@ using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 using Internal.Runtime.CompilerServices;
 
 namespace System.Threading
@@ -950,6 +951,7 @@ namespace System.Threading
         };
 
         [CLSCompliant(false)]
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle RegisterWaitForSingleObject(
              WaitHandle waitObject,
              WaitOrTimerCallback callBack,
@@ -964,6 +966,7 @@ namespace System.Threading
         }
 
         [CLSCompliant(false)]
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(
              WaitHandle waitObject,
              WaitOrTimerCallback callBack,
@@ -977,6 +980,7 @@ namespace System.Threading
             return RegisterWaitForSingleObject(waitObject, callBack, state, millisecondsTimeOutInterval, executeOnlyOnce, false);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle RegisterWaitForSingleObject(
              WaitHandle waitObject,
              WaitOrTimerCallback callBack,
@@ -990,6 +994,7 @@ namespace System.Threading
             return RegisterWaitForSingleObject(waitObject, callBack, state, (uint)millisecondsTimeOutInterval, executeOnlyOnce, true);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(
              WaitHandle waitObject,
              WaitOrTimerCallback callBack,
@@ -1003,6 +1008,7 @@ namespace System.Threading
             return RegisterWaitForSingleObject(waitObject, callBack, state, (uint)millisecondsTimeOutInterval, executeOnlyOnce, false);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle RegisterWaitForSingleObject(
             WaitHandle waitObject,
             WaitOrTimerCallback callBack,
@@ -1018,6 +1024,7 @@ namespace System.Threading
             return RegisterWaitForSingleObject(waitObject, callBack, state, (uint)millisecondsTimeOutInterval, executeOnlyOnce, true);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(
             WaitHandle waitObject,
             WaitOrTimerCallback callBack,
@@ -1033,6 +1040,7 @@ namespace System.Threading
             return RegisterWaitForSingleObject(waitObject, callBack, state, (uint)millisecondsTimeOutInterval, executeOnlyOnce, false);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle RegisterWaitForSingleObject(
                           WaitHandle waitObject,
                           WaitOrTimerCallback callBack,
@@ -1049,6 +1057,7 @@ namespace System.Threading
             return RegisterWaitForSingleObject(waitObject, callBack, state, (uint)tm, executeOnlyOnce, true);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(
                           WaitHandle waitObject,
                           WaitOrTimerCallback callBack,

--- a/src/libraries/System.Threading.ThreadPool/Directory.Build.props
+++ b/src/libraries/System.Threading.ThreadPool/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
+++ b/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
@@ -10,6 +10,7 @@ namespace System.Threading
     {
         void Execute();
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class RegisteredWaitHandle : System.MarshalByRefObject
     {
         internal RegisteredWaitHandle() { }
@@ -22,6 +23,7 @@ namespace System.Threading
         public static int ThreadCount { get { throw null; } }
         [System.ObsoleteAttribute("ThreadPool.BindHandle(IntPtr) has been deprecated.  Please use ThreadPool.BindHandle(SafeHandle) instead.", false)]
         public static bool BindHandle(System.IntPtr osHandle) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static bool BindHandle(System.Runtime.InteropServices.SafeHandle osHandle) { throw null; }
         public static void GetAvailableThreads(out int workerThreads, out int completionPortThreads) { throw null; }
         public static void GetMaxThreads(out int workerThreads, out int completionPortThreads) { throw null; }
@@ -29,10 +31,14 @@ namespace System.Threading
         public static bool QueueUserWorkItem(System.Threading.WaitCallback callBack) { throw null; }
         public static bool QueueUserWorkItem(System.Threading.WaitCallback callBack, object? state) { throw null; }
         public static bool QueueUserWorkItem<TState>(System.Action<TState> callBack, TState state, bool preferLocal) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle RegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, int millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle RegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, long millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle RegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, System.TimeSpan timeout, bool executeOnlyOnce) { throw null; }
         [System.CLSCompliantAttribute(false)]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle RegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, uint millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
         public static bool SetMaxThreads(int workerThreads, int completionPortThreads) { throw null; }
         public static bool SetMinThreads(int workerThreads, int completionPortThreads) { throw null; }
@@ -41,10 +47,14 @@ namespace System.Threading
         public static bool UnsafeQueueUserWorkItem(System.Threading.IThreadPoolWorkItem callBack, bool preferLocal) { throw null; }
         public static bool UnsafeQueueUserWorkItem(System.Threading.WaitCallback callBack, object? state) { throw null; }
         public static bool UnsafeQueueUserWorkItem<TState>(System.Action<TState> callBack, TState state, bool preferLocal) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, int millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, long millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, System.TimeSpan timeout, bool executeOnlyOnce) { throw null; }
         [System.CLSCompliantAttribute(false)]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Threading.RegisteredWaitHandle UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle waitObject, System.Threading.WaitOrTimerCallback callBack, object? state, uint millisecondsTimeOutInterval, bool executeOnlyOnce) { throw null; }
     }
     public delegate void WaitCallback(object? state);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
@@ -4,11 +4,13 @@
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Threading
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class RegisteredWaitHandle : MarshalByRefObject
     {
         internal RegisteredWaitHandle(WaitHandle waitHandle, _ThreadPoolWaitOrTimerCallback callbackHelper,

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Threading
 {
@@ -32,6 +33,7 @@ namespace System.Threading
             throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported); // Replaced by ThreadPoolBoundHandle.BindHandle
         }
 
+        [SupportedOSPlatform("windows")]
         public static bool BindHandle(SafeHandle osHandle)
         {
             throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported); // Replaced by ThreadPoolBoundHandle.BindHandle


### PR DESCRIPTION
An ongoing effort in https://github.com/dotnet/runtime/issues/41087 to mark APIs as unsupported on Browser led to many PRs being created with each targeting a unique namespace. Rather than back porting on every single one of those PRs, this PR intends to back port all of those merged changes as one batch. 

It is expected that more PRs will be created and merged today, and those will also be added to this PR.