### PR TITLE
Update the build script to support opening S.P.Corelib

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -118,18 +118,30 @@ if ($vs) {
 
   if (-Not (Test-Path $vs)) {
     $solution = $vs
-    # Search for the solution in libraries
-    $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "src\libraries" | Join-Path -ChildPath $vs | Join-Path -ChildPath "$vs.sln"
+
+    # Search for the solution in coreclr
+    $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "src\coreclr\src" | Join-Path -ChildPath $vs | Join-Path -ChildPath "$vs.sln"
+
     if (-Not (Test-Path $vs)) {
       $vs = $solution
-      # Search for the solution in installer
-      if (-Not ($vs.endswith(".sln"))) {
-        $vs = "$vs.sln"
-      }
-      $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "src\installer" | Join-Path -ChildPath $vs
+
+      # Search for the solution in libraries
+      $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "src\libraries" | Join-Path -ChildPath $vs | Join-Path -ChildPath "$vs.sln"
+
       if (-Not (Test-Path $vs)) {
-        Write-Error "Passed in solution cannot be resolved."
-        exit 1
+        $vs = $solution
+
+        # Search for the solution in installer
+        if (-Not ($vs.endswith(".sln"))) {
+          $vs = "$vs.sln"
+        }
+
+        $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "src\installer" | Join-Path -ChildPath $vs
+
+        if (-Not (Test-Path $vs)) {
+          Write-Error "Passed in solution cannot be resolved."
+          exit 1
+        }
       }
     }
   }
@@ -151,7 +163,7 @@ if ($vs) {
     # Respect the RuntimeConfiguration variable for building inside VS with different runtime configurations
     $env:RUNTIMECONFIGURATION=$runtimeConfiguration
   }
-  
+
   # Restore the solution to workaround https://github.com/dotnet/runtime/issues/32205
   Invoke-Expression "& dotnet restore $vs"
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -36,6 +36,8 @@ usage()
   echo "                                  Checked is exclusive to the CLR runtime. It is the same as Debug, except code is"
   echo "                                  compiled with optimizations enabled."
   echo "                                  [Default: Debug]"
+  echo "  -runtimeFlavor (-rf)            Runtime flavor: CoreCLR or Mono."
+  echo "                                  [Default: CoreCLR]"
   echo "  --subset (-s)                   Build a subset, print available subsets with -subset help."
   echo "                                 '--subset' can be omitted if the subset is given as the first argument."
   echo "                                  [Default: Builds the entire repo.]"
@@ -319,6 +321,26 @@ while [[ $# > 0 ]]; do
           ;;
       esac
       arguments="$arguments /p:RuntimeConfiguration=$val"
+      shift 2
+      ;;
+
+     -runtimeflavor|-rf)
+      if [ -z ${2+x} ]; then
+        echo "No runtime flavor supplied. See help (--help) for supported runtime flavors." 1>&2
+        exit 1
+      fi
+      passedRuntimeFlav="$(echo "$2" | awk '{print tolower($0)}')"
+      case "$passedRuntimeFlav" in
+        coreclr|mono)
+          val="$(tr '[:lower:]' '[:upper:]' <<< ${passedRuntimeFlav:0:1})${passedRuntimeFlav:1}"
+          ;;
+        *)
+          echo "Unsupported runtime flavor '$2'."
+          echo "The allowed values are CoreCLR and Mono."
+          exit 1
+          ;;
+      esac
+      arguments="$arguments /p:RuntimeFlavor=$val"
       shift 2
       ;;
 


### PR DESCRIPTION
This updates the `.\build.cmd -vs ...` command to support `System.Private.Corelib` as a valid option by resolving it against `src\coreclr\src\System.Private.Corelib\System.Private.Corelib.sln`. Previously it would resolve it to `src\libraries\System.Private.Corelib\System.Private.Corelib.sln` which does not exist.

CC. @ViktorHofer 