### PR TITLE
Tweak crossgen2 so that SuperPMI should work

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
@@ -41,7 +41,6 @@ CorJitResult __stdcall interceptor_ICJC::compileMethod(ICorJitInfo*             
     our_ICorJitInfo.getBuiltinClass(CLASSID_FIELD_HANDLE);
     our_ICorJitInfo.getBuiltinClass(CLASSID_METHOD_HANDLE);
     our_ICorJitInfo.getBuiltinClass(CLASSID_STRING);
-    our_ICorJitInfo.getBuiltinClass(CLASSID_ARGUMENT_HANDLE);
     our_ICorJitInfo.getBuiltinClass(CLASSID_RUNTIME_TYPE);
 
 #ifdef fatMC

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -403,6 +403,8 @@ namespace Internal.JitInterface
 
         private IntPtr ObjectToHandle(Object obj)
         {
+            // SuperPMI relies on the handle returned from this function being stable for the lifetime of the crossgen2 process
+            // If handle deletion is implemented, please update SuperPMI
             IntPtr handle;
             if (!_objectToHandle.TryGetValue(obj, out handle))
             {


### PR DESCRIPTION
Tweak crossgen2 so that SuperPMI is able to collect data successfully
- Remove unneeded getBuiltinClass for CLASSID_ARGUMENT_HANDLE from SuperPMI
- Tweak crossgen2 single threaded compilation to reliably only use exactly 1 for compilation
  - This allows superpmi to rely on the detail that handles are unique.
  - This assumes that superpmi collection is done with the compilation options `--parallelism 1`
