### PR TITLE
Fix wrong ARM JIT assert

### DIFF
--- a/src/coreclr/src/jit/emitarm.cpp
+++ b/src/coreclr/src/jit/emitarm.cpp
@@ -5550,7 +5550,7 @@ BYTE* emitter::emitOutputShortBranch(BYTE* dst, instruction ins, insFormat fmt, 
     else if (fmt == IF_T1_I)
     {
         assert(id != NULL);
-        assert(ins == INS_cbz || INS_cbnz);
+        assert(ins == INS_cbz || ins == INS_cbnz);
         assert((distVal & 1) == 0);
         assert(distVal >= 0);
         assert(distVal <= 126);


### PR DESCRIPTION
There is a wrong assert in the ARM JIT that I've hit while working on
cross build for ARM64 on x64 OSX. 
Interestingly, it was this way for many years, so the compiler just got
more picky and discovered it.