### PR TITLE
[release/5.0-rc2] Add JsonNumberHandling.AllowReadingFromString as a JsonSerializer web default (#41539)

### DIFF
--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -19,8 +19,7 @@ namespace System.Net.Http.Json
         private static MediaTypeHeaderValue DefaultMediaType
             => new MediaTypeHeaderValue(JsonMediaType) { CharSet = "utf-8" };
 
-        internal static readonly JsonSerializerOptions s_defaultSerializerOptions
-            = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        internal static readonly JsonSerializerOptions s_defaultSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 
         private readonly JsonSerializerOptions? _jsonSerializerOptions;
         public Type ObjectType { get; }

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpContentJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpContentJsonExtensionsTests.cs
@@ -22,8 +22,9 @@ namespace System.Net.Http.Json.Functional.Tests
             AssertExtensions.Throws<ArgumentNullException>("content", () => content.ReadFromJsonAsync(typeof(Person)));
         }
 
-        [Fact]
-        public async Task HttpContentGetThenReadFromJsonAsync()
+        [Theory]
+        [MemberData(nameof(ReadFromJsonTestData))]
+        public async Task HttpContentGetThenReadFromJsonAsync(string json)
         {
             await HttpMessageHandlerLoopbackServer.CreateClientAndServerAsync(
                 async (handler, uri) =>
@@ -42,7 +43,14 @@ namespace System.Net.Http.Json.Functional.Tests
                         per.Validate();
                     }
                 },
-                server => server.HandleRequestAsync(headers: _headers, content: Person.Create().Serialize()));
+                server => server.HandleRequestAsync(headers: _headers, content: json));
+        }
+
+        public static IEnumerable<object[]> ReadFromJsonTestData()
+        {
+            Person per = Person.Create();
+            yield return new object[] { per.Serialize() };
+            yield return new object[] { per.SerializeWithNumbersAsStrings() };
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/TestClasses.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/TestClasses.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Xunit;
@@ -32,16 +31,23 @@ namespace System.Net.Http.Json.Functional.Tests
         {
             return JsonSerializer.Serialize(this, options);
         }
+
+        public string SerializeWithNumbersAsStrings(JsonSerializerOptions options = null)
+        {
+            options ??= new JsonSerializerOptions();
+            options.NumberHandling = options.NumberHandling | JsonNumberHandling.WriteAsString;
+            return JsonSerializer.Serialize(this, options);
+        }
     }
 
     internal static class JsonOptions
     {
-        public static readonly JsonSerializerOptions DefaultSerializerOptions
-            = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
+        public static readonly JsonSerializerOptions DefaultSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        public static readonly JsonSerializerOptions DefaultSerializerOptions_StrictNumberHandling = new JsonSerializerOptions(DefaultSerializerOptions)
+        {
+            NumberHandling = JsonNumberHandling.Strict
+        };
     }
 
     internal class EnsureDefaultOptionsConverter : JsonConverter<EnsureDefaultOptions>
@@ -68,7 +74,8 @@ namespace System.Net.Http.Json.Functional.Tests
         private static void AssertDefaultOptions(JsonSerializerOptions options)
         {
             Assert.True(options.PropertyNameCaseInsensitive);
-            Assert.Equal(JsonNamingPolicy.CamelCase, options.PropertyNamingPolicy);
+            Assert.Same(JsonNamingPolicy.CamelCase, options.PropertyNamingPolicy);
+            Assert.Equal(JsonNumberHandling.AllowReadingFromString, options.NumberHandling);
         }
     }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerDefaults.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerDefaults.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json
         /// Specifies that values should be used more appropriate to web-based scenarios.
         /// </summary>
         /// <remarks>
-        /// This option implies that property names are treated as case-insensitive and that "camelCase" name formatting should be employed.
+        /// This option implies that property names are treated as case-insensitive, "camelCase" name formatting should be employed, and that numbers can be read from JSON strings.
         /// </remarks>
         Web = 1
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -106,6 +106,7 @@ namespace System.Text.Json
             {
                 _propertyNameCaseInsensitive = true;
                 _jsonPropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                _numberHandling = JsonNumberHandling.AllowReadingFromString;
             }
             else if (defaults != JsonSerializerDefaults.General)
             {

--- a/src/libraries/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -533,9 +533,9 @@ namespace System.Text.Json.Serialization.Tests
         public static void PredefinedSerializerOptions_Web()
         {
             var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-            JsonNamingPolicy policy = options.PropertyNamingPolicy;
             Assert.True(options.PropertyNameCaseInsensitive);
-            Assert.Same(JsonNamingPolicy.CamelCase, policy);
+            Assert.Same(JsonNamingPolicy.CamelCase, options.PropertyNamingPolicy);
+            Assert.Equal(JsonNumberHandling.AllowReadingFromString, options.NumberHandling);
         }
 
         [Theory]


### PR DESCRIPTION
Backport of #41539 to release/5.0-rc2

### Customer Impact

Follow up from https://github.com/dotnet/runtime/pull/39363 / https://github.com/dotnet/runtime/issues/30255.

During API review for the number handling feature, [it was discussed](https://youtu.be/Cw-kYXQ7Sw8?t=768) that number types being written as strings is a common pattern in many JSON producers (e.g API endpoints) across the web. Adding `JsonNumberHandling.AllowReadingFromString` as a JsonSerializer web default makes it easier for .NET web applications to consume these numbers in a consistent manner (same options for client/shared/server).

### Testing

- The number handling feature was implemented and tested independently of this change (https://github.com/dotnet/runtime/pull/39363). It is already checked in for .NET 5.
- The web defaults for the newly added JSON extension methods on `HttpClient` and `JsonContent` were updated to use the `JsonSerializerDefaults.Web` setting. Appropriate tests were added to make sure the options are honored accordingly.

### Risk

The `JsonSerializerDefaults` and number handling features are new in .NET 5.0. .NET web products such as ASP.NET MVC, `HttpRequestExtensions`, and the extension methods on `HttpClient`/`JsonContent` have been updated to use `JsonSerializerDefaults` by default. The change in this PR affects these areas and makes reading numbers from JSON strings the default behavior.