### PR TITLE
Bring ordering of HTTP/3 headers into spec

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -519,9 +519,6 @@ namespace System.Net.Http
                 BufferBytes(_connection.Pool._http3EncodedAuthorityHostHeader);
             }
 
-            // The only way to reach H3 is to upgrade via an Alt-Svc header, so we can encode Alt-Used for every connection.
-            BufferBytes(_connection.AltUsedEncodedHeaderBytes);
-
             Debug.Assert(request.RequestUri != null);
             string pathAndQuery = request.RequestUri.PathAndQuery;
             if (pathAndQuery == "/")
@@ -532,6 +529,9 @@ namespace System.Net.Http
             {
                 BufferLiteralHeaderWithStaticNameReference(H3StaticTable.PathSlash, pathAndQuery);
             }
+
+            // The only way to reach H3 is to upgrade via an Alt-Svc header, so we can encode Alt-Used for every connection.
+            BufferBytes(_connection.AltUsedEncodedHeaderBytes);
 
             if (request.HasHeaders)
             {


### PR DESCRIPTION
The Alt-Svc header was being encoded in the middle of pseudo-headers. This PR moves it to right after the pseudo-headers, to be compliant with [section 4.1.1.1 of spec](https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.1):

> All pseudo-header fields MUST appear in the header field section before regular header fields.