### PR TITLE
Fix Windows AccessViolationException in FileSystemWatcher when monitoring network share for changes

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
@@ -28,8 +28,8 @@ internal partial class Interop
             internal FileAction Action;
 
             // Note that the file name is not null terminated
-            private uint FileNameLength;
-            private char _FileName;
+            internal uint FileNameLength;
+            internal char _FileName;
 
             internal unsafe ReadOnlySpan<char> FileName
             {

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
@@ -28,13 +28,8 @@ internal partial class Interop
             internal FileAction Action;
 
             // Note that the file name is not null terminated
-            internal uint FileNameLength;
-            internal char _FileName;
-
-            internal unsafe ReadOnlySpan<char> FileName
-            {
-                get { fixed (char* c = &_FileName) { return new ReadOnlySpan<char>(c, (int)FileNameLength / sizeof(char)); } }
-            }
+            internal readonly uint FileNameLength;
+            internal readonly char FileName;
         }
 
         internal enum FileAction : uint

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -235,7 +235,7 @@ namespace System.IO
                 }
                 else
                 {
-                    ParseEventBufferAndNotifyForEach(state.Buffer);
+                    ParseEventBufferAndNotifyForEach(state.Buffer, numBytes);
                 }
             }
             finally
@@ -245,13 +245,16 @@ namespace System.IO
             }
         }
 
