### PR TITLE
AccessViolation when using ValueTypes as a Service

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -100,7 +100,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     ScopeParameter);
             }
 
-            return Expression.Lambda<Func<ServiceProviderEngineScope, object>>(VisitCallSite(callSite, null), ScopeParameter);
+            return Expression.Lambda<Func<ServiceProviderEngineScope, object>>(
+                Convert(VisitCallSite(callSite, null), typeof(object), forceValueTypeConversion: true),
+                ScopeParameter);
         }
 
         protected override Expression VisitRootCache(ServiceCallSite singletonCallSite, object context)
@@ -188,10 +190,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return Expression.New(callSite.ConstructorInfo, parameterExpressions);
         }
 
-        private static Expression Convert(Expression expression, Type type)
+        private static Expression Convert(Expression expression, Type type, bool forceValueTypeConversion = false)
         {
             // Don't convert if the expression is already assignable
-            if (type.GetTypeInfo().IsAssignableFrom(expression.Type.GetTypeInfo()))
+            if (type.GetTypeInfo().IsAssignableFrom(expression.Type.GetTypeInfo())
+                && (!expression.Type.GetTypeInfo().IsValueType || !forceValueTypeConversion))
             {
                 return expression;
             }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -150,7 +150,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             foreach (ServiceCallSite parameterCallSite in constructorCallSite.ParameterCallSites)
             {
                 VisitCallSite(parameterCallSite, argument);
+                if (parameterCallSite.ServiceType.IsValueType)
+                {
+                    argument.Generator.Emit(OpCodes.Unbox_Any, parameterCallSite.ServiceType);
+                }
             }
+
             argument.Generator.Emit(OpCodes.Newobj, constructorCallSite.ConstructorInfo);
             return null;
         }
@@ -184,12 +189,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         protected override object VisitConstant(ConstantCallSite constantCallSite, ILEmitResolverBuilderContext argument)
         {
             AddConstant(argument, constantCallSite.DefaultValue);
-
-            if (constantCallSite.ServiceType.IsValueType)
-            {
-                argument.Generator.Emit(OpCodes.Unbox_Any, constantCallSite.ServiceType);
-            }
-
             return null;
         }
 
@@ -229,7 +228,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     // push index
                     argument.Generator.Emit(OpCodes.Ldc_I4, i);
                     // create parameter
-                    VisitCallSite(enumerableCallSite.ServiceCallSites[i], argument);
+                    ServiceCallSite parameterCallSite = enumerableCallSite.ServiceCallSites[i];
+                    VisitCallSite(parameterCallSite, argument);
+                    if (parameterCallSite.ServiceType.IsValueType)
+                    {
+                        argument.Generator.Emit(OpCodes.Unbox_Any, parameterCallSite.ServiceType);
+                    }
+
                     // store
                     argument.Generator.Emit(OpCodes.Stelem, enumerableCallSite.ItemType);
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -164,12 +164,22 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ResolvesConstantValueTypeServicesCorrectly(bool useScoped)
+        [InlineData(ServiceLifetime.Transient)]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Singleton)]
+        public void ResolvesConstantValueTypeServicesCorrectly(ServiceLifetime lifetime)
         {
             var serviceCollection = new ServiceCollection();
-            if (useScoped)
+            if (lifetime == ServiceLifetime.Transient)
+            {
+                serviceCollection.AddTransient(typeof(int), _ => 4);
+                serviceCollection.AddTransient(typeof(DateTime), _ => new DateTime());
+                serviceCollection.AddTransient(typeof(TheEnum), _ => TheEnum.HelloWorld);
+
+                serviceCollection.AddTransient(typeof(TimeSpan), _ => TimeSpan.Zero);
+                serviceCollection.AddTransient(typeof(TimeSpan), _ => new TimeSpan(1, 2, 3));
+            }
+            else if (lifetime == ServiceLifetime.Scoped)
             {
                 serviceCollection.AddScoped(typeof(int), _ => 4);
                 serviceCollection.AddScoped(typeof(DateTime), _ => new DateTime());
@@ -178,7 +188,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 serviceCollection.AddScoped(typeof(TimeSpan), _ => TimeSpan.Zero);
                 serviceCollection.AddScoped(typeof(TimeSpan), _ => new TimeSpan(1, 2, 3));
             }
-            else
+            else if (lifetime == ServiceLifetime.Singleton)
             {
                 serviceCollection.AddSingleton(typeof(int), 4);
                 serviceCollection.AddSingleton(typeof(DateTime), new DateTime());
@@ -255,7 +265,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.NotNull(provider.CreateScope());
         }
 
-        [Theory(Skip = "We don't support value task services currently")]
+        [Theory(Skip = "https://github.com/dotnet/runtime/issues/42160 - We don't support value task services currently")]
         [InlineData(ServiceLifetime.Transient)]
         [InlineData(ServiceLifetime.Scoped)]
         [InlineData(ServiceLifetime.Singleton)]


### PR DESCRIPTION
When using ValueTypes as services in DependencyInjection, we are generating incorrect IL in a few cases:

- When the ValueType is a top level service
- When the ValueType is in an IEnumerable of services

We were double unboxing the ValueType, which was causing AccessViolations.

This was a regression caused by a previous change when ValueTypes were used in constructor parameters of services.

To fix this, I lifted the unboxing into the VisitConstructor and VisitIEnumerable methods instead of forcing VisitConstant to always do the unboxing. VisitConstant doesn't have enough context to know whether it should do the unboxing or not.

Fix #42037