### PR TITLE
Fix VN of an ASG involving struct retyping. 

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -16857,46 +16857,6 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
                     }
 #endif
                 }
-
-                // If we are inlining a method that returns a struct byref, check whether we are "reinterpreting" the
-                // struct.
-                GenTree* effectiveRetVal = op2->gtEffectiveVal();
-                if ((returnType == TYP_BYREF) && (info.compRetType == TYP_BYREF) &&
-                    (effectiveRetVal->OperGet() == GT_ADDR))
-                {
-                    GenTree* addrChild = effectiveRetVal->gtGetOp1();
-                    if (addrChild->OperGet() == GT_LCL_VAR)
-                    {
-                        LclVarDsc* varDsc = lvaGetDesc(addrChild->AsLclVarCommon());
-
-                        if (varTypeIsStruct(addrChild->TypeGet()) && !isOpaqueSIMDLclVar(varDsc))
-                        {
-                            CORINFO_CLASS_HANDLE referentClassHandle;
-                            CorInfoType          referentType =
-                                info.compCompHnd->getChildType(info.compMethodInfo->args.retTypeClass,
-                                                               &referentClassHandle);
-                            if (varTypeIsStruct(JITtype2varType(referentType)) &&
-                                (varDsc->GetStructHnd() != referentClassHandle))
-                            {
-                                // We are returning a byref to struct1; the method signature specifies return type as
-                                // byref
-                                // to struct2. struct1 and struct2 are different so we are "reinterpreting" the struct.
-                                // This may happen in, for example, System.Runtime.CompilerServices.Unsafe.As<TFrom,
-                                // TTo>.
-                                // We need to mark the source struct variable as having overlapping fields because its
-                                // fields may be accessed using field handles of a different type, which may confuse
-                                // optimizations, in particular, value numbering.
-
-                                JITDUMP("\nSetting lvOverlappingFields to true on V%02u because of struct "
-                                        "reinterpretation\n",
-                                        addrChild->AsLclVarCommon()->GetLclNum());
-
-                                varDsc->lvOverlappingFields = true;
-                            }
-                        }
-                    }
-                }
-
 #ifdef DEBUG
                 if (verbose)
                 {

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -6640,7 +6640,6 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
                         rhsVarDsc          = &lvaTable[rhsLclNum];
                         if (!lvaInSsa(rhsLclNum) || rhsFldSeq == FieldSeqStore::NotAField())
                         {
-                            rhsVNPair.SetBoth(vnStore->VNForExpr(compCurBB, rhsLclVarTree->TypeGet()));
                             isNewUniq = true;
                         }
                         else
@@ -6655,7 +6654,6 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
                     }
                     else
                     {
-                        rhsVNPair.SetBoth(vnStore->VNForExpr(compCurBB, rhs->TypeGet()));
                         isNewUniq = true;
                     }
                 }

