### PR TITLE
Socket tests: don't retry CanceledByDispose tests on timeout

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 c_static_assert(PAL_SSL_ERROR_NONE == SSL_ERROR_NONE);
 c_static_assert(PAL_SSL_ERROR_SSL == SSL_ERROR_SSL);
@@ -118,6 +119,8 @@ static void DetectCiphersuiteConfiguration()
     g_config_specified_ciphersuites = 1;
 
 #endif
+    write(0, "config\n", 7);
+    write(0, g_config_specified_ciphersuites == 1 ? "1\n" : "0\n", 2);
 }
 
 void CryptoNative_EnsureLibSslInitialized()

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -11,7 +11,6 @@
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
-#include <unistd.h>
 
 c_static_assert(PAL_SSL_ERROR_NONE == SSL_ERROR_NONE);
 c_static_assert(PAL_SSL_ERROR_SSL == SSL_ERROR_SSL);
@@ -119,8 +118,6 @@ static void DetectCiphersuiteConfiguration()
     g_config_specified_ciphersuites = 1;
 
 #endif
-    write(0, "config\n", 7);
-    write(0, g_config_specified_ciphersuites == 1 ? "1\n" : "0\n", 2);
 }
 
 void CryptoNative_EnsureLibSslInitialized()

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -154,9 +154,6 @@ namespace System.Net.Sockets.Tests
                 }
                 catch (SocketException se)
                 {
-                    // On connection timeout, retry.
-                    Assert.NotEqual(SocketError.TimedOut, se.SocketErrorCode);
-
                     localSocketError = se.SocketErrorCode;
                 }
                 catch (ObjectDisposedException)
@@ -166,6 +163,9 @@ namespace System.Net.Sockets.Tests
 
                 try
                 {
+                    // On connection timeout, retry.
+                    Assert.NotEqual(SocketError.TimedOut, localSocketError);
+
                     if (UsesApm)
                     {
                         Assert.Null(localSocketError);


### PR DESCRIPTION
These retries cause masking cases where the operation and
dispose Task are never completing.

Fixes https://github.com/dotnet/runtime/issues/42686#issuecomment-698767431

@MihaZupan @antonfirsov ptal