### PR TITLE
Disable ArrayBufferWriterTests.Advance with JitStress.

### DIFF
--- a/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
+++ b/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
@@ -65,7 +65,7 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/42517", RuntimeTestModes.JitStress)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/42517", RuntimeConfiguration.Checked)]
         public void Advance()
         {
             {

--- a/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
+++ b/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
@@ -65,6 +65,7 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/42517", RuntimeTestModes.JitStress)]
         public void Advance()
         {
             {


### PR DESCRIPTION
Issue #42517.
