### PR TITLE
Jit: propogate constant array length from creation for ReadyToRun

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3522,7 +3522,7 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
         }
 
         //
-        // Make sure that the number of elements look valid.
+        // This optimization is only valid for a constant array size.
         //
         if (arrayLengthNode->gtOper != GT_CNS_INT)
         {


### PR DESCRIPTION
Make sure EarlyProp understands the readyToRun way of creating arrays when looking to replace nodes. Regressions are encoding differences, due to encoding a constant int.

<pre>Total bytes of base: 32152284
Total bytes of diff: 31886929
Total bytes of delta: -265355 (-0.825% of base)
    diff is an improvement.

Top file improvements (bytes):
      -52115 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-1.583% of base)
      -42395 : System.Linq.Expressions.dasm (-1.463% of base)
      -27790 : System.Private.Xml.dasm (-0.862% of base)
      -17693 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.765% of base)
      -13486 : Microsoft.CodeAnalysis.CSharp.dasm (-0.642% of base)
      -12282 : System.Private.CoreLib.dasm (-0.379% of base)
       -9423 : System.Net.Http.dasm (-1.549% of base)
       -4720 : System.Text.RegularExpressions.dasm (-2.482% of base)
       -4608 : Microsoft.CodeAnalysis.dasm (-0.596% of base)
       -3962 : System.Data.Common.dasm (-0.353% of base)
       -3090 : Microsoft.CSharp.dasm (-1.155% of base)
       -3055 : xunit.runner.utility.netcoreapp10.dasm (-2.103% of base)
       -2973 : System.Private.DataContractSerialization.dasm (-0.411% of base)
       -2968 : FSharp.Core.dasm (-0.352% of base)
       -2773 : xunit.execution.dotnet.dasm (-1.518% of base)
       -2616 : System.CodeDom.dasm (-1.568% of base)
       -2555 : Microsoft.VisualBasic.Core.dasm (-0.602% of base)
       -2521 : System.Drawing.Primitives.dasm (-6.796% of base)
       -2467 : System.Drawing.Common.dasm (-0.884% of base)
       -2433 : System.Reflection.Metadata.dasm (-0.745% of base)

181 total files with Code Size differences (181 improved, 0 regressed), 86 unchanged.

