### PR TITLE
Equals and GetHashCode for Reflection.Pointer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Pointer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Pointer.cs
@@ -39,6 +39,18 @@ namespace System.Reflection
             return ((Pointer)ptr)._ptr;
         }
 
+        public override unsafe bool Equals(object? obj)
+        {
+            if (obj is Pointer pointer)
+            {
+                return _ptr == pointer._ptr;
+            }
+
+            return false;
+        }
+
+        public override unsafe int GetHashCode() => ((nuint)_ptr).GetHashCode();
+
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Reflection/tests/PointerTests.cs
+++ b/src/libraries/System.Reflection/tests/PointerTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System.Reflection;
 
 namespace System.Reflection.Tests
 {
@@ -55,6 +59,24 @@ namespace System.Reflection.Tests
             a.PublicInt = &someNumber;
 
             Assert.True(a.Equals(a));
+        }
+
+        [Fact]
+        public unsafe void Nullptrs_AreEqual()
+        {
+            var a = Pointer.Box(null, typeof(int*));
+            var b = Pointer.Box(null, typeof(int*));
+
+            Assert.True(a.Equals(b));
+        }
+
+        [Fact]
+        public unsafe void DifferentPointerTypes_AreEqual()
+        {
+            var a = Pointer.Box((void*)0x12340000, typeof(int*));
+            var b = Pointer.Box((void*)0x12340000, typeof(uint*));
+
+            Assert.True(a.Equals(b));
         }
     }
 }

--- a/src/libraries/System.Reflection/tests/PointerTests.cs
+++ b/src/libraries/System.Reflection/tests/PointerTests.cs
@@ -1,0 +1,60 @@
+﻿using Xunit;
+
+namespace System.Reflection.Tests
+{
+    public class PointerTests
+    {
+        public unsafe struct BitwiseComparable
+        {
+            public int* PublicInt;
+        }
+
+        public unsafe struct MemberwiseComparable
+        {
+            public string ReferenceType;
+            public int* PublicInt;
+        }
+
+        [Fact]
+        public unsafe void BitwiseEquality_AreEqual()
+        {
+            int someNumber = 1;
+            var a = new BitwiseComparable();
+            a.PublicInt = &someNumber;
+            var b = a;
+
+            Assert.True(a.Equals(b));
+        }
+
+        [Fact]
+        public unsafe void BitwiseEquality_EqualWithSelf()
+        {
+            int someNumber = 1;
+            var a = new BitwiseComparable();
+            a.PublicInt = &someNumber;
+
+            Assert.True(a.Equals(a));
+        }
+
+        [Fact]
+        public unsafe void MemberwiseEquality_AreEqual()
+        {
+            int someNumber = 1;
+            var a = new MemberwiseComparable();
+            a.PublicInt = &someNumber;
+            var b = a;
+
+            Assert.True(a.Equals(b));
+        }
+
+        [Fact]
+        public unsafe void MemberwiseEquality_EqualWithSelf()
+        {
+            int someNumber = 1;
+            var a = new MemberwiseComparable();
+            a.PublicInt = &someNumber;
+
+            Assert.True(a.Equals(a));
+        }
+    }
+}

--- a/src/libraries/System.Reflection/tests/PointerTests.cs
+++ b/src/libraries/System.Reflection/tests/PointerTests.cs
@@ -25,7 +25,7 @@ namespace System.Reflection.Tests
             int someNumber = 1;
             var a = new BitwiseComparable();
             a.PublicInt = &someNumber;
-            var b = a;
+            BitwiseComparable b = a;
 
             Assert.True(a.Equals(b));
         }
@@ -46,7 +46,7 @@ namespace System.Reflection.Tests
             int someNumber = 1;
             var a = new MemberwiseComparable();
             a.PublicInt = &someNumber;
-            var b = a;
+            MemberwiseComparable b = a;
 
             Assert.True(a.Equals(b));
         }
@@ -64,8 +64,8 @@ namespace System.Reflection.Tests
         [Fact]
         public unsafe void Nullptrs_AreEqual()
         {
-            var a = Pointer.Box(null, typeof(int*));
-            var b = Pointer.Box(null, typeof(int*));
+            object a = Pointer.Box(null, typeof(int*));
+            object b = Pointer.Box(null, typeof(int*));
 
             Assert.True(a.Equals(b));
         }
@@ -73,8 +73,8 @@ namespace System.Reflection.Tests
         [Fact]
         public unsafe void DifferentPointerTypes_AreEqual()
         {
-            var a = Pointer.Box((void*)0x12340000, typeof(int*));
-            var b = Pointer.Box((void*)0x12340000, typeof(uint*));
+            object a = Pointer.Box((void*)0x12340000, typeof(int*));
+            object b = Pointer.Box((void*)0x12340000, typeof(uint*));
 
             Assert.True(a.Equals(b));
         }

