### PR TITLE
[Android] Make AndroidAppBuilder "dotnet build" friendly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,7 +53,7 @@
 
   <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">
     <AppleAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder', 'Debug', '$(NetCoreAppCurrent)'))</AppleAppBuilderDir>
-    <AndroidAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidAppBuilder', 'Debug', '$(NetCoreAppCurrent)'))</AndroidAppBuilderDir>
+    <AndroidAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidAppBuilder', 'Debug', '$(NetCoreAppCurrent)', 'publish'))</AndroidAppBuilderDir>
     <WasmAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'WasmAppBuilder', 'Debug', '$(NetCoreAppCurrent)', 'publish'))</WasmAppBuilderDir>
     <WasmBuildTasksDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'WasmBuildTasks', 'Debug', '$(NetCoreAppCurrent)', 'publish'))</WasmBuildTasksDir>
     <MonoAOTCompilerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'MonoAOTCompiler', 'Debug', '$(NetCoreAppCurrent)'))</MonoAOTCompilerDir>

--- a/src/mono/netcore/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/netcore/sample/Android/AndroidSampleApp.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="BuildApp">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <OutputPath>bin</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TargetArchitecture Condition="'$(TargetArchitecture)'==''">x64</TargetArchitecture>
     <TargetOS>Android</TargetOS>
     <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.android-$(TargetArchitecture)\$(Configuration)\runtimes\android-$(TargetArchitecture)\</MicrosoftNetCoreAppRuntimePackDir>
-    <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\android</BuildDir>
-    <AppDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\publish</AppDir>
     <NoWarn>$(NoWarn),CA1050</NoWarn>
   </PropertyGroup>
 
@@ -35,7 +32,7 @@
       <StripDebugSymbols>False</StripDebugSymbols>
       <StripDebugSymbols Condition="'$(Configuration)' == 'Release'">True</StripDebugSymbols>
       <AdbTool>$(ANDROID_SDK_ROOT)\platform-tools\adb</AdbTool>
-      <ApkDir>$(MSBuildThisFileDirectory)bin\apk</ApkDir>
+      <ApkDir>$(OutputPath)apk</ApkDir>
     </PropertyGroup>
 
     <ItemGroup>
@@ -47,11 +44,11 @@
     <RemoveDir Directories="$(ApkDir)" />
 
     <AndroidAppBuilderTask
-        SourceDir="$(MSBuildThisFileDirectory)bin"
+        SourceDir="$(OutputPath)"
         Abi="$(AndroidAbi)"
         ProjectName="HelloAndroid"
         MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)\native\include\mono-2.0"
-        MainLibraryFileName="Program.dll"
+        MainLibraryFileName="$(AssemblyName).dll"
         StripDebugSymbols="$(StripDebugSymbols)"
         AssemblySearchPaths="@(AssemblySearchPaths)"
         OutputDir="$(ApkDir)">

--- a/src/mono/netcore/sample/Android/Makefile
+++ b/src/mono/netcore/sample/Android/Makefile
@@ -4,15 +4,16 @@ DOTNET := ../../../../.././dotnet.sh
 
 all: runtimepack run
 
-appbuilder:
-	$(DOTNET) build -c Release ../../../../../tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.csproj
-
 runtimepack:
 	../../../../.././build.sh Mono+Libs -os Android -arch $(MONO_ARCH) -c $(MONO_CONFIG)
 
-run: clean appbuilder
-	$(DOTNET) publish -c $(MONO_CONFIG) -r android-$(MONO_ARCH) \
-	/p:TargetArchitecture=$(MONO_ARCH) /p:DeployAndRun=true
+run:
+	$(DOTNET) build \
+	/p:TargetArchitecture=$(MONO_ARCH) \
+	/p:TargetOS=Android \
+	/p:Configuration=$(MONO_CONFIG) \
+	/p:DeployAndRun=true \
+	Program.csproj
 
 clean:
 	rm -rf bin

--- a/src/mono/netcore/sample/Android/Makefile
+++ b/src/mono/netcore/sample/Android/Makefile
@@ -12,8 +12,7 @@ run:
 	/p:TargetArchitecture=$(MONO_ARCH) \
 	/p:TargetOS=Android \
 	/p:Configuration=$(MONO_CONFIG) \
