### PR TITLE
Remove Windows / Unix duplications in send-to-helix script variants

### DIFF
--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -22,47 +22,28 @@ parameters:
             
 
 steps:
-  - powershell: $(Build.SourcesDirectory)\eng\common\msbuild.ps1 $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$env:BuildConfig\SendToHelix.binlog
-    displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
-    env:
-      BuildConfig: $(_BuildConfig)
-      HelixSource: ${{ parameters.HelixSource }}
-      HelixType: ${{ parameters.HelixType }}
-      HelixBuild: ${{ parameters.HelixBuild }}
-      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
-      HelixPreCommands: ${{ parameters.HelixPreCommands }}
-      HelixPostCommands: ${{ parameters.HelixPostCommands }}
-      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-      Creator: ${{ parameters.Creator }}
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}
-  - script: $BUILD_SOURCESDIRECTORY/eng/common/msbuild.sh $BUILD_SOURCESDIRECTORY/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
-    displayName: ${{ parameters.DisplayNamePrefix }} (Unix)
-    env:
-      BuildConfig: $(_BuildConfig)
-      HelixSource: ${{ parameters.HelixSource }}
-      HelixType: ${{ parameters.HelixType }}
-      HelixBuild: ${{ parameters.HelixBuild }}
-      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
-      HelixPreCommands: ${{ parameters.HelixPreCommands }}
-      HelixPostCommands: ${{ parameters.HelixPostCommands }}
-      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-      Creator: ${{ parameters.Creator }}
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}
+  - template: send-to-helix-inner-step.yml
+    parameters:
+      osGroup: ${{ variables['Agent.Os'] }}
+      sendParams: $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog
+      displayName: ${{ parameters.DisplayNamePrefix }}
+      condition: ${{ parameters.condition }}
+      continueOnError: ${{ parameters.continueOnError }}
+      environment:
+        BuildConfig: $(_BuildConfig)
+        HelixSource: ${{ parameters.HelixSource }}
+        HelixType: ${{ parameters.HelixType }}
+        HelixBuild: ${{ parameters.HelixBuild }}
+        HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+        HelixAccessToken: ${{ parameters.HelixAccessToken }}
+        HelixPreCommands: ${{ parameters.HelixPreCommands }}
+        HelixPostCommands: ${{ parameters.HelixPostCommands }}
+        WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+        CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+        IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+        DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+        DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+        EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+        WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+        Creator: ${{ parameters.Creator }}
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -22,28 +22,28 @@ parameters:
             
 
 steps:
-  - template: send-to-helix-inner-step.yml
-    parameters:
-      osGroup: ${{ variables['Agent.Os'] }}
-      sendParams: $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog
-      displayName: ${{ parameters.DisplayNamePrefix }}
-      condition: ${{ parameters.condition }}
-      continueOnError: ${{ parameters.continueOnError }}
-      environment:
-        BuildConfig: $(_BuildConfig)
-        HelixSource: ${{ parameters.HelixSource }}
-        HelixType: ${{ parameters.HelixType }}
-        HelixBuild: ${{ parameters.HelixBuild }}
-        HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-        HelixAccessToken: ${{ parameters.HelixAccessToken }}
-        HelixPreCommands: ${{ parameters.HelixPreCommands }}
-        HelixPostCommands: ${{ parameters.HelixPostCommands }}
-        WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-        CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-        IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-        DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-        DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-        EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-        WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-        Creator: ${{ parameters.Creator }}
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+- template: send-to-helix-inner-step.yml
+  parameters:
+    osGroup: ${{ variables['Agent.Os'] }}
+    sendParams: $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog
+    displayName: ${{ parameters.DisplayNamePrefix }}
+    condition: ${{ parameters.condition }}
+    continueOnError: ${{ parameters.continueOnError }}
+    environment:
+      BuildConfig: $(_BuildConfig)
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+      Creator: ${{ parameters.Creator }}
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -25,7 +25,7 @@ steps:
 - template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
   parameters:
     osGroup: ${{ variables['Agent.Os'] }}
-    sendParams: $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog
+    sendParams: $(Build.SourcesDirectory)/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: ${{ parameters.DisplayNamePrefix }}
     condition: ${{ parameters.condition }}
     continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -22,7 +22,7 @@ parameters:
             
 
 steps:
-- template: send-to-helix-inner-step.yml
+- template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
   parameters:
     osGroup: ${{ variables['Agent.Os'] }}
     sendParams: $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -30,7 +30,7 @@ parameters:
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
 
 steps:
