### PR TITLE
Cleanly split BinDir to RuntimeBinDir and TestBinDir

### DIFF
--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -33,12 +33,12 @@
     <BaseIntermediateOutputPath>$(RepoRoot)artifacts\obj\coreclr\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
     <SourceDir>$(ProjectDir)src\</SourceDir>
-    <BinDir>$(ArtifactsDir)bin\coreclr\$(PlatformConfigPathPart)\</BinDir>
+    <RuntimeBinDir>$(ArtifactsDir)bin\coreclr\$(PlatformConfigPathPart)\</RuntimeBinDir>
 
     <!-- We don't append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.
     -->
-    <PackagesBinDir>$(BinDir).nuget\</PackagesBinDir>
+    <PackagesBinDir>$(RuntimeBinDir).nuget\</PackagesBinDir>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/coreclr/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/coreclr/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)ilasm$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(RuntimeBinDir)ilasm$(ApplicationFileExtension)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/coreclr/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/coreclr/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)ildasm$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(RuntimeBinDir)ildasm$(ApplicationFileExtension)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/coreclr/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/coreclr/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)corerun$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(RuntimeBinDir)corerun$(ApplicationFileExtension)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/coreclr/src/Directory.Build.targets
+++ b/src/coreclr/src/Directory.Build.targets
@@ -10,10 +10,10 @@
           AfterTargets="Build"
           Condition="Exists(@(BuiltBinary -> '%(RootDir)%(Directory)%(Filename).pdb'))"
           Inputs="@(BuiltBinary -> '%(RootDir)%(Directory)%(Filename).pdb')"
-          Outputs="@(BuiltBinary -> '$(BinDir)PDB/%(Filename).pdb')">
+          Outputs="@(BuiltBinary -> '$(RuntimeBinDir)PDB/%(Filename).pdb')">
 
     <Move SourceFiles="@(BuiltBinary -> '%(RootDir)%(Directory)%(Filename).pdb')"
-          DestinationFolder="$(BinDir)PDB" />
+          DestinationFolder="$(RuntimeBinDir)PDB" />
 
   </Target>
 

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
 
     <!-- Force System.Private.CoreLib.dll into a special IL output directory -->
-    <OutputPath>$(BinDir)/IL/</OutputPath>
+    <OutputPath>$(RuntimeBinDir)/IL/</OutputPath>
     <Configurations>Debug;Release;Checked</Configurations>
     <Platforms>x64;x86;arm;arm64</Platforms>
 

--- a/src/coreclr/src/pal/tests/palsuite/producepaltestlist.proj
+++ b/src/coreclr/src/pal/tests/palsuite/producepaltestlist.proj
@@ -13,7 +13,7 @@
             <FilteredTestList Remove="@(ExcludeList)" />
         </ItemGroup>
 
-        <WriteLinesToFile File="$(BinDir)paltests/paltestlist.txt"
+        <WriteLinesToFile File="$(RuntimeBinDir)paltests/paltestlist.txt"
                           Lines="@(FilteredTestList)"
                           Overwrite="true"
                           WriteOnlyWhenDifferent="true"/>

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
@@ -11,7 +11,7 @@
     <CLSCompliant>false</CLSCompliant>
     <NoWarn>8002,NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
-    <OutputPath>$(BinDir)</OutputPath>
+    <OutputPath>$(RuntimeBinDir)</OutputPath>
     <Platforms>AnyCPU;x64</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>7.3</LangVersion>

--- a/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
@@ -9,7 +9,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendTargetFrameworkToOutputPath Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</AppendTargetFrameworkToOutputPath>
-    <OutputPath>$(BinDir)/crossgen2</OutputPath>
+    <OutputPath>$(RuntimeBinDir)/crossgen2</OutputPath>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
@@ -61,13 +61,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(BinDir)\$(JitInterfaceLibraryName)"
+    <Content Include="$(RuntimeBinDir)\$(JitInterfaceLibraryName)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="%(FileName)%(Extension)"
      />
 
