### PR TITLE
Harden AssemblyDependencyResolver assemblyPaths

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         {
             var component = sharedTestState.ComponentWithNoDependencies.Copy();
 
-            // cahnge the case of the first letter of AppDll
+            // change the case of the first letter of AppDll
             string fileName = component.AppDll;
             string nameWOExtension = Path.GetFileNameWithoutExtension(fileName);
             string nameWOExtensionCaseChanged = (Char.IsUpper(nameWOExtension[0]) ? nameWOExtension[0].ToString().ToLower() : nameWOExtension[0].ToString().ToUpper()) + nameWOExtension.Substring(1);

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -50,11 +50,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         }
 
         [Fact]
-        public void ComponentWithNoDependenciesAndCaseChanged()
+        public void ComponentWithNoDependenciesCaseChangedOnAsm()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Remove once https://github.com/dotnet/runtime/issues/42334 is resolved
+                return;
+            }
+
             var component = sharedTestState.ComponentWithNoDependencies.Copy();
 
-            // change the case of the first letter of AppDll
+            // Change the case of the first letter of AppDll
             string fileName = component.AppDll;
             string nameWOExtension = Path.GetFileNameWithoutExtension(fileName);
             string nameWOExtensionCaseChanged = (Char.IsUpper(nameWOExtension[0]) ? nameWOExtension[0].ToString().ToLower() : nameWOExtension[0].ToString().ToUpper()) + nameWOExtension.Substring(1);
@@ -62,6 +68,90 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
             // Rename
             File.Move(fileName, changeFile);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                sharedTestState.RunComponentResolutionTest(component)
+                    .Should().Pass()
+                    .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
+                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}]")
+                    .And.HaveStdErrContaining($"app_root='{component.Location}{Path.DirectorySeparatorChar}'")
+                    .And.HaveStdErrContaining($"deps='{component.DepsJson}'")
+                    .And.HaveStdErrContaining($"mgd_app='{component.AppDll}'");
+            }
+            else
+            {
+                // See https://github.com/dotnet/runtime/issues/42334
+                // We expect the test to fail due to the the case change of AppDll
+                sharedTestState.RunComponentResolutionTest(component)
+                    .Should().Pass()
+                    .And.HaveStdErrContaining($"Failed to locate managed application [{component.AppDll}]");
+            }
+        }
+
+        [Fact]
+        public void ComponentWithNoDependenciesCaseChangedOnDepsAndAsm()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Remove once https://github.com/dotnet/runtime/issues/42334 is resolved
+                return;
+            }
+
+            var component = sharedTestState.ComponentWithNoDependencies.Copy();
+
+            // Change the case of the first letter of AppDll
+            string fileName = component.AppDll;
+            string nameWOExtension = Path.GetFileNameWithoutExtension(fileName);
+            string nameWOExtensionCaseChanged = (Char.IsUpper(nameWOExtension[0]) ? nameWOExtension[0].ToString().ToLower() : nameWOExtension[0].ToString().ToUpper()) + nameWOExtension.Substring(1);
+            string changeFile = Path.Combine(Path.GetDirectoryName(fileName), (nameWOExtensionCaseChanged + Path.GetExtension(fileName)));
+
+            string changeDepsFile = Path.Combine(Path.GetDirectoryName(component.DepsJson), (nameWOExtensionCaseChanged + ".deps" + Path.GetExtension(component.DepsJson)));
+
+            // Rename
+            File.Move(fileName, changeFile);
+            File.Move(component.DepsJson, changeDepsFile);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                sharedTestState.RunComponentResolutionTest(component)
+                    .Should().Pass()
+                    .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
+                    .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[{component.AppDll}{Path.PathSeparator}]")
+                    .And.HaveStdErrContaining($"app_root='{component.Location}{Path.DirectorySeparatorChar}'")
+                    .And.HaveStdErrContaining($"deps='{component.DepsJson}'")
+                    .And.HaveStdErrContaining($"mgd_app='{component.AppDll}'");
+            }
+            else
+            {
+                // See https://github.com/dotnet/runtime/issues/42334
+                // We expect the test to fail due to the the case change of AppDll
+                sharedTestState.RunComponentResolutionTest(component)
+                    .Should().Pass()
+                    .And.HaveStdErrContaining($"Failed to locate managed application [{component.AppDll}]");
+            }
+        }
+
+        [Fact]
+        public void ComponentWithNoDependenciesNoDepsCaseChangedOnAsm()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Remove once https://github.com/dotnet/runtime/issues/42334 is resolved
+                return;
+            }
+
+            var component = sharedTestState.ComponentWithNoDependencies.Copy();
+
+            // Change the case of the first letter of AppDll
+            string fileName = component.AppDll;
+            string nameWOExtension = Path.GetFileNameWithoutExtension(fileName);
+            string nameWOExtensionCaseChanged = (Char.IsUpper(nameWOExtension[0]) ? nameWOExtension[0].ToString().ToLower() : nameWOExtension[0].ToString().ToUpper()) + nameWOExtension.Substring(1);
+            string changeFile = Path.Combine(Path.GetDirectoryName(fileName), (nameWOExtensionCaseChanged + Path.GetExtension(fileName)));
+
+            // Rename
+            File.Move(fileName, changeFile);
+            // Delete deps
             File.Delete(component.DepsJson);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -76,12 +166,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             }
             else
             {
-                //we expect the test to fail due to the the case change of AppDll
+                // See https://github.com/dotnet/runtime/issues/42334
+                // We expect the test to fail due to the the case change of AppDll
                 sharedTestState.RunComponentResolutionTest(component)
-                    .Should().Fail()
+                    .Should().Pass()
                     .And.HaveStdErrContaining($"Failed to locate managed application [{component.AppDll}]");
             }
