### PR TITLE
Fix SingleFile regression in IsolatedStorageFile

### DIFF
--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
@@ -51,14 +51,13 @@ namespace System.IO.IsolatedStorage
             Assembly? assembly = Assembly.GetEntryAssembly();
 
             if (assembly == null)
+            {
                 throw new IsolatedStorageException(SR.IsolatedStorage_Init);
+            }
 
             AssemblyName assemblyName = assembly.GetName();
-#pragma warning disable SYSLIB0012
-            Uri codeBase = new Uri(assembly.CodeBase!);
-#pragma warning restore SYSLIB0012
-
             hash = IdentityHelper.GetNormalizedStrongNameHash(assemblyName)!;
+
             if (hash != null)
             {
                 hash = "StrongName" + separator + hash;
@@ -66,8 +65,11 @@ namespace System.IO.IsolatedStorage
             }
             else
             {
-                hash = "Url" + separator + IdentityHelper.GetNormalizedUriHash(codeBase);
-                identity = codeBase;
+                // in case of SingleFile, Location.Length returns 0.
+                string fileName = assembly.Location.Length == 0 ? assemblyName.Name! : Path.GetFileName(assembly.Location);
+                Uri assemblyPath = new Uri(Path.Combine(AppContext.BaseDirectory, fileName));
+                hash = "Url" + separator + IdentityHelper.GetNormalizedUriHash(assemblyPath);
+                identity = assemblyPath;
             }
         }
 


### PR DESCRIPTION
In .NET 5, (true) single file application returns:

* a blank string from `Assembly.GetEntryAssembly().Location`
* `<Unknown>` string from `Assembly.GetEntryAssembly().ManifestModule.Name`
* `System.NotSupportedException: CodeBase is not supported on assemblies loaded from a single-file bundle.` from `Assembly.GetEntryAssembly().assembly.CodeBase`.

This change uses `Process.GetCurrentProcess().MainModule.FileName` for single file to fix this 3.1 -> 5.0 regression.

Fixes #42265.