### PR TITLE
Support open delegate for Nullable<>

### DIFF
--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -2600,11 +2600,6 @@ bool COMDelegate::IsMethodDescCompatible(TypeHandle   thFirstArg,
     if (flags & DBF_InstanceMethodOnly && pTargetMethod->IsStatic())
         return false;
 
-    // we don't allow you to bind to methods on Nullable<T> because the unboxing stubs don't know how to
-    // handle this case.
-    if (!pTargetMethod->IsStatic() && Nullable::IsNullableType(pTargetMethod->GetMethodTable()))
-        return false;
-
     // Get signatures for the delegate invoke and target methods.
     MetaSig sigInvoke(pInvokeMethod, thDelegate);
     MetaSig sigTarget(pTargetMethod, thExactMethodType);

--- a/src/libraries/System.Runtime/tests/System/DelegateTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DelegateTests.cs
@@ -1102,6 +1102,7 @@ namespace System.Tests
             Assert.NotNull(ex.Message);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49839", TestRuntimes.Mono)]
         [Fact]
         public static void CreateDelegate10_Nullable_Method()
         {
@@ -1113,6 +1114,7 @@ namespace System.Tests
             Assert.Equal(num.ToString(), s);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49839", TestRuntimes.Mono)]
         [Fact]
         public static void CreateDelegate10_Nullable_ClosedDelegate()
         {

--- a/src/libraries/System.Runtime/tests/System/DelegateTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DelegateTests.cs
@@ -1101,6 +1101,26 @@ namespace System.Tests
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
         }
+
+        [Fact]
+        public static void CreateDelegate10_Nullable_Method()
+        {
+            int? num = 123;
+            MethodInfo mi = typeof(int?).GetMethod("ToString");
+            NullableIntToString toString = (NullableIntToString)Delegate.CreateDelegate(
+                typeof(NullableIntToString), mi);
+            string s = toString(ref num);
+            Assert.Equal(num.ToString(), s);
+        }
+
+        [Fact]
+        public static void CreateDelegate10_Nullable_ClosedDelegate()
+        {
+            int? num = 123;
+            MethodInfo mi = typeof(int?).GetMethod("ToString");
+            AssertExtensions.Throws<ArgumentException>(
+                () => Delegate.CreateDelegate(typeof(NullableIntToString), num, mi));
+        }
         #endregion Tests
 
         #region Test Setup
@@ -1207,6 +1227,8 @@ namespace System.Tests
 
         public delegate void D(C c);
         public delegate int E(C c);
+
+        delegate string NullableIntToString(ref int? obj);
         #endregion Test Setup
     }
 }


### PR DESCRIPTION
Because of the boxing behavior specialization for `Nullable<>`, after the boxing, a nullable object may be boxed by the type it referred to or just `null`, the original type information lost.
For example, 
```c#
int? num1 = 123;
object box = num1;
// box.GetType() == typeof(int);

int? num2= null;
object box = num2;
// box is null
```
Thus it's reasonable that a closed delegate binding for `Nullable<>` such as `Delegate.CreateDelegate(invokeType, boxedNullable, method)` is prohibited.
However, if for an open delegate case for `Nullable<>`, the `invokeType` must point to a delegate in which the first parameter is `ref Nullable<XXX>`, so it's no need to worry about the type information lost.
Currently, there's a special check for nullable type:
https://github.com/dotnet/runtime/blob/38bf4dff86b649e6a31c5a3d715d2a7141e03920/src/coreclr/src/vm/comdelegate.cpp#L2614-L2617
This specialized check is unnecessary, we can just remove it.
case 1: a closed delegate with boxed nullable value, no matter which type it would be, it just can't pass the type validation because the type won't match the nullable type.
case 2: an open delegate targeted by `xx Func(ref Nullable<XXX> self)`, the `self` type for the target method would use its reference type, the `fromHandle` and `toHandle` pass to `IsLocationAssignable` would be the same one.
It makes the code like as follow can't be used on .NetCore(.Net framework as well), on the other side, mono can.
The present version throws an `ArgumentException` for these cases.

```c#
delegate bool HasValueDelegate(ref int? obj);
delegate int GetValueDelegate(ref int? obj);
delegate string ToStringDelegate(ref int? obj);

static void Main(string[] args)
{
    int? num = 123;
    Type type = typeof(int?);
    {
        var mHasValue = typeof(int?).GetProperty("HasValue").GetMethod;
        var HasValue = (HasValueDelegate)Delegate.CreateDelegate(typeof(HasValueDelegate), mHasValue);
        Console.WriteLine("HasValue: {0}", HasValue(ref num));
    }

    {
        var t2 = (GetValueDelegate)Delegate.CreateDelegate(typeof(GetValueDelegate), type.GetProperty("Value").GetMethod);
        int value = t2(ref num);
        Console.WriteLine("Value: {0}", value);
    }

    {
        const BindingFlags MethodFlag = BindingFlags.Public | BindingFlags.Instance;
        var mGetValueOrDefault = typeof(int?).GetMethods(MethodFlag)
            .Single(m => m.Name == "GetValueOrDefault" && m.GetParameters().Length == 0);
        var GetValueOrDefault = (GetValueDelegate)Delegate.CreateDelegate(typeof(GetValueDelegate), mGetValueOrDefault);
        Console.WriteLine("GetValueOrDefault: {0}", GetValueOrDefault(ref num));
    }

    {
        var mToString = type.GetMethod("ToString");
        var ToString = (ToStringDelegate)Delegate.CreateDelegate(typeof(ToStringDelegate), mToString);
        Console.WriteLine("ToString: {0}", ToString(ref num));
    }
}
```