### PR TITLE
[release/5.0-rc2] Sign CrossOSDiag packages even with post-build signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -159,6 +159,13 @@
         <ItemsToSign Include="$(CoreCLRSharedFrameworkDir)mscordaccore*.dll" />
         <ItemsToSign Include="$(CoreCLRSharedFrameworkDir)mscordbi.dll" />
       </ItemGroup>
+
+      <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
+        <!-- The cross OS diagnostics symbol packages need to be signed as they are the only packages
+        that have a specific version of assets that are only meant to be indexed in symbol servers.
+        Since only *symbols.nupkg get indexed, and installer doesn't produce these, we need to glob them for signing. -->
+        <ItemsToSign Include="$(DownloadDirectory)**\*CrossOsDiag*.symbols.nupkg" />
+      </ItemGroup>
     </When>
   </Choose>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -164,7 +164,7 @@
         <!-- The cross OS diagnostics symbol packages need to be signed as they are the only packages
         that have a specific version of assets that are only meant to be indexed in symbol servers.
         Since only *symbols.nupkg get indexed, and installer doesn't produce these, we need to glob them for signing. -->
-        <ItemsToSign Include="$(DownloadDirectory)**\*CrossOsDiag*.symbols.nupkg" />
+        <ItemsToSign Include="$(DownloadDirectory)**\*CrossOsDiag*.nupkg" />
       </ItemGroup>
     </When>
   </Choose>

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -10,7 +10,7 @@ jobs:
   dependsOn: ${{ parameters.dependsOn }}
   pool:
     name: NetCoreInternal-Pool
-    queue: buildpool.windows.10.amd64.vs2017
+    queue: buildpool.windows.10.amd64.vs2019
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -34,8 +34,7 @@ jobs:
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
     continueOnError: false
     condition: and(succeeded(), 
-                in(variables['SignType'], 'real', 'test'),
-                ne(variables['PostBuildSign'], 'true'))
+                in(variables['SignType'], 'real', 'test'))
 
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts


### PR DESCRIPTION
Also change over to using 2019 Pool for the leg.