### PR TITLE
Console.Unix: fix terminal settings during Console.KeyAvailable

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_console.c
+++ b/src/libraries/Native/Unix/System.Native/pal_console.c
@@ -378,7 +378,7 @@ void SystemNative_GetControlCharacters(
 
 int32_t SystemNative_StdinReady()
 {
-    SystemNative_InitializeConsoleBeforeRead(1, 0, 0);
+    SystemNative_InitializeConsoleBeforeRead(/* convertCrToNl */ 0, /* minChars */ 1, /* decisecondsTimeout */ 0);
     struct pollfd fd = { .fd = STDIN_FILENO, .events = POLLIN };
     int rv = poll(&fd, 1, 0) > 0 ? 1 : 0;
     SystemNative_UninitializeConsoleAfterRead();

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -89,6 +89,28 @@ namespace System
             AssertUserExpectedResults("\"console\" correctly not echoed as you typed it");
         }
 
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void EnterKeyIsEnterAfterKeyAvailableCheck()
+        {
+            Console.WriteLine("Please hold down the 'Enter' key for some time. You shouldn't see new lines appear:");
+            int keysRead = 0;
+            while (keysRead < 50)
+            {
+                if (Console.KeyAvailable)
+                {
+                    ConsoleKeyInfo keyInfo = Console.ReadKey(true);
+                    Assert.Equal(ConsoleKey.Enter, keyInfo.Key);
+                    keysRead++;
+                }
+            }
+            while (Console.KeyAvailable)
+            {
+                ConsoleKeyInfo keyInfo = Console.ReadKey(true);
+                Assert.Equal(ConsoleKey.Enter, keyInfo.Key);
+            }
+            AssertUserExpectedResults("no empty newlines appear");
+        }
+
         [ConditionalTheory(nameof(ManualTestsEnabled))]
         [MemberData(nameof(GetKeyChords))]
         public static void ReadKey_KeyChords(ConsoleKeyInfo expected)


### PR DESCRIPTION
Arguments passed to configure the terminal are in the wrong order.
This causes Enter keys to be returned as ConsoleKey.J instead of
ConsoleKey.Enter.

Fixes https://github.com/dotnet/runtime/issues/42333.
Regressed in https://github.com/dotnet/runtime/pull/37491.

cc @eiriktsarpalis @danmosemsft 