### PR TITLE
[5.0] Fix to allow entering cooperative GC mode when the thread is in a forbid-suspend-for-debugger region

### DIFF
--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -2277,8 +2277,9 @@ void Thread::RareDisablePreemptiveGC()
     // Note IsGCInProgress is also true for say Pause (anywhere SuspendEE happens) and GCThread is the
     // thread that did the Pause. While in Pause if another thread attempts Rev/Pinvoke it should get inside the following and
     // block until resume
-    if ((GCHeapUtilities::IsGCInProgress()  && (this != ThreadSuspend::GetSuspensionThread())) ||
-        (m_State & (TS_DebugSuspendPending | TS_StackCrawlNeeded)))
+    if ((GCHeapUtilities::IsGCInProgress() && (this != ThreadSuspend::GetSuspensionThread())) ||
+        ((m_State & TS_DebugSuspendPending) && !IsInForbidSuspendForDebuggerRegion()) ||
+        (m_State & TS_StackCrawlNeeded))
     {
         STRESS_LOG1(LF_SYNC, LL_INFO1000, "RareDisablePreemptiveGC: entering. Thread state = %x\n", m_State.Load());
 
@@ -2369,7 +2370,8 @@ void Thread::RareDisablePreemptiveGC()
             // thread while in this loop.  This happens if you use the COM+
             // debugger to suspend this thread and then release it.
             if (! ((GCHeapUtilities::IsGCInProgress() && (this != ThreadSuspend::GetSuspensionThread())) ||
-                    (m_State & (TS_DebugSuspendPending | TS_StackCrawlNeeded))) )
+                    ((m_State & TS_DebugSuspendPending) && !IsInForbidSuspendForDebuggerRegion()) ||
+                    (m_State & TS_StackCrawlNeeded)) )
             {
                 break;
             }


### PR DESCRIPTION
- Port of https://github.com/dotnet/runtime/pull/42587 to 5.0
- Followup to https://github.com/dotnet/runtime/pull/40060
- In short timing windows if a thread is placed in a pending-suspend-for-debugger state while in a forbid-suspend-for-debugger region, from the above PR it would not suspend for the debugger but it was missed that it can also get stuck in a perpetual spin-wait while entering cooperative GC mode. This causes the thread to not suspend for the debugger (VS times out after waiting) and the thread can only progress by unmarking it for debugger suspension.
- Fixed to break the spin-wait by checking whether the thread is in the forbid region

Fixes https://github.com/dotnet/runtime/issues/42375

### Customer impact

- When VS breaks a process for managed debugging at an arbitrary time, if it happens during a short window of time, the process does not suspend for the debugger and instead a thread gets stuck in a perpetual spin-wait. VS times out waiting, eventually showing an error.
- Detaching the debugger also times out, eventually giving an option to terminate the process. The process gets stuck in this deadlocked state and the only option appears to be to forcibly terminate it.
- A workaround is to disable tiering and profiler-rejit-on-attach when debugging. There are cases where the same issue may occur even then, but they are probably a lot more rare.

### Regression?

- Yes, from 3.1
- PR https://github.com/dotnet/runtime/pull/40060 changed how suspension for the debugger works with a particular lock used by tiering and profiler-rejit-on-attach. The intention was to allow entering cooperative GC mode and the perpetual spin-wait was missed.
- 3.1 used a different but incomplete solution that was problematic for VS debugger tests and with a bit worse diagnostic experience in some situations

### Testing

- Manual testing with VS/coreclr to induce the problem
- PAL, coreclr, and libraries tests

### Risk

Low:
- The change provides the originally intended behavior, I'm not aware of any significant risks