### PR TITLE
Fix stackalloc loop in hpack test

### DIFF
--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackIntegerTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackIntegerTest.cs
@@ -55,12 +55,13 @@ namespace System.Net.Http.Unit.Tests.HPack
         public void IntegerEncoderDecoderRoundtrips()
         {
             IntegerDecoder decoder = new IntegerDecoder();
+            Span<byte> integerBytes = stackalloc byte[5];
 
             for (int i = 0; i < 2048; ++i)
             {
                 for (int prefixLength = 1; prefixLength <= 8; ++prefixLength)
                 {
-                    Span<byte> integerBytes = stackalloc byte[5];
+                    integerBytes.Clear();
                     Assert.True(IntegerEncoder.Encode(i, prefixLength, integerBytes, out int length));
 
                     bool decodeResult = decoder.BeginTryDecode(integerBytes[0], prefixLength, out int intResult);


### PR DESCRIPTION
This is a test issue in code shared between aspnetcore and runtime. An analyzer identified the issue in aspnetcore and now I'm backporting the fix.