### PR TITLE
SPMI: Don't use BADCODE3 when inlining.

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -16370,6 +16370,12 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             case CEE_MACRO_END:
 
             default:
+                if (compIsForInlining())
+                {
+                    compInlineResult->NoteFatal(InlineObservation::CALLEE_COMPILATION_ERROR);
+                    return;
+                }
+
                 BADCODE3("unknown opcode", ": %02X", (int)opcode);
         }
 


### PR DESCRIPTION
If you try to run (or replay it using SPMI) `runtime\src\tests\JIT\Directed\coverage\importer\Desktop\ceeillegal_il_r.ilproj` in VS you will see that it stops inside `BADCODE3` (break if a debugger present), it is not the desired behavior if a developer looking for real asserts, so don't throw it if we are compiling for inlining.

