### PR TITLE
Update doc paths to build/run coreclr tests

### DIFF
--- a/docs/workflow/testing/coreclr/testing.md
+++ b/docs/workflow/testing/coreclr/testing.md
@@ -9,9 +9,9 @@ Details on test metadata can be found in [test-configuration.md](test-configurat
     * [macOS](../../building/coreclr/osx-instructions.md)
     * [Windows](../../building/coreclr/README.md)
 2) [Build the libraries](../../building/libraries/README.md) in Release configuration. Pass the configuration of CoreCLR you just built to the build script (e.g. `-runtimeconfiguration debug`).
-3) From the `src/coreclr` directory run the following command:
-    * Non-Windows - `./build-test.sh`
-    * Windows - `build-test.cmd`
+3) From the `src/tests` directory run the following command:
+    * Non-Windows - `./build.sh`
+    * Windows - `build.cmd`
     * Supply `-h` for usage flags
 
 ### Test priority

--- a/docs/workflow/testing/coreclr/testing.md
+++ b/docs/workflow/testing/coreclr/testing.md
@@ -21,16 +21,16 @@ The CoreCLR tests have two priorities, 0 and 1. The priority 0 tests run by defa
 ### Examples
 
 * Build all tests priority 1 and higher
-  * `build-test.cmd -priority=1`
-  * `build-test.sh -priority1`
+  * `build.cmd -priority=1`
+  * `build.sh -priority1`
 
 ## Build Individual Test
 
 Note:  CoreCLR must be built prior to building an individual test. See the first step, above, for building all tests.
 
 * Native Test: Build the generated CMake projects
-  * Projects are auto-generated when the `build-test.sh`/`build-test.cmd` script is run
-    * It is possible to explicitly run only the native test build with `build-test.sh/cmd skipmanaged`
+  * Projects are auto-generated when the `build.sh`/`build.cmd` script is run
+    * It is possible to explicitly run only the native test build with `build.sh/cmd skipmanaged`
 * Managed Test: Invoke `dotnet build` on the project directly. `dotnet` can be the `dotnet.sh` or `dotnet.cmd` script in the repo root.
 ```
 <runtime-repo-root>/dotnet.sh build <runtime-repo-root>/src/coreclr/tests/src/JIT/CodegenBringupTests/Array1_d.csproj /p:Configuration=Release

--- a/docs/workflow/testing/coreclr/unix-test-instructions.md
+++ b/docs/workflow/testing/coreclr/unix-test-instructions.md
@@ -15,13 +15,13 @@ Dotnet CLI is required to build the tests. This can be done on any platform then
 To build the tests on Unix:
 
 ```sh
-./src/coreclr/build-test.sh
+./src/tests/build.sh
 ```
 
 Please note that this builds the Priority 0 tests. To build priority 1:
 
 ```sh
-./src/coreclr/build-test.sh -priority1
+./src/tests/build.sh -priority1
 ```
 
 ## Building Individual Tests
@@ -41,16 +41,16 @@ During development there are many instances where building an individual test is
 The following instructions assume that on the Unix machine:
 - The CoreCLR repo is cloned at `/mnt/coreclr`
 
-`src/coreclr/build-test.sh` will have set up the `Core_Root` directory correctly after the test build.
+`src/tests/build.sh` will have set up the `Core_Root` directory correctly after the test build.
 
 ```sh
-./src/coreclr/tests/runtest.sh x64 checked
+./src/tests/run.sh x64 checked
 ```
 
 Please use the following command for help.
 
 ```sh
-./src/coreclr/tests/runtest.sh -h
+./src/tests/run.sh -h
 ```
 
 ### Unsupported and temporarily disabled tests
@@ -82,7 +82,7 @@ PAL tests
 Build CoreCLR with PAL tests on the Unix machine:
 
 ```sh
-./src/coreclr/build-runtime.sh -skipgenerateversion -nopgooptimize \
+./src/test/build.sh -skipgenerateversion -nopgooptimize \
     -cmakeargs -DCLR_CMAKE_BUILD_TESTS=1
 ```
 

--- a/docs/workflow/testing/coreclr/unix-test-instructions.md
+++ b/docs/workflow/testing/coreclr/unix-test-instructions.md
@@ -82,7 +82,7 @@ PAL tests
 Build CoreCLR with PAL tests on the Unix machine:
 
 ```sh
-./src/test/build.sh -skipgenerateversion -nopgooptimize \
+./src/coreclr/build-runtime.sh -skipgenerateversion -nopgooptimize \
     -cmakeargs -DCLR_CMAKE_BUILD_TESTS=1
 ```
 

--- a/docs/workflow/testing/coreclr/windows-test-instructions.md
+++ b/docs/workflow/testing/coreclr/windows-test-instructions.md
@@ -12,7 +12,7 @@ Building coreclr tests must be done using a specific script as follows:
 ## Building Precompiled Tests
 
 ```
-> src\coreclr\build-test.cmd crossgen
+> src\tests\build.cmd crossgen
 ```
 
 This will use `crossgen.exe` to precompile test executables before they are executed.
@@ -20,7 +20,7 @@ This will use `crossgen.exe` to precompile test executables before they are exec
 ## Building Specific Priority Tests
 
 ```
-> src\coreclr\build-test.cmd -priority=1
+> src\tests\build.cmd -priority=1
 ```
 
 The above is an example of requesting that priority '1' and below be built. The default priority value is '0'. If '1' is specified, all tests with `CLRTestPriorty` `0` **and** `1` will be built and run.
@@ -30,13 +30,13 @@ The above is an example of requesting that priority '1' and below be built. The 
 To run a priority '0' and '1' and crossgen'd test pass:
 
 ```
-> src\coreclr\build-test.cmd crossgen -priority=1
+> src\tests\build.cmd crossgen -priority=1
 ```
 
 For additional supported parameters use the following:
 
 ```
-> src\coreclr\build-test.cmd -?
+> src\tests\build.cmd -?
 ```
 
 ### Building Individual Tests
@@ -52,13 +52,13 @@ For additional supported parameters use the following:
 Will list supported parameters.
 
 ```
-> src\coreclr\tests\runtest.cmd /?
+> src\tests\run.cmd /?
 ```
 
 In order to run all of the tests using your checked build:
 
 ```
-> src\coreclr\tests\runtest.cmd checked
+> src\tests\run.cmd checked
 ```
 
 This will generate a report named `TestRun_<arch>_<flavor>.html` (e.g. `TestRun_Windows_NT_x64_Checked.html`) in the subdirectory `<repo_root>\artifacts\log`. Any tests that failed will be listed in `TestRunResults_Windows_NT_x64_Checked.err`.


### PR DESCRIPTION
They were moved in 3f30ac6bfb3c6bc6989ea450b8699709407ffee1 and the documentation wasn't updated to match.