-- template: send-to-helix-inner-step.yml
+- template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
   parameters:
     osGroup: ${{ variables['Agent.Os'] }}
     sendParams: $(Build.SourcesDirectory)\eng\common\helixpublish.proj /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog"'

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -30,37 +30,37 @@ parameters:
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
 
 steps:
-  - template: send-to-helix-inner-step.yml
-    parameters:
-      osGroup: ${{ variables['Agent.Os'] }}
-      sendParams: $(Build.SourcesDirectory)\eng\common\helixpublish.proj /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog"'
-      displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
-      condition: ${{ parameters.condition }}
-      continueOnError: ${{ parameters.continueOnError }}
-      environment:
-        BuildConfig: $(_BuildConfig)
-        HelixSource: ${{ parameters.HelixSource }}
-        HelixType: ${{ parameters.HelixType }}
-        HelixBuild: ${{ parameters.HelixBuild }}
-        HelixConfiguration:  ${{ parameters.HelixConfiguration }}
-        HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-        HelixAccessToken: ${{ parameters.HelixAccessToken }}
-        HelixPreCommands: ${{ parameters.HelixPreCommands }}
-        HelixPostCommands: ${{ parameters.HelixPostCommands }}
-        WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-        WorkItemCommand: ${{ parameters.WorkItemCommand }}
-        WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
-        CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-        XUnitProjects: ${{ parameters.XUnitProjects }}
-        XUnitWorkItemTimeout: ${{ parameters.XUnitWorkItemTimeout }}
-        XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
-        XUnitRuntimeTargetFramework: ${{ parameters.XUnitRuntimeTargetFramework }}
-        XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
-        IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-        DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-        DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-        EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-        WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-        HelixBaseUri: ${{ parameters.HelixBaseUri }}
-        Creator: ${{ parameters.Creator }}
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+- template: send-to-helix-inner-step.yml
+  parameters:
+    osGroup: ${{ variables['Agent.Os'] }}
+    sendParams: $(Build.SourcesDirectory)\eng\common\helixpublish.proj /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog"'
+    displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
+    condition: ${{ parameters.condition }}
+    continueOnError: ${{ parameters.continueOnError }}
+    environment:
+      BuildConfig: $(_BuildConfig)
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixConfiguration:  ${{ parameters.HelixConfiguration }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      XUnitProjects: ${{ parameters.XUnitProjects }}
+      XUnitWorkItemTimeout: ${{ parameters.XUnitWorkItemTimeout }}
+      XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
+      XUnitRuntimeTargetFramework: ${{ parameters.XUnitRuntimeTargetFramework }}
+      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+      HelixBaseUri: ${{ parameters.HelixBaseUri }}
+      Creator: ${{ parameters.Creator }}
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -30,65 +30,37 @@ parameters:
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
 
 steps:
-  - powershell: 'powershell "$env:BUILD_SOURCESDIRECTORY\eng\common\msbuild.ps1 $env:BUILD_SOURCESDIRECTORY\eng\common\helixpublish.proj /restore /t:Test /bl:$env:BUILD_SOURCESDIRECTORY\artifacts\log\$env:BuildConfig\SendToHelix.binlog"'
-    displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
-    env:
-      BuildConfig: $(_BuildConfig)
-      HelixSource: ${{ parameters.HelixSource }}
-      HelixType: ${{ parameters.HelixType }}
-      HelixBuild: ${{ parameters.HelixBuild }}
-      HelixConfiguration:  ${{ parameters.HelixConfiguration }}
-      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
-      HelixPreCommands: ${{ parameters.HelixPreCommands }}
-      HelixPostCommands: ${{ parameters.HelixPostCommands }}
-      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-      WorkItemCommand: ${{ parameters.WorkItemCommand }}
-      WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
-      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-      XUnitProjects: ${{ parameters.XUnitProjects }}
-      XUnitWorkItemTimeout: ${{ parameters.XUnitWorkItemTimeout }}
-      XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
-      XUnitRuntimeTargetFramework: ${{ parameters.XUnitRuntimeTargetFramework }}
-      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
-      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-      HelixBaseUri: ${{ parameters.HelixBaseUri }}
-      Creator: ${{ parameters.Creator }}
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}
-  - script: $BUILD_SOURCESDIRECTORY/eng/common/msbuild.sh $BUILD_SOURCESDIRECTORY/eng/common/helixpublish.proj /restore /t:Test /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
-    displayName: ${{ parameters.DisplayNamePrefix }} (Unix)
-    env:
-      BuildConfig: $(_BuildConfig)
-      HelixSource: ${{ parameters.HelixSource }}
-      HelixType: ${{ parameters.HelixType }}
-      HelixBuild: ${{ parameters.HelixBuild }}
-      HelixConfiguration:  ${{ parameters.HelixConfiguration }}
-      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
-      HelixPreCommands: ${{ parameters.HelixPreCommands }}
-      HelixPostCommands: ${{ parameters.HelixPostCommands }}
-      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-      WorkItemCommand: ${{ parameters.WorkItemCommand }}
-      WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
-      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-      XUnitProjects: ${{ parameters.XUnitProjects }}
-      XUnitWorkItemTimeout: ${{ parameters.XUnitWorkItemTimeout }}
-      XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
-      XUnitRuntimeTargetFramework: ${{ parameters.XUnitRuntimeTargetFramework }}
-      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
-      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-      HelixBaseUri: ${{ parameters.HelixBaseUri }}
-      Creator: ${{ parameters.Creator }}
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}
+  - template: send-to-helix-inner-step.yml
+    parameters:
+      osGroup: ${{ variables['Agent.Os'] }}
+      sendParams: $(Build.SourcesDirectory)\eng\common\helixpublish.proj /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog"'
+      displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
+      condition: ${{ parameters.condition }}
+      continueOnError: ${{ parameters.continueOnError }}
+      environment:
+        BuildConfig: $(_BuildConfig)
+        HelixSource: ${{ parameters.HelixSource }}
+        HelixType: ${{ parameters.HelixType }}
+        HelixBuild: ${{ parameters.HelixBuild }}
+        HelixConfiguration:  ${{ parameters.HelixConfiguration }}
+        HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+        HelixAccessToken: ${{ parameters.HelixAccessToken }}
+        HelixPreCommands: ${{ parameters.HelixPreCommands }}
+        HelixPostCommands: ${{ parameters.HelixPostCommands }}
+        WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+        WorkItemCommand: ${{ parameters.WorkItemCommand }}
+        WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
+        CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+        XUnitProjects: ${{ parameters.XUnitProjects }}
+        XUnitWorkItemTimeout: ${{ parameters.XUnitWorkItemTimeout }}
+        XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
+        XUnitRuntimeTargetFramework: ${{ parameters.XUnitRuntimeTargetFramework }}
+        XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
+        IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+        DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+        DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+        EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+        WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+        HelixBaseUri: ${{ parameters.HelixBaseUri }}
+        Creator: ${{ parameters.Creator }}
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -33,7 +33,7 @@ steps:
 - template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
   parameters:
     osGroup: ${{ variables['Agent.Os'] }}
