### PR TITLE
[utils] Don't use __builtin_available on x86 or amd64 macos

### DIFF
--- a/src/mono/mono/utils/mono-mmap.c
+++ b/src/mono/mono/utils/mono-mmap.c
@@ -305,9 +305,12 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 		}
 		if ((flags & MONO_MMAP_JIT) && (use_mmap_jit || is_hardened_runtime == 1))
 			mflags |= MAP_JIT;
+#if defined(HOST_ARM64)
 		/* Patching code on apple silicon seems to cause random crashes without this flag */
+		/* No __builtin_available in old versions of Xcode that could be building Mono on x86 or amd64 */
 		if (__builtin_available (macOS 11, *))
 			mflags |= MAP_JIT;
+#endif
 	}
 #endif
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20395,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>We build packages with Xcode 8.3.3 for x86 and amd64 build, and it is too old for `__builtin_available`