### PR TITLE
[wasm][debugger] Fixing step over in an async method

### DIFF
--- a/src/mono/mono/mini/debugger-engine.c
+++ b/src/mono/mono/mini/debugger-engine.c
@@ -1323,8 +1323,11 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 	} else {
 		frame_index = 1;
 
+#ifndef TARGET_WASM
 		if (ss_args->ctx && !frames) {
-
+#else
+		if (!frames) {
+#endif
 			mono_loader_lock ();
 			locked = TRUE;
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -323,6 +323,8 @@ namespace Microsoft.WebAssembly.Diagnostics
             SequencePoint prev = null;
             foreach (SequencePoint sp in DebugInformation.SequencePoints)
             {
+                if (sp.IsHidden)
+                    continue;
                 if (sp.Offset > pos)
                     break;
                 prev = sp;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -323,8 +323,6 @@ namespace Microsoft.WebAssembly.Diagnostics
             SequencePoint prev = null;
             foreach (SequencePoint sp in DebugInformation.SequencePoints)
             {
-                if (sp.IsHidden)
-                    continue;
                 if (sp.Offset > pos)
                     break;
                 prev = sp;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -903,8 +903,7 @@ namespace DebuggerTests
             });
         }
 
-        // [Fact]
-        // [ActiveIssue("https://github.com/dotnet/runtime/issues/42424")]
+        [Fact]
         public async Task BreakOnAwaitThenStepOverToNextAwaitCall()
         {
             var insp = new Inspector();
@@ -927,8 +926,7 @@ namespace DebuggerTests
             });
         }
 
-        // [Fact]
-        // [ActiveIssue("https://github.com/dotnet/runtime/issues/42424")]
+        [Fact]
         public async Task BreakOnAwaitThenStepOverToNextLine()
         {
             var insp = new Inspector();


### PR DESCRIPTION
We don't have ctx available on wasm, but we don't need it to calculate the frames, the ifdef on debugger-engine.h fix the #42424.
