### PR TITLE
Fix ilasm managed resource lookup on Linux.

### DIFF
--- a/src/coreclr/src/ilasm/asmman.cpp
+++ b/src/coreclr/src/ilasm/asmman.cpp
@@ -964,8 +964,7 @@ HRESULT AsmMan::EmitManifest()
                 for(j=0; (hFile == INVALID_HANDLE_VALUE)&&(pwzInputFiles[j] != NULL); j++)
                 {
                     wcscpy_s(wzFileName,2048,pwzInputFiles[j]);
-                    pwz = wcsrchr(wzFileName,'\\');
-                    if(pwz == NULL) pwz = wcsrchr(wzFileName,'/');
+                    pwz = wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
                     if(pwz == NULL) pwz = wcsrchr(wzFileName,':');
                     if(pwz == NULL) pwz = &wzFileName[0];
                     else pwz++;

--- a/src/coreclr/src/ilasm/asmman.cpp
+++ b/src/coreclr/src/ilasm/asmman.cpp
@@ -965,7 +965,9 @@ HRESULT AsmMan::EmitManifest()
                 {
                     wcscpy_s(wzFileName,2048,pwzInputFiles[j]);
                     pwz = wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
+#ifdef TARGET_WINDOWS
                     if(pwz == NULL) pwz = wcsrchr(wzFileName,':');
+#endif
                     if(pwz == NULL) pwz = &wzFileName[0];
                     else pwz++;
                     wcscpy_s(pwz,2048-(pwz-wzFileName),wzUniBuf);

--- a/src/coreclr/src/ilasm/asmman.cpp
+++ b/src/coreclr/src/ilasm/asmman.cpp
@@ -965,6 +965,7 @@ HRESULT AsmMan::EmitManifest()
                 {
                     wcscpy_s(wzFileName,2048,pwzInputFiles[j]);
                     pwz = wcsrchr(wzFileName,'\\');
+                    if(pwz == NULL) pwz = wcsrchr(wzFileName,'/');
                     if(pwz == NULL) pwz = wcsrchr(wzFileName,':');
                     if(pwz == NULL) pwz = &wzFileName[0];
                     else pwz++;

--- a/src/coreclr/src/ilasm/grammar_after.cpp
+++ b/src/coreclr/src/ilasm/grammar_after.cpp
@@ -843,7 +843,11 @@ Its_An_Id:
                             if(wzFile != NULL)
                             {
                                 if((parser->wzIncludePath != NULL)
-                                 &&(wcschr(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)&&(wcschr(wzFile,':')==NULL))
+                                 &&(wcschr(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)
+#ifdef TARGET_WINDOWS
+                                 &&(wcschr(wzFile,':')==NULL)
+#endif
+                                )
                                 {
                                     PathString wzFullName;
 

--- a/src/coreclr/src/ilasm/grammar_after.cpp
+++ b/src/coreclr/src/ilasm/grammar_after.cpp
@@ -843,7 +843,7 @@ Its_An_Id:
                             if(wzFile != NULL)
                             {
                                 if((parser->wzIncludePath != NULL)
-                                 &&(wcschr(wzFile,'\\')==NULL)&&(wcschr(wzFile,':')==NULL))
+                                 &&(wcschr(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)&&(wcschr(wzFile,':')==NULL))
                                 {
                                     PathString wzFullName;
 

--- a/src/coreclr/src/ilasm/main.cpp
+++ b/src/coreclr/src/ilasm/main.cpp
@@ -66,7 +66,7 @@ void MakeProperSourceFileName(__in __nullterminated WCHAR* wzOrigName,
     {
         j--;
         if(wzProperName[j] == '.') break;
-        if((wzProperName[j] == '\\')||(j == 0))
+        if((wzProperName[j] == DIRECTORY_SEPARATOR_CHAR_A)||(j == 0))
         {
             wcscat_s(wzProperName,MAX_FILENAME_LENGTH,W(".il"));
             break;

--- a/src/coreclr/src/ilasm/writer.cpp
+++ b/src/coreclr/src/ilasm/writer.cpp
@@ -379,7 +379,9 @@ HRESULT Assembler::CreateExportDirectory()
     memset(szOutputFileName,0,wcslen(m_wzOutputFileName)*3+3);
     WszWideCharToMultiByte(CP_ACP,0,m_wzOutputFileName,-1,szOutputFileName,Ldllname,NULL,NULL);
     pszDllName = strrchr(szOutputFileName,DIRECTORY_SEPARATOR_CHAR_A);
+#ifdef TARGET_WINDOWS
     if(pszDllName == NULL) pszDllName = strrchr(szOutputFileName,':');
+#endif
     if(pszDllName == NULL) pszDllName = szOutputFileName;
     Ldllname = (unsigned)strlen(pszDllName)+1;
 
@@ -1147,7 +1149,9 @@ HRESULT Assembler::CreatePEFile(__in __nullterminated WCHAR *pwzOutputFilename)
     {
         WCHAR* pwc;
         if ((pwc = wcsrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
+#ifdef TARGET_WINDOWS
         else if ((pwc = wcsrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
+#endif
         else pwc = m_wzOutputFileName;
 
         wcsncpy_s(wzScopeName, MAX_SCOPE_LENGTH, pwc, _TRUNCATE);

--- a/src/coreclr/src/ilasm/writer.cpp
+++ b/src/coreclr/src/ilasm/writer.cpp
@@ -378,7 +378,7 @@ HRESULT Assembler::CreateExportDirectory()
     char*                   szOutputFileName = new char[Ldllname];
     memset(szOutputFileName,0,wcslen(m_wzOutputFileName)*3+3);
     WszWideCharToMultiByte(CP_ACP,0,m_wzOutputFileName,-1,szOutputFileName,Ldllname,NULL,NULL);
-    pszDllName = strrchr(szOutputFileName,'\\');
+    pszDllName = strrchr(szOutputFileName,DIRECTORY_SEPARATOR_CHAR_A);
     if(pszDllName == NULL) pszDllName = strrchr(szOutputFileName,':');
     if(pszDllName == NULL) pszDllName = szOutputFileName;
     Ldllname = (unsigned)strlen(pszDllName)+1;
@@ -1146,7 +1146,7 @@ HRESULT Assembler::CreatePEFile(__in __nullterminated WCHAR *pwzOutputFilename)
     else
     {
         WCHAR* pwc;
-        if ((pwc = wcsrchr(m_wzOutputFileName, '\\')) != NULL) pwc++;
+        if ((pwc = wcsrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
         else if ((pwc = wcsrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
         else pwc = m_wzOutputFileName;
 


### PR DESCRIPTION
ILAsm did not properly find managed resources if they were not in the
working directory of ILAsm itself. While there was a provision for
Windows-based systems using backslashes as directory separators, there
was no such provision for *nix-based systems using forward slashes.

This commit enables ILAsm to lookup using both types of directory
separators.