-    <Content Include="$(BinDir)\$(NativeArchFolder)$(LibraryNamePrefix)clrjit_*_$(TargetArchitecture)$(LibraryNameExtension)"
+    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibraryNamePrefix)clrjit_*_$(TargetArchitecture)$(LibraryNameExtension)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="%(FileName)%(Extension)"
@@ -77,7 +77,7 @@
   <!-- On windows we can re-use the clrjit.dll produced in the build for aot compilation. On Linux
        this works at runtime, but makes it difficult to debug the jit.-->
   <ItemGroup Condition="'$(TargetOS)' == 'Windows_NT'">
-    <Content Include="$(BinDir)\$(NativeArchFolder)$(LibraryNamePrefix)clrjit$(LibraryNameExtension)"
+    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibraryNamePrefix)clrjit$(LibraryNameExtension)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="$(LibraryNamePrefix)clrjit_$(TargetSpec)$(LibraryNameExtension)"
@@ -87,13 +87,13 @@
   <Target Name="CreateCrossTargetingPackage" AfterTargets="Build" Condition="'$(CrossHostArch)' != ''">
 
     <PropertyGroup>
-      <CrossPackageFolder>$(BinDir)\$(CrossHostArch)\crossgen2</CrossPackageFolder>
+      <CrossPackageFolder>$(RuntimeBinDir)\$(CrossHostArch)\crossgen2</CrossPackageFolder>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageFile Include="$(BinDir)\crossgen2\*"
-        Exclude="$(BinDir)\crossgen2\$(JitInterfaceLibraryName);$(BinDir)\crossgen2\$(LibraryNamePrefix)clrjit_*$(LibraryNameExtension)" />
-      <PackageFile Include="$(BinDir)\$(CrossHostArch)\$(LibraryNamePrefix)jitinterface_$(CrossHostArch)$(LibraryNameExtension)" />
+      <PackageFile Include="$(RuntimeBinDir)\crossgen2\*"
+        Exclude="$(RuntimeBinDir)\crossgen2\$(JitInterfaceLibraryName);$(RuntimeBinDir)\crossgen2\$(LibraryNamePrefix)clrjit_*$(LibraryNameExtension)" />
+      <PackageFile Include="$(RuntimeBinDir)\$(CrossHostArch)\$(LibraryNamePrefix)jitinterface_$(CrossHostArch)$(LibraryNameExtension)" />
     </ItemGroup>
 
     <MakeDir Directories="$(CrossPackageFolder)" />
@@ -105,13 +105,13 @@
 
     <Copy
       Condition="'$(TargetOS)' != 'Windows_NT'"
-      SourceFiles="$(BinDir)$(CrossHostArch)\$(LibraryNamePrefix)clrjit_$(CrossTargetSpec)$(LibraryNameExtension)"
+      SourceFiles="$(RuntimeBinDir)$(CrossHostArch)\$(LibraryNamePrefix)clrjit_$(CrossTargetSpec)$(LibraryNameExtension)"
       DestinationFolder="$(CrossPackageFolder)"
       UseHardLinksIfPossible="true"
       />
     <Copy
       Condition="'$(TargetOS)' == 'Windows_NT'"
-      SourceFiles="$(BinDir)$(CrossHostArch)\$(LibraryNamePrefix)clrjit$(LibraryNameExtension)"
+      SourceFiles="$(RuntimeBinDir)$(CrossHostArch)\$(LibraryNamePrefix)clrjit$(LibraryNameExtension)"
       DestinationFiles="$(CrossPackageFolder)\$(LibraryNamePrefix)clrjit_$(CrossTargetSpec)$(LibraryNameExtension)"
       UseHardLinksIfPossible="true"
       />

--- a/src/coreclr/src/tools/dotnet-pgo/dotnet-pgo.csproj
+++ b/src/coreclr/src/tools/dotnet-pgo/dotnet-pgo.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8.0</LangVersion>
-    <OutputPath>$(BinDir)/dotnet-pgo</OutputPath>
+    <OutputPath>$(RuntimeBinDir)/dotnet-pgo</OutputPath>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>

--- a/src/coreclr/src/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.csproj
@@ -11,7 +11,7 @@
     <CLSCompliant>false</CLSCompliant>
     <NoWarn>8002,NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
