### PR TITLE
the other part of the fix for processors with weak memory model in suspension 

### DIFF
--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -6256,6 +6256,16 @@ retry_for_debugger:
     g_SuspendStatistics.EndSuspend(reason == SUSPEND_FOR_GC || reason == SUSPEND_FOR_GC_PREP);
 #endif //TIME_SUSPEND
     ThreadSuspend::s_fSuspended = true;
+
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+    // Flush the store buffers on all CPUs, to ensure that all changes made so far are seen
+    // by the GC threads. This only matters on weak memory ordered processors as 
+    // the strong memory ordered processors wouldn't have reordered the relevant writes.
+    // This is needed to synchronize threads that were running in preemptive mode thus were
+    // left alone by suspension to flush their writes that they made before they switched to
+    // preemptive mode.
+    ::FlushProcessWriteBuffers();
+#endif //TARGET_ARM || TARGET_ARM64
 }
 
 #if defined(FEATURE_HIJACK) && defined(TARGET_UNIX)


### PR DESCRIPTION
added the other part of flushing the write buffers for suspension. 

tested on the arm64 machine that @mangod9 provided with both gcsmall (I modified it to run for 10x longer than the current one) and GCPerfSim with this commandline

`-tc 4 -tagb 30 -tlgb 1 -lohar 0 -sohsi 0 -lohsi 0 -pohsi 0 -sohpi 0 -lohpi 0 -pohpi 0 -sohfi 0 -lohfi 0 -pohfi 0 -allocType simple -testKind time`

running with WKS GC. both tests were doing a lot of GCs with pure temporary allocations.

could not detect any perf difference with and without fix (note! the baseline is withOUT [#42243]( https://github.com/dotnet/runtime/pull/42243), comparing with a build with both [#42243]( https://github.com/dotnet/runtime/pull/42243) and this fix.
