### PR TITLE
restart fix for weak memory model processors

### DIFF
--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -5898,6 +5898,13 @@ void ThreadSuspend::RestartEE(BOOL bFinishedGC, BOOL SuspendSucceded)
 
     FireEtwGCRestartEEBegin_V1(GetClrInstanceId());
 
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+    // Flush the store buffers on all CPUs, to ensure that they all see changes made
+    // by the GC threads. This only matters on weak memory ordered processors as 
+    // the strong memory ordered processors wouldn't have reordered the relevant reads.
+    ::FlushProcessWriteBuffers();
+#endif //TARGET_ARM || TARGET_ARM64
+
     //
     // SyncClean holds a list of things to be cleaned up when it's possible.
     // SyncClean uses the GC mode to synchronize access to this list.  Threads must be


### PR DESCRIPTION
on processors with a weak memory model we need to flush the store buffers on all CPUs, to ensure that they all see changes made by the GC threads. this only matters on weak memory ordered processors as the strong memory ordered processors wouldn't have reordered the relevant reads.

