### PR TITLE
Fix typos in comment

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/GC.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/GC.Mono.cs
@@ -268,8 +268,8 @@ namespace System
 
         public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false)
         {
-            // Mono only does explicit zeroning if the array is to big for the nursery, but less than 1 Mb - 4 kb.
-            // If it is bigger than that, we grab memoroy directly from the OS which comes pre-zeroed.
+            // Mono only does explicit zeroing if the array is too big for the nursery, but less than 1 Mb - 4 kb.
+            // If it is bigger than that, we grab memory directly from the OS which comes pre-zeroed.
             // Experimentation shows that if we just skip the zeroing in this case, we do not save a measurable
             // amount of time. So we just allocate the normal way here.
             // Revist if we change LOS implementation.


### PR DESCRIPTION
Fix a handful of typos in a comment for `AllocateUninitializedArray<T>()`.
