### PR TITLE
[wasm] Renable build of some runtime tests on wasm

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_r.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'" >True</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_ro.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'" >True</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics_r.csproj
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics_r.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <DebugType>None</DebugType>
     <Optimize />
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'" >True</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TypeIntrinsics.cs" />

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics_ro.csproj
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics_ro.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'" >True</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TypeIntrinsics.cs" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34587/Runtime_34587.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34587/Runtime_34587.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'" >True</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />


### PR DESCRIPTION
These test now build on wasm; reenabling the build. Anything built is automatically run unless excluded in issues.targets, so these tests now also run on wasm.