-    <OutputPath>$(BinDir)/R2RDump</OutputPath>
+    <OutputPath>$(RuntimeBinDir)/R2RDump</OutputPath>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/src/coreclr/src/tools/r2rtest/R2RTest.csproj
+++ b/src/coreclr/src/tools/r2rtest/R2RTest.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <OutputPath>$(BinDir)\R2RTest</OutputPath>
+    <OutputPath>$(RuntimeBinDir)\R2RTest</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/src/tools/runincontext/runincontext.csproj
+++ b/src/coreclr/src/tools/runincontext/runincontext.csproj
@@ -5,6 +5,6 @@
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
     <UseAppHost>false</UseAppHost>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <OutputPath>$(BinDir)</OutputPath>
+    <OutputPath>$(RuntimeBinDir)</OutputPath>
   </PropertyGroup>
 </Project>

--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
-    <BinDir>$(ArtifactsBinDir)mono\$(PlatformConfigPathPart)\</BinDir>
+    <RuntimeBinDir>$(ArtifactsBinDir)mono\$(PlatformConfigPathPart)\</RuntimeBinDir>
 
     <BaseIntermediateOutputPath>$(ArtifactsObjDir)mono\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
   </PropertyGroup>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -807,11 +807,11 @@
   <!-- Copy Mono runtime bits to $(Destination) -->
   <Target Name="CopyMonoRuntimeFilesFromArtifactsToDestination">
     <ItemGroup>
-      <_MonoRuntimeArtifacts Include="$(BinDir)\*.*" />
+      <_MonoRuntimeArtifacts Include="$(RuntimeBinDir)\*.*" />
     </ItemGroup>
     <Error Condition="'$(Destination)' == ''" Text="Destination should not be empty" />
-    <Error Condition="@(_MonoRuntimeArtifacts->Count()) &lt; 2" Text="Mono artifacts were not found at $(BinDir)" />
-    <Message Text="Copying Mono Runtime artifacts from '$(BinDir)' to '$(Destination)'.'" Importance="High" />
+    <Error Condition="@(_MonoRuntimeArtifacts->Count()) &lt; 2" Text="Mono artifacts were not found at $(RuntimeBinDir)" />
+    <Message Text="Copying Mono Runtime artifacts from '$(RuntimeBinDir)' to '$(Destination)'.'" Importance="High" />
     <Copy SourceFiles="@(_MonoRuntimeArtifacts)" 
           DestinationFolder="$(Destination)"
           OverwriteReadOnlyFiles="true"
@@ -906,38 +906,38 @@
     <!-- Copy Mono runtime files to artifacts directory -->
     <ItemGroup>
       <_MonoRuntimeArtifacts Include="$(_MonoRuntimeFilePath)">
-        <Destination>$(BinDir)$(MonoFileName)</Destination>
+        <Destination>$(RuntimeBinDir)$(MonoFileName)</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Include="$(_MonoRuntimeStaticFilePath)">
-        <Destination>$(BinDir)$(MonoStaticFileName)</Destination>
+        <Destination>$(RuntimeBinDir)$(MonoStaticFileName)</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Include="$(_MonoAotCrossFilePath)">
-        <Destination>$(BinDir)cross\mono-aot-cross</Destination>
+        <Destination>$(RuntimeBinDir)cross\mono-aot-cross</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(MonoBundleLLVMOptimizer)' == 'true'" Include="$(MonoLLVMDir)\bin\llc">
-        <Destination>$(BinDir)\llc</Destination>
+        <Destination>$(RuntimeBinDir)\llc</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(MonoBundleLLVMOptimizer)' == 'true'" Include="$(MonoLLVMDir)\bin\opt">
-        <Destination>$(BinDir)\opt</Destination>
+        <Destination>$(RuntimeBinDir)\opt</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="$(MonoLLVMDir)\bin\llc">
-        <Destination>$(BinDir)cross\llc</Destination>
+        <Destination>$(RuntimeBinDir)cross\llc</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="$(MonoLLVMDir)\bin\opt">
-        <Destination>$(BinDir)cross\opt</Destination>
+        <Destination>$(RuntimeBinDir)cross\opt</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoIncludeArtifacts Include="$(MonoObjDir)out\include\**" />
       <_MonoRuntimeArtifacts Condition="'$(TargetsBrowser)' == 'true'" Include="$(MonoObjDir)out\lib\libmono-ee-interp.a">
