### PR TITLE
Fix singlefilehost build in non-portable mode

### DIFF
--- a/src/installer/corehost/build.sh
+++ b/src/installer/corehost/build.sh
@@ -92,6 +92,7 @@ export __BinDir __IntermediatesDir __CoreClrArtifacts __NativeLibsArtifacts
 __CMakeArgs="-DCLI_CMAKE_HOST_VER=\"$__host_ver\" -DCLI_CMAKE_COMMON_HOST_VER=\"$__apphost_ver\" -DCLI_CMAKE_HOST_FXR_VER=\"$__fxr_ver\" $__CMakeArgs"
 __CMakeArgs="-DCLI_CMAKE_HOST_POLICY_VER=\"$__policy_ver\" -DCLI_CMAKE_PKG_RID=\"$__DistroRid\" -DCLI_CMAKE_COMMIT_HASH=\"$__commit_hash\" $__CMakeArgs"
 __CMakeArgs="-DCORECLR_ARTIFACTS=\"$__CoreClrArtifacts\" -DNATIVE_LIBS_ARTIFACTS=\"$__NativeLibsArtifacts\" $__CMakeArgs"
+__CMakeArgs="-DFEATURE_DISTRO_AGNOSTIC_SSL=$__PortableBuild $__CMakeArgs"
 
 if [[ "$__PortableBuild" == 1 ]]; then
     __CMakeArgs="-DCLI_CMAKE_PORTABLE_BUILD=1 $__CMakeArgs"

--- a/src/installer/corehost/cli/apphost/static/CMakeLists.txt
+++ b/src/installer/corehost/cli/apphost/static/CMakeLists.txt
@@ -191,6 +191,11 @@ else()
     #     )
     endif ()
 
+    # Additional requirements for System.Security.Cryptography.Native.OpenSsl
+    if(NOT FEATURE_DISTRO_AGNOSTIC_SSL)
+        find_package(OpenSSL)
+    endif()
+
     if(CLR_CMAKE_TARGET_LINUX OR CLR_CMAKE_TARGET_FREEBSD OR CLR_CMAKE_TARGET_NETBSD OR CLR_CMAKE_TARGET_SUNOS)
         # These options are used to force every object to be included even if it's unused.
         set(START_WHOLE_ARCHIVE -Wl,--whole-archive)
@@ -213,3 +218,10 @@ target_link_libraries(singlefilehost
     ${NATIVE_LIBS_EXTRA}
 
 )
+
+if(NOT FEATURE_DISTRO_AGNOSTIC_SSL)
+    target_link_libraries(singlefilehost
+        ${OPENSSL_CRYPTO_LIBRARY}
+        ${OPENSSL_SSL_LIBRARY}
+    )
+endif()


### PR DESCRIPTION
The `singlefilehost` needs to follow libraries build in terms of how it links to OpenSSL: if it's a non-portable build, the singlefilehost needs to link to OpenSSL via linker arguments.

The installer also needs to have `FEATURE_DISTRO_AGNOSTIC_SSL` defined just like it is defined for the libraries build.

Fixes: #41768