-
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -27,7 +27,6 @@ namespace System.Runtime.Loader
         private readonly string[] _resourceSearchPaths;
         private readonly string[] _assemblyDirectorySearchPaths;
 
-
         public AssemblyDependencyResolver(string componentAssemblyPath)
         {
             if (componentAssemblyPath == null)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -22,15 +22,6 @@ namespace System.Runtime.Loader
         /// </summary>
         private const string ResourceAssemblyExtension = ".dll";
 
-        /// <summary>
-        /// The comparison mode for path comparison mode for assembly paths
-        /// </summary>
-#if TARGET_WINDOWS
-        private const StringComparison StringComparisonMode = StringComparison.OrdinalIgnoreCase;
-#else
-        private const StringComparison StringComparisonMode = StringComparison.Ordinal;
-#endif
-
         private readonly Dictionary<string, string> _assemblyPaths;
         private readonly string[] _nativeSearchPaths;
         private readonly string[] _resourceSearchPaths;
@@ -105,16 +96,9 @@ namespace System.Runtime.Loader
             _assemblyPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (string assemblyPath in assemblyPaths)
             {
-                // Check to see if we have the same managed assembly simple name in the dictionary.
-                // We compare the paths reported and if they're the same, simply ignore the duplicate entries. And only fail if the paths are different
-                // (since hostpolicy normalizes paths, the comparison should be sufficient to perform as simple string case sensitive/insensitive comparison)
-                // On Windows - OrdinalIgnoreCase comparison
-                // Elsewhere - Ordinal comparison
-                string assemblySimpleName = Path.GetFileNameWithoutExtension(assemblyPath);
-                if (!_assemblyPaths.ContainsKey(assemblySimpleName) || !_assemblyPaths[assemblySimpleName].Equals(assemblyPath, StringComparisonMode))
-                {
-                    _assemblyPaths.Add(assemblySimpleName, assemblyPath);
-                }
+                // Add the first entry with the same simple assembly name if there are multiples
+                // and ignore others
+                _assemblyPaths.TryAdd(Path.GetFileNameWithoutExtension(assemblyPath), assemblyPath);
             }
 
             _nativeSearchPaths = SplitPathsList(nativeSearchPathsList);


### PR DESCRIPTION
Pick the first simple assembly for multiples

AssemblyDependencyResolver is made resilience to the case when 
hostpolicy.dll returns multiple assembly paths for the same assembly 
by picking the first one.

Fix #37162