### PR TITLE
TraceSourceLogger now takes exception into account(adds it to the log…

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Logging.TraceSource
 
             if (exception != null)
             {
-                string exceptionDelimiter = !string.IsNullOrEmpty(message) ? Environment.NewLine : string.Empty;
+                string exceptionDelimiter = string.IsNullOrEmpty(message) ? string.Empty : Environment.NewLine;
                 message += exceptionDelimiter + "Error: " + exception;
             }
 

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using DiagnosticsTraceSource = System.Diagnostics.TraceSource;
 
 namespace Microsoft.Extensions.Logging.TraceSource
@@ -35,13 +36,20 @@ namespace Microsoft.Extensions.Logging.TraceSource
                 }
                 if (exception != null)
                 {
-                    message += Environment.NewLine + exception;
+                    message += string.Format(CultureInfo.InvariantCulture, "{0}{1}", Environment.NewLine, exception);
                 }
             }
-            if (!string.IsNullOrEmpty(message))
+
+            if (string.IsNullOrEmpty(message) && exception == null)
+                return;
+
+            if (exception != null)
             {
-                _traceSource.TraceEvent(GetEventType(logLevel), eventId.Id, message);
+                string exceptionDelimiter = !string.IsNullOrEmpty(message) ? Environment.NewLine : string.Empty;
+                message += string.Format(CultureInfo.InvariantCulture, "{0}Error: {1}", exceptionDelimiter, exception);
             }
+
+            _traceSource.TraceEvent(GetEventType(logLevel), eventId.Id, message);
         }
 
         public bool IsEnabled(LogLevel logLevel)

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using DiagnosticsTraceSource = System.Diagnostics.TraceSource;
 
 namespace Microsoft.Extensions.Logging.TraceSource
@@ -23,7 +22,9 @@ namespace Microsoft.Extensions.Logging.TraceSource
             {
                 return;
             }
+
             string message = string.Empty;
+
             if (formatter != null)
             {
                 message = formatter(state, exception);
@@ -34,10 +35,6 @@ namespace Microsoft.Extensions.Logging.TraceSource
                 {
                     message += state;
                 }
-                if (exception != null)
-                {
-                    message += string.Format(CultureInfo.InvariantCulture, "{0}{1}", Environment.NewLine, exception);
-                }
             }
 
             if (string.IsNullOrEmpty(message) && exception == null)
@@ -46,7 +43,7 @@ namespace Microsoft.Extensions.Logging.TraceSource
             if (exception != null)
             {
                 string exceptionDelimiter = !string.IsNullOrEmpty(message) ? Environment.NewLine : string.Empty;
-                message += string.Format(CultureInfo.InvariantCulture, "{0}Error: {1}", exceptionDelimiter, exception);
+                message += exceptionDelimiter + "Error: " + exception;
             }
 
             _traceSource.TraceEvent(GetEventType(logLevel), eventId.Id, message);

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/TraceSourceLogger.cs
@@ -29,24 +29,21 @@ namespace Microsoft.Extensions.Logging.TraceSource
             {
                 message = formatter(state, exception);
             }
-            else
+            else if (state != null)
             {
-                if (state != null)
-                {
-                    message += state;
-                }
+                message += state;
             }
-
-            if (string.IsNullOrEmpty(message) && exception == null)
-                return;
 
             if (exception != null)
             {
-                string exceptionDelimiter = string.IsNullOrEmpty(message) ? string.Empty : Environment.NewLine;
-                message += exceptionDelimiter + "Error: " + exception;
+                string exceptionDelimiter = string.IsNullOrEmpty(message) ? string.Empty : " " ;
+                message += exceptionDelimiter + exception;
             }
 
-            _traceSource.TraceEvent(GetEventType(logLevel), eventId.Id, message);
+            if (!string.IsNullOrEmpty(message))
+            {
+                _traceSource.TraceEvent(GetEventType(logLevel), eventId.Id, message);
+            }
         }
 
         public bool IsEnabled(LogLevel logLevel)

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-
 using Moq;
 
 using Xunit;

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Extensions.Logging.Test
             secondSwitch.Level = second;
 
             // Act
-
             var factory = TestLoggerBuilder.Create(builder => builder
                 .AddTraceSource(firstSwitch)
                 .AddTraceSource(secondSwitch));

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.Logging.Test
                 .AddTraceSource(secondSwitch));
 
             var logger = factory.CreateLogger("Test");
-            
+
             // Assert
             Assert.Equal(expected, logger.IsEnabled(LogLevel.Information));
         }

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/TraceSourceLoggerTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.Logging.Test
             Exception exception = new Exception("Some error occurred");
             Func<string, Exception, string> formatter = shouldFormatterBeNull ? (Func<string, Exception, string>)null : (value, passedException) => value;
 
-            string expectedMessage = $"{message}{Environment.NewLine}Error: {exception}";
+            string expectedMessage = $"{message} {exception}";
 
             // Act
             logger.Log(logLevel, eventId, message, exception, formatter);


### PR DESCRIPTION
TraceSourceLogger now takes the exception into account even if the formatter is not null, therefore the exception will be added to the log message.

This pull request fixes #42341

Please let me know if there is a better way to link the PR to the issue.

Br