### PR TITLE
Fix vtable chunk sharing with covariant returns

### DIFF
--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -11603,22 +11603,25 @@ BOOL MethodTableBuilder::ChangesImplementationOfVirtualSlot(SLOT_INDEX idx)
         if (!fChangesImplementation && (ParentImpl.GetSlotIndex() != idx))
             fChangesImplementation = TRUE;
 
-        if (!fChangesImplementation)
+        // If the current vtable slot is MethodImpl, is it possible that it will be updated by
+        // the ClassLoader::PropagateCovariantReturnMethodImplSlots.
+        if (!fChangesImplementation && VTImpl.GetMethodDesc()->IsMethodImpl())
         {
-            MethodDesc* pParentMD = ParentImpl.GetMethodDesc();
-            if (pParentMD->RequiresCovariantReturnTypeChecking())
-            {
-                // Search the previous slots in the parent vtable for the same implementation. If it exists and it was
-                // overriden, the ClassLoader::PropagateCovariantReturnMethodImplSlots will propagate the change to the current
-                // slot (idx), so the implementation of it will change.
+            // Note: to know exactly whether the slot will be updated or not, we would need to check the
+            // PreserveBaseOverridesAttribute presence on the current vtable slot and in the worst case
+            // on all of its ancestors. This is expensive, so we don't do that check here and accept
+            // the fact that we get some false positives and end up sharing less vtable chunks.
 
-                for (SLOT_INDEX i = 0; i < idx; i++)
+            // Search the previous slots in the parent vtable for the same implementation. If it exists and it was
+            // overriden, the ClassLoader::PropagateCovariantReturnMethodImplSlots will propagate the change to the current
+            // slot (idx), so the implementation of it will change.
+            MethodDesc* pParentMD = ParentImpl.GetMethodDesc();
+            for (SLOT_INDEX i = 0; i < idx; i++)
+            {
+                if ((*bmtParent)[i].Impl().GetMethodDesc() == pParentMD && (*bmtVT)[i].Impl().GetMethodDesc() != pParentMD)
                 {
-                    if ((*bmtParent)[i].Impl().GetMethodDesc() == pParentMD && (*bmtVT)[i].Impl().GetMethodDesc() != pParentMD)
-                    {
-                        fChangesImplementation = TRUE;
-                        break;
-                    }
+                    fChangesImplementation = TRUE;
+                    break;
                 }
             }
         }

--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -11602,6 +11602,23 @@ BOOL MethodTableBuilder::ChangesImplementationOfVirtualSlot(SLOT_INDEX idx)
         // methods.
         if (!fChangesImplementation && (ParentImpl.GetSlotIndex() != idx))
             fChangesImplementation = TRUE;
+
+        if (!fChangesImplementation)
+        {
+            // Search the previous slots in the parent vtable for the same implementation. If it exists and it was
+            // overriden, the ClassLoader::PropagateCovariantReturnMethodImplSlots will propagate the change to the current
+            // slot (idx), so the implementation of it will change.
+
+            MethodDesc* pParentMD = ParentImpl.GetMethodDesc();
+            for (SLOT_INDEX i = 0; i < idx; i++)
+            {
+                if ((*bmtParent)[i].Impl().GetMethodDesc() == pParentMD && (*bmtVT)[i].Impl().GetMethodDesc() != pParentMD)
+                {
+                    fChangesImplementation = TRUE;
+                    break;
+                }
+            }
+        }
     }
 
     return fChangesImplementation;

--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -11605,17 +11605,20 @@ BOOL MethodTableBuilder::ChangesImplementationOfVirtualSlot(SLOT_INDEX idx)
 
         if (!fChangesImplementation)
         {
-            // Search the previous slots in the parent vtable for the same implementation. If it exists and it was
-            // overriden, the ClassLoader::PropagateCovariantReturnMethodImplSlots will propagate the change to the current
-            // slot (idx), so the implementation of it will change.
-
             MethodDesc* pParentMD = ParentImpl.GetMethodDesc();
-            for (SLOT_INDEX i = 0; i < idx; i++)
+            if (pParentMD->RequiresCovariantReturnTypeChecking())
             {
-                if ((*bmtParent)[i].Impl().GetMethodDesc() == pParentMD && (*bmtVT)[i].Impl().GetMethodDesc() != pParentMD)
+                // Search the previous slots in the parent vtable for the same implementation. If it exists and it was
+                // overriden, the ClassLoader::PropagateCovariantReturnMethodImplSlots will propagate the change to the current
+                // slot (idx), so the implementation of it will change.
+
+                for (SLOT_INDEX i = 0; i < idx; i++)
                 {
-                    fChangesImplementation = TRUE;
-                    break;
+                    if ((*bmtParent)[i].Impl().GetMethodDesc() == pParentMD && (*bmtVT)[i].Impl().GetMethodDesc() != pParentMD)
+                    {
+                        fChangesImplementation = TRUE;
+                        break;
+                    }
                 }
             }
         }

