### PR TITLE
Revert "Make Console.ReadKey() distinguish between CR and LF inputs"

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(bool convertCrToNl = false, byte minChars = 1, byte decisecondsTimeout = 0);
+        internal static extern unsafe void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
         internal static extern unsafe void UninitializeConsoleAfterRead();

--- a/src/libraries/Native/Unix/System.Native/pal_console.c
+++ b/src/libraries/Native/Unix/System.Native/pal_console.c
@@ -160,7 +160,7 @@ static bool TcSetAttr(struct termios* termios, bool blockIfBackground)
     return rv;
 }
 
-static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minChars, uint8_t decisecondsTimeout, bool blockIfBackground, bool convertCrToNl)
+static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minChars, uint8_t decisecondsTimeout, bool blockIfBackground)
 {
     if (!g_hasTty)
     {
@@ -179,13 +179,8 @@ static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minCha
 
     if (!forChild)
     {
-        termios.c_iflag &= (uint32_t)(~(IXON | IXOFF | ICRNL | INLCR | IGNCR));
+        termios.c_iflag &= (uint32_t)(~(IXON | IXOFF));
         termios.c_lflag &= (uint32_t)(~(ECHO | ICANON | IEXTEN));
-
-        if (convertCrToNl)
-        {
-            termios.c_iflag |= (uint32_t)ICRNL;
-        }
     }
 
     termios.c_cc[VMIN] = minChars;
@@ -226,15 +221,13 @@ void UninitializeTerminal()
     }
 }
 
-void SystemNative_InitializeConsoleBeforeRead(int32_t convertCrToNl, uint8_t minChars, uint8_t decisecondsTimeout)
+void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout)
 {
-    assert(convertCrToNl == 0 || convertCrToNl == 1);
-
     if (pthread_mutex_lock(&g_lock) == 0)
     {
         g_reading = true;
 
-        ConfigureTerminal(g_signalForBreak, /* forChild */ false, minChars, decisecondsTimeout, /* blockIfBackground */ true, convertCrToNl);
+        ConfigureTerminal(g_signalForBreak, /* forChild */ false, minChars, decisecondsTimeout, /* blockIfBackground */ true);
 
         pthread_mutex_unlock(&g_lock);
     }
@@ -269,7 +262,7 @@ void SystemNative_ConfigureTerminalForChildProcess(int32_t childUsesTerminal)
             g_hasCurrentTermios = false;
         }
 
-        ConfigureTerminal(g_signalForBreak, /* forChild */ childUsesTerminal, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ false, /* convertCrToNl */ false);
+        ConfigureTerminal(g_signalForBreak, /* forChild */ childUsesTerminal, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ false);
 
         // Redo "Application mode" when there are no more children using the terminal.
         if (!childUsesTerminal)
