### PR TITLE
Fix illink invocation inside VS

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -281,7 +281,8 @@
     <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
          In this case, explicitly specify the path to the dotnet host. -->
     <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
-      <_DotNetHostDirectory>$(DotNetRoot)</_DotNetHostDirectory>
+      <!-- This is defined when building in Visual Studio. -->
+      <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
       <_DotNetHostFileName>$([System.IO.Path]::GetFileName('$(DotNetTool)'))</_DotNetHostFileName>
     </PropertyGroup>
 

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -73,7 +73,8 @@
     <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
       In this case, explicitly specify the path to the dotnet host. -->
     <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
-      <_DotNetHostDirectory>$(DotNetRoot)</_DotNetHostDirectory>
+      <!-- This is defined when building in Visual Studio. -->
+      <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
       <_DotNetHostFileName>$([System.IO.Path]::GetFileName('$(DotNetTool)'))</_DotNetHostFileName>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/42676. Tested locally and this works now as expected (also without the -vs switch).