### PR TITLE
Fix argument type in a call to SSLSetEnabledCiphers

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -594,7 +594,7 @@ int32_t AppleCryptoNative_SslSetEnabledCipherSuites(SSLContextRef sslContext, co
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         // macOS
-        return SSLSetEnabledCiphers(sslContext, cipherSuites, (size_t)numCipherSuites);
+        return SSLSetEnabledCiphers(sslContext, (const SSLCipherSuite *)cipherSuites, (size_t)numCipherSuites);
 #pragma clang diagnostic pop   
     }
     else


### PR DESCRIPTION
The latest version of macOS clang from XCode 12 beta complains about
data type of the 2nd argument passed to SSLSetEnabledCiphers.
Interestingly it complains about it only when cross-compiling for arm64.
When compiling with the same compiler for amd64 there
is no complaint.

```
runtime/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c:597:77: error: incompatible pointer types passing
      'const uint32_t *' (aka 'const unsigned int *') to parameter of type 'const SSLCipherSuite * _Nonnull' (aka 'const unsigned short *')
      [-Werror,-Wincompatible-pointer-types]
        return SSLSetEnabledCiphers(sslContext, cipherSuites, (size_t)numCipherSuites);
                                                ^~~~~~~~~~~~
```
This change fixes it by casting it to the actual argument type.