### PR TITLE
[5.0][browser][http] Set HttpResponseMessage.RequestMessage

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -224,8 +224,8 @@ namespace System.Net.Http
                 JSObject t = (JSObject)await response.ConfigureAwait(continueOnCapturedContext: true);
 
                 var status = new WasmFetchResponse(t, abortController, abortCts, abortRegistration);
-
                 HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)status.Status);
+                httpResponse.RequestMessage = request;
 
                 bool streamingEnabled = false;
                 if (StreamingSupported)


### PR DESCRIPTION
backport of #42822 

**Customer Impact**
Fixes https://github.com/dotnet/runtime/issues/42691 Sets RequestMessage on the browser response which was unset previously.  This is an important part of the response and worth fixing.

**Testing**
Manually tested.

An explicit test for this case is added in https://github.com/dotnet/runtime/pull/42844 but we will need a different solution for Browser and any other platform that doesn't support sockets and/or listening for requests.

**Risk**
Low.  This is a one line variable initialization that only impacts browser.



