### PR TITLE
do not call RemoteCertificateValidationCallback on the same certificate again

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -100,10 +100,12 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(GetAsync_AllowedSSLVersion_Succeeds_MemberData))]
         public async Task GetAsync_AllowedSSLVersion_Succeeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)
         {
+            int count = 0;
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (HttpClient client = CreateHttpClient(handler))
             {
-                handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
+                handler.ServerCertificateCustomValidationCallback =
+                    (request, cert, chain, errors) => { count++; return true; };
 
                 if (requestOnlyThisProtocol)
                 {
@@ -131,6 +133,8 @@ namespace System.Net.Http.Functional.Tests
                         server.AcceptConnectionSendResponseAndCloseAsync(),
                         client.GetAsync(url));
                 }, options);
+
+                Assert.Equal(1, count);
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -954,7 +954,17 @@ namespace System.Net.Security
 
             try
             {
-                _remoteCertificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
+                X509Certificate2? remoteCertificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
+
+                if (remoteCertificate != null && _remoteCertificate != null &&
+                    remoteCertificate.Equals(_remoteCertificate))
+                {
+                    // This is renegotiation or TLS 1.3 and the certificate did not change.
+                    // There is no reason to process callback again as we already established trust.
+                    return true;
+                }
+
+                _remoteCertificate = remoteCertificate;
 
                 if (_remoteCertificate == null)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Security;
@@ -954,17 +955,17 @@ namespace System.Net.Security
 
             try
             {
-                X509Certificate2? remoteCertificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
+                X509Certificate2? certificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
 
-                if (remoteCertificate != null && _remoteCertificate != null &&
-                    remoteCertificate.Equals(_remoteCertificate))
+                if (_remoteCertificate != null && certificate != null &&
+                    Enumerable.SequenceEqual(certificate.RawData, _remoteCertificate.RawData))
                 {
                     // This is renegotiation or TLS 1.3 and the certificate did not change.
                     // There is no reason to process callback again as we already established trust.
                     return true;
                 }
 
-                _remoteCertificate = remoteCertificate;
+                _remoteCertificate = certificate;
 
                 if (_remoteCertificate == null)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Security;
@@ -958,7 +957,7 @@ namespace System.Net.Security
                 X509Certificate2? certificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
 
                 if (_remoteCertificate != null && certificate != null &&
-                    certificate.RawData.SequenceEqual(_remoteCertificate.RawData))
+                    certificate.RawData.AsSpan().SequenceEqual(_remoteCertificate.RawData))
                 {
                     // This is renegotiation or TLS 1.3 and the certificate did not change.
                     // There is no reason to process callback again as we already established trust.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -958,7 +958,7 @@ namespace System.Net.Security
                 X509Certificate2? certificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
 
                 if (_remoteCertificate != null && certificate != null &&
-                    Enumerable.SequenceEqual(certificate.RawData, _remoteCertificate.RawData))
+                    certificate.RawData.SequenceEqual(_remoteCertificate.RawData))
                 {
                     // This is renegotiation or TLS 1.3 and the certificate did not change.
                     // There is no reason to process callback again as we already established trust.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -230,6 +230,7 @@ namespace System.Net.Security.Tests
         public async Task SslStream_TargetHostName_Succeeds(bool useEmptyName)
         {
             string targetName = useEmptyName ? string.Empty : Guid.NewGuid().ToString("N");
+            int count = 0;
 
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
             using (clientStream)
@@ -248,7 +249,7 @@ namespace System.Net.Security.Tests
                     {
                         SslStream stream = (SslStream)sender;
                         Assert.Equal(targetName, stream.TargetHostName);
-
+                        count++;
                         return true;
                     };
 
@@ -265,8 +266,12 @@ namespace System.Net.Security.Tests
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
                                 client.AuthenticateAsClientAsync(clientOptions),
                                 server.AuthenticateAsServerAsync(serverOptions));
+
+                await TestHelper.PingPong(client, server);
+
                 Assert.Equal(targetName, client.TargetHostName);
                 Assert.Equal(targetName, server.TargetHostName);
+                Assert.Equal(1, count);
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -9,6 +9,8 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.X509Certificates.Tests.Common;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace System.Net.Security.Tests
 {
@@ -29,6 +31,9 @@ namespace System.Net.Security.Tests
 
         private static readonly X509BasicConstraintsExtension s_eeConstraints =
             new X509BasicConstraintsExtension(false, false, 0, false);
+
+        private static readonly byte[] s_ping = Encoding.UTF8.GetBytes("PING");
+        private static readonly byte[] s_pong = Encoding.UTF8.GetBytes("PONG");
 
         public static (SslStream ClientStream, SslStream ServerStream) GetConnectedSslStreams()
         {
@@ -150,6 +155,34 @@ namespace System.Net.Security.Tests
             }
 
             return (endEntity, chain);
+        }
+
+        internal static async Task PingPong(SslStream client, SslStream server)
+        {
+            byte[] buffer = new byte[s_ping.Length];
+            ValueTask t = client.WriteAsync(s_ping);
+
+            int remains = s_ping.Length;
+            while (remains > 0)
+            {
+                int readLength = await server.ReadAsync(buffer, buffer.Length - remains, remains);
+                Assert.True(readLength > 0);
+                remains -= readLength;
+            }
+            Assert.Equal(s_ping, buffer);
+            await t;
+
+            t = server.WriteAsync(s_pong);
+            remains = s_pong.Length;
+            while (remains > 0)
+            {
+                int readLength = await client.ReadAsync(buffer, buffer.Length - remains, remains);
+                Assert.True(readLength > 0);
+                remains -= readLength;
+            }
+
+            Assert.Equal(s_pong, buffer);
+            await t;
         }
     }
 }