@@ -378,7 +371,7 @@ void SystemNative_GetControlCharacters(
 
 int32_t SystemNative_StdinReady()
 {
-    SystemNative_InitializeConsoleBeforeRead(/* convertCrToNl */ 0, /* minChars */ 1, /* decisecondsTimeout */ 0);
+    SystemNative_InitializeConsoleBeforeRead(/* minChars */ 1, /* decisecondsTimeout */ 0);
     struct pollfd fd = { .fd = STDIN_FILENO, .events = POLLIN };
     int rv = poll(&fd, 1, 0) > 0 ? 1 : 0;
     SystemNative_UninitializeConsoleAfterRead();
@@ -414,7 +407,7 @@ int32_t SystemNative_SetSignalForBreak(int32_t signalForBreak)
 
     if (pthread_mutex_lock(&g_lock) == 0)
     {
-        if (ConfigureTerminal(signalForBreak, /* forChild */ false, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ true, /* convertCrToNl */ false))
+        if (ConfigureTerminal(signalForBreak, /* forChild */ false, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ true))
         {
             g_signalForBreak = signalForBreak;
             rv = 1;

--- a/src/libraries/Native/Unix/System.Native/pal_console.h
+++ b/src/libraries/Native/Unix/System.Native/pal_console.h
@@ -91,7 +91,7 @@ PALEXPORT int32_t SystemNative_StdinReady(void);
 /**
  * Configures the terminal for System.Console Read.
  */
-PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t convertCrToNl, uint8_t minChars, uint8_t decisecondsTimeout);
+PALEXPORT void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout);
 
 /**
  * Configures the terminal after System.Console Read.

--- a/src/libraries/System.Console/src/System/ConsoleKeyInfo.cs
+++ b/src/libraries/System.Console/src/System/ConsoleKeyInfo.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-
 namespace System
 {
     public readonly struct ConsoleKeyInfo : IEquatable<ConsoleKeyInfo>

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -129,6 +129,15 @@ namespace System
             bool previouslyProcessed;
             ConsoleKeyInfo keyInfo = StdInReader.ReadKey(out previouslyProcessed);
 
+            // Replace the '\n' char for Enter by '\r' to match Windows behavior.
+            if (keyInfo.Key == ConsoleKey.Enter && keyInfo.KeyChar == '\n')
+            {
+                bool shift   = (keyInfo.Modifiers & ConsoleModifiers.Shift)   != 0;
+                bool alt     = (keyInfo.Modifiers & ConsoleModifiers.Alt)     != 0;
+                bool control = (keyInfo.Modifiers & ConsoleModifiers.Control) != 0;
+                keyInfo = new ConsoleKeyInfo('\r', keyInfo.Key, shift, alt, control);
+            }
+
             if (!intercept && !previouslyProcessed && keyInfo.KeyChar != '\0')
             {
                 Console.Write(keyInfo.KeyChar);
@@ -1210,19 +1219,11 @@ namespace System
         /// <returns>The number of bytes read, or a negative value if there's an error.</returns>
         internal static unsafe int Read(SafeFileHandle fd, byte[] buffer, int offset, int count)
         {
-            Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true);
-            try
+            fixed (byte* bufPtr = buffer)
             {
-                fixed (byte* bufPtr = buffer)
-                {
-                    int result = Interop.CheckIo(Interop.Sys.Read(fd, (byte*)bufPtr + offset, count));
-                    Debug.Assert(result <= count);
-                    return result;
-                }
-            }
-            finally
-            {
-                Interop.Sys.UninitializeConsoleAfterRead();
+                int result = Interop.CheckIo(Interop.Sys.Read(fd, (byte*)bufPtr + offset, count));
+                Debug.Assert(result <= count);
+                return result;
             }
         }
 

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -267,10 +267,9 @@ namespace System.IO
             if (_availableKeys.Count > 0)
             {
                 ConsoleKeyInfo keyInfo = peek ? _availableKeys.Peek() : _availableKeys.Pop();
-                char keyChar = (keyInfo.KeyChar == '\r') ? '\n' : keyInfo.KeyChar; // Map CR chars to LF
-                if (!IsEol(keyChar))
+                if (!IsEol(keyInfo.KeyChar))
                 {
-                    return keyChar;
+                    return keyInfo.KeyChar;
                 }
             }
 
@@ -298,7 +297,7 @@ namespace System.IO
                 case '\t':
                     return ConsoleKey.Tab;
 
-                case '\r':
+                case '\n':
                     return ConsoleKey.Enter;
 
                 case (char)(0x1B):
@@ -459,7 +458,6 @@ namespace System.IO
                 }
 
                 MapBufferToConsoleKey(out key, out ch, out isShift, out isAlt, out isCtrl);
-
                 return new ConsoleKeyInfo(ch, key, isShift, isAlt, isCtrl);
             }
             finally

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -298,6 +298,7 @@ namespace System.IO
                     return ConsoleKey.Tab;
 
                 case '\n':
+                case '\r':
                     return ConsoleKey.Enter;
 
                 case (char)(0x1B):

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -113,36 +113,38 @@ namespace System
 
         [ConditionalTheory(nameof(ManualTestsEnabled))]
         [MemberData(nameof(GetKeyChords))]
-        public static void ReadKey_KeyChords(ConsoleKeyInfo expected)
+        public static void ReadKey_KeyChords(string requestedKeyChord, ConsoleKeyInfo expected)
         {
-            Console.Write($"Please type key chord {RenderKeyChord(expected)}: ");
+            Console.Write($"Please type key chord {requestedKeyChord}: ");
             var actual = Console.ReadKey(intercept: true);
             Console.WriteLine();
 
             Assert.Equal(expected.Key, actual.Key);
             Assert.Equal(expected.Modifiers, actual.Modifiers);
             Assert.Equal(expected.KeyChar, actual.KeyChar);
-
-            static string RenderKeyChord(ConsoleKeyInfo key)
-            {
-                string modifiers = "";
-                if (key.Modifiers.HasFlag(ConsoleModifiers.Control)) modifiers += "Ctrl+";
-                if (key.Modifiers.HasFlag(ConsoleModifiers.Alt)) modifiers += "Alt+";
-                if (key.Modifiers.HasFlag(ConsoleModifiers.Shift)) modifiers += "Shift+";
-                return modifiers + key.Key;
-            }
         }
 
         public static IEnumerable<object[]> GetKeyChords()
         {
-            yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control);
-            yield return MkConsoleKeyInfo(OperatingSystem.IsWindows() ? '\x00' : '\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
-            yield return MkConsoleKeyInfo('\r', ConsoleKey.Enter, (ConsoleModifiers)0);
+            yield return MkConsoleKeyInfo("Ctrl+B", '\x02', ConsoleKey.B, ConsoleModifiers.Control);
+            yield return MkConsoleKeyInfo("Ctrl+Alt+B", OperatingSystem.IsWindows() ? '\x00' : '\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
+            yield return MkConsoleKeyInfo("Enter", '\r', ConsoleKey.Enter, default);
 
-            static object[] MkConsoleKeyInfo (char keyChar, ConsoleKey consoleKey, ConsoleModifiers modifiers)
+            if (OperatingSystem.IsWindows())
+            {
+                yield return MkConsoleKeyInfo("Ctrl+J", '\n', ConsoleKey.J, ConsoleModifiers.Control);
+            }
+            else
+            {
+                // Validate current Unix console behaviour: '\n' is reported as '\r'
+                yield return MkConsoleKeyInfo("Ctrl+J", '\r', ConsoleKey.Enter, default);
+            }
+
+            static object[] MkConsoleKeyInfo (string requestedKeyChord, char keyChar, ConsoleKey consoleKey, ConsoleModifiers modifiers)
             {
                 return new object[]
                 {
+                    requestedKeyChord,
                     new ConsoleKeyInfo(keyChar, consoleKey, 
                         control: modifiers.HasFlag(ConsoleModifiers.Control),
                         alt: modifiers.HasFlag(ConsoleModifiers.Alt),

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -138,8 +138,6 @@ namespace System
             yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control);
             yield return MkConsoleKeyInfo(OperatingSystem.IsWindows() ? '\x00' : '\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
             yield return MkConsoleKeyInfo('\r', ConsoleKey.Enter, (ConsoleModifiers)0);
-            // windows will report '\n' as 'Ctrl+Enter', which is typically not picked up by Unix terminals
-            yield return MkConsoleKeyInfo('\n', OperatingSystem.IsWindows() ? ConsoleKey.Enter : ConsoleKey.J, ConsoleModifiers.Control);
 
             static object[] MkConsoleKeyInfo (char keyChar, ConsoleKey consoleKey, ConsoleModifiers modifiers)
             {


### PR DESCRIPTION
Reverts #37491. Fixes #42418 

cc @tmds @stephentoub @jeffhandley 