### PR TITLE
Allow more obj(addr(lcl_var) foldings.

### DIFF
--- a/src/coreclr/src/jit/layout.cpp
+++ b/src/coreclr/src/jit/layout.cpp
@@ -430,10 +430,8 @@ bool ClassLayout::AreCompatible(const ClassLayout* layout1, const ClassLayout* l
 {
     CORINFO_CLASS_HANDLE clsHnd1 = layout1->GetClassHandle();
     CORINFO_CLASS_HANDLE clsHnd2 = layout2->GetClassHandle();
-    assert(clsHnd1 != NO_CLASS_HANDLE);
-    assert(clsHnd2 != NO_CLASS_HANDLE);
 
-    if (clsHnd1 == clsHnd2)
+    if ((clsHnd1 != NO_CLASS_HANDLE) && (clsHnd1 == clsHnd2))
     {
         return true;
     }
@@ -453,7 +451,10 @@ bool ClassLayout::AreCompatible(const ClassLayout* layout1, const ClassLayout* l
         return true;
     }
 
+    assert(clsHnd1 != NO_CLASS_HANDLE);
+    assert(clsHnd2 != NO_CLASS_HANDLE);
     assert(layout1->HasGCPtr() && layout2->HasGCPtr());
+
     if (layout1->GetGCPtrCount() != layout2->GetGCPtrCount())
     {
         return false;

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1021,7 +1021,8 @@ private:
         // otherwise the below layout equality check would be insufficient.
         assert(varDsc->GetLayout() != nullptr);
 
-        if ((val.Offset() == 0) && (structLayout == varDsc->GetLayout()))
+        if ((val.Offset() == 0) && (structLayout != nullptr) &&
+            ClassLayout::AreCompatible(structLayout, varDsc->GetLayout()))
         {
             indir->ChangeOper(GT_LCL_VAR);
             indir->AsLclVar()->SetLclNum(val.LclNum());


### PR DESCRIPTION
Diffs on libraries:
```
x64 win pmi: -18832 (-0.037% of base)
arm64 win pmi: -6532 (-0.012% of base)
x64 unix pmi: -10302 (-0.020% of base)

x64 win crossgen: -1011 (-0.003% of base)
arm64 win crossgen: -352 (-0.001% of base)
x64 unix crossgen: -527 (-0.001% of base)
```
a different number of improved methods, no regression.

x64 win pmi of System.Net.Http benefits the most:
```
       -6867 : System.Net.Http.dasm (-0.932% of base)
```

a typical improvement comes from copy propagation when we can delete an unnecessary block copy:

```diff
@@ -1,16 +1,7 @@
-***** BB01
-STMT00003 (IL 0x000...  ???)
-N005 ( 13, 12) [000017] -A------R---              *  ASG       struct (copy)
-N004 (  9,  9) [000016] n-----------              +--*  OBJ       struct<Microsoft.CodeAnalysis.SyntaxTriviaList, 40>
-N003 (  3,  5) [000015] ------------              |  \--*  ADDR      byref
-N002 (  3,  4) [000012] D------N----              |     \--*  LCL_FLD   struct V03 tmp1         d:1[+0] Fseq[_list]
-N001 (  3,  2) [000013] ------------              \--*  LCL_VAR   struct<Microsoft.CodeAnalysis.SyntaxTriviaList, 40> V04 tmp2         u:1 (last use)
-
-***** BB01
 STMT00001 (IL 0x00B...  ???)
 N004 ( 11,  8) [000008] -A-X--------              *  ASG       struct (copy)
 N002 (  7,  5) [000007] D--X--------              +--*  OBJ       struct<Reversed, 40>
 N001 (  1,  1) [000006] ------------              |  \--*  LCL_VAR   byref  V01 RetBuf       u:1
-N003 (  3,  2) [000005] ------------              \--*  LCL_VAR   struct<Reversed, 40> V03 tmp1         u:1 (last use)
+N003 (  3,  2) [000005] ------------              \--*  LCL_VAR   struct<Microsoft.CodeAnalysis.SyntaxTriviaList, 40> V04 tmp2         u:1 (last use)

-Method code size: 136
\ No newline at end of file
+Method code size: 81
\ No newline at end of file
```