### PR TITLE
Avoid reusing Regex.Replace Match objects with MatchEvaluator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -180,7 +180,7 @@ namespace System.Text.RegularExpressions
                     state.prevat = match.Index + match.Length;
                     state.segments.Add(state.evaluator(match).AsMemory());
                     return --state.count != 0;
-                });
+                }, reuseMatchObject: false);
 
                 if (state.segments.Count == 0)
                 {
@@ -199,7 +199,7 @@ namespace System.Text.RegularExpressions
                     state.prevat = match.Index;
                     state.segments.Add(evaluator(match).AsMemory());
                     return --state.count != 0;
-                });
+                }, reuseMatchObject: false);
 
                 if (state.segments.Count == 0)
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -104,7 +104,7 @@ namespace System.Text.RegularExpressions
                     }
 
                     return --state.count != 0;
-                });
+                }, reuseMatchObject: true);
 
                 if (state.results.Count == 0)
                 {
@@ -132,7 +132,7 @@ namespace System.Text.RegularExpressions
                     }
 
                     return --state.count != 0;
-                });
+                }, reuseMatchObject: true);
 
                 if (state.results.Count == 0)
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -404,13 +404,13 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        internal void Run<TState>(string input, int startat, ref TState state, MatchCallback<TState> callback)
+        internal void Run<TState>(string input, int startat, ref TState state, MatchCallback<TState> callback, bool reuseMatchObject)
         {
             Debug.Assert((uint)startat <= (uint)input.Length);
             RegexRunner runner = RentRunner();
             try
             {
-                runner.Scan(this, input, startat, ref state, callback, internalMatchTimeout);
+                runner.Scan(this, input, startat, ref state, callback, reuseMatchObject, internalMatchTimeout);
             }
             finally
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -221,7 +221,7 @@ namespace System.Text.RegularExpressions
                     state.prevat = match.Index + match.Length;
                     state.thisRef.ReplacementImpl(ref state.segments, match);
                     return --state.count != 0;
-                });
+                }, reuseMatchObject: true);
 
                 if (state.segments.Count == 0)
                 {
@@ -240,7 +240,7 @@ namespace System.Text.RegularExpressions
                     state.prevat = match.Index;
                     state.thisRef.ReplacementImplRTL(ref state.segments, match);
                     return --state.count != 0;
-                });
+                }, reuseMatchObject: true);
 
                 if (state.segments.Count == 0)
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -215,9 +215,10 @@ namespace System.Text.RegularExpressions
 
         /// <summary>Enumerates all of the matches with the specified regex, invoking the callback for each.</summary>
         /// <remarks>
-        /// This repeatedly hands out the same Match instance, updated with new information.
+        /// This optionally repeatedly hands out the same Match instance, updated with new information.
+        /// <paramref name="reuseMatchObject"/> should be set to false if the Match object is handed out to user code.
         /// </remarks>
-        internal void Scan<TState>(Regex regex, string text, int textstart, ref TState state, MatchCallback<TState> callback, TimeSpan timeout)
+        internal void Scan<TState>(Regex regex, string text, int textstart, ref TState state, MatchCallback<TState> callback, bool reuseMatchObject, TimeSpan timeout)
         {
             // Handle timeout argument
             _timeout = -1; // (int)Regex.InfiniteMatchTimeout.TotalMilliseconds
@@ -297,12 +298,27 @@ namespace System.Text.RegularExpressions
                     if (match._matchcount[0] > 0)
                     {
                         // Hand it out to the callback in canonical form.
+                        if (!reuseMatchObject)
+                        {
+                            // We're not reusing match objects, so null out our field reference to the instance.
+                            // It'll be recreated the next time one is needed.
+                            runmatch = null;
+                        }
                         match.Tidy(runtextpos);
                         initialized = false;
                         if (!callback(ref state, match))
                         {
                             // If the callback returns false, we're done.
-                            match.Text = runtext = null!; // drop reference to text to avoid keeping it alive in a cache
+                            // Drop reference to text to avoid keeping it alive in a cache.
+                            runtext = null!;
+                            if (reuseMatchObject)
+                            {
+                                // We're reusing the single match instance, so clear out its text as well.
+                                // We don't do this if we're not reusing instances, as in that case we're
+                                // dropping the whole reference to the match, and we no longer own the instance
+                                // having handed it out to the callback.
+                                match.Text = null!;
+                            }
                             return;
                         }
 
@@ -314,7 +330,13 @@ namespace System.Text.RegularExpressions
                         {
                             if (runtextpos == stoppos)
                             {
-                                match.Text = runtext = null!; // drop reference to text to avoid keeping it alive in a cache
+                                // Drop reference to text to avoid keeping it alive in a cache.
+                                runtext = null!;
+                                if (reuseMatchObject)
+                                {
+                                    // See above comment.
+                                    match.Text = null!;
+                                }
                                 return;
                             }
 
@@ -335,7 +357,10 @@ namespace System.Text.RegularExpressions
                 if (runtextpos == stoppos)
                 {
                     runtext = null; // drop reference to text to avoid keeping it alive in a cache
-                    if (runmatch != null) runmatch.Text = null!;
+                    if (runmatch != null)
+                    {
+                        runmatch.Text = null!;
+                    }
                     return;
                 }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -220,6 +220,26 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Same(input, Regex.Replace(input, "no-match", new MatchEvaluator(MatchEvaluator1)));
         }
 
+        [Fact]
+        public void Replace_MatchEvaluator_UniqueMatchObjects()
+        {
+            const string Input = "abcdefghijklmnopqrstuvwxyz";
+
+            var matches = new List<Match>();
+
+            string result = Regex.Replace(Input, @"[a-z]", match =>
+            {
+                Assert.Equal(((char)('a' + matches.Count)).ToString(), match.Value);
+                matches.Add(match);
+                return match.Value.ToUpperInvariant();
+            });
+
+            Assert.Equal(26, matches.Count);
+            Assert.Equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ", result);
+
+            Assert.Equal(Input, string.Concat(matches.Cast<Match>().Select(m => m.Value)));
+        }
+
         [Theory]
         [InlineData(RegexOptions.None)]
         [InlineData(RegexOptions.RightToLeft)]


### PR DESCRIPTION
One of the allocation-related optimizations we made for Regex in .NET 5 was for Regex.Replace and Regex.Split to not allocate unnecessary Match objects.  Previously, every match was producing a Match object which was then used to implement the API's semantics.  But in the case of an API like `Replace(string, string)`, those Match objects never make their way out to user code, so we can avoid creating a new Match object each time and instead only create one Match object for the whole operation and just reuse it over and over.

However, one of the overloads of Regex.Replace accepts a MatchEvaluator, a delegate that's handed the Match object.  The intent is that the callback fishes out from the Match whatever it needs and doesn't hold onto the Match object, that ownership isn't transferred... but it turns out some applications are indeed storing these Match objects and assuming ownership... and the reuse behavior breaks that.

This PR tweaks the caching behavior to be parameterized, only reusing the match object from callers where the Match object is never handed out to user code.

https://github.com/dotnet/runtime/issues/42448
cc: @pgovind, @eerhardt, @jeffhandley 