### PR TITLE
emit test for bounds checks against a 0 index

### DIFF
--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3689,8 +3689,8 @@ void CodeGen::genRangeCheck(GenTree* oper)
     noway_assert(oper->OperIsBoundsCheck());
     GenTreeBoundsChk* bndsChk = oper->AsBoundsChk();
 
-    GenTree* arrIndex  = bndsChk->gtIndex;
-    GenTree* arrLen    = bndsChk->gtArrLen;
+    GenTree* arrIndex = bndsChk->gtIndex;
+    GenTree* arrLen   = bndsChk->gtArrLen;
 
     GenTree *    src1, *src2;
     emitJumpKind jmpKind;

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3691,8 +3691,6 @@ void CodeGen::genRangeCheck(GenTree* oper)
 
     GenTree* arrIndex  = bndsChk->gtIndex;
     GenTree* arrLen    = bndsChk->gtArrLen;
-    GenTree* arrRef    = nullptr;
-    int      lenOffset = 0;
 
     GenTree *    src1, *src2;
     emitJumpKind jmpKind;

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3696,15 +3696,19 @@ void CodeGen::genRangeCheck(GenTree* oper)
 
     GenTree *    src1, *src2;
     emitJumpKind jmpKind;
-    instruction cmpKind;
+    instruction  cmpKind;
 
     genConsumeRegs(arrIndex);
     genConsumeRegs(arrLen);
 
     if (arrIndex->IsIntegralConst(0) && arrLen->isUsedFromReg())
     {
-        src1 = arrLen;
-        src2 = arrLen;
+        // arrIndex is 0 and arrLen is in a reg. In this case
+        // we can generate
+        //      test reg, reg
+        // since arrLen is non-negative
+        src1    = arrLen;
+        src2    = arrLen;
         jmpKind = EJ_je;
         cmpKind = INS_test;
     }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3696,11 +3696,19 @@ void CodeGen::genRangeCheck(GenTree* oper)
 
     GenTree *    src1, *src2;
     emitJumpKind jmpKind;
+    instruction cmpKind;
 
     genConsumeRegs(arrIndex);
     genConsumeRegs(arrLen);
 
-    if (arrIndex->isContainedIntOrIImmed())
+    if (arrIndex->IsIntegralConst(0) && arrLen->isUsedFromReg())
+    {
+        src1 = arrLen;
+        src2 = arrLen;
+        jmpKind = EJ_je;
+        cmpKind = INS_test;
+    }
+    else if (arrIndex->isContainedIntOrIImmed())
     {
         // arrIndex is a contained constant.  In this case
         // we will generate one of the following
@@ -3713,6 +3721,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
         src1    = arrLen;
         src2    = arrIndex;
         jmpKind = EJ_jbe;
+        cmpKind = INS_cmp;
     }
     else
     {
@@ -3721,7 +3730,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
         //      cmp  [mem], immed   (if arrLen is a constant)
         //      cmp  [mem], reg     (if arrLen is in a reg)
         //      cmp  reg, immed     (if arrIndex is in a reg)
-        //      cmp  reg1, reg2     (if arraIndex is in reg1)
+        //      cmp  reg1, reg2     (if arrIndex is in reg1)
         //      cmp  reg, [mem]     (if arrLen is a memory op)
         //
         // That is only one of arrIndex or arrLen can be a memory op.
@@ -3730,6 +3739,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
         src1    = arrIndex;
         src2    = arrLen;
         jmpKind = EJ_jae;
+        cmpKind = INS_cmp;
     }
 
     var_types bndsChkType = src2->TypeGet();
@@ -3741,7 +3751,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
     assert(emitTypeSize(bndsChkType) >= emitTypeSize(src1->TypeGet()));
 #endif // DEBUG
 
-    GetEmitter()->emitInsBinary(INS_cmp, emitTypeSize(bndsChkType), src1, src2);
+    GetEmitter()->emitInsBinary(cmpKind, emitTypeSize(bndsChkType), src1, src2);
     genJumpToThrowHlpBlk(jmpKind, bndsChk->gtThrowKind, bndsChk->gtIndRngFailBB);
 }
 


### PR DESCRIPTION
Since array length is always non-negative, when we have a bounds check against a constant 0 index, we can emit a slightly cheaper/smaller test.

<pre>Found 156 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of diff: -3809 (-0.012% of base)
    diff is an improvement.

Top file improvements (bytes):
        -891 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.027% of base)
        -597 : System.Private.CoreLib.dasm (-0.018% of base)
        -254 : System.Private.Xml.dasm (-0.008% of base)
        -121 : System.Data.Common.dasm (-0.011% of base)
        -101 : Microsoft.VisualBasic.Core.dasm (-0.024% of base)
         -77 : System.Net.Http.dasm (-0.013% of base)
         -68 : Microsoft.CodeAnalysis.dasm (-0.009% of base)
         -67 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.003% of base)
         -61 : System.Linq.Expressions.dasm (-0.002% of base)
         -57 : System.Runtime.Numerics.dasm (-0.083% of base)
         -51 : Microsoft.CodeAnalysis.CSharp.dasm (-0.002% of base)
         -51 : System.Private.DataContractSerialization.dasm (-0.007% of base)
         -50 : System.Drawing.Common.dasm (-0.018% of base)
         -44 : Newtonsoft.Json.dasm (-0.007% of base)
         -40 : System.CodeDom.dasm (-0.024% of base)
         -38 : System.Data.Odbc.dasm (-0.021% of base)
         -35 : FSharp.Core.dasm (-0.004% of base)
         -35 : System.Text.Json.dasm (-0.012% of base)
         -34 : System.Net.Primitives.dasm (-0.052% of base)
         -34 : System.ComponentModel.TypeConverter.dasm (-0.015% of base)

