### PR TITLE
Fix race condition in GetAppdomainStaticAddress test

### DIFF
--- a/src/tests/profiler/native/event.h
+++ b/src/tests/profiler/native/event.h
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+
+class AutoEvent
+{
+private:
+    std::mutex m_mtx;
+    std::condition_variable m_cv;
+    bool m_set = false;
+
+    static VOID DoNothing()
+    {
+
+    }
+
+public:
+    AutoEvent() = default;
+    ~AutoEvent() = default;
+    AutoEvent(AutoEvent& other) = delete;
+    AutoEvent(AutoEvent &&other) = delete;
+    AutoEvent &operator=(AutoEvent &other) = delete;
+    AutoEvent &operator=(AutoEvent &&other) = delete;
+
+    void Wait(std::function<void()> spuriousCallback = DoNothing)
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        while (!m_set)
+        {
+            m_cv.wait(lock, [&]() { return m_set; });
+            if (!m_set)
+            {
+                spuriousCallback();
+            }
+        }
+        m_set = false;
+    }
+
+    void WaitFor(int milliseconds, std::function<void()> spuriousCallback = DoNothing)
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        while (!m_set)
+        {
+            m_cv.wait_for(lock, std::chrono::milliseconds(milliseconds), [&]() { return m_set; });
+            if (!m_set)
+            {
+                spuriousCallback();
+            }
+        }
+        m_set = false;
+    }
+
+    void Signal()
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        m_set = true;
+        m_cv.notify_one();
+    }
+};
+
+class ManualEvent
+{
+private:
+    std::mutex m_mtx;
+    std::condition_variable m_cv;
+    bool m_set = false;
+
+    static VOID DoNothing()
+    {
+
+    }
+
+public:
+    ManualEvent() = default;
+    ~ManualEvent() = default;
+    ManualEvent(ManualEvent& other) = delete;
+    ManualEvent(ManualEvent&& other) = delete;
+    ManualEvent& operator= (ManualEvent& other) = delete;
+    ManualEvent& operator= (ManualEvent&& other) = delete;
+
+    void Wait(std::function<void()> spuriousCallback = DoNothing)
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        while (!m_set)
+        {
+            m_cv.wait(lock, [&]() { return m_set; });
+            if (!m_set)
+            {
+                spuriousCallback();
+            }
+        }
+    }
+
+    void Signal()
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        m_set = true;
+    }
+
+    void Reset()
+    {
+        std::unique_lock<std::mutex> lock(m_mtx);
+        m_set = false;
+    }
+};

--- a/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.h
+++ b/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.h
@@ -14,68 +14,11 @@
 #include <string>
 #include <thread>
 #include <chrono>
-#include <condition_variable>
 #include <functional>
 #include "cor.h"
 #include "corprof.h"
 
 typedef HRESULT (*GetDispenserFunc) (const CLSID &pClsid, const IID &pIid, void **ppv);
