### PR TITLE
HTTP stress test improvements

### DIFF
--- a/eng/docker/libraries-sdk-aspnetcore.linux.Dockerfile
+++ b/eng/docker/libraries-sdk-aspnetcore.linux.Dockerfile
@@ -1,6 +1,6 @@
 # Builds and copies library artifacts into target dotnet sdk image
 ARG BUILD_BASE_IMAGE=mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-f39df28-20191023143754
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:5.0-buster-slim
 
 FROM $BUILD_BASE_IMAGE as corefxbuild
 

--- a/eng/docker/libraries-sdk-aspnetcore.windows.Dockerfile
+++ b/eng/docker/libraries-sdk-aspnetcore.windows.Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 # Simple Dockerfile which copies library build artifacts into target dotnet sdk image
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:5.0-nanoserver-1809
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:5.0-nanoserver-1809
 FROM $SDK_BASE_IMAGE as target
 
 ARG TESTHOST_LOCATION=".\\artifacts\\bin\\testhost"

--- a/eng/docker/libraries-sdk.linux.Dockerfile
+++ b/eng/docker/libraries-sdk.linux.Dockerfile
@@ -1,6 +1,6 @@
 # Builds and copies library artifacts into target dotnet sdk image
 ARG BUILD_BASE_IMAGE=mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-f39df28-20191023143754
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:5.0-buster-slim
 
 FROM $BUILD_BASE_IMAGE as corefxbuild
 

--- a/eng/docker/libraries-sdk.windows.Dockerfile
+++ b/eng/docker/libraries-sdk.windows.Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 # Simple Dockerfile which copies clr and library build artifacts into target dotnet sdk image
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:5.0-nanoserver-1809
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:5.0-nanoserver-1809
 FROM $SDK_BASE_IMAGE as target
 
 ARG TESTHOST_LOCATION=".\\artifacts\\bin\\testhost"

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -25,7 +25,7 @@ variables:
 jobs:
 - job: linux
   displayName: Docker Linux
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   pool:
     name: NetCorePublic-Pool
     queue: BuildPool.Ubuntu.1604.Amd64.Open
@@ -65,7 +65,7 @@ jobs:
 
 - job: windows
   displayName: Docker NanoServer
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   pool:
     name: NetCorePublic-Pool
     queue: BuildPool.Server.Amd64.VS2019.Open

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
@@ -43,8 +43,8 @@ namespace HttpStress
         public double CancellationProbability { get; set; }
 
         public bool UseHttpSys { get; set; }
-        public string? LogPath { get; set; }
         public bool LogAspNet { get; set; }
+        public bool Trace { get; set; }
         public int? ServerMaxConcurrentStreams { get; set; }
         public int? ServerMaxFrameSize { get; set; }
         public int? ServerInitialConnectionWindowSize { get; set; }

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -1,4 +1,4 @@
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:5.0-buster-slim
 FROM $SDK_BASE_IMAGE
 
 RUN echo "DOTNET_SDK_VERSION="$DOTNET_SDK_VERSION

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpEventListener.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpEventListener.cs
@@ -3,17 +3,22 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Threading.Channels;
 using System.Text;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace HttpStress
 {
     public sealed class LogHttpEventListener : EventListener
     {
-        private readonly object _syncRoot = new object();
         private int _lastLogNumber = 0;
         private StreamWriter _log;
+        private Channel<string> _messagesChannel = Channel.CreateUnbounded<string>();
+        private Task _processMessages;
+        private CancellationTokenSource _stopProcessing;
 
         public LogHttpEventListener()
         {
@@ -25,6 +30,10 @@ namespace HttpStress
                 } catch {}
             }
             _log = new StreamWriter("client.log", false) { AutoFlush = true };
+
+            _messagesChannel = Channel.CreateUnbounded<string>();
+            _processMessages = ProcessMessages();
+            _stopProcessing = new CancellationTokenSource();
         }
 
         protected override void OnEventSourceCreated(EventSource eventSource)
@@ -35,9 +44,29 @@ namespace HttpStress
             }
         }
 
