### PR TITLE
Add running of the release/5.0 branch for the runtime repo

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - master
+    - release/5.0
   paths:
     include:
     - '*'


### PR DESCRIPTION
This turns on the release/5.0 branch for runtime performance runs.