### PR TITLE
Avoid Unnecessary Cast

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -373,7 +373,7 @@ namespace System
                     {
                         float fraction = ModF(x, &x);
 
-                        if (Abs(fraction) >= 0.5)
+                        if (Abs(fraction) >= 0.5f)
                         {
                             x += Sign(fraction);
                         }


### PR DESCRIPTION
By changing  `0.5` to `0.5f`  we no longer have a cast from double to float.

Fixes #41140