### PR TITLE
[release/5.0-rc2] Support sending events from runtime to debugging proxy

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -220,7 +220,7 @@ namespace Microsoft.WebAssembly.Diagnostics
     internal class MonoConstants
     {
         public const string RUNTIME_IS_READY = "mono_wasm_runtime_ready";
-        public const string EVENT_RAISED = "mono_wasm_event_raised:aef14bca-5519-4dfe-b35a-f867abc123ae";
+        public const string EVENT_RAISED = "mono_wasm_debug_event_raised:aef14bca-5519-4dfe-b35a-f867abc123ae";
     }
 
     class Frame

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -220,6 +220,7 @@ namespace Microsoft.WebAssembly.Diagnostics
     internal class MonoConstants
     {
         public const string RUNTIME_IS_READY = "mono_wasm_runtime_ready";
+        public const string EVENT_RAISED = "mono_wasm_event_raised:aef14bca-5519-4dfe-b35a-f867abc123ae";
     }
 
     class Frame

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
@@ -140,7 +140,7 @@ namespace DebuggerTests
         }
 
         [Fact]
-        public async Task BadRaiseEventsTest()
+        public async Task BadRaiseDebugEventsTest()
         {
             var insp = new Inspector();
             var scripts = SubscribeToScripts(insp);
@@ -152,12 +152,12 @@ namespace DebuggerTests
 
                 var bad_expressions = new[]
                 {
-                    "MONO.mono_wasm_raise_event('')",
-                    "MONO.mono_wasm_raise_event(undefined)",
-                    "MONO.mono_wasm_raise_event({})",
+                    "MONO.mono_wasm_raise_debug_event('')",
+                    "MONO.mono_wasm_raise_debug_event(undefined)",
+                    "MONO.mono_wasm_raise_debug_event({})",
 
-                    "MONO.mono_wasm_raise_event({eventName:'foo'}, '')",
-                    "MONO.mono_wasm_raise_event({eventName:'foo'}, 12)"
+                    "MONO.mono_wasm_raise_debug_event({eventName:'foo'}, '')",
+                    "MONO.mono_wasm_raise_debug_event({eventName:'foo'}, 12)"
                 };
 
                 foreach (var expression in bad_expressions)
@@ -177,7 +177,7 @@ namespace DebuggerTests
         [InlineData(true)]
         [InlineData(false)]
         [InlineData(null)]
-        public async Task RaiseEventTraceTest(bool? trace)
+        public async Task RaiseDebugEventTraceTest(bool? trace)
         {
             var insp = new Inspector();
             var scripts = SubscribeToScripts(insp);
@@ -191,7 +191,7 @@ namespace DebuggerTests
                 insp.On("Runtime.consoleAPICalled", async (args, token) => {
                     if (args?["type"]?.Value<string>() == "debug" &&
                        args?["args"]?.Type == JTokenType.Array &&
-                       args?["args"]?[0]?["value"]?.Value<string>()?.StartsWith("mono_wasm_event_raised:") == true)
+                       args?["args"]?[0]?["value"]?.Value<string>()?.StartsWith("mono_wasm_debug_event_raised:") == true)
                     {
                         tcs.SetResult(true);
                     }
@@ -200,7 +200,7 @@ namespace DebuggerTests
                 });
 
                 var trace_str = trace.HasValue ? $"trace: {trace.ToString().ToLower()}" : String.Empty;
-                var expression = $"MONO.mono_wasm_raise_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
+                var expression = $"MONO.mono_wasm_raise_debug_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
                 var res = await ctx.cli.SendCommand($"Runtime.evaluate", JObject.FromObject(new { expression }), ctx.token);
                 Assert.True(res.IsOk, $"Expected to pass for {expression}");
 

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -10,6 +10,13 @@
  * @property {object} o - value parsed as JSON
  */
 
+/**
+ * @typedef Event
+ * @type {object}
+ * @property {string} eventName - name of the event being raised
+ * @property {object} eventArgs - arguments for the event itself
+ */
+
 var MonoSupportLib = {
 	$MONO__postset: 'MONO.export_functions (Module);',
 	$MONO: {
@@ -1956,7 +1963,26 @@ var MonoSupportLib = {
 				data = data.slice(length);
 			}
 			return true;
-		}
+		},
+
+		/**
+		 * Raises an event for the debug proxy
+		 *
+		 * @param {Event} event - event to be raised
+		 * @param {object} args - arguments for raising this event, eg. `{trace: true}`
+		 */
+		mono_wasm_raise_event: function(event, args={}) {
+			if (typeof event !== 'object')
+				throw new Error(`event must be an object, but got ${JSON.stringify(event)}`);
+
+			if (event.eventName === undefined)
+				throw new Error(`event.eventName is a required parameter, in event: ${JSON.stringify(event)}`);
+
+			if (typeof args !== 'object')
+				throw new Error(`args must be an object, but got ${JSON.stringify(args)}`);
+
+			console.debug('mono_wasm_event_raised:aef14bca-5519-4dfe-b35a-f867abc123ae', JSON.stringify(event), JSON.stringify(args));
+		},
 	},
 
 	mono_wasm_add_typed_value: function (type, str_value, value) {

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -1971,7 +1971,7 @@ var MonoSupportLib = {
 		 * @param {Event} event - event to be raised
 		 * @param {object} args - arguments for raising this event, eg. `{trace: true}`
 		 */
-		mono_wasm_raise_event: function(event, args={}) {
+		mono_wasm_raise_debug_event: function(event, args={}) {
 			if (typeof event !== 'object')
 				throw new Error(`event must be an object, but got ${JSON.stringify(event)}`);
 
@@ -1981,7 +1981,7 @@ var MonoSupportLib = {
 			if (typeof args !== 'object')
 				throw new Error(`args must be an object, but got ${JSON.stringify(args)}`);
 
-			console.debug('mono_wasm_event_raised:aef14bca-5519-4dfe-b35a-f867abc123ae', JSON.stringify(event), JSON.stringify(args));
+			console.debug('mono_wasm_debug_event_raised:aef14bca-5519-4dfe-b35a-f867abc123ae', JSON.stringify(event), JSON.stringify(args));
 		},
 	},
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/42171 .

This adds support for sending custom events from the app, intended to be processed by the debug proxy. This will be useful for communicating between the two, without waiting for debugger to pause, or some other event to occur.

## Customer Impact

This API is internal and not customer facing.

However, it is a dependency for https://github.com/dotnet/runtime/pull/42403, which adds support for debugging lazily loaded assemblies in response to customer feedback.

## Testing

- New unit tests for this feature
- Also, tested as part of the PR that is based on this one (https://github.com/dotnet/runtime/pull/42403)

## Risk

**Low risk** because the API change has been validated via unit tests and integration in https://github.com/dotnet/runtime/pull/42403.