### PR TITLE
Jit preparation for arm64 apple: Use bytes in `fgArgTabEntry`.

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -3281,7 +3281,7 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize,
         unsigned reversePInvokeFrameVarNumber = compiler->lvaReversePInvokeFrameVar;
         assert(reversePInvokeFrameVarNumber != BAD_VAR_NUM && reversePInvokeFrameVarNumber < compiler->lvaRefCount);
         LclVarDsc& reversePInvokeFrameVar = compiler->lvaTable[reversePInvokeFrameVarNumber];
-        gcInfoEncoder->SetReversePInvokeFrameSlot(reversePInvokeFrameVar.lvStkOffs);
+        gcInfoEncoder->SetReversePInvokeFrameSlot(reversePInvokeFrameVar.GetStackOffset());
     }
 
     gcInfoEncoder->Build();

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -2355,25 +2355,25 @@ void CodeGen::genEmitMachineCode()
     }
 #endif
 
-#if EMIT_TRACK_STACK_DEPTH
+#if EMIT_TRACK_STACK_DEPTH && defined(DEBUG) && !defined(OSX_ARM64_ABI)
     // Check our max stack level. Needed for fgAddCodeRef().
     // We need to relax the assert as our estimation won't include code-gen
     // stack changes (which we know don't affect fgAddCodeRef()).
     // NOTE: after emitEndCodeGen (including here), emitMaxStackDepth is a
     // count of DWORD-sized arguments, NOT argument size in bytes.
     {
-        unsigned maxAllowedStackDepth = compiler->fgPtrArgCntMax +    // Max number of pointer-sized stack arguments.
-                                        compiler->compHndBBtabCount + // Return address for locally-called finallys
-                                        genTypeStSz(TYP_LONG) +       // longs/doubles may be transferred via stack, etc
+        unsigned maxAllowedStackDepth = compiler->fgGetPtrArgCntMax() + // Max number of pointer-sized stack arguments.
+                                        compiler->compHndBBtabCount +   // Return address for locally-called finallys
+                                        genTypeStSz(TYP_LONG) + // longs/doubles may be transferred via stack, etc
                                         (compiler->compTailCallUsed ? 4 : 0); // CORINFO_HELP_TAILCALL args
 #if defined(UNIX_X86_ABI)
         // Convert maxNestedAlignment to DWORD count before adding to maxAllowedStackDepth.
         assert(maxNestedAlignment % sizeof(int) == 0);
         maxAllowedStackDepth += maxNestedAlignment / sizeof(int);
 #endif
-        noway_assert(GetEmitter()->emitMaxStackDepth <= maxAllowedStackDepth);
+        assert(GetEmitter()->emitMaxStackDepth <= maxAllowedStackDepth);
     }
-#endif // EMIT_TRACK_STACK_DEPTH
+#endif // EMIT_TRACK_STACK_DEPTH && DEBUG
 
     *nativeSizeOfCode                 = codeSize;
     compiler->info.compNativeCodeSize = (UNATIVE_OFFSET)codeSize;

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6763,15 +6763,15 @@ void CodeGen::genReportGenericContextArg(regNumber initReg, bool* pInitRegZeroed
         if (isFramePointerUsed())
         {
 #if defined(TARGET_ARM)
-            // lvStkOffs is always valid for incoming stack-arguments, even if the argument
+            // GetStackOffset() is always valid for incoming stack-arguments, even if the argument
             // will become enregistered.
             // On Arm compiler->compArgSize doesn't include r11 and lr sizes and hence we need to add 2*REGSIZE_BYTES
-            noway_assert((2 * REGSIZE_BYTES <= varDsc->lvStkOffs) &&
-                         (size_t(varDsc->lvStkOffs) < compiler->compArgSize + 2 * REGSIZE_BYTES));
+            noway_assert((2 * REGSIZE_BYTES <= varDsc->GetStackOffset()) &&
+                         (size_t(varDsc->GetStackOffset()) < compiler->compArgSize + 2 * REGSIZE_BYTES));
 #else
-            // lvStkOffs is always valid for incoming stack-arguments, even if the argument
+            // GetStackOffset() is always valid for incoming stack-arguments, even if the argument
             // will become enregistered.
-            noway_assert((0 < varDsc->lvStkOffs) && (size_t(varDsc->lvStkOffs) < compiler->compArgSize));
+            noway_assert((0 < varDsc->GetStackOffset()) && (size_t(varDsc->GetStackOffset()) < compiler->compArgSize));
 #endif
         }
 
@@ -6781,7 +6781,8 @@ void CodeGen::genReportGenericContextArg(regNumber initReg, bool* pInitRegZeroed
         *pInitRegZeroed = false;
 
         // mov reg, [compiler->info.compTypeCtxtArg]
-        GetEmitter()->emitIns_R_AR(ins_Load(TYP_I_IMPL), EA_PTRSIZE, reg, genFramePointerReg(), varDsc->lvStkOffs);
+        GetEmitter()->emitIns_R_AR(ins_Load(TYP_I_IMPL), EA_PTRSIZE, reg, genFramePointerReg(),
+                                   varDsc->GetStackOffset());
         regSet.verifyRegUsed(reg);
     }
 
@@ -7459,8 +7460,8 @@ void CodeGen::genFnProlog()
             continue;
         }
 
-        signed int loOffs = varDsc->lvStkOffs;
-        signed int hiOffs = varDsc->lvStkOffs + compiler->lvaLclSize(varNum);
+        signed int loOffs = varDsc->GetStackOffset();
+        signed int hiOffs = varDsc->GetStackOffset() + compiler->lvaLclSize(varNum);
 
         /* We need to know the offset range of tracked stack GC refs */
         /* We assume that the GC reference can be anywhere in the TYP_STRUCT */
@@ -7860,7 +7861,7 @@ void CodeGen::genFnProlog()
 #else
         // mov [lvaStubArgumentVar], EAX
         GetEmitter()->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SECRET_STUB_PARAM, genFramePointerReg(),
-                                   compiler->lvaTable[compiler->lvaStubArgumentVar].lvStkOffs);
+                                   compiler->lvaTable[compiler->lvaStubArgumentVar].GetStackOffset());
 #endif
         assert(intRegState.rsCalleeRegArgMaskLiveIn & RBM_SECRET_STUB_PARAM);
 
@@ -8109,7 +8110,7 @@ void CodeGen::genFnProlog()
 
         LclVarDsc* lastArg = &compiler->lvaTable[compiler->info.compArgsCount - 1];
         noway_assert(!lastArg->lvRegister);
-        signed offset = lastArg->lvStkOffs;
+        signed offset = lastArg->GetStackOffset();
         assert(offset != BAD_STK_OFFS);
         noway_assert(lastArg->lvFramePointerBased);
 
@@ -10617,8 +10618,8 @@ void CodeGen::genSetScopeInfo(unsigned       which,
         // Can't check compiler->lvaTable[varNum].lvOnFrame as we don't set it for
         // arguments of vararg functions to avoid reporting them to GC.
         noway_assert(!compiler->lvaTable[varNum].lvRegister);
-        unsigned cookieOffset = compiler->lvaTable[compiler->lvaVarargsHandleArg].lvStkOffs;
-        unsigned varOffset    = compiler->lvaTable[varNum].lvStkOffs;
+        unsigned cookieOffset = compiler->lvaTable[compiler->lvaVarargsHandleArg].GetStackOffset();
+        unsigned varOffset    = compiler->lvaTable[varNum].GetStackOffset();
 
         noway_assert(cookieOffset < varOffset);
         unsigned offset     = varOffset - cookieOffset;

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1822,7 +1822,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk, unsigned outArg
 // We can't write beyond the arg area unless this is a tail call, in which case we use
 // the first stack arg as the base of the incoming arg area.
 #ifdef DEBUG
-        size_t areaSize = compiler->lvaLclSize(outArgVarNum);
+        unsigned areaSize = compiler->lvaLclSize(outArgVarNum);
 #if FEATURE_FASTTAILCALL
         if (putArgStk->gtCall->IsFastTailCall())
         {

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -8547,7 +8547,7 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
                       EA_UNKNOWN); // retSize
 
     // Check that we have place for the push.
-    assert(compiler->fgPtrArgCntMax >= 1);
+    assert(compiler->fgGetPtrArgCntMax() >= 1);
 
 #if defined(UNIX_X86_ABI)
     // Restoring alignment manually. This is similar to CodeGen::genRemoveAlignmentAfterCall
@@ -8628,7 +8628,7 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper)
     genEmitHelperCall(helper, argSize, EA_UNKNOWN /* retSize */);
 
     // Check that we have place for the push.
-    assert(compiler->fgPtrArgCntMax >= 1);
+    assert(compiler->fgGetPtrArgCntMax() >= 1);
 
 #if defined(UNIX_X86_ABI)
     // Restoring alignment manually. This is similar to CodeGen::genRemoveAlignmentAfterCall

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -8271,7 +8271,7 @@ void CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize 
         unsigned reversePInvokeFrameVarNumber = compiler->lvaReversePInvokeFrameVar;
         assert(reversePInvokeFrameVarNumber != BAD_VAR_NUM && reversePInvokeFrameVarNumber < compiler->lvaRefCount);
         LclVarDsc& reversePInvokeFrameVar = compiler->lvaTable[reversePInvokeFrameVarNumber];
-        gcInfoEncoder->SetReversePInvokeFrameSlot(reversePInvokeFrameVar.lvStkOffs);
+        gcInfoEncoder->SetReversePInvokeFrameSlot(reversePInvokeFrameVar.GetStackOffset());
     }
 
     gcInfoEncoder->Build();

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4921,10 +4921,13 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     m_pLowering = new (this, CMK_LSRA) Lowering(this, m_pLinearScan); // PHASE_LOWERING
     m_pLowering->Run();
 
-    // Set stack levels
-    //
+#if !defined(OSX_ARM64_ABI)
+    // Set stack levels, this informmation is necessary for x86
+    // but on other platforms it is used only in asserts
+    // TODO: do not run it in release on other platforms, see https://github.com/dotnet/runtime/issues/42673.
     StackLevelSetter stackLevelSetter(this);
     stackLevelSetter.Run();
+#endif // !OSX_ARM64_ABI
 
     // We can not add any new tracked variables after this point.
     lvaTrackedFixed = true;

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -5028,7 +5028,7 @@ void Compiler::generatePatchpointInfo()
         assert(varDsc->lvFramePointerBased);
 
         // Record FramePtr relative offset (no localloc yet)
-        patchpointInfo->SetOffset(lclNum, varDsc->lvStkOffs);
+        patchpointInfo->SetOffset(lclNum, varDsc->GetStackOffset());
 
         // Note if IL stream contained an address-of that potentially leads to exposure.
         // This bit of IL may be skipped by OSR partial importation.
