### PR TITLE
Fix a few Socket.SendFile issues

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.TransmitFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.TransmitFile.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Mswsock, SetLastError = true)]
         internal static extern unsafe bool TransmitFile(
             SafeHandle socket,
-            SafeHandle? fileHandle,
+            IntPtr fileHandle,
             int numberOfBytesToWrite,
             int numberOfBytesPerSend,
             NativeOverlapped* overlapped,

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -383,7 +383,7 @@ namespace System.Net.Sockets
         public int Send(System.ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags) { throw null; }
         public int Send(System.ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, out System.Net.Sockets.SocketError errorCode) { throw null; }
         public bool SendAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
-        public void SendFile(string fileName) { }
+        public void SendFile(string? fileName) { }
         public void SendFile(string? fileName, byte[]? preBuffer, byte[]? postBuffer, System.Net.Sockets.TransmitFileOptions flags) { }
         public bool SendPacketsAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
         public int SendTo(byte[] buffer, int offset, int size, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1299,7 +1299,7 @@ namespace System.Net.Sockets
             return bytesTransferred;
         }
 
-        public void SendFile(string fileName)
+        public void SendFile(string? fileName)
         {
             SendFile(fileName, null, null, TransmitFileOptions.UseDefaultWorkerThread);
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1809,9 +1809,9 @@ namespace System.Net.Sockets
         }
 
         public static SocketError SendFileAsync(SafeSocketHandle handle, FileStream fileStream, Action<long, SocketError> callback) =>
-            SendFileAsync(handle, fileStream, 0, (int)fileStream.Length, callback);
+            SendFileAsync(handle, fileStream, 0, fileStream.Length, callback);
 
-        private static SocketError SendFileAsync(SafeSocketHandle handle, FileStream fileStream, long offset, int count, Action<long, SocketError> callback)
+        private static SocketError SendFileAsync(SafeSocketHandle handle, FileStream fileStream, long offset, long count, Action<long, SocketError> callback)
         {
             long bytesSent;
             SocketError socketError = handle.AsyncContext.SendFileAsync(fileStream.SafeFileHandle, offset, count, out bytesSent, callback);
@@ -1849,7 +1849,7 @@ namespace System.Net.Sockets
 
                             var tcs = new TaskCompletionSource<SocketError>();
                             error = SendFileAsync(socket.InternalSafeHandle, fs, e.OffsetLong,
-                                e.Count > 0 ? e.Count : checked((int)(fs.Length - e.OffsetLong)),
+                                e.Count > 0 ? e.Count : fs.Length - e.OffsetLong,
                                 (transferred, se) =>
                                 {
                                     bytesTransferred += transferred;


### PR DESCRIPTION
- The string argument in the single-argument overload should be nullable.
- All overloads on Windows should allow a null file path, but they've been throwing an exception
- On Linux, data was silently truncated when sending a file larger than int.MaxValue with BeginSendFile.

Fixes https://github.com/dotnet/runtime/issues/42530
Fixes https://github.com/dotnet/runtime/issues/42529
Fixes https://github.com/dotnet/runtime/issues/41906