### PR TITLE
Re-enable tests for Directory.GetFileSystemEntries

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -217,7 +217,6 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22168", TestPlatforms.AnyUnix)]
         [Theory,
             // Question marks collapse (right) to periods
             InlineData(
@@ -242,8 +241,6 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22168", TestPlatforms.AnyUnix)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22169", TestPlatforms.AnyUnix)]
         [Theory,
             // Periods are optional if left of ? and end of match
             InlineData(
@@ -283,7 +280,6 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22169", TestPlatforms.AnyUnix)]
         [Theory,
             // Periods are optional if left of * and end of match
             InlineData(
@@ -303,7 +299,6 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22169", TestPlatforms.AnyUnix)]
         // Can't do these without extended path support on Windows, UsingNewNormalization filters appropriately
         [ConditionalTheory(nameof(UsingNewNormalization)),
             // Periods are optional if left of * or ? and end of match
@@ -348,7 +343,6 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22170", TestPlatforms.AnyUnix)]
         [Theory,
             InlineData(
                 "foo*.",
@@ -362,7 +356,6 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22170", TestPlatforms.AnyUnix)]
         // Can't do these without extended path support on Windows, UsingNewNormalization filters appropriately
         [ConditionalTheory(nameof(UsingNewNormalization)),
             InlineData(
@@ -408,7 +401,6 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22170", TestPlatforms.AnyUnix)]
         [OuterLoop("These are pretty corner, don't need to run all the time.")]
         [Theory,
             // "foo*." actually becomes "foo<" when passed to NT. It matches all characters up to, and including, the final period.


### PR DESCRIPTION
These tests does not longer fail on Unix nor Windows, therefore they can be enabled.
This closes https://github.com/dotnet/runtime/issues/22168, https://github.com/dotnet/runtime/issues/22169, and https://github.com/dotnet/runtime/issues/22170