### PR TITLE
Add wildcard to release branch trigger

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -3,7 +3,7 @@ trigger:
   branches:
     include:
     - master
-    - release/5.0
+    - release/5.0*
   paths:
     include:
     - '*'

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -3,7 +3,7 @@ trigger:
   branches:
     include:
     - master
-    - release/5.0*
+    - release/*
   paths:
     include:
     - '*'


### PR DESCRIPTION
This will add a wildcard to the release trigger so that we will keep running the right bits as we change release branches.