### PR TITLE
Memory Leak in Microsoft.Extensions.Caching.Memory when handling exceptions

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
@@ -43,39 +43,43 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value)
         {
-            ICacheEntry entry = cache.CreateEntry(key);
-            entry.Value = value;
-            entry.Dispose();
+            using (ICacheEntry entry = cache.CreateEntry(key))
+            {
+                entry.Value = value;
+            }
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, DateTimeOffset absoluteExpiration)
         {
-            ICacheEntry entry = cache.CreateEntry(key);
-            entry.AbsoluteExpiration = absoluteExpiration;
-            entry.Value = value;
-            entry.Dispose();
+            using (ICacheEntry entry = cache.CreateEntry(key))
+            {
+                entry.AbsoluteExpiration = absoluteExpiration;
+                entry.Value = value;
+            }
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, TimeSpan absoluteExpirationRelativeToNow)
         {
-            ICacheEntry entry = cache.CreateEntry(key);
-            entry.AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow;
-            entry.Value = value;
-            entry.Dispose();
+            using (ICacheEntry entry = cache.CreateEntry(key))
+            {
+                entry.AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow;
+                entry.Value = value;
+            }
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, IChangeToken expirationToken)
         {
-            ICacheEntry entry = cache.CreateEntry(key);
-            entry.AddExpirationToken(expirationToken);
-            entry.Value = value;
-            entry.Dispose();
+            using (ICacheEntry entry = cache.CreateEntry(key))
+            {
+                entry.AddExpirationToken(expirationToken);
+                entry.Value = value;
+            }
 
             return value;
         }
@@ -99,13 +103,11 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (!cache.TryGetValue(key, out object result))
             {
-                ICacheEntry entry = cache.CreateEntry(key);
-                result = factory(entry);
-                entry.SetValue(result);
-                // need to manually call dispose instead of having a using
-                // in case the factory passed in throws, in which case we
-                // do not want to add the entry to the cache
-                entry.Dispose();
+                using (ICacheEntry entry = cache.CreateEntry(key))
+                {
+                    result = factory(entry);
+                    entry.SetValue(result);
+                }
             }
 
             return (TItem)result;
@@ -115,13 +117,11 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (!cache.TryGetValue(key, out object result))
             {
-                ICacheEntry entry = cache.CreateEntry(key);
-                result = await factory(entry).ConfigureAwait(false);
-                entry.SetValue(result);
-                // need to manually call dispose instead of having a using
-                // in case the factory passed in throws, in which case we
-                // do not want to add the entry to the cache
-                entry.Dispose();
+                using (ICacheEntry entry = cache.CreateEntry(key))
+                {
+                    result = await factory(entry).ConfigureAwait(false);
+                    entry.SetValue(result);
+                }
             }
 
             return (TItem)result;

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
@@ -43,58 +43,48 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value)
         {
-            using (ICacheEntry entry = cache.CreateEntry(key))
-            {
-                entry.Value = value;
-            }
+            using ICacheEntry entry = cache.CreateEntry(key);
+            entry.Value = value;
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, DateTimeOffset absoluteExpiration)
         {
-            using (ICacheEntry entry = cache.CreateEntry(key))
-            {
-                entry.AbsoluteExpiration = absoluteExpiration;
-                entry.Value = value;
-            }
+            using ICacheEntry entry = cache.CreateEntry(key);
+            entry.AbsoluteExpiration = absoluteExpiration;
+            entry.Value = value;
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, TimeSpan absoluteExpirationRelativeToNow)
         {
-            using (ICacheEntry entry = cache.CreateEntry(key))
-            {
-                entry.AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow;
-                entry.Value = value;
-            }
+            using ICacheEntry entry = cache.CreateEntry(key);
+            entry.AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow;
+            entry.Value = value;
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, IChangeToken expirationToken)
         {
-            using (ICacheEntry entry = cache.CreateEntry(key))
-            {
-                entry.AddExpirationToken(expirationToken);
-                entry.Value = value;
-            }
+            using ICacheEntry entry = cache.CreateEntry(key);
+            entry.AddExpirationToken(expirationToken);
+            entry.Value = value;
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, MemoryCacheEntryOptions options)
         {
-            using (ICacheEntry entry = cache.CreateEntry(key))
+            using ICacheEntry entry = cache.CreateEntry(key);
+            if (options != null)
             {
-                if (options != null)
-                {
-                    entry.SetOptions(options);
-                }
-
-                entry.Value = value;
+                entry.SetOptions(options);
             }
+
+            entry.Value = value;
 
             return value;
         }
@@ -103,11 +93,10 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (!cache.TryGetValue(key, out object result))
             {
-                using (ICacheEntry entry = cache.CreateEntry(key))
-                {
-                    result = factory(entry);
-                    entry.SetValue(result);
-                }
+                using ICacheEntry entry = cache.CreateEntry(key);
+
+                result = factory(entry);
+                entry.Value = result;
             }
 
             return (TItem)result;
@@ -117,11 +106,10 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (!cache.TryGetValue(key, out object result))
             {
-                using (ICacheEntry entry = cache.CreateEntry(key))
-                {
-                    result = await factory(entry).ConfigureAwait(false);
-                    entry.SetValue(result);
-                }
+                using ICacheEntry entry = cache.CreateEntry(key);
+
+                result = await factory(entry).ConfigureAwait(false);
+                entry.Value = result;
             }
 
             return (TItem)result;

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.Caching.Memory
         private TimeSpan? _slidingExpiration;
         private long? _size;
         private IDisposable _scope;
+        private object _value;
 
         internal readonly object _lock = new object();
 
@@ -182,7 +183,17 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public object Key { get; private set; }
 
