### PR TITLE
SemaphoreSlim spelling corrections

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -27,13 +27,13 @@ namespace System.Threading
     {
         #region Private Fields
 
-        // The semaphore count, initialized in the constructor to the initial value, every release call incremetns it
+        // The semaphore count, initialized in the constructor to the initial value, every release call increments it
         // and every wait call decrements it as long as its value is positive otherwise the wait will block.
         // Its value must be between the maximum semaphore value and zero
         private volatile int m_currentCount;
 
         // The maximum semaphore value, it is initialized to Int.MaxValue if the client didn't specify it. it is used
-        // to check if the count excceeded the maxi value or not.
+        // to check if the count exceeded the maxi value or not.
         private readonly int m_maxCount;
 
         // The number of synchronously waiting threads, it is set to zero in the constructor and increments before blocking the

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -33,7 +33,7 @@ namespace System.Threading
         private volatile int m_currentCount;
 
         // The maximum semaphore value, it is initialized to Int.MaxValue if the client didn't specify it. it is used
-        // to check if the count exceeded the maxi value or not.
+        // to check if the count exceeded the maximum value or not.
         private readonly int m_maxCount;
 
         // The number of synchronously waiting threads, it is set to zero in the constructor and increments before blocking the


### PR DESCRIPTION
I spotted two typos and fixed them.
Also there was one place where a shortened word, "maxi" for "maximum", was used where the other comments and variables didnt use shortform.