-        <Destination>$(BinDir)libmono-ee-interp.a</Destination>
+        <Destination>$(RuntimeBinDir)libmono-ee-interp.a</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(TargetsBrowser)' == 'true'" Include="$(MonoObjDir)out\lib\libmono-icall-table.a">
-        <Destination>$(BinDir)libmono-icall-table.a</Destination>
+        <Destination>$(RuntimeBinDir)libmono-icall-table.a</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(TargetsBrowser)' == 'true'" Include="$(MonoObjDir)out\lib\libmono-ilgen.a">
-        <Destination>$(BinDir)libmono-ilgen.a</Destination>
+        <Destination>$(RuntimeBinDir)libmono-ilgen.a</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(TargetsBrowser)' == 'true'" Include="$(MonoObjDir)out\lib\libmono-profiler-aot.a">
-        <Destination>$(BinDir)libmono-profiler-aot.a</Destination>
+        <Destination>$(RuntimeBinDir)libmono-profiler-aot.a</Destination>
       </_MonoRuntimeArtifacts>
     </ItemGroup>
 
@@ -946,11 +946,11 @@
           SkipUnchangedFiles="true" />
 
     <Copy SourceFiles="@(_MonoIncludeArtifacts)"
-          DestinationFiles="@(_MonoIncludeArtifacts->'$(BinDir)include\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(_MonoIncludeArtifacts->'$(RuntimeBinDir)include\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
           Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsAndroid)' == 'true' or '$(TargetsBrowser)' == 'true'"/>
 
-    <Exec Condition="'$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" Command="install_name_tool -id @rpath/$(MonoFileName) $(BinDir)$(MonoFileName)" />
+    <Exec Condition="'$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" Command="install_name_tool -id @rpath/$(MonoFileName) $(RuntimeBinDir)$(MonoFileName)" />
   </Target>
 
   <Target Name="CleanMono">

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
 
     <!-- Force System.Private.CoreLib.dll into a special IL output directory -->
-    <OutputPath>$(BinDir)IL/</OutputPath>
+    <OutputPath>$(RuntimeBinDir)IL/</OutputPath>
     <Configurations>Debug;Release;Checked</Configurations>
     <Platforms>x64;x86;arm;arm64;wasm</Platforms>
   </PropertyGroup>
@@ -306,8 +306,8 @@
   <Import Project="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System.Private.CoreLib.Shared.projitems" Label="Shared" />
 
   <Target Name="CopyCoreLibToBinDir" AfterTargets="Build">
-    <Copy SourceFiles="$(BinDir)/IL/System.Private.CoreLib.dll;$(BinDir)/IL/System.Private.CoreLib.pdb"
-        DestinationFolder="$(BinDir)"
+    <Copy SourceFiles="$(RuntimeBinDir)/IL/System.Private.CoreLib.dll;$(RuntimeBinDir)/IL/System.Private.CoreLib.pdb"
+        DestinationFolder="$(RuntimeBinDir)"
         SkipUnchangedFiles="true" />
   </Target>
 

