### PR TITLE
Mark System.Runtime APIs Supported on Windows

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Type.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Type.CoreCLR.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 using StackCrawlMark = System.Threading.StackCrawlMark;
 
 namespace System
@@ -89,6 +90,7 @@ namespace System
         //   param progID:     the progID of the class to retrieve
         //   returns:          the class object associated to the progID
         ////
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromProgID(string progID, string? server, bool throwOnError)
         {
             return RuntimeType.GetTypeFromProgIDImpl(progID, server, throwOnError);
@@ -101,6 +103,7 @@ namespace System
         //   param CLSID:      the CLSID of the class to retrieve
         //   returns:          the class object associated to the CLSID
         ////
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromCLSID(Guid clsid, string? server, bool throwOnError)
         {
             return RuntimeType.GetTypeFromCLSIDImpl(clsid, server, throwOnError);

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace System
@@ -399,12 +400,18 @@ namespace System
 
         public abstract Guid GUID { get; }
 
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromCLSID(Guid clsid) => GetTypeFromCLSID(clsid, null, throwOnError: false);
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromCLSID(Guid clsid, bool throwOnError) => GetTypeFromCLSID(clsid, null, throwOnError: throwOnError);
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromCLSID(Guid clsid, string? server) => GetTypeFromCLSID(clsid, server, throwOnError: false);
 
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromProgID(string progID) => GetTypeFromProgID(progID, null, throwOnError: false);
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromProgID(string progID, bool throwOnError) => GetTypeFromProgID(progID, null, throwOnError: throwOnError);
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromProgID(string progID, string? server) => GetTypeFromProgID(progID, server, throwOnError: false);
 
         public abstract Type? BaseType { get; }

--- a/src/libraries/System.Runtime/Directory.Build.props
+++ b/src/libraries/System.Runtime/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Runtime/Directory.Build.props
+++ b/src/libraries/System.Runtime/Directory.Build.props
@@ -2,6 +2,5 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4325,14 +4325,22 @@ namespace System
         public static System.Type[] GetTypeArray(object[] args) { throw null; }
         public static System.TypeCode GetTypeCode(System.Type? type) { throw null; }
         protected virtual System.TypeCode GetTypeCodeImpl() { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromCLSID(System.Guid clsid) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromCLSID(System.Guid clsid, bool throwOnError) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromCLSID(System.Guid clsid, string? server) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromCLSID(System.Guid clsid, string? server, bool throwOnError) { throw null; }
         public static System.Type GetTypeFromHandle(System.RuntimeTypeHandle handle) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromProgID(string progID) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromProgID(string progID, bool throwOnError) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromProgID(string progID, string? server) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromProgID(string progID, string? server, bool throwOnError) { throw null; }
         public static System.RuntimeTypeHandle GetTypeHandle(object o) { throw null; }
         protected abstract bool HasElementTypeImpl();

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace System
@@ -96,8 +97,10 @@ namespace System
             return internal_from_handle(handle.Value);
         }
 
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromCLSID(Guid clsid, string? server, bool throwOnError) => throw new PlatformNotSupportedException();
 
+        [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromProgID(string progID, string? server, bool throwOnError) => throw new PlatformNotSupportedException();
 
         internal virtual Type InternalResolve()


### PR DESCRIPTION
```
all mono M:System.ArgIterator.#ctor(System.RuntimeArgumentHandle),System,ArgIterator,.ctor(RuntimeArgumentHandle),0
all mono "M:System.ArgIterator.#ctor(System.RuntimeArgumentHandle,System.Void*)",System,ArgIterator,".ctor(RuntimeArgumentHandle, Void*)",0
serialization "M:System.Delegate.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System,Delegate,"GetObjectData(SerializationInfo, StreamingContext)",0
all PNSE M:System.Exception.remove_SerializeObjectState(System.EventHandler{System.Runtime.Serialization.SafeSerializationEventArgs}),System,Exception,remove_SerializeObjectState(EventHandler<SafeSerializationEventArgs>),0
all PNSE M:System.Exception.add_SerializeObjectState(System.EventHandler{System.Runtime.Serialization.SafeSerializationEventArgs}),System,Exception,add_SerializeObjectState(EventHandler<SafeSerializationEventArgs>),0
all mono M:System.GC.GetGCMemoryInfo(System.GCKind),System,GC,GetGCMemoryInfo(GCKind),0
serialization "M:System.RuntimeFieldHandle.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System,RuntimeFieldHandle,"GetObjectData(SerializationInfo, StreamingContext)",0
serialization "M:System.RuntimeMethodHandle.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System,RuntimeMethodHandle,"GetObjectData(SerializationInfo, StreamingContext)",0
serialization "M:System.RuntimeTypeHandle.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)",System,RuntimeTypeHandle,"GetObjectData(SerializationInfo, StreamingContext)",0
Partially PNSE M:System.String.IsNormalized(System.Text.NormalizationForm),System,String,IsNormalized(NormalizationForm),3
Partially PNSE M:System.String.Normalize(System.Text.NormalizationForm),System,String,Normalize(NormalizationForm),3
Not implemented by design M:System.Type.GetType(System.String),System,Type,GetType(String),3
Not implemented by design "M:System.Type.GetType(System.String,System.Boolean,System.Boolean)",System,Type,"GetType(String, Boolean, Boolean)",3
all mono "M:System.Type.GetTypeFromCLSID(System.Guid,System.String,System.Boolean)",System,Type,"GetTypeFromCLSID(Guid, String, Boolean)",0
all mono "M:System.Type.GetTypeFromProgID(System.String,System.String,System.Boolean)",System,Type,"GetTypeFromProgID(String, String, Boolean)",0
all mono M:System.Type.GetTypeFromProgID(System.String),System,Type,GetTypeFromProgID(String),1
all mono "M:System.Type.GetTypeFromProgID(System.String,System.Boolean)",System,Type,"GetTypeFromProgID(String, Boolean)",1
all mono M:System.Type.GetTypeFromCLSID(System.Guid),System,Type,GetTypeFromCLSID(Guid),1
all mono "M:System.Type.GetTypeFromProgID(System.String,System.String)",System,Type,"GetTypeFromProgID(String, String)",1
all mono "M:System.Type.GetTypeFromCLSID(System.Guid,System.Boolean)",System,Type,"GetTypeFromCLSID(Guid, Boolean)",1
all PNSE "M:System.Type.ReflectionOnlyGetType(System.String,System.Boolean,System.Boolean)",System,Type,"ReflectionOnlyGetType(String, Boolean, Boolean)",0
Not implemented by design "M:System.Type.GetType(System.String,System.Boolean)",System,Type,"GetType(String, Boolean)",3
all mono "M:System.Type.GetTypeFromCLSID(System.Guid,System.String)",System,Type,"GetTypeFromCLSID(Guid, String)",1
```

Of the APIs listed to be marked as unsupported, many were serialization related (had `System.Runtime.Serialization.SerializationInfo` as a parameter), throw PNSE everywhere, or throw PNSE on mono.

This PR marks `System.Type.GetTypeFromCLSID` and `System.Type.GetTypeFromProgID` as Supported on Windows only.