### PR TITLE
[browser] Reenable marshal library tests

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using Xunit;

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -5,9 +5,6 @@
     <TestRuntime>true</TestRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\JavaScript\JavaScriptTests.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\DataViewTests.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\TypedArrayTests.cs" />

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -92,6 +92,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void FunctionMath()
         {
             JSObject math = (JSObject)Runtime.GetGlobalObject("Math");

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.JavaScript.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
     public static class MarshalTests
     {
         [Fact]
@@ -323,6 +322,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void MarshalTypedArray()
         {
             Runtime.InvokeJS(@"
@@ -454,6 +454,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void MarshalTypedArrayByte()
         {
             Runtime.InvokeJS(@"
@@ -557,6 +558,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void TestFunctionApply()
         {
             HelperMarshal._minValue = 0;


### PR DESCRIPTION
This re-enables the entire marshal test suite on browser and instead marks the particular tests. Besides, it removes unnecessary  assembly info file.

Related to https://github.com/dotnet/runtime/issues/40112