### PR TITLE
[release/5.0-rc2][wasm] Update ICU (fixes #42328)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>cfe95a23647c7de1fe1a349343115bd7720d6949</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20467.1">
+    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="5.0.0-rc.1.20472.3">
       <Uri>https://github.com/dotnet/icu</Uri>
-      <Sha>aadcc34756039c3c8729b21ef7918a7887aea249</Sha>
+      <Sha>4bd3aa3a73628c059fb4563ff4ae91e2340a11e7</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -145,7 +145,7 @@
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>5.0.0-rc.1.20420.3</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->
-    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20467.1</MicrosoftNETCoreRuntimeICUTransportVersion>
+    <MicrosoftNETCoreRuntimeICUTransportVersion>5.0.0-rc.1.20472.3</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>9.0.1-alpha.1.20410.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -92,7 +92,7 @@ namespace System.Globalization.Tests
         public void DateTimeFormat_En_Locales_ShortDatePattern(string locale, string shortDatePattern)
         {
             var cultureInfo = new CultureInfo(locale);
-            Assert.Equal(shortDatePattern, culture.DateTimeFormat.ShortDatePattern);
+            Assert.Equal(shortDatePattern, cultureInfo.DateTimeFormat.ShortDatePattern);
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -69,16 +69,13 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> DateTimeFormat_En_Locales_ShortDatePattern_TestData()
         {
             yield return new object[] { "en-AS", "M/d/yyyy" };
-            yield return new object[] { "en-AU", "d/M/yyyy" };
             yield return new object[] { "en-BI", "M/d/yyyy" };
-            yield return new object[] { "en-CA", "yyyy-MM-dd" };
             yield return new object[] { "en-GU", "M/d/yyyy" };
             yield return new object[] { "en-HK", "d/M/yyyy" };
             yield return new object[] { "en-MH", "M/d/yyyy" };
             yield return new object[] { "en-MP", "M/d/yyyy" };
             yield return new object[] { "en-NZ", "d/MM/yyyy" };
             yield return new object[] { "en-PR", "M/d/yyyy" };
-            yield return new object[] { "en-SE", "yyyy-MM-dd" };
             yield return new object[] { "en-SG", "d/M/yyyy" };
             yield return new object[] { "en-UM", "M/d/yyyy" };
             yield return new object[] { "en-US", "M/d/yyyy" };

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -82,7 +82,6 @@ namespace System.Globalization.Tests
             yield return new object[] { "en-SG", "d/M/yyyy" };
             yield return new object[] { "en-UM", "M/d/yyyy" };
             yield return new object[] { "en-US", "M/d/yyyy" };
-            yield return new object[] { "en-US-posix", "M/d/yyyy" };
             yield return new object[] { "en-VI", "M/d/yyyy" };
             yield return new object[] { "en-ZA", "yyyy/MM/dd" };
             yield return new object[] { "en-ZW", "d/M/yyyy" };

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -66,7 +66,7 @@ namespace System.Globalization.Tests
             Assert.Throws<InvalidOperationException>(() => CultureInfo.InvariantCulture.DateTimeFormat = new DateTimeFormatInfo()); // DateTimeFormatInfo.InvariantInfo is read only
         }
 
-        public static IEnumerable<object[]> EnLocalesShortDatePatternsTestData()
+        public static IEnumerable<object[]> DateTimeFormat_En_Locales_ShortDatePattern_TestData()
         {
             yield return new object[] { "en-AS", "M/d/yyyy" };
             yield return new object[] { "en-AU", "d/M/yyyy" };
@@ -89,7 +89,7 @@ namespace System.Globalization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(EnLocalesShortDatePatternsTestData))]
+        [MemberData(nameof(DateTimeFormat_En_Locales_ShortDatePattern_TestData))]
         public void DateTimeFormat_En_Locales_ShortDatePattern(string locale, string shortDatePattern)
         {
             var cultureInfo = new CultureInfo(locale);

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -84,7 +84,7 @@ namespace System.Globalization.Tests
             yield return new object[] { "en-ZW", "d/M/yyyy" };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         [MemberData(nameof(DateTimeFormat_En_Locales_ShortDatePattern_TestData))]
         public void DateTimeFormat_En_Locales_ShortDatePattern(string locale, string shortDatePattern)
         {

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoDateTimeFormat.cs
@@ -65,5 +65,35 @@ namespace System.Globalization.Tests
             AssertExtensions.Throws<ArgumentNullException>("value", () => new CultureInfo("en-US").DateTimeFormat = null); // Value is null
             Assert.Throws<InvalidOperationException>(() => CultureInfo.InvariantCulture.DateTimeFormat = new DateTimeFormatInfo()); // DateTimeFormatInfo.InvariantInfo is read only
         }
+
+        public static IEnumerable<object[]> EnLocalesShortDatePatternsTestData()
+        {
+            yield return new object[] { "en-AS", "M/d/yyyy" };
+            yield return new object[] { "en-AU", "d/M/yyyy" };
+            yield return new object[] { "en-BI", "M/d/yyyy" };
+            yield return new object[] { "en-CA", "yyyy-MM-dd" };
+            yield return new object[] { "en-GU", "M/d/yyyy" };
+            yield return new object[] { "en-HK", "d/M/yyyy" };
+            yield return new object[] { "en-MH", "M/d/yyyy" };
+            yield return new object[] { "en-MP", "M/d/yyyy" };
+            yield return new object[] { "en-NZ", "d/MM/yyyy" };
+            yield return new object[] { "en-PR", "M/d/yyyy" };
+            yield return new object[] { "en-SE", "yyyy-MM-dd" };
+            yield return new object[] { "en-SG", "d/M/yyyy" };
+            yield return new object[] { "en-UM", "M/d/yyyy" };
+            yield return new object[] { "en-US", "M/d/yyyy" };
+            yield return new object[] { "en-US-posix", "M/d/yyyy" };
+            yield return new object[] { "en-VI", "M/d/yyyy" };
+            yield return new object[] { "en-ZA", "yyyy/MM/dd" };
+            yield return new object[] { "en-ZW", "d/M/yyyy" };
+        }
+
+        [Theory]
+        [MemberData(nameof(EnLocalesShortDatePatternsTestData))]
+        public void DateTimeFormat_En_Locales_ShortDatePattern(string locale, string shortDatePattern)
+        {
+            var cultureInfo = new CultureInfo(locale);
+            Assert.Equal(shortDatePattern, culture.DateTimeFormat.ShortDatePattern);
+        }
     }
 }


### PR DESCRIPTION
This PR brings newer `icudt.dat` file with https://github.com/dotnet/icu/pull/42 fix for missing en-* locales.

## Customer Impact
With the icudt.dat file from the previous .NET 5.0 preview 8 users couldn't use en-* locales other than `en_US`, `en_GB` and `en_CA`. It was intentional as we wanted to strip as much data as we could from ICU. The list of locales initially was based on https://developer.chrome.com/webstore/i18n set. It turned out we can add missing en-* locales almost for free (~adds 2 kb to the icudt.dat.br after compression). 

Fixes https://github.com/dotnet/runtime/issues/42328

## Testing
System.Globalization.* tests (`DateTimeFormat_En_Locales_ShortDatePattern`) + local testing

## Risk
Low, this PR only updates icudat.dat resource files