### PR TITLE
Use the concrete ECDiffieHellmanCng type.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDiffieHellmanCng.Derive.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDiffieHellmanCng.Derive.cs
@@ -111,11 +111,15 @@ namespace System.Security.Cryptography
 
             ECParameters otherPartyParameters = otherPartyPublicKey.ExportParameters();
 
-            using (ECDiffieHellmanCng otherPartyCng = (ECDiffieHellmanCng)Create(otherPartyParameters))
-            using (otherKey = (ECDiffieHellmanCngPublicKey)otherPartyCng.PublicKey)
-            using (CngKey importedKey = otherKey.Import())
+            using (ECDiffieHellmanCng otherPartyCng = new ECDiffieHellmanCng())
             {
-                return DeriveSecretAgreementHandle(importedKey);
+                otherPartyCng.ImportParameters(otherPartyParameters);
+
+                using (otherKey = (ECDiffieHellmanCngPublicKey)otherPartyCng.PublicKey)
+                using (CngKey importedKey = otherKey.Import())
+                {
+                    return DeriveSecretAgreementHandle(importedKey);
+                }
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
@@ -179,5 +179,15 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             using (var ecdhCng = new ECDiffieHellmanCng())
                 Assert.Equal(CngAlgorithm.Sha256, ecdhCng.HashAlgorithm);
         }
+
+        [Fact]
+        public static void HashAlgorithm_SupportsOtherECDHImplementations()
+        {
+            using ECDiffieHellman ecdh = ECDiffieHellman.Create(ECCurve.NamedCurves.nistP256);
+            using ECDiffieHellmanCng ecdhCng = new ECDiffieHellmanCng(ECCurve.NamedCurves.nistP256);
+            byte[] key1 = ecdhCng.DeriveKeyFromHash(ecdh.PublicKey, HashAlgorithmName.SHA256);
+            byte[] key2 = ecdh.DeriveKeyFromHash(ecdhCng.PublicKey, HashAlgorithmName.SHA256);
+            Assert.Equal(key1, key2);
+        }
     }
 }


### PR DESCRIPTION
This avoids using the `Create` method which can give us the wrong `ECDiffieHellmanCng` type, and instead create the required type explicitly and import the parameters.

Fixes #42081 