### PR TITLE
Make Process.WaitForExitAsync wait for redirected output reads

### DIFF
--- a/src/libraries/Common/src/System/Threading/Tasks/TaskTimeoutExtensions.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskTimeoutExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Threading.Tasks
             static async Task WithCancellationCore(Task task, CancellationToken cancellationToken)
             {
                 var tcs = new TaskCompletionSource();
-                using IDisposable _ = cancellationToken.UnsafeRegister(static s => ((TaskCompletionSource)s!).SetResult(), tcs);
+                using IDisposable _ = cancellationToken.UnsafeRegister(static s => ((TaskCompletionSource)s!).TrySetResult(), tcs);
 
                 if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                 {

--- a/src/libraries/Common/src/System/Threading/Tasks/TaskTimeoutExtensions.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskTimeoutExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Threading.Tasks
             static async Task WithCancellationCore(Task task, CancellationToken cancellationToken)
             {
                 var tcs = new TaskCompletionSource();
-                using IDisposable _ = cancellationToken.UnsafeRegister(static s => ((TaskCompletionSource)s!).TrySetResult(), tcs);
+                using CancellationTokenRegistration _ = cancellationToken.UnsafeRegister(static s => ((TaskCompletionSource)s!).TrySetResult(), tcs);
 
                 if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                 {

--- a/src/libraries/Common/src/System/Threading/Tasks/TaskTimeoutExtensions.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskTimeoutExtensions.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Task timeout helper based on https://devblogs.microsoft.com/pfxteam/crafting-a-task-timeoutafter-method/
+    /// </summary>
+    internal static class TaskTimeoutExtensions
+    {
+        public static async Task WithCancellation(this Task task, CancellationToken cancellationToken)
+        {
+            if (task is null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            if (task.IsCompleted || !cancellationToken.CanBeCanceled)
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tcs = new TaskCompletionSource<bool>();
+            using (cancellationToken.Register(static s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), tcs))
+            {
+                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+
+#pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
+                await task; // already completed; propagate any exception
+#pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
+            }
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRY</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -39,6 +39,8 @@
              Link="Common\Interop\Windows\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskCompletionSourceWithCancellation.cs"
              Link="Common\System\Threading\Tasks\TaskCompletionSourceWithCancellation.cs" />
+    <Compile Include="$(CommonPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
+         Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.EnumProcessModules.cs"

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
@@ -258,17 +258,17 @@ namespace System.Diagnostics
             if (_readToBufferTask is Task task)
             {
                 task.GetAwaiter().GetResult();
-                _readToBufferTask = null;
             }
         }
 
-        internal async ValueTask WaitUntilEOFAsync(CancellationToken cancellationToken)
+        internal Task WaitUntilEOFAsync(CancellationToken cancellationToken)
         {
             if (_readToBufferTask is Task task)
             {
-                await task.WithCancellation(cancellationToken).ConfigureAwait(false);
-                _readToBufferTask = null;
+                return task.WithCancellation(cancellationToken);
             }
+
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
@@ -253,11 +253,20 @@ namespace System.Diagnostics
 
         // Wait until we hit EOF. This is called from Process.WaitForExit
         // We will lose some information if we don't do this.
-        internal void WaitUtilEOF()
+        internal void WaitUntilEOF()
         {
-            if (_readToBufferTask != null)
+            if (_readToBufferTask is Task task)
             {
-                _readToBufferTask.GetAwaiter().GetResult();
+                task.GetAwaiter().GetResult();
+                _readToBufferTask = null;
+            }
+        }
+
+        internal async ValueTask WaitUntilEOFAsync()
+        {
+            if (_readToBufferTask is Task task)
+            {
+                await task.ConfigureAwait(false);
                 _readToBufferTask = null;
             }
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
@@ -262,11 +262,11 @@ namespace System.Diagnostics
             }
         }
 
-        internal async ValueTask WaitUntilEOFAsync()
+        internal async ValueTask WaitUntilEOFAsync(CancellationToken cancellationToken)
         {
             if (_readToBufferTask is Task task)
             {
-                await task.ConfigureAwait(false);
+                await task.WithCancellation(cancellationToken).ConfigureAwait(false);
                 _readToBufferTask = null;
             }
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -207,11 +207,11 @@ namespace System.Diagnostics
             {
                 if (_output != null)
                 {
-                    _output.WaitUtilEOF();
+                    _output.WaitUntilEOF();
                 }
                 if (_error != null)
                 {
-                    _error.WaitUtilEOF();
+                    _error.WaitUntilEOF();
                 }
             }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -180,10 +180,10 @@ namespace System.Diagnostics
             {
                 // If we have a hard timeout, we cannot wait for the streams
                 if (_output != null && milliseconds == Timeout.Infinite)
-                    _output.WaitUtilEOF();
+                    _output.WaitUntilEOF();
 
                 if (_error != null && milliseconds == Timeout.Infinite)
-                    _error.WaitUtilEOF();
+                    _error.WaitUntilEOF();
 
                 handle?.Dispose();
             }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1486,7 +1486,7 @@ namespace System.Diagnostics
             async ValueTask WaitUntilOutputEOF()
             {
                 // if we have a hard timeout, we cannot wait for the streams
-                if (!cancellationToken.IsCancellationRequested)
+                if (!cancellationToken.CanBeCanceled)
                 {
                     if (_output != null)
                     {

--- a/src/libraries/System.Diagnostics.Process/tests/RemotelyInvokable.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/RemotelyInvokable.cs
@@ -66,6 +66,12 @@ namespace System.Diagnostics.Tests
             return line == "Success" ? SuccessExitCode : SuccessExitCode + 1;
         }
 
+        public static int Echo(string value)
+        {
+            Console.WriteLine(value);
+            return SuccessExitCode;
+        }
+
         public static int ReadLineWriteIfNull()
         {
             string line = Console.ReadLine();


### PR DESCRIPTION
Addresses an issue where Process.WaitForExitAsync doesn't wait for background redirected output reads, a behaviour which diverges from the sync method equivalent. Fixes #42556.

cc @adamsitnik @stephentoub 