### PR TITLE
Fix DefaultContext test on wasm

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -36,7 +36,8 @@ namespace System.Runtime.Loader.Tests
         protected override Assembly Load(AssemblyName assemblyName)
         {
             // Override the assembly that was loaded in DefaultContext.
-            string assemblyPath = Path.Combine(Path.GetDirectoryName(typeof(string).Assembly.Location), assemblyName.Name + ".dll");
+            string dirName = Path.GetDirectoryName(AssemblyPathHelper.GetAssemblyLocation(typeof(string).Assembly));
+            string assemblyPath = Path.Combine(dirName, assemblyName.Name + ".dll");
             Assembly assembly = LoadFromAssemblyPath(assemblyPath);
             LoadedFromContext = true;
             return assembly;
@@ -61,7 +62,7 @@ namespace System.Runtime.Loader.Tests
 
         private static string GetDefaultAssemblyLoadDirectory()
         {
-            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            return Path.GetDirectoryName(AssemblyPathHelper.GetAssemblyLocation(Assembly.GetExecutingAssembly()));
         }
 
         private Assembly ResolveAssembly(AssemblyLoadContext sender, AssemblyName assembly)
@@ -83,7 +84,6 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39202", TestPlatforms.Browser)]
         public void LoadInDefaultContext()
         {
             // This will attempt to load an assembly, by path, in the Default Load context via the Resolving event

--- a/src/libraries/System.Runtime.Loader/tests/DefaultContext/System.Runtime.Loader.DefaultContext.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/DefaultContext/System.Runtime.Loader.DefaultContext.Tests.csproj
@@ -11,10 +11,8 @@
   <ItemGroup>
     <ProjectReference Include="../System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj"
                       ReferenceOutputAssembly="false"
-                      OutputItemType="content"
-                      CopyToOutputDirectory="PreserveNewest" />
+                      OutputItemType="ContentWithTargetPath"
+                      CopyToOutputDirectory="PreserveNewest"
+                      TargetPath="System.Runtime.Loader.Noop.Assembly_test.dll" />
   </ItemGroup>
-  <Target Name="RenameTestAssembly" AfterTargets="PrepareForRun">
-    <Move SourceFiles="$(OutDir)System.Runtime.Loader.Noop.Assembly.dll" DestinationFiles="$(OutDir)System.Runtime.Loader.Noop.Assembly_test.dll" />
-  </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39202

Hopefully the test still works on Desktop with this change.