### PR TITLE
Fix mono_aot_plt_trampoline GC unsafe assumption.

### DIFF
--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -968,23 +968,24 @@ gpointer
 mono_aot_plt_trampoline (host_mgreg_t *regs, guint8 *code, guint8 *aot_module, 
 						 guint8* tramp)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
-
 	gpointer res;
 	ERROR_DECL (error);
 
+	MONO_ENTER_GC_UNSAFE;
 	UnlockedIncrement (&trampoline_calls);
 
 	res = mono_aot_plt_resolve (aot_module, regs, code, error);
 	if (!res) {
 		if (!is_ok (error)) {
 			mono_error_set_pending_exception (error);
-			return NULL;
+			res = NULL;
+		} else {
+			// FIXME: Error handling (how ?)
+			g_assert (res);
 		}
-		// FIXME: Error handling (how ?)
-		g_assert (res);
 	}
 
+	MONO_EXIT_GC_UNSAFE;
 	return res;
 }
 #endif


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20431,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>managed->native wrapper does the following under coop:

enter gc safe
native call
exit gc safe

since enter/exit gc safe are icalls they will be called through PLT on AOT builds. First call through a PLT slot will resolve the function using mono_aot_plt_trampoline and it currently assumes GC safe mode, so when hit as part of resolving exit gc safe, it is called under GC safe mode.

This has not showed up to be an issue under coop AOT, but asserts when running under checked build.

Fix will make sure thread is in GC unsafe mode making sure assumption of GC unsafe mode holds.