### PR TITLE
Update bug report template for Blazor

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -24,6 +24,7 @@ assignees: ''
 * What OS and version, and what distro if applicable?
 * What is the architecture (x64, x86, ARM, ARM64)?
 * Do you know whether it is specific to that configuration?
+* If you're using Blazor, which web browser(s) do you see this issue in?
   -->
 
 ### Regression?


### PR DESCRIPTION
Bug reports about Blazor should include info on the user's web browser(s).