### PR TITLE
Fix order of singlefilehost libarires passed to the linker

### DIFF
--- a/src/installer/corehost/cli/apphost/static/CMakeLists.txt
+++ b/src/installer/corehost/cli/apphost/static/CMakeLists.txt
@@ -204,11 +204,12 @@ target_link_libraries(singlefilehost
     libhostcommon
     ${CORECLR_LIBRARIES}
 
+    ${START_WHOLE_ARCHIVE}
+    ${NATIVE_LIBS}
+    ${END_WHOLE_ARCHIVE}
+
     ${ZLIB_LIBRARIES}
     ${LIBGSS}
     ${NATIVE_LIBS_EXTRA}
 
-    ${START_WHOLE_ARCHIVE}
-    ${NATIVE_LIBS}
-    ${END_WHOLE_ARCHIVE}
 )


### PR DESCRIPTION
We give a list of arguments to the linker which includes a list of static objects we want to be linked together and a set of system-wide native libraries they should be dynamically linked against.

Some build environments, such as Fedora, use the `--as-needed` linker flag. This makes the linker pay attention to the order in which libraries appear and remove uneeded libararies.

When the linker sees this:

    ld --as-needed -lz staticobject.a

It works from left to right and sees that nothing so far depends on libz. The linker removes libz from the set of objects being linked. Then it links staticobject.a, which needs symbols from libz. The linker then complains that it contains an undefined reference.

We can fix that by changing the order so that dependencies appear last in the linker command line:

    ld --as-needed staticobject.a -lz

This makes the linker link staticobject.a against libz correctly.