### PR TITLE
Add test for type linking with custom ALCs

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/LoaderLinkTest.Dynamic.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/LoaderLinkTest.Dynamic.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SharedInterfaceImplementation.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LoaderLinkTest.Shared\LoaderLinkTest.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/SharedInterfaceImplementation.cs
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/SharedInterfaceImplementation.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+using LoaderLinkTest.Shared;
+
+namespace LoaderLinkTest.Dynamic
+{
+    public class SharedInterfaceImplementation : ISharedInterface
+    {
+        public string TestString => "Hello";
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/ISharedInterface.cs
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/ISharedInterface.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace LoaderLinkTest.Shared
+{
+    public interface ISharedInterface
+    {
+        string TestString { get; }
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/LoaderLinkTest.Shared.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/LoaderLinkTest.Shared.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ISharedInterface.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+using LoaderLinkTest.Shared;
+
+namespace LoaderLinkTest
+{
+    public class LoaderLinkTest
+    {
+        [Fact]
+        public static void EnsureTypesLinked() // https://github.com/dotnet/runtime/issues/42207
+        {
+            string parentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            byte[] bytes = File.ReadAllBytes(Path.Combine(parentDir != null ? parentDir : "/", "LoaderLinkTest.Dynamic.dll"));
+            Assembly asm = Assembly.Load(bytes);
+            var dynamicType = asm.GetType("LoaderLinkTest.Dynamic.SharedInterfaceImplementation", true);
+            var sharedInterface = dynamicType.GetInterfaces().First(e => e.Name == nameof(ISharedInterface));
+            Assert.Equal(typeof(ISharedInterface).Assembly, sharedInterface.Assembly);
+            Assert.Equal(typeof(ISharedInterface), sharedInterface);
+
+            var instance = Activator.CreateInstance(dynamicType);
+            Assert.True(instance is ISharedInterface);
+
+            Assert.NotNull(((ISharedInterface)instance).TestString); // cast should not fail
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="CustomTPALoadContext.cs" />
     <Compile Include="ResourceAssemblyLoadContext.cs" />
     <Compile Include="SatelliteAssemblies.cs" />
+    <Compile Include="LoaderLinkTest.cs" />
     <EmbeddedResource Include="MainStrings*.resx" />
   </ItemGroup>
   <ItemGroup>
@@ -29,6 +30,8 @@
     <ProjectReference Include="ContextualReflectionDependency\System.Runtime.Loader.Test.ContextualReflectionDependency.csproj" />
     <ProjectReference Include="ReferencedClassLib\ReferencedClassLib.csproj" />
     <ProjectReference Include="ReferencedClassLibNeutralIsSatellite\ReferencedClassLibNeutralIsSatellite.csproj" />
+    <ProjectReference Include="LoaderLinkTest.Shared\LoaderLinkTest.Shared.csproj" />
+    <ProjectReference Include="LoaderLinkTest.Dynamic\LoaderLinkTest.Dynamic.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/42207
This should fail on wasm, fix to follow