### PR TITLE
 [Mono] [GC] Fix TotalBytesAllocated and reenable test

### DIFF
--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -870,7 +870,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/2280", TestRuntimes.Mono)]
         public static void GetTotalAllocatedBytes()
         {
             byte[] stash;

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2216,7 +2216,7 @@ sgen_client_thread_detach_with_lock (SgenThreadInfo *p)
 
 	mono_tls_set_sgen_thread_info (NULL);
 
-	sgen_increment_bytes_allocated_detached (p->total_bytes_allocated);
+	sgen_increment_bytes_allocated_detached (p->total_bytes_allocated + (p->tlab_next - p->tlab_start));
 
 	tid = mono_thread_info_get_tid (p);
 


### PR DESCRIPTION
TotalBytesAllocated was sometimes not monotonically increasing on Mono. The reason was that when a thread was detached, we were not counting bytes allocated in its thread local allocation buffer. So, under the right circumstances the bytes would be counted while the thread is attached, but then get lost when the thread detached.

Fixes: https://github.com/dotnet/runtime/issues/2280