### PR TITLE
Remove unnecessary logic to determine E format when parsing floating...

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
@@ -38,7 +38,6 @@ namespace System.Text.Json
             internal bool IsUnknownSize => _sizeOrLengthUnion == UnknownSize;
 
             /// <summary>
-            /// Number: Use scientific format.
             /// String/PropertyName: Unescaping is required.
             /// Array: At least one element is an object/array.
             /// Otherwise; false

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -586,9 +586,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> data = _utf8Json.Span;
             ReadOnlySpan<byte> segment = data.Slice(row.Location, row.SizeOrLength);
 
-            char standardFormat = row.HasComplexChildren ? JsonConstants.ScientificNotationFormat : default;
-
-            if (Utf8Parser.TryParse(segment, out double tmp, out int bytesConsumed, standardFormat) &&
+            if (Utf8Parser.TryParse(segment, out double tmp, out int bytesConsumed) &&
                 segment.Length == bytesConsumed)
             {
                 value = tmp;
@@ -610,9 +608,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> data = _utf8Json.Span;
             ReadOnlySpan<byte> segment = data.Slice(row.Location, row.SizeOrLength);
 
-            char standardFormat = row.HasComplexChildren ? JsonConstants.ScientificNotationFormat : default;
-
-            if (Utf8Parser.TryParse(segment, out float tmp, out int bytesConsumed, standardFormat) &&
+            if (Utf8Parser.TryParse(segment, out float tmp, out int bytesConsumed) &&
                 segment.Length == bytesConsumed)
             {
                 value = tmp;
@@ -634,9 +630,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> data = _utf8Json.Span;
             ReadOnlySpan<byte> segment = data.Slice(row.Location, row.SizeOrLength);
 
-            char standardFormat = row.HasComplexChildren ? JsonConstants.ScientificNotationFormat : default;
-
-            if (Utf8Parser.TryParse(segment, out decimal tmp, out int bytesConsumed, standardFormat) &&
+            if (Utf8Parser.TryParse(segment, out decimal tmp, out int bytesConsumed) &&
                 segment.Length == bytesConsumed)
             {
                 value = tmp;
@@ -1067,21 +1061,6 @@ namespace System.Text.Json
                     else
                     {
                         database.Append(tokenType, tokenStart, reader.ValueSpan.Length);
-
-                        if (tokenType == JsonTokenType.Number)
-                        {
-                            switch (reader._numberFormat)
-                            {
-                                case JsonConstants.ScientificNotationFormat:
-                                    database.SetHasComplexChildren(database.Length - DbRow.Size);
-                                    break;
-                                default:
-                                    Debug.Assert(
-                                        reader._numberFormat == default,
-                                        $"Unhandled numeric format {reader._numberFormat}");
-                                    break;
-                            }
-                        }
                     }
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -88,8 +88,6 @@ namespace System.Text.Json
         public const int MinimumDateTimeParseLength = 10; // YYYY-MM-DD
         public const int MaximumEscapedDateTimeOffsetParseLength = MaxExpansionFactorWhileEscaping * MaximumDateTimeOffsetParseLength;
 
-        internal const char ScientificNotationFormat = 'e';
-
         // Encoding Helpers
         public const char HighSurrogateStart = '\ud800';
         public const char HighSurrogateEnd = '\udbff';

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -322,21 +322,6 @@ namespace System.Text.Json
             return false;
         }
 
-        public static char GetFloatingPointStandardParseFormat(ReadOnlySpan<byte> span)
-        {
-            // Assume that 'e/E' is closer to the end.
-            int startIndex = span.Length - 1;
-            for (int i = startIndex; i >= 0; i--)
-            {
-                byte token = span[i];
-                if (token == 'E' || token == 'e')
-                {
-                    return JsonConstants.ScientificNotationFormat;
-                }
-            }
-            return default;
-        }
-
         public static bool TryGetFloatingPointConstant(ReadOnlySpan<byte> span, out float value)
         {
             if (span.Length == 3)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
@@ -17,7 +17,6 @@ namespace System.Text.Json
         internal long _bytePositionInLine;
         internal bool _inObject;
         internal bool _isNotPrimitive;
-        internal char _numberFormat;
         internal bool _stringHasEscaping;
         internal bool _trailingCommaBeforeComment;
         internal JsonTokenType _tokenType;
@@ -43,7 +42,6 @@ namespace System.Text.Json
             _bytePositionInLine = default;
             _inObject = default;
             _isNotPrimitive = default;
-            _numberFormat = default;
             _stringHasEscaping = default;
             _trailingCommaBeforeComment = default;
             _tokenType = default;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -32,7 +32,6 @@ namespace System.Text.Json
             _bytePositionInLine = state._bytePositionInLine;
             _inObject = state._inObject;
             _isNotPrimitive = state._isNotPrimitive;
-            _numberFormat = state._numberFormat;
             _stringHasEscaping = state._stringHasEscaping;
             _trailingCommaBeforeComment = state._trailingCommaBeforeComment;
             _tokenType = state._tokenType;
@@ -1122,8 +1121,6 @@ namespace System.Text.Json
             // TODO: https://github.com/dotnet/runtime/issues/27837
             Debug.Assert(data.Length > 0);
 
-            _numberFormat = default;
-
             PartialStateForRollback rollBackState = CaptureState();
 
             consumed = 0;
@@ -1207,7 +1204,6 @@ namespace System.Text.Json
 
             Debug.Assert(nextByte == 'E' || nextByte == 'e');
             i++;
-            _numberFormat = JsonConstants.ScientificNotationFormat;
             _bytePositionInLine++;
 
             signResult = ConsumeSignMultiSegment(ref data, ref i, rollBackState);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -422,8 +422,7 @@ namespace System.Text.Json
                 return value;
             }
 
-            char numberFormat = JsonReaderHelper.GetFloatingPointStandardParseFormat(span);
-            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed, numberFormat)
+            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed)
                 && span.Length == bytesConsumed)
             {
                 // NETCOREAPP implementation of the TryParse method above permits case-insenstive variants of the
@@ -482,11 +481,10 @@ namespace System.Text.Json
                 return value;
             }
 
-            char numberFormat = JsonReaderHelper.GetFloatingPointStandardParseFormat(span);
-            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed, numberFormat)
+            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed)
                 && span.Length == bytesConsumed)
             {
-                // NETCOREAPP implmentation of the TryParse method above permits case-insenstive variants of the
+                // NETCOREAPP implementation of the TryParse method above permits case-insenstive variants of the
                 // float constants "NaN", "Infinity", "-Infinity". This differs from the NETFRAMEWORK implementation.
                 // The following logic reconciles the two implementations to enforce consistent behavior.
                 if (!double.IsNaN(value) && !double.IsPositiveInfinity(value) && !double.IsNegativeInfinity(value))
@@ -536,15 +534,11 @@ namespace System.Text.Json
         internal decimal GetDecimalWithQuotes()
         {
             ReadOnlySpan<byte> span = GetUnescapedSpan();
-
-            char numberFormat = JsonReaderHelper.GetFloatingPointStandardParseFormat(span);
-            if (Utf8Parser.TryParse(span, out decimal value, out int bytesConsumed, numberFormat)
-                && span.Length == bytesConsumed)
+            if (!TryGetDecimalCore(out decimal value, span))
             {
-                return value;
+                throw ThrowHelper.GetFormatException(NumericType.Decimal);
             }
-
-            throw ThrowHelper.GetFormatException(NumericType.Decimal);
+            return value;
         }
 
         /// <summary>
@@ -979,7 +973,7 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
 
-            if (Utf8Parser.TryParse(span, out float tmp, out int bytesConsumed, _numberFormat)
+            if (Utf8Parser.TryParse(span, out float tmp, out int bytesConsumed)
                 && span.Length == bytesConsumed)
             {
                 value = tmp;
@@ -1009,7 +1003,7 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
 
-            if (Utf8Parser.TryParse(span, out double tmp, out int bytesConsumed, _numberFormat)
+            if (Utf8Parser.TryParse(span, out double tmp, out int bytesConsumed)
                 && span.Length == bytesConsumed)
             {
                 value = tmp;
@@ -1038,8 +1032,13 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
+            return TryGetDecimalCore(out value, span);
+        }
 
-            if (Utf8Parser.TryParse(span, out decimal tmp, out int bytesConsumed, _numberFormat)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryGetDecimalCore(out decimal value, ReadOnlySpan<byte> span)
+        {
+            if (Utf8Parser.TryParse(span, out decimal tmp, out int bytesConsumed)
                 && span.Length == bytesConsumed)
             {
                 value = tmp;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -33,7 +33,6 @@ namespace System.Text.Json
         private int _consumed;
         private bool _inObject;
         private bool _isNotPrimitive;
-        internal char _numberFormat;
         private JsonTokenType _tokenType;
         private JsonTokenType _previousTokenType;
         private JsonReaderOptions _readerOptions;
@@ -183,7 +182,6 @@ namespace System.Text.Json
             _bytePositionInLine = _bytePositionInLine,
             _inObject = _inObject,
             _isNotPrimitive = _isNotPrimitive,
-            _numberFormat = _numberFormat,
             _stringHasEscaping = _stringHasEscaping,
             _trailingCommaBeforeComment = _trailingCommaBeforeComment,
             _tokenType = _tokenType,
@@ -215,7 +213,6 @@ namespace System.Text.Json
             _bytePositionInLine = state._bytePositionInLine;
             _inObject = state._inObject;
             _isNotPrimitive = state._isNotPrimitive;
-            _numberFormat = state._numberFormat;
             _stringHasEscaping = state._stringHasEscaping;
             _trailingCommaBeforeComment = state._trailingCommaBeforeComment;
             _tokenType = state._tokenType;
@@ -1415,7 +1412,6 @@ namespace System.Text.Json
             // TODO: https://github.com/dotnet/runtime/issues/27837
             Debug.Assert(data.Length > 0);
 
-            _numberFormat = default;
             consumed = 0;
             int i = 0;
 
@@ -1493,7 +1489,6 @@ namespace System.Text.Json
 
             Debug.Assert(nextByte == 'E' || nextByte == 'e');
             i++;
-            _numberFormat = JsonConstants.ScientificNotationFormat;
 
             signResult = ConsumeSign(ref data, ref i);
             if (signResult == ConsumeNumberResult.NeedMoreData)


### PR DESCRIPTION
... point values on Utf8JsonReader and JsonDocument.

The internal field `Utf8JsonReader._numberFormat` is set to `'e'` only if the JSON number that was read was in scientific notation format and is then passed as the `standardFormat` argument on [`Utf8Parser.TryParse`](https://source.dot.net/#System.Private.CoreLib/Utf8Parser.Float.cs,81) method. 

There is no difference from parsing using the default format, except for the next condition, which is granted to always evaluate as false when called from `Utf8JsonReader`:
https://github.com/dotnet/runtime/blob/33dba9518b4eb7fbc487fadc9718c408f95a826c/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Float.cs#L104-L108

With that said, the `_numberFormat` field and all the related logic can be safely removed. 
This change was motivated by https://github.com/dotnet/runtime/pull/39363#discussion_r455294658.