### PR TITLE
[wasm] Mark System.IO.MemoryMappedFiles APIs unsupported on browser

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/ref/System.IO.MemoryMappedFiles.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/ref/System.IO.MemoryMappedFiles.cs
@@ -24,14 +24,23 @@ namespace System.IO.MemoryMappedFiles
     {
         internal MemoryMappedFile() { }
         public Microsoft.Win32.SafeHandles.SafeMemoryMappedFileHandle SafeMemoryMappedFileHandle { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateFromFile(System.IO.FileStream fileStream, string? mapName, long capacity, System.IO.MemoryMappedFiles.MemoryMappedFileAccess access, System.IO.HandleInheritability inheritability, bool leaveOpen) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateFromFile(string path) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateFromFile(string path, System.IO.FileMode mode) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateFromFile(string path, System.IO.FileMode mode, string? mapName) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateFromFile(string path, System.IO.FileMode mode, string? mapName, long capacity) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateFromFile(string path, System.IO.FileMode mode, string? mapName, long capacity, System.IO.MemoryMappedFiles.MemoryMappedFileAccess access) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateNew(string? mapName, long capacity) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateNew(string? mapName, long capacity, System.IO.MemoryMappedFiles.MemoryMappedFileAccess access) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateNew(string? mapName, long capacity, System.IO.MemoryMappedFiles.MemoryMappedFileAccess access, System.IO.MemoryMappedFiles.MemoryMappedFileOptions options, System.IO.HandleInheritability inheritability) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.IO.MemoryMappedFiles.MemoryMappedFile CreateOrOpen(string mapName, long capacity) { throw null; }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -92,25 +92,30 @@ namespace System.IO.MemoryMappedFiles
         // page size.  One can use FileStream.SetLength to bring the length back to a desirable size. By default,
         // the MemoryMappedFile will close the FileStream object when it is disposed.  This behavior can be
         // changed by the leaveOpen boolean argument.
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateFromFile(string path)
         {
             return CreateFromFile(path, FileMode.Open, null, DefaultSize, MemoryMappedFileAccess.ReadWrite);
         }
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateFromFile(string path, FileMode mode)
         {
             return CreateFromFile(path, mode, null, DefaultSize, MemoryMappedFileAccess.ReadWrite);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateFromFile(string path, FileMode mode, string? mapName)
         {
             return CreateFromFile(path, mode, mapName, DefaultSize, MemoryMappedFileAccess.ReadWrite);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateFromFile(string path, FileMode mode, string? mapName, long capacity)
         {
             return CreateFromFile(path, mode, mapName, capacity, MemoryMappedFileAccess.ReadWrite);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateFromFile(string path, FileMode mode, string? mapName, long capacity,
                                                                         MemoryMappedFileAccess access)
         {
@@ -179,6 +184,7 @@ namespace System.IO.MemoryMappedFiles
             return new MemoryMappedFile(handle, fileStream, false);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateFromFile(FileStream fileStream, string? mapName, long capacity,
                                                         MemoryMappedFileAccess access,
                                                         HandleInheritability inheritability, bool leaveOpen)
@@ -235,18 +241,21 @@ namespace System.IO.MemoryMappedFiles
 
         // Factory Method Group #3: Creates a new empty memory mapped file.  Such memory mapped files are ideal
         // for IPC, when mapName != null.
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateNew(string? mapName, long capacity)
         {
             return CreateNew(mapName, capacity, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None,
                    HandleInheritability.None);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateNew(string? mapName, long capacity, MemoryMappedFileAccess access)
         {
             return CreateNew(mapName, capacity, access, MemoryMappedFileOptions.None,
                    HandleInheritability.None);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static MemoryMappedFile CreateNew(string? mapName, long capacity, MemoryMappedFileAccess access,
                                                     MemoryMappedFileOptions options,
                                                     HandleInheritability inheritability)


### PR DESCRIPTION
Contributes to #41087 

```
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.OpenExisting(System.String,System.IO.MemoryMappedFiles.MemoryMappedFileRights)",System.IO.MemoryMappedFiles,MemoryMappedFile,"OpenExisting(String, MemoryMappedFileRights)",2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateNew(System.String,System.Int64)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateNew(String, Int64)",2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(System.String,System.IO.FileMode,System.String,System.Int64)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateFromFile(String, FileMode, String, Int64)",2
M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(System.String),System.IO.MemoryMappedFiles,MemoryMappedFile,CreateFromFile(String),2
M:System.IO.MemoryMappedFiles.MemoryMappedFile.OpenExisting(System.String),System.IO.MemoryMappedFiles,MemoryMappedFile,OpenExisting(String),2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateOrOpen(System.String,System.Int64)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateOrOpen(String, Int64)",2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateNew(System.String,System.Int64,System.IO.MemoryMappedFiles.MemoryMappedFileAccess,System.IO.MemoryMappedFiles.MemoryMappedFileOptions,System.IO.HandleInheritability)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateNew(String, Int64, MemoryMappedFileAccess, MemoryMappedFileOptions, HandleInheritability)",1
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(System.IO.FileStream,System.String,System.Int64,System.IO.MemoryMappedFiles.MemoryMappedFileAccess,System.IO.HandleInheritability,System.Boolean)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateFromFile(FileStream, String, Int64, MemoryMappedFileAccess, HandleInheritability, Boolean)",1
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(System.String,System.IO.FileMode,System.String,System.Int64,System.IO.MemoryMappedFiles.MemoryMappedFileAccess)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateFromFile(String, FileMode, String, Int64, MemoryMappedFileAccess)",1
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(System.String,System.IO.FileMode,System.String)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateFromFile(String, FileMode, String)",2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(System.String,System.IO.FileMode)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateFromFile(String, FileMode)",2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateOrOpen(System.String,System.Int64,System.IO.MemoryMappedFiles.MemoryMappedFileAccess)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateOrOpen(String, Int64, MemoryMappedFileAccess)",2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.OpenExisting(System.String,System.IO.MemoryMappedFiles.MemoryMappedFileRights,System.IO.HandleInheritability)",System.IO.MemoryMappedFiles,MemoryMappedFile,"OpenExisting(String, MemoryMappedFileRights, HandleInheritability)",1
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateNew(System.String,System.Int64,System.IO.MemoryMappedFiles.MemoryMappedFileAccess)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateNew(String, Int64, MemoryMappedFileAccess)",2
"M:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateOrOpen(System.String,System.Int64,System.IO.MemoryMappedFiles.MemoryMappedFileAccess,System.IO.MemoryMappedFiles.MemoryMappedFileOptions,System.IO.HandleInheritability)",System.IO.MemoryMappedFiles,MemoryMappedFile,"CreateOrOpen(String, Int64, MemoryMappedFileAccess, MemoryMappedFileOptions, HandleInheritability)",1
```

`CreateOrOpen` `OpenExisting` are windows supported only.