-        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        private async Task ProcessMessages()
         {
-            lock (_syncRoot)
+            await Task.Yield();
+
+            try
+            {
+                int i = 0;
+                await foreach (string message in _messagesChannel.Reader.ReadAllAsync(_stopProcessing.Token))
+                {
+                    if ((++i % 10_000) == 0)
+                    {
+                        RotateFiles();
+                    }
+
+                    _log.WriteLine(message);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            void RotateFiles()
             {
                 // Rotate the log if it reaches 50 MB size.
                 if (_log.BaseStream.Length > (50 << 20))
@@ -45,24 +74,33 @@ namespace HttpStress
                     _log.Close();
                     _log = new StreamWriter($"client_{++_lastLogNumber:000}.log", false) { AutoFlush = true };
                 }
-
-                var sb = new StringBuilder().Append($"{eventData.TimeStamp:HH:mm:ss.fffffff}[{eventData.EventName}] ");
-                for (int i = 0; i < eventData.Payload?.Count; i++)
-                {
-                    if (i > 0)
-                    {
-                        sb.Append(", ");
-                    }
-                    sb.Append(eventData.PayloadNames?[i]).Append(": ").Append(eventData.Payload[i]);
-                }
-                _log.WriteLine(sb.ToString());
             }
+        }
+
+        protected override async void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            var sb = new StringBuilder().Append($"{eventData.TimeStamp:HH:mm:ss.fffffff}[{eventData.EventName}] ");
+            for (int i = 0; i < eventData.Payload?.Count; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+                sb.Append(eventData.PayloadNames?[i]).Append(": ").Append(eventData.Payload[i]);
+            }
+            await _messagesChannel.Writer.WriteAsync(sb.ToString());
         }
 
         public override void Dispose()
         {
-            _log.Dispose();
             base.Dispose();
+
+            if (!_processMessages.Wait(TimeSpan.FromSeconds(30)))
+            {
+                _stopProcessing.Cancel();
+                _processMessages.Wait();
+            }
+            _log.Dispose();
         }
     }
 }

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpEventListener.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpEventListener.cs
@@ -32,7 +32,7 @@ namespace HttpStress
             _log = new StreamWriter("client.log", false) { AutoFlush = true };
 
             _messagesChannel = Channel.CreateUnbounded<string>();
-            _processMessages = ProcessMessages();
+            _processMessages = ProcessMessagesAsync();
             _stopProcessing = new CancellationTokenSource();
         }
 
@@ -44,7 +44,7 @@ namespace HttpStress
             }
         }
 