--- a/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
+++ b/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
@@ -65,7 +65,6 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/42517", RuntimeConfiguration.Checked)]
         public void Advance()
         {
             {

--- a/src/tests/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.cs
@@ -29,7 +29,8 @@ namespace GitHub_24159
     {
         static int i;
 
-        public static int Main()
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int Test1()
         {
             i = 0;
 
@@ -50,11 +51,71 @@ namespace GitHub_24159
             // The bug was that value numbering couldn't recognize
             // that this field has been updated on str1.
             int k = str2.j2;
-
-            Console.WriteLine(k);
-
             return k + 93;
 
         }
+
+        public static Str2 Cast(Str1 s1)
+        {
+            return Unsafe.As<Str1, Str2>(ref s1);
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int Test2()
+        {
+            i = 0;
+
+            Str1 str1 = new Str1();
+
+            if (i != 0)
+            {
+                str1 = new Str1();
+            }
+            else
+            {
+                str1.i2 = 7;
+            }
+
+            // The code protecting from the bug in Test1 was supposed to put
+            // `lvOverlappingFields` on the source `LclVar` of reinterpritation copy,
+            // but if we do the cast using another call and a return buffer it is incorrectly 
+            // set the flag on the destination `LclVar`, so if the source is copy propagated 
+            // instead of the destination the result node loses the flag.
+            Str2 str2 = Cast(str1);
+
+            Str2 str3 = str2;
+
+            int k = str3.j2;
+            return k + 93;
+
+        }
+
+
+        public static int Main()
+        {
+            bool passed = true;
+            int r1 = Test1();
+            if (r1 != 100)
+            {
+                Console.WriteLine("Test1 failed");
+                passed = false;
+            }
+
+            int r2 = Test2();
+            if (r2 != 100)
+            {
+                Console.WriteLine("Test2 failed");
+                passed = false;
+            }
+
+            if (passed)
+            {
+                return 100;
+            }
+            return 101;
+
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #42517, replaces logic from dotnet/coreclr#24482 .


Diffs are small as expected:
x64 crossgen - no diffs;
x64 pmi - +113 (1 improved, 3 regressed);
arm64 crossgen - +8 (1 regressed);
arm64 pmi - +40 (1 improved, 3 regressed);
and similar for x86.

An example diff (from arm64 win pmi):

```diff
N005 ( 10, 10) [000097] -A------R---              *  ASG       struct (copy)
N004 (  6,  7) [000096] n-----------              +--*  BLK       struct<StackFrame, 16>
N003 (  3,  5) [000095] ------------              |  \--*  ADDR      byref 
N002 (  3,  4) [000084] U------N----              |     \--*  LCL_FLD   struct V07 tmp3         ud:2->3[+16] Fseq[_frame]
N001 (  3,  2) [000093] -------N----              \--*  LCL_VAR   struct<StackFrame, 16> V11 tmp7         u:1 (last use)

--- "a/D:\\Sergey\\logs\\PushTag\\old.txt"
+++ "b/D:\\Sergey\\logs\\PushTag\\new.txt"
@@ -5,7 +5,7 @@ 
 N003 (  3,  5) [000095] ------------              |  \--*  ADDR      byref
 N002 (  3,  4) [000084] U------N----              |     \--*  LCL_FLD   struct V07 tmp3         ud:2->3[+16] Fseq[_frame]
 N001 (  3,  2) [000093] -------N----              \--*  LCL_VAR   struct<StackFrame, 16> V11 tmp7         u:1 (last use)

-N001 [000093]   LCL_VAR   V11 tmp7         u:1 (last use) => $388 {388}
+N001 [000093]   LCL_VAR   V11 tmp7         u:1 (last use) => $387 {387}
   VNApplySelectors:
     VNForHandle(_frame) is $1ca, fieldType is struct, size = 16
       AX2: $1ca != $1c8 ==> select([$342]store($1, $1c8, $80), $1ca) ==> select($1, $1ca).
@@ -19,13 +19,13 @@
 N001 [000093]   LCL_VAR   V11 tmp7         u:1 (last use) => $388 {388}
 N002 [000084]   LCL_FLD   V07 tmp3         ud:2->3[+16] Fseq[_frame] => <l:$252 {252}, c:$253 {253}>
     FieldSeq {_frame} is $214
 N003 [000095]   ADDR      => $185 {PtrToLoc($45, $214)}
-  VNApplySelectorsAssign:
-    VNForHandle(_frame) is $1ca, fieldType is struct
-    VNForMapStore($342, $1ca, $388):struct returns $500 {$342[$1ca := $388]}
-  VNApplySelectorsAssign:
-    VNForHandle(_frame) is $1ca, fieldType is struct
-    VNForMapStore($342, $1ca, $388):struct returns $500 {$342[$1ca := $388]}
-Tree [000097] assigned VN to local var V07/3: $500 {$342[$1ca := $388]}
+Generate a unique VN for  on V11 because of struct reinterpretation
+
+
+
+
+
+Tree [000097] assigned VN to local var V07/3: new uniq $388 {388}
 N005 [000097]   ASG       => $VN.Void

 ***** BB03, STMT00021(after)
@@ -33,4 +33,4 @@ N005 ( 10, 10) [000097] -A------R---              *  ASG       struct (copy) $VN
 N004 (  6,  7) [000096] n-----------              +--*  BLK       struct<StackFrame, 16>
 N003 (  3,  5) [000095] ------------              |  \--*  ADDR      byref  $185
 N002 (  3,  4) [000084] U------N----              |     \--*  LCL_FLD   struct V07 tmp3         ud:2->3[+16] Fseq[_frame] <l:$252, c:$253>
-N001 (  3,  2) [000093] -------N----              \--*  LCL_VAR   struct<StackFrame, 16> V11 tmp7         u:1 (last use) $388
+N001 (  3,  2) [000093] -------N----              \--*  LCL_VAR   struct<StackFrame, 16> V11 tmp7         u:1 (last use) $387
```

it looks like this change is valid because if `000084` type was not `<StackFrame, 16>` it could confuse VN optimizations. For example, if the type was `NotAStackFrame` and we access its field using an VN from `StackField` we will get the same bug as this PR is fixing.