### PR TITLE
pal_ssl: use same code to DetectCiphersuiteConfiguration for portable and non-portable builds

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -43,21 +43,18 @@ static int32_t g_config_specified_ciphersuites = 0;
 
 static void DetectCiphersuiteConfiguration()
 {
-    // This routine will always produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x,
-    // so if we're building direct for 1.0.x (the only time NEED_OPENSSL_1_1 is undefined) then
-    // just omit all the code here.
-    //
-    // The method uses OpenSSL 1.0.x API, except for the fallback function SSL_CTX_config, to
-    // make the portable version easier.
-#ifdef NEED_OPENSSL_1_1
-
+    // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
+    // Always produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
     if (API_EXISTS(SSL_state))
     {
-        // For portable builds NEED_OPENSSL_1_1 is always set.
-        // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
         g_config_specified_ciphersuites = 1;
         return;
     }
+#elif OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0_RTM
+    g_config_specified_ciphersuites = 1;
+    return;
+#endif
 
     // Check to see if there's a registered default CipherString. If not, we will use our own.
     SSL_CTX* ctx = SSL_CTX_new(TLS_method());
@@ -103,21 +100,13 @@ static void DetectCiphersuiteConfiguration()
     {
         ssl = SSL_new(ctx);
         assert(ssl != NULL);
-        int after = sk_SSL_CIPHER_num(SSL_get_ciphers(ssl));
+        int systemDefaultCount = sk_SSL_CIPHER_num(SSL_get_ciphers(ssl));
         SSL_free(ssl);
 
-        g_config_specified_ciphersuites = (allCount != after);
+        g_config_specified_ciphersuites = (allCount != systemDefaultCount);
     }
 
     SSL_CTX_free(ctx);
-
-#else
-
-    // The Fedora, RHEL, and CentOS builds replace the normal defaults (with a configuration model).
-    // Consider their non-portable builds to always have specified ciphersuites in config.
-    g_config_specified_ciphersuites = 1;
-
-#endif
 }
 
 void CryptoNative_EnsureLibSslInitialized()


### PR DESCRIPTION
This is a small refactoring without functional impact.

@bartonjs @wfurt ptal

cc @omajid 