### PR TITLE
Fix several BeginXx nullable annotations

### DIFF
--- a/src/libraries/Common/src/System/Threading/Tasks/TaskToApm.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskToApm.cs
@@ -5,7 +5,7 @@
 //
 // Example usage, wrapping a Task<int>-returning FooAsync method with Begin/EndFoo methods:
 //
-//     public IAsyncResult BeginFoo(..., AsyncCallback callback, object state) =>
+//     public IAsyncResult BeginFoo(..., AsyncCallback? callback, object? state) =>
 //         TaskToApm.Begin(FooAsync(...), callback, state);
 //
 //     public int EndFoo(IAsyncResult asyncResult) =>

--- a/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.cs
+++ b/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.cs
@@ -69,7 +69,7 @@ namespace System.IO.Pipes
         public NamedPipeServerStream(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
         public NamedPipeServerStream(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode, System.IO.Pipes.PipeOptions options) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
         public NamedPipeServerStream(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode, System.IO.Pipes.PipeOptions options, int inBufferSize, int outBufferSize) : base (default(System.IO.Pipes.PipeDirection), default(int)) { }
-        public System.IAsyncResult BeginWaitForConnection(System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginWaitForConnection(System.AsyncCallback? callback, object? state) { throw null; }
         public void Disconnect() { }
         public void EndWaitForConnection(System.IAsyncResult asyncResult) { }
         ~NamedPipeServerStream() { }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -176,7 +176,7 @@ namespace System.IO.Pipes
             return WaitForConnectionAsync(CancellationToken.None);
         }
 
-        public System.IAsyncResult BeginWaitForConnection(AsyncCallback callback, object state) =>
+        public System.IAsyncResult BeginWaitForConnection(AsyncCallback? callback, object? state) =>
             TaskToApm.Begin(WaitForConnectionAsync(), callback, state);
 
         public void EndWaitForConnection(IAsyncResult asyncResult) =>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -134,7 +134,7 @@ namespace System.Net.Http
             WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
         }
 
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) =>
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? asyncCallback, object? asyncState) =>
             TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
 
         public override void EndWrite(IAsyncResult asyncResult) =>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -198,7 +198,7 @@ namespace System.Net.Http
             return ReadAsyncCore(buffer, offset, count, token);
         }
 
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
             TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
 
         public override int EndRead(IAsyncResult asyncResult) =>

--- a/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
@@ -24,7 +24,7 @@ namespace System.Net
         public System.Net.HttpListenerTimeoutManager TimeoutManager { get { throw null; } }
         public bool UnsafeConnectionNtlmAuthentication { get { throw null; } set { } }
         public void Abort() { }
-        public System.IAsyncResult BeginGetContext(System.AsyncCallback callback, object state) { throw null; }
+        public System.IAsyncResult BeginGetContext(System.AsyncCallback? callback, object? state) { throw null; }
         public void Close() { }
         public System.Net.HttpListenerContext EndGetContext(System.IAsyncResult asyncResult) { throw null; }
         public System.Net.HttpListenerContext GetContext() { throw null; }
@@ -109,7 +109,7 @@ namespace System.Net
         public string UserHostAddress { get { throw null; } }
         public string UserHostName { get { throw null; } }
         public string[]? UserLanguages { get { throw null; } }
-        public System.IAsyncResult BeginGetClientCertificate(System.AsyncCallback requestCallback, object state) { throw null; }
+        public System.IAsyncResult BeginGetClientCertificate(System.AsyncCallback? requestCallback, object? state) { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate2? EndGetClientCertificate(System.IAsyncResult asyncResult) { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate2? GetClientCertificate() { throw null; }
         public System.Threading.Tasks.Task<System.Security.Cryptography.X509Certificates.X509Certificate2?> GetClientCertificateAsync() { throw null; }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -246,7 +246,7 @@ namespace System.Net
             return ClientCertificate;
         }
 
-        public IAsyncResult BeginGetClientCertificate(AsyncCallback requestCallback, object state)
+        public IAsyncResult BeginGetClientCertificate(AsyncCallback? requestCallback, object? state)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             if (ClientCertState == ListenerClientCertState.InProgress)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -382,7 +382,7 @@ namespace System.Net
 
         public Guid RequestTraceIdentifier { get; } = Guid.NewGuid();
 
-        private IAsyncResult BeginGetClientCertificateCore(AsyncCallback requestCallback, object state)
+        private IAsyncResult BeginGetClientCertificateCore(AsyncCallback? requestCallback, object? state)
         {
             var asyncResult = new GetClientCertificateAsyncResult(this, state, requestCallback);
 
@@ -422,7 +422,7 @@ namespace System.Net
 
         private class GetClientCertificateAsyncResult : LazyAsyncResult
         {
-            public GetClientCertificateAsyncResult(object myObject, object myState, AsyncCallback myCallBack) : base(myObject, myState, myCallBack) { }
+            public GetClientCertificateAsyncResult(object myObject, object? myState, AsyncCallback? myCallBack) : base(myObject, myState, myCallBack) { }
         }
     }
 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -607,7 +607,7 @@ namespace System.Net
             return true;
         }
 
-        public IAsyncResult BeginGetContext(AsyncCallback callback, object state)
+        public IAsyncResult BeginGetContext(AsyncCallback? callback, object? state)
         {
             ListenerAsyncResult? asyncResult = null;
             try

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -329,7 +329,7 @@ namespace System.Net
             _isDisposed = true;
         }
 
-        private ListenerClientCertAsyncResult BeginGetClientCertificateCore(AsyncCallback requestCallback, object state)
+        private ListenerClientCertAsyncResult BeginGetClientCertificateCore(AsyncCallback? requestCallback, object? state)
         {
             ListenerClientCertAsyncResult? asyncResult = null;
             //--------------------------------------------------------------------

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerAsyncResult.Windows.cs
@@ -13,7 +13,7 @@ namespace System.Net
 
         internal static IOCompletionCallback IOCallback => s_ioCallback;
 
-        internal ListenerAsyncResult(HttpListenerSession session, object userState, AsyncCallback callback) :
+        internal ListenerAsyncResult(HttpListenerSession session, object? userState, AsyncCallback? callback) :
             base(session, userState, callback)
         {
             _requestContext = new AsyncRequestContext(session.RequestQueueBoundHandle, this);

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
@@ -35,7 +35,7 @@ namespace System.Net
 
         private static readonly IOCompletionCallback s_IOCallback = new IOCompletionCallback(WaitCallback);
 
-        internal ListenerClientCertAsyncResult(ThreadPoolBoundHandle boundHandle, object asyncObject, object userState, AsyncCallback callback, uint size) : base(asyncObject, userState, callback)
+        internal ListenerClientCertAsyncResult(ThreadPoolBoundHandle boundHandle, object asyncObject, object? userState, AsyncCallback? callback, uint size) : base(asyncObject, userState, callback)
         {
             // we will use this overlapped structure to issue async IO to ul
             // the event handle will be put in by the BeginHttpApi2.ERROR_SUCCESS() method


### PR DESCRIPTION
AsyncCallback and object state parameters in APM BeginXx methods should always be nullable.  Several in annotated libraries were annotated incorrectly.

Fixes https://github.com/dotnet/runtime/issues/42434
cc: @jeffhandley, @pgovind, @buyaa-n 

@danmosemsft, thoughts for backporting to RC2?  Risk is very low; doesn't impact execution, and it's only making inputs more permissive.