### PR TITLE
Fix createdump on the alpine distro

### DIFF
--- a/src/coreclr/src/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/src/debug/createdump/crashinfounix.cpp
@@ -262,7 +262,7 @@ CrashInfo::GetDSOInfo()
 void
 CrashInfo::VisitModule(uint64_t baseAddress, std::string& moduleName)
 {
-    if (baseAddress == 0 || baseAddress == m_auxvValues[AT_SYSINFO_EHDR]) {
+    if (baseAddress == 0 || baseAddress == m_auxvValues[AT_SYSINFO_EHDR] || baseAddress == m_auxvValues[AT_BASE]) {
         return;
     }
     if (m_coreclrPath.empty())


### PR DESCRIPTION
The stack unwinding in createdump was looping forever on the same IP (different SP) when it
was attempting to unwind a frame that was in the ld module (typically libld*.so or on alpine
ld-musl-x86_64.so). The ld module on Alpine doesn't having any unwind info (GNU_EH_FRAME empty)
causing the libunwind code to loop on the same IP.

This was caused by a recent change in PR #42159 to createdump that included the ld in the
coredump. Createdump wouldn't attempt to unwind IPs in the ld module because it wasn't added
to the module lookup list.

Including the ld module is important to the windbg linux support so it will have to be revisited
in 6.0 by changing the remote unwinder to handle this case of the Alpine ld module.