### PR TITLE
[release/5.0-rc2] Add support for associating BrowserDebugHost with parent process

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Program.cs
@@ -16,6 +16,8 @@ namespace Microsoft.WebAssembly.Diagnostics
     public class ProxyOptions
     {
         public Uri DevToolsUrl { get; set; } = new Uri("http://localhost:9222");
+
+        public int? OwnerPid { get; set; }
     }
 
     public class Program

--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -32,9 +34,23 @@ namespace Microsoft.WebAssembly.Diagnostics
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IOptionsMonitor<ProxyOptions> optionsAccessor, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IOptionsMonitor<ProxyOptions> optionsAccessor, IWebHostEnvironment env, IHostApplicationLifetime applicationLifetime)
         {
             var options = optionsAccessor.CurrentValue;
+
+            if (options.OwnerPid.HasValue)
+            {
+                Process ownerProcess = Process.GetProcessById(options.OwnerPid.Value);
+                if (ownerProcess != null)
+                {
+                    ownerProcess.EnableRaisingEvents = true;
+                    ownerProcess.Exited += (sender, eventArgs) =>
+                    {
+                        applicationLifetime.StopApplication();
+                    };
+                }
+            }
+
             app.UseDeveloperExceptionPage()
                 .UseWebSockets()
                 .UseDebugProxy(options);


### PR DESCRIPTION
Manual backport of #42541 to to release/5.0-rc2.

## Description

This change adds an `OwnerPid` command line parameter to the BrowserDebugHost server. It also registers a callback on the process associated with the `OwnerPid` that will close the BrowserDebugHost process when the owner process exits.

## Customer Impact

Without this change, stopping the Blazor application server leaves behind an orphaned BrowserDebugHost process. If a user is starting and stopping the Blazor app multiple times for development purposes, they end up accumulating dozens of the orphaned BrowserDebugHost processes on their machine that consume memory and open ports.

This code fixes a regression from the experience in Blazor WASM 3.2 and addresses some user feedback we received in RC1.

## Testing

Manual validation.

## Risk

**Low**, because:

- This change only impacts users debugging with Blazor WASM.
- This code is a direct copy of the logic that we shipped from the aspnetcore repo in Blazor WASM 3.2 ([ref](https://github.com/dotnet/aspnetcore/blob/release/3.1/src/Components/WebAssembly/DebugProxy/src/Program.cs#L43-L56)).