### PR TITLE
Compile test framework using R2RTest

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildFolderSet.cs
@@ -223,7 +223,7 @@ namespace R2RTest
             string coreRoot = _options.CoreRootDirectory.FullName;
             string[] frameworkFolderFiles = Directory.GetFiles(coreRoot);
 
-            IEnumerable<CompilerRunner> frameworkRunners = _options.CompilerRunners(isFramework: true);
+            IEnumerable<CompilerRunner> frameworkRunners = _options.CompilerRunners(isFramework: true, overrideOutputPath: _options.OutputDirectory.FullName);
 
             // Pre-populate the output folders with the input files so that we have backdrops
             // for failing compilations.

--- a/src/coreclr/src/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildOptions.cs
@@ -15,6 +15,9 @@ namespace R2RTest
         public DirectoryInfo CoreRootDirectory { get; set; }
         public bool Crossgen { get; set; }
         public FileInfo CrossgenPath { get; set; }
+        public FileInfo Crossgen2Path { get; set; }
+        public bool VerifyTypeAndFieldLayout { get; set; }
+        public string TargetArch { get; set; }
         public bool Exe { get; set; }
         public bool NoJit { get; set; }
         public bool NoCrossgen2 { get; set; }
@@ -107,7 +110,7 @@ namespace R2RTest
         /// </summary>
         /// <param name="isFramework">True if compiling the CoreFX framework assemblies</param>
         /// <param name="referencePaths">Optional set of reference paths to use instead of BuildOptions.ReferencePaths()</param>
-        public IEnumerable<CompilerRunner> CompilerRunners(bool isFramework, IEnumerable<string> overrideReferencePaths = null)
+        public IEnumerable<CompilerRunner> CompilerRunners(bool isFramework, IEnumerable<string> overrideReferencePaths = null, string overrideOutputPath = null)
         {
             List<CompilerRunner> runners = new List<CompilerRunner>();
 
@@ -116,7 +119,7 @@ namespace R2RTest
                 List<string> cpaotReferencePaths = new List<string>();
                 cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
                 cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new Crossgen2Runner(this, new Crossgen2RunnerOptions(), cpaotReferencePaths));
+                runners.Add(new Crossgen2Runner(this, new Crossgen2RunnerOptions(), cpaotReferencePaths, overrideOutputPath));
             }
 
             if (Crossgen)
@@ -124,7 +127,7 @@ namespace R2RTest
                 List<string> crossgenReferencePaths = new List<string>();
                 crossgenReferencePaths.Add(CoreRootOutputPath(CompilerIndex.Crossgen, isFramework));
                 crossgenReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new CrossgenRunner(this, crossgenReferencePaths));
+                runners.Add(new CrossgenRunner(this, crossgenReferencePaths, overrideOutputPath));
             }
 
             if (!NoJit)

--- a/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
@@ -43,6 +43,9 @@ namespace R2RTest
                         OutputDirectory(),
                         Crossgen(),
                         CrossgenPath(),
+                        Crossgen2Path(),
+                        TargetArch(),
+                        VerifyTypeAndFieldLayout(),
                         NoJit(),
                         NoCrossgen2(),
                         Exe(),
@@ -76,6 +79,9 @@ namespace R2RTest
                         OutputDirectory(),
                         Crossgen(),
                         CrossgenPath(),
+                        Crossgen2Path(),
+                        TargetArch(),
+                        VerifyTypeAndFieldLayout(),
                         NoJit(),
                         NoCrossgen2(),
                         Exe(),
@@ -106,8 +112,12 @@ namespace R2RTest
                     {
                         Crossgen(),
                         CrossgenPath(),
+                        Crossgen2Path(),
+                        TargetArch(),
+                        VerifyTypeAndFieldLayout(),
                         NoCrossgen2(),
                         NoCleanup(),
+                        Crossgen2Parallelism(),
                         DegreeOfParallelism(),
                         Sequential(),
                         Release(),
@@ -119,6 +129,7 @@ namespace R2RTest
                         R2RDumpPath(),
                         MeasurePerf(),
                         InputFileSearchString(),
+                        OutputDirectory(),
                     },
                     CompileFrameworkCommand.CompileFramework);
 
@@ -176,6 +187,12 @@ namespace R2RTest
 
             Option CrossgenPath() =>
                 new Option<FileInfo>(new[] { "--crossgen-path", "-cp" }, "Explicit Crossgen path (useful for cross-targeting)").ExistingOnly();
+
+            Option Crossgen2Path() =>
+                new Option<FileInfo>(new[] { "--crossgen2-path", "-c2p" }, "Explicit Crossgen2 path (useful for cross-targeting)").ExistingOnly();
+
+            Option VerifyTypeAndFieldLayout() =>
+                new Option<bool>(new[] { "--verify-type-and-field-layout" }, "Verify that struct type layout and field offsets match between compile time and runtime. Use only for diagnostic purposes.");
 
             Option NoJit() =>
                 new Option<bool>(new[] { "--nojit" }, "Don't run tests in JITted mode");
@@ -246,7 +263,9 @@ namespace R2RTest
 
             Option DotNetCli() =>
                 new Option<string>(new [] { "--dotnet-cli", "-cli" }, "For dev box testing, point at .NET 5 dotnet.exe or <repo>/dotnet.cmd.");
