### PR TITLE
Fix SingleFile regression in client configuration

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -126,7 +126,7 @@ namespace System.Configuration
             string applicationUriLower = !string.IsNullOrEmpty(ApplicationUri)
                 ? ApplicationUri.ToLowerInvariant()
                 : null;
-            string hashSuffix = GetTypeAndHashSuffix(applicationUriLower);
+            string hashSuffix = GetTypeAndHashSuffix(applicationUriLower, isSingleFile);
             string part2 = !string.IsNullOrEmpty(namePrefix) && !string.IsNullOrEmpty(hashSuffix)
                 ? namePrefix + hashSuffix
                 : null;
@@ -219,7 +219,7 @@ namespace System.Configuration
         // The evidence we use, in priority order, is Strong Name, Url and Exe Path. If one of
         // these is found, we compute a SHA1 hash of it and return a suffix based on that.
         // If none is found, we return null.
-        private static string GetTypeAndHashSuffix(string exePath)
+        private static string GetTypeAndHashSuffix(string exePath, bool isSingleFile)
         {
             Assembly assembly = Assembly.GetEntryAssembly();
 
@@ -227,7 +227,7 @@ namespace System.Configuration
             string typeName = null;
             string hash = null;
 
-            if (assembly != null)
+            if (assembly != null && !isSingleFile)
             {
                 AssemblyName assemblyName = assembly.GetName();
                 Uri codeBase = new Uri(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly.ManifestModule.Name));

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -50,7 +50,7 @@ namespace System.Configuration
                 exeAssembly = Assembly.GetEntryAssembly();
 
                 // in case of SingleFile deployment, Assembly.Location is empty.
-                if (exeAssembly != null && string.IsNullOrEmpty(exeAssembly.Location))
+                if (exeAssembly?.Location.Length == 0)
                 {
                     isSingleFile = true;
                     HasEntryAssembly = true;


### PR DESCRIPTION
This PR attempts to fix a 3.1 to 5.0 observable regression in `ConfigurationManager` APIs.

Starting with 5.0`System.Reflection.Assembly.GetEntryAssembly().ManifestModule.Name` in app published with `PublishSingleFile=True` returns `<Unknown>` string.
With 3.1 it returns a pseudoname: `MyApp.dll` with the singlefile executable with name `MyApp` (without `.dll`).

This change adjusts `ClientConfigPaths` implementation such that it stays compatible with 3.1 behavior.

Fixes #42161

cc @vitek-karas, @jkotas, I tested locally that it fixes the reported 3.1 -> 5.0 regression in #42161; but I am not sure if there is enough infra to exercise SingleFile publish integration test.