### PR TITLE
Fix composite framework build in R2RTest

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildOptions.cs
@@ -119,7 +119,7 @@ namespace R2RTest
                 List<string> cpaotReferencePaths = new List<string>();
                 cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
                 cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new Crossgen2Runner(this, new Crossgen2RunnerOptions(), cpaotReferencePaths, overrideOutputPath));
+                runners.Add(new Crossgen2Runner(this, new Crossgen2RunnerOptions() { Composite = this.Composite }, cpaotReferencePaths, overrideOutputPath));
             }
 
             if (Crossgen)


### PR DESCRIPTION
During investigation of Sergey Andreenko's issue I noticed that
there's something wrong with CG2 framework compilation in composite
mode as according to the lab logs it took just about a second.
Indeed, most likely some of the refactorings related to Serp support
apparently broke composite framework compilation in R2RTest. The
tool is less widely used than it was 1-2 years ago so it went
overlooked for a bit but got uncovered after JanV switched over
framework compilation in the lab to use it.

Cheers to code coverage!

Tomas

/cc @dotnet/crossgen-contrib