### PR TITLE
Enable clang 10,11 and gcc 10 detection

### DIFF
--- a/eng/native/init-compiler.sh
+++ b/eng/native/init-compiler.sh
@@ -45,8 +45,8 @@ if [[ -z "$CLR_CC" ]]; then
     # Set default versions
     if [[ -z "$majorVersion" ]]; then
         # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
-        if [[ "$compiler" == "clang" ]]; then versions=( 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
-        elif [[ "$compiler" == "gcc" ]]; then versions=( 9 8 7 6 5 4.9 ); fi
+        if [[ "$compiler" == "clang" ]]; then versions=( 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
+        elif [[ "$compiler" == "gcc" ]]; then versions=( 10 9 8 7 6 5 4.9 ); fi
 
         for version in "${versions[@]}"; do
             parts=(${version//./ })

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -26147,7 +26147,7 @@ void gc_heap::gc_thread_stub (void* arg)
 
     // server GC threads run at a higher priority than normal.
     GCToOSInterface::BoostThreadPriority();
-    _alloca (256*heap->heap_number);
+    void* tmp = _alloca (256*heap->heap_number);
     heap->gc_thread_function();
 }
 #ifdef _MSC_VER


### PR DESCRIPTION
Also fix the one fatal error produced by gcc 10, in `src/coreclr/src/gc/gc.cpp`:

```sh
[ 99%] Building CXX object src/vm/wks/CMakeFiles/cee_wks_core.dir/__/__/gc/handletablecache.cpp.o
In file included from /runtime/src/coreclr/src/gc/gcsvr.cpp:29:
/runtime/src/coreclr/src/gc/gc.cpp: In static member function 'static void SVR::gc_heap::gc_thread_stub(void*)':
/runtime/src/coreclr/src/gc/gc.cpp:26150:13: error: ignoring return value of 'void* __builtin_alloca(long unsigned int)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
26150 |     _alloca (256*heap->heap_number);
```

after that building all coreclr,mono,libraries,installer subsets succeed on Ubuntu 20.04 amd64 with clang 11 and gcc 10 (I've previously tested clang 10 as well but not in this iteration).

cc @janvorli