### PR TITLE
Ensure ReadWithNumberHandling() not called for custom converters of numeric-typed collection elements

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -536,11 +536,11 @@
   <data name="IgnoreConditionOnValueTypeInvalid" xml:space="preserve">
     <value>The ignore condition 'JsonIgnoreCondition.WhenWritingNull' is not valid on value-type member '{0}' on type '{1}'. Consider using 'JsonIgnoreCondition.WhenWritingDefault'.</value>
   </data>
-  <data name="NumberHandlingConverterMustBeBuiltIn" xml:space="preserve">
-    <value>'JsonNumberHandlingAttribute' cannot be placed on a property, field, or type that is handled by a custom converter. See usage(s) of converter '{0}' on type '{1}'.</value>
+  <data name="NumberHandlingOnTypeInvalid" xml:space="preserve">
+    <value>Number handling is only applicable to number types or collections of numbers. When applied to a property or field, the member cannot be handled by a custom converter. If the member is a collection of numbers, the number elements cannot be handled by a custom converter. See type '{0}'.</value>
   </data>
-  <data name="NumberHandlingOnPropertyTypeMustBeNumberOrCollection" xml:space="preserve">
-    <value>When 'JsonNumberHandlingAttribute' is placed on a property or field, the property or field must be a number or a collection of numbers. See member '{0}' on type '{1}'.</value>
+  <data name="NumberHandlingOnPropertyInvalid" xml:space="preserve">
+    <value>Number handling is only applicable to number types or collections of numbers. When applied to a property or field, the member cannot be handled by a custom converter. If the member is a collection of numbers, the number elements cannot be handled by a custom converter. See member '{0}' on type '{1}'.</value>
   </data>
   <data name="ConverterCanConvertNullableRedundant" xml:space="preserve">
     <value>The converter '{0}' handles type '{1}' but is being asked to convert type '{2}'. Either create a separate converter for type '{2}' or change the converter's 'CanConvert' method to only return 'true' for a single type.</value>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -536,11 +536,8 @@
   <data name="IgnoreConditionOnValueTypeInvalid" xml:space="preserve">
     <value>The ignore condition 'JsonIgnoreCondition.WhenWritingNull' is not valid on value-type member '{0}' on type '{1}'. Consider using 'JsonIgnoreCondition.WhenWritingDefault'.</value>
   </data>
-  <data name="NumberHandlingOnTypeInvalid" xml:space="preserve">
-    <value>Number handling is only applicable to number types or collections of numbers. When applied to a property or field, the member cannot be handled by a custom converter. If the member is a collection of numbers, the number elements cannot be handled by a custom converter. See type '{0}'.</value>
-  </data>
   <data name="NumberHandlingOnPropertyInvalid" xml:space="preserve">
