### PR TITLE
Fix Activity.Baggage items Order

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -432,9 +432,9 @@ namespace System.Diagnostics
         {
             KeyValuePair<string, string?> kvp = new KeyValuePair<string, string?>(key, value);
 
-            if (_baggage != null || Interlocked.CompareExchange(ref _baggage, new LinkedList<KeyValuePair<string, string?>>(kvp, reversed: true), null) != null)
+            if (_baggage != null || Interlocked.CompareExchange(ref _baggage, new LinkedList<KeyValuePair<string, string?>>(kvp), null) != null)
             {
-                _baggage.Add(kvp);
+                _baggage.AddFront(kvp);
             }
 
             return this;
@@ -1268,11 +1268,9 @@ namespace System.Diagnostics
         {
             private LinkedListNode<T> _first;
             private LinkedListNode<T> _last;
-            private bool _reversed;
 
-            public LinkedList(T firstValue, bool reversed = false)
+            public LinkedList(T firstValue)
             {
-                _reversed = reversed;
                 _last = _first = new LinkedListNode<T>(firstValue);
             }
 
@@ -1295,16 +1293,19 @@ namespace System.Diagnostics
 
                 lock (this)
                 {
-                    if (_reversed)
-                    {
-                        newNode.Next = _first;
-                        _first = newNode;
-                    }
-                    else
-                    {
-                        _last.Next = newNode;
-                        _last = newNode;
-                    }
+                    _last.Next = newNode;
+                    _last = newNode;
+                }
+            }
+
+            public void AddFront(T value)
+            {
+                LinkedListNode<T> newNode = new LinkedListNode<T>(value);
+
+                lock (this)
+                {
+                    newNode.Next = _first;
+                    _first = newNode;
                 }
             }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1269,10 +1269,7 @@ namespace System.Diagnostics
             private LinkedListNode<T> _first;
             private LinkedListNode<T> _last;
 
-            public LinkedList(T firstValue)
-            {
-                _last = _first = new LinkedListNode<T>(firstValue);
-            }
+            public LinkedList(T firstValue) => _last = _first = new LinkedListNode<T>(firstValue);
 
             public LinkedList(IEnumerator<T> e)
             {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -84,9 +84,9 @@ namespace System.Diagnostics.Tests
                     Assert.Equal("world", anotherActivity.GetBaggageItem("hello"));
                     Assert.Equal(4, anotherActivity.Baggage.Count());
                     Assert.Equal(new KeyValuePair<string, string>("hello", "world"), anotherActivity.Baggage.First());
-                    Assert.Equal(new KeyValuePair<string, string>(Key + 0, Value + 0), anotherActivity.Baggage.Skip(1).First());
+                    Assert.Equal(new KeyValuePair<string, string>(Key + 2, Value + 2), anotherActivity.Baggage.Skip(1).First());
                     Assert.Equal(new KeyValuePair<string, string>(Key + 1, Value + 1), anotherActivity.Baggage.Skip(2).First());
-                    Assert.Equal(new KeyValuePair<string, string>(Key + 2, Value + 2), anotherActivity.Baggage.Skip(3).First());
+                    Assert.Equal(new KeyValuePair<string, string>(Key + 0, Value + 0), anotherActivity.Baggage.Skip(3).First());
                 }
                 finally
                 {
@@ -97,6 +97,27 @@ namespace System.Diagnostics.Tests
             {
                 activity.Stop();
             }
+        }
+
+        [Fact]
+        public void TestBaggageOrderAndDuplicateKeys()
+        {
+            Activity a = new Activity("Baggage");
+            a.AddBaggage("1", "1");
+            a.AddBaggage("1", "2");
+            a.AddBaggage("1", "3");
+            a.AddBaggage("1", "4");
+
+            int value = 4;
+
+            foreach (KeyValuePair<string, string> kvp in a.Baggage)
+            {
+                Assert.Equal("1", kvp.Key);
+                Assert.Equal(value.ToString(), kvp.Value);
+                value--;
+            }
+
+            Assert.Equal("4", a.GetBaggageItem("1"));
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -120,6 +120,48 @@ namespace System.Diagnostics.Tests
             Assert.Equal("4", a.GetBaggageItem("1"));
         }
 
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void TestBaggageWithChainedActivities()
+        {
+            RemoteExecutor.Invoke(() => {
+                Activity a1 = new Activity("a1");
+                a1.Start();
+
+                a1.AddBaggage("1", "1");
+                a1.AddBaggage("2", "2");
+
+                IEnumerable<KeyValuePair<string, string>> baggages = a1.Baggage;
+                Assert.Equal(2, baggages.Count());
+                Assert.Equal(new KeyValuePair<string, string>("2", "2"), baggages.ElementAt(0));
+                Assert.Equal(new KeyValuePair<string, string>("1", "1"), baggages.ElementAt(1));
+
+                Activity a2 = new Activity("a2");
+                a2.Start();
+
+                a2.AddBaggage("3", "3");
+                baggages = a2.Baggage;
+                Assert.Equal(3, baggages.Count());
+                Assert.Equal(new KeyValuePair<string, string>("3", "3"), baggages.ElementAt(0));
+                Assert.Equal(new KeyValuePair<string, string>("2", "2"), baggages.ElementAt(1));
+                Assert.Equal(new KeyValuePair<string, string>("1", "1"), baggages.ElementAt(2));
+
+                Activity a3 = new Activity("a3");
+                a3.Start();
+
+                a3.AddBaggage("4", "4");
+                baggages = a3.Baggage;
+                Assert.Equal(4, baggages.Count());
+                Assert.Equal(new KeyValuePair<string, string>("4", "4"), baggages.ElementAt(0));
+                Assert.Equal(new KeyValuePair<string, string>("3", "3"), baggages.ElementAt(1));
+                Assert.Equal(new KeyValuePair<string, string>("2", "2"), baggages.ElementAt(2));
+                Assert.Equal(new KeyValuePair<string, string>("1", "1"), baggages.ElementAt(3));
+
+                a3.Dispose();
+                a2.Dispose();
+                a1.Dispose();
+            }).Dispose();
+        }
+
         /// <summary>
         /// Tests Tags operations
         /// </summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/42596

In pre 5.0 .NET versions, when calling `Activity.AddBaggage`, will add a new Baggage item to internal linked list. The list was LIFO, which means when calling `Activity.Baggage` it will return the list in the reverse order of the added items. Also,  `Activity.AddBaggage` allow adding 2 items with same key and when calling `Activity.GetBaggageItem` to get a Baggage item value for a key which has duplication in the list, the API will return the last added item with that key. 

In 5.0, we used the internal LinkedList for other new scenarios (e.g. AddEvent) which required to have the list maintained on the order of the input. This had a side effect on `Baggage` order. The Baggage order became FIFO. Also, affected `Activity.GetBaggageItem` which made it to return the first added item with the specified input key instead of last added items. 

This is important to fix because `Baggage` is intended to be serialized over the wire across the process/machine. Looks users assumed specific order of the list even we didn't document the behavior. The change here is to ensure the old behavior to avoid breaking anyone and allow services using different version of the `System.Diagnostics.DiagnosticSource` to communicate reliably through serializing/deserializing the Baggage list. 