-        private async Task ProcessMessages()
+        private async Task ProcessMessagesAsync()
         {
             await Task.Yield();
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19577.1" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.5.4" />
   </ItemGroup>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -18,7 +18,6 @@ using HttpStress;
 /// </summary>
 public static class Program
 {
-
     public enum ExitCode { Success = 0, StressError = 1, CliError = 2 };
 
     public static async Task<int> Main(string[] args)
@@ -46,8 +45,8 @@ public static class Program
         cmd.AddOption(new Option("-connectionLifetime", "Max connection lifetime length (milliseconds).") { Argument = new Argument<int?>("connectionLifetime", null) });
         cmd.AddOption(new Option("-ops", "Indices of the operations to use") { Argument = new Argument<int[]?>("space-delimited indices", null) });
         cmd.AddOption(new Option("-xops", "Indices of the operations to exclude") { Argument = new Argument<int[]?>("space-delimited indices", null) });
-        cmd.AddOption(new Option("-trace", "Enable System.Net.Http.InternalDiagnostics tracing.") { Argument = new Argument<string>("\"console\" or path") });
-        cmd.AddOption(new Option("-aspnetlog", "Enable ASP.NET warning and error logging.") { Argument = new Argument<bool>("enable", false) });
+        cmd.AddOption(new Option("-trace", "Enable System.Net.Http.InternalDiagnostics (client) and/or ASP.NET dignostics (server) tracing.") { Argument = new Argument<bool>("enable", false) });
+        cmd.AddOption(new Option("-aspnetlog", "Enable ASP.NET warning and error console logging.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-listOps", "List available options.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-seed", "Seed for generating pseudo-random parameters for a given -n argument.") { Argument = new Argument<int?>("seed", null) });
         cmd.AddOption(new Option("-numParameters", "Max number of query parameters or form fields for a request.") { Argument = new Argument<int>("queryParameters", 1) });
@@ -99,7 +98,7 @@ public static class Program
 
             UseHttpSys = cmdline.ValueForOption<bool>("-httpSys"),
             LogAspNet = cmdline.ValueForOption<bool>("-aspnetlog"),
-            LogPath = cmdline.HasOption("-trace") ? cmdline.ValueForOption<string>("-trace") : null,
+            Trace = cmdline.ValueForOption<bool>("-trace"),
             ServerMaxConcurrentStreams = cmdline.ValueForOption<int?>("-serverMaxConcurrentStreams"),
             ServerMaxFrameSize = cmdline.ValueForOption<int?>("-serverMaxFrameSize"),
             ServerInitialConnectionWindowSize = cmdline.ValueForOption<int?>("-serverInitialConnectionWindowSize"),
@@ -158,11 +157,12 @@ public static class Program
         Console.WriteLine(" System.Net.Http: " + GetAssemblyInfo(typeof(System.Net.Http.HttpClient).Assembly));
         Console.WriteLine("          Server: " + (config.UseHttpSys ? "http.sys" : "Kestrel"));
         Console.WriteLine("      Server URL: " + config.ServerUri);
-        Console.WriteLine("         Tracing: " + (config.LogPath == null ? (object)false : config.LogPath.Length == 0 ? (object)true : config.LogPath));
+        Console.WriteLine("  Client Tracing: " + (config.Trace && config.RunMode.HasFlag(RunMode.client) ? "ON (client.log)" : "OFF"));
+        Console.WriteLine("  Server Tracing: " + (config.Trace && config.RunMode.HasFlag(RunMode.server) ? "ON (server.log)" : "OFF"));
         Console.WriteLine("     ASP.NET Log: " + config.LogAspNet);
         Console.WriteLine("     Concurrency: " + config.ConcurrentRequests);
         Console.WriteLine("  Content Length: " + config.MaxContentLength);
-        Console.WriteLine("   HTTP2 Version: " + config.HttpVersion);
+        Console.WriteLine("    HTTP Version: " + config.HttpVersion);
         Console.WriteLine("        Lifetime: " + (config.ConnectionLifetime.HasValue ? $"{config.ConnectionLifetime.Value.TotalMilliseconds}ms" : "(infinite)"));
         Console.WriteLine("      Operations: " + string.Join(", ", usedClientOperations.Select(o => o.name)));
         Console.WriteLine("     Random Seed: " + config.RandomSeed);

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -46,7 +46,7 @@ public static class Program
         cmd.AddOption(new Option("-ops", "Indices of the operations to use") { Argument = new Argument<int[]?>("space-delimited indices", null) });
         cmd.AddOption(new Option("-xops", "Indices of the operations to exclude") { Argument = new Argument<int[]?>("space-delimited indices", null) });
         cmd.AddOption(new Option("-trace", "Enable System.Net.Http.InternalDiagnostics (client) and/or ASP.NET dignostics (server) tracing.") { Argument = new Argument<bool>("enable", false) });
-        cmd.AddOption(new Option("-aspnetlog", "Enable ASP.NET warning and error console logging.") { Argument = new Argument<bool>("enable", false) });
+        cmd.AddOption(new Option("-aspnetlog", "Enable ASP.NET warning and error logging.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-listOps", "List available options.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-seed", "Seed for generating pseudo-random parameters for a given -n argument.") { Argument = new Argument<int?>("seed", null) });
         cmd.AddOption(new Option("-numParameters", "Max number of query parameters or form fields for a request.") { Argument = new Argument<int>("queryParameters", 1) });

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -72,6 +72,7 @@ namespace HttpStress
                 }
                 Console.WriteLine("Client is stopping ...");
             }
+            _client.Dispose();
             _stopwatch.Stop();
             _cts.Dispose();
         }

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:5.0-nanoserver-1809
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:5.0-nanoserver-1809
 FROM $SDK_BASE_IMAGE
 
 # Use powershell as the default shell


### PR DESCRIPTION
Fixes:
- stress client double read of content fixed
- fixed stress client hangs at start and stop
- leveraged `HttpVersionPolicy`
- increased pipeline timeout since we doubled the runs
- fixed base docker images to avoid missing IO.Pipelines Kestrel exception.

Re-hauled tracing:
- added server file logging
- added log file rotation

Minor renames.

Contributes to: #42211 and #42198
