### PR TITLE
Re-enable support for using the system libunwind

### DIFF
--- a/src/installer/corehost/cli/apphost/static/CMakeLists.txt
+++ b/src/installer/corehost/cli/apphost/static/CMakeLists.txt
@@ -107,15 +107,6 @@ elseif(CLR_CMAKE_TARGET_LINUX)
     #   )
     # endif(CLR_CMAKE_TARGET_OSX)
     # 
-    # # On OSX and *BSD, we use the libunwind that's part of the OS
-    # if(CLR_CMAKE_TARGET_FREEBSD)
-    #     find_unwind_libs(UNWIND_LIBS)
-    # 
-    #     LIST(APPEND CORECLR_LIBRARIES
-    #       ${UNWIND_LIBS}
-    #     )
-    # endif(CLR_CMAKE_TARGET_FREEBSD)
-    # 
     # if(CLR_CMAKE_TARGET_NETBSD)
     #     find_library(KVM kvm)
     # 
@@ -128,6 +119,15 @@ endif(CLR_CMAKE_TARGET_WIN32)
 # Path like: artifacts/bin/native/net5.0-Linux-Release-arm/
 set(NATIVE_LIBS_LOCATION "${NATIVE_LIBS_ARTIFACTS}")
 message ("Looking for native libs at location: '${NATIVE_LIBS_LOCATION}'.")
+
+# If/when OSX and *BSD are supported, they should also use the libunwind that's part of the OS
+if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+    find_unwind_libs(UNWIND_LIBS)
+
+    LIST(APPEND CORECLR_LIBRARIES
+      ${UNWIND_LIBS}
+    )
+endif()
 
 if(NOT CLR_CMAKE_TARGET_LINUX)
     set(NATIVE_LIBS

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -42,6 +42,12 @@ else ()
     message(FATAL_ERROR "Unknown platform. Cannot define PAL_UNIX_NAME, used by RuntimeInformation.")
 endif ()
 
+if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+    # This variable can be set and used by the coreclr and installer builds.
+    # Libraries doesn't need it, but not using it makes the build fail.  So
+    # just check and igore the variable.
+endif()
+
 # We compile with -Werror, so we need to make sure these code fragments compile without warnings.
 # Older CMake versions (3.8) do not assign the result of their tests, causing unused-value errors
 # which are not distinguished from the test failing. So no error for that one.


### PR DESCRIPTION
You can now build runtime against the system libunwind using:

    ./build.sh -cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND

This allows Linux distributions that already ship a compatible version of libunwind library to use that instead of carrying a duplicate in .NET. This provides some benefits to them, including smaller build sizes, slightly faster builds and fewer places to fix any vulnerabilities

This functionality was already supported in .NET Core 3.1 and has regressed since.

CoreCLR already handles `-DCLR_CMAKE_USE_SYSTEM_LIBUNWIND`, so no changes are needed there.

The libraries build doesn't care about this cmake variable, but cmake itself fails if the variable is not used:

    EXEC : CMake error : [runtime/src/libraries/Native/build-native.proj]
        Manually-specified variables were not used by the project:

          CLR_CMAKE_USE_SYSTEM_LIBUNWIND

So libraries just needs to check and ignore this variable.

The singlefilehost needs to link against libunwind too. Otherwise the linker fails to resolve symbols, making the build fail:

    /usr/bin/ld: runtime/artifacts/bin/coreclr/Linux.x64.Debug//lib/libcoreclrpal.a(seh.cpp.o): in function `UnwindContextToWinContext(unw_cursor*, _CONTEXT*)':
      dotnet/runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:176: undefined reference to `_ULx86_64_get_reg'
    /usr/bin/ld: runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:177: undefined reference to `_ULx86_64_get_reg'
    /usr/bin/ld: runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:178: undefined reference to `_ULx86_64_get_reg'
    /usr/bin/ld: runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:179: undefined reference to `_ULx86_64_get_reg'
    /usr/bin/ld: runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:180: undefined reference to `_ULx86_64_get_reg'
    /usr/bin/ld: runtime/artifacts/bin/coreclr/Linux.x64.Debug//lib/libcoreclrpal.a(seh.cpp.o): runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:181: more undefined references to `_ULx86_64_get_reg' follow
    /usr/bin/ld: runtime/artifacts/bin/coreclr/Linux.x64.Debug//lib/libcoreclrpal.a(seh.cpp.o): in function `GetContextPointer(unw_cursor*, ucontext_t*, int, unsigned long**)':
      runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:227: undefined reference to `_ULx86_64_get_save_loc'
    /usr/bin/ld: runtime/artifacts/bin/coreclr/Linux.x64.Debug//lib/libcoreclrpal.a(seh.cpp.o): in function `PAL_VirtualUnwind':
      runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:340: undefined reference to `_ULx86_64_init_local'
    /usr/bin/ld: runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:351: undefined reference to `_ULx86_64_step'
    /usr/bin/ld: runtime/src/coreclr/src/pal/src/exception/seh-unwind.cpp:360: undefined reference to `_ULx86_64_is_signal_frame'
    clang-10: error: linker command failed with exit code 1 (use -v to see invocation)

Fixes: #42661