### PR TITLE
Fix MacOS createdump testing failures

### DIFF
--- a/src/coreclr/src/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/src/debug/createdump/crashinfo.cpp
@@ -477,11 +477,6 @@ CrashInfo::InsertMemoryRegion(const MemoryRegion& region)
             m_memoryRegions.insert(region);
             return;
         }
-        else 
-        {
-            TRACE("INVALID REGION #1 ");
-            region.Trace();
-        }
     }
     else
     {
@@ -509,11 +504,6 @@ CrashInfo::InsertMemoryRegion(const MemoryRegion& region)
             // All the single pages added here will be combined in CombineMemoryRegions()
             if (ValidRegion(memoryRegionPage)) {
                 m_memoryRegions.insert(memoryRegionPage);
-            }
-            else 
-            {
-                TRACE("INVALID REGION #2 ");
-                region.Trace();
             }
         }
         else {

--- a/src/coreclr/src/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/src/debug/createdump/crashinfo.cpp
@@ -477,6 +477,11 @@ CrashInfo::InsertMemoryRegion(const MemoryRegion& region)
             m_memoryRegions.insert(region);
             return;
         }
+        else 
+        {
+            TRACE("INVALID REGION #1 ");
+            region.Trace();
+        }
     }
     else
     {
@@ -504,6 +509,11 @@ CrashInfo::InsertMemoryRegion(const MemoryRegion& region)
             // All the single pages added here will be combined in CombineMemoryRegions()
             if (ValidRegion(memoryRegionPage)) {
                 m_memoryRegions.insert(memoryRegionPage);
+            }
+            else 
+            {
+                TRACE("INVALID REGION #2 ");
+                region.Trace();
             }
         }
         else {

--- a/src/coreclr/src/debug/createdump/memoryregion.h
+++ b/src/coreclr/src/debug/createdump/memoryregion.h
@@ -124,7 +124,7 @@ public:
 
     void Trace() const
     {
-        TRACE("%" PRIA PRIx64 " - %" PRIA PRIx64 " (%06" PRId64 ") %" PRIA PRIx64 " %c%c%c%c%c%c %s\n",
+        TRACE("%" PRIA PRIx64 " - %" PRIA PRIx64 " (%06" PRIx64 ") %" PRIA PRIx64 " %c%c%c%c%c%c %02x %s\n",
             m_startAddress,
             m_endAddress,
             Size() / PAGE_SIZE,
@@ -135,6 +135,7 @@ public:
             (m_flags & MEMORY_REGION_FLAG_SHARED) ? 's' : '-',
             (m_flags & MEMORY_REGION_FLAG_PRIVATE) ? 'p' : '-',
             (m_flags & MEMORY_REGION_FLAG_MEMORY_BACKED) ? 'b' : '-',
+            m_flags,
             m_fileName.c_str());
     }
 };


### PR DESCRIPTION
There are a few things that are causing MacOS dumps not to be complete and causing the diagnostics SOS tests to fail:

1) The threads were completely stopped with the per thread suspend. Switch from thread_suspend to task_suspend.
2) .Stopping filtering out SM_EMPTY share_mode type memory regions. There are read/write sections that are needed in the dump by the tools