### PR TITLE
Reduce the number of platforms run by the ilasm round-trip test

### DIFF
--- a/eng/pipelines/coreclr/ilasm.yml
+++ b/eng/pipelines/coreclr/ilasm.yml
@@ -20,8 +20,15 @@ jobs:
   parameters:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
-    platformGroup: all
     platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    - Windows_NT_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: ilasm
@@ -40,7 +47,15 @@ jobs:
   parameters:
     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
     buildConfig: checked
-    platformGroup: all
+    platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    - Windows_NT_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:


### PR DESCRIPTION
Specifically, don't run on Windows arm32. Also, don't
run on the musl platforms, either; just run on the same set
as most of the JIT pipelines.