### PR TITLE
Fix createdump Windows triage dumps

### DIFF
--- a/src/coreclr/src/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/src/debug/createdump/crashinfounix.cpp
@@ -262,7 +262,7 @@ CrashInfo::GetDSOInfo()
 void
 CrashInfo::VisitModule(uint64_t baseAddress, std::string& moduleName)
 {
-    if (baseAddress == 0 || baseAddress == m_auxvValues[AT_SYSINFO_EHDR] || baseAddress == m_auxvValues[AT_BASE]) {
+    if (baseAddress == 0 || baseAddress == m_auxvValues[AT_SYSINFO_EHDR]) {
         return;
     }
     if (m_coreclrPath.empty())

--- a/src/coreclr/src/debug/createdump/main.cpp
+++ b/src/coreclr/src/debug/createdump/main.cpp
@@ -74,6 +74,8 @@ int __cdecl main(const int argc, const char* argv[])
             {
                 dumpType = "minidump";
                 minidumpType = (MINIDUMP_TYPE)(MiniDumpNormal |
+                                               MiniDumpWithDataSegs |
+                                               MiniDumpWithHandleData |
                                                MiniDumpWithThreadInfo);
             }
             else if ((strcmp(*argv, "-h") == 0) || (strcmp(*argv, "--withheap") == 0))
@@ -91,6 +93,9 @@ int __cdecl main(const int argc, const char* argv[])
             {
                 dumpType = "triage minidump";
                 minidumpType = (MINIDUMP_TYPE)(MiniDumpFilterTriage |
+                                               MiniDumpWithDataSegs |
+                                               MiniDumpWithHandleData |
+                                               MiniDumpFilterModulePaths |
                                                MiniDumpWithThreadInfo);
             }
             else if ((strcmp(*argv, "-u") == 0) || (strcmp(*argv, "--full") == 0))


### PR DESCRIPTION
Add ld (i.e. ld_2_23.so) interpreter program headers to Linux coredumps. This is important to the windbg linux support.