### PR TITLE
[release/5.0-rc2][wasm][debugger] Fixing step over in an async method

### DIFF
--- a/src/mono/mono/mini/debugger-engine.c
+++ b/src/mono/mono/mini/debugger-engine.c
@@ -1323,8 +1323,11 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 	} else {
 		frame_index = 1;
 
+#ifndef TARGET_WASM
 		if (ss_args->ctx && !frames) {
-
+#else
+		if (!frames) {
+#endif
 			mono_loader_lock ();
 			locked = TRUE;
 


### PR DESCRIPTION
Backport of #42639 to release/5.0-rc2

/cc @thaystg

Fixes incorrect stack reporting when stepping in async methods in the WASM debugger.

## Customer Impact
When a user is trying to step over an async method the line numbers shown in the call stack are wrong.

## Testing
I test locally and @radical created two test case for it.

## Risk
Very Low. Browser debugging specific and the check that is relaxed does not apply to the single threaded case.