### PR TITLE
Avoid race condition in WebClient.IsBusy.

### DIFF
--- a/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -213,7 +213,7 @@ namespace System.Net
 
         public RequestCachePolicy? CachePolicy { get; set; }
 
-        public bool IsBusy => _asyncOp != null;
+        public bool IsBusy => Volatile.Read(ref _callNesting) > 0;
 
         protected virtual WebRequest GetWebRequest(Uri address)
         {


### PR DESCRIPTION
Fixes #42013.

Instead of checking `_asyncOp` for `null`, `_callNesting` is checked for being greater than zero, covering both synchronous and asynchronous operations.

The proposal of checking _both_ fields seems redundant to me because when `asyncOp` is not `null`, `_callNesting` is always greater than zero (barring a short time window until it gets decreased). Besides, it is the `_callNesting` that checks whether a `WebClient` operation is permitted, as seen in line 93.