### PR TITLE
Fix mapping of files from bundle to only map the necessary part

### DIFF
--- a/src/coreclr/src/vm/peimagelayout.cpp
+++ b/src/coreclr/src/vm/peimagelayout.cpp
@@ -712,6 +712,8 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
         if (m_FileMap == NULL)
             ThrowLastError();
 
+        // - Windows - MapViewOfFileEx requires offset to be allocation granularity aligned (typically 64KB)
+        // - Linux/OSX - mmap requires offset to be page aligned (PAL sets allocation granularity to page size)
         UINT32 alignment = g_SystemInfo.dwAllocationGranularity;
         UINT64 mapBegin = AlignDown((UINT64)offset, alignment);
         UINT64 mapSize = ((UINT64)(offset + size)) - mapBegin;

--- a/src/coreclr/src/vm/peimagelayout.cpp
+++ b/src/coreclr/src/vm/peimagelayout.cpp
@@ -712,14 +712,20 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
         if (m_FileMap == NULL)
             ThrowLastError();
 
-        //DWORD lowPart = (DWORD)offset;
-        //DWORD highPart = (DWORD)(offset >> 32);
-        char *addr = (char*)CLRMapViewOfFile(m_FileMap, FILE_MAP_READ, 0, 0, 0);
-        addr += offset;
-        m_FileView.Assign((LPVOID)addr);
+        UINT32 alignment = g_SystemInfo.dwAllocationGranularity;
+        UINT64 mapBegin = AlignDown((UINT64)offset, alignment);
+        UINT64 mapSize = ((UINT64)(offset + size)) - mapBegin;
 
-        if (m_FileView == NULL)
+        _ASSERTE((offset - mapBegin) < alignment);
+        _ASSERTE((offset - mapBegin) < mapSize);
+        _ASSERTE(mapSize >= (UINT64)size);
+
+        char *addr = (char*)CLRMapViewOfFile(m_FileMap, FILE_MAP_READ, mapBegin >> 32, (DWORD)mapBegin, (DWORD)mapSize);
+        if (addr == NULL)
             ThrowLastError();
+
+        addr += (offset - mapBegin);
+        m_FileView.Assign((LPVOID)addr);
     }
     Init(m_FileView, (COUNT_T)size);
 }


### PR DESCRIPTION
Mapping the whole bundle every time leads to VM space starvation. Which mostly matters on 32bit.

The fix is to map just the part of the bundle file which contains the assembly we're after. Memory mapping API needs the offset to be aligned to allocation granularity, so a bit more math to prealign and so on, but otherwise straightforward.

Fixes https://github.com/dotnet/runtime/issues/41816