### PR TITLE
[release/5.0-rc2] Backport Additional Browser Unsupported Attribute Changes

### DIFF
--- a/src/libraries/System.IO.Pipes/Directory.Build.props
+++ b/src/libraries/System.IO.Pipes/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Http/Directory.Build.props
+++ b/src/libraries/System.Net.Http/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -103,28 +103,44 @@ namespace System.Net.Http
     {
         public HttpClientHandler() { }
         public bool AllowAutoRedirect { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool CheckCertificateRevocationList { get { throw null; } set { } }
         public System.Net.Http.ClientCertificateOption ClientCertificateOptions { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.X509Certificates.X509CertificateCollection ClientCertificates { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }
         public static System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2?, System.Security.Cryptography.X509Certificates.X509Chain?, System.Net.Security.SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.ICredentials? DefaultProxyCredentials { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public int MaxAutomaticRedirections { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public int MaxConnectionsPerServer { get { throw null; } set { } }
         public long MaxRequestContentBufferSize { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public int MaxResponseHeadersLength { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool PreAuthenticate { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, object?> Properties { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.IWebProxy? Proxy { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2?, System.Security.Cryptography.X509Certificates.X509Chain?, System.Net.Security.SslPolicyErrors, bool>? ServerCertificateCustomValidationCallback { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
         public virtual bool SupportsAutomaticDecompression { get { throw null; } }
         public virtual bool SupportsProxy { get { throw null; } }
         public virtual bool SupportsRedirectConfiguration { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseCookies { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseDefaultCredentials { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool UseProxy { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected internal override System.Net.Http.HttpResponseMessage Send(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -325,6 +341,7 @@ namespace System.Net.Http
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected internal override bool TryComputeLength(out long length) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class SocketsHttpHandler : System.Net.Http.HttpMessageHandler
     {
         public SocketsHttpHandler() { }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -4,12 +4,14 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Security;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class SocketsHttpHandler : HttpMessageHandler
     {
         public static bool IsSupported => false;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Net.Security;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -52,12 +53,14 @@ namespace System.Net.Http
         public virtual bool SupportsProxy => _underlyingHandler.SupportsProxy;
         public virtual bool SupportsRedirectConfiguration => _underlyingHandler.SupportsRedirectConfiguration;
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseCookies
         {
             get => _underlyingHandler.UseCookies;
             set => _underlyingHandler.UseCookies = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public CookieContainer CookieContainer
         {
             get => _underlyingHandler.CookieContainer;
@@ -72,36 +75,42 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public DecompressionMethods AutomaticDecompression
         {
             get => _underlyingHandler.AutomaticDecompression;
             set => _underlyingHandler.AutomaticDecompression = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseProxy
         {
             get => _underlyingHandler.UseProxy;
             set => _underlyingHandler.UseProxy = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public IWebProxy? Proxy
         {
             get => _underlyingHandler.Proxy;
             set => _underlyingHandler.Proxy = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public ICredentials? DefaultProxyCredentials
         {
             get => _underlyingHandler.DefaultProxyCredentials;
             set => _underlyingHandler.DefaultProxyCredentials = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool PreAuthenticate
         {
             get => _underlyingHandler.PreAuthenticate;
             set => _underlyingHandler.PreAuthenticate = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool UseDefaultCredentials
         {
             // SocketsHttpHandler doesn't have a separate UseDefaultCredentials property.  There
@@ -124,6 +133,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public ICredentials? Credentials
         {
             get => _underlyingHandler.Credentials;
@@ -136,12 +146,14 @@ namespace System.Net.Http
             set => _underlyingHandler.AllowAutoRedirect = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public int MaxAutomaticRedirections
         {
             get => _underlyingHandler.MaxAutomaticRedirections;
             set => _underlyingHandler.MaxAutomaticRedirections = value;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public int MaxConnectionsPerServer
         {
             get => _underlyingHandler.MaxConnectionsPerServer;
@@ -181,6 +193,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public int MaxResponseHeadersLength
         {
             get => _underlyingHandler.MaxResponseHeadersLength;
@@ -220,6 +233,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public X509CertificateCollection ClientCertificates
         {
             get
@@ -234,6 +248,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? ServerCertificateCustomValidationCallback
         {
 #if TARGETS_BROWSER
@@ -251,6 +266,7 @@ namespace System.Net.Http
 #endif
         }
 
+        [UnsupportedOSPlatform("browser")]
         public bool CheckCertificateRevocationList
         {
             get => _underlyingHandler.SslOptions.CertificateRevocationCheckMode == X509RevocationMode.Online;
@@ -261,6 +277,7 @@ namespace System.Net.Http
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public SslProtocols SslProtocols
         {
             get => _underlyingHandler.SslOptions.EnabledSslProtocols;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Security;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
@@ -12,6 +13,7 @@ using System.Text;
 
 namespace System.Net.Http
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed class SocketsHttpHandler : HttpMessageHandler
     {
         private readonly HttpConnectionSettings _settings = new HttpConnectionSettings();

--- a/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
@@ -13,7 +13,7 @@ namespace System.Net
         public System.Net.AuthenticationSchemes AuthenticationSchemes { get { throw null; } set { } }
         public System.Net.AuthenticationSchemeSelector? AuthenticationSchemeSelectorDelegate { get { throw null; } set { } }
         public System.Security.Authentication.ExtendedProtection.ServiceNameCollection DefaultServiceNames { get { throw null; } }
-        public System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy ExtendedProtectionPolicy { get { throw null; } set { } }
+        public System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy ExtendedProtectionPolicy { get { throw null; } [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")] set { } }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]
         public System.Net.HttpListener.ExtendedProtectionSelector? ExtendedProtectionSelectorDelegate { get { throw null; } set { } }
         public bool IgnoreWriteExceptions { get { throw null; } set { } }
@@ -87,14 +87,17 @@ namespace System.Net
         public string HttpMethod { get { throw null; } }
         public System.IO.Stream InputStream { get { throw null; } }
         public bool IsAuthenticated { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool IsLocal { get { throw null; } }
         public bool IsSecureConnection { get { throw null; } }
         public bool IsWebSocketRequest { get { throw null; } }
         public bool KeepAlive { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.IPEndPoint LocalEndPoint { get { throw null; } }
         public System.Version ProtocolVersion { get { throw null; } }
         public System.Collections.Specialized.NameValueCollection QueryString { get { throw null; } }
         public string? RawUrl { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
         public System.Guid RequestTraceIdentifier { get { throw null; } }
         public string? ServiceName { get { throw null; } }
@@ -102,6 +105,7 @@ namespace System.Net
         public System.Uri? Url { get { throw null; } }
         public System.Uri? UrlReferrer { get { throw null; } }
         public string UserAgent { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public string UserHostAddress { get { throw null; } }
         public string UserHostName { get { throw null; } }
         public string[]? UserLanguages { get { throw null; } }
@@ -125,11 +129,14 @@ namespace System.Net
         public bool SendChunked { get { throw null; } set { } }
         public int StatusCode { get { throw null; } set { } }
         public string StatusDescription { get { throw null; } set { } }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void Abort() { }
         public void AddHeader(string name, string value) { }
         public void AppendCookie(System.Net.Cookie cookie) { }
         public void AppendHeader(string name, string value) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void Close() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void Close(byte[] responseEntity, bool willBlock) { }
         public void CopyFrom(System.Net.HttpListenerResponse templateResponse) { }
         public void Redirect(string url) { }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
 using System.Security.Authentication.ExtendedProtection;
 using System.Text;
 using System.Threading.Tasks;
@@ -81,6 +82,7 @@ namespace System.Net
         public ExtendedProtectionPolicy ExtendedProtectionPolicy
         {
             get => _extendedProtectionPolicy;
+            [UnsupportedOSPlatform("browser")]
             set
             {
                 CheckDisposed();

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Net.WebSockets;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -110,6 +111,7 @@ namespace System.Net
 
         public string? ContentType => Headers[HttpKnownHeaderNames.ContentType];
 
+        [UnsupportedOSPlatform("browser")]
         public bool IsLocal => LocalEndPoint!.Address.Equals(RemoteEndPoint!.Address);
 
         public bool IsWebSocketRequest
@@ -206,6 +208,7 @@ namespace System.Net
 
         public string UserAgent => Headers[HttpKnownHeaderNames.UserAgent]!;
 
+        [UnsupportedOSPlatform("browser")]
         public string UserHostAddress => LocalEndPoint!.ToString();
 
         public string UserHostName => Headers[HttpKnownHeaderNames.Host]!;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -34,6 +34,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -373,8 +374,10 @@ namespace System.Net
 
         public bool IsSecureConnection => _context.Connection.IsSecure;
 
+        [UnsupportedOSPlatform("browser")]
         public IPEndPoint? LocalEndPoint => _context.Connection.LocalEndPoint;
 
+        [UnsupportedOSPlatform("browser")]
         public IPEndPoint? RemoteEndPoint => _context.Connection.RemoteEndPoint;
 
         public Guid RequestTraceIdentifier { get; } = Guid.NewGuid();

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerResponse.Managed.cs
@@ -30,6 +30,7 @@
 
 using System.Globalization;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Text;
 
 namespace System.Net
@@ -92,6 +93,7 @@ namespace System.Net
 
         private void Dispose() => Close(true);
 
+        [UnsupportedOSPlatform("browser")]
         public void Close()
         {
             if (Disposed)
@@ -100,6 +102,7 @@ namespace System.Net
             Close(false);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void Abort()
         {
             if (Disposed)
@@ -114,6 +117,7 @@ namespace System.Net
             _httpContext!.Connection.Close(force);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void Close(byte[] responseEntity, bool willBlock)
         {
             CheckDisposed();

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography;
@@ -288,6 +289,7 @@ namespace System.Net
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public IPEndPoint RemoteEndPoint
         {
             get
@@ -301,6 +303,7 @@ namespace System.Net
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public IPEndPoint LocalEndPoint
         {
             get

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Net
@@ -95,6 +96,7 @@ namespace System.Net
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void Abort()
         {
             if (Disposed)
@@ -106,6 +108,7 @@ namespace System.Net
             HttpListenerContext.Abort();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void Close()
         {
             try
@@ -118,6 +121,7 @@ namespace System.Net
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         public void Close(byte[] responseEntity, bool willBlock)
         {
             CheckDisposed();

--- a/src/libraries/System.Security.Cryptography.Algorithms/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Algorithms/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -6,12 +6,14 @@
 
 namespace System.Security.Cryptography
 {
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected Aes() { }
         public static new System.Security.Cryptography.Aes Create() { throw null; }
         public static new System.Security.Cryptography.Aes? Create(string algorithmName) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class AesCcm : System.IDisposable
     {
         public AesCcm(byte[] key) { }
@@ -24,6 +26,7 @@ namespace System.Security.Cryptography
         public void Encrypt(byte[] nonce, byte[] plaintext, byte[] ciphertext, byte[] tag, byte[]? associatedData = null) { }
         public void Encrypt(System.ReadOnlySpan<byte> nonce, System.ReadOnlySpan<byte> plaintext, System.Span<byte> ciphertext, System.Span<byte> tag, System.ReadOnlySpan<byte> associatedData = default(System.ReadOnlySpan<byte>)) { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class AesGcm : System.IDisposable
     {
         public AesGcm(byte[] key) { }
@@ -37,6 +40,7 @@ namespace System.Security.Cryptography
         public void Encrypt(System.ReadOnlySpan<byte> nonce, System.ReadOnlySpan<byte> plaintext, System.Span<byte> ciphertext, System.Span<byte> tag, System.ReadOnlySpan<byte> associatedData = default(System.ReadOnlySpan<byte>)) { }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class AesManaged : System.Security.Cryptography.Aes
     {
         public AesManaged() { }
@@ -57,6 +61,7 @@ namespace System.Security.Cryptography
         public override void GenerateIV() { }
         public override void GenerateKey() { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class AsymmetricKeyExchangeDeformatter
     {
         protected AsymmetricKeyExchangeDeformatter() { }
@@ -64,6 +69,7 @@ namespace System.Security.Cryptography
         public abstract byte[] DecryptKeyExchange(byte[] rgb);
         public abstract void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key);
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class AsymmetricKeyExchangeFormatter
     {
         protected AsymmetricKeyExchangeFormatter() { }
@@ -72,6 +78,7 @@ namespace System.Security.Cryptography
         public abstract byte[] CreateKeyExchange(byte[] data, System.Type? symAlgType);
         public abstract void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key);
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class AsymmetricSignatureDeformatter
     {
         protected AsymmetricSignatureDeformatter() { }
@@ -80,6 +87,7 @@ namespace System.Security.Cryptography
         public abstract bool VerifySignature(byte[] rgbHash, byte[] rgbSignature);
         public virtual bool VerifySignature(System.Security.Cryptography.HashAlgorithm hash, byte[] rgbSignature) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class AsymmetricSignatureFormatter
     {
         protected AsymmetricSignatureFormatter() { }
@@ -88,6 +96,7 @@ namespace System.Security.Cryptography
         public abstract void SetHashAlgorithm(string strName);
         public abstract void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key);
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class CryptoConfig
     {
         public CryptoConfig() { }
@@ -101,6 +110,7 @@ namespace System.Security.Cryptography
         public static byte[] EncodeOID(string str) { throw null; }
         public static string? MapNameToOID(string name) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class DeriveBytes : System.IDisposable
     {
         protected DeriveBytes() { }
@@ -110,6 +120,7 @@ namespace System.Security.Cryptography
         public abstract void Reset();
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class DES : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected DES() { }
@@ -119,6 +130,7 @@ namespace System.Security.Cryptography
         public static bool IsSemiWeakKey(byte[] rgbKey) { throw null; }
         public static bool IsWeakKey(byte[] rgbKey) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class DSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected DSA() { }
@@ -189,6 +201,7 @@ namespace System.Security.Cryptography
         public byte[]? X;
         public byte[]? Y;
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class DSASignatureDeformatter : System.Security.Cryptography.AsymmetricSignatureDeformatter
     {
         public DSASignatureDeformatter() { }
@@ -202,6 +215,7 @@ namespace System.Security.Cryptography
         IeeeP1363FixedFieldConcatenation = 0,
         Rfc3279DerSequence = 1,
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class DSASignatureFormatter : System.Security.Cryptography.AsymmetricSignatureFormatter
     {
         public DSASignatureFormatter() { }
@@ -210,6 +224,7 @@ namespace System.Security.Cryptography
         public override void SetHashAlgorithm(string strName) { }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial struct ECCurve
     {
         private object _dummy;
@@ -263,6 +278,7 @@ namespace System.Security.Cryptography
             public static System.Security.Cryptography.ECCurve nistP521 { get { throw null; } }
         }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class ECDiffieHellman : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected ECDiffieHellman() { }
@@ -311,6 +327,7 @@ namespace System.Security.Cryptography
         public virtual byte[] ToByteArray() { throw null; }
         public virtual string ToXmlString() { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class ECDsa : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected ECDsa() { }
@@ -377,6 +394,7 @@ namespace System.Security.Cryptography
         public bool VerifyHash(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> signature, System.Security.Cryptography.DSASignatureFormat signatureFormat) { throw null; }
         protected virtual bool VerifyHashCore(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> signature, System.Security.Cryptography.DSASignatureFormat signatureFormat) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial struct ECParameters
     {
         public System.Security.Cryptography.ECCurve Curve;
@@ -389,6 +407,7 @@ namespace System.Security.Cryptography
         public byte[]? X;
         public byte[]? Y;
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public static partial class HKDF
     {
         public static byte[] DeriveKey(System.Security.Cryptography.HashAlgorithmName hashAlgorithmName, byte[] ikm, int outputLength, byte[]? salt = null, byte[]? info = null) { throw null; }
@@ -398,6 +417,7 @@ namespace System.Security.Cryptography
         public static byte[] Extract(System.Security.Cryptography.HashAlgorithmName hashAlgorithmName, byte[] ikm, byte[]? salt = null) { throw null; }
         public static int Extract(System.Security.Cryptography.HashAlgorithmName hashAlgorithmName, System.ReadOnlySpan<byte> ikm, System.ReadOnlySpan<byte> salt, System.Span<byte> prk) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACMD5 : System.Security.Cryptography.HMAC
     {
         public HMACMD5() { }
@@ -410,6 +430,7 @@ namespace System.Security.Cryptography
         public override void Initialize() { }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA1 : System.Security.Cryptography.HMAC
     {
         public HMACSHA1() { }
@@ -424,6 +445,7 @@ namespace System.Security.Cryptography
         public override void Initialize() { }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA256 : System.Security.Cryptography.HMAC
     {
         public HMACSHA256() { }
@@ -436,6 +458,7 @@ namespace System.Security.Cryptography
         public override void Initialize() { }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA384 : System.Security.Cryptography.HMAC
     {
         public HMACSHA384() { }
@@ -449,6 +472,7 @@ namespace System.Security.Cryptography
         public override void Initialize() { }
         protected override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class HMACSHA512 : System.Security.Cryptography.HMAC
     {
         public HMACSHA512() { }
@@ -471,7 +495,9 @@ namespace System.Security.Cryptography
         public void AppendData(byte[] data, int offset, int count) { }
         public void AppendData(System.ReadOnlySpan<byte> data) { }
         public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.ReadOnlySpan<byte> key) { throw null; }
         public void Dispose() { }
         public byte[] GetCurrentHash() { throw null; }
@@ -481,11 +507,13 @@ namespace System.Security.Cryptography
         public bool TryGetCurrentHash(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryGetHashAndReset(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class MaskGenerationMethod
     {
         protected MaskGenerationMethod() { }
         public abstract byte[] GenerateMask(byte[] rgbSeed, int cbReturn);
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class MD5 : System.Security.Cryptography.HashAlgorithm
     {
         protected MD5() { }
@@ -496,6 +524,7 @@ namespace System.Security.Cryptography
         public static int HashData(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
         public static bool TryHashData(System.ReadOnlySpan<byte> source, System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class PKCS1MaskGenerationMethod : System.Security.Cryptography.MaskGenerationMethod
     {
         public PKCS1MaskGenerationMethod() { }
@@ -506,6 +535,7 @@ namespace System.Security.Cryptography
     {
         protected RandomNumberGenerator() { }
         public static System.Security.Cryptography.RandomNumberGenerator Create() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Security.Cryptography.RandomNumberGenerator? Create(string rngName) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
@@ -519,6 +549,7 @@ namespace System.Security.Cryptography
         public virtual void GetNonZeroBytes(System.Span<byte> data) { }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class RC2 : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected int EffectiveKeySizeValue;
@@ -528,6 +559,7 @@ namespace System.Security.Cryptography
         public static new System.Security.Cryptography.RC2 Create() { throw null; }
         public static new System.Security.Cryptography.RC2? Create(string AlgName) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
     {
         public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }
@@ -547,6 +579,7 @@ namespace System.Security.Cryptography
         public override void Reset() { }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class Rijndael : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected Rijndael() { }
@@ -554,6 +587,7 @@ namespace System.Security.Cryptography
         public static new System.Security.Cryptography.Rijndael? Create(string algName) { throw null; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class RijndaelManaged : System.Security.Cryptography.Rijndael
     {
         public RijndaelManaged() { }
@@ -572,6 +606,7 @@ namespace System.Security.Cryptography
         public override void GenerateIV() { }
         public override void GenerateKey() { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
     {
         protected RSA() { }
@@ -624,6 +659,7 @@ namespace System.Security.Cryptography
         public virtual bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
         public virtual bool VerifyHash(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class RSAEncryptionPadding : System.IEquatable<System.Security.Cryptography.RSAEncryptionPadding>
     {
         internal RSAEncryptionPadding() { }
@@ -647,6 +683,7 @@ namespace System.Security.Cryptography
         Pkcs1 = 0,
         Oaep = 1,
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class RSAOAEPKeyExchangeDeformatter : System.Security.Cryptography.AsymmetricKeyExchangeDeformatter
     {
         public RSAOAEPKeyExchangeDeformatter() { }
@@ -655,6 +692,7 @@ namespace System.Security.Cryptography
         public override byte[] DecryptKeyExchange(byte[] rgbData) { throw null; }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class RSAOAEPKeyExchangeFormatter : System.Security.Cryptography.AsymmetricKeyExchangeFormatter
     {
         public RSAOAEPKeyExchangeFormatter() { }
@@ -677,6 +715,7 @@ namespace System.Security.Cryptography
         public byte[]? P;
         public byte[]? Q;
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class RSAPKCS1KeyExchangeDeformatter : System.Security.Cryptography.AsymmetricKeyExchangeDeformatter
     {
         public RSAPKCS1KeyExchangeDeformatter() { }
@@ -686,6 +725,7 @@ namespace System.Security.Cryptography
         public override byte[] DecryptKeyExchange(byte[] rgbIn) { throw null; }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class RSAPKCS1KeyExchangeFormatter : System.Security.Cryptography.AsymmetricKeyExchangeFormatter
     {
         public RSAPKCS1KeyExchangeFormatter() { }
@@ -696,6 +736,7 @@ namespace System.Security.Cryptography
         public override byte[] CreateKeyExchange(byte[] rgbData, System.Type? symAlgType) { throw null; }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class RSAPKCS1SignatureDeformatter : System.Security.Cryptography.AsymmetricSignatureDeformatter
     {
         public RSAPKCS1SignatureDeformatter() { }
@@ -704,6 +745,7 @@ namespace System.Security.Cryptography
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
         public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class RSAPKCS1SignatureFormatter : System.Security.Cryptography.AsymmetricSignatureFormatter
     {
         public RSAPKCS1SignatureFormatter() { }
@@ -712,6 +754,7 @@ namespace System.Security.Cryptography
         public override void SetHashAlgorithm(string strName) { }
         public override void SetKey(System.Security.Cryptography.AsymmetricAlgorithm key) { }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public sealed partial class RSASignaturePadding : System.IEquatable<System.Security.Cryptography.RSASignaturePadding>
     {
         internal RSASignaturePadding() { }
@@ -814,6 +857,7 @@ namespace System.Security.Cryptography
         public sealed override void Initialize() { }
         protected sealed override bool TryHashFinal(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public partial class SignatureDescription
     {
         public SignatureDescription() { }
@@ -826,6 +870,7 @@ namespace System.Security.Cryptography
         public virtual System.Security.Cryptography.HashAlgorithm? CreateDigest() { throw null; }
         public virtual System.Security.Cryptography.AsymmetricSignatureFormatter CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
     public abstract partial class TripleDES : System.Security.Cryptography.SymmetricAlgorithm
     {
         protected TripleDES() { }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/ExcludeApiList.PNSE.Browser.txt
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/ExcludeApiList.PNSE.Browser.txt
@@ -1,6 +1,5 @@
 T:System.Security.Cryptography.RandomNumberGenerator
 T:System.Security.Cryptography.IncrementalHash
-T:System.Security.Cryptography.MD5
 T:System.Security.Cryptography.SHA1
 T:System.Security.Cryptography.SHA256
 T:System.Security.Cryptography.SHA384

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -595,7 +595,6 @@
     <Compile Include="Internal\Cryptography\SHAHashProvider.Browser.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGenerator.cs" />
     <Compile Include="System\Security\Cryptography\IncrementalHash.cs" />
-    <Compile Include="System\Security\Cryptography\MD5.cs" />
     <Compile Include="System\Security\Cryptography\SHA1.cs" />
     <Compile Include="System\Security\Cryptography\SHA1Managed.cs" />
     <Compile Include="System\Security\Cryptography\SHA256.cs" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Aes.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract class Aes : SymmetricAlgorithm
     {
         protected Aes()

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesCcm.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesCcm.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed partial class AesCcm : IDisposable
     {
         public static KeySizes NonceByteSizes { get; } = new KeySizes(7, 13, 1);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesGcm.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesGcm.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public sealed partial class AesGcm : IDisposable
     {
         private const int NonceSize = 12;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesManaged.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesManaged.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class AesManaged : Aes
     {

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricKeyExchangeDeformatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricKeyExchangeDeformatter.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract class AsymmetricKeyExchangeDeformatter
     {
         protected AsymmetricKeyExchangeDeformatter() { }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricKeyExchangeFormatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricKeyExchangeFormatter.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract class AsymmetricKeyExchangeFormatter
     {
         protected AsymmetricKeyExchangeFormatter() { }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricSignatureDeformatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricSignatureDeformatter.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract class AsymmetricSignatureDeformatter
     {
         protected AsymmetricSignatureDeformatter() { }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricSignatureFormatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AsymmetricSignatureFormatter.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract class AsymmetricSignatureFormatter
     {
         protected AsymmetricSignatureFormatter() { }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -8,9 +8,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class CryptoConfig
     {
         private const string AssemblyName_Cng = "System.Security.Cryptography.Cng";

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Internal.Cryptography;
-using System.ComponentModel;
 using System.Buffers.Binary;
+using System.ComponentModel;
+using System.Runtime.Versioning;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class DES : SymmetricAlgorithm
     {

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
@@ -5,11 +5,13 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Formats.Asn1;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.Asn1;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract partial class DSA : AsymmetricAlgorithm
     {
         // As of FIPS 186-4 the maximum Q size is 256 bits (32 bytes).

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSASignatureDeformatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSASignatureDeformatter.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class DSASignatureDeformatter : AsymmetricSignatureDeformatter
     {
         private DSA? _dsaKey;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSASignatureFormatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSASignatureFormatter.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class DSASignatureFormatter : AsymmetricSignatureFormatter
     {
         private DSA? _dsaKey;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DeriveBytes.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract class DeriveBytes : IDisposable
     {
         public abstract byte[] GetBytes(int cb);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
@@ -13,6 +14,7 @@ namespace System.Security.Cryptography
     /// which is either a prime curve or a characteristic-2 curve.
     /// </remarks>
     [DebuggerDisplay("ECCurve: {Oid}")]
+    [UnsupportedOSPlatform("browser")]
     public partial struct ECCurve
     {
         /// <summary>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellman.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellman.cs
@@ -2,14 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Formats.Asn1;
-using Internal.Cryptography;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.Asn1;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
     /// <summary>
     ///     Abstract base class for implementations of elliptic curve Diffie-Hellman to derive from
     /// </summary>
+    [UnsupportedOSPlatform("browser")]
     public abstract partial class ECDiffieHellman : AsymmetricAlgorithm
     {
         private static readonly string[] s_validOids =

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
@@ -6,10 +6,12 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Formats.Asn1;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.Asn1;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract partial class ECDsa : AsymmetricAlgorithm
     {
         // secp521r1 maxes out at 139 bytes in the DER format, so 256 should always be enough

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECParameters.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECParameters.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.Asn1;
 
 namespace System.Security.Cryptography
@@ -10,6 +11,7 @@ namespace System.Security.Cryptography
     /// <summary>
     /// Represents the public and private key of the specified elliptic curve.
     /// </summary>
+    [UnsupportedOSPlatform("browser")]
     public struct ECParameters
     {
         /// <summary>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
@@ -13,6 +14,7 @@ namespace System.Security.Cryptography
     /// phase to be skipped, and the master key to be used directly as the pseudorandom key.
     /// See <a href="https://tools.ietf.org/html/rfc5869">RFC5869</a> for more information.
     /// </remarks>
+    [UnsupportedOSPlatform("browser")]
     public static class HKDF
     {
         /// <summary>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -10,6 +11,7 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
+    [UnsupportedOSPlatform("browser")]
     public class HMACMD5 : HMAC
     {
         public HMACMD5()

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
@@ -3,6 +3,7 @@
 
 using Internal.Cryptography;
 using System.ComponentModel;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
@@ -11,6 +12,7 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
+    [UnsupportedOSPlatform("browser")]
     public class HMACSHA1 : HMAC
     {
         public HMACSHA1()

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
+    [UnsupportedOSPlatform("browser")]
     public class HMACSHA256 : HMAC
     {
         public HMACSHA256()

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
+    [UnsupportedOSPlatform("browser")]
     public class HMACSHA384 : HMAC
     {
         public HMACSHA384()

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography
     // preexisting contract from the .NET Framework locks all of these into deriving directly from HMAC, it can't be helped.
     //
 
+    [UnsupportedOSPlatform("browser")]
     public class HMACSHA512 : HMAC
     {
         public HMACSHA512()

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
@@ -1,8 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using Internal.Cryptography;
+using System.Diagnostics;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
@@ -346,6 +347,7 @@ namespace System.Security.Cryptography
         ///     the empty string.
         /// </exception>
         /// <exception cref="CryptographicException"><paramref name="hashAlgorithm"/> is not a known hash algorithm.</exception>
+        [UnsupportedOSPlatform("browser")]
         public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, byte[] key)
         {
             if (key == null)
@@ -376,6 +378,7 @@ namespace System.Security.Cryptography
         ///     the empty string.
         /// </exception>
         /// <exception cref="CryptographicException"><paramref name="hashAlgorithm"/> is not a known hash algorithm.</exception>
+        [UnsupportedOSPlatform("browser")]
         public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> key)
         {
             if (string.IsNullOrEmpty(hashAlgorithm.Name))

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
@@ -1,8 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Internal.Cryptography;
 using System.Diagnostics;
+using System.Runtime.Versioning;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
@@ -12,6 +13,7 @@ namespace System.Security.Cryptography
     // it can't be helped.
     //
 
+    [UnsupportedOSPlatform("browser")]
     public abstract class MD5 : HashAlgorithm
     {
         private const int HashSizeBits = 128;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MaskGenerationMethod.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MaskGenerationMethod.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract class MaskGenerationMethod
     {
         public abstract byte[] GenerateMask(byte[] rgbSeed, int cbReturn);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/PKCS1MaskGenerationMethod.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/PKCS1MaskGenerationMethod.cs
@@ -3,10 +3,12 @@
 
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class PKCS1MaskGenerationMethod : MaskGenerationMethod
     {
         private string _hashNameValue;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RC2.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RC2.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Internal.Cryptography;
 using System.ComponentModel;
+using System.Runtime.Versioning;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [UnsupportedOSPlatform("browser")]
     public abstract class RC2 : SymmetricAlgorithm
     {
         protected int EffectiveKeySizeValue;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -5,11 +5,13 @@ using System.Buffers;
 using System.Formats.Asn1;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.Asn1;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public abstract partial class RSA : AsymmetricAlgorithm
     {
         public static new RSA? Create(string algName)

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAEncryptionPadding.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAEncryptionPadding.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
     /// <summary>
     /// Specifies the padding mode and parameters to use with RSA encryption or decryption operations.
     /// </summary>
+    [UnsupportedOSPlatform("browser")]
     public sealed class RSAEncryptionPadding : IEquatable<RSAEncryptionPadding>
     {
         private static readonly RSAEncryptionPadding s_pkcs1 = new RSAEncryptionPadding(RSAEncryptionPaddingMode.Pkcs1, default(HashAlgorithmName));

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAOAEPKeyExchangeDeformatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAOAEPKeyExchangeDeformatter.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class RSAOAEPKeyExchangeDeformatter : AsymmetricKeyExchangeDeformatter
     {
         private RSA? _rsaKey;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAOAEPKeyExchangeFormatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAOAEPKeyExchangeFormatter.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class RSAOAEPKeyExchangeFormatter : AsymmetricKeyExchangeFormatter
     {
         private byte[]? ParameterValue;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1KeyExchangeDeformatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1KeyExchangeDeformatter.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class RSAPKCS1KeyExchangeDeformatter : AsymmetricKeyExchangeDeformatter
     {
         private RSA? _rsaKey;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1KeyExchangeFormatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1KeyExchangeFormatter.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class RSAPKCS1KeyExchangeFormatter : AsymmetricKeyExchangeFormatter
     {
         private RSA? _rsaKey;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureDeformatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureDeformatter.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class RSAPKCS1SignatureDeformatter : AsymmetricSignatureDeformatter
     {
         private RSA? _rsaKey;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureFormatter.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureFormatter.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class RSAPKCS1SignatureFormatter : AsymmetricSignatureFormatter
     {
         private RSA? _rsaKey;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSASignaturePadding.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSASignaturePadding.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Security.Cryptography
 {
     // NOTE: This is *currently* 1:1 with the enum, but it exists to reserve room for more options
@@ -10,6 +12,7 @@ namespace System.Security.Cryptography
     /// <summary>
     /// Specifies the padding mode  and parameters to use with RSA signature creation or verification operations.
     /// </summary>
+    [UnsupportedOSPlatform("browser")]
     public sealed class RSASignaturePadding : IEquatable<RSASignaturePadding>
     {
         private static readonly RSASignaturePadding s_pkcs1 = new RSASignaturePadding(RSASignaturePaddingMode.Pkcs1);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
@@ -15,6 +16,7 @@ namespace System.Security.Cryptography
             return new RandomNumberGeneratorImplementation();
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static RandomNumberGenerator? Create(string rngName)
         {
             return (RandomNumberGenerator?)CryptoConfig.CreateFromName(rngName);

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -5,12 +5,13 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
 using System.Text;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class Rfc2898DeriveBytes : DeriveBytes
     {
         private const int MinimumSaltSize = 8;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rijndael.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Internal.Cryptography;
 using System.ComponentModel;
+using System.Runtime.Versioning;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [UnsupportedOSPlatform("browser")]
     public abstract class Rijndael : SymmetricAlgorithm
     {
         public static new Rijndael Create()

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
@@ -3,10 +3,12 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [UnsupportedOSPlatform("browser")]
     public sealed class RijndaelManaged : Rijndael
     {
         private readonly Aes _impl;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SignatureDescription.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SignatureDescription.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
+    [UnsupportedOSPlatform("browser")]
     public class SignatureDescription
     {
         public string? KeyAlgorithm { get; set; }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-
+using System.Runtime.Versioning;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "We are providing the implementation for TripleDES, not consuming it.")]
+    [UnsupportedOSPlatform("browser")]
     public abstract class TripleDES : SymmetricAlgorithm
     {
         protected TripleDES()

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HashDerivedTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HashDerivedTests.cs
@@ -36,6 +36,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         }
 
         [Fact]
+        [SkipOnMono("Not supported on Browser")]
         public static void HashSize_SetForDerived_MD5()
         {
             using DerivedMD5 sha = new DerivedMD5();


### PR DESCRIPTION
Fixes Issue
Ongoing analyzer work.

Master PR
#41976 #42074 #42063 #42010

# Description
The [Platform Compatibility Analyzer](https://github.com/dotnet/platform-compat) can be used to identify APIs that are problematic on other specific platforms or deprecated. With the attribute `UnsupportedOSPlatformAttribute("browser")`,  numerous APIs that are not supported on Browser WASM are marked for the platform compatibility analyzer to pick up. 

# Customer Impact
Without this fix, customers will not be warned against using certain unsupported APIs on Browser WASM.  Importantly some Http request settings and the cryptography APIs that are not supported.

# Risk
Low.  These attributes only impact the compatibility analyzer for browser-wasm.