### PR TITLE
Fix the mechanism getting Constructed Culture

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -27,6 +27,7 @@ internal static partial class Interop
         internal const uint LOCALE_SNAME                = 0x0000005C;
         internal const uint LOCALE_INEUTRAL             = 0x00000071;
         internal const uint LOCALE_SSHORTTIME           = 0x00000079;
+        internal const uint LOCALE_ICONSTRUCTEDLOCALE   = 0x0000007d;
         internal const uint LOCALE_STIMEFORMAT          = 0x00001003;
         internal const uint LOCALE_IFIRSTDAYOFWEEK      = 0x0000100C;
         internal const uint LOCALE_RETURN_NUMBER        = 0x20000000;

--- a/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
@@ -33,6 +33,18 @@ namespace System.Globalization.Tests
         }
 
         [ConditionalTheory(nameof(PlatformSupportsFakeCulture))]
+        [InlineData("en")]
+        [InlineData("en-US")]
+        [InlineData("ja-JP")]
+        [InlineData("ar-SA")]
+        public void TestGetCultureInfoWithNoneConstructedCultures(string name)
+        {
+            Assert.Equal(name, CultureInfo.GetCultureInfo(name).Name);
+            Assert.Equal(name, CultureInfo.GetCultureInfo(name, predefinedOnly: false).Name);
+            Assert.Equal(name, CultureInfo.GetCultureInfo(name, predefinedOnly: true).Name);
+        }
+
+        [ConditionalTheory(nameof(PlatformSupportsFakeCulture))]
         [InlineData("xx")]
         [InlineData("xx-XX")]
         [InlineData("xx-YY")]

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.Nls.cs
@@ -11,20 +11,12 @@ namespace System.Globalization
         {
             Debug.Assert(GlobalizationMode.UseNls);
 
-            CultureInfo culture = GetCultureInfo(name);
-            string englishName = culture.EnglishName;
-
-            // Check if the English Name starts with "Unknown Locale" or "Unknown Language" terms.
-            const int SecondTermIndex = 8;
-
-            if (englishName.StartsWith("Unknown ", StringComparison.Ordinal) && englishName.Length > SecondTermIndex &&
-                (englishName.IndexOf("Locale", SecondTermIndex, StringComparison.Ordinal) == SecondTermIndex ||
-                 englishName.IndexOf("Language", SecondTermIndex, StringComparison.Ordinal) == SecondTermIndex))
+            if (CultureData.GetLocaleInfoExInt(name, Interop.Kernel32.LOCALE_ICONSTRUCTEDLOCALE) == 1)
             {
                 throw new CultureNotFoundException(nameof(name), SR.Format(SR.Argument_InvalidPredefinedCultureName, name));
             }
 
-            return culture;
+            return GetCultureInfo(name);
         }
     }
 }


### PR DESCRIPTION
In 5.0 we have exposed a new API overload for [CultureInfo.GetCultureInfo](https://github.com/dotnet/runtime/blob/2a1735b162437bb35a112014092a834c2496c3e3/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs#L1126). This was requested by [PowerShell issue](https://github.com/dotnet/runtime/issues/27352).
When using NLS, we have implemented the API by checking the Culture EnglishName to be "Unknown Locale" or "Unknown Language". This was the only public way to check if the culture is a constructed culture and not backed by its own data in Windows. We have learned that Windows is going to change the English culture names for constructed locales which obviously will break our API. The good news is Windows exposing a new flag `LOCALE_ICONSTRUCTEDLOCALE` to check if the locale is a constructed locale.

The change here is remove the culture EnglishName checking and use the flag for checking. This should guarantee not breaking the API now and in the future. The good news is this flag was already supported in Windows as internal flag and now Windows is exposing it and documenting it.