### PR TITLE
[mono] Minor fixes to the wasm browser sample

### DIFF
--- a/src/mono/netcore/sample/wasm/browser/Makefile
+++ b/src/mono/netcore/sample/wasm/browser/Makefile
@@ -13,4 +13,4 @@ clean:
 	rm -rf bin
 
 run:
-	cd bin/$(CONFIG)/publish && python server.py
+	cd bin/$(CONFIG)/publish && python3 server.py

--- a/src/mono/netcore/sample/wasm/browser/Program.cs
+++ b/src/mono/netcore/sample/wasm/browser/Program.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Sample
 {
@@ -13,6 +14,7 @@ namespace Sample
             Console.WriteLine ("Hello, World!");
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static int TestMeaning()
         {
             return 42;

--- a/src/mono/netcore/sample/wasm/browser/index.html
+++ b/src/mono/netcore/sample/wasm/browser/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <h3 id="header">Wasm Browser Sample</h3>
-    Result from Sample.Test.TestMeaaning: <span id="out"></span>
+    Result from Sample.Test.TestMeaning: <span id="out"></span>
     <script type='text/javascript'>
       var App = {
         init: function () {


### PR DESCRIPTION
Use python 3, fix typo, prevent inlining

If the NoInlining is a problem I can remove it, but its inclusion makes checking for that method much easier. The others are hopefully uncontroversial; all our containers should have py3 after my work a few months ago.