@@ -5061,7 +5061,7 @@ void Compiler::generatePatchpointInfo()
     {
         assert(lvaGSSecurityCookie != BAD_VAR_NUM);
         LclVarDsc* const varDsc = lvaGetDesc(lvaGSSecurityCookie);
-        patchpointInfo->SetSecurityCookieOffset(varDsc->lvStkOffs);
+        patchpointInfo->SetSecurityCookieOffset(varDsc->GetStackOffset());
         JITDUMP("--OSR-- security cookie V%02u offset is FP %d\n", lvaGSSecurityCookie,
                 patchpointInfo->SecurityCookieOffset());
     }

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4922,8 +4922,8 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     m_pLowering->Run();
 
 #if !defined(OSX_ARM64_ABI)
-    // Set stack levels, this informmation is necessary for x86
-    // but on other platforms it is used only in asserts
+    // Set stack levels; this information is necessary for x86
+    // but on other platforms it is used only in asserts.
     // TODO: do not run it in release on other platforms, see https://github.com/dotnet/runtime/issues/42673.
     StackLevelSetter stackLevelSetter(this);
     stackLevelSetter.Run();

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -805,7 +805,20 @@ public:
     void incLvRefCntWtd(BasicBlock::weight_t delta, RefCountState state = RCS_NORMAL);
     void setLvRefCntWtd(BasicBlock::weight_t newValue, RefCountState state = RCS_NORMAL);
 
-    int      lvStkOffs;   // stack offset of home
+private:
+    int lvStkOffs; // stack offset of home in bytes.
+
+public:
+    int GetStackOffset() const
+    {
+        return lvStkOffs;
+    }
+
+    void SetStackOffset(int offset)
+    {
+        lvStkOffs = offset;
+    }
+
     unsigned lvExactSize; // (exact) size of the type in bytes
 
     // Is this a promoted struct?

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1471,7 +1471,10 @@ public:
 
     // Return number of stack slots that this argument is taking.
     // TODO-Cleanup: this function does not align with arm64 apple model,
-    // delete it.
+    // delete it. In most cases we just want to know if we it is using stack or not
+    // but in some cases we are checking if it is a multireg arg, like:
+    // `numRegs + GetStackSlotsNumber() > 1` that is harder to replace.
+    //
     unsigned GetStackSlotsNumber() const
     {
         return roundUp(GetStackByteSize(), TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;
@@ -1657,7 +1660,7 @@ public:
         if (type != TYP_UNDEF)
         {
             // We must already have set the passing mode.
-            assert(numRegs != 0 || GetStackSlotsNumber() != 0);
+            assert(numRegs != 0 || GetStackByteSize() != 0);
             // We originally set numRegs according to the size of the struct, but if the size of the
             // hfaType is not the same as the pointer size, we need to correct it.
             // Note that hfaSlots is the number of registers we will use. For ARM, that is twice

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1459,7 +1459,7 @@ public:
     unsigned structFloatRegs;
 #endif // UNIX_AMD64_ABI
 
-#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+#if defined(DEBUG_ARG_SLOTS)
     // These fields were used to calculate stack size in stack slots for arguments
     // but now they are replaced by precise `m_byteOffset/m_byteSize` because of
     // arm64 apple abi requirements.
@@ -1467,7 +1467,7 @@ public:
     // A slot is a pointer sized region in the OutArg area.
     unsigned slotNum;  // When an argument is passed in the OutArg area this is the slot number in the OutArg area
     unsigned numSlots; // Count of number of slots that this argument uses
-#endif                 // DEBUG_NOT_OSX_ARM64_ABI
+#endif                 // DEBUG_ARG_SLOTS
 
     // Return number of stack slots that this argument is taking.
     // TODO-Cleanup: this function does not align with arm64 apple model,
@@ -1741,7 +1741,7 @@ public:
         return !IsSplit() && ((numRegs == 1) || (m_byteSize <= TARGET_POINTER_SIZE));
     }
 
-#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+#if defined(DEBUG_ARG_SLOTS)
     // Returns the number of "slots" used, where for this purpose a
     // register counts as a slot.
     unsigned getSlotCount() const
@@ -1764,7 +1764,7 @@ public:
     }
 #endif
 
-#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+#if defined(DEBUG_ARG_SLOTS)
     // Returns the size as a multiple of pointer-size.
     // For targets without HFAs, this is the same as getSlotCount().
     unsigned getSize() const
@@ -1809,19 +1809,19 @@ private:
 public:
     void SetByteOffset(unsigned byteOffset)
     {
-        DEBUG_NOT_OSX_ARM64_ASSERT(byteOffset / TARGET_POINTER_SIZE == slotNum);
+        DEBUG_ARG_SLOTS_ASSERT(byteOffset / TARGET_POINTER_SIZE == slotNum);
         m_byteOffset = byteOffset;
     }
 
     unsigned GetByteOffset() const
     {
-        DEBUG_NOT_OSX_ARM64_ASSERT(m_byteOffset / TARGET_POINTER_SIZE == slotNum);
+        DEBUG_ARG_SLOTS_ASSERT(m_byteOffset / TARGET_POINTER_SIZE == slotNum);
         return m_byteOffset;
     }
 
     void SetByteSize(unsigned byteSize)
     {
-#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+#if defined(DEBUG_ARG_SLOTS)
         assert(byteAlignment != 0);
         if (!isStruct)
         {
@@ -1919,7 +1919,7 @@ class fgArgInfo
     Compiler*    compiler; // Back pointer to the compiler instance so that we can allocate memory
     GenTreeCall* callTree; // Back pointer to the GT_CALL node for this fgArgInfo
     unsigned     argCount; // Updatable arg count value
-#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+#if defined(DEBUG_ARG_SLOTS)
     unsigned nextSlotNum; // Updatable slot count value
 #endif
     unsigned nextStackByteOffset;
@@ -2011,7 +2011,7 @@ public:
         return argTable;
     }
 
-#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+#if defined(DEBUG_ARG_SLOTS)
     unsigned GetNextSlotNum() const
     {
         return nextSlotNum;

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1460,13 +1460,17 @@ public:
 #endif // UNIX_AMD64_ABI
 
 #if defined(DEBUG_NOT_OSX_ARM64_ABI)
+    // These fields were used to calculate stack size in stack slots for arguments
+    // but now they are replaced by precise `m_byteOffset/m_byteSize` because of
+    // arm64 apple abi requirements.
+
     // A slot is a pointer sized region in the OutArg area.
     unsigned slotNum;  // When an argument is passed in the OutArg area this is the slot number in the OutArg area
     unsigned numSlots; // Count of number of slots that this argument uses
 #endif                 // DEBUG_NOT_OSX_ARM64_ABI
 
     // Return number of stack slots that this argument is taking.
-    // TODO-Cleanup: this funtion does not align with arm64 apple model,
+    // TODO-Cleanup: this function does not align with arm64 apple model,
     // delete it.
     unsigned GetStackSlotsNumber() const
     {
@@ -1623,24 +1627,18 @@ public:
         return 0;
     }
 
-    // Get the number of bytes that this argument is occyping on the stack.
+    // Get the number of bytes that this argument is occupying on the stack.
     unsigned GetStackByteSize() const
     {
-        if (IsHfaRegArg())
-        {
-            return 0;
-        }
-        assert(!IsHfaArg() || !IsSplit());
-
         if (!IsSplit() && numRegs > 0)
         {
             return 0;
         }
+
+        assert(!IsHfaArg() || !IsSplit());
+
         assert(GetByteSize() > TARGET_POINTER_SIZE * numRegs);
         unsigned stackByteSize = GetByteSize() - TARGET_POINTER_SIZE * numRegs;
-#if !defined(OSX_ARM64_ABI)
-
-#endif
         return GetByteSize() - TARGET_POINTER_SIZE * numRegs;
     }
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1613,7 +1613,8 @@ public:
         return 0;
     }
 
-    unsigned stackSize() const
+    // Get the number of bytes that this argument is occyping on the stack.
+    unsigned GetStackSize() const
     {
         return (TARGET_POINTER_SIZE * this->numSlots);
     }

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9140,8 +9140,8 @@ public:
         unsigned  compArgsCount;     // Number of arguments (incl. implicit and     hidden)
 
 #if FEATURE_FASTTAILCALL
-        size_t compArgStackSize; // Incoming argument stack size in bytes
-#endif                           // FEATURE_FASTTAILCALL
+        unsigned compArgStackSize; // Incoming argument stack size in bytes
+#endif                             // FEATURE_FASTTAILCALL
 
         unsigned compRetBuffArg; // position of hidden return param var (0, 1) (BAD_VAR_NUM means not present);
         int compTypeCtxtArg; // position of hidden param for type context for generic code (CORINFO_CALLCONV_PARAMTYPE)

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -2117,7 +2117,7 @@ inline
         }
 #endif // DEBUG
 
-        varOffset = varDsc->lvStkOffs;
+        varOffset = varDsc->GetStackOffset();
     }
     else // Its a spill-temp
     {

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -4802,7 +4802,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             }
 #endif // FEATURE_FIXED_OUT_ARGS
 
-            int offs = dsc->lvStkOffs;
+            int offs = dsc->GetStackOffset();
 
             /* Is it within the interesting range of offsets */
 

--- a/src/coreclr/src/jit/gcencode.cpp
+++ b/src/coreclr/src/jit/gcencode.cpp
@@ -1597,7 +1597,7 @@ size_t GCInfo::gcInfoBlockHdrSave(
     if (compiler->getNeedsGSSecurityCookie())
     {
         assert(compiler->lvaGSSecurityCookie != BAD_VAR_NUM);
-        int stkOffs            = compiler->lvaTable[compiler->lvaGSSecurityCookie].lvStkOffs;
+        int stkOffs            = compiler->lvaTable[compiler->lvaGSSecurityCookie].GetStackOffset();
         header->gsCookieOffset = compiler->isFramePointerUsed() ? -stkOffs : stkOffs;
         assert(header->gsCookieOffset != INVALID_GS_COOKIE_OFFSET);
     }
@@ -2198,7 +2198,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                     continue;
                 }
 
-                int offset = varDsc->lvStkOffs;
+                int offset = varDsc->GetStackOffset();
 #if DOUBLE_ALIGN
                 // For genDoubleAlign(), locals are addressed relative to ESP and
                 // arguments are addressed relative to EBP.
@@ -2247,7 +2247,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                         continue;
                     }
 
