### PR TITLE
[release/5.0-rc2] Fix artifact source globbing for extract

### DIFF
--- a/eng/pipelines/common/download-artifact-step.yml
+++ b/eng/pipelines/common/download-artifact-step.yml
@@ -19,6 +19,6 @@ steps:
   - task: ExtractFiles@1
     displayName: 'Unzip ${{ parameters.displayName }}'
     inputs:
-      archiveFilePatterns: $(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}/${{ parameters.artifactFileName }}
+      archiveFilePatterns: $(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}/**/${{ parameters.artifactFileName }}
       destinationFolder: ${{ parameters.unpackFolder }}
       cleanDestinationFolder: ${{ parameters.cleanUnpackFolder }}

--- a/eng/pipelines/common/download-artifact-step.yml
+++ b/eng/pipelines/common/download-artifact-step.yml
@@ -19,6 +19,6 @@ steps:
   - task: ExtractFiles@1
     displayName: 'Unzip ${{ parameters.displayName }}'
     inputs:
-      archiveFilePatterns: $(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}/**/${{ parameters.artifactFileName }}
+      archiveFilePatterns: $(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}/${{ parameters.artifactFileName }}
       destinationFolder: ${{ parameters.unpackFolder }}
       cleanDestinationFolder: ${{ parameters.cleanUnpackFolder }}

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -409,14 +409,14 @@ jobs:
         displayName: 'Unzip $(runtimeFlavorName) artifacts: ${{ platform }}'
         inputs:
           archiveFilePatterns: |
-            $(Build.SourcesDirectory)/__download__/AllPlatforms/$(runtimeFlavorName)Product_${{ platform }}_${{ parameters.liveRuntimeBuildConfig }}.*
+            $(Build.SourcesDirectory)/__download__/AllPlatforms/**/$(runtimeFlavorName)Product_${{ platform }}_${{ parameters.liveRuntimeBuildConfig }}.*
           destinationFolder: $(AllArtifactsDownloadPath)/$(runtimeFlavorName)Product_${{ platform }}_${{ parameters.liveRuntimeBuildConfig }}/
           cleanUnpackFolder: false
       - task: ExtractFiles@1
         displayName: 'Unzip Libraries artifacts: ${{ platform }}'
         inputs:
           archiveFilePatterns: |
-            $(Build.SourcesDirectory)/__download__/AllPlatforms/libraries_bin_${{ platform }}_${{ parameters.liveLibrariesBuildConfig }}.*
+            $(Build.SourcesDirectory)/__download__/AllPlatforms/**/libraries_bin_${{ platform }}_${{ parameters.liveLibrariesBuildConfig }}.*
           destinationFolder: $(AllArtifactsDownloadPath)/libraries_bin_${{ platform }}_${{ parameters.liveLibrariesBuildConfig }}/
           cleanUnpackFolder: false
 


### PR DESCRIPTION
There was a change the extract AzDO task that fixed a bug where it appeared to be matching some subpaths without globbing.

If you specified foo/x* it would apparently match subpaths of foo. Runtime was relying on this behavior, as the artifact target directory would implicitly get a subdirectory which was the artifact name, but not including that artifact name in the globbing pattern.

Fix this by including ** before the archive.