### PR TITLE
Fix additional warnings introduced after fixing inconsistencty

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/IOControlKeepAlive.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/IOControlKeepAlive.Windows.cs
@@ -74,6 +74,7 @@ namespace System.Net.Sockets
             byte[] buffer = s_keepAliveValuesBuffer ?? (s_keepAliveValuesBuffer = new byte[3 * sizeof(uint)]);
             ioControlKeepAlive.Fill(buffer);
             int realOptionLength = 0;
+            Debug.Assert(OperatingSystem.IsWindows());
             return SocketPal.WindowsIoctl(handle, unchecked((int)IOControlCode.KeepAliveValues), buffer, null, out realOptionLength);
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using System.Runtime.Versioning;
+using System.Diagnostics;
 
 namespace System.Net.Sockets
 {
@@ -262,6 +263,7 @@ namespace System.Net.Sockets
             return listener;
         }
 
+        [SupportedOSPlatform("windows")]
         private void SetIPProtectionLevel(bool allowed)
             => _serverSocket!.SetIPProtectionLevel(allowed ? IPProtectionLevel.Unrestricted : IPProtectionLevel.EdgeRestricted);
 
@@ -276,6 +278,7 @@ namespace System.Net.Sockets
 
             if (_allowNatTraversal != null)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 SetIPProtectionLevel(_allowNatTraversal.GetValueOrDefault());
                 _allowNatTraversal = null; // Reset value to avoid affecting more sockets
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
@@ -412,6 +412,7 @@ namespace Internal.Cryptography.Pal.Windows
                 CryptoPool.Return(rented, maxClear);
             }
 
+            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             return new CspParameters(provType)
             {
                 Flags = provFlags,

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
@@ -166,6 +166,7 @@ namespace Internal.Cryptography.Pal.Windows
                 // 3) PNSE.
                 // 4) Defer to cert.Get{R|D}SAPrivateKey if not silent, throw otherwise.
                 CspParameters cspParams = handle.GetProvParameters();
+                Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
                 Debug.Assert((cspParams.Flags & CspProviderFlags.UseExistingKey) != 0);
                 cspParams.KeyNumber = (int)keySpec;
 


### PR DESCRIPTION
After fixing the platform inconsistency issue https://github.com/dotnet/roslyn-analyzers/issues/4168 a few CA1416 warnings introduced which were hidden before because of the inconsistency issue https://github.com/dotnet/roslyn-analyzers/issues/4168 
New warnings found in runtime:
 ```
D:\dotnet\runtime\src\libraries\System.Net.Sockets\src\System\Net\Sockets\IOControlKeepAlive.Windows.cs(77,66): error CA1416: 'IOControlCode.KeepAliveValues' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Net.Sockets\src\System.Net.Sockets.csproj]
D:\dotnet\runtime\src\libraries\System.Net.Sockets\src\System\Net\Sockets\TCPListener.cs(266,16): error CA1416: 'Socket.SetIPProtectionLevel(IPProtectionLevel)' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Net.Sockets\src\System.Net.Sockets.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\PkcsPalWindows.cs(174,21): error CA1416: 'CspParameters.Flags.get' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\PkcsPalWindows.cs(180,39): error CA1416: 'DSACryptoServiceProvider' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\PkcsPalWindows.cs(169,31): error CA1416: 'CspParameters.Flags.get' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\PkcsPalWindows.cs(170,17): error CA1416: 'CspParameters.KeyNumber' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\PkcsPalWindows.cs(178,39): error CA1416: 'RSACryptoServiceProvider' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\HelpersWindows.cs(419,17): error CA1416: 'CspParameters.ProviderName' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\HelpersWindows.cs(415,20): error CA1416: 'CspParameters' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\HelpersWindows.cs(417,17): error CA1416: 'CspParameters.Flags.set' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\Internal\Cryptography\Pal\Windows\HelpersWindows.cs(418,17): error CA1416: 'CspParameters.KeyContainerName' is supported on 'windows' [D:\dotnet\runtime\src\libraries\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj]
```