-
-class AutoEvent
-{
-private:
-    std::mutex m_mtx;
-    std::condition_variable m_cv;
-    bool m_set = false;
-
-    static VOID DoNothing()
-    {
-
-    }
-
-public:
-    AutoEvent() = default;
-    ~AutoEvent() = default;
-    AutoEvent(AutoEvent& other) = delete;
-    AutoEvent(AutoEvent &&other) = delete;
-    AutoEvent &operator=(AutoEvent &other) = delete;
-    AutoEvent &operator=(AutoEvent &&other) = delete;
-
-    void Wait(std::function<void()> spuriousCallback = DoNothing)
-    {
-        std::unique_lock<std::mutex> lock(m_mtx);
-        while (!m_set)
-        {
-            m_cv.wait(lock, [&]() { return m_set; });
-            if (!m_set)
-            {
-                spuriousCallback();
-            }
-        }
-        m_set = false;
-    }
-
-    void WaitFor(int milliseconds, std::function<void()> spuriousCallback = DoNothing)
-    {
-        std::unique_lock<std::mutex> lock(m_mtx);
-        while (!m_set)
-        {
-            m_cv.wait_for(lock, std::chrono::milliseconds(milliseconds), [&]() { return m_set; });
-            if (!m_set)
-            {
-                spuriousCallback();
-            }
-        }
-        m_set = false;
-    }
-
-    void Signal()
-    {
-        std::unique_lock<std::mutex> lock(m_mtx);
-        m_set = true;
-        m_cv.notify_one();
-    }
-};
 
 class GetAppDomainStaticAddress : public Profiler
 {

--- a/src/tests/profiler/native/holder.h
+++ b/src/tests/profiler/native/holder.h
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+template <class MetaInterface>
+class COMPtrHolder
+{
+public:
+    COMPtrHolder()
+    {
+        m_ptr = NULL;
+    }
+
+    COMPtrHolder(MetaInterface* ptr)
+    {
+        if (ptr != NULL)
+        {
+            ptr->AddRef();
+        }
+        m_ptr = ptr;
+    }
+
+    ~COMPtrHolder()
+    {
+        if (m_ptr != NULL)
+        {
+            m_ptr->Release();
+            m_ptr = NULL;
+        }
+    }
+    MetaInterface* operator->()
+    {
+        return m_ptr;
+    }
+
+    MetaInterface** operator&()
+    {
+       // _ASSERT(m_ptr == NULL);
+        return &m_ptr;
+    }
+
+    operator MetaInterface*()
+    {
+        return m_ptr;
+    }
+private:
+    MetaInterface* m_ptr;
+};
+
+template <class T>
+class NewArrayHolder
+{
+public:
+    NewArrayHolder()
+    {
+        m_pArray = NULL;
+    }
+
+    NewArrayHolder(T* pArray)
+    {
+        m_pArray = pArray;
+    }
+
+    NewArrayHolder<T>& operator=(T* other)
+    {
+        delete[] m_pArray;
+        m_pArray = other;
+        return *this;
+    }
+
+    operator T*()
+    {
+        return m_pArray;
+    }
+
+    ~NewArrayHolder()
+    {
+        delete[] m_pArray;
+    }
+private:
+    NewArrayHolder(const NewArrayHolder& other)
+    {
+        assert(!"Unreachable");
+    }
+
+    T* m_pArray;
+};

--- a/src/tests/profiler/native/profiler.h
+++ b/src/tests/profiler/native/profiler.h
@@ -9,7 +9,9 @@
 #include <cstdio>
 #include "cor.h"
 #include "corprof.h"
+#include "holder.h"
 #include "profilerstring.h"
+#include "event.h"
 
 #if WIN32
 #define EXPORT
@@ -20,90 +22,6 @@
 #define SHORT_LENGTH    32
 #define STRING_LENGTH  256
 #define LONG_LENGTH   1024
-
-template <class MetaInterface>
-class COMPtrHolder
-{
-public:
-    COMPtrHolder()
-    {
-        m_ptr = NULL;
-    }
-
-    COMPtrHolder(MetaInterface* ptr)
-    {
-        if (ptr != NULL)
-        {
-            ptr->AddRef();
-        }
-        m_ptr = ptr;
-    }
-
-    ~COMPtrHolder()
-    {
-        if (m_ptr != NULL)
-        {
-            m_ptr->Release();
-            m_ptr = NULL;
-        }
-    }
-    MetaInterface* operator->()
-    {
-        return m_ptr;
-    }
-
-    MetaInterface** operator&()
-    {
-       // _ASSERT(m_ptr == NULL);
-        return &m_ptr;
-    }
-
-    operator MetaInterface*()
-    {
-        return m_ptr;
-    }
-private:
-    MetaInterface* m_ptr;
-};
-
-template <class T>
-class NewArrayHolder
-{
-public:
-    NewArrayHolder()
-    {
-        m_pArray = NULL;
-    }
-
-    NewArrayHolder(T* pArray)
-    {
-        m_pArray = pArray;
-    }
-
-    NewArrayHolder<T>& operator=(T* other)
-    {
-        delete[] m_pArray;
-        m_pArray = other;
-        return *this;
-    }
-
-    operator T*()
-    {
-        return m_pArray;
-    }
-
-    ~NewArrayHolder()
-    {
-        delete[] m_pArray;
-    }
-private:
-    NewArrayHolder(const NewArrayHolder& other)
-    {
-        assert(!"Unreachable");
-    }
-
-    T* m_pArray;
-};
 
 class Profiler : public ICorProfilerCallback10
 {


### PR DESCRIPTION
I have seen two intermittent failure modes for this test.

1. The thread that sits and does GCs can AV because there is a race with shutdown. When shutdown sets pCorProfilerInfo to null the GC thread can still be trying to call ForceGC
2. Occasionally the test will fail because it never sees any statics from the collectible module. I haven't been able to repro this, but the only way I can think of that it would fail is if the module is loaded and then unloaded while the GC thread is doing its 100 ms sleep. This changes the test so GCs are triggered for every module load and unload instead of occurring randomly.