### PR TITLE
[wasm][debugger][test] Change DateTime format test

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/DateTimeTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DateTimeTests.cs
@@ -12,15 +12,11 @@ namespace DebuggerTests
     {
 
         [Theory]
-        [InlineData("en-US")]
-
-        // Currently not passing tests. Issue #19743
-        // [InlineData ("ja-JP")]
-        // [InlineData ("es-ES")]
-        //[InlineData ("de-DE")]
-        //[InlineData ("ka-GE")]
-        //[InlineData ("hu-HU")]
-        public async Task CheckDateTimeLocale(string locale)
+        [InlineData("en-US", "dddd, MMMM d, yyyy h:mm:ss tt", "dddd, MMMM d, yyyy", "h:mm:ss tt", "M/d/yyyy", "h:mm tt")]
+        [InlineData ("ja-JP", "yyyy年M月d日dddd H:mm:ss", "yyyy年M月d日dddd", "H:mm:ss", "yyyy/MM/dd", "H:mm")]
+        [InlineData ("es-ES", "dddd, d 'de' MMMM 'de' yyyy H:mm:ss", "dddd, d 'de' MMMM 'de' yyyy", "H:mm:ss", "d/M/yyyy", "H:mm")]
+        [InlineData ("de-DE", "dddd, d. MMMM yyyy HH:mm:ss", "dddd, d. MMMM yyyy", "HH:mm:ss", "dd.MM.yyyy", "HH:mm")]
+        public async Task CheckDateTimeLocale(string locale, string fdtp, string ldp, string ltp, string sdp, string stp)
         {
             var insp = new Inspector();
             var scripts = SubscribeToScripts(insp);
@@ -42,13 +38,6 @@ namespace DebuggerTests
                        DateTimeFormatInfo dtfi = CultureInfo.GetCultureInfo(locale).DateTimeFormat;
                        CultureInfo.CurrentCulture = new CultureInfo(locale, false);
                        DateTime dt = new DateTime(2020, 1, 2, 3, 4, 5);
-                       string dt_str = dt.ToString();
-
-                       var fdtp = dtfi.FullDateTimePattern;
-                       var ldp = dtfi.LongDatePattern;
-                       var ltp = dtfi.LongTimePattern;
-                       var sdp = dtfi.ShortDatePattern;
-                       var stp = dtfi.ShortTimePattern;
 
                        CheckString(locals, "fdtp", fdtp);
                        CheckString(locals, "ldp", ldp);
@@ -56,7 +45,6 @@ namespace DebuggerTests
                        CheckString(locals, "sdp", sdp);
                        CheckString(locals, "stp", stp);
                        await CheckDateTime(locals, "dt", dt);
-                       CheckString(locals, "dt_str", dt_str);
                    }
                 );
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DateTimeTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DateTimeTests.cs
@@ -13,9 +13,9 @@ namespace DebuggerTests
 
         [Theory]
         [InlineData("en-US", "dddd, MMMM d, yyyy h:mm:ss tt", "dddd, MMMM d, yyyy", "h:mm:ss tt", "M/d/yyyy", "h:mm tt")]
-        [InlineData ("ja-JP", "yyyy年M月d日dddd H:mm:ss", "yyyy年M月d日dddd", "H:mm:ss", "yyyy/MM/dd", "H:mm")]
-        [InlineData ("es-ES", "dddd, d 'de' MMMM 'de' yyyy H:mm:ss", "dddd, d 'de' MMMM 'de' yyyy", "H:mm:ss", "d/M/yyyy", "H:mm")]
-        [InlineData ("de-DE", "dddd, d. MMMM yyyy HH:mm:ss", "dddd, d. MMMM yyyy", "HH:mm:ss", "dd.MM.yyyy", "HH:mm")]
+        [InlineData("ja-JP", "yyyy年M月d日dddd H:mm:ss", "yyyy年M月d日dddd", "H:mm:ss", "yyyy/MM/dd", "H:mm")]
+        [InlineData("es-ES", "dddd, d 'de' MMMM 'de' yyyy H:mm:ss", "dddd, d 'de' MMMM 'de' yyyy", "H:mm:ss", "d/M/yyyy", "H:mm")]
+        [InlineData("de-DE", "dddd, d. MMMM yyyy HH:mm:ss", "dddd, d. MMMM yyyy", "HH:mm:ss", "dd.MM.yyyy", "HH:mm")]
         public async Task CheckDateTimeLocale(string locale, string fdtp, string ldp, string ltp, string sdp, string stp)
         {
             var insp = new Inspector();
@@ -34,18 +34,20 @@ namespace DebuggerTests
                     $"'{locale}'); }}, 1);",
                     debugger_test_loc, 25, 12, "LocaleTest",
                     locals_fn: async (locals) =>
-                   {
-                       DateTimeFormatInfo dtfi = CultureInfo.GetCultureInfo(locale).DateTimeFormat;
-                       CultureInfo.CurrentCulture = new CultureInfo(locale, false);
-                       DateTime dt = new DateTime(2020, 1, 2, 3, 4, 5);
+                    {
+                        DateTimeFormatInfo dtfi = CultureInfo.GetCultureInfo(locale).DateTimeFormat;
+                        CultureInfo.CurrentCulture = new CultureInfo(locale, false);
 
-                       CheckString(locals, "fdtp", fdtp);
-                       CheckString(locals, "ldp", ldp);
-                       CheckString(locals, "ltp", ltp);
-                       CheckString(locals, "sdp", sdp);
-                       CheckString(locals, "stp", stp);
-                       await CheckDateTime(locals, "dt", dt);
-                   }
+                        await CheckProps(locals, new
+                        {
+                            fdtp = TString(fdtp),
+                            ldp = TString(ldp),
+                            ltp = TString(ltp),
+                            sdp = TString(sdp),
+                            stp = TString(stp),
+                            dt = TDateTime(new DateTime(2020, 1, 2, 3, 4, 5))
+                        }, "locals", num_fields: 8);
+                    }
                 );
 
             });

--- a/src/mono/wasm/debugger/tests/debugger-datetime-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-datetime-test.cs
@@ -7,7 +7,7 @@ namespace DebuggerTests
 {
     public class DateTimeTest
     {
-        public static string LocaleTest(string locale)
+        public static void LocaleTest(string locale)
         {
             CultureInfo.CurrentCulture = new CultureInfo(locale, false);
             Console.WriteLine("CurrentCulture is {0}", CultureInfo.CurrentCulture.Name);
@@ -20,10 +20,10 @@ namespace DebuggerTests
             var stp = dtfi.ShortTimePattern;
 
             DateTime dt = new DateTime(2020, 1, 2, 3, 4, 5);
-            string dt_str = dt.ToString();
-            Console.WriteLine("Current time is {0}", dt_str);
 
-            return dt_str;
+            Console.WriteLine("Current time is {0}", dt);
+
+            return;
         }
     }
 }


### PR DESCRIPTION
Changing DateTime format tests, we cannot test how we were doing before because wasm and dotnet core uses different versions of ICU.
ka-GE is not supported on wasm, that is why I removed the test.