-        public object Value { get; set; }
+        public object Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                ValueHasBeenSet = true;
+            }
+        }
+
+        internal bool ValueHasBeenSet { get; private set; }
 
         internal DateTimeOffset LastAccessed { get; set; }
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Extensions.Caching.Memory
 {
     internal class CacheEntry : ICacheEntry
     {
-        private bool _added;
+        private bool _disposed;
         private static readonly Action<object> ExpirationCallback = ExpirationTokensExpired;
         private readonly Action<CacheEntry> _notifyCacheOfExpiration;
-        private readonly Action<CacheEntry> _notifyCacheEntryDisposed;
+        private readonly Action<CacheEntry> _notifyCacheEntryCommit;
         private IList<IDisposable> _expirationTokenRegistrations;
         private IList<PostEvictionCallbackRegistration> _postEvictionCallbacks;
         private bool _isExpired;
@@ -28,12 +28,13 @@ namespace Microsoft.Extensions.Caching.Memory
         private long? _size;
         private IDisposable _scope;
         private object _value;
+        private bool _valueHasBeenSet;
 
         internal readonly object _lock = new object();
 
         internal CacheEntry(
             object key,
-            Action<CacheEntry> notifyCacheEntryDisposed,
+            Action<CacheEntry> notifyCacheEntryCommit,
             Action<CacheEntry> notifyCacheOfExpiration,
             ILogger logger)
         {
@@ -42,9 +43,9 @@ namespace Microsoft.Extensions.Caching.Memory
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (notifyCacheEntryDisposed == null)
+            if (notifyCacheEntryCommit == null)
             {
-                throw new ArgumentNullException(nameof(notifyCacheEntryDisposed));
+                throw new ArgumentNullException(nameof(notifyCacheEntryCommit));
             }
 
             if (notifyCacheOfExpiration == null)
@@ -58,7 +59,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Key = key;
-            _notifyCacheEntryDisposed = notifyCacheEntryDisposed;
+            _notifyCacheEntryCommit = notifyCacheEntryCommit;
             _notifyCacheOfExpiration = notifyCacheOfExpiration;
 
             _scope = CacheEntryHelper.EnterScope(this);
@@ -189,11 +190,9 @@ namespace Microsoft.Extensions.Caching.Memory
             set
             {
                 _value = value;
-                ValueHasBeenSet = true;
+                _valueHasBeenSet = true;
             }
         }
-
-        internal bool ValueHasBeenSet { get; private set; }
 
         internal DateTimeOffset LastAccessed { get; set; }
 
@@ -201,12 +200,19 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public void Dispose()
         {
-            if (!_added)
+            if (!_disposed)
             {
-                _added = true;
+                _disposed = true;
                 _scope.Dispose();
-                _notifyCacheEntryDisposed(this);
-                PropagateOptions(CacheEntryHelper.Current);
+
+                // Don't commit or propagate options if the CacheEntry Value was never set.
+                // We assume an exception occurred causing the caller to not set the Value successfully,
+                // so don't use this entry.
+                if (_valueHasBeenSet)
+                {
+                    _notifyCacheEntryCommit(this);
+                    PropagateOptions(CacheEntryHelper.Current);
+                }
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -203,7 +203,11 @@ namespace Microsoft.Extensions.Caching.Memory
             if (!_disposed)
             {
                 _disposed = true;
+
+                // Ensure the _scope reference is cleared because it can reference other CacheEntry instances.
+                // This CacheEntry is going to be put into a MemoryCache, and we don't want to root unnecessary objects.
                 _scope.Dispose();
+                _scope = null;
 
                 // Don't commit or propagate options if the CacheEntry Value was never set.
                 // We assume an exception occurred causing the caller to not set the Value successfully,

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -116,13 +116,6 @@ namespace Microsoft.Extensions.Caching.Memory
                 return;
             }
 
-            if (!entry.ValueHasBeenSet)
-            {
-                // No-op if the CacheEntry Value was never set. We assume an exception occurred and the caller
-                // never set the Value successfully, so don't use this entry.
-                return;
-            }
-
             if (_options.SizeLimit.HasValue && !entry.Size.HasValue)
             {
                 throw new InvalidOperationException($"Cache entry must specify a value for {nameof(entry.Size)} when {nameof(_options.SizeLimit)} is set.");

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -116,6 +116,13 @@ namespace Microsoft.Extensions.Caching.Memory
                 return;
             }
 
+            if (!entry.ValueHasBeenSet)
+            {
+                // No-op if the CacheEntry Value was never set. We assume an exception occurred and the caller
+                // never set the Value successfully, so don't use this entry.
+                return;
+            }
+
             if (_options.SizeLimit.HasValue && !entry.Size.HasValue)
             {
                 throw new InvalidOperationException($"Cache entry must specify a value for {nameof(entry.Size)} when {nameof(_options.SizeLimit)} is set.");

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
@@ -180,6 +180,9 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Assert.False(cache.TryGetValue(key, out int obj));
+
+            // verify that throwing an exception doesn't leak CacheEntry objects
+            Assert.Null(CacheEntryHelper.Current);
         }
 
         [Fact]
@@ -199,6 +202,9 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Assert.False(cache.TryGetValue(key, out int obj));
+
+            // verify that throwing an exception doesn't leak CacheEntry objects
+            Assert.Null(CacheEntryHelper.Current);
         }
 
         [Fact]


### PR DESCRIPTION
When an exception is thrown inside MemoryCache.GetOrCreate, we are leaking CacheEntry objects. This is because they are not being Disposed properly, and the async local CacheEntryStack is growing indefinitely.

The fix is to ensure the CacheEntry objects are disposed correctly. In order to do this, I set a flag to indicate whether the CacheEntry.Value has been set. If it hasn't, Disposing the CacheEntry won't add it to the cache.

Fix #42321