### PR TITLE
Do not run stack level setter in release except for x86.

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -2355,25 +2355,25 @@ void CodeGen::genEmitMachineCode()
     }
 #endif
 
-#if EMIT_TRACK_STACK_DEPTH
+#if EMIT_TRACK_STACK_DEPTH && defined(DEBUG)
     // Check our max stack level. Needed for fgAddCodeRef().
     // We need to relax the assert as our estimation won't include code-gen
     // stack changes (which we know don't affect fgAddCodeRef()).
     // NOTE: after emitEndCodeGen (including here), emitMaxStackDepth is a
     // count of DWORD-sized arguments, NOT argument size in bytes.
     {
-        unsigned maxAllowedStackDepth = compiler->fgPtrArgCntMax +    // Max number of pointer-sized stack arguments.
-                                        compiler->compHndBBtabCount + // Return address for locally-called finallys
-                                        genTypeStSz(TYP_LONG) +       // longs/doubles may be transferred via stack, etc
+        unsigned maxAllowedStackDepth = compiler->fgGetPtrArgCntMax() + // Max number of pointer-sized stack arguments.
+                                        compiler->compHndBBtabCount +   // Return address for locally-called finallys
+                                        genTypeStSz(TYP_LONG) + // longs/doubles may be transferred via stack, etc
                                         (compiler->compTailCallUsed ? 4 : 0); // CORINFO_HELP_TAILCALL args
 #if defined(UNIX_X86_ABI)
         // Convert maxNestedAlignment to DWORD count before adding to maxAllowedStackDepth.
         assert(maxNestedAlignment % sizeof(int) == 0);
         maxAllowedStackDepth += maxNestedAlignment / sizeof(int);
 #endif
-        noway_assert(GetEmitter()->emitMaxStackDepth <= maxAllowedStackDepth);
+        assert(GetEmitter()->emitMaxStackDepth <= maxAllowedStackDepth);
     }
-#endif // EMIT_TRACK_STACK_DEPTH
+#endif // EMIT_TRACK_STACK_DEPTH && DEBUG
 
     *nativeSizeOfCode                 = codeSize;
     compiler->info.compNativeCodeSize = (UNATIVE_OFFSET)codeSize;

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -8514,7 +8514,7 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
                       EA_UNKNOWN); // retSize
 
     // Check that we have place for the push.
-    assert(compiler->fgPtrArgCntMax >= 1);
+    assert(compiler->fgGetPtrArgCntMax() >= 1);
 
 #if defined(UNIX_X86_ABI)
     // Restoring alignment manually. This is similar to CodeGen::genRemoveAlignmentAfterCall
@@ -8595,7 +8595,7 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper)
     genEmitHelperCall(helper, argSize, EA_UNKNOWN /* retSize */);
 
     // Check that we have place for the push.
-    assert(compiler->fgPtrArgCntMax >= 1);
+    assert(compiler->fgGetPtrArgCntMax() >= 1);
 
 #if defined(UNIX_X86_ABI)
     // Restoring alignment manually. This is similar to CodeGen::genRemoveAlignmentAfterCall

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4917,10 +4917,12 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     m_pLowering = new (this, CMK_LSRA) Lowering(this, m_pLinearScan); // PHASE_LOWERING
     m_pLowering->Run();
 
-    // Set stack levels
-    //
+#if defined(TARGET_X86) || defined(DEBUG)
+    // Set stack levels, this informmation is necessary for x86
+    // but on other platforms it is used only in asserts.
     StackLevelSetter stackLevelSetter(this);
     stackLevelSetter.Run();
+#endif // X86 || debug
 
     // We can not add any new tracked variables after this point.
     lvaTrackedFixed = true;

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5451,6 +5451,9 @@ private:
 
     //------------------------- Morphing --------------------------------------
 
+
+#if defined(TARGET_X86) || defined(DEBUG)
+private:
     unsigned fgPtrArgCntMax;
 
 public:
@@ -5474,6 +5477,7 @@ public:
     {
         fgPtrArgCntMax = argCntMax;
     }
+#endif // X86 || DEBUG
 
     bool compCanEncodePtrArgCntMax();
 

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -116,8 +116,10 @@ void Compiler::fgInit()
         fgExcptnTargetCache[i] = nullptr;
     }
 
