### PR TITLE
[wasm][bindings] Fix an api regression introduced in #42486

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -142,6 +142,9 @@ var BindingSupportLib = {
 		},
 
 		js_string_to_mono_string: function (string) {
+			if (string === null || typeof string === "undefined")
+				return null;
+
 			var buffer = Module._malloc ((string.length + 1) * 2);
 			var buffer16 = (buffer / 2) | 0;
 			for (var i = 0; i < string.length; i++)

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -143,7 +143,7 @@ var BindingSupportLib = {
 
 		js_string_to_mono_string: function (string) {
 			if (string === null || typeof string === "undefined")
-				return null;
+				return 0;
 
 			var buffer = Module._malloc ((string.length + 1) * 2);
 			var buffer16 = (buffer / 2) | 0;


### PR DESCRIPTION
Return null from js_string_to_mono_string when passed null, like it did prior to #42486

fixed broken wasm debugger tests that need to run in CI https://github.com/dotnet/runtime/pull/42190