### PR TITLE
Enable Unsafe.As NotNullIfNotNull on .NET Standard 2.0

### DIFF
--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
@@ -18,9 +18,7 @@ namespace System.Runtime.CompilerServices
         public unsafe static void* AsPointer<T>(ref T value) { throw null; }
         public unsafe static ref T AsRef<T>(void* source) { throw null; }
         public static ref T AsRef<T>(in T source) { throw null; }
-#if NETSTANDARD2_1
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("o")]
-#endif
         public static T? As<T>(object? o) where T : class? { throw null; }
         public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
         public static System.IntPtr ByteOffset<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref T origin, [System.Diagnostics.CodeAnalysis.AllowNull] ref T target) { throw null; }


### PR DESCRIPTION
### Overview

The `Unsafe.As<T>(object)` API was not using the nullability attribute for the return value when not on .NET Standard 2.1:

https://github.com/dotnet/runtime/blob/37c5a3e6bf685bb08550baba54a742d21c91ffe7/src/libraries/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs#L21-L24

This caused some incorrect null reference warnings when using the library in a .NET Standard 2.0 project, eg.:

![image](https://user-images.githubusercontent.com/10199417/94491768-2550eb80-01e9-11eb-86bc-7579780a1531.png)

This PR simply removes the compiler directive so that the .NET Standard 2.0 target will still have access to that nullability attribute.