--- a/src/tests/Common/dir.common.props
+++ b/src/tests/Common/dir.common.props
@@ -16,8 +16,6 @@
     <BaseOutputPathWithConfig>$([MSBuild]::NormalizePath('$(BaseOutputPath)\$(OSPlatformConfig)\'))</BaseOutputPathWithConfig>
     <TestBinDir>$(BaseOutputPathWithConfig)</TestBinDir>
 
-    <TestWorkingDir>$(BaseOutputPathWithConfig)</TestWorkingDir>
-
     <TestSrcDir>$([MSBuild]::NormalizePath('$(RepoRoot)/src/tests/'))</TestSrcDir>
     <TestSrcDir Condition="$([System.String]::new('$(MSBuildProjectDirectory)').StartsWith('$(BaseOutputPathWithConfig)'))">$(BaseOutputPathWithConfig)</TestSrcDir>
     <BuildProjectRelativeDir>$([MSBuild]::MakeRelative($(TestSrcDir), $(MSBuildProjectDirectory)))\$(MSBuildProjectName)\</BuildProjectRelativeDir>

--- a/src/tests/Common/dir.common.props
+++ b/src/tests/Common/dir.common.props
@@ -14,7 +14,7 @@
 
     <BaseOutputPath>$(ArtifactsDir)tests\coreclr</BaseOutputPath>
     <BaseOutputPathWithConfig>$([MSBuild]::NormalizePath('$(BaseOutputPath)\$(OSPlatformConfig)\'))</BaseOutputPathWithConfig>
-    <BinDir>$(BaseOutputPathWithConfig)</BinDir>
+    <TestBinDir>$(BaseOutputPathWithConfig)</TestBinDir>
 
     <TestWorkingDir>$(BaseOutputPathWithConfig)</TestWorkingDir>
 

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -122,8 +122,8 @@
 
   <Import Project="$(MSBuildThisFileDirectory)dir.traversal.targets" />
 
-  <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
+  <!-- Override clean from dir.traversal.targets and just remove the full TestBinDir -->
   <Target Name="Clean">
-    <RemoveDir Directories="$(BinDir)" />
+    <RemoveDir Directories="$(TestBinDir)" />
   </Target>
 </Project>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -85,7 +85,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TestBinDir>$([MSBuild]::NormalizeDirectory($(TestWorkingDir)))</TestBinDir>
     <CoreRootDirectory>$(TestBinDir)Tests\Core_Root\</CoreRootDirectory>
     <PayloadsRootDirectory>$(TestBinDir)Payloads\</PayloadsRootDirectory>
     <PayloadsRootDirectory>$([MSBuild]::NormalizeDirectory($(PayloadsRootDirectory)))</PayloadsRootDirectory>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -85,9 +85,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BinDir>$([MSBuild]::NormalizeDirectory($(TestWorkingDir)))</BinDir>
-    <CoreRootDirectory>$(BinDir)Tests\Core_Root\</CoreRootDirectory>
-    <PayloadsRootDirectory>$(BinDir)Payloads\</PayloadsRootDirectory>
+    <TestBinDir>$([MSBuild]::NormalizeDirectory($(TestWorkingDir)))</TestBinDir>
+    <CoreRootDirectory>$(TestBinDir)Tests\Core_Root\</CoreRootDirectory>
+    <PayloadsRootDirectory>$(TestBinDir)Payloads\</PayloadsRootDirectory>
     <PayloadsRootDirectory>$([MSBuild]::NormalizeDirectory($(PayloadsRootDirectory)))</PayloadsRootDirectory>
     <TestEnvFileName Condition=" '$(TargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
     <TestEnvFileName Condition=" '$(TargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
@@ -115,10 +115,10 @@
       </_XUnitWrapperDll>
       <_XUnitWrapperDll Include="@(XUnitWrapperGrouping)" />
 
-      <!-- This adds the remaining *.XUnitWrapper.dll files in BinDir unless
+      <!-- This adds the remaining *.XUnitWrapper.dll files in TestBinDir unless
            1) they are in PayloadsRootDirectory or
            2) they are grouped by XUnitWrapperGrouping. -->
-      <_XUnitWrapperDll Include="$(BinDir)**\*.XUnitWrapper.dll" Exclude="$(PayloadsRootDirectory)**\*.XUnitWrapper.dll;@(XUnitWrapperGrouping->Metadata('FullPath'))">
+      <_XUnitWrapperDll Include="$(TestBinDir)**\*.XUnitWrapper.dll" Exclude="$(PayloadsRootDirectory)**\*.XUnitWrapper.dll;@(XUnitWrapperGrouping->Metadata('FullPath'))">
          <!-- Set PayloadGroup to empty string, so we can update _XUnitWrapperDll items with no PayloadGroup to default value. Unfortunatelly, we can't do this right here. -->
          <PayloadGroup></PayloadGroup>
       </_XUnitWrapperDll>
@@ -155,7 +155,7 @@
       <_PayloadFiles Update="@(_PayloadFiles)">
         <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
              MakeRelative function calls Escape function internally that replaces all the Unicode characters with %<xx>. -->
-        <FileRelativeToPayloadsRootDirectory>$(_PayloadGroup)\$([System.IO.Path]::GetRelativePath($(BinDir), %(FullPath)))</FileRelativeToPayloadsRootDirectory>
+        <FileRelativeToPayloadsRootDirectory>$(_PayloadGroup)\$([System.IO.Path]::GetRelativePath($(TestBinDir), %(FullPath)))</FileRelativeToPayloadsRootDirectory>
       </_PayloadFiles>
     </ItemGroup>
 

--- a/src/tests/Common/ilasm/ilasm.ilproj
+++ b/src/tests/Common/ilasm/ilasm.ilproj
@@ -5,6 +5,5 @@
 
   <PropertyGroup>
     <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
-    <ProjectAssetsFile>$(TestSourceDir)Common\ilasm\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 </Project>

--- a/src/tests/Common/testgrouping.proj
+++ b/src/tests/Common/testgrouping.proj
@@ -1,154 +1,154 @@
 <Project>
   <ItemGroup>
-    <TestGrouping Include="$(BinDir)baseservices\threading\generics\**">
+    <TestGrouping Include="$(TestBinDir)baseservices\threading\generics\**">
       <TestGroup>baseservices.threading.generics</TestGroup>
-      <XUnitWrapperDll>$(BinDir)baseservices\threading\baseservices.threading.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)baseservices\threading\baseservices.threading.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\jit64\hfa\**">
+    <TestGrouping Include="$(TestBinDir)JIT\jit64\hfa\**">
       <TestGroup>JIT.jit64.hfa</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(BinDir)JIT\jit64\mcc\**">
+    <TestGrouping Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(TestBinDir)JIT\jit64\mcc\**">
       <TestGroup>JIT.jit64.mcc</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\jit64\opt\**">
+    <TestGrouping Include="$(TestBinDir)JIT\jit64\opt\**">
       <TestGroup>JIT.jit64.opt</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\jit64\valuetypes\**">
+    <TestGrouping Include="$(TestBinDir)JIT\jit64\valuetypes\**">
       <TestGroup>JIT.jit64.valuetypes</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\Methodical\a*\**;
-                           $(BinDir)JIT\Methodical\b*\**;
-                           $(BinDir)JIT\Methodical\c*\**;
-                           $(BinDir)JIT\Methodical\d*\**;
-                           $(BinDir)JIT\Methodical\A*\**;
-                           $(BinDir)JIT\Methodical\B*\**;
-                           $(BinDir)JIT\Methodical\C*\**;
-                           $(BinDir)JIT\Methodical\D*\**">
+    <TestGrouping Include="$(TestBinDir)JIT\Methodical\a*\**;
+                           $(TestBinDir)JIT\Methodical\b*\**;
+                           $(TestBinDir)JIT\Methodical\c*\**;
+                           $(TestBinDir)JIT\Methodical\d*\**;
+                           $(TestBinDir)JIT\Methodical\A*\**;
+                           $(TestBinDir)JIT\Methodical\B*\**;
+                           $(TestBinDir)JIT\Methodical\C*\**;
+                           $(TestBinDir)JIT\Methodical\D*\**">
       <TestGroup>JIT.Methodical.a-dA-D</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\Methodical\eh\**">
+    <TestGrouping Include="$(TestBinDir)JIT\Methodical\eh\**">
       <TestGroup>JIT.Methodical.eh</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\Methodical\e*\**;
-                           $(BinDir)JIT\Methodical\E*\**"
-                  Exclude="$(BinDir)JIT\Methodical\eh\**">
+    <TestGrouping Include="$(TestBinDir)JIT\Methodical\e*\**;
+                           $(TestBinDir)JIT\Methodical\E*\**"
+                  Exclude="$(TestBinDir)JIT\Methodical\eh\**">
       <TestGroup>JIT.Methodical.e-iE-I</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\Methodical\f*\**;
-                           $(BinDir)JIT\Methodical\g*\**;
-                           $(BinDir)JIT\Methodical\h*\**;
-                           $(BinDir)JIT\Methodical\i*\**;
-                           $(BinDir)JIT\Methodical\F*\**;
-                           $(BinDir)JIT\Methodical\G*\**;
-                           $(BinDir)JIT\Methodical\H*\**;
-                           $(BinDir)JIT\Methodical\I*\**">
+    <TestGrouping Include="$(TestBinDir)JIT\Methodical\f*\**;
+                           $(TestBinDir)JIT\Methodical\g*\**;
+                           $(TestBinDir)JIT\Methodical\h*\**;
+                           $(TestBinDir)JIT\Methodical\i*\**;
+                           $(TestBinDir)JIT\Methodical\F*\**;
+                           $(TestBinDir)JIT\Methodical\G*\**;
+                           $(TestBinDir)JIT\Methodical\H*\**;
+                           $(TestBinDir)JIT\Methodical\I*\**">
       <TestGroup>JIT.Methodical.e-iE-I</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\Regression\CLR-x86-JIT\V1-M09*\**;
-                           $(BinDir)JIT\Regression\CLR-x86-JIT\V1-M10*\**;
-                           $(BinDir)JIT\Regression\CLR-x86-JIT\V1-M11*\**">
+    <TestGrouping Include="$(TestBinDir)JIT\Regression\CLR-x86-JIT\V1-M09*\**;
+                           $(TestBinDir)JIT\Regression\CLR-x86-JIT\V1-M10*\**;
+                           $(TestBinDir)JIT\Regression\CLR-x86-JIT\V1-M11*\**">
       <TestGroup>JIT.Regression.CLR-x86-JIT.V1-M09-M11</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\Regression\JIT.Regression.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\Regression\JIT.Regression.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)JIT\Regression\CLR-x86-JIT\V1-M12*\**;
