### PR TITLE
Attempt fixing failing process test in server core

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -1,21 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using System.Text;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.Win32;
 using Xunit;
 
 namespace System.Diagnostics.Tests
 {
     public class ProcessStandardConsoleTests : ProcessTestBase
     {
-        private const int s_ConsoleEncoding = 437;
+        private const int ConsoleEncoding = 437;
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestChangesInConsoleEncoding()
         {
-            Action<int> run = expectedCodePage =>
+            void RunWithExpectedCodePage(int expectedCodePage)
             {
                 Process p = CreateProcessLong();
                 p.StartInfo.RedirectStandardInput = true;
@@ -31,9 +31,11 @@ namespace System.Diagnostics.Tests
                 Assert.True(p.WaitForExit(WaitInMS));
             };
 
-            if (!OperatingSystem.IsWindows())
+            // Don't test this on Windows containers, as the test is currently failing
+            // cf. https://github.com/dotnet/runtime/issues/42000
+            if (!OperatingSystem.IsWindows() || IsRunningInWindowsContainer())
             {
-                run(Encoding.UTF8.CodePage);
+                RunWithExpectedCodePage(Encoding.UTF8.CodePage);
                 return;
             }
 
@@ -42,20 +44,22 @@ namespace System.Diagnostics.Tests
 
             try
             {
-                // Don't test this on Windows Nano, Windows Nano only supports UTF8.
-                if (File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "regedit.exe")))
-                {
-                    Interop.SetConsoleCP(s_ConsoleEncoding);
-                    Interop.SetConsoleOutputCP(s_ConsoleEncoding);
+                Interop.SetConsoleCP(ConsoleEncoding);
+                Interop.SetConsoleOutputCP(ConsoleEncoding);
 
-                    run(s_ConsoleEncoding);
-                }
+                RunWithExpectedCodePage(ConsoleEncoding);
             }
             finally
             {
                 Interop.SetConsoleCP(inputEncoding);
                 Interop.SetConsoleOutputCP(outputEncoding);
             }
+        }
+
+        private static bool IsRunningInWindowsContainer()
+        {
+            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control");
+            return key?.GetValue("ContainerType") is not null;
         }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -33,7 +33,7 @@ namespace System.Diagnostics.Tests
 
             // Don't test this on Windows containers, as the test is currently failing
             // cf. https://github.com/dotnet/runtime/issues/42000
-            if (!OperatingSystem.IsWindows() || IsRunningInWindowsContainer())
+            if (!OperatingSystem.IsWindows() || PlatformDetection.IsInContainer)
             {
                 RunWithExpectedCodePage(Encoding.UTF8.CodePage);
                 return;
@@ -54,12 +54,6 @@ namespace System.Diagnostics.Tests
                 Interop.SetConsoleCP(inputEncoding);
                 Interop.SetConsoleOutputCP(outputEncoding);
             }
-        }
-
-        private static bool IsRunningInWindowsContainer()
-        {
-            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control");
-            return key?.GetValue("ContainerType") is not null;
         }
     }
 }


### PR DESCRIPTION
Addresses #42000. Changes the Nano server heuristic so that it also incorporates all windows containers to unblock #41701. Ensures that the test still runs in windows container contexts, using the UTF8 codepage.