### PR TITLE
Add additional ALC assertions and test

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -78,6 +78,7 @@ namespace System.Runtime.Loader.Tests
             var asm = loadContext.LoadFromAssemblyName(asmName);
 
             Assert.NotNull(asm);
+            Assert.Same(loadContext, AssemblyLoadContext.GetLoadContext(asm));
             Assert.Contains(asm.DefinedTypes, t => t.Name == "TestClass");
         }
 
@@ -91,6 +92,7 @@ namespace System.Runtime.Loader.Tests
             var asm = loadContext.LoadFromAssemblyName(asmName);
 
             Assert.NotNull(asm);
+            Assert.Same(loadContext, AssemblyLoadContext.GetLoadContext(asm));
             Assert.Contains(asm.DefinedTypes, t => t.Name == "TestClass");
         }
 
@@ -122,6 +124,23 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        public static void LoadFromAssemblyName_FallbackToDefaultContext()
+        {
+            var asmName = typeof(System.Linq.Enumerable).Assembly.GetName();
+            asmName.CodeBase = null;
+            var loadContext = new AssemblyLoadContext("FallbackToDefaultContextTest");
+
+            // This should not have any special handlers, so it should just find the version in the default context
+            var asm = loadContext.LoadFromAssemblyName(asmName);
+            Assert.NotNull(asm);
+            var loadedContext = AssemblyLoadContext.GetLoadContext(asm);
+            Assert.NotNull(loadedContext);
+            Assert.Same(AssemblyLoadContext.Default, loadedContext);
+            Assert.NotEqual(loadContext, loadedContext);
+            Assert.Same(typeof(System.Linq.Enumerable).Assembly, asm);
+        }
+
+        [Fact]
         public static void GetLoadContextTest_ValidUserAssembly()
         {
             var asmName = new AssemblyName(TestAssembly);
@@ -141,6 +160,7 @@ namespace System.Runtime.Loader.Tests
             var context = AssemblyLoadContext.GetLoadContext(asm);
 
             Assert.NotNull(context);
+            Assert.Same(AssemblyLoadContext.Default, context);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/LoaderLinkTest.cs
@@ -25,7 +25,7 @@ namespace LoaderLinkTest
             Assert.Equal(typeof(ISharedInterface), sharedInterface);
 
             var instance = Activator.CreateInstance(dynamicType);
-            Assert.True(instance is ISharedInterface);
+            Assert.IsAssignableFrom<ISharedInterface>(instance);
 
             Assert.NotNull(((ISharedInterface)instance).TestString); // cast should not fail
         }

--- a/src/libraries/System.Runtime.Loader/tests/SatelliteAssemblies.cs
+++ b/src/libraries/System.Runtime.Loader/tests/SatelliteAssemblies.cs
@@ -203,7 +203,9 @@ namespace System.Runtime.Loader.Tests
             AssemblyName parentAssemblyName = new AssemblyName(assemblyName);
             Assembly parentAssembly = assemblyLoadContext.LoadFromAssemblyName(parentAssemblyName);
 
-            Assert.Equal(AssemblyLoadContext.GetLoadContext(parentAssembly), AssemblyLoadContext.GetLoadContext(satelliteAssembly));
+            Assert.Same(AssemblyLoadContext.GetLoadContext(parentAssembly), AssemblyLoadContext.GetLoadContext(satelliteAssembly));
+
+            Assert.Equal(culture, satelliteAssembly.GetName().CultureName);
         }
         
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
@@ -219,8 +221,7 @@ namespace System.Runtime.Loader.Tests
 
             Assert.NotNull(satelliteAssembly);
 
-            AssemblyName parentAssemblyName = new AssemblyName(assemblyName);
-            Assembly parentAssembly = assemblyLoadContext.LoadFromAssemblyName(parentAssemblyName);
+            Assert.Same(assemblyLoadContext, AssemblyLoadContext.GetLoadContext(satelliteAssembly));
 
             Assert.Equal(culture, satelliteAssembly.GetName().CultureName);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/42468

This particular test should cover the scenario we previously missed: ensuring the fallback mechanism works correctly. The other assertions were added in a similar vein and should ensure the same assembly is consistently loaded.

One quirk here is that in the satellite FromPath test, if you attempt to load the parent assembly similar to the FromName test and check its ALC, it will sometimes differ between desktop and wasm. I spent a fair bit of time trying to figure this out, and ultimately convinced myself that it's a quirk of the fact that images registered from the bundle will not be the same as the corresponding image on disk on wasm, while they will be for desktop. This means that it shouldn't matter for customer scenarios and isn't concerning, it's just a difference between single-file and normal operation. Given that, there's no reason to create a test to highlight the difference.