### PR TITLE
Add missing opcodes to k_rgnStackPushes

### DIFF
--- a/src/tests/profiler/native/rejitprofiler/ilrewriter.h
+++ b/src/tests/profiler/native/rejitprofiler/ilrewriter.h
@@ -153,6 +153,8 @@ static int k_rgnStackPushes[] = {
 #undef PushRef
 #undef VarPush
 #undef OPDEF
+    0,  // CEE_COUNT
+    0   // CEE_SWITCH_ARG
 };
 
 


### PR DESCRIPTION
The rewriter defines two extra opcodes, CEE_COUNT and CEE_SWITCH_ARG, but does not add them to the `k_rgnStackPushes` array. This can cause out-of-bounds reads when computing the value of maxstack.