### PR TITLE
Redo annotation of Enumerable.Cast and friends to use oblivious TResult

### DIFF
--- a/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -122,9 +122,9 @@ namespace System.Collections.Immutable
         public System.ReadOnlyMemory<T> AsMemory() { throw null; }
         public System.ReadOnlySpan<T> AsSpan() { throw null; }
 #endif
-        public System.Collections.Immutable.ImmutableArray<TOther?> As<TOther>() where TOther : class? { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther?> CastArray<TOther>() where TOther : class? { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T?> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class?, T { throw null; }
+        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class? { throw null; }
+        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class? { throw null; }
+        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class?, T { throw null; }
         public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
         public bool Contains(T item) { throw null; }
         public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }

--- a/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -122,9 +122,21 @@ namespace System.Collections.Immutable
         public System.ReadOnlyMemory<T> AsMemory() { throw null; }
         public System.ReadOnlySpan<T> AsSpan() { throw null; }
 #endif
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class? { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class? { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class?, T { throw null; }
+        public System.Collections.Immutable.ImmutableArray<
+#nullable disable
+            TOther
+#nullable restore
+            > As<TOther>() where TOther : class? { throw null; }
+        public System.Collections.Immutable.ImmutableArray<
+#nullable disable
+            TOther
+#nullable restore
+            > CastArray<TOther>() where TOther : class? { throw null; }
+        public static System.Collections.Immutable.ImmutableArray<
+#nullable disable
+            T
+#nullable restore
+            > CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class?, T { throw null; }
         public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
         public bool Contains(T item) { throw null; }
         public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -333,7 +333,11 @@ namespace System.Collections.Immutable
         /// Covariant upcasts from this method may be reversed by calling the
         /// <see cref="ImmutableArray{T}.As{TOther}"/>  or <see cref="ImmutableArray{T}.CastArray{TOther}"/>method.
         /// </remarks>
-        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+        public static ImmutableArray<
+#nullable disable
+            T
+#nullable restore
+            > CastUp<TDerived>(ImmutableArray<TDerived> items)
             where TDerived : class?, T
         {
             return new ImmutableArray<T>(items.array);
@@ -344,7 +348,11 @@ namespace System.Collections.Immutable
         /// array to an array of type <typeparam name="TOther"/>.
         /// </summary>
         /// <exception cref="InvalidCastException">Thrown if the cast is illegal.</exception>
-        public ImmutableArray<TOther> CastArray<TOther>() where TOther : class?
+        public ImmutableArray<
+#nullable disable
+            TOther
+#nullable restore
+            > CastArray<TOther>() where TOther : class?
         {
             return new ImmutableArray<TOther>((TOther[])(object)array!);
         }
@@ -364,7 +372,11 @@ namespace System.Collections.Immutable
         /// element types to their derived types. However, downcasting is only successful
         /// when it reverses a prior upcasting operation.
         /// </remarks>
-        public ImmutableArray<TOther> As<TOther>() where TOther : class?
+        public ImmutableArray<
+#nullable disable
+            TOther
+#nullable restore
+            > As<TOther>() where TOther : class?
         {
             return new ImmutableArray<TOther>((this.array as TOther[]));
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -333,10 +333,10 @@ namespace System.Collections.Immutable
         /// Covariant upcasts from this method may be reversed by calling the
         /// <see cref="ImmutableArray{T}.As{TOther}"/>  or <see cref="ImmutableArray{T}.CastArray{TOther}"/>method.
         /// </remarks>
-        public static ImmutableArray<T?> CastUp<TDerived>(ImmutableArray<TDerived> items)
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
             where TDerived : class?, T
         {
-            return new ImmutableArray<T?>(items.array);
+            return new ImmutableArray<T>(items.array);
         }
 
         /// <summary>
@@ -344,9 +344,9 @@ namespace System.Collections.Immutable
         /// array to an array of type <typeparam name="TOther"/>.
         /// </summary>
         /// <exception cref="InvalidCastException">Thrown if the cast is illegal.</exception>
-        public ImmutableArray<TOther?> CastArray<TOther>() where TOther : class?
+        public ImmutableArray<TOther> CastArray<TOther>() where TOther : class?
         {
-            return new ImmutableArray<TOther?>((TOther?[]?)(object?)array);
+            return new ImmutableArray<TOther>((TOther[])(object)array!);
         }
 
         /// <summary>
@@ -364,9 +364,9 @@ namespace System.Collections.Immutable
         /// element types to their derived types. However, downcasting is only successful
         /// when it reverses a prior upcasting operation.
         /// </remarks>
-        public ImmutableArray<TOther?> As<TOther>() where TOther : class?
+        public ImmutableArray<TOther> As<TOther>() where TOther : class?
         {
-            return new ImmutableArray<TOther?>((this.array as TOther?[]));
+            return new ImmutableArray<TOther>((this.array as TOther[]));
         }
 
         /// <summary>

--- a/src/libraries/System.Data.Common/src/System/Data/EnumerableRowCollection.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/EnumerableRowCollection.cs
@@ -89,7 +89,7 @@ namespace System.Data
         internal EnumerableRowCollection(DataTable table)
         {
             _table = table;
-            _enumerableRows = table.Rows.Cast<TRow>()!;
+            _enumerableRows = table.Rows.Cast<TRow>();
             _listOfPredicates = new List<Func<TRow, bool>>();
             _sortExpression = new SortExpressionBuilder<TRow>();
         }

--- a/src/libraries/System.Data.Common/src/System/Data/EnumerableRowCollectionExtensions.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/EnumerableRowCollectionExtensions.cs
@@ -152,7 +152,7 @@ namespace System.Data
 
                 Debug.Assert(source != null);
 
-                IEnumerable<TResult> typedEnumerable = Enumerable.Cast<TResult>(source)!;
+                IEnumerable<TResult> typedEnumerable = Enumerable.Cast<TResult>(source);
 
                 EnumerableRowCollection<TResult> newEdt = new EnumerableRowCollection<TResult>(
                     typedEnumerable,

--- a/src/libraries/System.Data.Common/src/System/Data/TypeLimiter.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/TypeLimiter.cs
@@ -107,7 +107,7 @@ namespace System.Data
         private static IEnumerable<Type> GetPreviouslyDeclaredDataTypes(DataTable dataTable)
         {
             return (dataTable != null)
-                ? dataTable.Columns.Cast<DataColumn>().Select(column => column!.DataType)
+                ? dataTable.Columns.Cast<DataColumn>().Select(column => column.DataType)
                 : Enumerable.Empty<Type>();
         }
 
@@ -118,7 +118,7 @@ namespace System.Data
         private static IEnumerable<Type> GetPreviouslyDeclaredDataTypes(DataSet dataSet)
         {
             return (dataSet != null)
-                ? dataSet.Tables.Cast<DataTable>().SelectMany(table => GetPreviouslyDeclaredDataTypes(table!))
+                ? dataSet.Tables.Cast<DataTable>().SelectMany(table => GetPreviouslyDeclaredDataTypes(table))
                 : Enumerable.Empty<Type>();
         }
 

--- a/src/libraries/System.Data.Common/src/System/Data/TypedTableBase.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/TypedTableBase.cs
@@ -37,7 +37,7 @@ namespace System.Data
         /// <returns>IEnumerable of T.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            return Rows.Cast<T>().GetEnumerator()!;
+            return Rows.Cast<T>().GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
@@ -149,7 +149,7 @@ namespace System.Data.Common.Tests
             foreach (var column in _testDataTable.Columns.Cast<DataColumn>())
             {
                 var row = table.NewRow();
-                row["ColumnName"] = column!.ColumnName;
+                row["ColumnName"] = column.ColumnName;
                 row["DataType"] = column.DataType;
                 table.Rows.Add(row);
             }

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbDataReaderTest.cs
@@ -518,7 +518,7 @@ namespace System.Data.Common.Tests
 
             var table = (await new SchemaDbDataReaderMock(readerTable).GetSchemaTableAsync())!;
 
-            DataRow textColRow = table.Rows.Cast<DataRow>().Single()!;
+            var textColRow = table.Rows.Cast<DataRow>().Single();
             Assert.Equal("text_col", textColRow["ColumnName"]);
             Assert.Same(typeof(string), textColRow["DataType"]);
         }

--- a/src/libraries/System.Linq/ref/System.Linq.cs
+++ b/src/libraries/System.Linq/ref/System.Linq.cs
@@ -36,7 +36,11 @@ namespace System.Linq
         public static double? Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, long?> selector) { throw null; }
         public static float? Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, float?> selector) { throw null; }
         public static float Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, float> selector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Cast<TResult>(this System.Collections.IEnumerable source) { throw null; }
+        public static System.Collections.Generic.IEnumerable<
+#nullable disable
+            TResult
+#nullable restore
+            > Cast<TResult>(this System.Collections.IEnumerable source) { throw null; }
         public static System.Collections.Generic.IEnumerable<TSource> Concat<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second) { throw null; }
         public static bool Contains<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource value) { throw null; }
         public static bool Contains<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource value, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }

--- a/src/libraries/System.Linq/ref/System.Linq.cs
+++ b/src/libraries/System.Linq/ref/System.Linq.cs
@@ -36,7 +36,7 @@ namespace System.Linq
         public static double? Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, long?> selector) { throw null; }
         public static float? Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, float?> selector) { throw null; }
         public static float Average<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, float> selector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult?> Cast<TResult>(this System.Collections.IEnumerable source) { throw null; }
+        public static System.Collections.Generic.IEnumerable<TResult> Cast<TResult>(this System.Collections.IEnumerable source) { throw null; }
         public static System.Collections.Generic.IEnumerable<TSource> Concat<TSource>(this System.Collections.Generic.IEnumerable<TSource> first, System.Collections.Generic.IEnumerable<TSource> second) { throw null; }
         public static bool Contains<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource value) { throw null; }
         public static bool Contains<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, TSource value, System.Collections.Generic.IEqualityComparer<TSource>? comparer) { throw null; }

--- a/src/libraries/System.Linq/src/System/Linq/Cast.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Cast.cs
@@ -29,7 +29,11 @@ namespace System.Linq
             }
         }
 
-        public static IEnumerable<TResult> Cast<TResult>(this IEnumerable source)
+        public static IEnumerable<
+#nullable disable // there's no way to annotate the connection of the nullability of TResult to that of the source
+                TResult
+#nullable restore
+                > Cast<TResult>(this IEnumerable source)
         {
             if (source is IEnumerable<TResult> typedSource)
             {

--- a/src/libraries/System.Linq/src/System/Linq/Cast.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Cast.cs
@@ -29,9 +29,9 @@ namespace System.Linq
             }
         }
 