--- a/src/libraries/System.Reflection/tests/PointerTests.cs
+++ b/src/libraries/System.Reflection/tests/PointerTests.cs
@@ -20,7 +20,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        public unsafe void BitwiseEquality_AreEqual()
+        public unsafe void EqualBitwiseComparables_AreEqual()
         {
             int someNumber = 1;
             var a = new BitwiseComparable();
@@ -28,10 +28,22 @@ namespace System.Reflection.Tests
             BitwiseComparable b = a;
 
             Assert.True(a.Equals(b));
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
         }
 
         [Fact]
-        public unsafe void BitwiseEquality_EqualWithSelf()
+        public unsafe void UnequalBitwiseComparables_AreUnequal()
+        {
+            int someNumber = 1;
+            var a = new BitwiseComparable();
+            a.PublicInt = &someNumber;
+            var b = new BitwiseComparable();
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public unsafe void SameBitwiseComparable_EqualWithSelf()
         {
             int someNumber = 1;
             var a = new BitwiseComparable();
@@ -41,7 +53,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        public unsafe void MemberwiseEquality_AreEqual()
+        public unsafe void EqualMemberwiseComparables_AreEqual()
         {
             int someNumber = 1;
             var a = new MemberwiseComparable();
@@ -49,16 +61,38 @@ namespace System.Reflection.Tests
             MemberwiseComparable b = a;
 
             Assert.True(a.Equals(b));
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
         }
 
         [Fact]
-        public unsafe void MemberwiseEquality_EqualWithSelf()
+        public unsafe void UnequalMemberwiseComparables_AreUnequal()
+        {
+            int someNumber = 1;
+            var a = new MemberwiseComparable();
+            a.PublicInt = &someNumber;
+            var b = new MemberwiseComparable();
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public unsafe void SameMemberwiseComparable_EqualWithSelf()
         {
             int someNumber = 1;
             var a = new MemberwiseComparable();
             a.PublicInt = &someNumber;
 
             Assert.True(a.Equals(a));
+        }
+
+        [Fact]
+        public unsafe void EqualPointers_AreEqual()
+        {
+            object a = Pointer.Box((void*)0x12340000, typeof(int*));
+            object b = Pointer.Box((void*)0x12340000, typeof(int*));
+
+            Assert.True(a.Equals(b));
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
         }
 
         [Fact]
@@ -68,6 +102,7 @@ namespace System.Reflection.Tests
             object b = Pointer.Box(null, typeof(int*));
 
             Assert.True(a.Equals(b));
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
         }
 
         [Fact]
@@ -77,6 +112,16 @@ namespace System.Reflection.Tests
             object b = Pointer.Box((void*)0x12340000, typeof(uint*));
 
             Assert.True(a.Equals(b));
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public unsafe void DifferentPointers_AreUnequal()
+        {
+            object a = Pointer.Box((void*)0x12340000, typeof(int*));
+            object b = Pointer.Box((void*)0x56780000, typeof(int*));
+
+            Assert.False(a.Equals(b));
         }
     }
 }

--- a/src/libraries/System.Reflection/tests/PointerTests.cs
+++ b/src/libraries/System.Reflection/tests/PointerTests.cs
@@ -123,5 +123,14 @@ namespace System.Reflection.Tests
 
             Assert.False(a.Equals(b));
         }
+
+        [Fact]
+        public unsafe void DifferentPointerTypes_Null_AreEqual()
+        {
+            object a = Pointer.Box(null, typeof(int*));
+            object b = Pointer.Box(null, typeof(long*));
+
+            Assert.True(a.Equals(b));
+        }
     }
 }

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="TypeDerivedTests.cs" />
     <Compile Include="TypeInfoTests.cs" />
     <Compile Include="ExceptionTests.cs" />
+    <Compile Include="PointerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedImage.png">

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8551,6 +8551,8 @@ namespace System.Reflection
         public unsafe static object Box(void* ptr, System.Type type) { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public unsafe static void* Unbox(object ptr) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
     }
     [System.FlagsAttribute]
     public enum PortableExecutableKinds


### PR DESCRIPTION
If a pointer is accessed via reflection it is boxed into a
`System.Reflection.Pointer`. This type didn't override `Equals` and
`GetHashCode`, meaning instances are equal by reference.

On the other hand, pointers are compared by their value. Since
value types are equal by either memcmp or memberwise equality
(via reflection), the outcome of an equality test of a pointer itself
depends on the type that holds that pointer.

Fix #42457 