### PR TITLE
Fix bad configure tests that breaks homebrew/clang

### DIFF
--- a/src/coreclr/src/pal/src/configure.cmake
+++ b/src/coreclr/src/pal/src/configure.cmake
@@ -1049,7 +1049,7 @@ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   list(INSERT CMAKE_REQUIRED_INCLUDES 0 ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
 endif()
 
-set(CMAKE_REQUIRED_FLAGS "-c -Werror=implicit-function-declaration")
+set(CMAKE_REQUIRED_FLAGS "-Werror=implicit-function-declaration")
 
 check_c_source_compiles("
 #include <libunwind.h>


### PR DESCRIPTION
The clang script that's included with homebrew gets confused with the -c flag and returns a wrong result for some configure tests. The -c flag is not needed for this check.

See https://github.com/dotnet/source-build/issues/1744#issuecomment-697934318 and https://github.com/dotnet/source-build/issues/1744#issuecomment-698001380 for more details.

@janvorli found the bug and came up with the fix. I am just trying to get it merged here.