### PR TITLE
Fix Enumerable.Take/SkipLast on mutable collections

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Skip.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.SizeOpt.cs
@@ -18,8 +18,5 @@ namespace System.Linq
                 }
             }
         }
-
-        private static IEnumerable<TSource> SkipLastEnumerableFactory<TSource>(IEnumerable<TSource> source, int count) =>
-            SkipLastIterator<TSource>(source, count);
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -12,32 +11,5 @@ namespace System.Linq
             source is IList<TSource> sourceList ?
                 (IEnumerable<TSource>)new ListPartition<TSource>(sourceList, count, int.MaxValue) :
                 new EnumerablePartition<TSource>(source, count, -1);
-
-        private static IEnumerable<TSource> SkipLastEnumerableFactory<TSource>(IEnumerable<TSource> source, int count)
-        {
-            Debug.Assert(count > 0);
-
-            if (source is IPartition<TSource> partition)
-            {
-                int length = partition.GetCount(onlyIfCheap: true);
-
-                if (length >= 0)
-                {
-                    return length - count > 0 ?
-                        partition.Take(length - count) :
-                        EmptyPartition<TSource>.Instance;
-                }
-            }
-            else if (source is IList<TSource> sourceList)
-            {
-                int sourceCount = sourceList.Count;
-
-                return sourceCount > count ?
-                    new ListPartition<TSource>(sourceList, 0, sourceCount - count - 1) :
-                    EmptyPartition<TSource>.Instance;
-            }
-
-            return SkipLastIterator<TSource>(source, count);
-        }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.cs
@@ -121,7 +121,7 @@ namespace System.Linq
 
             return count <= 0 ?
                 source.Skip(0) :
-                SkipLastEnumerableFactory(source, count);
+                SkipLastIterator(source, count);
         }
 
         private static IEnumerable<TSource> SkipLastIterator<TSource>(IEnumerable<TSource> source, int count)

--- a/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
@@ -18,8 +18,5 @@ namespace System.Linq
                 if (--count == 0) break;
             }
         }
-
-        private static IEnumerable<TSource> TakeLastEnumerableFactory<TSource>(IEnumerable<TSource> source, int count) =>
-            TakeLastIterator<TSource>(source, count);
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -12,35 +11,5 @@ namespace System.Linq
             source is IPartition<TSource> partition ? partition.Take(count) :
             source is IList<TSource> sourceList ? (IEnumerable<TSource>)new ListPartition<TSource>(sourceList, 0, count - 1) :
             new EnumerablePartition<TSource>(source, 0, count - 1);
-
-        private static IEnumerable<TSource> TakeLastEnumerableFactory<TSource>(IEnumerable<TSource> source, int count)
-        {
-            Debug.Assert(count > 0);
-
-            if (source is IPartition<TSource> partition)
-            {
-                int length = partition.GetCount(onlyIfCheap: true);
-
-                if (length >= 0)
-                {
-                    return length - count > 0 ? partition.Skip(length - count) : partition;
-                }
-            }
-            else if (source is IList<TSource> sourceList)
-            {
-                int sourceCount = sourceList.Count;
-
-                if (sourceCount > count)
-                {
-                    return new ListPartition<TSource>(sourceList, sourceCount - count, sourceCount);
-                }
-                else
-                {
-                    return new ListPartition<TSource>(sourceList, 0, sourceCount);
-                }
-            }
-
-            return TakeLastIterator<TSource>(source, count);
-        }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.cs
@@ -91,7 +91,7 @@ namespace System.Linq
 
             return count <= 0 ?
                 Empty<TSource>() :
-                TakeLastEnumerableFactory(source, count);
+                TakeLastIterator(source, count);
         }
 
         private static IEnumerable<TSource> TakeLastIterator<TSource>(IEnumerable<TSource> source, int count)

--- a/src/libraries/System.Linq/tests/SkipLastTests.cs
+++ b/src/libraries/System.Linq/tests/SkipLastTests.cs
@@ -74,5 +74,30 @@ namespace System.Linq.Tests
             IEnumerable<int> expected = source.SkipLast(count);
             Assert.Equal(expected, source.SkipLast(count).RunOnce());
         }
+
+        [Fact]
+        public void List_ChangesAfterSkipLast_ChangesReflectedInResults()
+        {
+            var list = new List<int>() { 1, 2, 3, 4, 5 };
+
+            IEnumerable<int> e = list.SkipLast(2);
+
+            list.RemoveAt(4);
+            list.RemoveAt(3);
+
+            Assert.Equal(new[] { 1 }, e.ToArray());
+        }
+
+        [Fact]
+        public void List_Skip_ChangesAfterSkipLast_ChangesReflectedInResults()
+        {
+            var list = new List<int>() { 1, 2, 3, 4, 5 };
+
+            IEnumerable<int> e = list.Skip(1).SkipLast(2);
+
+            list.RemoveAt(4);
+
+            Assert.Equal(new[] { 2 }, e.ToArray());
+        }
     }
 }

--- a/src/libraries/System.Linq/tests/TakeLastTests.cs
+++ b/src/libraries/System.Linq/tests/TakeLastTests.cs
@@ -80,5 +80,30 @@ namespace System.Linq.Tests
             IEnumerable<int> expected = source.TakeLast(count);
             Assert.Equal(expected, source.TakeLast(count).RunOnce());
         }
+
+        [Fact]
+        public void List_ChangesAfterTakeLast_ChangesReflectedInResults()
+        {
+            var list = new List<int>() { 1, 2, 3, 4, 5 };
+
+            IEnumerable<int> e = list.TakeLast(3);
+
+            list.RemoveAt(0);
+            list.RemoveAt(0);
+
+            Assert.Equal(new[] { 3, 4, 5 }, e.ToArray());
+        }
+
+        [Fact]
+        public void List_Skip_ChangesAfterTakeLast_ChangesReflectedInResults()
+        {
+            var list = new List<int>() { 1, 2, 3, 4, 5 };
+
+            IEnumerable<int> e = list.Skip(1).TakeLast(3);
+
+            list.RemoveAt(0);
+
+            Assert.Equal(new[] { 3, 4, 5 }, e.ToArray());
+        }
     }
 }


### PR DESCRIPTION
LINQ operators are lazy and can't factor in the current contents of a mutable list when making decisions about how to subsequently process that list.  The optimizations in https://github.com/dotnet/corefx/pull/36051 and https://github.com/dotnet/corefx/pull/41342 violated that and broke TakeLast and SkipLast when the underlying source changes after calling Take/SkipLast and before calling GetEnumerator.

Fixes https://github.com/dotnet/runtime/issues/39864