### PR TITLE
[metadata] Use MONO_PROFILER_API on MonoClass getters in checked builds

### DIFF
--- a/src/mono/mono/metadata/class-abi-details.h
+++ b/src/mono/mono/metadata/class-abi-details.h
@@ -10,8 +10,13 @@
 #include <mono/metadata/abi-details.h>
 
 #define MONO_CLASS_GETTER(funcname, rettype, optref, argtype, fieldname) /*nothing*/
+/*
+ * In-tree profilers are allowed to use the offset functions.  So if we're
+ * compiling with --enable-checked-build=private_types, mark the symbols with
+ * MONO_PROFILER_API
+ */
 #ifdef MONO_CLASS_DEF_PRIVATE
-#define MONO_CLASS_OFFSET(funcname, argtype, fieldname) intptr_t funcname (void);
+#define MONO_CLASS_OFFSET(funcname, argtype, fieldname) MONO_PROFILER_API intptr_t funcname (void);
 #else
 #define MONO_CLASS_OFFSET(funcname, argtype, fieldname) static inline intptr_t funcname (void) { return MONO_STRUCT_OFFSET (argtype, fieldname); }
 #endif

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -294,9 +294,13 @@ union _MonoClassSizes {
 
 /* If MonoClass definition is hidden, just declare the getters.
  * Otherwise, define them as static inline functions.
+ *
+ * In-tree profilers are allowed to use the getters.  So if we're compiling
+ * with --enable-checked-build=private_types, mark the symbols with
+ * MONO_PROFILER_API
  */
 #ifdef MONO_CLASS_DEF_PRIVATE
-#define MONO_CLASS_GETTER(funcname, rettype, optref, argtype, fieldname) rettype funcname (argtype *klass);
+#define MONO_CLASS_GETTER(funcname, rettype, optref, argtype, fieldname) MONO_PROFILER_API rettype funcname (argtype *klass);
 #else
 #define MONO_CLASS_GETTER(funcname, rettype, optref, argtype, fieldname) static inline rettype funcname (argtype *klass) { return optref klass-> fieldname ; }
 #endif


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20440,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>In normal builds, the getters are `static inline` functions, so the profiler doesn't reference the symbols - it just accesses the fields by offset.

In checked builds with `--enable-checked-build=private_types`, the getters are not inlined, so the profiler shared libraries need the symbols to be visible.

