### PR TITLE
a small improvement for `fgMorphMultiregStructArg`.

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -3323,7 +3323,7 @@ public:
         return &lvaTable[lclNum];
     }
 
-    LclVarDsc* lvaGetDesc(GenTreeLclVarCommon* lclVar)
+    LclVarDsc* lvaGetDesc(const GenTreeLclVarCommon* lclVar)
     {
         assert(lclVar->GetLclNum() < lvaCount);
         return &lvaTable[lclVar->GetLclNum()];


### PR DESCRIPTION
don't force a multireg node to stack when it is used as a compatible type, this happens when we inline a method with [Canon] and replace [Canon] with the exact type from the caller.

```
arm64 crossgen:
Total bytes of delta: -144 (-0.000% of base)
Top method improvements (percentages):
         -24 (-28.571% of base) : Newtonsoft.Json.dasm - DefaultSerializationBinder:BindToType(String,String):Type:this
         -20 (-19.231% of base) : Newtonsoft.Json.dasm - EnumUtils:GetEnumValuesAndNames(Type):EnumInfo
         -16 (-15.385% of base) : Newtonsoft.Json.dasm - DefaultSerializationBinder:GetTypeByName(StructMultiKey`2):Type:this
         -16 (-5.000% of base) : Newtonsoft.Json.dasm - EnumUtils:TryToString(Type,Object,NamingStrategy,byref):bool
         -16 (-3.252% of base) : Newtonsoft.Json.dasm - ConvertUtils:EnsureTypeAssignable(Object,Type,Type):Object
         -12 (-2.308% of base) : Newtonsoft.Json.dasm - DefaultSerializationBinder:GetGenericTypeFromTypeName(String,Assembly):Type:this
         -16 (-0.778% of base) : Newtonsoft.Json.dasm - EnumUtils:ParseEnum(Type,NamingStrategy,String,bool):Object
         -24 (-0.360% of base) : System.Private.CoreLib.dasm - ManifestBuilder:CreateManifestString():String:this
8 total methods with Code Size differences (8 improved, 0 regressed), 195402 unchanged.

arm64 pmi:
Total bytes of delta: -1300 (-0.002% of base)
similar method improvements.
```

cc @dotnet/jit-contrib 