-                    unsigned offset = varDsc->lvStkOffs + i * TARGET_POINTER_SIZE;
+                    unsigned offset = varDsc->GetStackOffset() + i * TARGET_POINTER_SIZE;
 #if DOUBLE_ALIGN
                     // For genDoubleAlign(), locals are addressed relative to ESP and
                     // arguments are addressed relative to EBP.
@@ -2352,7 +2352,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
 
             assert(compiler->lvaTable[compiler->info.compThisArg].TypeGet() == TYP_REF);
 
-            unsigned varOffs = compiler->lvaTable[compiler->info.compThisArg].lvStkOffs;
+            unsigned varOffs = compiler->lvaTable[compiler->info.compThisArg].GetStackOffset();
 
             /* For negative stack offsets we must reset the low bits,
                 * take abs and then set them back */
@@ -4169,18 +4169,19 @@ void GCInfo::gcMakeRegPtrTable(
                 // No need to hash/lookup untracked GC refs; just grab a new Slot Id.
                 if (mode == MAKE_REG_PTR_MODE_ASSIGN_SLOTS)
                 {
-                    gcInfoEncoderWithLog->GetStackSlotId(varDsc->lvStkOffs, flags, stackSlotBase);
+                    gcInfoEncoderWithLog->GetStackSlotId(varDsc->GetStackOffset(), flags, stackSlotBase);
                 }
             }
             else
             {
-                StackSlotIdKey sskey(varDsc->lvStkOffs, (stackSlotBase == GC_FRAMEREG_REL), flags);
+                StackSlotIdKey sskey(varDsc->GetStackOffset(), (stackSlotBase == GC_FRAMEREG_REL), flags);
                 GcSlotId       varSlotId;
                 if (mode == MAKE_REG_PTR_MODE_ASSIGN_SLOTS)
                 {
                     if (!m_stackSlotMap->Lookup(sskey, &varSlotId))
                     {
-                        varSlotId = gcInfoEncoderWithLog->GetStackSlotId(varDsc->lvStkOffs, flags, stackSlotBase);
+                        varSlotId =
+                            gcInfoEncoderWithLog->GetStackSlotId(varDsc->GetStackOffset(), flags, stackSlotBase);
                         m_stackSlotMap->Set(sskey, varSlotId);
                     }
                 }
@@ -4201,7 +4202,7 @@ void GCInfo::gcMakeRegPtrTable(
                     continue;
                 }
 
-                int offset = varDsc->lvStkOffs + i * TARGET_POINTER_SIZE;
+                int offset = varDsc->GetStackOffset() + i * TARGET_POINTER_SIZE;
 #if DOUBLE_ALIGN
                 // For genDoubleAlign(), locals are addressed relative to ESP and
                 // arguments are addressed relative to EBP.

--- a/src/coreclr/src/jit/gcinfo.cpp
+++ b/src/coreclr/src/jit/gcinfo.cpp
@@ -394,7 +394,7 @@ void GCInfo::gcCountForHeader(UNALIGNED unsigned int* pUntrackedCount, UNALIGNED
 #ifdef DEBUG
             if (compiler->verbose)
             {
-                int offs = varDsc->lvStkOffs;
+                int offs = varDsc->GetStackOffset();
 
                 printf("GCINFO: untrckd %s lcl at [%s", varTypeGCstring(varDsc->TypeGet()),
                        compiler->GetEmitter()->emitGetFrameReg());

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -11114,8 +11114,6 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
 
     switch (tree->gtOper)
     {
-        unsigned   varNum;
-        LclVarDsc* varDsc;
 
         case GT_LCL_FLD:
         case GT_LCL_FLD_ADDR:
@@ -11127,9 +11125,10 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
         case GT_LCL_VAR:
         case GT_LCL_VAR_ADDR:
         case GT_STORE_LCL_VAR:
+        {
             printf(" ");
-            varNum = tree->AsLclVarCommon()->GetLclNum();
-            varDsc = &lvaTable[varNum];
+            const unsigned   varNum = tree->AsLclVarCommon()->GetLclNum();
+            const LclVarDsc* varDsc = lvaGetDesc(varNum);
             gtDispLclVar(varNum);
             if (tree->AsLclVarCommon()->HasSsaName())
             {
@@ -11170,8 +11169,6 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                 }
                 else
                 {
-                    CORINFO_CLASS_HANDLE typeHnd = varDsc->GetStructHnd();
-                    CORINFO_FIELD_HANDLE fldHnd;
 
                     for (unsigned i = varDsc->lvFieldLclStart; i < varDsc->lvFieldLclStart + varDsc->lvFieldCnt; ++i)
                     {
@@ -11185,7 +11182,9 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                         else
 #endif // !defined(TARGET_64BIT)
                         {
-                            fldHnd    = info.compCompHnd->getFieldInClass(typeHnd, fieldVarDsc->lvFldOrdinal);
+                            CORINFO_CLASS_HANDLE typeHnd = varDsc->GetStructHnd();
+                            CORINFO_FIELD_HANDLE fldHnd =
+                                info.compCompHnd->getFieldInClass(typeHnd, fieldVarDsc->lvFldOrdinal);
                             fieldName = eeGetFieldName(fldHnd);
                         }
 
@@ -11217,7 +11216,8 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                     printf(" (last use)");
                 }
             }
-            break;
+        }
+        break;
 
         case GT_JMP:
         {

--- a/src/coreclr/src/jit/jit.h
+++ b/src/coreclr/src/jit/jit.h
@@ -245,6 +245,20 @@
 #define UNIX_AMD64_ABI_ONLY(x)
 #endif // defined(UNIX_AMD64_ABI)
 
+#if defined(DEBUG) && !defined(OSX_ARM64_ABI)
+#define DEBUG_NOT_OSX_ARM64_ABI
+#endif
+
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+#define DEBUG_NOT_OSX_ARM64_ARG(x) , x
+#define DEBUG_NOT_OSX_ARM64(x) x
+#define DEBUG_NOT_OSX_ARM64_ASSERT(x) assert(x)
+#else
+#define DEBUG_NOT_OSX_ARM64_ARG(x)
+#define DEBUG_NOT_OSX_ARM64(x)
+#define DEBUG_NOT_OSX_ARM64_ASSERT(x)
+#endif
+
 #if defined(UNIX_AMD64_ABI) || !defined(TARGET_64BIT) || defined(TARGET_ARM64)
 #define FEATURE_PUT_STRUCT_ARG_STK 1
 #define PUT_STRUCT_ARG_STK_ONLY_ARG(x) , x

--- a/src/coreclr/src/jit/jit.h
+++ b/src/coreclr/src/jit/jit.h
@@ -246,17 +246,20 @@
 #endif // defined(UNIX_AMD64_ABI)
 
 #if defined(DEBUG) && !defined(OSX_ARM64_ABI)
-#define DEBUG_NOT_OSX_ARM64_ABI
+// On all platforms except Arm64 OSX arguments on the stack are taking
+// register size slots. On these platforms we could check that stack slots count
+// matchs out new byte size calculations.
+#define DEBUG_ARG_SLOTS
 #endif
 
-#if defined(DEBUG_NOT_OSX_ARM64_ABI)
-#define DEBUG_NOT_OSX_ARM64_ARG(x) , x
-#define DEBUG_NOT_OSX_ARM64(x) x
-#define DEBUG_NOT_OSX_ARM64_ASSERT(x) assert(x)
+#if defined(DEBUG_ARG_SLOTS)
+#define DEBUG_ARG_SLOTS_ARG(x) , x
+#define DEBUG_ARG_SLOTS_ONLY(x) x
+#define DEBUG_ARG_SLOTS_ASSERT(x) assert(x)
 #else
-#define DEBUG_NOT_OSX_ARM64_ARG(x)
-#define DEBUG_NOT_OSX_ARM64(x)
-#define DEBUG_NOT_OSX_ARM64_ASSERT(x)
+#define DEBUG_ARG_SLOTS_ARG(x)
+#define DEBUG_ARG_SLOTS_ONLY(x)
+#define DEBUG_ARG_SLOTS_ASSERT(x)
 #endif
 
 #if defined(UNIX_AMD64_ABI) || !defined(TARGET_64BIT) || defined(TARGET_ARM64)

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1041,8 +1041,15 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
 #endif // TARGET_ARM
         }
 
+        unsigned slotNumber = info->GetByteOffset() / TARGET_POINTER_SIZE;
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
+        unsigned numberOfStackSlots = info->GetStackSlotsNumber();
+        DEBUG_NOT_OSX_ARM64_ASSERT(numberOfStackSlots == info->numSlots);
+#endif
+        DEBUG_NOT_OSX_ARM64_ASSERT(slotNumber == info->slotNum);
+
         putArg = new (comp, GT_PUTARG_SPLIT)
-            GenTreePutArgSplit(arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots), info->numRegs,
+            GenTreePutArgSplit(arg, slotNumber PUT_STRUCT_ARG_STK_ONLY_ARG(numberOfStackSlots), info->numRegs,
                                call->IsFastTailCall(), call);
 
         // If struct argument is morphed to GT_FIELD_LIST node(s),
@@ -1126,12 +1133,16 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
             // Mark this one as tail call arg if it is a fast tail call.
             // This provides the info to put this argument in in-coming arg area slot
             // instead of in out-going arg area slot.
+            CLANG_FORMAT_COMMENT_ANCHOR;
 
+#ifdef DEBUG
             // Make sure state is correct. The PUTARG_STK has TYP_VOID, as it doesn't produce
             // a result. So the type of its operand must be the correct type to push on the stack.
             // For a FIELD_LIST, this will be the type of the field (not the type of the arg),
             // but otherwise it is generally the type of the operand.
             info->checkIsStruct();
+#endif
+
             if ((arg->OperGet() != GT_FIELD_LIST))
             {
 #if defined(FEATURE_SIMD) && defined(FEATURE_PUT_STRUCT_ARG_STK)
@@ -1145,10 +1156,16 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
                     assert(genActualType(arg->TypeGet()) == type);
                 }
             }
+            unsigned slotNumber = info->GetByteOffset() / TARGET_POINTER_SIZE;
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
+            unsigned numberOfStackSlots = info->GetStackSlotsNumber();
+            DEBUG_NOT_OSX_ARM64_ASSERT(numberOfStackSlots == info->numSlots);
+#endif
+            DEBUG_NOT_OSX_ARM64_ASSERT(slotNumber == info->slotNum);
 
             putArg =
                 new (comp, GT_PUTARG_STK) GenTreePutArgStk(GT_PUTARG_STK, TYP_VOID, arg,
-                                                           info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots),
+                                                           slotNumber PUT_STRUCT_ARG_STK_ONLY_ARG(numberOfStackSlots),
                                                            call->IsFastTailCall(), call);
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
@@ -2115,7 +2132,10 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     // We need to figure out the size of the outgoing stack arguments, not including the special args.
     // The number of 4-byte words is passed to the helper for the incoming and outgoing argument sizes.
     // This number is exactly the next slot number in the call's argument info struct.
-    unsigned nNewStkArgsWords = call->fgArgInfo->GetNextSlotNum();
+    unsigned  nNewStkArgsBytes = call->fgArgInfo->GetNextSlotByteOffset();
+    const int wordSize         = 4;
+    unsigned  nNewStkArgsWords = nNewStkArgsBytes / wordSize;
+    DEBUG_NOT_OSX_ARM64_ASSERT(call->fgArgInfo->GetNextSlotNum() == nNewStkArgsWords);
     assert(nNewStkArgsWords >= 4); // There must be at least the four special stack args.
     nNewStkArgsWords -= 4;
 
@@ -4167,7 +4187,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
         // On x86 targets, PInvoke calls need the size of the stack args in InlinedCallFrame.m_Datum.
         // This is because the callee pops stack arguments, and we need to keep track of this during stack
         // walking
-        const unsigned    numStkArgBytes = call->fgArgInfo->GetNextSlotNum() * TARGET_POINTER_SIZE;
+        const unsigned    numStkArgBytes = call->fgArgInfo->GetNextSlotByteOffset();
         GenTree*          stackBytes     = comp->gtNewIconNode(numStkArgBytes, TYP_INT);
         GenTreeCall::Use* args           = comp->gtNewCallArgs(frameAddr, stackBytes);
 #else
@@ -4201,9 +4221,9 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     {
 #if !defined(TARGET_64BIT)
         // On 32-bit targets, indirect calls need the size of the stack args in InlinedCallFrame.m_Datum.
-        const unsigned numStkArgBytes = call->fgArgInfo->GetNextSlotNum() * TARGET_POINTER_SIZE;
+        const unsigned stackByteOffset = call->fgArgInfo->GetNextSlotByteOffset();
 
-        src = comp->gtNewIconNode(numStkArgBytes, TYP_INT);
+        src = comp->gtNewIconNode(stackByteOffset, TYP_INT);
 #else
         // On 64-bit targets, indirect calls may need the stub parameter value in InlinedCallFrame.m_Datum.
         // If the stub parameter value is not needed, m_Datum will be initialized by the VM.

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1044,9 +1044,9 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
         unsigned slotNumber = info->GetByteOffset() / TARGET_POINTER_SIZE;
 #if defined(FEATURE_PUT_STRUCT_ARG_STK)
         unsigned numberOfStackSlots = info->GetStackSlotsNumber();
-        DEBUG_NOT_OSX_ARM64_ASSERT(numberOfStackSlots == info->numSlots);
+        DEBUG_ARG_SLOTS_ASSERT(numberOfStackSlots == info->numSlots);
 #endif
-        DEBUG_NOT_OSX_ARM64_ASSERT(slotNumber == info->slotNum);
+        DEBUG_ARG_SLOTS_ASSERT(slotNumber == info->slotNum);
 
         putArg = new (comp, GT_PUTARG_SPLIT)
             GenTreePutArgSplit(arg, slotNumber PUT_STRUCT_ARG_STK_ONLY_ARG(numberOfStackSlots), info->numRegs,
@@ -1159,9 +1159,9 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
             unsigned slotNumber = info->GetByteOffset() / TARGET_POINTER_SIZE;
 #if defined(FEATURE_PUT_STRUCT_ARG_STK)
             unsigned numberOfStackSlots = info->GetStackSlotsNumber();
-            DEBUG_NOT_OSX_ARM64_ASSERT(numberOfStackSlots == info->numSlots);
+            DEBUG_ARG_SLOTS_ASSERT(numberOfStackSlots == info->numSlots);
 #endif
-            DEBUG_NOT_OSX_ARM64_ASSERT(slotNumber == info->slotNum);
+            DEBUG_ARG_SLOTS_ASSERT(slotNumber == info->slotNum);
 
             putArg =
                 new (comp, GT_PUTARG_STK) GenTreePutArgStk(GT_PUTARG_STK, TYP_VOID, arg,
@@ -2135,7 +2135,7 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     unsigned  nNewStkArgsBytes = call->fgArgInfo->GetNextSlotByteOffset();
     const int wordSize         = 4;
     unsigned  nNewStkArgsWords = nNewStkArgsBytes / wordSize;
-    DEBUG_NOT_OSX_ARM64_ASSERT(call->fgArgInfo->GetNextSlotNum() == nNewStkArgsWords);
+    DEBUG_ARG_SLOTS_ASSERT(call->fgArgInfo->GetNextSlotNum() == nNewStkArgsWords);
     assert(nNewStkArgsWords >= 4); // There must be at least the four special stack args.
     nNewStkArgsWords -= 4;
 

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1895,19 +1895,19 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
                 unsigned int argStart = callerArgLclNum * TARGET_POINTER_SIZE;
                 unsigned int argEnd   = argStart + static_cast<unsigned int>(callerArgDsc->lvArgStackSize());
 #else
-                assert(callerArgDsc->lvStkOffs != BAD_STK_OFFS);
+                assert(callerArgDsc->GetStackOffset() != BAD_STK_OFFS);
 
                 if (baseOff == -1)
                 {
-                    baseOff = callerArgDsc->lvStkOffs;
+                    baseOff = callerArgDsc->GetStackOffset();
                 }
 
                 // On all ABIs where we fast tail call the stack args should come in order.
-                assert(baseOff <= callerArgDsc->lvStkOffs);
+                assert(baseOff <= callerArgDsc->GetStackOffset());
 
                 // Compute offset of this stack argument relative to the first stack arg.
                 // This will be its offset into the incoming arg space area.
-                unsigned int argStart = static_cast<unsigned int>(callerArgDsc->lvStkOffs - baseOff);
+                unsigned int argStart = static_cast<unsigned int>(callerArgDsc->GetStackOffset() - baseOff);
                 unsigned int argEnd   = argStart + comp->lvaLclSize(callerArgLclNum);
 #endif
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6695,7 +6695,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
     {
         fgArgTabEntry* arg = argInfo->GetArgEntry(index, false);
 
-        calleeArgStackSize += arg->stackSize();
+        calleeArgStackSize += arg->GetStackSize();
     }
 
     auto reportFastTailCallDecision = [&](const char* thisFailReason) {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5738,8 +5738,8 @@ GenTree* Compiler::fgMorphStackArgForVarArgs(unsigned lclNum, var_types varType,
         // Create a node representing the local pointing to the base of the args
         GenTree* ptrArg =
             gtNewOperNode(GT_SUB, TYP_I_IMPL, gtNewLclvNode(lvaVarargsBaseOfStkArgs, TYP_I_IMPL),
-                          gtNewIconNode(varDsc->lvStkOffs - codeGen->intRegState.rsCalleeRegArgCount * REGSIZE_BYTES -
-                                        lclOffs));
+                          gtNewIconNode(varDsc->GetStackOffset() -
+                                        codeGen->intRegState.rsCalleeRegArgCount * REGSIZE_BYTES - lclOffs));
 
         // Access the argument through the local
         GenTree* tree;

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -783,7 +783,7 @@ void fgArgTabEntry::Dump() const
             printf(" %s", getRegName(regNums[i]));
         }
     }
-    if (GetStackSlotsNumber() > 0)
+    if (GetStackByteSize() > 0)
     {
 #if defined(DEBUG_NOT_OSX_ARM64_ABI)
         printf(", numSlots=%u, slotNum=%u, byteSize=%u, byteOffset=%u", numSlots, slotNum, m_byteSize, m_byteOffset);

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -77,8 +77,10 @@ GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, GenTreeCall:
 
 #if DEBUG
     // Helper calls are never candidates.
-
     call->gtInlineObservation = InlineObservation::CALLSITE_IS_CALL_TO_HELPER;
+
+    call->callSig = nullptr;
+
 #endif // DEBUG
 
 #ifdef FEATURE_READYTORUN_COMPILER
@@ -781,11 +783,16 @@ void fgArgTabEntry::Dump() const
             printf(" %s", getRegName(regNums[i]));
         }
     }
-    if (numSlots > 0)
+    if (GetStackSlotsNumber() > 0)
     {
-        printf(", numSlots=%u, slotNum=%u", numSlots, slotNum);
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+        printf(", numSlots=%u, slotNum=%u, byteSize=%u, byteOffset=%u", numSlots, slotNum, m_byteSize, m_byteOffset);
+#else
+        printf(", byteSize=%u, byteOffset=%u", m_byteSize, m_byteOffset);
+
+#endif
     }
-    printf(", align=%u", alignment);
+    printf(", byteAlignment=%u", byteAlignment);
     if (isLateArg())
     {
         printf(", lateArgInx=%u", GetLateArgInx());
@@ -832,11 +839,12 @@ void fgArgTabEntry::Dump() const
 
 fgArgInfo::fgArgInfo(Compiler* comp, GenTreeCall* call, unsigned numArgs)
 {
-    compiler    = comp;
-    callTree    = call;
-    argCount    = 0; // filled in arg count, starts at zero
-    nextSlotNum = INIT_ARG_STACK_SLOT;
-    stkLevel    = 0;
+    compiler = comp;
+    callTree = call;
+    argCount = 0; // filled in arg count, starts at zero
+    DEBUG_NOT_OSX_ARM64(nextSlotNum = INIT_ARG_STACK_SLOT;)
+    nextStackByteOffset = INIT_ARG_STACK_SLOT * TARGET_POINTER_SIZE;
+    stkLevel            = 0;
 #if defined(UNIX_X86_ABI)
     alignmentDone = false;
     stkSizeBytes  = 0;
@@ -879,11 +887,12 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
 {
     fgArgInfo* oldArgInfo = oldCall->AsCall()->fgArgInfo;
 
-    compiler    = oldArgInfo->compiler;
-    callTree    = newCall;
-    argCount    = 0; // filled in arg count, starts at zero
-    nextSlotNum = INIT_ARG_STACK_SLOT;
-    stkLevel    = oldArgInfo->stkLevel;
+    compiler = oldArgInfo->compiler;
+    callTree = newCall;
+    argCount = 0; // filled in arg count, starts at zero
+    DEBUG_NOT_OSX_ARM64(nextSlotNum = INIT_ARG_STACK_SLOT;)
+    nextStackByteOffset = INIT_ARG_STACK_SLOT * TARGET_POINTER_SIZE;
+    stkLevel            = oldArgInfo->stkLevel;
 #if defined(UNIX_X86_ABI)
     alignmentDone = oldArgInfo->alignmentDone;
     stkSizeBytes  = oldArgInfo->stkSizeBytes;
@@ -957,8 +966,10 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
         }
     }
 
-    argCount     = oldArgInfo->argCount;
-    nextSlotNum  = oldArgInfo->nextSlotNum;
+    argCount = oldArgInfo->argCount;
+    DEBUG_NOT_OSX_ARM64(nextSlotNum = oldArgInfo->nextSlotNum;)
+    nextStackByteOffset = oldArgInfo->nextStackByteOffset;
+
     hasRegArgs   = oldArgInfo->hasRegArgs;
     hasStackArgs = oldArgInfo->hasStackArgs;
     argsComplete = true;
@@ -977,7 +988,8 @@ fgArgTabEntry* fgArgInfo::AddRegArg(unsigned          argNum,
                                     GenTreeCall::Use* use,
                                     regNumber         regNum,
                                     unsigned          numRegs,
-                                    unsigned          alignment,
+                                    unsigned          byteSize,
+                                    unsigned          byteAlignment,
                                     bool              isStruct,
                                     bool              isVararg /*=false*/)
 {
@@ -989,14 +1001,18 @@ fgArgTabEntry* fgArgInfo::AddRegArg(unsigned          argNum,
     // may actually be less.
     curArgTabEntry->setRegNum(0, regNum);
 
-    curArgTabEntry->argNum    = argNum;
-    curArgTabEntry->argType   = node->TypeGet();
-    curArgTabEntry->use       = use;
-    curArgTabEntry->lateUse   = nullptr;
-    curArgTabEntry->slotNum   = 0;
-    curArgTabEntry->numRegs   = numRegs;
-    curArgTabEntry->numSlots  = 0;
-    curArgTabEntry->alignment = alignment;
+    curArgTabEntry->argNum  = argNum;
+    curArgTabEntry->argType = node->TypeGet();
+    curArgTabEntry->use     = use;
+    curArgTabEntry->lateUse = nullptr;
+    curArgTabEntry->numRegs = numRegs;
+
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+    curArgTabEntry->slotNum  = 0;
+    curArgTabEntry->numSlots = 0;
+#endif
+
+    curArgTabEntry->byteAlignment = byteAlignment;
     curArgTabEntry->SetLateArgInx(UINT_MAX);
     curArgTabEntry->tmpNum = BAD_VAR_NUM;
     curArgTabEntry->SetSplit(false);
@@ -1011,6 +1027,8 @@ fgArgTabEntry* fgArgInfo::AddRegArg(unsigned          argNum,
     curArgTabEntry->isNonStandard = false;
     curArgTabEntry->isStruct      = isStruct;
     curArgTabEntry->SetIsVararg(isVararg);
+    curArgTabEntry->SetByteSize(byteSize);
+    curArgTabEntry->SetByteOffset(0);
 
     hasRegArgs = true;
     AddArg(curArgTabEntry);
@@ -1023,7 +1041,8 @@ fgArgTabEntry* fgArgInfo::AddRegArg(unsigned                                    
                                     GenTreeCall::Use*                                                use,
                                     regNumber                                                        regNum,
                                     unsigned                                                         numRegs,
-                                    unsigned                                                         alignment,
+                                    unsigned                                                         byteSize,
+                                    unsigned                                                         byteAlignment,
                                     const bool                                                       isStruct,
                                     const bool                                                       isVararg,
                                     const regNumber                                                  otherRegNum,
@@ -1031,14 +1050,15 @@ fgArgTabEntry* fgArgInfo::AddRegArg(unsigned                                    
                                     const unsigned                                                   structFloatRegs,
                                     const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr)
 {
-    fgArgTabEntry* curArgTabEntry = AddRegArg(argNum, node, use, regNum, numRegs, alignment, isStruct, isVararg);
+    fgArgTabEntry* curArgTabEntry =
+        AddRegArg(argNum, node, use, regNum, numRegs, byteSize, byteAlignment, isStruct, isVararg);
     assert(curArgTabEntry != nullptr);
 
     curArgTabEntry->isStruct        = isStruct; // is this a struct arg
     curArgTabEntry->structIntRegs   = structIntRegs;
     curArgTabEntry->structFloatRegs = structFloatRegs;
 
-    curArgTabEntry->checkIsStruct();
+    INDEBUG(curArgTabEntry->checkIsStruct();)
     assert(numRegs <= 2);
     if (numRegs == 2)
     {
@@ -1058,27 +1078,36 @@ fgArgTabEntry* fgArgInfo::AddStkArg(unsigned          argNum,
                                     GenTree*          node,
                                     GenTreeCall::Use* use,
                                     unsigned          numSlots,
-                                    unsigned          alignment,
+                                    unsigned          byteSize,
+                                    unsigned          byteAlignment,
                                     bool              isStruct,
                                     bool              isVararg /*=false*/)
 {
     fgArgTabEntry* curArgTabEntry = new (compiler, CMK_fgArgInfo) fgArgTabEntry;
 
-    nextSlotNum = roundUp(nextSlotNum, alignment);
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+    nextSlotNum = roundUp(nextSlotNum, byteAlignment / TARGET_POINTER_SIZE);
+#endif
+
+    nextStackByteOffset = roundUp(nextStackByteOffset, byteAlignment);
+    DEBUG_NOT_OSX_ARM64_ASSERT(nextStackByteOffset / TARGET_POINTER_SIZE == nextSlotNum);
 
     curArgTabEntry->setRegNum(0, REG_STK);
     curArgTabEntry->argNum  = argNum;
     curArgTabEntry->argType = node->TypeGet();
     curArgTabEntry->use     = use;
     curArgTabEntry->lateUse = nullptr;
-    curArgTabEntry->slotNum = nextSlotNum;
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+    curArgTabEntry->numSlots = numSlots;
+    curArgTabEntry->slotNum  = nextSlotNum;
+#endif
+
     curArgTabEntry->numRegs = 0;
 #if defined(UNIX_AMD64_ABI)
     curArgTabEntry->structIntRegs   = 0;
     curArgTabEntry->structFloatRegs = 0;
 #endif // defined(UNIX_AMD64_ABI)
-    curArgTabEntry->numSlots  = numSlots;
-    curArgTabEntry->alignment = alignment;
+    curArgTabEntry->byteAlignment = byteAlignment;
     curArgTabEntry->SetLateArgInx(UINT_MAX);
     curArgTabEntry->tmpNum = BAD_VAR_NUM;
     curArgTabEntry->SetSplit(false);
@@ -1094,16 +1123,20 @@ fgArgTabEntry* fgArgInfo::AddStkArg(unsigned          argNum,
     curArgTabEntry->isStruct      = isStruct;
     curArgTabEntry->SetIsVararg(isVararg);
 
+    curArgTabEntry->SetByteSize(byteSize);
+    curArgTabEntry->SetByteOffset(nextStackByteOffset);
+
     hasStackArgs = true;
     AddArg(curArgTabEntry);
-
-    nextSlotNum += numSlots;
+    DEBUG_NOT_OSX_ARM64(nextSlotNum += numSlots;)
+    nextStackByteOffset += byteSize;
     return curArgTabEntry;
 }
 
 void fgArgInfo::RemorphReset()
 {
-    nextSlotNum = INIT_ARG_STACK_SLOT;
+    DEBUG_NOT_OSX_ARM64(nextSlotNum = INIT_ARG_STACK_SLOT;)
+    nextStackByteOffset = INIT_ARG_STACK_SLOT * TARGET_POINTER_SIZE;
 }
 
 //------------------------------------------------------------------------
@@ -1149,10 +1182,22 @@ void fgArgInfo::UpdateStkArg(fgArgTabEntry* curArgTabEntry, GenTree* node, bool 
     noway_assert(curArgTabEntry->use != callTree->gtCallThisArg);
     assert((curArgTabEntry->GetRegNum() == REG_STK) || curArgTabEntry->IsSplit());
     assert(curArgTabEntry->use->GetNode() == node);
-    nextSlotNum = (unsigned)roundUp(nextSlotNum, curArgTabEntry->alignment);
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+    nextSlotNum = roundUp(nextSlotNum, curArgTabEntry->byteAlignment / TARGET_POINTER_SIZE);
     assert(curArgTabEntry->slotNum == nextSlotNum);
-
     nextSlotNum += curArgTabEntry->numSlots;
+#endif
+    nextStackByteOffset = roundUp(nextStackByteOffset, curArgTabEntry->byteAlignment);
+    assert(curArgTabEntry->GetByteOffset() == nextStackByteOffset);
+
+    if (!curArgTabEntry->IsSplit())
+    {
+        nextStackByteOffset += curArgTabEntry->GetByteSize();
+    }
+    else
+    {
+        nextStackByteOffset += curArgTabEntry->GetStackByteSize();
+    }
 }
 
 void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)
@@ -1175,17 +1220,20 @@ void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)
     {
         assert(curArgTabEntry->IsSplit() == true);
         assert(curArgTabEntry->numRegs == numRegs);
-        assert(curArgTabEntry->numSlots == numSlots);
+        DEBUG_NOT_OSX_ARM64(assert(curArgTabEntry->numSlots == numSlots);)
         assert(hasStackArgs == true);
     }
     else
     {
         curArgTabEntry->SetSplit(true);
-        curArgTabEntry->numRegs  = numRegs;
-        curArgTabEntry->numSlots = numSlots;
-        hasStackArgs             = true;
+        curArgTabEntry->numRegs = numRegs;
+        DEBUG_NOT_OSX_ARM64(curArgTabEntry->numSlots = numSlots;)
+        curArgTabEntry->SetByteOffset(0);
+        hasStackArgs = true;
     }
-    nextSlotNum += numSlots;
+    DEBUG_NOT_OSX_ARM64(nextSlotNum += numSlots;)
+    // TODO-Cleanup: structs are aligned to 8 bytes on arm64 apple, so it would work, but pass the precise size.
+    nextStackByteOffset += numSlots * TARGET_POINTER_SIZE;
 }
 
 //------------------------------------------------------------------------
@@ -1378,7 +1426,8 @@ void fgArgInfo::ArgsComplete()
         //
         CLANG_FORMAT_COMMENT_ANCHOR;
 #ifdef TARGET_ARM
-        bool isMultiRegArg = (curArgTabEntry->numRegs > 0) && (curArgTabEntry->numRegs + curArgTabEntry->numSlots > 1);
+        bool isMultiRegArg =
+            (curArgTabEntry->numRegs > 0) && (curArgTabEntry->numRegs + curArgTabEntry->GetStackSlotsNumber() > 1);
 #else
         bool isMultiRegArg = (curArgTabEntry->numRegs > 1);
 #endif
@@ -1901,7 +1950,7 @@ GenTree* Compiler::fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry)
         // Otherwise, it will return TYP_UNKNOWN and we will pass it as a struct type.
 
         bool passedAsPrimitive = false;
-        if (curArgTabEntry->isSingleRegOrSlot())
+        if (curArgTabEntry->TryPassAsPrimitive())
         {
             CORINFO_CLASS_HANDLE clsHnd = varDsc->GetStructHnd();
             var_types            structBaseType =
@@ -2384,7 +2433,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
     unsigned argIndex     = 0;
     unsigned intArgRegNum = 0;
     unsigned fltArgRegNum = 0;
-    unsigned argSlots     = 0;
+    DEBUG_NOT_OSX_ARM64(unsigned argSlots = 0;)
 
     bool callHasRetBuffArg = call->HasRetBufArg();
     bool callIsVararg      = call->IsVarargs();
@@ -2677,7 +2726,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         *insertionPoint = gtNewCallArgs(arg);
 #else  // !defined(TARGET_X86)
         // All other architectures pass the cookie in a register.
-        call->gtCallArgs = gtPrependNewCallArg(arg, call->gtCallArgs);
+        call->gtCallArgs       = gtPrependNewCallArg(arg, call->gtCallArgs);
 #endif // defined(TARGET_X86)
 
         nonStandardArgs.Add(arg, REG_PINVOKE_COOKIE_PARAM);
@@ -2736,10 +2785,16 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         assert(call->gtCallType == CT_USER_FUNC || call->gtCallType == CT_INDIRECT);
         assert(varTypeIsGC(argx) || (argx->gtType == TYP_I_IMPL));
 
+        const regNumber regNum        = genMapIntRegArgNumToRegNum(intArgRegNum);
+        const unsigned  numRegs       = 1;
+        const unsigned  byteSize      = TARGET_POINTER_SIZE;
+        const unsigned  byteAlignment = TARGET_POINTER_SIZE;
+        const bool      isStruct      = false;
+
         // This is a register argument - put it in the table.
-        call->fgArgInfo->AddRegArg(argIndex, argx, call->gtCallThisArg, genMapIntRegArgNumToRegNum(intArgRegNum), 1, 1,
-                                   false, callIsVararg UNIX_AMD64_ABI_ONLY_ARG(REG_STK) UNIX_AMD64_ABI_ONLY_ARG(0)
-                                              UNIX_AMD64_ABI_ONLY_ARG(0) UNIX_AMD64_ABI_ONLY_ARG(nullptr));
+        call->fgArgInfo->AddRegArg(argIndex, argx, call->gtCallThisArg, regNum, numRegs, byteSize, byteAlignment,
+                                   isStruct, callIsVararg UNIX_AMD64_ABI_ONLY_ARG(REG_STK) UNIX_AMD64_ABI_ONLY_ARG(0)
+                                                 UNIX_AMD64_ABI_ONLY_ARG(0) UNIX_AMD64_ABI_ONLY_ARG(nullptr));
 
         intArgRegNum++;
 #ifdef WINDOWS_AMD64_ABI
@@ -2748,7 +2803,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         fltArgRegNum++;
 #endif // WINDOWS_AMD64_ABI
         argIndex++;
-        argSlots++;
+        DEBUG_NOT_OSX_ARM64(argSlots++;)
     }
 
 #ifdef TARGET_X86
@@ -2856,9 +2911,14 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         var_types hfaType  = TYP_UNDEF;
         unsigned  hfaSlots = 0;
 
-        bool                 passUsingFloatRegs;
-        unsigned             argAlign      = 1;
+        bool passUsingFloatRegs;
+#if !defined(OSX_ARM64_ABI)
+        unsigned argAlignBytes = TARGET_POINTER_SIZE;
+#else
+        unsigned argAlignBytes = TARGET_POINTER_SIZE; // TODO-OSX-ARM64: change it after other changes are merged.
+#endif
         unsigned             size          = 0;
+        unsigned             byteSize      = 0;
         CORINFO_CLASS_HANDLE copyBlkClass  = nullptr;
         bool                 isRegArg      = false;
         bool                 isNonStandard = false;
@@ -2892,12 +2952,11 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         bool passUsingIntRegs = passUsingFloatRegs ? false : (intArgRegNum < MAX_REG_ARG);
 
         // We don't use the "size" return value from InferOpSizeAlign().
-        codeGen->InferOpSizeAlign(argx, &argAlign);
+        codeGen->InferOpSizeAlign(argx, &argAlignBytes);
 
-        argAlign = roundUp(argAlign, TARGET_POINTER_SIZE);
-        argAlign /= TARGET_POINTER_SIZE;
+        argAlignBytes = roundUp(argAlignBytes, TARGET_POINTER_SIZE);
 
-        if (argAlign == 2)
+        if (argAlignBytes == 2 * TARGET_POINTER_SIZE)
         {
             if (passUsingFloatRegs)
             {
@@ -2916,10 +2975,12 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
                 }
             }
 
+#if defined(DEBUG)
             if (argSlots % 2 == 1)
             {
                 argSlots++;
             }
+#endif
         }
 
 #elif defined(TARGET_ARM64)
@@ -2988,15 +3049,22 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 #ifdef UNIX_AMD64_ABI
         if (!isStructArg)
         {
-            size = 1; // On AMD64, all primitives fit in a single (64-bit) 'slot'
+            size     = 1; // On AMD64, all primitives fit in a single (64-bit) 'slot'
+            byteSize = genTypeSize(argx);
         }
         else
         {
-            size = (unsigned)(roundUp(structSize, TARGET_POINTER_SIZE)) / TARGET_POINTER_SIZE;
+            size     = (unsigned)(roundUp(structSize, TARGET_POINTER_SIZE)) / TARGET_POINTER_SIZE;
+            byteSize = structSize;
             eeGetSystemVAmd64PassStructInRegisterDescriptor(objClass, &structDesc);
         }
-#else  // !UNIX_AMD64_ABI
+#else // !UNIX_AMD64_ABI
         size               = 1; // On AMD64 Windows, all args fit in a single (64-bit) 'slot'
+        if (!isStructArg)
+        {
+            byteSize = genTypeSize(argx);
+        }
+
 #endif // UNIX_AMD64_ABI
 #elif defined(TARGET_ARM64)
         if (isStructArg)
@@ -3005,7 +3073,9 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
             {
                 // HFA structs are passed by value in multiple registers.
                 // The "size" in registers may differ the size in pointer-sized units.
-                size = GetHfaCount(argx);
+                CORINFO_CLASS_HANDLE structHnd = gtGetStructHandle(argx);
+                size                           = GetHfaCount(structHnd);
+                byteSize                       = info.compCompHnd->getClassSize(structHnd);
             }
             else
             {
@@ -3014,8 +3084,8 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
                 // if sufficient registers are available.
                 // Structs that are larger than 2 pointers (except for HFAs) are passed by
                 // reference (to a copy)
-                size = (unsigned)(roundUp(structSize, TARGET_POINTER_SIZE)) / TARGET_POINTER_SIZE;
-
+                size     = (unsigned)(roundUp(structSize, TARGET_POINTER_SIZE)) / TARGET_POINTER_SIZE;
+                byteSize = structSize;
                 if (size > 2)
                 {
                     size = 1;
@@ -3026,52 +3096,48 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         }
         else
         {
-            size = 1; // Otherwise, all primitive types fit in a single (64-bit) 'slot'
+            size     = 1; // Otherwise, all primitive types fit in a single (64-bit) 'slot'
+            byteSize = genTypeSize(argx);
         }
 #elif defined(TARGET_ARM) || defined(TARGET_X86)
         if (isStructArg)
         {
-            size = (unsigned)(roundUp(structSize, TARGET_POINTER_SIZE)) / TARGET_POINTER_SIZE;
+            size     = (unsigned)(roundUp(structSize, TARGET_POINTER_SIZE)) / TARGET_POINTER_SIZE;
+            byteSize = structSize;
         }
         else
         {
             // The typical case.
             // Long/double type argument(s) will be modified as needed in Lowering.
-            size = genTypeStSz(argx->gtType);
+            size     = genTypeStSz(argx->gtType);
+            byteSize = genTypeSize(argx);
         }
 #else
 #error Unsupported or unset target architecture
 #endif // TARGET_XXX
+
         if (isStructArg)
         {
             // We have an argument with a struct type, but it may be be a child of a GT_COMMA
             GenTree* argObj = argx->gtEffectiveVal(true /*commaOnly*/);
 
             assert(argx == args->GetNode());
-
-            unsigned originalSize = structSize;
-            originalSize          = (originalSize == 0 ? TARGET_POINTER_SIZE : originalSize);
-            unsigned roundupSize  = (unsigned)roundUp(originalSize, TARGET_POINTER_SIZE);
-
-            structSize = originalSize;
+            assert(structSize != 0);
 
             structPassingKind howToPassStruct;
-
-            structBaseType = getArgTypeForStruct(objClass, &howToPassStruct, callIsVararg, originalSize);
-
-            bool passedInRegisters = false;
-            passStructByRef        = (howToPassStruct == SPK_ByReference);
+            structBaseType  = getArgTypeForStruct(objClass, &howToPassStruct, callIsVararg, structSize);
+            passStructByRef = (howToPassStruct == SPK_ByReference);
+            if (howToPassStruct == SPK_ByReference)
+            {
+                byteSize = TARGET_POINTER_SIZE;
+            }
+            else
+            {
+                byteSize = structSize;
+            }
 
             if (howToPassStruct == SPK_PrimitiveType)
             {
-// For ARM64 or AMD64/UX we can pass non-power-of-2 structs in a register.
-// For ARM or AMD64/Windows only power-of-2 structs are passed in registers.
-#if !defined(TARGET_ARM64) && !defined(UNIX_AMD64_ABI)
-                if (!isPow2(originalSize))
-#endif //  !TARGET_ARM64 && !UNIX_AMD64_ABI
-                {
-                    passedInRegisters = true;
-                }
 #ifdef TARGET_ARM
                 // TODO-CQ: getArgTypeForStruct should *not* return TYP_DOUBLE for a double struct,
                 // or for a struct of two floats. This causes the struct to be address-taken.
@@ -3093,6 +3159,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 
         // The 'size' value has now must have been set. (the original value of zero is an invalid value)
         assert(size != 0);
+        assert(byteSize != 0);
 
         //
         // Figure out if the argument will be passed in a register.
@@ -3335,11 +3402,11 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 #endif
 
             // This is a register argument - put it in the table
-            newArgEntry = call->fgArgInfo->AddRegArg(argIndex, argx, args, nextRegNum, size, argAlign, isStructArg,
-                                                     callIsVararg UNIX_AMD64_ABI_ONLY_ARG(nextOtherRegNum)
-                                                         UNIX_AMD64_ABI_ONLY_ARG(structIntRegs)
-                                                             UNIX_AMD64_ABI_ONLY_ARG(structFloatRegs)
-                                                                 UNIX_AMD64_ABI_ONLY_ARG(&structDesc));
+            newArgEntry = call->fgArgInfo->AddRegArg(argIndex, argx, args, nextRegNum, size, byteSize, argAlignBytes,
+                                                     isStructArg, callIsVararg UNIX_AMD64_ABI_ONLY_ARG(nextOtherRegNum)
+                                                                      UNIX_AMD64_ABI_ONLY_ARG(structIntRegs)
+                                                                          UNIX_AMD64_ABI_ONLY_ARG(structFloatRegs)
+                                                                              UNIX_AMD64_ABI_ONLY_ARG(&structDesc));
 
             newArgEntry->SetIsBackFilled(isBackFilled);
             newArgEntry->isNonStandard = isNonStandard;
@@ -3400,7 +3467,8 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         else // We have an argument that is not passed in a register
         {
             // This is a stack argument - put it in the table
-            newArgEntry = call->fgArgInfo->AddStkArg(argIndex, argx, args, size, argAlign, isStructArg, callIsVararg);
+            newArgEntry = call->fgArgInfo->AddStkArg(argIndex, argx, args, size, byteSize, argAlignBytes, isStructArg,
+                                                     callIsVararg);
 #ifdef UNIX_AMD64_ABI
             // TODO-Amd64-Unix-CQ: This is temporary (see also in fgMorphArgs).
             if (structDesc.passedInRegisters)
@@ -3429,7 +3497,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
             newArgEntry->argType = argx->TypeGet();
         }
 
-        argSlots += size;
+        DEBUG_NOT_OSX_ARM64(argSlots += size;)
     } // end foreach argument loop
 
 #ifdef DEBUG
@@ -3491,7 +3559,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     unsigned flagsSummary = 0;
 
     unsigned argIndex = 0;
-    unsigned argSlots = 0;
+
+    DEBUG_NOT_OSX_ARM64(unsigned argSlots = 0;)
 
     bool reMorphing = call->AreArgsComplete();
 
@@ -3530,7 +3599,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         flagsSummary |= argx->gtFlags;
         assert(argIndex == 0);
         argIndex++;
-        argSlots++;
+        DEBUG_NOT_OSX_ARM64(argSlots++;)
     }
 
     // Note that this name is a bit of a misnomer - it indicates that there are struct args
@@ -3547,17 +3616,18 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         *parentArgx = argx;
         assert(argx == args->GetNode());
 
-        unsigned             argAlign     = argEntry->alignment;
-        unsigned             size         = argEntry->getSize();
+        DEBUG_NOT_OSX_ARM64(unsigned size = argEntry->getSize();)
         CORINFO_CLASS_HANDLE copyBlkClass = NO_CLASS_HANDLE;
 
-        if (argAlign == 2)
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+        if (argEntry->byteAlignment == 2 * TARGET_POINTER_SIZE)
         {
             if (argSlots % 2 == 1)
             {
                 argSlots++;
             }
         }
+#endif // DEBUG
         if (argEntry->isNonStandard)
         {
             // We need to update the node field for this nonStandard arg here
@@ -3566,9 +3636,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             flagsSummary |= argx->gtFlags;
             continue;
         }
-
-        assert(size != 0);
-        argSlots += argEntry->getSlotCount();
+        DEBUG_NOT_OSX_ARM64_ASSERT(size != 0);
+        DEBUG_NOT_OSX_ARM64(argSlots += argEntry->getSlotCount();)
 
         if (argx->IsLocalAddrExpr() != nullptr)
         {
@@ -3619,7 +3688,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             // First, handle the case where the argument is passed by reference.
             if (argEntry->passedByRef)
             {
-                assert(size == 1);
+                DEBUG_NOT_OSX_ARM64_ASSERT(size == 1);
                 copyBlkClass = objClass;
 #ifdef UNIX_AMD64_ABI
                 assert(!"Structs are not passed by reference on x64/ux");
@@ -3631,7 +3700,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #ifndef TARGET_X86
                 // Check to see if we can transform this into load of a primitive type.
                 // 'size' must be the number of pointer sized items
-                assert(size == roundupSize / TARGET_POINTER_SIZE);
+                DEBUG_NOT_OSX_ARM64_ASSERT(size == roundupSize / TARGET_POINTER_SIZE);
 
                 structSize           = originalSize;
                 unsigned passingSize = originalSize;
@@ -3728,12 +3797,11 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     // or a local.
                     // Change our argument, as needed, into a value of the appropriate type.
                     CLANG_FORMAT_COMMENT_ANCHOR;
-
 #ifdef TARGET_ARM
-                    assert((size == 1) || ((structBaseType == TYP_DOUBLE) && (size == 2)));
+                    DEBUG_NOT_OSX_ARM64_ASSERT((size == 1) || ((structBaseType == TYP_DOUBLE) && (size == 2)));
 #else
-                    assert((size == 1) ||
-                           (varTypeIsSIMD(structBaseType) && size == (genTypeSize(structBaseType) / REGSIZE_BYTES)));
+                    DEBUG_NOT_OSX_ARM64_ASSERT((size == 1) || (varTypeIsSIMD(structBaseType) &&
+                                                               size == (genTypeSize(structBaseType) / REGSIZE_BYTES)));
 #endif
 
                     assert((structBaseType != TYP_STRUCT) && (genTypeSize(structBaseType) >= originalSize));
@@ -3827,9 +3895,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                 // We still have a struct unless we converted the GT_OBJ into a GT_IND above...
                 if (isHfaArg && passUsingFloatRegs)
                 {
-                    size = argEntry->numRegs;
                 }
-                else if (structBaseType == TYP_STRUCT)
+                else if ((!isHfaArg || !passUsingFloatRegs) && (structBaseType == TYP_STRUCT))
                 {
                     // If the valuetype size is not a multiple of TARGET_POINTER_SIZE,
                     // we must copyblk to a temp before doing the obj to avoid
@@ -3849,8 +3916,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                             copyBlkClass = NO_CLASS_HANDLE;
                         }
                     }
-
-                    size = roundupSize / TARGET_POINTER_SIZE; // Normalize size to number of pointer sized items
                 }
 
 #endif // !UNIX_AMD64_ABI
@@ -3916,7 +3981,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #if FEATURE_MULTIREG_ARGS
         if (isStructArg)
         {
-            if (((argEntry->numRegs + argEntry->numSlots) > 1) || (isHfaArg && argx->TypeGet() == TYP_STRUCT))
+            if (((argEntry->numRegs + argEntry->GetStackSlotsNumber()) > 1) ||
+                (isHfaArg && argx->TypeGet() == TYP_STRUCT))
             {
                 hasMultiregStructArgs = true;
             }
@@ -3930,8 +3996,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         else
         {
             // We must have exactly one register or slot.
-            assert(((argEntry->numRegs == 1) && (argEntry->numSlots == 0)) ||
-                   ((argEntry->numRegs == 0) && (argEntry->numSlots == 1)));
+            assert(((argEntry->numRegs == 1) && (argEntry->GetStackSlotsNumber() == 0)) ||
+                   ((argEntry->numRegs == 0) && (argEntry->GetStackSlotsNumber() == 1)));
         }
 #endif
 
@@ -4001,21 +4067,33 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     // outgoing arg size.
     if (!call->IsFastTailCall())
     {
-        unsigned preallocatedArgCount = call->fgArgInfo->GetNextSlotNum();
 
 #if defined(UNIX_AMD64_ABI)
         // This is currently required for the UNIX ABI to work correctly.
         opts.compNeedToAlignFrame = true;
 #endif // UNIX_AMD64_ABI
 
-        const unsigned outgoingArgSpaceSize = preallocatedArgCount * REGSIZE_BYTES;
+        const unsigned outgoingArgSpaceSize = GetOutgoingArgByteSize(call->fgArgInfo->GetNextSlotByteOffset());
+
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+        unsigned preallocatedArgCount = call->fgArgInfo->GetNextSlotNum();
+        assert(outgoingArgSpaceSize == preallocatedArgCount * REGSIZE_BYTES);
+#endif
         call->fgArgInfo->SetOutArgSize(max(outgoingArgSpaceSize, MIN_ARG_AREA_FOR_CALL));
 
 #ifdef DEBUG
         if (verbose)
         {
-            printf("argSlots=%d, preallocatedArgCount=%d, nextSlotNum=%d, outgoingArgSpaceSize=%d\n", argSlots,
-                   preallocatedArgCount, call->fgArgInfo->GetNextSlotNum(), outgoingArgSpaceSize);
+            const fgArgInfo* argInfo = call->fgArgInfo;
+#if defined(DEBUG_NOT_OSX_ARM64_ABI)
+            printf("argSlots=%d, preallocatedArgCount=%d, nextSlotNum=%d, nextSlotByteOffset=%d, "
+                   "outgoingArgSpaceSize=%d\n",
+                   argSlots, preallocatedArgCount, argInfo->GetNextSlotNum(), argInfo->GetNextSlotByteOffset(),
+                   outgoingArgSpaceSize);
+#else
+            printf("nextSlotByteOffset=%d, outgoingArgSpaceSize=%d\n", argInfo->GetNextSlotByteOffset(),
+                   outgoingArgSpaceSize);
+#endif
         }
 #endif
     }
@@ -4122,7 +4200,7 @@ void Compiler::fgMorphMultiregStructArgs(GenTreeCall* call)
             continue;
         }
 
-        unsigned size = (fgEntryPtr->numRegs + fgEntryPtr->numSlots);
+        unsigned size = (fgEntryPtr->numRegs + fgEntryPtr->GetStackSlotsNumber());
         if ((size > 1) || (fgEntryPtr->IsHfaArg() && argx->TypeGet() == TYP_STRUCT))
         {
             foundStructArg = true;
@@ -4216,7 +4294,7 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
 #endif
 
 #ifdef TARGET_ARM
-    if ((fgEntryPtr->IsSplit() && fgEntryPtr->numSlots + fgEntryPtr->numRegs > 4) ||
+    if ((fgEntryPtr->IsSplit() && fgEntryPtr->GetStackSlotsNumber() + fgEntryPtr->numRegs > 4) ||
         (!fgEntryPtr->IsSplit() && fgEntryPtr->GetRegNum() == REG_STK))
 #else
     if (fgEntryPtr->GetRegNum() == REG_STK)
@@ -6695,8 +6773,10 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
     {
         fgArgTabEntry* arg = argInfo->GetArgEntry(index, false);
 
-        calleeArgStackSize += arg->GetStackSize();
+        calleeArgStackSize = roundUp(calleeArgStackSize, arg->byteAlignment);
+        calleeArgStackSize += arg->GetStackByteSize();
     }
+    calleeArgStackSize = GetOutgoingArgByteSize(calleeArgStackSize);
 
     auto reportFastTailCallDecision = [&](const char* thisFailReason) {
         if (failReason != nullptr)

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6688,8 +6688,8 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
 
     fgArgInfo* argInfo = callee->fgArgInfo;
 
-    size_t calleeArgStackSize = 0;
-    size_t callerArgStackSize = info.compArgStackSize;
+    unsigned calleeArgStackSize = 0;
+    unsigned callerArgStackSize = info.compArgStackSize;
 
     for (unsigned index = 0; index < argInfo->ArgCount(); ++index)
     {

--- a/src/coreclr/src/jit/scopeinfo.cpp
+++ b/src/coreclr/src/jit/scopeinfo.cpp
@@ -487,7 +487,7 @@ CodeGenInterface::siVarLoc CodeGenInterface::getSiVarLoc(const LclVarDsc* varDsc
     // For stack vars, find the base register, and offset
 
     regNumber baseReg;
-    signed    offset = varDsc->lvStkOffs;
+    signed    offset = varDsc->GetStackOffset();
 
     if (!varDsc->lvFramePointerBased)
     {
@@ -603,7 +603,7 @@ CodeGenInterface::siVarLoc CodeGen::getSiVarLoc(const LclVarDsc* varDsc, const s
     // For stack vars, find the base register, and offset
 
     regNumber baseReg;
-    signed    offset = varDsc->lvStkOffs;
+    signed    offset = varDsc->GetStackOffset();
 
     if (!varDsc->lvFramePointerBased)
     {
@@ -1487,17 +1487,17 @@ NATIVE_OFFSET CodeGen::psiGetVarStackOffset(const LclVarDsc* lclVarDsc) const
 #ifdef TARGET_AMD64
     // scOffset = offset from caller SP - REGSIZE_BYTES
     // TODO-Cleanup - scOffset needs to be understood.  For now just matching with the existing definition.
-    stackOffset =
-        compiler->lvaToCallerSPRelativeOffset(lclVarDsc->lvStkOffs, lclVarDsc->lvFramePointerBased) + REGSIZE_BYTES;
+    stackOffset = compiler->lvaToCallerSPRelativeOffset(lclVarDsc->GetStackOffset(), lclVarDsc->lvFramePointerBased) +
+                  REGSIZE_BYTES;
 #else  // !TARGET_AMD64
     if (doubleAlignOrFramePointerUsed())
     {
         // REGSIZE_BYTES - for the pushed value of EBP
-        stackOffset = lclVarDsc->lvStkOffs - REGSIZE_BYTES;
+        stackOffset = lclVarDsc->GetStackOffset() - REGSIZE_BYTES;
     }
     else
     {
-        stackOffset = lclVarDsc->lvStkOffs - genTotalFrameSize();
+        stackOffset = lclVarDsc->GetStackOffset() - genTotalFrameSize();
     }
 #endif // !TARGET_AMD64
 
@@ -1867,7 +1867,7 @@ void CodeGen::psiMoveToStack(unsigned varNum)
         psiScope* newScope     = psiNewPrologScope(scope->scLVnum, scope->scSlotNum);
         newScope->scRegister   = false;
         newScope->u2.scBaseReg = (compiler->lvaTable[varNum].lvFramePointerBased) ? REG_FPBASE : REG_SPBASE;
-        newScope->u2.scOffset  = compiler->lvaTable[varNum].lvStkOffs;
+        newScope->u2.scOffset  = compiler->lvaTable[varNum].GetStackOffset();
 
         psiEndPrologScope(scope);
         return;

--- a/src/coreclr/src/jit/stacklevelsetter.cpp
+++ b/src/coreclr/src/jit/stacklevelsetter.cpp
@@ -249,9 +249,9 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
     {
         for (unsigned i = 0; i < argInfo->ArgCount(); ++i)
         {
-            const fgArgTabEntry* argTab      = argInfo->ArgTable()[i];
-            const unsigned       slotsNumber = argTab->GetStackSlotsNumber();
-            if (slotsNumber != 0)
+            const fgArgTabEntry* argTab    = argInfo->ArgTable()[i];
+            const unsigned       slotCount = argTab->GetStackSlotsNumber();
+            if (slotCount != 0)
             {
                 GenTree* node = argTab->GetNode();
                 assert(node->OperIsPutArgStkOrSplit());
@@ -259,13 +259,13 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
                 GenTreePutArgStk* putArg = node->AsPutArgStk();
 
 #if !FEATURE_FIXED_OUT_ARGS
-                assert(slotsNumber == putArg->gtNumSlots);
+                assert(slotCount == putArg->gtNumSlots);
 #endif // !FEATURE_FIXED_OUT_ARGS
 
-                putArgNumSlots.Set(putArg, slotsNumber);
+                putArgNumSlots.Set(putArg, slotCount);
 
-                usedStackSlotsCount += slotsNumber;
-                AddStackLevel(slotsNumber);
+                usedStackSlotsCount += slotCount;
+                AddStackLevel(slotCount);
             }
         }
     }

--- a/src/coreclr/src/jit/stacklevelsetter.cpp
+++ b/src/coreclr/src/jit/stacklevelsetter.cpp
@@ -249,8 +249,9 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
     {
         for (unsigned i = 0; i < argInfo->ArgCount(); ++i)
         {
-            fgArgTabEntry* argTab = argInfo->ArgTable()[i];
-            if (argTab->numSlots != 0)
+            const fgArgTabEntry* argTab      = argInfo->ArgTable()[i];
+            const unsigned       slotsNumber = argTab->GetStackSlotsNumber();
+            if (slotsNumber != 0)
             {
                 GenTree* node = argTab->GetNode();
                 assert(node->OperIsPutArgStkOrSplit());
@@ -258,13 +259,13 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
                 GenTreePutArgStk* putArg = node->AsPutArgStk();
 
 #if !FEATURE_FIXED_OUT_ARGS
-                assert(argTab->numSlots == putArg->gtNumSlots);
+                assert(slotsNumber == putArg->gtNumSlots);
 #endif // !FEATURE_FIXED_OUT_ARGS
 
-                putArgNumSlots.Set(putArg, argTab->numSlots);
+                putArgNumSlots.Set(putArg, slotsNumber);
 
-                usedStackSlotsCount += argTab->numSlots;
-                AddStackLevel(argTab->numSlots);
+                usedStackSlotsCount += slotsNumber;
+                AddStackLevel(slotsNumber);
             }
         }
     }

--- a/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntNative.cpp
+++ b/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntNative.cpp
@@ -30,6 +30,26 @@ extern "C" DLL_EXPORT int STDMETHODCALLTYPE Marshal_In(/*[in]*/int intValue)
     return intReturn;
 }
 
+extern "C" DLL_EXPORT int STDMETHODCALLTYPE Marshal_InMany(/*[in]*/short i1, short i2, short i3, short i4, short i5, short i6, short i7, short i8, short i9, short i10, short i11, unsigned char i12, unsigned char i13, int i14, short i15)
+{
+    //Check the input
+    if(i1 != 1 || i2 != 2 || i3 != 3 || i4 != 4 || i5 != 5 || i6 != 6 || i7 != 7 || i8 != 8 || i9 != 9 || i10 != 10 || i11 != 11 || i12 != 12 || i13 != 13 || i14 != 14 || i15 != 15)
+    {
+        printf("Error in Function Marshal_InMany(Native Client)\n");
+
+        //Expected
+        printf("Expected: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15\n");
+
+        //Actual
+        printf("Actual: %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %i, %i, %i, %hi\n", i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, (int)i12, (int)i13, i14, i15);
+
+        //Return the error value instead if verification failed
+        return intErrReturn;
+    }
+
+    return i1 + i2 + i3 + i4 + i5 + i6 + i7 + i8 + i9 + i10 + i11 + i12 + i13 + i14 + i15;
+}
+
 extern "C" DLL_EXPORT int STDMETHODCALLTYPE Marshal_InOut(/*[In,Out]*/int intValue)
 {
     //Check the input

--- a/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.cs
+++ b/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.cs
@@ -24,6 +24,9 @@ class ClientPInvokeIntNativeTest
     [DllImport("PInvokeIntNative")]
     private static extern int MarshalPointer_Out(out int pintValue);
 
+    [DllImport("PInvokeIntNative")]
+    private static extern int Marshal_InMany([In]short i1, [In]short i2, [In]short i3, [In]short i4, [In]short i5, [In]short i6, [In]short i7, [In]short i8, [In]short i9, [In]short i10, [In]short i11, [In]byte i12, [In]byte i13, [In]int i14, [In]short i15);
+
 
     public static int Main(string[] args)
     {
@@ -97,6 +100,12 @@ class ClientPInvokeIntNativeTest
         {
             failures++;
             Console.WriteLine("Out byref value is wrong.");
+        }
+
+        if(120 != Marshal_InMany(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        {
+            failures++;
+            Console.WriteLine("InMany return value is wrong");
         }
 
         return 100 + failures;


### PR DESCRIPTION
In order to support Arm64 Apple ABI we need to know the exact size of small arguments because when they are passed on stack they are passed without alignment. 

There are two main parts that need changes: `fgArgInfo` and `GenTreePutArgStk`. In this PR I am adding `byteSize/byteOffset` to `fgArgInfo`. I am keeping the old `stackSlot/stackSize(in target_pointer sized slots) in place for now but use it only in asserts under debug. I will delete them after all changes are in and we confirm that both models give us the same results on non affected platforms.

No diffs(both jit-diff and spmi).

I recommend reviewing by commits (because the first are just refactoring changes):
d888195a069: fix a dumping error introduced in my recent ref PR.

5f5e631fdae: add a pinvoke test with many small stack arguments.

It will fail on arm64 apple.

345d35588ee: Add get/set for lclVar::lvStkOffs.

20fdade6c08: Change some types from `size_t` to `unsigned` when working with stack offsets.

80beef05c62: Rename `stackSize` to `GetStackSize`.

49ed3847368: Do not run stack level setter for arm64 apple.

I had a prototype that was supporting byte sizes there but the cost was too high for this PR. The main issue is that we will have to track alignment between the currect argument and the next one and currently it is not working well. For example, the stack level setter ignores arm32 double alignment requirements and gives wrong results there when I fixed it I got asm diffs because of the #42673. The stack level setter does not affect arm64 because there we always save stack frame so it is safe to skip it there.

1ca1a426ba0: Use bytes in `fgArgTabEntry`.

The main change, I could put it in a separate PR if that will make review easier.