### PR TITLE
Remove workarounds from BitConverter for single/double <-> int/long conversion

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -761,13 +761,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe long DoubleToInt64Bits(double value)
         {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.X64.IsSupported)
-            {
-                Vector128<long> vec = Vector128.CreateScalarUnsafe(value).AsInt64();
-                return Sse2.X64.ConvertToInt64(vec);
-            }
-
             return *((long*)&value);
         }
 
@@ -779,13 +772,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe double Int64BitsToDouble(long value)
         {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.X64.IsSupported)
-            {
-                Vector128<double> vec = Vector128.CreateScalarUnsafe(value).AsDouble();
-                return vec.ToScalar();
-            }
-
             return *((double*)&value);
         }
 
@@ -797,13 +783,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int SingleToInt32Bits(float value)
         {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.IsSupported)
-            {
-                Vector128<int> vec = Vector128.CreateScalarUnsafe(value).AsInt32();
-                return Sse2.ConvertToInt32(vec);
-            }
-
             return *((int*)&value);
         }
 
@@ -815,13 +794,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe float Int32BitsToSingle(int value)
         {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.IsSupported)
-            {
-                Vector128<float> vec = Vector128.CreateScalarUnsafe(value).AsSingle();
-                return vec.ToScalar();
-            }
-
             return *((float*)&value);
         }
 


### PR DESCRIPTION
Looks like these workarounds are not needed anymore, test:
```csharp
public static unsafe int SingleToInt32Bits_vec(float value)
{
    Vector128<int> vec = Vector128.CreateScalarUnsafe(value).AsInt32();
    return Sse2.ConvertToInt32(vec);
}
public static unsafe int SingleToInt32Bits(float value)
{
    return *((int*)&value);
}


public static unsafe float Int32BitsToSingle_vec(int value)
{
    Vector128<float> vec = Vector128.CreateScalarUnsafe(value).AsSingle();
    return vec.ToScalar();
}
public static unsafe float Int32BitsToSingle(int value)
{
    return *((float*)&value);
}


public static unsafe long DoubleToInt64Bits_vec(double value)
{
    Vector128<long> vec = Vector128.CreateScalarUnsafe(value).AsInt64();
    return Sse2.X64.ConvertToInt64(vec);
}
public static unsafe long DoubleToInt64Bits(double value)
{
    return *((long*)&value);
}


public static unsafe double Int64BitsToDouble_vec(long value)
{
    Vector128<double> vec = Vector128.CreateScalarUnsafe(value).AsDouble();
    return vec.ToScalar();
}
public static unsafe double Int64BitsToDouble(long value)
{
    return *((double*)&value);
}
```
codegen:
```asm
; Method Foo:SingleToInt32Bits_vec(float):int
       C5F877               vzeroupper
       C5F97EC0             vmovd    eax, xmm0
       C3                   ret
; Method Foo:SingleToInt32Bits(float):int
       C5F877               vzeroupper
       C5F97EC0             vmovd    eax, xmm0
       C3                   ret


; Method Foo:Int32BitsToSingle_vec(int):float
       C5F877               vzeroupper
       C5F96EC1             vmovd    xmm0, ecx
       C3                   ret
; Method Foo:Int32BitsToSingle(int):float
       C5F877               vzeroupper
       C5F96EC1             vmovd    xmm0, ecx
       C3                   ret


; Method Foo:DoubleToInt64Bits_vec(double):long
       C5F877               vzeroupper
       C4E1F97EC0           vmovd    rax, xmm0
       C3                   ret
; Method Foo:DoubleToInt64Bits(double):long
       C5F877               vzeroupper
       C4E1F97EC0           vmovd    rax, xmm0
       C3                   ret


; Method Foo:Int64BitsToDouble_vec(long):double
       C5F877               vzeroupper
       C4E1F96EC1           vmovd    xmm0, rcx
       C3                   ret
; Method Foo:Int64BitsToDouble(long):double
       C5F877               vzeroupper 
       C4E1F96EC1           vmovd    xmm0, rcx
       C3                   ret
```

/cc @gfoidl @tannergooding 