-    <value>Number handling is only applicable to number types or collections of numbers. When applied to a property or field, the member cannot be handled by a custom converter. If the member is a collection of numbers, the number elements cannot be handled by a custom converter. See member '{0}' on type '{1}'.</value>
+    <value>'JsonNumberHandlingAttribute' is only valid on a number or a collection of numbers when applied to a property or field. See member '{0}' on type '{1}'.</value>
   </data>
   <data name="ConverterCanConvertNullableRedundant" xml:space="preserve">
     <value>The converter '{0}' handles type '{1}' but is being asked to convert type '{2}'. Either create a separate converter for type '{2}' or change the converter's 'CanConvert' method to only return 'true' for a single type.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -163,7 +163,7 @@ namespace System.Text.Json.Serialization
                 // For performance, only perform validation on internal converters on debug builds.
                 if (IsInternalConverter)
                 {
-                    if (state.Current.NumberHandling != null)
+                    if (state.Current.NumberHandling != null && IsInternalConverterForNumberType)
                     {
                         value = ReadNumberWithCustomHandling(ref reader, state.Current.NumberHandling.Value);
                     }
@@ -179,7 +179,7 @@ namespace System.Text.Json.Serialization
                     int originalPropertyDepth = reader.CurrentDepth;
                     long originalPropertyBytesConsumed = reader.BytesConsumed;
 
-                    if (state.Current.NumberHandling != null)
+                    if (state.Current.NumberHandling != null && IsInternalConverterForNumberType)
                     {
                         value = ReadNumberWithCustomHandling(ref reader, state.Current.NumberHandling.Value);
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -248,25 +248,16 @@ namespace System.Text.Json
             Type? elementType = ConverterBase.ElementType;
             Debug.Assert(elementType != null);
 
-            elementType = Nullable.GetUnderlyingType(elementType) ?? elementType;
-
-            if (elementType == typeof(byte) ||
-                elementType == typeof(decimal) ||
-                elementType == typeof(double) ||
-                elementType == typeof(short) ||
-                elementType == typeof(int) ||
-                elementType == typeof(long) ||
-                elementType == typeof(sbyte) ||
-                elementType == typeof(float) ||
-                elementType == typeof(ushort) ||
-                elementType == typeof(uint) ||
-                elementType == typeof(ulong) ||
-                elementType == JsonClassInfo.ObjectType)
+            try
             {
-                return true;
+                JsonConverter converter = Options.GetConverter(elementType);
+                return converter.IsInternalConverterForNumberType;
             }
-
-            return false;
+            catch (NotSupportedException)
+            {
+                // Allow NotSupportedException to be thrown with correct path information during (de)serialization.
+                return false;
+            }
         }
 
         public static TAttribute? GetAttribute<TAttribute>(MemberInfo memberInfo) where TAttribute : Attribute

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -243,20 +243,11 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(JsonPropertyInfo jsonPropertyInfo)
         {
-            if (jsonPropertyInfo.IsForClassInfo)
-            {
-                throw new InvalidOperationException(SR.Format(SR.NumberHandlingOnTypeInvalid, jsonPropertyInfo.DeclaredPropertyType));
-            }
-            else
-            {
-                MemberInfo? memberInfo = jsonPropertyInfo.MemberInfo;
-                Debug.Assert(memberInfo != null);
+            MemberInfo? memberInfo = jsonPropertyInfo.MemberInfo;
+            Debug.Assert(memberInfo != null);
+            Debug.Assert(!jsonPropertyInfo.IsForClassInfo);
 
-                throw new InvalidOperationException(SR.Format(
-                    SR.NumberHandlingOnPropertyInvalid,
-                    memberInfo.Name,
-                    memberInfo.DeclaringType));
-            }
+            throw new InvalidOperationException(SR.Format(SR.NumberHandlingOnPropertyInvalid, memberInfo.Name, memberInfo.DeclaringType));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -243,22 +243,20 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(JsonPropertyInfo jsonPropertyInfo)
         {
-            MemberInfo? memberInfo = jsonPropertyInfo.MemberInfo;
-
-            if (!jsonPropertyInfo.ConverterBase.IsInternalConverter)
+            if (jsonPropertyInfo.IsForClassInfo)
             {
-                throw new InvalidOperationException(SR.Format(
-                    SR.NumberHandlingConverterMustBeBuiltIn,
-                    jsonPropertyInfo.ConverterBase.GetType(),
-                    jsonPropertyInfo.IsForClassInfo ? jsonPropertyInfo.DeclaredPropertyType : memberInfo!.DeclaringType));
+                throw new InvalidOperationException(SR.Format(SR.NumberHandlingOnTypeInvalid, jsonPropertyInfo.DeclaredPropertyType));
             }
+            else
+            {
+                MemberInfo? memberInfo = jsonPropertyInfo.MemberInfo;
+                Debug.Assert(memberInfo != null);
 
-            // This exception is only thrown for object properties.
-            Debug.Assert(!jsonPropertyInfo.IsForClassInfo && memberInfo != null);
-            throw new InvalidOperationException(SR.Format(
-                SR.NumberHandlingOnPropertyTypeMustBeNumberOrCollection,
-                memberInfo.Name,
-                memberInfo.DeclaringType));
+                throw new InvalidOperationException(SR.Format(
+                    SR.NumberHandlingOnPropertyInvalid,
+                    memberInfo.Name,
+                    memberInfo.DeclaringType));
+            }
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
@@ -1519,38 +1519,31 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void Attribute_NotAllowed_On_Property_WithCustomConverter()
+        public static void Attribute_Ignored_On_Property_WithCustomConverter()
         {
-            string json = @"";
-            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWith_NumberHandlingOn_Property_WithCustomConverter>(json));
-            string exAsStr = ex.ToString();
-            Assert.Contains("MyProp", exAsStr);
-            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Property_WithCustomConverter).ToString(), exAsStr);
+            string json = @"{""Prop"":1}";
 
-            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWith_NumberHandlingOn_Property_WithCustomConverter()));
-            exAsStr = ex.ToString();
-            Assert.Contains("MyProp", exAsStr);
-            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Property_WithCustomConverter).ToString(), exAsStr);
+            // Ensure custom converter is honored.
+            var obj = JsonSerializer.Deserialize<ClassWith_NumberHandlingOn_Property_WithCustomConverter>(json);
+            Assert.Equal(25, obj.Prop);
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(obj));
         }
 
         public class ClassWith_NumberHandlingOn_Property_WithCustomConverter
         {
             [JsonNumberHandling(JsonNumberHandling.Strict)]
             [JsonConverter(typeof(ConverterForInt32))]
-            public int MyProp { get; set; }
+            public int Prop { get; set; }
         }
 
         [Fact]
