### PR TITLE
Add Type.Namespace tests with array types, disable on Mono

### DIFF
--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -1407,6 +1407,9 @@ namespace System.Reflection.Tests
         [InlineData(typeof(PublicEnum), "System.Reflection.Tests")]
         [InlineData(typeof(TI_BaseClass.PublicNestedClass1), "System.Reflection.Tests")]
         [InlineData(typeof(int), "System")]
+        [InlineData(typeof(TI_BaseClass[]), "System.Reflection.Tests")]
+        [InlineData(typeof(TI_BaseClass.PublicNestedClass1[]), "System.Reflection.Tests")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/42633", TestRuntimes.Mono)]
         public void Namespace(Type type, string expected)
         {
             Assert.Equal(expected, type.GetTypeInfo().Namespace);


### PR DESCRIPTION
We probably have more issues lurking in here since a lot of these reflection APIs don't seem to test array types, but this particular one was in response to a customer bug report.

It might be worth going through and adding array types for a lot of these as part of the effort to increase test coverage?

Relevant issue: https://github.com/dotnet/runtime/issues/42633