### PR TITLE
Cleanup libraries CMakeLists

### DIFF
--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -102,7 +102,12 @@ endif()
 string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
 
 if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL CHECKED)
-    add_compile_options(-O0)
+    if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+        add_compile_options(-O0)
+    elseif (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL CHECKED)
+        add_compile_options(-O2)
+    endif ()
+
     add_definitions(-DDEBUG)
 
     # obtain settings from running coreclr\enablesanitizers.sh

--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -100,7 +100,8 @@ if(CLR_CMAKE_TARGET_ANDROID)
 endif()
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
-if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+
+if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL CHECKED)
     add_compile_options(-O0)
     add_definitions(-DDEBUG)
 
@@ -118,10 +119,10 @@ if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
         message("Undefined Behavior Sanitizer (ubsan) enabled")
       endif ()
 
-      set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} ${CLR_SANITIZE_LINK_FLAGS}")
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CLR_SANITIZE_LINK_FLAGS}")
 
       # -Wl and --gc-sections: drop unused sections\functions (similar to Windows /Gy function-level-linking)
-      set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} ${CLR_SANITIZE_LINK_FLAGS} -Wl,--gc-sections")
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CLR_SANITIZE_LINK_FLAGS} -Wl,--gc-sections")
     endif ()
 elseif (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
     # Use O1 option when the clang version is smaller than 3.9

--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -70,11 +70,18 @@ list(APPEND __SharedLinkArgs /GUARD:CF)
 # For Release builds, we shall dynamically link into uCRT [ucrtbase.dll] (which is pushed down as a Windows Update on downlevel OS) but
 # won't do the same for debug/checked builds since ucrtbased.dll is not redistributable and Debug/Checked builds are not
 # production-time scenarios.
-add_compile_options(/MT$<$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>:d>)
+
+add_compile_options($<$<CONFIG:DEBUG>:/MTd>)
+add_compile_options($<$<CONFIG:RELEASE>:/MT>)
+
 add_compile_options($<$<CONFIG:RELEASE>:/GL>)
 add_compile_options($<$<CONFIG:RELEASE>:/O1>)
-list(APPEND __LinkLibraries libcmt$<$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>:d>.lib)
-list(APPEND __LinkLibraries libvcruntime$<$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>:d>.lib)
+
+list(APPEND __LinkLibraries $<$<CONFIG:DEBUG>:libcmtd.lib>)
+list(APPEND __LinkLibraries $<$<CONFIG:RELEASE>:libcmt.lib>)
+
+list(APPEND __LinkLibraries $<$<CONFIG:DEBUG>:libvcruntimed.lib>)
+list(APPEND __LinkLibraries $<$<CONFIG:RELEASE>:libvcruntime.lib>)
 
 # Linker flags
 list(APPEND __SharedLinkArgs /INCREMENTAL:NO)

--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -11,7 +11,12 @@ SET (CMAKE_ASM_MASM_FLAGS                   "${CMAKE_ASM_MASM_FLAGS} /ZH:SHA_256
 SET (CMAKE_INSTALL_PREFIX                   $ENV{__CMakeBinDir})
 SET (CMAKE_INCLUDE_CURRENT_DIR              ON)
 SET (CMAKE_SHARED_LIBRARY_PREFIX            "")
-SET (__LinkArgs $ENV{__LinkArgs})
+
+set(__SharedLinkArgs)
+set(__LinkArgs)
+if ($ENV{__LinkArgs})
+    SET (__LinkArgs $ENV{__LinkArgs})
+endif()
 
 # Force an out of source build
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
@@ -19,7 +24,6 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif()
 
 project(CoreFX)
-string(TOUPPER $ENV{CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
 
 # The following options are set by the razzle build
 add_compile_options(/d2Zi+)       # make optimized builds debugging easier
@@ -58,7 +62,7 @@ endif ()
 
 # enable control-flow-guard support for native components
 add_compile_options(/guard:cf) 
-set(__LinkArgs "${__LinkArgs} /GUARD:CF")
+list(APPEND __SharedLinkArgs /GUARD:CF)
 
 # Statically linked CRT (libcmt[d].lib, libvcruntime[d].lib and libucrt[d].lib) by default. This is done to avoid
 # linking in VCRUNTIME140.DLL for a simplified xcopy experience by reducing the dependency on VC REDIST.
@@ -66,64 +70,46 @@ set(__LinkArgs "${__LinkArgs} /GUARD:CF")
 # For Release builds, we shall dynamically link into uCRT [ucrtbase.dll] (which is pushed down as a Windows Update on downlevel OS) but
 # won't do the same for debug/checked builds since ucrtbased.dll is not redistributable and Debug/Checked builds are not
 # production-time scenarios.
-if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
-    add_compile_options(/MT)
-    add_compile_options(/GL)
-    add_compile_options(/O1)
-    set(__LinkLibraries "${__LinkLibraries} libcmt.lib")
-    set(__LinkLibraries "${__LinkLibraries} libvcruntime.lib")
-    set(STATIC_UCRT_LIB "libucrt.lib")
-    set(DYNAMIC_UCRT_LIB "ucrt.lib")
-else()
-    add_compile_options(/MTd)
-    set(__LinkLibraries "${__LinkLibraries} libcmtd.lib")
-    set(__LinkLibraries "${__LinkLibraries} libvcruntimed.lib")
-    set(STATIC_UCRT_LIB "libucrtd.lib")
-    set(DYNAMIC_UCRT_LIB "ucrtd.lib")
-endif()
+add_compile_options(/MT$<$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>:d>)
+add_compile_options($<$<CONFIG:RELEASE>:/GL>)
+add_compile_options($<$<CONFIG:RELEASE>:/O1>)
+list(APPEND __LinkLibraries libcmt$<$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>:d>.lib)
+list(APPEND __LinkLibraries libvcruntime$<$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>:d>.lib)
 
 # Linker flags
-set(__LinkArgs "${__LinkArgs} /INCREMENTAL:NO")
-set(__LinkArgs "${__LinkArgs} /MANIFEST:NO")            #Do not create Side-by-Side Assembly Manifest
-set(__LinkArgs "${__LinkArgs} /LARGEADDRESSAWARE")      # can handle addresses larger than 2 gigabytes
-set(__LinkArgs "${__LinkArgs} /RELEASE")                #sets the checksum in the header
-set(__LinkArgs "${__LinkArgs} /NXCOMPAT")               #Compatible with Data Execution Prevention
-set(__LinkArgs "${__LinkArgs} /DYNAMICBASE")            #Use address space layout randomization
-set(__LinkArgs "${__LinkArgs} /DEBUGTYPE:cv,fixup")     #debugging format
-set(__LinkArgs "${__LinkArgs} /PDBCOMPRESS")            #shrink pdb size
-set(__LinkArgs "${__LinkArgs} /DEBUG")
-set(__LinkArgs "${__LinkArgs} /IGNORE:4197,4013,4254,4070,4221")
+list(APPEND __SharedLinkArgs /INCREMENTAL:NO)
+list(APPEND __SharedLinkArgs /MANIFEST:NO)            #Do not create Side-by-Side Assembly Manifest
+list(APPEND __SharedLinkArgs /LARGEADDRESSAWARE)      # can handle addresses larger than 2 gigabytes
+list(APPEND __SharedLinkArgs /RELEASE)                #sets the checksum in the header
+list(APPEND __SharedLinkArgs /NXCOMPAT)               #Compatible with Data Execution Prevention
+list(APPEND __SharedLinkArgs /DYNAMICBASE)            #Use address space layout randomization
+list(APPEND __SharedLinkArgs /DEBUGTYPE:cv,fixup)     #debugging format
+list(APPEND __SharedLinkArgs /PDBCOMPRESS)            #shrink pdb size
+list(APPEND __SharedLinkArgs /DEBUG)
+list(APPEND __SharedLinkArgs /IGNORE:4197,4013,4254,4070,4221)
 
-if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
-    # Release build specific flags
-    set(__LinkArgs "${__LinkArgs} /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO")
-    
-    # Force uCRT to be dynamically linked for Release build (unless env variable CLR_CMAKE_WIN32_FORCE_STATIC_LINK is set to true)
-    set(CLR_CMAKE_WIN32_FORCE_STATIC_LINK $ENV{CLR_CMAKE_WIN32_FORCE_STATIC_LINK})
-    if(NOT CLR_CMAKE_WIN32_FORCE_STATIC_LINK)
-      set(__LinkArgs "${__LinkArgs} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
-    endif()
-    
-    if ($ENV{__BuildArch} STREQUAL x86)
-        set(__LinkArgs "${__LinkArgs} /SAFESEH")
-    endif()
-else()
-    # Debug build specific flags
-    set(__LinkArgs "/NOVCFEATURE ${__LinkArgs}")
+# Release build specific flags
+list(APPEND __LinkArgs $<$<CONFIG:RELEASE>:/LTCG>)
+list(APPEND __SharedLinkArgs $<$<CONFIG:RELEASE>:/OPT:REF>)
+list(APPEND __SharedLinkArgs $<$<CONFIG:RELEASE>:/OPT:ICF>)
+
+# Force uCRT to be dynamically linked for Release build (unless env variable CLR_CMAKE_WIN32_FORCE_STATIC_LINK is set to true)
+set(CLR_CMAKE_WIN32_FORCE_STATIC_LINK $ENV{CLR_CMAKE_WIN32_FORCE_STATIC_LINK})
+if(NOT CLR_CMAKE_WIN32_FORCE_STATIC_LINK)
+    list(APPEND __SharedLinkArgs $<$<CONFIG:RELEASE>:/NODEFAULTLIB:libucrt.lib>)
+    list(APPEND __SharedLinkArgs $<$<CONFIG:RELEASE>:/DEFAULTLIB:ucrt.lib>)
 endif()
+
+# Debug build specific flags
+list(INSERT __SharedLinkArgs 0 $<$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>:/NOVCFEATURE>)
 
 if ($ENV{__BuildArch} STREQUAL "x86_64" OR $ENV{__BuildArch} STREQUAL "amd64")
     add_definitions(-DTARGET_64BIT=1)
 endif ()
 
-if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-    # Do not define DEBUG. zlib has asserts under DEBUG for non-catastrophic cases,
-    # such as on bad user-provided inputs.  We leave NDEBUG defined, however,
-    # as other asserts should still be included.
-elseif (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
-    add_definitions(-DNDEBUG)
-else ()
-    message(FATAL_ERROR "Unknown build type. Set CMAKE_BUILD_TYPE to DEBUG or RELEASE.")
-endif ()
+# Do not define DEBUG. zlib has asserts under DEBUG for non-catastrophic cases,
+# such as on bad user-provided inputs.  We leave NDEBUG defined, however,
+# as other asserts should still be included.
+add_compile_definitions($<$<CONFIG:RELEASE>:NDEBUG>)
 
 add_subdirectory(clrcompression)

--- a/src/libraries/Native/Windows/clrcompression/CMakeLists.txt
+++ b/src/libraries/Native/Windows/clrcompression/CMakeLists.txt
@@ -88,14 +88,12 @@ SET_TARGET_PROPERTIES(clrcompression-static PROPERTIES PREFIX "")
 SET_TARGET_PROPERTIES(clrcompression-static PROPERTIES OUTPUT_NAME libclrcompression)
 
 # Allow specification of arguments that should be passed to the linker
-SET_TARGET_PROPERTIES(clrcompression PROPERTIES LINK_FLAGS ${__LinkArgs})
-SET_TARGET_PROPERTIES(clrcompression-static PROPERTIES LINK_FLAGS ${__LinkArgs})
+SET_TARGET_PROPERTIES(clrcompression PROPERTIES LINK_OPTIONS "${__LinkArgs};${__SharedLinkArgs}")
+SET_TARGET_PROPERTIES(clrcompression-static PROPERTIES STATIC_LIBRARY_OPTIONS "${__LinkArgs}")
 
 # Allow specification of libraries that should be linked against
-# CMake doesn't like space delimiters as input to target_link_libraries
-separate_arguments(linker_libs_sanitized WINDOWS_COMMAND ${__LinkLibraries})
-target_link_libraries(clrcompression ${linker_libs_sanitized})
-target_link_libraries(clrcompression-static ${linker_libs_sanitized})
+target_link_libraries(clrcompression ${__LinkLibraries})
+target_link_libraries(clrcompression-static ${__LinkLibraries})
 
 GENERATE_EXPORT_HEADER( clrcompression
      BASE_NAME clrcompression


### PR DESCRIPTION
The Windows CMakeLists.txt was unnecessarily using build configuration
information extracted from an environment variable to set
configuration specific options. Generator expressions are a better way
to handle that.

Besides that, I've also added support for Checked build.

Both of these changes are needed for the single exe host work where
libraries will be built during coreclr build.