-        public static void Attribute_NotAllowed_On_Type_WithCustomConverter()
+        public static void Attribute_Ignored_On_Type_WithCustomConverter()
         {
-            string json = @"";
-            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWith_NumberHandlingOn_Type_WithCustomConverter>(json));
-            string exAsStr = ex.ToString();
-            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Type_WithCustomConverter).ToString(), exAsStr);
+            string json = @"{}";
 
-            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWith_NumberHandlingOn_Type_WithCustomConverter()));
-            exAsStr = ex.ToString();
-            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Type_WithCustomConverter).ToString(), exAsStr);
+            // Assert regular Read/Write methods on custom converter are called.
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Deserialize<ClassWith_NumberHandlingOn_Type_WithCustomConverter>(json));
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(new ClassWith_NumberHandlingOn_Type_WithCustomConverter()));
         }
 
         [JsonNumberHandling(JsonNumberHandling.Strict)]
@@ -1639,7 +1632,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void InternalCollectionConverter_CustomNumberConverter()
+        public static void InternalCollectionConverter_CustomNumberConverter_GlobalOption()
         {
             var list = new List<int> { 1 };
             var options = new JsonSerializerOptions(s_optionReadAndWriteFromStr)
@@ -1655,24 +1648,64 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(list2, options));
             Assert.Equal(25, JsonSerializer.Deserialize<List<int?>>(@"[""1""]", options)[0]);
 
-            // Invalid to set number handling for number collection property when number is handled with custom converter.
-            var ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithListPropAndAttribute>("", options));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWithListPropAndAttribute(), options));
+            // Okay to set number handling for number collection property when number is handled with custom converter;
+            // converter Read/Write methods called.
+            ClassWithListPropAndAttribute obj1 = JsonSerializer.Deserialize<ClassWithListPropAndAttribute>(@"{""Prop"":[""1""]}", options);
+            Assert.Equal(25, obj1.Prop[0]);
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(obj1, options));
 
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithDictPropAndAttribute>("", options));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWithDictPropAndAttribute(), options));
+            ClassWithDictPropAndAttribute obj2 = JsonSerializer.Deserialize<ClassWithDictPropAndAttribute>(@"{""Prop"":{""1"":""1""}}", options);
+            Assert.Equal(25, obj2.Prop[1]);
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(obj2, options));
         }
 
         private class ClassWithListPropAndAttribute
         {
             [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
-            public List<int> IntProp { get; set; }
+            public List<int> Prop { get; set; }
         }
 
         private class ClassWithDictPropAndAttribute
         {
             [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+            public Dictionary<int, int?> Prop { get; set; }
+        }
+
+        [Fact]
+        public static void InternalCollectionConverter_CustomNumberConverter_OnProperty()
+        {
+            // Invalid to set number handling for number collection property when number is handled with custom converter.
+            var ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithListPropAndAttribute_ConverterOnProp>(""));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWithListPropAndAttribute_ConverterOnProp()));
+
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithDictPropAndAttribute_ConverterOnProp>(""));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWithDictPropAndAttribute_ConverterOnProp()));
+        }
+
+        private class ClassWithListPropAndAttribute_ConverterOnProp
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+            [JsonConverter(typeof(ListOfIntConverter))]
+            public List<int> IntProp { get; set; }
+        }
+
+        private class ClassWithDictPropAndAttribute_ConverterOnProp
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+            [JsonConverter(typeof(ClassWithDictPropAndAttribute_ConverterOnProp))]
             public Dictionary<int, int?> IntProp { get; set; }
+        }
+
+        public class ListOfIntConverter : JsonConverter<List<int>>
+        {
+            public override List<int> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
+            public override void Write(Utf8JsonWriter writer, List<int> value, JsonSerializerOptions options) => throw new NotImplementedException();
+        }
+
+        public class DictionaryOfNullableIntConverter : JsonConverter<Dictionary<int, int?>>
+        {
+            public override Dictionary<int, int?> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
+            public override void Write(Utf8JsonWriter writer, Dictionary<int, int?> value, JsonSerializerOptions options) => throw new NotImplementedException();
         }
 
         [Fact]
@@ -1688,9 +1721,9 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(dict, options));
             Assert.Equal(25, JsonSerializer.Deserialize<Dictionary<int, int?>> (@"{""1"":""1""}", options)[1]);
 
-            // Invalid to set number handling for number collection property when number is handled with custom converter.
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithDictPropAndAttribute>("", options));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWithDictPropAndAttribute(), options));
+            var obj = JsonSerializer.Deserialize<ClassWithDictPropAndAttribute>(@"{""Prop"":{""1"":""1""}}", options);
+            Assert.Equal(25, obj.Prop[1]);
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(obj, options));
         }
 
         public class ConverterForNullableInt32 : JsonConverter<int?>


### PR DESCRIPTION
Fixes issue in .NET 6.0/master following https://github.com/dotnet/runtime/pull/41679. The issue is not present in .NET 5.