-	/p:DeployAndRun=true \
-	Program.csproj
+	/p:DeployAndRun=true
 
 clean:
 	rm -rf bin

--- a/src/mono/netcore/sample/Android/Makefile
+++ b/src/mono/netcore/sample/Android/Makefile
@@ -1,5 +1,5 @@
 MONO_CONFIG=Release
-MONO_ARCH=arm64
+MONO_ARCH=x64
 DOTNET := ../../../../.././dotnet.sh
 
 all: runtimepack run

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -1,72 +1,79 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="BuildApp">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
-    <DebugType>Portable</DebugType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.android-$(TargetArchitecture)\$(Configuration)\runtimes\android-$(TargetArchitecture)</MicrosoftNetCoreAppRuntimePackDir>
-    <AndroidAppBuilderDir>$(ArtifactsBinDir)AndroidAppBuilder\$(Configuration)\$(NetCoreAppCurrent)</AndroidAppBuilderDir>
-    <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
-    <PublishTrimmed>true</PublishTrimmed>
-    <_TrimmerDefaultAction>link</_TrimmerDefaultAction>
-    <InvariantGlobalization>true</InvariantGlobalization> <!-- workaround for https://github.com/dotnet/runtime/issues/41866 -->
+    <TargetArchitecture>x64</TargetArchitecture>
+    <TargetOS>Android</TargetOS>
+    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.android-$(TargetArchitecture)\$(Configuration)\runtimes\android-$(TargetArchitecture)\</MicrosoftNetCoreAppRuntimePackDir>
+    <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\android</BuildDir>
+    <AppDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\publish</AppDir>
     <NoWarn>$(NoWarn),CA1050</NoWarn>
   </PropertyGroup>
 
-  <!-- Redirect 'dotnet publish' to in-tree runtime pack -->
-  <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
+  <Target Name="RebuildAndroidAppBuilder">
     <ItemGroup>
-      <RuntimePack>
-        <PackageDirectory>$(ArtifactsBinDir)microsoft.netcore.app.runtime.android-$(TargetArchitecture)\$(Configuration)</PackageDirectory>
-      </RuntimePack>
+      <AndroidAppBuilderProject Include="$(RepoTasksDir)mobile.tasks\AndroidAppBuilder\AndroidAppBuilder.csproj" />
     </ItemGroup>
-    <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />
+    <MSBuild Projects="@(AndroidAppBuilderProject)"
+             Properties="Configuration=$(Configuration);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
+             Targets="Restore"/>
+    <MSBuild Projects="@(AndroidAppBuilderProject)"
+             Properties="Configuration=$(Configuration)"
+             Targets="Build;Publish"/>
   </Target>
 
-  <UsingTask TaskName="AndroidAppBuilderTask"
-             AssemblyFile="$(AndroidAppBuilderDir)\AndroidAppBuilder.dll" />
+  <UsingTask TaskName="AndroidAppBuilderTask" 
+             AssemblyFile="$(ArtifactsBinDir)AndroidAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\publish\AndroidAppBuilder.dll"/>
 
-  <!-- Build APK during 'dotnet publish' -->
-  <Target Name="BuildAppBundle" AfterTargets="CopyFilesToPublishDirectory">
+  <Target Name="BuildApp" DependsOnTargets="RebuildAndroidAppBuilder;Build">
     <PropertyGroup>
       <AndroidAbi Condition="'$(Platform)'=='arm64'">arm64-v8a</AndroidAbi>
       <AndroidAbi Condition="'$(Platform)'=='arm'">armeabi-v7a</AndroidAbi>
       <AndroidAbi Condition="'$(Platform)'=='x64'">x86_64</AndroidAbi>
       <AndroidAbi Condition="'$(AndroidAbi)'==''">$(Platform)</AndroidAbi>
-      <ApkDir>$(MSBuildThisFileDirectory)$(PublishDir)\apk</ApkDir>
       <StripDebugSymbols>False</StripDebugSymbols>
       <StripDebugSymbols Condition="'$(Configuration)' == 'Release'">True</StripDebugSymbols>
       <AdbTool>$(ANDROID_SDK_ROOT)\platform-tools\adb</AdbTool>
