### PR TITLE
Temporarily disable arm64 intrinsics in UTF-16 validation code paths

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -79,7 +79,11 @@ namespace System.Text.Unicode
             long tempUtf8CodeUnitCountAdjustment = 0;
             int tempScalarCountAdjustment = 0;
 
-            if ((AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || Sse2.IsSupported)
+            // Per https://github.com/dotnet/runtime/issues/41699, temporarily disabling
+            // ARM64-intrinsicified code paths. ARM64 platforms may still use the vectorized
+            // non-intrinsicified 'else' block below.
+
+            if (/* (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || */ Sse2.IsSupported)
             {
                 if (inputLength >= Vector128<ushort>.Count)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/41699.

Disables the ARM64-intrinsicified UTF-16 validation code paths since they ended up having poorer performance characteristics for non-ASCII data compared to their 3.x counterparts. With this PR, we skip the intrinsics entirely but stay within vectorized code as much as possible. The codegen and perf should be on-par with what shipped in 3.x.

Once this change is in, we can re-introduce tweaked versions of the arm64 code path, validate the perf numbers, and cherry-pick the "real" fix into the 5.x servicing branches.

/cc @jeffhandley