### PR TITLE
[runtime] Add a memory manager for dynamic methods, use it to allocate some of the memory allocated by the runtime for dynamic methods.

### DIFF
--- a/src/mono/mono/metadata/class-inlines.h
+++ b/src/mono/mono/metadata/class-inlines.h
@@ -218,4 +218,10 @@ m_method_is_wrapper (MonoMethod *method)
 	return method->wrapper_type != 0;
 }
 
+static inline gboolean
+m_method_is_dynamic (MonoMethod *method)
+{
+	return method->dynamic;
+}
+
 #endif

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -89,6 +89,8 @@ struct _MonoMemoryManager {
 	gboolean is_generic;
 	// Whether the MemoryManager is in the process of being freed
 	gboolean freeing;
+	// Whenever this is owned by a dynamic method
+	gboolean dynamic_method;
 
 	// If taking this with the loader lock, always take this second
 	// Currently unused, we take the domain lock instead
@@ -212,6 +214,12 @@ mono_mem_manager_free_singleton (MonoSingletonMemoryManager *memory_manager, gbo
 
 void
 mono_mem_manager_free_objects_singleton (MonoSingletonMemoryManager *memory_manager);
+
+MonoMemoryManager *
+mono_mem_manager_create_dynamic_method (MonoDomain *domain);
+
+void
+mono_mem_manager_free_dynamic_method (MonoMemoryManager *memory_manager);
 
 void
 mono_mem_manager_lock (MonoMemoryManager *memory_manager);

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1402,9 +1402,10 @@ mono_free_method  (MonoMethod *method)
 		/* mono_metadata_free_method_signature (method->signature); */
 		/* g_free (method->signature); */
 	}
-	
+
 	if (method_is_dynamic (method)) {
 		MonoMethodWrapper *mw = (MonoMethodWrapper*)method;
+		MonoMemoryManager *mem_manager = ((MonoDynamicMethod*)method)->mem_manager;
 		int i;
 
 		mono_marshal_free_dynamic_wrappers (method);
@@ -1422,6 +1423,8 @@ mono_free_method  (MonoMethod *method)
 		g_free (mw->method_data);
 		g_free (method->signature);
 		g_free (method);
+
+		mono_mem_manager_free_dynamic_method (mem_manager);
 	}
 }
 

--- a/src/mono/mono/metadata/method-builder-ilgen-internals.h
+++ b/src/mono/mono/metadata/method-builder-ilgen-internals.h
@@ -19,9 +19,9 @@ struct _MonoMethodBuilder {
 	MonoMethod *method;
 	gchar *name;
 	gboolean no_dup_name;
+	gboolean dynamic;
 	GList *locals_list;
 	gint locals;
-	gboolean dynamic;
 	gboolean skip_visibility;
 	gboolean init_locals;
 	guint32 code_size;

--- a/src/mono/mono/metadata/method-builder-ilgen.c
+++ b/src/mono/mono/metadata/method-builder-ilgen.c
@@ -88,7 +88,9 @@ create_method_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, int 
 	image = m_class_get_image (mb->method->klass);
 
 	if (mb->dynamic) {
-		method = mb->method;
+		method = (MonoMethod*)g_new0 (MonoDynamicMethod, 1);
+		memcpy (method, mb->method, sizeof (MonoMethodWrapper));
+		((MonoDynamicMethod*)method)->mem_manager = mono_mem_manager_create_dynamic_method (mono_domain_get ());
 		mw = (MonoMethodWrapper*)method;
 
 		method->name = mb->name;
@@ -102,10 +104,8 @@ create_method_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, int 
 		for (i = 0, l = mb->locals_list; l; l = l->next, i++) {
 			header->locals [i] = (MonoType*)l->data;
 		}
-	} else
-	{
+	} else {
 		/* Realloc the method info into a mempool */
-
 		method = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethodWrapper));
 		memcpy (method, mb->method, sizeof (MonoMethodWrapper));
 		mw = (MonoMethodWrapper*) method;

--- a/src/mono/mono/metadata/method-builder-internals.h
+++ b/src/mono/mono/metadata/method-builder-internals.h
@@ -19,6 +19,7 @@ struct _MonoMethodBuilder {
 	MonoMethod *method;
 	gchar *name;
 	gboolean no_dup_name;
+	gboolean dynamic;
 };
 
 #endif

--- a/src/mono/mono/metadata/method-builder.c
+++ b/src/mono/mono/metadata/method-builder.c
@@ -101,18 +101,21 @@ create_method_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 
 	image = m_class_get_image (mb->method->klass);
 
-	{
-		/* Realloc the method info into a mempool */
-
+	/* Realloc the method info into a mempool */
+	if (mb->dynamic)
+		method = (MonoMethod *)g_malloc0 (sizeof (MonoDynamicMethod));
+	else
 		method = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethodWrapper));
-		memcpy (method, mb->method, sizeof (MonoMethodWrapper));
-		mw = (MonoMethodWrapper*) method;
+	memcpy (method, mb->method, sizeof (MonoMethodWrapper));
+	mw = (MonoMethodWrapper*) method;
 
-		if (mb->no_dup_name)
-			method->name = mb->name;
-		else
-			method->name = mono_image_strdup (image, mb->name);
-	}
+	if (mb->dynamic)
+		((MonoDynamicMethod*)method)->mem_manager = mono_mem_manager_create_dynamic_method (mono_domain_get ());
+
+	if (mb->no_dup_name)
+		method->name = mb->name;
+	else
+		method->name = mono_image_strdup (image, mb->name);
 
 	method->signature = signature;
 	if (!signature->hasthis)

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -3038,7 +3038,8 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 		m = (MonoMethod *)image_g_new0 (image, MonoMethodPInvoke, 1);
 	else
 		m = (MonoMethod *)image_g_new0 (image, MonoDynamicMethod, 1);
-
+	if (dynamic)
+		((MonoDynamicMethod*)m)->mem_manager = mono_mem_manager_create_dynamic_method (mono_domain_get ());
 	wrapperm = (MonoMethodWrapper*)m;
 
 	m->dynamic = dynamic;

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -155,7 +155,6 @@ typedef struct
 
 typedef struct {
 	MonoJitInfo *ji;
-	MonoCodeManager *code_mp;
 } MonoJitDynamicMethodInfo;
 
 /* An extension of MonoGenericParamFull used in generic sharing */
@@ -2789,7 +2788,7 @@ gboolean mini_is_gsharedvt_sharable_inst (MonoGenericInst *inst);
 gboolean mini_method_is_default_method (MonoMethod *m);
 gboolean mini_method_needs_mrgctx (MonoMethod *m);
 gpointer mini_method_get_rgctx (MonoMethod *m);
-void mini_init_gsctx (MonoDomain *domain, MonoMemPool *mp, MonoGenericContext *context, MonoGenericSharingContext *gsctx);
+void mini_init_gsctx (MonoGenericContext *context, MonoGenericSharingContext *gsctx);
 
 gpointer mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSignature *normal_sig, MonoMethodSignature *gsharedvt_sig,
 									 gint32 vcall_offset, gboolean calli);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20441,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>