### PR TITLE
Opt out of UseSystemResourceKeys for ComponentModel.DataAnnotations

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -2,6 +2,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <!--
+      Since many resource strings in this library are shown to an end-user,
+      always generate default resource string values which will be used when UseSystemResourceKeys is true in trimmed apps.
+    -->
+    <GenerateResxSourceIncludeDefaultValues>true</GenerateResxSourceIncludeDefaultValues>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptor.cs" />


### PR DESCRIPTION
Since many resource strings in ComponentModel.DataAnnotations contain messages that will be shown to end-users, we shouldn't be trimming these resources.

Fix #42257

/cc @pranavkm 