-                           $(BinDir)JIT\Regression\CLR-x86-JIT\V1-M13*\**">
+    <TestGrouping Include="$(TestBinDir)JIT\Regression\CLR-x86-JIT\V1-M12*\**;
+                           $(TestBinDir)JIT\Regression\CLR-x86-JIT\V1-M13*\**">
       <TestGroup>JIT.Regression.CLR-x86-JIT.V1-M12-M13</TestGroup>
-      <XUnitWrapperDll>$(BinDir)JIT\Regression\JIT.Regression.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)JIT\Regression\JIT.Regression.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)Loader\classloader\generics\**">
+    <TestGrouping Include="$(TestBinDir)Loader\classloader\generics\**">
       <TestGroup>Loader.classloader.generics</TestGroup>
-      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest?\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest2??\**">
+    <TestGrouping Include="$(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest?\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest2??\**">
       <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest0-299</TestGroup>
-      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest3??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest4??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest5??\**">
+    <TestGrouping Include="$(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest3??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest4??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest5??\**">
       <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest300-599</TestGroup>
-      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest6??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest7??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest8??\**">
+    <TestGrouping Include="$(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest6??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest7??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest8??\**">
       <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest600-899</TestGroup>
-      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest9??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest10??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest11??\**">
+    <TestGrouping Include="$(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest9??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest10??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest11??\**">
       <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest900-1199</TestGroup>