156 total files with Code Size differences (156 improved, 0 regressed), 111 unchanged.

Top method improvements (bytes):
         -38 (-1.332% of base) : System.Private.CoreLib.dasm - ArraySortHelper`2:HeapSort(Span`1,Span`1,IComparer`1) (11 methods)
         -30 (-1.162% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`2:HeapSort(Span`1,Span`1) (11 methods)
         -22 (-0.285% of base) : System.Private.CoreLib.dasm - Vector128`1:ToString():String:this (11 methods)
         -22 (-0.267% of base) : System.Private.CoreLib.dasm - Vector256`1:ToString():String:this (11 methods)
         -22 (-0.277% of base) : System.Private.CoreLib.dasm - Vector64`1:ToString():String:this (11 methods)
         -15 (-0.169% of base) : System.Private.Xml.dasm - XsltLoader:.ctor():this
         -14 (-0.536% of base) : System.Private.CoreLib.dasm - ArraySortHelper`1:HeapSort(Span`1,Comparison`1) (14 methods)
         -14 (-0.491% of base) : System.Net.Http.dasm - KnownHeaders:GetCandidate(StringAccessor):KnownHeader
         -13 (-0.569% of base) : System.Private.CoreLib.dasm - GenericArraySortHelper`1:HeapSort(Span`1) (13 methods)
         -12 (-0.259% of base) : System.Data.Common.dasm - FunctionNode:EvalFunction(int,ref,DataRow,int):Object:this
         -11 (-0.197% of base) : System.CodeDom.dasm - VBCodeGenerator:.cctor()
          -8 (-0.726% of base) : CommandLine.dasm - &lt;&gt;c:&lt;get_FormatError&gt;b__11_0(Error):String:this
          -7 (-2.160% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CSharpSyntaxNode:CreateList(IEnumerable`1,bool):GreenNode:this
          -7 (-3.182% of base) : Newtonsoft.Json.Bson.dasm - BsonDataReader:BytesInSequence(ubyte):int:this
          -7 (-3.365% of base) : Newtonsoft.Json.Bson.dasm - BsonDataReader:.cctor()
          -7 (-3.125% of base) : Newtonsoft.Json.dasm - BsonReader:.cctor()
          -7 (-0.421% of base) : System.Data.Common.dasm - SqlDecimal:MpDiv(ReadOnlySpan`1,int,Span`1,int,Span`1,byref,Span`1,byref)
          -6 (-1.575% of base) : System.Private.CoreLib.dasm - Number:FormatExponent(byref,NumberFormatInfo,int,ushort,int,bool)
          -6 (-0.311% of base) : System.Private.CoreLib.dasm - Number:.cctor()
          -6 (-0.286% of base) : System.Private.CoreLib.dasm - CalendarData:CreateInvariant():CalendarData

Top method improvements (percentages):
          -7 (-3.365% of base) : Newtonsoft.Json.Bson.dasm - BsonDataReader:.cctor()
          -7 (-3.182% of base) : Newtonsoft.Json.Bson.dasm - BsonDataReader:BytesInSequence(ubyte):int:this
          -1 (-3.125% of base) : System.Collections.Immutable.dasm - ImmutableArrayExtensions:FirstOrDefault(ImmutableArray`1):__Canon
          -7 (-3.125% of base) : Newtonsoft.Json.dasm - BsonReader:.cctor()
          -1 (-2.703% of base) : Microsoft.VisualBasic.Core.dasm - CharType:FromString(String):ushort
          -1 (-2.703% of base) : Microsoft.VisualBasic.Core.dasm - Conversions:ToChar(String):ushort
          -1 (-2.564% of base) : System.Private.Xml.dasm - Compiler:IsPhantomNamespace(String):bool:this
          -1 (-2.564% of base) : xunit.execution.dotnet.dasm - Pack:UInt16_To_LE(ushort,ref)
          -1 (-2.500% of base) : System.Private.CoreLib.dasm - Statics:ShouldOverrideFieldName(String):bool
          -1 (-2.500% of base) : Microsoft.VisualBasic.Core.dasm - FileSystem:ChDrive(String)
          -1 (-2.500% of base) : System.Private.Xml.dasm - OutputScopeManager:Reset():this
          -1 (-2.500% of base) : xunit.execution.dotnet.dasm - Pack:UInt16_To_BE(ushort,ref)
          -1 (-2.439% of base) : System.Private.Xml.dasm - BigInteger:InitFromDigits(int,int,int):this
          -5 (-2.427% of base) : Microsoft.CodeAnalysis.dasm - UnionCollection`1:Create(ImmutableArray`1,Func`2):ICollection`1
          -1 (-2.381% of base) : Microsoft.CodeAnalysis.CSharp.dasm - CodeGenerator:IsMultidimensionalInitializer(ImmutableArray`1):bool
          -1 (-2.381% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CodeGenerator:IsMultidimensionalInitializer(ImmutableArray`1):bool:this
          -1 (-2.381% of base) : xunit.execution.dotnet.dasm - Pack:BE_To_UInt16(ref):ushort
          -1 (-2.381% of base) : xunit.execution.dotnet.dasm - Pack:LE_To_UInt16(ref):ushort
          -1 (-2.326% of base) : Newtonsoft.Json.Bson.dasm - StringUtils:StartsWith(String,ushort):bool
          -1 (-2.326% of base) : Newtonsoft.Json.dasm - StringUtils:StartsWith(String,ushort):bool

3127 total methods with Code Size differences (3127 improved, 0 regressed), 188060 unchanged.</pre>