### PR TITLE
Change TARGETS_BROWSER define to TARGET_BROWSER

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -10,7 +10,7 @@
     <DefineConstants>$(DefineConstants);SYSNETHTTP_NO_OPENSSL</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsBrowser)' == 'true'">
-    <DefineConstants>$(DefineConstants);TARGETS_BROWSER</DefineConstants>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
   </PropertyGroup>
   <!-- ILLinker settings -->
   <PropertyGroup>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
 {
     public partial class HttpClientHandler : HttpMessageHandler
     {
-#if TARGETS_BROWSER
+#if TARGET_BROWSER
         private readonly BrowserHttpHandler _underlyingHandler;
 #else
         private readonly SocketsHttpHandler _underlyingHandler;
@@ -26,7 +26,7 @@ namespace System.Net.Http
 
         public HttpClientHandler()
         {
-#if TARGETS_BROWSER
+#if TARGET_BROWSER
             _underlyingHandler = new BrowserHttpHandler();
 #else
             _underlyingHandler = new SocketsHttpHandler();
@@ -208,7 +208,7 @@ namespace System.Net.Http
                 switch (value)
                 {
                     case ClientCertificateOption.Manual:
-#if TARGETS_BROWSER
+#if TARGET_BROWSER
                         _clientCertificateOptions = value;
 #else
                         ThrowForModifiedManagedSslOptionsIfStarted();
@@ -218,7 +218,7 @@ namespace System.Net.Http
                         break;
 
                     case ClientCertificateOption.Automatic:
-#if TARGETS_BROWSER
+#if TARGET_BROWSER
                         _clientCertificateOptions = value;
 #else
                         ThrowForModifiedManagedSslOptionsIfStarted();
@@ -251,7 +251,7 @@ namespace System.Net.Http
         [UnsupportedOSPlatform("browser")]
         public Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? ServerCertificateCustomValidationCallback
         {
-#if TARGETS_BROWSER
+#if TARGET_BROWSER
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();
 #else


### PR DESCRIPTION
This makes our define name consistent across the codebase. I noticed this while making unrelated wasm-specific changes to our tests.