-      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest12??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest13??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest14??\**;
-                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1500\**">
+    <TestGrouping Include="$(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest12??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest13??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest14??\**;
+                           $(TestBinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1500\**">
       <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest1200-1500</TestGroup>
-      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+      <XUnitWrapperDll>$(TestBinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
 
-    <XUnitWrapperGrouping Include="$(BinDir)baseservices\compilerservices\*.XUnitWrapper.dll;
-                                   $(BinDir)baseservices\exceptions\*.XUnitWrapper.dll;
-                                   $(BinDir)baseservices\multidimmarray\*.XUnitWrapper.dll;
-                                   $(BinDir)baseservices\TieredCompilation\*.XUnitWrapper.dll;
-                                   $(BinDir)baseservices\typeequivalence\*.XUnitWrapper.dll;
-                                   $(BinDir)baseservices\varargs\*.XUnitWrapper.dll;
-                                   $(BinDir)CoreMangLib\**\*.XUnitWrapper.dll;
-                                   $(BinDir)Exceptions\**\*.XUnitWrapper.dll;
-                                   $(BinDir)GC\**\*.XUnitWrapper.dll;
-                                   $(BinDir)hosting\**\*.XUnitWrapper.dll;
-                                   $(BinDir)ilasm\**\*.XUnitWrapper.dll;
-                                   $(BinDir)Loader\**\*.XUnitWrapper.dll;
-                                   $(BinDir)managed\**\*.XUnitWrapper.dll;
-                                   $(BinDir)readytorun\**\*.XUnitWrapper.dll;
-                                   $(BinDir)reflection\**\*.XUnitWrapper.dll;
-                                   $(BinDir)Regressions\**\*.XUnitWrapper.dll;
-                                   $(BinDir)tracing\**\*.XUnitWrapper.dll"
-                          Exclude="$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll">
+    <XUnitWrapperGrouping Include="$(TestBinDir)baseservices\compilerservices\*.XUnitWrapper.dll;
+                                   $(TestBinDir)baseservices\exceptions\*.XUnitWrapper.dll;
+                                   $(TestBinDir)baseservices\multidimmarray\*.XUnitWrapper.dll;
+                                   $(TestBinDir)baseservices\TieredCompilation\*.XUnitWrapper.dll;
+                                   $(TestBinDir)baseservices\typeequivalence\*.XUnitWrapper.dll;
+                                   $(TestBinDir)baseservices\varargs\*.XUnitWrapper.dll;
+                                   $(TestBinDir)CoreMangLib\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)Exceptions\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)GC\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)hosting\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)ilasm\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)Loader\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)managed\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)readytorun\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)reflection\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)Regressions\**\*.XUnitWrapper.dll;
+                                   $(TestBinDir)tracing\**\*.XUnitWrapper.dll"
+                          Exclude="$(TestBinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll">
       <PayloadGroup>PayloadGroup0</PayloadGroup>
     </XUnitWrapperGrouping>
 
