### PR TITLE
Backport string marshaling fixes #42486 and #42658

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -119,7 +119,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         private static string GetBigTestString() {
             var expectedSb = new System.Text.StringBuilder();
             expectedSb.Append("start<<<");
-            for (int i = 0; i < 409600; i++)
+            for (int i = 0; i < 4096000; i++)
                 expectedSb.Append(i % 10);
             expectedSb.Append(">>>end");
             return expectedSb.ToString();
@@ -143,9 +143,11 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Equal("a\0bc", HelperMarshal._stringResource);
 
             var expected = GetBigTestString();
-            HelperMarshal._stringResource = null;
-            Runtime.InvokeJS("App.call_test_method(\"InvokeString\", [\"" + expected + "\"])");
-            Assert.Equal(expected, HelperMarshal._stringResource);
+            for (var i = 0; i < 10; i++) {
+                HelperMarshal._stringResource = null;
+                Runtime.InvokeJS("App.call_test_method(\"InvokeString\", [\"" + expected + "\"])");
+                Assert.Equal(expected, HelperMarshal._stringResource);
+            }
         }
     }
 }

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -52,7 +52,7 @@ var BindingSupportLib = {
 			this.find_method = Module.cwrap ('mono_wasm_assembly_find_method', 'number', ['number', 'string', 'number']);
 			this.invoke_method = Module.cwrap ('mono_wasm_invoke_method', 'number', ['number', 'number', 'number', 'number']);
 			this.mono_string_get_utf8 = Module.cwrap ('mono_wasm_string_get_utf8', 'number', ['number']);
-			this.js_string_to_mono_string = Module.cwrap ('mono_wasm_string_from_js', 'number', ['string']);
+			this.mono_wasm_string_from_utf16 = Module.cwrap ('mono_wasm_string_from_utf16', 'number', ['number', 'number']);
 			this.mono_get_obj_type = Module.cwrap ('mono_wasm_get_obj_type', 'number', ['number']);
 			this.mono_unbox_int = Module.cwrap ('mono_unbox_int', 'number', ['number']);
 			this.mono_unbox_float = Module.cwrap ('mono_wasm_unbox_float', 'number', ['number']);
@@ -140,6 +140,17 @@ var BindingSupportLib = {
 			return this.call_method (this.is_simple_array, null, "mi", [ ele ]);
 		},
 
+		js_string_to_mono_string: function (string) {
+			var buffer = Module._malloc ((string.length + 1) * 2);
+			var buffer16 = (buffer / 2) | 0;
+			for (var i = 0; i < string.length; i++)
+				Module.HEAP16[buffer16 + i] = string.charCodeAt (i);
+			Module.HEAP16[buffer16 + string.length] = 0;
+			var result = this.mono_wasm_string_from_utf16 (buffer, string.length);
+			Module._free (buffer);
+			return result;
+		},
+		
 		mono_array_to_js_array: function (mono_array) {
 			if (mono_array == 0)
 				return null;

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -141,6 +141,9 @@ var BindingSupportLib = {
 		},
 
 		js_string_to_mono_string: function (string) {
+			if (string === null || typeof string === "undefined")
+				return 0;
+
 			var buffer = Module._malloc ((string.length + 1) * 2);
 			var buffer16 = (buffer / 2) | 0;
 			for (var i = 0; i < string.length; i++)

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -144,11 +144,14 @@ var BindingSupportLib = {
 			if (string === null || typeof string === "undefined")
 				return 0;
 
-			var buffer = Module._malloc ((string.length + 1) * 2);
+			var buffer = Module._malloc (string.length * 2);
+			if (!buffer)
+				throw new Error ("out of memory");
+
 			var buffer16 = (buffer / 2) | 0;
 			for (var i = 0; i < string.length; i++)
 				Module.HEAP16[buffer16 + i] = string.charCodeAt (i);
-			Module.HEAP16[buffer16 + string.length] = 0;
+			
 			var result = this.mono_wasm_string_from_utf16 (buffer, string.length);
 			Module._free (buffer);
 			return result;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -604,6 +604,17 @@ mono_wasm_string_from_js (const char *str)
 		return NULL;
 }
 
+EMSCRIPTEN_KEEPALIVE MonoString *
+mono_wasm_string_from_utf16 (const mono_unichar2 * chars, int length)
+{
+	assert (length >= 0);
+
+	if (chars)
+		return mono_string_new_utf16 (root_domain, chars, length);
+	else
+		return NULL;
+}
+
 static int
 class_is_task (MonoClass *klass)
 {


### PR DESCRIPTION
This backport fixes some intermittent crashes when marshaling strings between JS and WASM, and also fixes an issue where strings were truncated at the first null.