### PR TITLE
[release/5.0-rc2] Add test for wasm loader regression, fix loading from bundle

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -105,6 +105,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)]
         public static void LoadFromAssemblyName_ValidTrustedPlatformAssembly()
         {
             var asmName = typeof(System.Linq.Enumerable).Assembly.GetName();

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/LoaderLinkTest.Dynamic.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/LoaderLinkTest.Dynamic.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SharedInterfaceImplementation.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LoaderLinkTest.Shared\LoaderLinkTest.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/SharedInterfaceImplementation.cs
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Dynamic/SharedInterfaceImplementation.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+using LoaderLinkTest.Shared;
+
+namespace LoaderLinkTest.Dynamic
+{
+    public class SharedInterfaceImplementation : ISharedInterface
+    {
+        public string TestString => "Hello";
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/ISharedInterface.cs
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/ISharedInterface.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace LoaderLinkTest.Shared
+{
+    public interface ISharedInterface
+    {
+        string TestString { get; }
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/LoaderLinkTest.Shared.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.Shared/LoaderLinkTest.Shared.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ISharedInterface.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+using LoaderLinkTest.Shared;
+
+namespace LoaderLinkTest
+{
+    public class LoaderLinkTest
+    {
+        [Fact]
+        public static void EnsureTypesLinked() // https://github.com/dotnet/runtime/issues/42207
+        {
+            string parentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            byte[] bytes = File.ReadAllBytes(Path.Combine(parentDir != null ? parentDir : "/", "LoaderLinkTest.Dynamic.dll"));
+            Assembly asm = Assembly.Load(bytes);
+            var dynamicType = asm.GetType("LoaderLinkTest.Dynamic.SharedInterfaceImplementation", true);
+            var sharedInterface = dynamicType.GetInterfaces().First(e => e.Name == nameof(ISharedInterface));
+            Assert.Equal(typeof(ISharedInterface).Assembly, sharedInterface.Assembly);
+            Assert.Equal(typeof(ISharedInterface), sharedInterface);
+
+            var instance = Activator.CreateInstance(dynamicType);
+            Assert.True(instance is ISharedInterface);
+
+            Assert.NotNull(((ISharedInterface)instance).TestString); // cast should not fail
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="CustomTPALoadContext.cs" />
     <Compile Include="ResourceAssemblyLoadContext.cs" />
     <Compile Include="SatelliteAssemblies.cs" />
+    <Compile Include="LoaderLinkTest.cs" />
     <EmbeddedResource Include="MainStrings*.resx" />
   </ItemGroup>
   <ItemGroup>
@@ -29,6 +30,8 @@
     <ProjectReference Include="ContextualReflectionDependency\System.Runtime.Loader.Test.ContextualReflectionDependency.csproj" />
     <ProjectReference Include="ReferencedClassLib\ReferencedClassLib.csproj" />
     <ProjectReference Include="ReferencedClassLibNeutralIsSatellite\ReferencedClassLibNeutralIsSatellite.csproj" />
+    <ProjectReference Include="LoaderLinkTest.Shared\LoaderLinkTest.Shared.csproj" />
+    <ProjectReference Include="LoaderLinkTest.Dynamic\LoaderLinkTest.Dynamic.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -16,7 +16,8 @@
 #else
 #define MONO_ASSEMBLY_CORLIB_NAME "System.Private.CoreLib"
 #endif
-#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME (MONO_ASSEMBLY_CORLIB_NAME ".resources")
+#define MONO_ASSEMBLY_RESOURCE_SUFFIX ".resources"
+#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME (MONO_ASSEMBLY_CORLIB_NAME MONO_ASSEMBLY_RESOURCE_SUFFIX)
 
 /* Flag bits for mono_assembly_names_equal_flags (). */
 typedef enum {

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1684,37 +1684,33 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	 * Try these until one of them succeeds (by returning a non-NULL reference):
 	 * 1. Check if it's already loaded by the ALC.
 	 *
-	 * 2. If we have a bundle registered, search the images for a matching name.
+	 * 2. If it's a non-default ALC, call the Load() method.
 	 *
-	 * 3. If it's a non-default ALC, call the Load() method.
-	 *
-	 * 4. If the ALC is not the default and this is not a satellite request,
+	 * 3. If the ALC is not the default and this is not a satellite request,
 	 *    check if it's already loaded by the default ALC.
 	 *
-	 * 5. If the ALC is the default or this is not a satellite request,
+	 * 4. If we have a bundle registered and this is not a satellite request, search the images for a matching name
+	 *    and load into the default ALC.
+	 *
+	 * 5. If we have a bundle registered and this is a satellite request, search the images for a matching name
+	 *    and load into the parent assembly's ALC.
+	 *
+	 * 6. If the ALC is the default or this is not a satellite request,
 	 *    check the TPA list, APP_PATHS, and ApplicationBase.
 	 *
-	 * 6. If this is a satellite request, call the ALC ResolveSatelliteAssembly method.
+	 * 7. If this is a satellite request, call the ALC ResolveSatelliteAssembly method.
 	 *
-	 * 7. Call the ALC Resolving event.
+	 * 8. Call the ALC Resolving event.
 	 *
-	 * 8. Call the ALC AssemblyResolve event (except for corlib satellite assemblies).
+	 * 9. Call the ALC AssemblyResolve event (except for corlib satellite assemblies).
 	 *
-	 * 9. Return NULL.
+	 * 10. Return NULL.
 	 */
 
 	reference = mono_assembly_loaded_internal (alc, aname, FALSE);
 	if (reference) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Assembly already loaded in the active ALC: '%s'.", aname->name);
 		goto leave;
-	}
-
-	if (bundles != NULL) {
-		reference = search_bundle_for_assembly (alc, aname);
-		if (reference) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Assembly found in the bundle: '%s'.", aname->name);
-			goto leave;
-		}
 	}
 
 	if (!is_default) {
@@ -1729,6 +1725,38 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 		reference = mono_assembly_loaded_internal (mono_domain_default_alc (mono_alc_domain (alc)), aname, FALSE);
 		if (reference) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Assembly already loaded in the default ALC: '%s'.", aname->name);
+			goto leave;
+		}
+	}
+
+	if (bundles != NULL && !is_satellite) {
+		reference = search_bundle_for_assembly (mono_domain_default_alc (mono_alc_domain (alc)), aname);
+		if (reference) {
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Assembly found in the bundle: '%s'.", aname->name);
+			goto leave;
+		}
+	}
+
+	if (bundles != NULL && is_satellite) {
+		// Satellite assembly byname requests should be loaded in the same ALC as their parent assembly
+		size_t name_len = strlen (aname->name);
+		char *parent_name = NULL;
+		MonoAssemblyLoadContext *parent_alc = NULL;
+		if (g_str_has_suffix (aname->name, MONO_ASSEMBLY_RESOURCE_SUFFIX))
+			parent_name = g_strdup_printf ("%s.dll", g_strndup (aname->name, name_len - strlen (MONO_ASSEMBLY_RESOURCE_SUFFIX)));
+
+		if (parent_name) {
+			MonoAssemblyOpenRequest req;
+			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
+			MonoAssembly *parent_assembly = mono_assembly_request_open (parent_name, &req, NULL);
+			parent_alc = mono_assembly_get_alc (parent_assembly);
+		}
+
+		if (parent_alc)
+			reference = search_bundle_for_assembly (parent_alc, aname);
+
+		if (reference) {
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Satellite assembly found in the bundle: '%s'.", aname->name);
 			goto leave;
 		}
 	}


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/42425 to to release/5.0-rc2

## Customer Impact
Without this fix, custom ALCs are are somewhat broken on wasm when using the bundle. Any reference from an assembly in a custom ALC will not check the default ALC to see if that assembly is already loaded there, and will instead load a new copy of the assembly into the custom ALC. This means types won't be linked and you can get multiple copies of common assemblies unintentionally. The added test highlights some of the ways this can break customer code, and of particular note is the fact that `Assembly.Load(byte[])` creates a new ALC, so this is actually a regression from 3.2.

## Testing
A new test was added to catch this specific regression, and the existing ALC tests should still pass.

## Risk
Moderate. While this is making a change to the loading algorithm, it's wasm-specific, straightforward, and fixes previously broken behavior. With that said, it is possible that code was unintentionally relying on that broken behavior (which is why some of our tests were passing that shouldn't have, for example).

I believe this to be worth the risk, since the type decoupling makes custom ALCs borderline unusable in a lot of scenarios and regresses Assembly.Load.

cc: @marek-safar @SamMonoRT 