-    <XUnitWrapperGrouping Include="$(BinDir)Interop\**\Interop.*.XUnitWrapper.dll">
+    <XUnitWrapperGrouping Include="$(TestBinDir)Interop\**\Interop.*.XUnitWrapper.dll">
       <PayloadGroup>Interop</PayloadGroup>
     </XUnitWrapperGrouping>
 
-    <XUnitWrapperGrouping Include="$(BinDir)JIT\BBT\*.XUnitWrapper.dll;
-                                   $(BinDir)JIT\CheckProjects\*.XUnitWrapper.dll;
-                                   $(BinDir)JIT\Intrinsics\*.XUnitWrapper.dll;
-                                   $(BinDir)JIT\opt\*.XUnitWrapper.dll;
-                                   $(BinDir)JIT\Performance\*.XUnitWrapper.dll;
-                                   $(BinDir)JIT\RyuJIT\*.XUnitWrapper.dll;
-                                   $(BinDir)JIT\SIMD\*.XUnitWrapper.dll;
-                                   $(BinDir)JIT\superpmi\*.XUnitWrapper.dll">
+    <XUnitWrapperGrouping Include="$(TestBinDir)JIT\BBT\*.XUnitWrapper.dll;
+                                   $(TestBinDir)JIT\CheckProjects\*.XUnitWrapper.dll;
+                                   $(TestBinDir)JIT\Intrinsics\*.XUnitWrapper.dll;
+                                   $(TestBinDir)JIT\opt\*.XUnitWrapper.dll;
+                                   $(TestBinDir)JIT\Performance\*.XUnitWrapper.dll;
+                                   $(TestBinDir)JIT\RyuJIT\*.XUnitWrapper.dll;
+                                   $(TestBinDir)JIT\SIMD\*.XUnitWrapper.dll;
+                                   $(TestBinDir)JIT\superpmi\*.XUnitWrapper.dll">
       <PayloadGroup>JIT</PayloadGroup>
     </XUnitWrapperGrouping>
   </ItemGroup>


### PR DESCRIPTION
Remove the annoying ambiguity that BinDir sometimes refers to
artifacts/bin/coreclr/$(OSPlatformConfig) and sometimes to
artifacts/tests/coreclr/$(OSPlatformConfig) for easier orientation.
I'm not sure about the packaging projects under src/coreclr/.nuget,
does anyone happen to know whether they require special treatment?

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 