-                
+
+            Option TargetArch() =>
+                new Option<string>(new[] { "--target-arch" }, "Target architecture for crossgen2");
 
             //
             // compile-nuget specific options

--- a/src/coreclr/src/tools/r2rtest/Commands/CompileFrameworkCommand.cs
+++ b/src/coreclr/src/tools/r2rtest/Commands/CompileFrameworkCommand.cs
@@ -21,7 +21,10 @@ namespace R2RTest
 
             string logsFolder = Path.Combine(options.CoreRootDirectory.FullName, "logs");
             Directory.CreateDirectory(logsFolder);
-            options.OutputDirectory = new DirectoryInfo(logsFolder);
+            if (options.OutputDirectory == null)
+            {
+                options.OutputDirectory = new DirectoryInfo(logsFolder);
+            }
             options.Framework = true;
             options.NoJit = true;
             options.NoEtw = true;

--- a/src/coreclr/src/tools/r2rtest/CompilerRunner.cs
+++ b/src/coreclr/src/tools/r2rtest/CompilerRunner.cs
@@ -82,9 +82,12 @@ namespace R2RTest
 
         protected readonly BuildOptions _options;
         protected readonly List<string> _referenceFolders = new List<string>();
-        public CompilerRunner(BuildOptions options, IEnumerable<string> references)
+        protected readonly string _overrideOutputPath;
+
+        public CompilerRunner(BuildOptions options, IEnumerable<string> references, string overrideOutputPath = null)
         {
             _options = options;
+            _overrideOutputPath = overrideOutputPath;
 
             foreach (var reference in references)
             {
@@ -298,7 +301,7 @@ namespace R2RTest
             }
         }
 
-        public string GetOutputPath(string outputRoot) => Path.Combine(outputRoot, CompilerName + _options.ConfigurationSuffix);
+        public string GetOutputPath(string outputRoot) => _overrideOutputPath ?? Path.Combine(outputRoot, CompilerName + _options.ConfigurationSuffix);
 
         // <input>\a.dll -> <output>\a.dll
         public string GetOutputFileName(string outputRoot, string fileName) =>

--- a/src/coreclr/src/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/src/tools/r2rtest/Crossgen2Runner.cs
@@ -32,11 +32,11 @@ namespace R2RTest
         protected override string CompilerFileName => _options.DotNetCli;
         protected readonly List<string> _referenceFiles = new List<string>();
 
-        private string Crossgen2Path => Path.Combine(_options.CoreRootDirectory.FullName, "crossgen2", "crossgen2.dll");
+        private string Crossgen2Path => _options.Crossgen2Path != null ? _options.Crossgen2Path.FullName : Path.Combine(_options.CoreRootDirectory.FullName, "crossgen2", "crossgen2.dll");
         private bool CompositeMode => Crossgen2RunnerOptions != null ? Crossgen2RunnerOptions.Composite : _options.Composite;
 
-        public Crossgen2Runner(BuildOptions options, Crossgen2RunnerOptions crossgen2RunnerOptions, IEnumerable<string> references)
-            : base(options, references)
+        public Crossgen2Runner(BuildOptions options, Crossgen2RunnerOptions crossgen2RunnerOptions, IEnumerable<string> references, string overrideOutputPath = null)
+            : base(options, references, overrideOutputPath)
         {
             Crossgen2RunnerOptions = crossgen2RunnerOptions;
 
@@ -86,8 +86,15 @@ namespace R2RTest
             // Output
             yield return $"-o:{outputFileName}";
 
-            // Todo: Allow cross-architecture compilation
-            //yield return "--targetarch=x64";
+            if (_options.TargetArch != null)
+            {
+                yield return $"--targetarch={_options.TargetArch}";
+            }
+
+            if (_options.VerifyTypeAndFieldLayout)
+            {
+                yield return "--verify-type-and-field-layout";
+            }
 
             if (_options.Map)
             {

--- a/src/coreclr/src/tools/r2rtest/CrossgenRunner.cs
+++ b/src/coreclr/src/tools/r2rtest/CrossgenRunner.cs
@@ -28,8 +28,8 @@ namespace R2RTest
             }
         }
 
-        public CrossgenRunner(BuildOptions options, IEnumerable<string> referencePaths)
-            : base(options, referencePaths) { }
+        public CrossgenRunner(BuildOptions options, IEnumerable<string> referencePaths, string overrideOutputPath = null)
+            : base(options, referencePaths, overrideOutputPath) { }
 
         protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {

--- a/src/coreclr/src/tools/r2rtest/R2RTest.csproj
+++ b/src/coreclr/src/tools/r2rtest/R2RTest.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
-    <Platform>AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>$(BinDir)\R2RTest</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
This change switches crossgening of framework when building coreclr
tests to using R2RTest instead of explicitly invoking crossgen /
crossgen2.
To support that, the R2RTest was slightly updated to support specifying
target architecture, full path to crossgen2 and overriding the output
directory.

Tested on Windows targeting arm, arm64, x64 and x86 for both crossgen2 and crossgen
Tested on Linux targeting arm, arm64, x64 for both crossgen2 and crossgen