+#if defined(TARGET_X86) || defined(DEBUG)
     /* Keep track of the max count of pointer arguments */
     fgPtrArgCntMax = 0;
+#endif
 
     /* This global flag is set whenever we remove a statement */
     fgStmtRemoved = false;

--- a/src/coreclr/src/jit/stacklevelsetter.cpp
+++ b/src/coreclr/src/jit/stacklevelsetter.cpp
@@ -6,6 +6,8 @@
 #pragma hdrstop
 #endif
 
+#if defined(TARGET_X86) || defined(DEBUG)
+
 #include "stacklevelsetter.h"
 
 StackLevelSetter::StackLevelSetter(Compiler* compiler)
@@ -304,7 +306,7 @@ void StackLevelSetter::SubStackLevel(unsigned value)
 //
 // Notes:
 //    CheckArgCnt records the maximum number of pushed arguments.
-//    Depending upon this value of the maximum number of pushed arguments
+//    On x86 depending upon this value of the maximum number of pushed arguments
 //    we may need to use an EBP frame or be partially interuptible.
 //    This functionality has to be called after maxStackLevel is set.
 //
@@ -314,6 +316,7 @@ void StackLevelSetter::SubStackLevel(unsigned value)
 //
 void StackLevelSetter::CheckArgCnt()
 {
+#if defined(TARGET_X86)
     if (!comp->compCanEncodePtrArgCntMax())
     {
 #ifdef DEBUG
@@ -325,6 +328,11 @@ void StackLevelSetter::CheckArgCnt()
 #endif
         comp->SetInterruptible(false);
     }
+#else
+    assert(comp->compCanEncodePtrArgCntMax());
+#endif
+
+#if defined(TARGET_X86)
     if (maxStackLevel >= sizeof(unsigned))
     {
 #ifdef DEBUG
@@ -335,6 +343,7 @@ void StackLevelSetter::CheckArgCnt()
 #endif
         comp->codeGen->setFramePointerRequired(true);
     }
+#endif
 }
 
 //------------------------------------------------------------------------
@@ -356,3 +365,5 @@ void StackLevelSetter::CheckAdditionalArgs()
     }
 #endif // TARGET_X86
 }
+
+#endif // X86 || DEBUG

--- a/src/coreclr/src/jit/stacklevelsetter.h
+++ b/src/coreclr/src/jit/stacklevelsetter.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#if defined(TARGET_X86) || defined(DEBUG)
+
 #include "compiler.h"
 #include "phase.h"
 
@@ -42,3 +44,5 @@ private:
     bool throwHelperBlocksUsed; // Were any throw helper blocks created for this method.
 #endif                          // !FEATURE_FIXED_OUT_ARGS
 };
+
+#endif // X86 || DEBUG


### PR DESCRIPTION
It saves ~0.20% of the Jit time.

This change has no diffs on arm/arm64 because we always save frame pointer there, the change does not affect x86.

x64 changes are both size improvement (because we don't push and pop rbp and it is available for LSRA) and regression, because we often encode a bigger immediate, for example:

```diff
-000013 lea      rbp, [rsp+C0H]
-000104 mov      dword ptr [V04 rbp+30H], r15d
-000108 mov      dword ptr [V06 rbp+40H], r12d
-00010C mov      dword ptr [V07 rbp+48H], r13d
-
+000102 mov      dword ptr [V04 rsp+F0H], r14d
+00010A mov      dword ptr [V06 rsp+100H], r15d
+000112 mov      dword ptr [V07 rsp+108H], r12d
```

so we encode a bigger immediate for each stack access and it gives us bigger code size, but it looks like something that could be optimized similar to `COMPlus_JitConstCSE`.  If we see many patterns like `reg + common_base + positive_small_const` and it should use the number of accesses when currently it is using the number of stack variables that is a very rude heuristic. I will try to use `COMPlus_JitConstCSE=3` and update the description, cc @briansull .

If I measure PerfScore it ignores such changes (it is questionable if immediate size should affect PerfScore or not but it is another discussion) and shows improvements but some regressions (many) as well, a typical regression is when critical edge resolution forces more variables to be on stack when in fact we start with a better condition: we have rbp available for register allocation.
It looks like an issue in regAlloc, @CarolEidt could you please look at the dump and say if my analysis is correct? Could it be fixed with combine free/busy reg allocation PR?


 