-    sendParams: $(Build.SourcesDirectory)\eng\common\helixpublish.proj /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SendToHelix.binlog"'
+    sendParams: $(Build.SourcesDirectory)/eng/common/helixpublish.proj /restore /t:Test /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
     condition: ${{ parameters.condition }}
     continueOnError: ${{ parameters.continueOnError }}

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
@@ -10,25 +10,25 @@ steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.cmd.
   - powershell: $(Build.SourcesDirectory)\eng\common\build.ps1 -ci ${{ parameters.restoreParams }}
-    displayName: Restore blob feed tasks
-    condition: ${{ parameters.condition }}
+    displayName: Restore blob feed tasks (Windows)
+    condition: ${{ and(ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
 
   - powershell: $(Build.SourcesDirectory)\eng\common\msbuild.ps1 -ci ${{ parameters.sendParams }}
-    displayName: ${{ parameters.displayName }}
-    condition: ${{ parameters.condition }}
+    displayName: ${{ parameters.displayName }} (Windows)
+    condition: ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
     env: ${{ parameters.environment }}
 
 - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.sh.
   - script: $(Build.SourcesDirectory)/eng/common/build.sh --ci ${{ parameters.restoreParams }}
-    displayName: Restore blob feed tasks
-    condition: ${{ parameters.condition }}
+    displayName: Restore blob feed tasks (Unix)
+    condition: ${{ and(ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
     ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       env:
         # Arcade uses this SDK instead of trying to restore one.
         DotNetCoreSdkDir: /usr/local/dotnet
 
   - script: $(Build.SourcesDirectory)/eng/common/msbuild.sh --ci ${{ parameters.sendParams }}
-    displayName: ${{ parameters.displayName }}
-    condition: ${{ parameters.condition }}
+    displayName: ${{ parameters.displayName }} (Unix)
+    condition: ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
     env: ${{ parameters.environment }}


### PR DESCRIPTION
After cleaning up send-to-helix-step / send-to-helix-inner-step,
I have noticed two more scripts unnecessarily duplicating the
Windows / Unix variant the same way, both of which can be adapted
to my (slightly generalized) send-to-helix-inner-step.

Thanks

Tomas