-        private unsafe void ParseEventBufferAndNotifyForEach(byte[] buffer)
+        private unsafe void ParseEventBufferAndNotifyForEach(byte[] buffer, uint numBytes)
         {
             Debug.Assert(buffer != null);
             Debug.Assert(buffer.Length > 0);
+            Debug.Assert(numBytes <= buffer.Length);
 
             fixed (byte* b = buffer)
             {
+                byte* pBufferLimit = b + numBytes;
+
                 Interop.Kernel32.FILE_NOTIFY_INFORMATION* info = (Interop.Kernel32.FILE_NOTIFY_INFORMATION*)b;
 
                 ReadOnlySpan<char> oldName = ReadOnlySpan<char>.Empty;
@@ -259,6 +262,22 @@ namespace System.IO
                 // Parse each event from the buffer and notify appropriate delegates
                 do
                 {
+                    // Validate the data we received in case it's corrupted. This can happen
+                    // if we are watching files over the network with a poor connection.
+
+                    // Verify the info object is within the expected bounds
+                    if (info < b || (((byte*)info) + sizeof(Interop.Kernel32.FILE_NOTIFY_INFORMATION)) > pBufferLimit)
+                    {
+                        break;
+                    }
+
+                    // Verify the file path is within the bounds
+                    byte* pFileEnd = ((byte*)&(info->_FileName)) + info->FileNameLength;
+                    if (pFileEnd < &(info->_FileName) || pFileEnd > pBufferLimit)
+                    {
+                        break;
+                    }
+
                     // A slightly convoluted piece of code follows.  Here's what's happening:
                     //
                     // We wish to collapse the poorly done rename notifications from the

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -249,6 +249,7 @@ namespace System.IO
         {
             Debug.Assert(buffer != null);
             Debug.Assert(buffer.Length > 0);
+            Debug.Assert(numBytes <= buffer.Length);
 
             numBytes = Math.Min(numBytes, (uint)buffer.Length);
 

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -249,7 +249,8 @@ namespace System.IO
         {
             Debug.Assert(buffer != null);
             Debug.Assert(buffer.Length > 0);
-            Debug.Assert(numBytes <= buffer.Length);
+
+            numBytes = Math.Min(numBytes, (uint)buffer.Length);
 
             fixed (byte* b = buffer)
             {
@@ -272,8 +273,8 @@ namespace System.IO
                     }
 
                     // Verify the file path is within the bounds
-                    byte* pFileEnd = ((byte*)&(info->_FileName)) + info->FileNameLength;
-                    if (pFileEnd < &(info->_FileName) || pFileEnd > pBufferLimit)
+                    byte* pFileEnd = ((byte*)&(info->FileName)) + info->FileNameLength;
+                    if (pFileEnd < &(info->FileName) || pFileEnd > pBufferLimit)
                     {
                         break;
                     }
@@ -303,17 +304,19 @@ namespace System.IO
                     //
                     // (Phew!)
 
+                    ReadOnlySpan<char> fileName = new ReadOnlySpan<char>(&(info->FileName), (int)info->FileNameLength / sizeof(char));
+
                     switch (info->Action)
                     {
                         case Interop.Kernel32.FileAction.FILE_ACTION_RENAMED_OLD_NAME:
                             // Action is renamed from, save the name of the file
-                            oldName = info->FileName;
+                            oldName = fileName;
                             break;
                         case Interop.Kernel32.FileAction.FILE_ACTION_RENAMED_NEW_NAME:
                             // oldName may be empty if we didn't receive FILE_ACTION_RENAMED_OLD_NAME first
                             NotifyRenameEventArgs(
                                 WatcherChangeTypes.Renamed,
-                                info->FileName,
+                                fileName,
                                 oldName);
                             oldName = ReadOnlySpan<char>.Empty;
                             break;
@@ -328,13 +331,13 @@ namespace System.IO
                             switch (info->Action)
                             {
                                 case Interop.Kernel32.FileAction.FILE_ACTION_ADDED:
-                                    NotifyFileSystemEventArgs(WatcherChangeTypes.Created, info->FileName);
+                                    NotifyFileSystemEventArgs(WatcherChangeTypes.Created, fileName);
                                     break;
                                 case Interop.Kernel32.FileAction.FILE_ACTION_REMOVED:
-                                    NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, info->FileName);
+                                    NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, fileName);
                                     break;
                                 case Interop.Kernel32.FileAction.FILE_ACTION_MODIFIED:
-                                    NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, info->FileName);
+                                    NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, fileName);
                                     break;
                                 default:
                                     Debug.Fail($"Unknown FileSystemEvent action type!  Value: {info->Action}");


### PR DESCRIPTION
This issue was reported for 3.1 twice:
- https://github.com/dotnet/runtime/issues/40412 - w3wp.exe crash in FileSystemWatcher after 2.2 -> 3.1 migration (c0000005 Access Violation)
- https://github.com/dotnet/runtime/issues/42108 - FileSystemWatcher crash UNALIGNED_STACK_POINTER

When monitoring a network share with `FileSystemWatcher`, if there are network issues that could cause the data to arrive malformed, then after casting the byte array to a `FILE_NOTIFY_INFORMATION`, attempts to access the struct fields can throw an AV.

The issue was also reported internally by one of the customers. Our CSS partner was able to reproduce it locally (I couldn't).

I provided him a private binary of System.IO.FileSystem.Watcher.dll with the changes in this fix, and he confirmed the AV no longer happens.

We need this change to be backported to 5.0 and 3.1.

Here is a small repro code, which was executed along with [clumsy](https://github.com/jagt/clumsy), which can alter the network quality.

<details>
  <summary>Code</summary>

  ```cs
using System;
using System.IO;

namespace FileWatcherConsole
{
    class Program
    {
        static void Main()
        {
            try
            {
                var w = new Watcher();
                w.InitializeFilewatcher();
            }
            catch (Exception ex)
            {
                Console.WriteLine(ex.Message);
                Console.WriteLine(ex.StackTrace);
            }
        }
    }

    class Watcher
    {
        const string WatchPath = @"\\remote\location\goes\here";
        FileSystemWatcher _watcher = new FileSystemWatcher();

        public void InitializeFilewatcher()
        {
            _watcher = new FileSystemWatcher(WatchPath);
            _watcher.InternalBufferSize = 65536;
            _watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName;
            _watcher.Changed += new FileSystemEventHandler(FileChanged);
            _watcher.Created += new FileSystemEventHandler(FileCreated);
            _watcher.Renamed += new RenamedEventHandler(FileRenamed);
            _watcher.Deleted += new FileSystemEventHandler(FileDeleted);
            _watcher.Error += Watcher_Error;
            _watcher.EnableRaisingEvents = true;
        }

        private void FileRenamed(object sender, RenamedEventArgs e) => Console.WriteLine($"Renamed: {e.OldName} -> {e.Name}");

        private void FileCreated(object sender, FileSystemEventArgs e) => Console.WriteLine($"Created: {e.Name} - {e.FullPath}");

        private void FileChanged(object sender, FileSystemEventArgs e) => Console.WriteLine($"Changed: {e.Name} - {e.FullPath}");

        private void FileDeleted(object sender, FileSystemEventArgs e) => Console.WriteLine($"Deleted: {e.Name} - {e.FullPath}");

        private void Watcher_Error(object sender, ErrorEventArgs e)
        {
            Exception ex = e.GetException();
            Console.WriteLine(ex.Message);
            Console.WriteLine(ex.StackTrace);
        }
    }
}
  ```
</details>