### PR TITLE
Set targetplatform only if necessary in runsetting

### DIFF
--- a/eng/testing/.runsettings
+++ b/eng/testing/.runsettings
@@ -10,7 +10,7 @@
     <!-- Degree of parallelization, spawns n test hosts to run tests. -->
     <MaxCpuCount>$$MAXCPUCOUNT$$</MaxCpuCount>
     <!-- Configures the architecture of test host. -->
-    <TargetPlatform>$$TARGETPLATFORM$$</TargetPlatform>
+    $$TARGETPLATFORM$$
     <!-- If true, an adapter should disable any test case parallelization. -->
     <DisableParallelization>$$DISABLEPARALLELIZATION$$</DisableParallelization>
     <!-- If true, an adapter shouldn't create appdomains to run tests. -->

--- a/eng/testing/runsettings.targets
+++ b/eng/testing/runsettings.targets
@@ -29,7 +29,8 @@
       <RunSettingsFileContent Condition="'$(TestDisableParallelization)' == 'true'">$(RunSettingsFileContent.Replace('$$MAXCPUCOUNT$$', '1'))</RunSettingsFileContent>
       <RunSettingsFileContent Condition="'$(TestDisableParallelization)' != 'true'">$(RunSettingsFileContent.Replace('$$MAXCPUCOUNT$$', '0'))</RunSettingsFileContent>
       <!-- Arm64 is currently not a known TargetPlatform value in VSTEST: https://github.com/microsoft/vstest/issues/2566 -->
-      <RunSettingsFileContent Condition="'$(TargetArchitecture)' != 'arm64'">$(RunSettingsFileContent.Replace('$$TARGETPLATFORM$$', '$(TargetArchitecture)'))</RunSettingsFileContent>
+      <RunSettingsFileContent Condition="'$(TargetArchitecture)' != 'arm64'">$(RunSettingsFileContent.Replace('$$TARGETPLATFORM$$', '<TargetPlatform>$(TargetArchitecture)</TargetPlatform>'))</RunSettingsFileContent>
+      <RunSettingsFileContent Condition="'$(TargetArchitecture)' == 'arm64'">$(RunSettingsFileContent.Replace('$$TARGETPLATFORM$$', ''))</RunSettingsFileContent>
       <RunSettingsFileContent>$(RunSettingsFileContent.Replace('$$COVERAGE_INCLUDE$$', '$(CoverageIncludeFilter)')
                                                       .Replace('$$COVERAGE_EXCLUDEBYFILE$$', '$(CoverageExcludeByFileFilter)')
                                                       .Replace('$$COVERAGE_INCLUDEDIRECTORY$$', '$(CoverageIncludeDirectoryFilter)')


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/088504d243d24018ca258c726ec983e2ee20e840 was not sufficient. The whole TargetPlatform node shouldn't be set if arm64 is chosen to avoid such errors:

`Incompatible Target platform settings 'X64' with system architecture 'ARM'.`