### PR TITLE
Add support for associating BrowserDebugHost with parent process

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
@@ -16,6 +16,8 @@ namespace Microsoft.WebAssembly.Diagnostics
     public class ProxyOptions
     {
         public Uri DevToolsUrl { get; set; } = new Uri("http://localhost:9222");
+
+        public int? OwnerPid { get; set; }
     }
 
     public class Program


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/25991.

This PR brings in some logic that used to exist in the BlazorDebugProxy ([ref](https://github.com/dotnet/aspnetcore/blob/release/3.1/src/Components/WebAssembly/DebugProxy/src/Program.cs#L43-L56)) into the BrowserDebugHost.

It allows a program to pass an owner PID parameter to the BrowserDebugHost. The BrowserDebugHost will listen for when this process shuts down and close itself.

Without this change, whenever a user starts a debugging session an orphaned BrowserDebugHost process is left behind when they stop it.