### PR TITLE
Extend IDynamicInterfaceCastable test to cover public default-implemented methods on interface impl types.

### DIFF
--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -71,7 +71,8 @@ namespace IDynamicInterfaceCastableTests
 
         public int GetNumberHelper()
         {
-            Asssert.Fail("Calling a public interface method with a default implementation should go through IDynamicInterfaceCastable for interface dispatch.");
+            Assert.Fail("Calling a public interface method with a default implementation should go through IDynamicInterfaceCastable for interface dispatch.");
+            return 0;
         }
 
         int ITest.CallImplemented(ImplementationToCall toCall)

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -69,7 +69,7 @@ namespace IDynamicInterfaceCastableTests
             return GetNumberStaticReturnValue;
         }
 
-        int GetNumberHelper()
+        public int GetNumberHelper()
         {
             Asssert.Fail("Calling a public interface method with a default implementation should go through IDynamicInterfaceCastable for interface dispatch.");
         }

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -14,7 +14,8 @@ namespace IDynamicInterfaceCastableTests
         Class,
         Interface,
         InterfacePrivate,
-        InterfaceStatic
+        InterfaceStatic,
+        ImplInterfacePublic,
     }
 
     public interface ITest
@@ -68,6 +69,12 @@ namespace IDynamicInterfaceCastableTests
             return GetNumberStaticReturnValue;
         }
 
+        public static int GetNumberHelperReturnValue = 4;
+        int GetNumberHelper()
+        {
+            return GetNumberHelperReturnValue;
+        }
+
         int ITest.CallImplemented(ImplementationToCall toCall)
         {
             switch (toCall)
@@ -81,6 +88,8 @@ namespace IDynamicInterfaceCastableTests
                     return GetNumberPrivate();
                 case ImplementationToCall.InterfaceStatic:
                     return GetNumberStatic();
+                case ImplementationToCall.ImplInterfacePublic:
+                    return GetNumberHelper();
             }
 
             return 0;
@@ -291,6 +300,7 @@ namespace IDynamicInterfaceCastableTests
             Assert.AreEqual(ITestImpl.GetNumberReturnValue, testObj.CallImplemented(ImplementationToCall.Interface));
             Assert.AreEqual(ITestImpl.GetNumberPrivateReturnValue, testObj.CallImplemented(ImplementationToCall.InterfacePrivate));
             Assert.AreEqual(ITestImpl.GetNumberStaticReturnValue, testObj.CallImplemented(ImplementationToCall.InterfaceStatic));
+            Assert.Throws<InvalidCastException>(() => testObj.CallImplemented(ImplementationToCall.ImplInterfacePublic));
 
             Console.WriteLine(" -- Validate delegate call");
             Func<ITest> func = new Func<ITest>(testObj.ReturnThis);

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -69,10 +69,9 @@ namespace IDynamicInterfaceCastableTests
             return GetNumberStaticReturnValue;
         }
 
-        public static int GetNumberHelperReturnValue = 4;
         int GetNumberHelper()
         {
-            return GetNumberHelperReturnValue;
+            Asssert.Fail("Calling a public interface method with a default implementation should go through IDynamicInterfaceCastable for interface dispatch.");
         }
 
         int ITest.CallImplemented(ImplementationToCall toCall)


### PR DESCRIPTION
Extend IDynamicInterfaceCastable test suite to validate current behavior around calling a default-implemented public method defined on the interface impl type. Today we throw an InvalidCastException because we try to use interface dispatch to resolve the implementation of the method in case the object overrides the implementation.

This behavior was discovered when working on using IDynamicInterfaceCastable in C#/WinRT.
