### PR TITLE
Add CompileDesignTime target to IL.Sdk

### DIFF
--- a/src/coreclr/src/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
+++ b/src/coreclr/src/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
@@ -143,6 +143,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''"/>
   </Target>
+  
+  <!-- Target is called by the language server. No-op for ILProj as there is no language service support. -->
+  <Target Name="CompileDesignTime" />
 
   <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
   <!-- Required for project to load in Visual Studio. -->


### PR DESCRIPTION
Visual Studio requires the CompileDesignTime target to be present as it is called by the language service. This fixed building ilproj projects inside Visual Studio.