### PR TITLE
[wasm][debugger] Log messages in the proxy with the correct debug level

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
@@ -277,7 +277,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         // , HttpContext context)
         public async Task Run(Uri browserUri, WebSocket ideSocket)
         {
-            Log("info", $"DevToolsProxy: Starting on {browserUri}");
+            Log("debug", $"DevToolsProxy: Starting on {browserUri}");
             using (this.ide = ideSocket)
             {
                 Log("verbose", $"DevToolsProxy: IDE waiting for connection on {browserUri}");
@@ -369,9 +369,15 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "verbose":
                     logger.LogDebug(msg);
                     break;
-                case "info":
-                case "warning":
                 case "error":
+                    logger.LogError(msg);
+                    break;
+                case "info":
+                    logger.LogInformation(msg);
+                    break;
+                case "warning":
+                    logger.LogWarning(msg);
+                    break;
                 default:
                     logger.LogDebug(msg);
                     break;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -533,7 +533,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         var asm = store.GetAssemblyByName(assembly_name);
                         if (asm == null)
                         {
-                            Log("info", $"Unable to find assembly: {assembly_name}");
+                            Log("debug", $"Unable to find assembly: {assembly_name}");
                             continue;
                         }
 
@@ -541,7 +541,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                         if (method == null)
                         {
-                            Log("info", $"Unable to find il offset: {il_pos} in method token: {method_token} assembly name: {assembly_name}");
+                            Log("debug", $"Unable to find il offset: {il_pos} in method token: {method_token} assembly name: {assembly_name}");
                             continue;
                         }
 
@@ -556,8 +556,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                             continue;
                         }
 
-                        Log("info", $"frame il offset: {il_pos} method token: {method_token} assembly name: {assembly_name}");
-                        Log("info", $"\tmethod {method_name} location: {location}");
+                        Log("debug", $"frame il offset: {il_pos} method token: {method_token} assembly name: {assembly_name}");
+                        Log("debug", $"\tmethod {method_name} location: {location}");
                         frames.Add(new Frame(method, location, frame_id));
 
                         callFrames.Add(new


### PR DESCRIPTION
- Eg. exceptions thrown in the proxy get logged as debug, instead of an
error, so you might get strange test failures with no details!

Also, updated the current messages logged as `info` to `debug`, since
that is what they were being logged as anyway.