### PR TITLE
Adapt to new behavior of nano server in resource updater

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -138,6 +138,8 @@ namespace Microsoft.NET.HostModel
             [DllImport(nameof(Kernel32), SetLastError=true)]
             public static extern uint SizeofResource(IntPtr hModule,
                                                      IntPtr hResInfo);
+
+            public const int ERROR_CALL_NOT_IMPLEMENTED = 0x78;
         }
 
         /// <summary>
@@ -183,9 +185,13 @@ namespace Microsoft.NET.HostModel
             {
                 // On Nano Server 1709+, `BeginUpdateResource` is exported but returns a null handle with a zero error
                 // Try to call `BeginUpdateResource` with an invalid parameter; the error should be non-zero if supported
+                // On Nano Server 20213, `BeginUpdateResource` fails with ERROR_CALL_NOT_IMPLEMENTED
                 using (var handle = Kernel32.BeginUpdateResource("", false))
                 {
-                    if (handle.IsInvalid && Marshal.GetLastWin32Error() == 0)
+                    int lastWin32Error = Marshal.GetLastWin32Error();
+
+                    if ((handle.IsInvalid && lastWin32Error == 0) ||
+                        lastWin32Error == Kernel32.ERROR_CALL_NOT_IMPLEMENTED)
                     {
                         return false;
                     }


### PR DESCRIPTION
In recent builds of nano server BeginUpdateResource will return ERROR_CALL_NOT_IMPLEMENTED. ResourceUpdater needs to adapt to provide a good error experience.

Without this change the code still fails, but with a much less friendly error.

Fixes https://github.com/dotnet/runtime/issues/42443