### PR TITLE
SIngle-pass `CopyValueClassUnchecked`

### DIFF
--- a/src/coreclr/src/vm/object.cpp
+++ b/src/coreclr/src/vm/object.cpp
@@ -335,62 +335,43 @@ void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT)
 
     _ASSERTE(!pMT->IsArray());  // bunch of assumptions about arrays wrong.
 
-    // <TODO> @todo Only call MemoryBarrier() if needed.
-    // Reflection is a known use case where this is required.
-    // Unboxing is a use case where this should not be required.
-    // </TODO>
-    MemoryBarrier();
-
-        // Copy the bulk of the data, and any non-GC refs.
-    switch (pMT->GetNumInstanceFieldBytes())
-    {
-    case 1:
-        *(UINT8*)dest = *(UINT8*)src;
-        break;
-#ifndef ALIGN_ACCESS
-        // we can hit an alignment fault if the value type has multiple
-        // smaller fields.  Example: if there are two I4 fields, the
-        // value class can be aligned to 4-byte boundaries, yet the
-        // NumInstanceFieldBytes is 8
-    case 2:
-        *(UINT16*)dest = *(UINT16*)src;
-        break;
-    case 4:
-        *(UINT32*)dest = *(UINT32*)src;
-        break;
-    case 8:
-        *(UINT64*)dest = *(UINT64*)src;
-        break;
-#endif // !ALIGN_ACCESS
-    default:
-        memcpyNoGCRefs(dest, src, pMT->GetNumInstanceFieldBytes());
-        break;
-    }
-
-        // Tell the GC about any copies.
     if (pMT->ContainsPointers())
     {
-        CGCDesc* map = CGCDesc::GetCGCDescFromMT(pMT);
-        CGCDescSeries* cur = map->GetHighestSeries();
-        CGCDescSeries* last = map->GetLowestSeries();
-        DWORD size = pMT->GetBaseSize();
-        _ASSERTE(cur >= last);
-        do
+        memmoveGCRefs(dest, src, pMT->GetNumInstanceFieldBytes());
+    }
+    else
+    {
+        // <TODO> @todo Only call MemoryBarrier() if needed.
+        // Reflection is a known use case where this is required.
+        // Unboxing is a use case where this should not be required.
+        // </TODO>
+        MemoryBarrier();
+
+        // Copy the bulk of the data, and any non-GC refs.
+        switch (pMT->GetNumInstanceFieldBytes())
         {
-            // offset to embedded references in this series must be
-            // adjusted by the VTable pointer, when in the unboxed state.
-            size_t offset = cur->GetSeriesOffset() - sizeof(void*);
-            OBJECTREF* srcPtr = (OBJECTREF*)(((BYTE*) src) + offset);
-            OBJECTREF* destPtr = (OBJECTREF*)(((BYTE*) dest) + offset);
-            OBJECTREF* srcPtrStop = (OBJECTREF*)((BYTE*) srcPtr + cur->GetSeriesSize() + size);
-            while (srcPtr < srcPtrStop)
-            {
-                SetObjectReference(destPtr, ObjectToOBJECTREF(*(Object**)srcPtr));
-                srcPtr++;
-                destPtr++;
-            }
-            cur--;
-        } while (cur >= last);
+        case 1:
+            *(UINT8*)dest = *(UINT8*)src;
+            break;
+#ifndef ALIGN_ACCESS
+            // we can hit an alignment fault if the value type has multiple
+            // smaller fields.  Example: if there are two I4 fields, the
+            // value class can be aligned to 4-byte boundaries, yet the
+            // NumInstanceFieldBytes is 8
+        case 2:
+            *(UINT16*)dest = *(UINT16*)src;
+            break;
+        case 4:
+            *(UINT32*)dest = *(UINT32*)src;
+            break;
+        case 8:
+            *(UINT64*)dest = *(UINT64*)src;
+            break;
+#endif // !ALIGN_ACCESS
+        default:
+            memcpyNoGCRefs(dest, src, pMT->GetNumInstanceFieldBytes());
+            break;
+        }
     }
 }
 

--- a/src/coreclr/src/vm/object.cpp
+++ b/src/coreclr/src/vm/object.cpp
@@ -341,13 +341,6 @@ void STDCALL CopyValueClassUnchecked(void* dest, void* src, MethodTable *pMT)
     }
     else
     {
-        // <TODO> @todo Only call MemoryBarrier() if needed.
-        // Reflection is a known use case where this is required.
-        // Unboxing is a use case where this should not be required.
-        // </TODO>
-        MemoryBarrier();
-
-        // Copy the bulk of the data, and any non-GC refs.
         switch (pMT->GetNumInstanceFieldBytes())
         {
         case 1:


### PR DESCRIPTION
Currently for structs with GC references `CopyValueClassUnchecked` does two passes - 1) to copy all data 2) to copy reference fields individually, doing fences and cards for each.

- It makes reference assignments not atomic. I.E for two reference fields `a` and `b`, assignments will be like - `a` is copied, `b` is copied, then `a` is copied again then `b` is copied again. 
Although it is the same values so it is hard to see someone broken by this. We do not guarantee the order of elements/fields updates while copying anyways.
- It is redundant in terms of number of copies and barriers executed.

We have a helper that does the same in a more economic way:  1-pass copy + bulk update cards - `memmoveGCRefs`. We already use that to copy arrays and for cloning objects. We should use that for struct copying too, for the same benefits.





