### PR TITLE
Improve error message thrown by Microsoft.Extensions.Configuration.Json.JsonConfigurationFileParser

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Configuration.Json
             {
                 if (doc.RootElement.ValueKind != JsonValueKind.Object)
                 {
-                    throw new FormatException(SR.Format(SR.Error_UnsupportedJSONToken, doc.RootElement.ValueKind));
+                    throw new FormatException(SR.Format(SR.Error_InvalidTopLevelJSONElement, doc.RootElement.ValueKind));
                 }
                 VisitElement(doc.RootElement);
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="Error_InvalidFilePath" xml:space="preserve">
     <value>File path must be a non-empty string.</value>
   </data>
+  <data name="Error_InvalidTopLevelJSONElement" xml:space="preserve">
+    <value>Top-level JSON element must be an object. Instead, '{0}' was found.</value>
+  </data>
   <data name="Error_JSONParseError" xml:space="preserve">
     <value>Could not parse the JSON file.</value>
   </data>


### PR DESCRIPTION
Improve error message thrown by Microsoft.Extensions.Configuration.Json.JsonConfigurationFileParser when the root element of a JSON config file is not an object.

JSON configuration files must have an object as the root element. Previously, the exception message produced by Microsoft.Extensions.Configuration.Json.JsonConfigurationFileParser when a non-object root element was parsed was Error: Unsupported JSON token 'TOKEN_TYPE' was found. This error message was vague and caused confusion. This commit updates the error message to specifically mention that the root element must be an object.

Fix dotnet/extensions#3543