### PR TITLE
Fix MathF.Round exception message when out of bounds with numDigits - Issue #41650 

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1843,6 +1843,9 @@
   <data name="ArgumentOutOfRange_RoundingDigits" xml:space="preserve">
     <value>Rounding digits must be between 0 and 15, inclusive.</value>
   </data>
+  <data name="ArgumentOutOfRange_RoundingDigits_MathF" xml:space="preserve">
+    <value>Rounding digits must be between 0 and 6, inclusive.</value>
+  </data>
   <data name="ArgumentOutOfRange_SmallCapacity" xml:space="preserve">
     <value>capacity was less than the current size.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -344,7 +344,7 @@ namespace System
         {
             if ((digits < 0) || (digits > maxRoundingDigits))
             {
-                throw new ArgumentOutOfRangeException(nameof(digits), SR.ArgumentOutOfRange_RoundingDigits);
+                throw new ArgumentOutOfRangeException(nameof(digits), SR.ArgumentOutOfRange_RoundingDigits_MathF);
             }
 
             if (mode < MidpointRounding.ToEven || mode > MidpointRounding.ToPositiveInfinity)


### PR DESCRIPTION
This is a fix for Issue #41650 

Add new resource string with correct bounds
Use new resource string in MathF.Round