### PR TITLE
Keep deps.json in APP_CONTEXT_DEPS_FILE for .NET Core 3 compat mode

### DIFF
--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -736,7 +736,8 @@ void deps_resolver_t::get_app_context_deps_files_range(fx_definition_vector_t::i
     auto begin_iter = m_fx_definitions.begin();
     auto end_iter = m_fx_definitions.end();
 
-    if ((m_host_mode == host_mode_t::libhost || bundle::info_t::is_single_file_bundle())
+    if ((m_host_mode == host_mode_t::libhost
+        || (bundle::info_t::is_single_file_bundle() && !bundle::runner_t::app()->is_netcoreapp3_compat_mode()))
         && begin_iter != end_iter)
     {
         // Neither in a libhost scenario nor in a bundled app

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -81,9 +81,7 @@ namespace AppHost.Bundle.Tests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining("SingleFileApiTests.deps.json")
-                .And
-                .HaveStdOutContaining("Microsoft.NETCore.App.deps.json");
+                .HaveStdOutContaining("SingleFileApiTests.deps.json");
         }
 
         [Fact]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -2,6 +2,7 @@
 using BundleTests.Helpers;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.NET.HostModel.Bundle;
 using Xunit;
 
 namespace AppHost.Bundle.Tests
@@ -65,6 +66,24 @@ namespace AppHost.Bundle.Tests
                 .NotHaveStdOutContaining("SingleFileApiTests.deps.json")
                 .And
                 .NotHaveStdOutContaining("Microsoft.NETCore.App.deps.json");
+        }
+
+        [Fact]
+        public void AppContext_Deps_Files_Bundled_Self_Contained_NetCoreApp3_CompatMode()
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
+            string singleFile = BundleHelper.BundleApp(fixture, BundleOptions.BundleAllContent);
+
+            Command.Create(singleFile, "appcontext")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("SingleFileApiTests.deps.json")
+                .And
+                .HaveStdOutContaining("Microsoft.NETCore.App.deps.json");
         }
 
         [Fact]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
@@ -122,6 +122,15 @@ namespace BundleTests.Helpers
                    throw new ArgumentException(nameof (runtimeIdentifier));
         }
 
+        private static void UseOwnSharedLibrary(TestProjectFixture fixture, string libraryName)
+        {
+            string sharedLibraryName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform(libraryName);
+            File.Copy(
+                Path.Combine(fixture.RepoDirProvider.HostArtifacts, sharedLibraryName),
+                Path.Combine(BundleHelper.GetPublishPath(fixture), sharedLibraryName),
+                overwrite: true);
+        }
+
         /// Generate a bundle containind the (embeddable) files in sourceDir
         public static string GenerateBundle(Bundler bundler, string sourceDir, string outputDir, bool copyExludedFiles=true)
         {
@@ -174,6 +183,10 @@ namespace BundleTests.Helpers
             var bundleDir = GetBundleDir(fixture);
             var targetOS = GetTargetOS(fixture.CurrentRid);
             var targetArch = GetTargetArch(fixture.CurrentRid);
+
+            // In order to test the hosting components we need the hostpolicy and hostfxr built by the repo
+            UseOwnSharedLibrary(fixture, "hostfxr");
+            UseOwnSharedLibrary(fixture, "hostpolicy");
 
             var bundler = new Bundler(hostName, bundleDir.FullName, options, targetOS, targetArch, targetFrameworkVersion);
             singleFile = GenerateBundle(bundler, publishPath, bundleDir.FullName, copyExcludedFiles);


### PR DESCRIPTION
Setting the `IncludeAllContentForSelfExtract` property for single-file apps causes the bundled files to be extracted just as they did in .NET 3. In this case, the user would expect the extracted deps.json to be in `APP_CONTEXT_DEPS_FILES`.