### PR TITLE
Remove unaligned offsets for mapped layout

### DIFF
--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -276,7 +276,7 @@ private:
     LONG        m_refCount;
 
     BundleFileLocation m_bundleFileLocation; // If this image is located within a single-file bundle, 
-                                             // the location within the bundle. If m_bundleFileLocation is vaild, 
+                                             // the location within the bundle. If m_bundleFileLocation is valid,
                                              // it takes precedence over m_path for loading.
 
     // This variable will have the data of module name.

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -500,9 +500,8 @@ MappedImageLayout::MappedImageLayout(PEImage* pOwner)
     m_Layout=LAYOUT_MAPPED;
     m_pOwner=pOwner;
 
+    _ASSERTE(!pOwner->IsInBundle());
     HANDLE hFile = pOwner->GetFileHandle();
-    INT64 offset = pOwner->GetOffset();
-    INT64 size = pOwner->GetSize();
 
     // If mapping was requested, try to do SEC_IMAGE mapping
     LOG((LF_LOADER, LL_INFO100, "PEImage: Opening OS mapped %S (hFile %p)\n", (LPCWSTR) GetPath(), hFile));
@@ -539,19 +538,16 @@ MappedImageLayout::MappedImageLayout(PEImage* pOwner)
         return;
     }
 
-    DWORD offsetLowPart = (DWORD)offset;
-    DWORD offsetHighPart = (DWORD)(offset >> 32);
-
 #ifdef _DEBUG
     // Force relocs by occuping the preferred base while the actual mapping is performed
     CLRMapViewHolder forceRelocs;
     if (PEDecoder::GetForceRelocs())
     {
-        forceRelocs.Assign(CLRMapViewOfFile(m_FileMap, 0, offsetHighPart, offsetLowPart, (SIZE_T)size));
+        forceRelocs.Assign(CLRMapViewOfFile(m_FileMap, 0, 0, 0, 0));
     }
 #endif // _DEBUG
 
-    m_FileView.Assign(CLRMapViewOfFile(m_FileMap, 0, offsetHighPart, offsetLowPart, (SIZE_T)size));
+    m_FileView.Assign(CLRMapViewOfFile(m_FileMap, 0, 0, 0, 0));
     if (m_FileView == NULL)
         ThrowLastError();
     IfFailThrow(Init((void *) m_FileView));
@@ -607,7 +603,7 @@ MappedImageLayout::MappedImageLayout(PEImage* pOwner)
 #else //!TARGET_UNIX
 
 #ifndef CROSSGEN_COMPILE
-    m_LoadedFile = PAL_LOADLoadPEFile(hFile, offset);
+    m_LoadedFile = PAL_LOADLoadPEFile(hFile, 0);
 
     if (m_LoadedFile == NULL)
     {

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -500,14 +500,14 @@ MappedImageLayout::MappedImageLayout(PEImage* pOwner)
     m_Layout=LAYOUT_MAPPED;
     m_pOwner=pOwner;
 
-    _ASSERTE(!pOwner->IsInBundle());
     HANDLE hFile = pOwner->GetFileHandle();
+    INT64 offset = pOwner->GetOffset();
 
     // If mapping was requested, try to do SEC_IMAGE mapping
     LOG((LF_LOADER, LL_INFO100, "PEImage: Opening OS mapped %S (hFile %p)\n", (LPCWSTR) GetPath(), hFile));
 
 #ifndef TARGET_UNIX
-
+    _ASSERTE(!pOwner->IsInBundle());
 
     // Let OS map file for us
 
@@ -603,7 +603,7 @@ MappedImageLayout::MappedImageLayout(PEImage* pOwner)
 #else //!TARGET_UNIX
 
 #ifndef CROSSGEN_COMPILE
-    m_LoadedFile = PAL_LOADLoadPEFile(hFile, 0);
+    m_LoadedFile = PAL_LOADLoadPEFile(hFile, offset);
 
     if (m_LoadedFile == NULL)
     {


### PR DESCRIPTION
These offsets would need to be aligned like we do in https://github.com/dotnet/runtime/pull/42402, but I don't think there is a case where we use `MappedImageLayout` for bundled files.