### PR TITLE
Console.Unix: fix inverted TreatControlCAsInput

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -151,7 +151,7 @@ namespace System
                 if (!Console.IsInputRedirected)
                 {
                     EnsureConsoleInitialized();
-                    if (Interop.Sys.SetSignalForBreak(Convert.ToInt32(value)) == 0)
+                    if (Interop.Sys.SetSignalForBreak(Convert.ToInt32(!value)) == 0)
                         throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo());
                 }
             }


### PR DESCRIPTION
The logical negation was unintentionally removed while refactoring.

Fixes https://github.com/dotnet/runtime/issues/42423.
Regressed in https://github.com/dotnet/runtime/pull/39206.

cc @stephentoub @eiriktsarpalis