### PR TITLE
Mark some System.Net.Http APIs as unsupported on browser

### DIFF
--- a/src/libraries/System.Net.Http/Directory.Build.props
+++ b/src/libraries/System.Net.Http/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -103,28 +103,44 @@ namespace System.Net.Http
     {
         public HttpClientHandler() { }
         public bool AllowAutoRedirect { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool CheckCertificateRevocationList { get { throw null; } set { } }
         public System.Net.Http.ClientCertificateOption ClientCertificateOptions { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }
         public static System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2?, System.Security.Cryptography.X509Certificates.X509Chain?, System.Net.Security.SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.ICredentials? DefaultProxyCredentials { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public int MaxAutomaticRedirections { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public int MaxConnectionsPerServer { get { throw null; } set { } }
         public long MaxRequestContentBufferSize { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public int MaxResponseHeadersLength { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool PreAuthenticate { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, object?> Properties { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.IWebProxy? Proxy { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2?, System.Security.Cryptography.X509Certificates.X509Chain?, System.Net.Security.SslPolicyErrors, bool>? ServerCertificateCustomValidationCallback { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
         public virtual bool SupportsAutomaticDecompression { get { throw null; } }
         public virtual bool SupportsProxy { get { throw null; } }
         public virtual bool SupportsRedirectConfiguration { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseCookies { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseDefaultCredentials { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseProxy { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected internal override System.Net.Http.HttpResponseMessage Send(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -325,6 +341,7 @@ namespace System.Net.Http
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected internal override bool TryComputeLength(out long length) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class SocketsHttpHandler : System.Net.Http.HttpMessageHandler
     {
         public SocketsHttpHandler() { }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -3,12 +3,14 @@
 
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class SocketsHttpHandler : HttpMessageHandler
     {
         public static bool IsSupported => false;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Net.Security;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -52,12 +53,14 @@ namespace System.Net.Http
         public virtual bool SupportsProxy => _underlyingHandler.SupportsProxy;
         public virtual bool SupportsRedirectConfiguration => _underlyingHandler.SupportsRedirectConfiguration;
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseCookies
         {
             get => _underlyingHandler.UseCookies;
             set => _underlyingHandler.UseCookies = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public CookieContainer CookieContainer
         {
             get => _underlyingHandler.CookieContainer;
@@ -72,36 +75,42 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public DecompressionMethods AutomaticDecompression
         {
             get => _underlyingHandler.AutomaticDecompression;
             set => _underlyingHandler.AutomaticDecompression = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseProxy
         {
             get => _underlyingHandler.UseProxy;
             set => _underlyingHandler.UseProxy = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public IWebProxy? Proxy
         {
             get => _underlyingHandler.Proxy;
             set => _underlyingHandler.Proxy = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public ICredentials? DefaultProxyCredentials
         {
             get => _underlyingHandler.DefaultProxyCredentials;
             set => _underlyingHandler.DefaultProxyCredentials = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool PreAuthenticate
         {
             get => _underlyingHandler.PreAuthenticate;
             set => _underlyingHandler.PreAuthenticate = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseDefaultCredentials
         {
             // SocketsHttpHandler doesn't have a separate UseDefaultCredentials property.  There
@@ -124,6 +133,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public ICredentials? Credentials
         {
             get => _underlyingHandler.Credentials;
@@ -136,12 +146,14 @@ namespace System.Net.Http
             set => _underlyingHandler.AllowAutoRedirect = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public int MaxAutomaticRedirections
         {
             get => _underlyingHandler.MaxAutomaticRedirections;
             set => _underlyingHandler.MaxAutomaticRedirections = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public int MaxConnectionsPerServer
         {
             get => _underlyingHandler.MaxConnectionsPerServer;
@@ -181,6 +193,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public int MaxResponseHeadersLength
         {
             get => _underlyingHandler.MaxResponseHeadersLength;
@@ -220,6 +233,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public X509CertificateCollection ClientCertificates
         {
             get
@@ -234,6 +248,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? ServerCertificateCustomValidationCallback
         {
 #if TARGETS_BROWSER
@@ -251,6 +266,7 @@ namespace System.Net.Http
 #endif
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool CheckCertificateRevocationList
         {
             get => _underlyingHandler.SslOptions.CertificateRevocationCheckMode == X509RevocationMode.Online;
@@ -261,6 +277,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public SslProtocols SslProtocols
         {
             get => _underlyingHandler.SslOptions.EnabledSslProtocols;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Security;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
@@ -11,6 +12,7 @@ using System.Text;
 
 namespace System.Net.Http
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class SocketsHttpHandler : HttpMessageHandler
     {
         private readonly HttpConnectionSettings _settings = new HttpConnectionSettings();


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/41087

DocID |Namespace| Type | Member | Nesting |
-- | -- | -- | -- | --
M:System.Net.Http.HttpClientHandler.set_MaxConnectionsPerServer(System.Int32) | System.Net.Http | HttpClientHandler | set_MaxConnectionsPerServer(Int32) | 1
M:System.Net.Http.HttpClientHandler.get_UseProxy | System.Net.Http | HttpClientHandler | get_UseProxy() | 1
M:System.Net.Http.HttpClientHandler.set_CookieContainer(System.Net.CookieContainer) | System.Net.Http | HttpClientHandler | set_CookieContainer(CookieContainer) | 1
M:System.Net.Http.HttpClientHandler.set_PreAuthenticate(System.Boolean) | System.Net.Http | HttpClientHandler | set_PreAuthenticate(Boolean) | 1
M:System.Net.Http.HttpClientHandler.get_CookieContainer | System.Net.Http | HttpClientHandler | get_CookieContainer() | 1
M:System.Net.Http.HttpClientHandler.get_MaxAutomaticRedirections | System.Net.Http | HttpClientHandler | get_MaxAutomaticRedirections() | 1
M:System.Net.Http.HttpClientHandler.get_MaxResponseHeadersLength | System.Net.Http | HttpClientHandler | get_MaxResponseHeadersLength() | 1
M:System.Net.Http.HttpClientHandler.get_UseCookies | System.Net.Http | HttpClientHandler | get_UseCookies() | 1
M:System.Net.Http.HttpClientHandler.get_Proxy | System.Net.Http | HttpClientHandler | get_Proxy() | 1
M:System.Net.Http.HttpClientHandler.set_Proxy(System.Net.IWebProxy) | System.Net.Http | HttpClientHandler | set_Proxy(IWebProxy) | 1
M:System.Net.Http.HttpClientHandler.set_MaxAutomaticRedirections(System.Int32) | System.Net.Http | HttpClientHandler | set_MaxAutomaticRedirections(Int32) | 1
M:System.Net.Http.HttpClientHandler.set_SslProtocols(System.Security.Authentication.SslProtocols) | System.Net.Http | HttpClientHandler | set_SslProtocols(SslProtocols) | 1
M:System.Net.Http.HttpClientHandler.set_MaxResponseHeadersLength(System.Int32) | System.Net.Http | HttpClientHandler | set_MaxResponseHeadersLength(Int32) | 1
M:System.Net.Http.HttpClientHandler.set_ServerCertificateCustomValidationCallback(System.Func{System.Net.Http.HttpRequestMessage,System.Security.Cryptography.X509Certificates.X509Certificate2,System.Security.Cryptography.X509Certificates.X509Chain,System.Net.Security.SslPolicyErrors,System.Boolean}) | System.Net.Http | HttpClientHandler | set_ServerCertificateCustomValidationCallback(Func<HttpRequestMessage,   X509Certificate2, X509Chain, SslPolicyErrors, Boolean>) | 0
M:System.Net.Http.HttpClientHandler.get_SslProtocols | System.Net.Http | HttpClientHandler | get_SslProtocols() | 1
M:System.Net.Http.HttpClientHandler.set_CheckCertificateRevocationList(System.Boolean) | System.Net.Http | HttpClientHandler | set_CheckCertificateRevocationList(Boolean) | 1
M:System.Net.Http.HttpClientHandler.get_AutomaticDecompression | System.Net.Http | HttpClientHandler | get_AutomaticDecompression() | 1
M:System.Net.Http.HttpClientHandler.set_UseDefaultCredentials(System.Boolean) | System.Net.Http | HttpClientHandler | set_UseDefaultCredentials(Boolean) | 1
M:System.Net.Http.HttpClientHandler.set_UseProxy(System.Boolean) | System.Net.Http | HttpClientHandler | set_UseProxy(Boolean) | 1
M:System.Net.Http.HttpClientHandler.get_UseDefaultCredentials | System.Net.Http | HttpClientHandler | get_UseDefaultCredentials() | 1
M:System.Net.Http.HttpClientHandler.get_MaxConnectionsPerServer | System.Net.Http | HttpClientHandler | get_MaxConnectionsPerServer() | 1
M:System.Net.Http.HttpClientHandler.get_CheckCertificateRevocationList | System.Net.Http | HttpClientHandler | get_CheckCertificateRevocationList() | 1
M:System.Net.Http.HttpClientHandler.set_UseCookies(System.Boolean) | System.Net.Http | HttpClientHandler | set_UseCookies(Boolean) | 1
M:System.Net.Http.HttpClientHandler.get_Credentials | System.Net.Http | HttpClientHandler | get_Credentials() | 1
M:System.Net.Http.HttpClientHandler.get_ClientCertificates | System.Net.Http | HttpClientHandler | get_ClientCertificates() | 1
M:System.Net.Http.HttpClientHandler.set_AutomaticDecompression(System.Net.DecompressionMethods) | System.Net.Http | HttpClientHandler | set_AutomaticDecompression(DecompressionMethods) | 1
M:System.Net.Http.HttpClientHandler.set_DefaultProxyCredentials(System.Net.ICredentials) | System.Net.Http | HttpClientHandler | set_DefaultProxyCredentials(ICredentials) | 1
M:System.Net.Http.HttpClientHandler.get_PreAuthenticate | System.Net.Http | HttpClientHandler | get_PreAuthenticate() | 1
M:System.Net.Http.HttpClientHandler.get_ServerCertificateCustomValidationCallback | System.Net.Http | HttpClientHandler | get_ServerCertificateCustomValidationCallback() | 0
M:System.Net.Http.HttpClientHandler.get_DefaultProxyCredentials | System.Net.Http | HttpClientHandler | get_DefaultProxyCredentials() | 1
M:System.Net.Http.HttpClientHandler.set_Credentials(System.Net.ICredentials) | System.Net.Http | HttpClientHandler | set_Credentials(ICredentials) | 1
M:System.Net.Http.SocketsHttpHandler.set_MaxConnectionsPerServer(System.Int32) | System.Net.Http | SocketsHttpHandler | set_MaxConnectionsPerServer(Int32) | 0
M:System.Net.Http.SocketsHttpHandler.get_ResponseDrainTimeout | System.Net.Http | SocketsHttpHandler | get_ResponseDrainTimeout() | 0
M:System.Net.Http.SocketsHttpHandler.set_KeepAlivePingPolicy(System.Net.Http.HttpKeepAlivePingPolicy) | System.Net.Http | SocketsHttpHandler | set_KeepAlivePingPolicy(HttpKeepAlivePingPolicy) | 0
M:System.Net.Http.SocketsHttpHandler.get_UseProxy | System.Net.Http | SocketsHttpHandler | get_UseProxy() | 0
M:System.Net.Http.SocketsHttpHandler.set_CookieContainer(System.Net.CookieContainer) | System.Net.Http | SocketsHttpHandler | set_CookieContainer(CookieContainer) | 0
M:System.Net.Http.SocketsHttpHandler.set_KeepAlivePingDelay(System.TimeSpan) | System.Net.Http | SocketsHttpHandler | set_KeepAlivePingDelay(TimeSpan) | 0
M:System.Net.Http.SocketsHttpHandler.get_KeepAlivePingPolicy | System.Net.Http | SocketsHttpHandler | get_KeepAlivePingPolicy() | 0
M:System.Net.Http.SocketsHttpHandler.set_PreAuthenticate(System.Boolean) | System.Net.Http | SocketsHttpHandler | set_PreAuthenticate(Boolean) | 0
M:System.Net.Http.SocketsHttpHandler.get_CookieContainer | System.Net.Http | SocketsHttpHandler | get_CookieContainer() | 0
M:System.Net.Http.SocketsHttpHandler.set_RequestHeaderEncodingSelector(System.Net.Http.HeaderEncodingSelector{System.Net.Http.HttpRequestMessage}) | System.Net.Http | SocketsHttpHandler | set_RequestHeaderEncodingSelector(HeaderEncodingSelector<HttpRequestMessage>) | 0
M:System.Net.Http.SocketsHttpHandler.get_PooledConnectionLifetime | System.Net.Http | SocketsHttpHandler | get_PooledConnectionLifetime() | 0
M:System.Net.Http.SocketsHttpHandler.get_KeepAlivePingDelay | System.Net.Http | SocketsHttpHandler | get_KeepAlivePingDelay() | 0
M:System.Net.Http.SocketsHttpHandler.get_MaxAutomaticRedirections | System.Net.Http | SocketsHttpHandler | get_MaxAutomaticRedirections() | 0
M:System.Net.Http.SocketsHttpHandler.get_MaxResponseHeadersLength | System.Net.Http | SocketsHttpHandler | get_MaxResponseHeadersLength() | 0
M:System.Net.Http.SocketsHttpHandler.get_UseCookies | System.Net.Http | SocketsHttpHandler | get_UseCookies() | 0
M:System.Net.Http.SocketsHttpHandler.get_Expect100ContinueTimeout | System.Net.Http | SocketsHttpHandler | get_Expect100ContinueTimeout() | 0
M:System.Net.Http.SocketsHttpHandler.get_ConnectionFactory | System.Net.Http | SocketsHttpHandler | get_ConnectionFactory() | 0
M:System.Net.Http.SocketsHttpHandler.set_PooledConnectionLifetime(System.TimeSpan) | System.Net.Http | SocketsHttpHandler | set_PooledConnectionLifetime(TimeSpan) | 0
M:System.Net.Http.SocketsHttpHandler.get_RequestHeaderEncodingSelector | System.Net.Http | SocketsHttpHandler | get_RequestHeaderEncodingSelector() | 0
M:System.Net.Http.SocketsHttpHandler.get_AllowAutoRedirect | System.Net.Http | SocketsHttpHandler | get_AllowAutoRedirect() | 0
M:System.Net.Http.SocketsHttpHandler.get_PooledConnectionIdleTimeout | System.Net.Http | SocketsHttpHandler | get_PooledConnectionIdleTimeout() | 0
M:System.Net.Http.SocketsHttpHandler.set_Proxy(System.Net.IWebProxy) | System.Net.Http | SocketsHttpHandler | set_Proxy(IWebProxy) | 0
M:System.Net.Http.SocketsHttpHandler.set_MaxAutomaticRedirections(System.Int32) | System.Net.Http | SocketsHttpHandler | set_MaxAutomaticRedirections(Int32) | 0
M:System.Net.Http.SocketsHttpHandler.get_PlaintextFilter | System.Net.Http | SocketsHttpHandler | get_PlaintextFilter() | 0
M:System.Net.Http.SocketsHttpHandler.set_MaxResponseHeadersLength(System.Int32) | System.Net.Http | SocketsHttpHandler | set_MaxResponseHeadersLength(Int32) | 0
M:System.Net.Http.SocketsHttpHandler.get_MaxResponseDrainSize | System.Net.Http | SocketsHttpHandler | get_MaxResponseDrainSize() | 0
M:System.Net.Http.SocketsHttpHandler.get_SslOptions | System.Net.Http | SocketsHttpHandler | get_SslOptions() | 0
M:System.Net.Http.SocketsHttpHandler.get_Proxy | System.Net.Http | SocketsHttpHandler | get_Proxy() | 0
M:System.Net.Http.SocketsHttpHandler.get_ResponseHeaderEncodingSelector | System.Net.Http | SocketsHttpHandler | get_ResponseHeaderEncodingSelector() | 0
M:System.Net.Http.SocketsHttpHandler.set_ResponseDrainTimeout(System.TimeSpan) | System.Net.Http | SocketsHttpHandler | set_ResponseDrainTimeout(TimeSpan) | 0
M:System.Net.Http.SocketsHttpHandler.set_Expect100ContinueTimeout(System.TimeSpan) | System.Net.Http | SocketsHttpHandler | set_Expect100ContinueTimeout(TimeSpan) | 0
M:System.Net.Http.SocketsHttpHandler.get_AutomaticDecompression | System.Net.Http | SocketsHttpHandler | get_AutomaticDecompression() | 0
M:System.Net.Http.SocketsHttpHandler.set_MaxResponseDrainSize(System.Int32) | System.Net.Http | SocketsHttpHandler | set_MaxResponseDrainSize(Int32) | 0
M:System.Net.Http.SocketsHttpHandler.set_EnableMultipleHttp2Connections(System.Boolean) | System.Net.Http | SocketsHttpHandler | set_EnableMultipleHttp2Connections(Boolean) | 0
M:System.Net.Http.SocketsHttpHandler.set_UseProxy(System.Boolean) | System.Net.Http | SocketsHttpHandler | set_UseProxy(Boolean) | 0
M:System.Net.Http.SocketsHttpHandler.set_ConnectTimeout(System.TimeSpan) | System.Net.Http | SocketsHttpHandler | set_ConnectTimeout(TimeSpan) | 0
M:System.Net.Http.SocketsHttpHandler.set_ConnectionFactory(System.Net.Connections.ConnectionFactory) | System.Net.Http | SocketsHttpHandler | set_ConnectionFactory(ConnectionFactory) | 0
M:System.Net.Http.SocketsHttpHandler.get_MaxConnectionsPerServer | System.Net.Http | SocketsHttpHandler | get_MaxConnectionsPerServer() | 0
M:System.Net.Http.SocketsHttpHandler.set_SslOptions(System.Net.Security.SslClientAuthenticationOptions) | System.Net.Http | SocketsHttpHandler | set_SslOptions(SslClientAuthenticationOptions) | 0
M:System.Net.Http.SocketsHttpHandler.get_KeepAlivePingTimeout | System.Net.Http | SocketsHttpHandler | get_KeepAlivePingTimeout() | 0
M:System.Net.Http.SocketsHttpHandler.set_KeepAlivePingTimeout(System.TimeSpan) | System.Net.Http | SocketsHttpHandler | set_KeepAlivePingTimeout(TimeSpan) | 0
M:System.Net.Http.SocketsHttpHandler.get_Properties | System.Net.Http | SocketsHttpHandler | get_Properties() | 0
M:System.Net.Http.SocketsHttpHandler.set_AutomaticDecompression(System.Net.DecompressionMethods) | System.Net.Http | SocketsHttpHandler | set_AutomaticDecompression(DecompressionMethods) | 0
M:System.Net.Http.SocketsHttpHandler.get_Credentials | System.Net.Http | SocketsHttpHandler | get_Credentials() | 0
M:System.Net.Http.SocketsHttpHandler.set_AllowAutoRedirect(System.Boolean) | System.Net.Http | SocketsHttpHandler | set_AllowAutoRedirect(Boolean) | 0
M:System.Net.Http.SocketsHttpHandler.set_UseCookies(System.Boolean) | System.Net.Http | SocketsHttpHandler | set_UseCookies(Boolean) | 0
M:System.Net.Http.SocketsHttpHandler.get_EnableMultipleHttp2Connections | System.Net.Http | SocketsHttpHandler | get_EnableMultipleHttp2Connections() | 0
M:System.Net.Http.SocketsHttpHandler.set_DefaultProxyCredentials(System.Net.ICredentials) | System.Net.Http | SocketsHttpHandler | set_DefaultProxyCredentials(ICredentials) | 0
M:System.Net.Http.SocketsHttpHandler.get_PreAuthenticate | System.Net.Http | SocketsHttpHandler | get_PreAuthenticate() | 0
M:System.Net.Http.SocketsHttpHandler.set_PlaintextFilter(System.Func{System.Net.Http.HttpRequestMessage,System.Net.Connections.Connection,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask{System.Net.Connections.Connection}}) | System.Net.Http | SocketsHttpHandler | set_PlaintextFilter(Func<HttpRequestMessage, Connection,   CancellationToken, ValueTask<Connection>>) | 0
M:System.Net.Http.SocketsHttpHandler.get_ConnectTimeout | System.Net.Http | SocketsHttpHandler | get_ConnectTimeout() | 0
M:System.Net.Http.SocketsHttpHandler.set_ResponseHeaderEncodingSelector(System.Net.Http.HeaderEncodingSelector{System.Net.Http.HttpRequestMessage}) | System.Net.Http | SocketsHttpHandler | set_ResponseHeaderEncodingSelector(HeaderEncodingSelector<HttpRequestMessage>) | 0
M:System.Net.Http.SocketsHttpHandler.set_PooledConnectionIdleTimeout(System.TimeSpan) | System.Net.Http | SocketsHttpHandler | set_PooledConnectionIdleTimeout(TimeSpan) | 0
M:System.Net.Http.SocketsHttpHandler.get_DefaultProxyCredentials | System.Net.Http | SocketsHttpHandler | get_DefaultProxyCredentials() | 0
M:System.Net.Http.SocketsHttpHandler.set_Credentials(System.Net.ICredentials) | System.Net.Http | SocketsHttpHandler | set_Credentials(ICredentials) | 0