-        public static IEnumerable<TResult?> Cast<TResult>(this IEnumerable source)
+        public static IEnumerable<TResult> Cast<TResult>(this IEnumerable source)
         {
-            if (source is IEnumerable<TResult?> typedSource)
+            if (source is IEnumerable<TResult> typedSource)
             {
                 return typedSource;
             }
@@ -44,11 +44,11 @@ namespace System.Linq
             return CastIterator<TResult>(source);
         }
 
-        private static IEnumerable<TResult?> CastIterator<TResult>(IEnumerable source)
+        private static IEnumerable<TResult> CastIterator<TResult>(IEnumerable source)
         {
-            foreach (object? obj in source)
+            foreach (object obj in source)
             {
-                yield return (TResult?)obj;
+                yield return (TResult)obj;
             }
         }
     }


### PR DESCRIPTION
We just recently changed `Enumerable.Cast<TResult>` to return an `IEnumerable<TResult?>`.  This is technically correct, more so than returning `IEnumerable<TResult>`, because the API can take arbitrary `IEnumerable`s (e.g. `IEnumerable`, `IEnumerable<object?>`, etc.) that can contain nulls.  But in practice it can be very annoying, e.g. if you have an `IEnumerable<object>` using `Cast<string>` on it results in unnecessary warnings.

Consensus amongst C# LDM was to recognize that we can't annotate this well, and so we should just make the TResult be oblivious (as we did for the non-generic `IEnumerable.Current` to aid in `foreach` usage.)

cc: @jcouv, @cston, @eiriktsarpalis, @adamsitnik 

Contributes to https://github.com/dotnet/runtime/issues/40518
@danmosemsft, this will need to be ported to .NET 5.