Top method regressions (bytes):
          10 (0.670% of base) : ILCompiler.Reflection.ReadyToRun.dasm - UnwindInfo:.ctor(ref,int):this (4 methods)
           6 (2.970% of base) : System.Private.Xml.dasm - NumberFormatterBase:ConvertToAlphabetic(StringBuilder,double,ushort,int)
           3 (4.054% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CRC32:InitCrc32Table():ref
           3 (0.081% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceEventSession:EnableProvider(Guid,int,long,TraceEventProviderOptions):bool:this
           2 (3.390% of base) : System.Private.CoreLib.dasm - Guid:ToByteArray():ref:this
           2 (0.401% of base) : System.Formats.Asn1.dasm - AsnCharacterStringEncodings:.cctor()
           2 (0.141% of base) : Microsoft.CodeAnalysis.dasm - CustomDebugInfoWriter:SerializeDynamicLocalInfo(IMethodBody,ArrayBuilder`1)
           2 (1.087% of base) : System.Data.Odbc.dasm - DbBuffer:ReadDateTime(int):DateTime:this
           2 (1.562% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - PortableSymbolModule:get_PdbGuid():Guid:this
           2 (0.195% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - SymbolReader:CopyStreamToFile(Stream,String,String,byref):int:this
           1 (0.820% of base) : System.Private.CoreLib.dasm - TextReader:ReadToEnd():String:this
           1 (0.870% of base) : System.Formats.Asn1.dasm - IA5Encoding:.ctor():this
           1 (0.847% of base) : System.Formats.Asn1.dasm - VisibleStringEncoding:.ctor():this
           1 (0.361% of base) : System.Data.Common.dasm - DbDataReader:GetStream(int):Stream:this
           1 (0.187% of base) : System.Private.Xml.dasm - XmlPreloadedResolver:Add(Uri,Stream):this
           1 (0.299% of base) : System.Data.Odbc.dasm - OdbcConnection:GetConnectAttr(int,int):int:this
           1 (0.813% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StreamUtilities:CopyStream(Stream,Stream):int
           1 (0.090% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - EventPipeEventSource:.ctor(PinnedStreamReader,String):this

Top method improvements (bytes):
      -37560 (-3.160% of base) : System.Linq.Expressions.dasm - FuncCallInstruction`3:Run(InterpretedFrame):int:this (3375 methods)
       -4542 (-25.687% of base) : System.Text.RegularExpressions.dasm - RegexCharClass:.cctor()
       -3396 (-28.719% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SyntaxFactory:GetNodeTypes():IEnumerable`1
       -3270 (-19.189% of base) : System.Net.Http.dasm - Huffman:.cctor()
       -2504 (-3.521% of base) : System.Linq.Expressions.dasm - ActionCallInstruction`2:Run(InterpretedFrame):int:this (225 methods)
       -2088 (-11.797% of base) : System.Private.Xml.dasm - XsdBuilder:.cctor()
       -1875 (-31.866% of base) : System.Drawing.Primitives.dasm - KnownColorNames:.cctor()
       -1793 (-32.156% of base) : System.CodeDom.dasm - VBCodeGenerator:.cctor()
       -1750 (-19.763% of base) : System.Private.Xml.dasm - XsltLoader:.ctor():this
       -1261 (-5.562% of base) : ILCompiler.Reflection.ReadyToRun.dasm - InfoHdrDecoder:.cctor()
       -1217 (-18.132% of base) : Microsoft.CSharp.dasm - NameManager:.cctor()
       -1206 (-32.332% of base) : Microsoft.CodeAnalysis.dasm - SpecialMembers:.cctor()
       -1123 (-16.447% of base) : System.Reflection.Metadata.dasm - MetadataReader:InitializeProjectedTypes()
       -1113 (-29.720% of base) : System.Private.Xml.dasm - XmlCustomFormatter:.cctor()
       -1080 (-13.080% of base) : System.Net.Http.dasm - QPackStaticTable:.cctor()
        -926 (-19.172% of base) : System.Net.Http.dasm - Http2Stream:.cctor()
        -836 (-9.408% of base) : System.Private.Xml.dasm - BigNumber:.cctor()
        -836 (-30.323% of base) : System.Private.Xml.dasm - CodeGenerator:.cctor()
        -716 (-29.296% of base) : System.Reflection.Metadata.dasm - StringHeap:.ctor(MemoryBlock,int):this
        -697 (-29.447% of base) : System.Drawing.Common.dasm - DEVMODE:ToString():String:this

Top method regressions (percentages):
           3 (4.054% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CRC32:InitCrc32Table():ref
           2 (3.390% of base) : System.Private.CoreLib.dasm - Guid:ToByteArray():ref:this
           6 (2.970% of base) : System.Private.Xml.dasm - NumberFormatterBase:ConvertToAlphabetic(StringBuilder,double,ushort,int)
           2 (1.562% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - PortableSymbolModule:get_PdbGuid():Guid:this
           2 (1.087% of base) : System.Data.Odbc.dasm - DbBuffer:ReadDateTime(int):DateTime:this
           1 (0.870% of base) : System.Formats.Asn1.dasm - IA5Encoding:.ctor():this
           1 (0.847% of base) : System.Formats.Asn1.dasm - VisibleStringEncoding:.ctor():this
           1 (0.820% of base) : System.Private.CoreLib.dasm - TextReader:ReadToEnd():String:this
           1 (0.813% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StreamUtilities:CopyStream(Stream,Stream):int
          10 (0.670% of base) : ILCompiler.Reflection.ReadyToRun.dasm - UnwindInfo:.ctor(ref,int):this (4 methods)
           2 (0.401% of base) : System.Formats.Asn1.dasm - AsnCharacterStringEncodings:.cctor()
           1 (0.361% of base) : System.Data.Common.dasm - DbDataReader:GetStream(int):Stream:this
           1 (0.299% of base) : System.Data.Odbc.dasm - OdbcConnection:GetConnectAttr(int,int):int:this
           2 (0.195% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - SymbolReader:CopyStreamToFile(Stream,String,String,byref):int:this
           1 (0.187% of base) : System.Private.Xml.dasm - XmlPreloadedResolver:Add(Uri,Stream):this
           2 (0.141% of base) : Microsoft.CodeAnalysis.dasm - CustomDebugInfoWriter:SerializeDynamicLocalInfo(IMethodBody,ArrayBuilder`1)
           1 (0.090% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - EventPipeEventSource:.ctor(PinnedStreamReader,String):this
           3 (0.081% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - TraceEventSession:EnableProvider(Guid,int,long,TraceEventProviderOptions):bool:this

Top method improvements (percentages):
        -165 (-50.000% of base) : System.Net.Http.dasm - MailBnfHelper:CreateCharactersAllowedInAtoms():ref
        -165 (-50.000% of base) : System.Net.Mail.dasm - MailBnfHelper:CreateCharactersAllowedInAtoms():ref
        -131 (-48.881% of base) : System.Data.Common.dasm - XPathNodePointer:CreateXmlNodeTypeToXpathNodeTypeMap():ref
        -148 (-46.984% of base) : System.Runtime.Serialization.Formatters.dasm - Converter:InitCodeA()
        -121 (-44.322% of base) : System.Runtime.Serialization.Formatters.dasm - Converter:InitTypeCodeA()
         -19 (-43.182% of base) : System.Private.Xml.dasm - Ucs4Encoding1234:GetPreamble():ref:this
         -19 (-43.182% of base) : System.Private.Xml.dasm - Ucs4Encoding4321:GetPreamble():ref:this
         -19 (-43.182% of base) : System.Private.Xml.dasm - Ucs4Encoding2143:GetPreamble():ref:this
         -19 (-43.182% of base) : System.Private.Xml.dasm - Ucs4Encoding3412:GetPreamble():ref:this
         -19 (-43.182% of base) : System.Net.Mail.dasm - EncodedStreamFactory:CreateFooter():ref:this
        -117 (-40.345% of base) : System.Net.Http.dasm - SOCKADDR_IN6:get_Address():ref:this
        -132 (-38.040% of base) : System.Data.Common.dasm - SqlDecimal:get_BinData():ref:this
         -65 (-36.932% of base) : System.Net.Http.dasm - HttpRuleParser:CreateTokenChars():ref
         -29 (-35.366% of base) : System.Net.Http.dasm - SOCKADDR_IN:get_Address():ref:this
         -24 (-35.294% of base) : System.Private.CoreLib.dasm - BitConverter:GetBytes(int):ref (2 methods)
         -51 (-34.459% of base) : System.Net.Http.dasm - MailBnfHelper:CreateCharactersAllowedInTokens():ref
         -51 (-34.459% of base) : System.Net.Mail.dasm - MailBnfHelper:CreateCharactersAllowedInTokens():ref
         -12 (-34.286% of base) : System.Private.CoreLib.dasm - BitConverter:GetBytes(short):ref
         -12 (-34.286% of base) : System.Private.CoreLib.dasm - BitConverter:GetBytes(Half):ref
         -12 (-34.286% of base) : System.Private.CoreLib.dasm - Path:GetInvalidFileNameChars():ref

4618 total methods with Code Size differences (4600 improved, 18 regressed), 185409 unchanged.
</pre>