### PR TITLE
[release/5.0-rc2][wasm][debugger] Fix line number information for hidden locations

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -323,9 +323,16 @@ namespace Microsoft.WebAssembly.Diagnostics
             SequencePoint prev = null;
             foreach (var sp in DebugInformation.SequencePoints)
             {
-                if (sp.Offset > pos)
+                if (sp.Offset > pos) {
+                    //get the earlier line number if the offset is in a hidden sequence point and has a earlier line number available
+                    // if is doesn't continue and get the next line number that is not in a hidden sequence point
+                    if (sp.IsHidden && prev == null)
+                        continue;
                     break;
-                prev = sp;
+                }
+
+                if (!sp.IsHidden)
+                    prev = sp;
             }
 
             if (prev != null)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1983,6 +1983,34 @@ namespace DebuggerTests
             Assert.True(load_assemblies_res.IsOk);
         }
 
+        [Fact]
+        public async Task StepOverHiddenSequencePoint()
+        {
+            var insp = new Inspector();
+
+            //Collect events
+            var scripts = SubscribeToScripts(insp);
+
+            await Ready();
+            await insp.Ready(async (cli, token) =>
+            {
+                ctx = new DebugTestContext(cli, insp, token, scripts);
+
+                var bp = await SetBreakpointInMethod("debugger-test.dll", "HiddenSequencePointTest", "StepOverHiddenSP2", 0);
+
+                var pause_location = await EvaluateAndCheck(
+                    "window.setTimeout(function() { invoke_static_method ('[debugger-test] HiddenSequencePointTest:StepOverHiddenSP'); }, 1);",
+                    "dotnet://debugger-test.dll/debugger-test.cs", 546, 4,
+                    "StepOverHiddenSP2");
+
+                var top_frame = pause_location["callFrames"][1];
+                Assert.Equal("StepOverHiddenSP", top_frame["functionName"].Value<string>());
+                Assert.Contains("debugger-test.cs", top_frame["url"].Value<string>());
+
+                CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 537, 8, scripts, top_frame["location"]);
+
+            });
+        }
         //TODO add tests covering basic stepping behavior as step in/out/over
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -531,3 +531,20 @@ public class LoadDebuggerTest {
         Console.WriteLine($"Loaded - {loadedAssembly}");
     }
 }
+
+public class HiddenSequencePointTest {
+    public static void StepOverHiddenSP()
+    {
+        Console.WriteLine("first line");
+        #line hidden
+        Console.WriteLine("second line");
+        StepOverHiddenSP2();
+        #line default
+        Console.WriteLine("third line");
+
+    }
+    public static void StepOverHiddenSP2()
+    {
+        Console.WriteLine("StepOverHiddenSP2");
+    }
+}


### PR DESCRIPTION
Backport of #42640 to release/5.0-rc2

/cc @thaystg

Fixes debugger line information for hidden sequence points in the WASM debugger.

## Customer Impact
When a user is trying to step over in a method that is called from another method which has a hidden line we are showing the line number 16777215.

## Testing
I test locally and created a test case for it.

## Risk
Very low, wasm debugger specific and tested