### PR TITLE
Adjust for roslyn change on ref parameters and NotNullIfNotNull

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -585,7 +585,7 @@ namespace System.Runtime.InteropServices
                 if (!SetComObjectData(o, t, Wrapper))
                 {
                     // Another thead already cached the wrapper so use that one instead.
-                    Wrapper = GetComObjectData(o, t);
+                    Wrapper = GetComObjectData(o, t)!;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
@@ -143,7 +143,7 @@ namespace System.Threading
                 return target!;
             }
 
-            return EnsureInitializedCore(ref target, ref initialized, ref syncLock);
+            return EnsureInitializedCore<T>(ref target, ref initialized, ref syncLock);
         }
 
         /// <summary>


### PR DESCRIPTION
Roslyn now uses the R-value/flow-state for `ref` parameters, instead of the declared type (L-value). (PR https://github.com/dotnet/roslyn/pull/47952)
This affected call to `EnsureInitializedCore`, which now needs explicit type parmaeters. 

Roslyn now enforced `NotNullIfNotNull` attribute within method bodies. This affected `CreateWrapperOfType`, which now needs a suppression.
Fixes `D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\src\System\Runtime\InteropServices\Marshal.CoreCLR.cs(592,13): error CS8825: Return value must be non-null because parameter 'o' is non-null. [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]`

FYI, more fixes will be need to integrate a new version of roslyn, mostly due to `UnmanagedCallersOnly`:

 ```
D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\src\System\Runtime\CompilerServices\CastHelpers.cs(140,32): error CS0030: Cannot convert type 'nuint' to 'System.Runtime.CompilerServices.CastHelpers.CastResult' [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
 
D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Globalization\CalendarData.Icu.cs(428,59): error CS1503: Argument 1: cannot convert from '&method group' to 'delegate*<char*, IntPtr, void>' [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Globalization\CalendarData.Windows.cs(269,51): error CS1503: Argument 1: cannot convert from '&method group' to 'delegate*<char*, uint, IntPtr, void*, Interop.BOOL>' [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Globalization\CalendarData.Windows.cs(421,56): error CS8786: Calling convention of 'CalendarData.EnumCalendarsCallback(char*, uint, IntPtr, void*)' is not compatible with 'Default'. [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Globalization\CultureData.Nls.cs(120,55): error CS8786: Calling convention of 'CultureData.EnumSystemLocalesProc(char*, uint, void*)' is not compatible with 'Default'. [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Globalization\CultureData.Nls.cs(407,49): error CS8786: Calling convention of 'CultureData.EnumTimeCallback(char*, void*)' is not compatible with 'Default'. [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Globalization\CultureData.Nls.cs(493,55): error CS8786: Calling convention of 'CultureData.EnumAllSystemLocalesProc(char*, uint, void*)' is not compatible with 'Default'. [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Globalization\CultureData.Nls.cs(521,59): error CS8786: Calling convention of 'CultureData.EnumAllSystemLocalesProc(char*, uint, void*)' is not compatible with 'Default'. [D:\repos\runtime\src\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
```