### PR TITLE
Fix build warning/error about converting a constant to a boolean

### DIFF
--- a/src/coreclr/src/jit/emitarm.cpp
+++ b/src/coreclr/src/jit/emitarm.cpp
@@ -5550,7 +5550,7 @@ BYTE* emitter::emitOutputShortBranch(BYTE* dst, instruction ins, insFormat fmt, 
     else if (fmt == IF_T1_I)
     {
         assert(id != NULL);
-        assert(ins == INS_cbz || INS_cbnz);
+        assert(ins == INS_cbz || ins == INS_cbnz);
         assert((distVal & 1) == 0);
         assert(distVal >= 0);
         assert(distVal <= 126);


### PR DESCRIPTION
On Fedora 32 with Clang 10, I get this warning/error when building coreclr:

    /home/omajid/devel/dotnet/runtime/src/coreclr/src/jit/emitarm.cpp:5553:31: error: converting the enum constant to a boolean [-Werror,-Wint-in-bool-context]
            assert(ins == INS_cbz || INS_cbnz);
                                  ^

This looks like a bug that should be fixed: ins should be compared with the constant on both sides of the boolean operator. Otherwise the conditional can always evaluate to true.