### PR DESCRIPTION
This is fix fix for #42823 to make the verification more consistent. On Windows, the callback can be triggered by sending data as the handshake is not quite finished when AuthenticateAs*() returns. 

I'm not sure if the X509Certificate.Equals is sufficient but for now I assume so since the peer is already verified and trusted.

While testing this I bump to 
```
Process terminated. Assertion failed.
     at System.Net.Http.ConnectHelper.<>c__DisplayClass3_0.<EstablishSslConnectionAsync>b__0(Object sender, X509Certificate certificate, X509Chain chain, SslPo
  licyErrors sslPolicyErrors) in C:\Users\toweinfu\github\wfurt-runtime\src\libraries\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\ConnectHelper.cs:l
  ine 84
     at System.Net.Security.SecureChannel.VerifyRemoteCertificate(RemoteCertificateValidationCallback remoteCertValidationCallback, ProtocolToken& alertToken,
  SslPolicyErrors& sslPolicyErrors, X509ChainStatusFlags& chainStatus) in C:\Users\toweinfu\github\wfurt-runtime\src\libraries\System.Net.Security\src\System\N
  et\Security\SecureChannel.cs:line 1006
     at System.Net.Security.SslStream.CompleteHandshake(ProtocolToken& alertToken, SslPolicyErrors& sslPolicyErrors, X509ChainStatusFlags& chainStatus) in C:\U
  sers\toweinfu\github\wfurt-runtime\src\libraries\System.Net.Security\src\System\Net\Security\SslStream.Implementation.cs:line 612
     at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](TIOAdapter adapter, Boolean receiveFirst, Byte[] reAuthenticationData, Boolean isApm
  ) in C:\Users\toweinfu\github\wfurt-runtime\src\libraries\System.Net.Security\src\System\Net\Security\SslStream.Implementation.cs:line 411
     at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine) in C:\Users\toweinfu\github\wfurt-runtime\src\
  libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\AsyncMethodBuilderCore.cs:line 42
     at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](TIOAdapter adapter, Boolean receiveFirst, Byte[] reAuthenticationData, Boolean isApm
  )
```

It seems like the HTTP callback is not ready to called multiple times. In this case it is lame, but if renegotiation is enabled this may happen.  Since there is no field issue, I left it as it was. 