+      <ApkDir>$(MSBuildThisFileDirectory)\bin\apk</ApkDir>
     </PropertyGroup>
+
+    <ItemGroup>
+      <AssemblySearchPaths Include="bin"/>
+      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)native"/>
+      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)"/>
+    </ItemGroup>
 
     <RemoveDir Directories="$(ApkDir)" />
 
-    <!-- These native libs are not needed for HelloWorld
-         and can be deleted to save 0.4 Mb for APK size -->
-    <Delete Files="$(PublishDir)\libSystem.IO.Compression.Native.so" />
-    <Delete Files="$(PublishDir)\libSystem.Security.Cryptography.Native.OpenSsl.so" />
-
     <AndroidAppBuilderTask
+        SourceDir="$(MSBuildThisFileDirectory)\bin"
         Abi="$(AndroidAbi)"
         ProjectName="HelloAndroid"
-        MonoRuntimeHeaders="%(ResolvedRuntimePack.PackageDirectory)\runtimes\android-$(Platform)\native\include\mono-2.0"
+        MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)\native\include\mono-2.0"
         MainLibraryFileName="Program.dll"
         StripDebugSymbols="$(StripDebugSymbols)"
-        SourceDir="$(MSBuildThisFileDirectory)$(PublishDir)"
+        AssemblySearchPaths="@(AssemblySearchPaths)"
         OutputDir="$(ApkDir)">
         <Output TaskParameter="ApkBundlePath" PropertyName="ApkBundlePath" />
         <Output TaskParameter="ApkPackageId" PropertyName="ApkPackageId" />
     </AndroidAppBuilderTask>
+
     <Message Importance="High" Text="Apk:       $(ApkBundlePath)"/>
     <Message Importance="High" Text="PackageId: $(ApkPackageId)"/>
 
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) kill-server"/>
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) start-server"/>
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) logcat -c" ContinueOnError="WarnAndContinue" />
-    <Message Condition="'$(DeployAndRun)' == 'true'" Importance="High" Text="Uninstalling app if it exists (throws an error if it doesn't but it can be ignored):"/>
+    <Message Condition="'$(DeployAndRun)' == 'true'" Importance="High" Text="Uninstalling apk (ignore errors if any):"/>
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) uninstall net.dot.HelloAndroid" ContinueOnError="WarnAndContinue" />
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) install $(ApkDir)/bin/HelloAndroid.apk" />
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) shell am instrument -w net.dot.HelloAndroid/net.dot.MonoRunner" />
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) logcat -d -s DOTNET" />
   </Target>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
 </Project>

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -24,8 +24,7 @@
              Targets="Build;Publish"/>
   </Target>
 
-  <UsingTask TaskName="AndroidAppBuilderTask" 
-             AssemblyFile="$(ArtifactsBinDir)AndroidAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\publish\AndroidAppBuilder.dll"/>
+  <UsingTask TaskName="AndroidAppBuilderTask" AssemblyFile="$(AndroidAppBuilderTasksAssemblyPath)"/>
 
   <Target Name="BuildApp" DependsOnTargets="RebuildAndroidAppBuilder;Build">
     <PropertyGroup>

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -4,7 +4,7 @@
     <OutputPath>bin</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <TargetArchitecture>x64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)'==''">x64</TargetArchitecture>
     <TargetOS>Android</TargetOS>
     <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.android-$(TargetArchitecture)\$(Configuration)\runtimes\android-$(TargetArchitecture)\</MicrosoftNetCoreAppRuntimePackDir>
     <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\android</BuildDir>

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -35,11 +35,11 @@
       <StripDebugSymbols>False</StripDebugSymbols>
       <StripDebugSymbols Condition="'$(Configuration)' == 'Release'">True</StripDebugSymbols>
       <AdbTool>$(ANDROID_SDK_ROOT)\platform-tools\adb</AdbTool>
-      <ApkDir>$(MSBuildThisFileDirectory)\bin\apk</ApkDir>
+      <ApkDir>$(MSBuildThisFileDirectory)bin\apk</ApkDir>
     </PropertyGroup>
 
     <ItemGroup>
