### PR TITLE
Remove p/invoke to RtlMoveMemory, cleanup caller

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/UnsafeNativeMethods.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/UnsafeNativeMethods.cs
@@ -7,9 +7,6 @@ namespace System.Drawing
 {
     internal class UnsafeNativeMethods
     {
-        [DllImport(ExternDll.Kernel32, SetLastError = true, ExactSpelling = true, EntryPoint = "RtlMoveMemory")]
-        public static extern void CopyMemory(HandleRef destData, HandleRef srcData, int size);
-
         [DllImport(ExternDll.Kernel32, SetLastError = true)]
         public static extern int GetSystemDefaultLCID();
 


### PR DESCRIPTION
Two code cleanup changes:

1. Remove call to `RtlMoveMemory`, which is getting flagged by Semmle as prohibited. I think this usage is fine, but easier to remove the call site than to fight the tool. The p/invoke signature is incorrect anyway.

2. Cleanup call site to use raw pointers and to call the existing framework-provided `MemoryCopy` routine. Note: `MemoryCopy` takes _src_ before _dest_ in the arguments list.