### PR TITLE
[wasm][debugger] Fix line number = 16777215

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -323,6 +323,8 @@ namespace Microsoft.WebAssembly.Diagnostics
             SequencePoint prev = null;
             foreach (SequencePoint sp in DebugInformation.SequencePoints)
             {
+                if (sp.IsHidden)
+                    continue;
                 if (sp.Offset > pos)
                     break;
                 prev = sp;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -323,11 +323,14 @@ namespace Microsoft.WebAssembly.Diagnostics
             SequencePoint prev = null;
             foreach (SequencePoint sp in DebugInformation.SequencePoints)
             {
-                if (sp.IsHidden)
-                    continue;
-                if (sp.Offset > pos)
+                if (sp.Offset > pos) {
+                    if (sp.IsHidden && prev == null)
+                        continue;
                     break;
-                prev = sp;
+                }
+
+                if (!sp.IsHidden)
+                    prev = sp;
             }
 
             if (prev != null)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -324,6 +324,8 @@ namespace Microsoft.WebAssembly.Diagnostics
             foreach (SequencePoint sp in DebugInformation.SequencePoints)
             {
                 if (sp.Offset > pos) {
+                    //get the earlier line number if the offset is in a hidden sequence point and has a earlier line number available
+                    // if is doesn't continue and get the next line number that is not in a hidden sequence point
                     if (sp.IsHidden && prev == null)
                         continue;
                     break;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -1001,5 +1001,34 @@ namespace DebuggerTests
                 await StepAndCheck(StepKind.Resume, source_file, 56, 12, "MoveNext");
             });
         }
+
+        [Fact]
+        public async Task StepOverHiddenSequencePoint()
+        {
+            var insp = new Inspector();
+
+            //Collect events
+            var scripts = SubscribeToScripts(insp);
+
+            await Ready();
+            await insp.Ready(async (cli, token) =>
+            {
+                ctx = new DebugTestContext(cli, insp, token, scripts);
+
+                var bp = await SetBreakpointInMethod("debugger-test.dll", "HiddenSequencePointTest", "StepOverHiddenSP2", 0);
+                
+                var pause_location = await EvaluateAndCheck(
+                    "window.setTimeout(function() { invoke_static_method ('[debugger-test] HiddenSequencePointTest:StepOverHiddenSP'); }, 1);",
+                    "dotnet://debugger-test.dll/debugger-test.cs", 547, 4,
+                    "StepOverHiddenSP2");
+                
+                var top_frame = pause_location["callFrames"][1];
+                Assert.Equal("StepOverHiddenSP", top_frame["functionName"].Value<string>());
+                Assert.Contains("debugger-test.cs", top_frame["url"].Value<string>());
+
+                CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 538, 8, scripts, top_frame["location"]);
+
+            });
+        }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -1019,14 +1019,14 @@ namespace DebuggerTests
                 
                 var pause_location = await EvaluateAndCheck(
                     "window.setTimeout(function() { invoke_static_method ('[debugger-test] HiddenSequencePointTest:StepOverHiddenSP'); }, 1);",
-                    "dotnet://debugger-test.dll/debugger-test.cs", 547, 4,
+                    "dotnet://debugger-test.dll/debugger-test.cs", 546, 4,
                     "StepOverHiddenSP2");
                 
                 var top_frame = pause_location["callFrames"][1];
                 Assert.Equal("StepOverHiddenSP", top_frame["functionName"].Value<string>());
                 Assert.Contains("debugger-test.cs", top_frame["url"].Value<string>());
 
-                CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 538, 8, scripts, top_frame["location"]);
+                CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 537, 8, scripts, top_frame["location"]);
 
             });
         }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-
 public partial class Math
 { //Only append content to this class as the test suite depends on line info
     public static int IntAdd(int a, int b)

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+
 public partial class Math
 { //Only append content to this class as the test suite depends on line info
     public static int IntAdd(int a, int b)
@@ -529,5 +530,22 @@ public class LoadDebuggerTest {
 
         var loadedAssembly = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromStream(new System.IO.MemoryStream(asm_bytes), new System.IO.MemoryStream(pdb_bytes));
         Console.WriteLine($"Loaded - {loadedAssembly}");
+    }
+}
+
+public class HiddenSequencePointTest {
+    public static void StepOverHiddenSP()
+    {
+        Console.WriteLine("first line");
+        #line hidden
+        Console.WriteLine("second line");
+        StepOverHiddenSP2();
+        #line default
+        Console.WriteLine("third line");
+
+    }
+    public static void StepOverHiddenSP2()
+    {
+        Console.WriteLine("StepOverHiddenSP2");
     }
 }


### PR DESCRIPTION
If sp.Offset > pos and it's a hidden breakpoint this is the line number that would be visible in the call stack, so skipping hidden breakpoints would avoid it.