### PR TITLE
[release/5.0-rc2] Update ICU dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>cfe95a23647c7de1fe1a349343115bd7720d6949</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20451.2">
+    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20466.2">
       <Uri>https://github.com/dotnet/icu</Uri>
-      <Sha>ed7daa0d0a29de51ecaacf8e7820adf59a3bac1f</Sha>
+      <Sha>7dc307fe7ad0dccfacfd60067dcb565056c78e5f</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -145,7 +145,7 @@
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>5.0.0-rc.1.20420.3</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->
-    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20451.2</MicrosoftNETCoreRuntimeICUTransportVersion>
+    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20466.2</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.cs
@@ -176,10 +176,6 @@ namespace System.Globalization.Tests
             DateTime dt = new DateTime(1989, 01, 08); // Start of Heisei Era
 
             string formattedDateWithGannen = "\u5E73\u6210 \u5143\u5E74 01\u6708 08\u65E5";
-            if (PlatformDetection.IsBrowser)
-            {
-                formattedDateWithGannen = "Heisei \u5143\u5E74 01\u6708 08\u65E5";
-            }
 
             string formattedDate = dt.ToString(pattern, jpnFormat);
 


### PR DESCRIPTION
This PR brings fixes from https://github.com/dotnet/icu/pull/38 for icudt*.dat files (resources).

## Customer Impact
We tried to strip as much data as we can from icudt.dat for 5.0 release and got rid of some pieces that our customers might need.
Fortunately, these pieces don't increase size much: +~30kb uncompressed or +4kb after compression).

https://github.com/dotnet/icu/pull/37 - Add all en-* locales (fixes https://github.com/dotnet/runtime/issues/42328)
https://github.com/dotnet/icu/pull/34 - Fix datetime formats for KN and several other locales (fixes https://github.com/dotnet/aspnetcore/pull/25521#discussion_r482632985)
https://github.com/dotnet/icu/pull/25 - Add Japanese calendar for ja(ja_JP) locale (it used to accept only english letters for japanese era name, e.g. "Heisei" instead of "平成")

## Testing
System.Globalization.* tests + local testing

## Risk
Low, this PR only updates icudat.dat resource files