### PR TITLE
[mono] Turn on hybrid suspend by default on ARM64 desktops

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -5812,6 +5812,11 @@ if test x$enable_cooperative_suspend_default != xyes; then
 			enable_hybrid_suspend_default=yes
 		fi
 		;;
+	ARM64)
+		if test x$target_osx = xyes -o x$host_linux = xyes; then
+			enable_hybrid_suspend_default=yes
+		fi
+		;;
 	esac
 fi
 


### PR DESCRIPTION
Try to shake out bugs early in the release cycle