### PR TITLE
[mono] Enable startup stats timer on wasm

### DIFF
--- a/src/mono/mono/mini/mini-posix.c
+++ b/src/mono/mono/mini/mini-posix.c
@@ -523,6 +523,7 @@ static clock_serv_t sampling_clock;
 static void
 clock_init_for_profiler (MonoProfilerSampleMode mode)
 {
+	mono_clock_init (&sampling_clock);
 }
 
 static void
@@ -691,7 +692,6 @@ init:
 		goto init;
 	}
 
-	mono_clock_init (&sampling_clock);
 	clock_init_for_profiler (mode);
 
 	for (guint64 sleep = mono_clock_get_time_ns (sampling_clock); mono_atomic_load_i32 (&sampling_thread_running); clock_sleep_ns_abs (sleep)) {

--- a/src/mono/mono/utils/mono-counters.c
+++ b/src/mono/mono/utils/mono-counters.c
@@ -8,9 +8,11 @@
 #include <stdlib.h>
 #include <glib.h>
 #include "config.h"
-#include "mono-counters.h"
-#include "mono-proclib.h"
-#include "mono-os-mutex.h"
+
+#include "mono/utils/mono-counters.h"
+#include "mono/utils/mono-proclib.h"
+#include "mono/utils/mono-os-mutex.h"
+#include "mono/utils/mono-time.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -26,6 +28,9 @@ struct _MonoCounter {
 
 static MonoCounter *counters = NULL;
 static mono_mutex_t counters_mutex;
+
+static mono_clock_id_t real_time_clock;
+static guint64 real_time_start;
 
 static volatile gboolean initialized = FALSE;
 
@@ -130,6 +135,9 @@ mono_counters_init (void)
 		return;
 
 	mono_os_mutex_init (&counters_mutex);
+
+	mono_clock_init (&real_time_clock);
+	real_time_start = mono_clock_get_time_ns (real_time_clock);
 
 	initialize_system_counters ();
 
@@ -311,6 +319,12 @@ total_time (void)
 	return mono_process_get_data (GINT_TO_POINTER (mono_process_current_pid ()), MONO_PROCESS_TOTAL_TIME);
 }
 
+static guint64
+real_time (void)
+{
+	return mono_clock_get_time_ns (real_time_clock) - real_time_start;
+}
+
 static gint64
 working_set (void)
 {
@@ -411,6 +425,7 @@ initialize_system_counters (void)
 	register_internal ("User Time", SYSCOUNTER_TIME, (gpointer) &user_time, sizeof (gint64));
 	register_internal ("System Time", SYSCOUNTER_TIME, (gpointer) &system_time, sizeof (gint64));
 	register_internal ("Total Time", SYSCOUNTER_TIME, (gpointer) &total_time, sizeof (gint64));
+	register_internal ("Real Time", SYSCOUNTER_TIME, (gpointer) &real_time, sizeof (guint64));
 	register_internal ("Working Set", SYSCOUNTER_BYTES, (gpointer) &working_set, sizeof (gint64));
 	register_internal ("Private Bytes", SYSCOUNTER_BYTES, (gpointer) &private_bytes, sizeof (gint64));
 	register_internal ("Virtual Bytes", SYSCOUNTER_BYTES, (gpointer) &virtual_bytes, sizeof (gint64));

--- a/src/mono/mono/utils/mono-time.c
+++ b/src/mono/mono/utils/mono-time.c
@@ -279,11 +279,16 @@ mono_clock_get_time_ns (mono_clock_id_t clk_id)
 	return ((guint64) mach_ts.tv_sec * 1000000000) + (guint64) mach_ts.tv_nsec;
 }
 
-#elif defined(__linux__)
+// TODO: Potentially make this the default?
+// Can we assume clock_gettime exists on all modern POSIX systems? Maybe add a better check for it in configure.ac?
+#elif defined(__linux__) || defined (TARGET_WASM)
 
 void
 mono_clock_init (mono_clock_id_t *clk_id)
-{	
+{
+#ifdef HAVE_CLOCK_MONOTONIC
+	*clk_id = CLOCK_MONOTONIC;
+#endif
 }
 
 void
@@ -307,22 +312,19 @@ mono_clock_get_time_ns (mono_clock_id_t clk_id)
 void
 mono_clock_init (mono_clock_id_t *clk_id)
 {
-	// TODO: need to implement this function for PC
-	g_assert_not_reached ();
+	// TODO: need to implement this function for Windows
 }
 
 void
 mono_clock_cleanup (mono_clock_id_t clk_id)
 {
-	// TODO: need to implement this function for PC
-	g_assert_not_reached ();
+	// TODO: need to implement this function for Windows
 }
 
 guint64
 mono_clock_get_time_ns (mono_clock_id_t clk_id)
 {
-	// TODO: need to implement time stamp function for PC
-	g_assert_not_reached ();
+	// TODO: need to implement time stamp function for Windows
 }
 
 #endif

--- a/src/mono/mono/utils/mono-time.c
+++ b/src/mono/mono/utils/mono-time.c
@@ -325,6 +325,7 @@ guint64
 mono_clock_get_time_ns (mono_clock_id_t clk_id)
 {
 	// TODO: need to implement time stamp function for Windows
+	return 0;
 }
 
 #endif


### PR DESCRIPTION
I recommend reviewing each commit individually with the corresponding commit message. If desired I can split this into two PRs.

The end result is that this adds a new timer to the startup stats that works by getting the time early in Mono startup and then comparing with that at the time of stat dumps, as opposed to reading in process information. This means it should be easy to get working on all desired platforms.

Contributes to https://github.com/mono/mono/issues/18754