### PR TITLE
Mark Thread.ResetAbort as obsolete

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.Unix.cs
@@ -179,20 +179,13 @@ namespace System.Drawing
 
         public void LoopHandler()
         {
-            try
+            int n = 0;
+            while (true)
             {
-                int n = 0;
-                while (true)
-                {
-                    Thread.Sleep(delay[n++]);
-                    frameChangeHandler(null, animateEventArgs);
-                    if (n == delay.Length)
-                        n = 0;
-                }
-            }
-            catch (ThreadAbortException)
-            {
-                Thread.ResetAbort(); // we're going to finish anyway
+                Thread.Sleep(delay[n++]);
+                frameChangeHandler(null, animateEventArgs);
+                if (n == delay.Length)
+                    n = 0;
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -189,6 +189,7 @@ namespace System.Threading
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);
         }
 
+        [Obsolete(Obsoletions.ThreadAbortMessage, DiagnosticId = Obsoletions.ThreadAbortDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void ResetAbort()
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -77,6 +77,7 @@ namespace System.Threading
         public bool Join(int millisecondsTimeout) { throw null; }
         public bool Join(System.TimeSpan timeout) { throw null; }
         public static void MemoryBarrier() { }
+        [System.ObsoleteAttribute("Thread.ResetAbort is not supported and throws PlatformNotSupportedException.", DiagnosticId = "SYSLIB0006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static void ResetAbort() { }
         [System.ObsoleteAttribute("Thread.Resume has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
         public void Resume() { }

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -735,7 +735,7 @@ namespace System.Threading.Threads.Tests
 #pragma warning disable SYSLIB0006, 618 // Obsolete: Abort, Suspend, Resume, ResetAbort
                 Assert.Throws<PlatformNotSupportedException>(() => t.Abort());
                 Assert.Throws<PlatformNotSupportedException>(() => t.Abort(t));
-                Assert.Throws<PlatformNotSupportedException>(() => t.ResetAbort());
+                Assert.Throws<PlatformNotSupportedException>(() => Thread.ResetAbort());
                 Assert.Throws<PlatformNotSupportedException>(() => t.Suspend());
                 Assert.Throws<PlatformNotSupportedException>(() => t.Resume());
 #pragma warning restore SYSLIB0006, 618 // Obsolete: Abort, Suspend, Resume, ResetAbort

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -732,12 +732,13 @@ namespace System.Threading.Threads.Tests
 
             Action verify = () =>
             {
-#pragma warning disable SYSLIB0006, 618 // Obsolete: Abort, Suspend, Resume
+#pragma warning disable SYSLIB0006, 618 // Obsolete: Abort, Suspend, Resume, ResetAbort
                 Assert.Throws<PlatformNotSupportedException>(() => t.Abort());
                 Assert.Throws<PlatformNotSupportedException>(() => t.Abort(t));
+                Assert.Throws<PlatformNotSupportedException>(() => t.ResetAbort());
                 Assert.Throws<PlatformNotSupportedException>(() => t.Suspend());
                 Assert.Throws<PlatformNotSupportedException>(() => t.Resume());
-#pragma warning restore SYSLIB0006, 618 // Obsolete: Abort, Suspend, Resume
+#pragma warning restore SYSLIB0006, 618 // Obsolete: Abort, Suspend, Resume, ResetAbort
             };
             verify();
 
@@ -745,9 +746,7 @@ namespace System.Threading.Threads.Tests
             verify();
 
             e.Set();
-            waitForThread();
-
-            Assert.Throws<PlatformNotSupportedException>(() => Thread.ResetAbort());
+            waitForThread(); 
         }
 
         private static void VerifyLocalDataSlot(LocalDataStoreSlot slot)


### PR DESCRIPTION
Closes #41925 

Uses the same diagnostic ID as per the issue discussion.