### PR TITLE
[runtime] Throw a MarshalDirectiveException when returning an array from a pinvoke method.

### DIFF
--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -2737,10 +2737,12 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldloc (mb, conv_arg);
 		break;
 
-	case MARSHAL_ACTION_CONV_RESULT:
-		/* fixme: we need conversions here */
-		mono_mb_emit_stloc (mb, 3);
+	case MARSHAL_ACTION_CONV_RESULT: {
+		mono_mb_emit_byte (mb, CEE_POP);
+		char *msg = g_strdup_printf ("Cannot marshal 'return value': Invalid managed/unmanaged type combination.");
+		mono_mb_emit_exception_marshal_directive (mb, msg);
 		break;
+	}
 
 	case MARSHAL_ACTION_MANAGED_CONV_IN: {
 		guint32 label1, label2, label3;

--- a/src/mono/mono/tests/libtest.c
+++ b/src/mono/mono/tests/libtest.c
@@ -8251,6 +8251,14 @@ mono_test_ccw_class_type_auto_dispatch (IDispatch *disp)
 	return 0;
 }
 
+static guint8 static_arr[] = { 1, 2, 3, 4 };
+
+LIBTEST_API guint8*
+mono_test_marshal_return_array (void)
+{
+	return static_arr;
+}
+
 #ifdef __cplusplus
 } // extern C
 #endif

--- a/src/mono/mono/tests/pinvoke2.cs
+++ b/src/mono/mono/tests/pinvoke2.cs
@@ -2147,5 +2147,16 @@ public unsafe class Tests {
 		return 0;
 	}
 
+	[DllImport ("libtest", EntryPoint="mono_test_marshal_return_array")]
+	public static extern int[] mono_test_marshal_return_array ();
+
+	public static int test_0_return_array () {
+		try {
+			var arr = mono_test_marshal_return_array ();
+			return 1;
+		} catch (MarshalDirectiveException) {
+			return 0;
+		}
+	}
 }
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20425,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/mono/mono/issues/20367.