### PR TITLE
superpmi.py script improvements

### DIFF
--- a/src/coreclr/scripts/.pylintrc
+++ b/src/coreclr/scripts/.pylintrc
@@ -1,0 +1,31 @@
+# Settings for pylint
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=invalid-name,
+        no-member,
+        bare-except,
+        missing-module-docstring,
+        broad-except,
+        wildcard-import,
+        unused-wildcard-import,
+        raise-missing-from,
+        import-outside-toplevel,
+        redefined-outer-name
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=300
+
+# Maximum number of lines in a module.
+max-module-lines=5000

--- a/src/coreclr/scripts/coreclr_arguments.py
+++ b/src/coreclr/scripts/coreclr_arguments.py
@@ -15,26 +15,18 @@
 ################################################################################
 
 import argparse
-import datetime
-import json
 import os
 import platform
-import shutil
 import subprocess
 import sys
-import tempfile
-import time
-import re
-import string
-
-import xml.etree.ElementTree
-
-from collections import defaultdict
 
 ################################################################################
 ################################################################################
+
 
 class CoreclrArguments:
+    """ Class to process arguments for CoreCLR specific Python code.
+    """
 
     ############################################################################
     # ctor
@@ -82,9 +74,14 @@ class CoreclrArguments:
     ############################################################################
 
     def check_build_type(self, build_type):
-        if build_type == None:
+        """ Process the `build_type` argument.
+
+            If unset, provide a default. Otherwise, check that it is valid.
+        """
+
+        if build_type is None:
             build_type = self.default_build_type
-            assert(build_type in self.valid_build_types)
+            assert build_type in self.valid_build_types
             return build_type
 
         if len(build_type) > 0:
@@ -146,7 +143,7 @@ class CoreclrArguments:
         else:
             arg_value = args
 
-        if modify_arg != None and not modify_after_validation:
+        if modify_arg is not None and not modify_after_validation:
             arg_value = modify_arg(arg_value)
 
         try:
@@ -154,17 +151,17 @@ class CoreclrArguments:
         except:
             pass
 
-        if verified == False and isinstance(failure_str, str):
+        if verified is False and isinstance(failure_str, str):
             print(failure_str)
             sys.exit(1)
-        elif verified == False:
+        elif verified is False:
             print(failure_str(arg_value))
             sys.exit(1)
 
-        if modify_arg != None and modify_after_validation:
+        if modify_arg is not None and modify_after_validation:
             arg_value = modify_arg(arg_value)
 
-        if verified != True and arg_value is None:
+        if verified is not True and arg_value is None:
             arg_value = verified
 
         # Add a new member variable based on the verified arg
@@ -176,6 +173,11 @@ class CoreclrArguments:
 
     @staticmethod
     def provide_default_host_os():
+        """ Return a string representing the current host operating system.
+
+            Returns one of: Linux, OSX, Windows_NT, illumos, Solaris
+        """
+
         if sys.platform == "linux" or sys.platform == "linux2":
             return "Linux"
         elif sys.platform == "darwin":
@@ -191,6 +193,11 @@ class CoreclrArguments:
 
     @staticmethod
     def provide_default_arch():
+        """ Return a string representing the current processor architecture.
+
+            Returns one of: x64, x86, arm, armel, arm64.
+        """
+
         platform_machine = platform.machine().lower()
         if platform_machine == "x86_64" or platform_machine == "amd64":
             return "x64"

--- a/src/coreclr/scripts/setup.cfg
+++ b/src/coreclr/scripts/setup.cfg
@@ -1,0 +1,10 @@
+# Configuration options for pycodestyle
+
+[pycodestyle]
+count = False
+# E722: do not use bare 'except'
+# E127: continuation line over-indented for visual indent
+# W503: line break before binary operator
+ignore = E127,E201,E202,E266,E501,E722,W503
+max-line-length = 160
+statistics = False


### PR DESCRIPTION
1. Make the script pylint and pycodestyle clean (with exclusions).
Add pylint/pycodestyle configuration files.

2. Simplify and remove duplication in asm diffs code for generating
asm and JIT dump files.

3. Add cases to automatically upload and download associated .MCT files
if one or more specific .MCH files are specified.

4. Fix a few bugs related to using VS Code to view diffs. (I'm inclined
to remove this complication entirely unless someone actually uses it.)