### PR TITLE
Make nullable-related checks consistent and faster

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;netcoreapp3.0;net461</TargetFrameworks>
@@ -182,7 +182,6 @@
     <Compile Include="System\Text\Json\Serialization\WriteStackFrame.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.Serialization.cs" />
-    <Compile Include="System\Text\Json\TypeExtensions.cs" />
     <Compile Include="System\Text\Json\Writer\JsonWriterHelper.cs" />
     <Compile Include="System\Text\Json\Writer\JsonWriterHelper.Date.cs" />
     <Compile Include="System\Text\Json\Writer\JsonWriterHelper.Escaping.cs" />
@@ -217,6 +216,7 @@
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.SignedNumber.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.String.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.UnsignedNumber.cs" />
+    <Compile Include="System\TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverterFactory.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override bool CanConvert(Type typeToConvert)
         {
-            return Nullable.GetUnderlyingType(typeToConvert) != null;
+            return typeToConvert.IsNullableOfT();
         }
 
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/GenericMethodHolder.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/GenericMethodHolder.cs
@@ -26,7 +26,7 @@ namespace System.Text.Json.Serialization
         {
             // For performance, we only want to call this method for non-nullable value types.
             // Nullable types should be checked againt 'null' before calling this method.
-            Debug.Assert(Nullable.GetUnderlyingType(value.GetType()) == null);
+            Debug.Assert(!value.GetType().CanBeNull());
 
             return EqualityComparer<T>.Default.Equals(default, (T)value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization
             // In the future, this will be check for !IsSealed (and excluding value types).
             CanBePolymorphic = TypeToConvert == JsonClassInfo.ObjectType;
             IsValueType = TypeToConvert.IsValueType;
-            CanBeNull = !IsValueType || Nullable.GetUnderlyingType(TypeToConvert) != null;
+            CanBeNull = !IsValueType || TypeToConvert.IsNullableOfT();
             IsInternalConverter = GetType().Assembly == typeof(JsonConverter).Assembly;
 
             if (HandleNull)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -12,7 +12,6 @@ namespace System.Text.Json
     internal abstract class JsonPropertyInfo
     {
         public static readonly JsonPropertyInfo s_missingProperty = GetPropertyPlaceholder();
-        public static readonly Type s_NullableType = typeof(Nullable<>);
 
         private JsonClassInfo? _runtimeClassInfo;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -105,8 +105,7 @@ namespace System.Text.Json
             }
 
             _converterIsExternalAndPolymorphic = !converter.IsInternalConverter && DeclaredPropertyType != converter.TypeToConvert;
-            _propertyTypeCanBeNull = !DeclaredPropertyType.IsValueType ||
-                (DeclaredPropertyType.IsGenericType && DeclaredPropertyType.GetGenericTypeDefinition() == s_NullableType);
+            _propertyTypeCanBeNull = DeclaredPropertyType.CanBeNull();
             _propertyTypeEqualsTypeToConvert = typeof(T) == DeclaredPropertyType;
 
             GetPolicies(ignoreCondition, parentTypeNumberHandling, defaultValueIsNull: _propertyTypeCanBeNull);
@@ -285,7 +284,7 @@ namespace System.Text.Json
                                     ThrowHelper.ThrowInvalidCastException_DeserializeUnableToAssignValue(typeOfValue, DeclaredPropertyType);
                                 }
                             }
-                            else if (DeclaredPropertyType.IsValueType && !DeclaredPropertyType.IsNullableValueType())
+                            else if (!_propertyTypeCanBeNull)
                             {
                                 ThrowHelper.ThrowInvalidOperationException_DeserializeUnableToAssignNull(DeclaredPropertyType);
                             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -185,7 +185,7 @@ namespace System.Text.Json
             // We also throw to avoid passing an invalid argument to setters for nullable struct properties,
             // which would cause an InvalidProgramException when the generated IL is invoked.
             // This is not an issue of the converter is wrapped in NullableConverter<T>.
-            if (runtimePropertyType.IsNullableType() && !converter.TypeToConvert.IsNullableType())
+            if (runtimePropertyType.CanBeNull() && !converter.TypeToConvert.CanBeNull())
             {
                 ThrowHelper.ThrowInvalidOperationException_ConverterCanConvertNullableRedundant(runtimePropertyType, converter);
             }

--- a/src/libraries/System.Text.Json/src/System/TypeExtensions.cs
+++ b/src/libraries/System.Text.Json/src/System/TypeExtensions.cs
@@ -1,27 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
     internal static class TypeExtensions
     {
-        private static readonly Type s_NullableType = typeof(Nullable<>);
+        private static readonly Type s_nullableType = typeof(Nullable<>);
 
         /// <summary>
         /// Returns <see langword="true" /> when the given type is of type <see cref="Nullable{T}"/>.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNullableOfT(this Type type) =>
-            type.IsGenericType && type.GetGenericTypeDefinition() == s_NullableType;
+            type.IsGenericType && type.GetGenericTypeDefinition() == s_nullableType;
 
         /// <summary>
         /// Returns <see langword="true" /> when the given type is either a reference type or of type <see cref="Nullable{T}"/>.
         /// </summary>
         /// <remarks>This calls <see cref="Type.IsValueType"/> which is slow. If knowledge already exists
         /// that the type is a value type, call <see cref="IsNullableOfT"/> instead.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CanBeNull(this Type type) =>
-            !type.IsValueType || (type.IsGenericType && type.GetGenericTypeDefinition() == s_NullableType);
+            !type.IsValueType || type.IsNullableOfT();
 
         /// <summary>
         /// Returns <see langword="true" /> when the given type is assignable from <paramref name="from"/> including support


### PR DESCRIPTION
Based on feedback and timings from https://github.com/dotnet/runtime/pull/42319, updated other areas in STJ to use a faster way to check for nullability.

Ran existing benchmarks locally and these changes didn't measurably affect performance; see the [micro benchmarks from the PR linked above](https://github.com/dotnet/runtime/pull/42319#discussion_r489564665).