-      <AssemblySearchPaths Include="bin"/>
+      <AssemblySearchPaths Include="bin" />
       <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)native"/>
       <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)"/>
     </ItemGroup>
@@ -47,7 +47,7 @@
     <RemoveDir Directories="$(ApkDir)" />
 
     <AndroidAppBuilderTask
-        SourceDir="$(MSBuildThisFileDirectory)\bin"
+        SourceDir="$(MSBuildThisFileDirectory)bin"
         Abi="$(AndroidAbi)"
         ProjectName="HelloAndroid"
         MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)\native\include\mono-2.0"

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -10,6 +11,10 @@ public class AndroidAppBuilderTask : Task
 {
     [Required]
     public string SourceDir { get; set; } = ""!;
+
+    public ITaskItem[]? AssemblySearchPaths { get; set; }
+
+    public ITaskItem[]? ExtraAssemblies { get; set; }
 
     [Required]
     public string MonoRuntimeHeaders { get; set; } = ""!;
@@ -61,6 +66,8 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.BuildApiLevel = BuildApiLevel;
         apkBuilder.BuildToolsVersion = BuildToolsVersion;
         apkBuilder.StripDebugSymbols = StripDebugSymbols;
+        apkBuilder.AssemblySearchPaths = AssemblySearchPaths?.Select(a => a.ItemSpec)?.ToArray();
+        apkBuilder.ExtraAssemblies = ExtraAssemblies?.Select(a => a.ItemSpec)?.ToArray();
         (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, Abi, MainLibraryFileName, MonoRuntimeHeaders);
 
         return true;

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.csproj
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
@@ -15,10 +15,16 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(RefOnlyMicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RefOnlyMicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApkBuilder.cs" />
     <Compile Include="AndroidAppBuilder.cs" />
+    <Compile Include="AssemblyResolver.cs" />
     <Compile Include="Utils.cs" />
   </ItemGroup>
+
+  <Target Name="PublishBuilder"
+          AfterTargets="Build"
+          DependsOnTargets="Publish" />
 </Project>

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -18,6 +18,8 @@ public class ApkBuilder
     public string? BuildToolsVersion { get; set; }
     public string? OutputDir { get; set; }
     public bool StripDebugSymbols { get; set; }
+    public string[]? AssemblySearchPaths { get; set; }
+    public string[]? ExtraAssemblies { get; set; }
 
     public (string apk, string packageId) BuildApk(
         string sourceDir, string abi, string entryPointLib, string monoRuntimeHeaders)
@@ -31,7 +33,8 @@ public class ApkBuilder
         if (string.IsNullOrEmpty(entryPointLib))
             throw new ArgumentException("entryPointLib shouldn't be empty");
 
-        if (!File.Exists(Path.Combine(sourceDir, entryPointLib)))
+        string entryPointLibPath = Path.Combine(sourceDir, entryPointLib);
+        if (!File.Exists(entryPointLibPath))
             throw new ArgumentException($"{entryPointLib} was not found in sourceDir='{sourceDir}'");
 
         if (string.IsNullOrEmpty(ProjectName))
@@ -93,7 +96,38 @@ public class ApkBuilder
             extensionsToIgnore.Add(".dbg");
         }
 
-        // Copy AppDir to OutputDir/assets-tozip (ignore native files)
+        var assembliesToResolve = new List<string> { entryPointLibPath };
+        if (ExtraAssemblies != null)
+            assembliesToResolve.AddRange(ExtraAssemblies);
+
+        // try to resolve dependencies of entryPointLib + ExtraAssemblies from AssemblySearchPaths
+        // and copy them to sourceDir
+        if (AssemblySearchPaths?.Length > 0)
+        {
+            string[] resolvedDependencies = AssemblyResolver.ResolveDependencies(assembliesToResolve.ToArray(), AssemblySearchPaths, true);
+            foreach (string resolvedDependency in resolvedDependencies)
+            {
+                string destination = Path.Combine(sourceDir, Path.GetFileName(resolvedDependency));
+                if (!File.Exists(destination))
+                    File.Copy(resolvedDependency, destination);
+            }
+        }
+        else
+        {
+            AssemblySearchPaths = new[] {OutputDir};
+        }
+
+        // copy all native libs from AssemblySearchPaths to sourceDir
+        // TODO: skip some if not used by the app
+        string[] allFiles = AssemblySearchPaths.SelectMany(p => Directory.GetFiles(p, "*", SearchOption.AllDirectories)).ToArray();
+        foreach (string nativeLib in allFiles.Where(f => f.EndsWith(".a") || f.EndsWith(".so")))
+        {
+            string destination = Path.Combine(sourceDir, Path.GetFileName(nativeLib));
+            if (!File.Exists(destination))
+                File.Copy(nativeLib, destination);
+        }
+
+        // Copy sourceDir to OutputDir/assets-tozip (ignore native files)
         // these files then will be zipped and copied to apk/assets/assets.zip
         Utils.DirectoryCopy(sourceDir, Path.Combine(OutputDir, "assets-tozip"), file =>
         {

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -229,7 +229,6 @@ public class ApkBuilder
         Utils.RunProcess(aapt, $"package -f -m -F {apkFile} -A assets -M AndroidManifest.xml -I {androidJar}", workingDir: OutputDir);
 
         var dynamicLibs = new List<string>();
-        dynamicLibs.Add(Path.Combine(OutputDir, "monodroid", "libmonodroid.so"));
         dynamicLibs.AddRange(Directory.GetFiles(sourceDir, "*.so"));
 
         // add all *.so files to lib/%abi%/

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AssemblyResolver.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AssemblyResolver.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AssemblyResolver.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AssemblyResolver.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+internal class AssemblyResolver : MetadataAssemblyResolver
+{
+    private string[] _searchPaths;
+
+    public AssemblyResolver(string[] searchPaths) => _searchPaths = searchPaths;
+
+    public static string[] ResolveDependencies(
+        string[] assembliesToResolve, string[] searchPaths, bool ignoreErrors = true)
+    {
+        var assemblies = new Dictionary<string, Assembly>();
+        var mlc = new MetadataLoadContext(new AssemblyResolver(searchPaths), "System.Private.CoreLib");
+        foreach (string assemblyPath in assembliesToResolve)
+        {
+            try
+            {
+                AddAssembly(mlc, mlc.LoadFromAssemblyPath(assemblyPath), assemblies, ignoreErrors);
+            }
+            catch (Exception)
+            {
+                if (!ignoreErrors)
+                {
+                    throw;
+                }
+            }
+        }
+        return assemblies.Values.Select(i => i.Location).Distinct().ToArray();
+    }
+
+    private static void AddAssembly(MetadataLoadContext mlc, Assembly assembly, Dictionary<string, Assembly> assemblies, bool ignoreErrors)
+    {
+        if (assemblies.ContainsKey(assembly.GetName().Name!))
+            return;
+        assemblies[assembly.GetName().Name!] = assembly;
+        foreach (AssemblyName name in assembly.GetReferencedAssemblies())
+        {
+            try
+            {
+                Assembly refAssembly = mlc.LoadFromAssemblyName(name);
+                AddAssembly(mlc, refAssembly, assemblies, ignoreErrors);
+            }
+            catch (Exception)
+            {
+                if (!ignoreErrors)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+
+    public override Assembly? Resolve(MetadataLoadContext context, AssemblyName assemblyName)
+    {
+        string name = assemblyName.Name!;
+        foreach (string dir in _searchPaths)
+        {
+            string path = Path.Combine(dir, name + ".dll");
+            if (File.Exists(path))
+                return context.LoadFromAssemblyPath(path);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
`AndroidAppBuilderTask` used to work only with `dotnet publish`. 
The task delegated all the work to copy dependencies to the output directory to `publish` command. This PR makes it `dotnet build` friendly by re-using some pieces from WasmAppBuilder. Maybe later we can unify some things between all the *AppBuilders (iOS, Android and Wasm).

It should unblock @fanyang-mono to bring coreclr tests to Android.

libs tests still use  `dotnet publish` pipeline but I guess we'll fix it.