### PR TITLE
Update Helix.SDK to consume fix on Download files from results container task

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -16,7 +16,7 @@
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20471.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0365488709f58e37de6c2180e7fb243203ca0a9c</Sha>
+      <Sha>a8d7ecca110a9932c8ee7fc9e1065b6ad7c96dfd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20471.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20471.1",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20471.1",
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20471.1",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20471.1",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20472.5",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20359.4",
     "Microsoft.Build.NoTargets": "2.0.1",


### PR DESCRIPTION
Motivation to update it is to bring the fix in https://github.com/dotnet/arcade/pull/6179/.