--- a/src/tests/Loader/classloader/regressions/GitHub_42047/GitHub_42047.il
+++ b/src/tests/Loader/classloader/regressions/GitHub_42047/GitHub_42047.il
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime {}
+.assembly testchangesimpofvirtslot {}
+
+.class private auto ansi beforefieldinit A
+{
+    .method public hidebysig newslot virtual instance class A M () cil managed
+    {
+        ldnull
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance void Dummy1 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void Dummy2 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void Dummy3 () cil managed { ret }
+
+    .method public hidebysig specialname rtspecialname instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}
+
+.class private auto ansi beforefieldinit B extends A
+{
+    .method public hidebysig newslot virtual instance class B M () cil managed
+    {
+        .custom instance void [System.Runtime]System.Runtime.CompilerServices.PreserveBaseOverridesAttribute::.ctor() = (01 00 00 00)
+        .override method instance class A A::M()
+
+        ldnull
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance void DummyB1 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void DummyB2 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void DummyB3 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void DummyB4 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void DummyB5 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void DummyB6 () cil managed { ret }
+    .method public hidebysig newslot virtual instance void DummyB7 () cil managed { ret }
+
+    .method public hidebysig specialname rtspecialname instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void A::.ctor()
+        ret
+    }
+}
+
+.class private auto ansi beforefieldinit C extends B
+{
+    .method public hidebysig virtual instance class C M () cil managed
+    {
+        .custom instance void [System.Runtime]System.Runtime.CompilerServices.PreserveBaseOverridesAttribute::.ctor() = (01 00 00 00)
+        .override method instance class A A::M()
+        ldnull
+        ret
+    }
+
+    .method public hidebysig specialname rtspecialname instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void B::.ctor()
+        ret
+    }
+}
+
+.class private auto ansi beforefieldinit D extends C
+{
+    .method public hidebysig virtual instance class D M () cil managed
+    {
+        .custom instance void [System.Runtime]System.Runtime.CompilerServices.PreserveBaseOverridesAttribute::.ctor() = (01 00 00 00)
+        .override method instance class A A::M()
+        ldnull
+        ret
+    }
+
+    .method public hidebysig specialname rtspecialname instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void C::.ctor()
+        ret
+    }
+}
+
+.class private auto ansi beforefieldinit Program
+{
+    .method private hidebysig static int32 Main (string[] args) cil managed
+    {
+        .entrypoint
+
+        newobj instance void C::.ctor()
+        callvirt instance class B B::M()
+        pop
+
+        newobj instance void D::.ctor()
+        callvirt instance class A A::M()
+        pop
+
+        ldc.i4.s 100
+        ret
+    }
+
+    .method public hidebysig specialname rtspecialname instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}

--- a/src/tests/Loader/classloader/regressions/GitHub_42047/GitHub_42047.ilproj
+++ b/src/tests/Loader/classloader/regressions/GitHub_42047/GitHub_42047.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_42047.il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is an issue causing invalid sharing of a vtable chunk when a
method is overridden using method impl in a class and its parent class
and the slot in the parent class is in a previous vtable chunk. The
algorithm in `MethodTableBuilder::ChangesImplementationOfVirtualSlot` that
detects whether a slot in a vtable chunk was changed doesn't know that
the override will be propagated to all slots occupied by the method
being overridden. In the test attached to this fix, it leads to a stack
overflow due to an infinite recursion in the type system code. It could
also result in an overwrite of the method in the parent class, so when
another class derives from it, it would get a method from its sibling.

This change fixes it by checking if the parent method of a current slot
was overridden in some previous slot in the vtable.

This is a fix for #42047