### PR TITLE
[wasm] Mark System.Net.SocketAddress APIs unsupported on Browser

### DIFF
--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Net.Sockets;
+using System.Runtime.Versioning;
 using System.Text;
 
 #if SYSTEM_NET_PRIMITIVES_DLL
@@ -36,6 +37,7 @@ namespace System.Net.Internals
         private bool _changed = true;
         private int _hash;
 
+        [UnsupportedOSPlatform("browser")]
         public AddressFamily Family
         {
             get
@@ -80,10 +82,12 @@ namespace System.Net.Internals
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public SocketAddress(AddressFamily family) : this(family, MaxSize)
         {
         }
 
+        [UnsupportedOSPlatform("browser")]
         public SocketAddress(AddressFamily family, int size)
         {
             if (size < MinSize)
@@ -235,6 +239,7 @@ namespace System.Net.Internals
             return _hash;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public override string ToString()
         {
             // Get the address family string.  In almost all cases, this should be a cached string

--- a/src/libraries/System.Net.Primitives/Directory.Build.props
+++ b/src/libraries/System.Net.Primitives/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -269,6 +269,7 @@ namespace System.Net
         public System.Net.IPAddress Address { get { throw null; } set { } }
         public override System.Net.Sockets.AddressFamily AddressFamily { get { throw null; } }
         public int Port { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override System.Net.EndPoint Create(System.Net.SocketAddress socketAddress) { throw null; }
         public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -308,13 +309,17 @@ namespace System.Net
     }
     public partial class SocketAddress
     {
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public SocketAddress(System.Net.Sockets.AddressFamily family) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public SocketAddress(System.Net.Sockets.AddressFamily family, int size) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.Sockets.AddressFamily Family { get { throw null; } }
         public byte this[int offset] { get { throw null; } set { } }
         public int Size { get { throw null; } }
         public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public override string ToString() { throw null; }
     }
     public abstract partial class TransportContext

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Sockets;
+using System.Runtime.Versioning;
 
 namespace System.Net
 {
@@ -154,6 +155,7 @@ namespace System.Net
 
         public override SocketAddress Serialize() => new SocketAddress(Address, Port);
 
+        [UnsupportedOSPlatform("browser")]
         public override EndPoint Create(SocketAddress socketAddress)
         {
             if (socketAddress == null)


### PR DESCRIPTION
Contributes to #41087 

```
M:System.Net.IPEndPoint.Create(System.Net.SocketAddress),System.Net,IPEndPoint,Create(SocketAddress),3
M:System.Net.SocketAddress.get_Family,System.Net,SocketAddress,get_Family(),2
M:System.Net.SocketAddress.ToString,System.Net,SocketAddress,ToString(),3
M:System.Net.SocketAddress.#ctor(System.Net.Sockets.AddressFamily),System.Net,SocketAddress,.ctor(AddressFamily),3
"M:System.Net.SocketAddress.#ctor(System.Net.Sockets.AddressFamily,System.Int32)",System.Net,SocketAddress,".ctor(AddressFamily, Int32)",2
```