### PR TITLE
a naive fix for Jit Time log with the new style phases.

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4949,6 +4949,8 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     {
 #if MEASURE_CLRAPI_CALLS
         EndPhase(PHASE_CLR_API);
+#else
+       EndPhase(PHASE_POST_EMIT);
 #endif
         pCompJitTimer->Terminate(this, CompTimeSummaryInfo::s_compTimeSummary, true);
     }

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4950,7 +4950,7 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
 #if MEASURE_CLRAPI_CALLS
         EndPhase(PHASE_CLR_API);
 #else
-       EndPhase(PHASE_POST_EMIT);
+        EndPhase(PHASE_POST_EMIT);
 #endif
         pCompJitTimer->Terminate(this, CompTimeSummaryInfo::s_compTimeSummary, true);
     }


### PR DESCRIPTION
A new phase was added in https://github.com/dotnet/runtime/pull/32899/files that we don't call `EndPhase` for, so this code:
```
            if (phase + 1 == lastPhase)
            {
                m_info.m_totalCycles = (threadCurCycles - m_start);
            }
```
never executes and `COMPlus_JitTimeLogFile` shows 0 as the total time and inf as % for each phase.