### PR TITLE
[mono] Retarget HelloWorld sample to in-tree runtime pack (it used to use ".dotnet-mono" hack)

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -814,20 +814,14 @@
     <Message Text="Copying Mono Runtime artifacts from '$(BinDir)' to '$(Destination)'.'" Importance="High" />
     <Copy SourceFiles="@(_MonoRuntimeArtifacts)" 
           DestinationFolder="$(Destination)"
-          OverwriteReadOnlyFiles="true" />
+          OverwriteReadOnlyFiles="true"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Copy Mono runtime bits to the coreclr's Core_Root in order to run runtime tests -->
   <Target Name="PatchCoreClrCoreRoot">
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Properties="Destination=$(CoreClrTestCoreRoot)"
-             Targets="CopyMonoRuntimeFilesFromArtifactsToDestination" />
-  </Target>
-
-  <!-- Copy Mono runtime bits to the coreclr's Core_Root in order to run runtime tests -->
-  <Target Name="PatchLibrariesTesthost">
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Properties="Destination=$(LibrariesTesthostRuntimeDir)"
              Targets="CopyMonoRuntimeFilesFromArtifactsToDestination" />
   </Target>
 
@@ -849,14 +843,6 @@
   <Target Name="RunCoreClrTests" DependsOnTargets="PatchCoreClrCoreRoot">
     <Exec Condition="'$(OS)' == 'Windows_NT'" Command="$(MonoProjectRoot)..\tests\run.cmd $(CoreClrTestConfig)" ContinueOnError="ErrorAndContinue" />
     <Exec Condition="'$(OS)' != 'Windows_NT'" Command="$(MonoProjectRoot)../tests/run.sh $(CoreClrTestConfig)" ContinueOnError="ErrorAndContinue" />
-  </Target>
-
-  <!-- Run Libraries tests using testhost -->
-  <Target Name="RunLibrariesTest" DependsOnTargets="PatchLibrariesTesthost">
-    <Error Condition="$(LibraryToTest) == ''" Text="LibraryToTest variable is not set" />
-    <Error Condition="$(LibraryToTest.EndsWith('.Tests'))" Text="LibraryToTest should not end with .Tests, e.g. just 'System.Runtime'" />
-    <MSBuild Projects="$(RepoRoot)src\libraries\$(LibraryToTest)\tests\$(LibraryToTest).Tests.csproj" 
-             Properties="Configuration=$(LibrariesTestConfig)" Targets="Test" />
   </Target>
 
   <Target Name="BuildMonoRuntimeCMake" Condition="'$(MonoEnableCMake)' == 'true'">

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -12,8 +12,6 @@
     <DotNetExec Condition="'$(DotNetExec)' == ''">dotnet</DotNetExec>
     <LocalDotnetDir>$(RepoRoot).dotnet</LocalDotnetDir>
     <LocalDotnet>$(LocalDotnetDir)\$(DotNetExec)</LocalDotnet>
-    <LocalMonoDotnetDir>$(RepoRoot).dotnet-mono</LocalMonoDotnetDir>
-    <LocalMonoDotnet>$(LocalMonoDotnetDir)\$(DotNetExec)</LocalMonoDotnet>
     <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</ScriptExt>
     <ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</ScriptExt>
     <CoreClrFileName Condition="'$(TargetsWindows)' == 'true'">coreclr.dll</CoreClrFileName>
@@ -810,52 +808,6 @@
     <Exec Command="$(_MonoBuildCommand)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
-  <!-- Precompile (AssembliesToPrecompile) using (MonoExec) -->
-  <Target Name="PrecompileAssembly">
-   <PropertyGroup>
-      <EnvVars Condition="'$(OS)' == 'Windows_NT'">set MONO_ENV_OPTIONS=--aot=mcpu=native &amp; $(EnvVars)</EnvVars>
-      <EnvVars Condition="'$(OS)' != 'Windows_NT'">export MONO_ENV_OPTIONS=--aot=mcpu=native &amp;&amp; $(EnvVars)</EnvVars>
-    </PropertyGroup>
-    <Exec Command="$(EnvVars) $(MonoExec) %(AssembliesToPrecompile.Identity)" ContinueOnError="WarnAndContinue" />
-  </Target>
-
-  <!-- Precompile (AOT) managed libs in .dotnet-mono\shared\Microsoft.NETCore.App\**\*.dll -->
-  <Target Name="PrecompileLocalMonoDotnetBcl" DependsOnTargets="PrepareLocalMonoDotnetBclForAot;PrecompileAssembly" />
-  <Target Name="PrepareLocalMonoDotnetBclForAot" DependsOnTargets="PatchLocalMonoDotnet">
-    <PropertyGroup>
-      <MonoExec>$(LocalMonoDotnet)</MonoExec>
-    </PropertyGroup>
-    <ItemGroup>
-      <AssembliesToPrecompile 
-          Include="$(LocalMonoDotnetDir)\shared\Microsoft.NETCore.App\**\*.dll"
-          Exclude="$(LocalMonoDotnetDir)\shared\Microsoft.NETCore.App\**\System.Runtime.WindowsRuntime.dll" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Precompile (AOT) $(ArtifactsDir)bin\**\*Tests\**\System.*.dll -->
-  <Target Name="PrecompileLibrariesTests" DependsOnTargets="PrepareLibrariesTestsForAot;PrecompileAssembly" />
-  <Target Name="PrepareLibrariesTestsForAot" DependsOnTargets="PatchLibrariesTesthost">
-    <PropertyGroup>
-      <MonoExec>$(LibrariesTesthostRoot)$(DotNetExec)</MonoExec>
-    </PropertyGroup>
-    <ItemGroup>
-      <AssembliesToPrecompile
-          Include="$(ArtifactsDir)bin\**\*Tests\**\System.*.dll" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Precompile (AOT) $(ArtifactsDir)bin\**\*Tests\**\System.*.dll -->
-  <Target Name="PrecompileTesthostLibraries" DependsOnTargets="PrepareTesthostLibrariesForAot;PrecompileAssembly" />
-  <Target Name="PrepareTesthostLibrariesForAot" DependsOnTargets="PatchLibrariesTesthost">
-    <PropertyGroup>
-      <MonoExec>$(LibrariesTesthostRoot)$(DotNetExec)</MonoExec>
-    </PropertyGroup>
-    <ItemGroup>
-      <AssembliesToPrecompile
-          Include="$(LibrariesTesthostRuntimeDir)\System.*.dll" />
-    </ItemGroup>
-  </Target>
-
   <!-- Copy Mono runtime bits to $(Destination) -->
   <Target Name="CopyMonoRuntimeFilesFromArtifactsToDestination">
     <ItemGroup>
@@ -869,63 +821,36 @@
           OverwriteReadOnlyFiles="true" />
   </Target>
 
-  <Target Name="CloneLocalDotnet" DependsOnTargets="ValidateLocalDotnet">
-    <ItemGroup>
-      <_LocalDotnetFiles Include="$(LocalDotnetDir)\**\*.*" />
-    </ItemGroup>
-    <!-- copy .dotnet to .dotnet-mono if it doesn't exist -->
-    <Copy SourceFiles="@(_LocalDotnetFiles)"
-          DestinationFolder="$(LocalMonoDotnetDir)\%(RecursiveDir)"
-          SkipUnchangedFiles="true" />
-  </Target>
-
-  <!-- Copy Mono runtime bits to the local .dotnet-mono (clone of .dotnet) dir for local experiments (temp solution) -->
-  <Target Name="PatchLocalMonoDotnet" DependsOnTargets="CloneLocalDotnet">
-      <MSBuild Projects ="$(MSBuildProjectFullPath)"
-               Properties="Destination=$([System.IO.Directory]::GetDirectories('$(LocalMonoDotnetDir)\shared\Microsoft.NETCore.App')[0])"
-               Targets="CopyMonoRuntimeFilesFromArtifactsToDestination" />
-  </Target>
-
   <!-- Copy Mono runtime bits to the coreclr's Core_Root in order to run runtime tests -->
-  <Target Name="PatchCoreClrCoreRoot" DependsOnTargets="ValidateLocalDotnet">
+  <Target Name="PatchCoreClrCoreRoot">
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Properties="Destination=$(CoreClrTestCoreRoot)"
              Targets="CopyMonoRuntimeFilesFromArtifactsToDestination" />
   </Target>
 
   <!-- Copy Mono runtime bits to the coreclr's Core_Root in order to run runtime tests -->
-  <Target Name="PatchLibrariesTesthost" DependsOnTargets="ValidateLocalDotnet">
+  <Target Name="PatchLibrariesTesthost">
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Properties="Destination=$(LibrariesTesthostRuntimeDir)"
              Targets="CopyMonoRuntimeFilesFromArtifactsToDestination" />
   </Target>
 
   <!-- Copy Coreclr runtime bits back to Core_Root -->
-  <Target Name="RestoreCoreClrCoreRoot" DependsOnTargets="ValidateLocalDotnet">
+  <Target Name="RestoreCoreClrCoreRoot">
     <Copy SourceFiles="$(CoreCLRArtifactsPath)\System.Private.CoreLib.dll"
           DestinationFiles="$(CoreClrTestCoreRoot)\System.Private.CoreLib.dll" />
     <Copy SourceFiles="$(CoreCLRArtifactsPath)\$(CoreClrFileName)"
           DestinationFiles="$(CoreClrTestCoreRoot)\$(CoreClrFileName)" />
   </Target>
 
-  <!-- Run netcore\sample\HelloWorld sample using Mono Runtime -->
-  <Target Name="RunSample" DependsOnTargets="PatchLocalMonoDotnet">
-     <PropertyGroup>
-      <SampleDir>$(MonoProjectRoot)netcore\sample\HelloWorld</SampleDir>
-      <EnvVars Condition="'$(OS)' == 'Windows_NT'">set COMPlus_DebugWriteToStdErr=1 &amp; $(EnvVars)</EnvVars>
-      <EnvVars Condition="'$(OS)' != 'Windows_NT'">export COMPlus_DebugWriteToStdErr=1 &amp;&amp; $(EnvVars)</EnvVars>
-    </PropertyGroup>
-    <Exec Command="$(EnvVars) $(LocalMonoDotnet) run -c $(Configuration) -p $(SampleDir)" />
-  </Target>
-
   <!-- Run CoreCLR runtime test using testhost -->
-  <Target Name="RunCoreClrTest" DependsOnTargets="ValidateLocalDotnet;PatchCoreClrCoreRoot">
+  <Target Name="RunCoreClrTest" DependsOnTargets="PatchCoreClrCoreRoot">
     <Error Condition="$(CoreClrTest) == ''" Text="'CoreClrTest' is not set. E.g. set it to `$(ArtifactsDir)tests/coreclr/$(TargetOS).$(Platform).$(CoreClrTestConfig)/JIT/opt/InstructionCombining/DivToMul/DivToMul$(ScriptExt)` in order to run DivToMul test." />
     <Exec Command="$(CoreClrTest) -coreroot=&quot;$(CoreClrTestCoreRoot)&quot;"/>
   </Target>
 
   <!-- Run coreclr tests using runtest.py -->
-  <Target Name="RunCoreClrTests" DependsOnTargets="ValidateLocalDotnet;PatchCoreClrCoreRoot">
+  <Target Name="RunCoreClrTests" DependsOnTargets="PatchCoreClrCoreRoot">
     <Exec Condition="'$(OS)' == 'Windows_NT'" Command="$(MonoProjectRoot)..\tests\run.cmd $(CoreClrTestConfig)" ContinueOnError="ErrorAndContinue" />
     <Exec Condition="'$(OS)' != 'Windows_NT'" Command="$(MonoProjectRoot)../tests/run.sh $(CoreClrTestConfig)" ContinueOnError="ErrorAndContinue" />
   </Target>
@@ -936,17 +861,6 @@
     <Error Condition="$(LibraryToTest.EndsWith('.Tests'))" Text="LibraryToTest should not end with .Tests, e.g. just 'System.Runtime'" />
     <MSBuild Projects="$(RepoRoot)src\libraries\$(LibraryToTest)\tests\$(LibraryToTest).Tests.csproj" 
              Properties="Configuration=$(LibrariesTestConfig)" Targets="Test" />
-  </Target>
-
-  <Target Name="RunBenchmarks" DependsOnTargets="PatchLocalMonoDotnet">
-    <Error Condition="$(BenchmarksRepo) == ''" Text="BenchmarksRepo variable is not set" />
-    <Exec WorkingDirectory="$(BenchmarksRepo)\src\benchmarks\micro" Command="$(LocalDotnet) run -c Release -f $(NetCoreAppCurrent) --cli $(LocalMonoDotnet)" />
-  </Target>
-
-  <Target Name="ValidateLocalDotnet">
-    <Error Condition="$([System.IO.Directory]::GetDirectories('$(LocalDotnetDir)\shared\Microsoft.NETCore.App').Length) > 1" Text="$(LocalDotnetDir) contains more than one SDK, please delete unused ones." />
-    <Error Condition="Exists('$(LocalMonoDotnetDir)') AND $([System.IO.Directory]::GetDirectories('$(LocalMonoDotnetDir)\shared\Microsoft.NETCore.App').Length) > 1" Text="$(LocalMonoDotnetDir) contains more than one SDK, please delete unused ones." />
-    <Error Condition="!Exists('$(LocalDotnet)')" Text="'$(LocalDotnet)' doesn't exist." />
   </Target>
 
   <Target Name="BuildMonoRuntimeCMake" Condition="'$(MonoEnableCMake)' == 'true'">

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -8,10 +8,6 @@
   <PropertyGroup>
     <MonoCrossDir Condition="'$(MonoCrossDir)' == '' and '$(ROOTFS_DIR)' != ''">$(ROOTFS_DIR)</MonoCrossDir>
     <MonoEnableInterpreter Condition="'$(MonoEnableInterpreter)' == ''">false</MonoEnableInterpreter>
-    <DotNetExec Condition="'$(OS)' == 'Windows_NT'">dotnet.exe</DotNetExec>
-    <DotNetExec Condition="'$(DotNetExec)' == ''">dotnet</DotNetExec>
-    <LocalDotnetDir>$(RepoRoot).dotnet</LocalDotnetDir>
-    <LocalDotnet>$(LocalDotnetDir)\$(DotNetExec)</LocalDotnet>
     <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</ScriptExt>
     <ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</ScriptExt>
     <CoreClrFileName Condition="'$(TargetsWindows)' == 'true'">coreclr.dll</CoreClrFileName>

--- a/src/mono/netcore/Makefile
+++ b/src/mono/netcore/Makefile
@@ -28,7 +28,7 @@ MONO_PROJ=/p:CoreClrTestConfig=$(CORECLR_TESTS_CONFIG) /p:LibrariesTestConfig=$(
 # run sample using local .dotnet-mono
 # build it with .dotnet first in order to be able to use LLVM only for the actual sample
 run-sample:
-	cd sample/HelloWorld && make run
+	make run -C sample/HelloWorld
 
 # run sample using local .dotnet (coreclr)
 run-sample-coreclr:

--- a/src/mono/netcore/Makefile
+++ b/src/mono/netcore/Makefile
@@ -58,6 +58,5 @@ run-tests-coreclr-all:
 #   make run-tests-corefx-System.Runtime 
 # for `System.Runtime.Tests` (the rule builds both the lib and the test if needed)
 run-tests-corefx-%:
-	$(DOTNET) msbuild /t:PatchLibrariesTesthost $(MONO_PROJ)
 	$(DOTNET) build ../../../src/libraries/$*/tests -c $(LIBRARIES_TESTS_CONFIG) /p:RuntimeFlavor=mono /t:Test
 

--- a/src/mono/netcore/Makefile
+++ b/src/mono/netcore/Makefile
@@ -27,14 +27,12 @@ MONO_PROJ=/p:CoreClrTestConfig=$(CORECLR_TESTS_CONFIG) /p:LibrariesTestConfig=$(
 
 # run sample using local .dotnet-mono
 # build it with .dotnet first in order to be able to use LLVM only for the actual sample
-run-sample: patch-mono-dotnet
-	$(DOTNET) build -c Release sample/HelloWorld
-	MONO_ENV_OPTIONS="--llvm" COMPlus_DebugWriteToStdErr=1 \
-	$(DOTNET_MONO) sample/HelloWorld/bin/HelloWorld.dll
+run-sample:
+	cd sample/HelloWorld && make run
 
 # run sample using local .dotnet (coreclr)
 run-sample-coreclr:
-	$(DOTNET) run -c Debug -p sample/HelloWorld
+	$(DOTNET) run -c Release -p sample/HelloWorld
 
 # build System.Private.CoreLib.dll
 bcl corelib:
@@ -43,14 +41,6 @@ bcl corelib:
 # build runtime and copy to artifacts
 runtime:
 	../../.././build.sh -c $(MONO_RUNTIME_CONFIG) -subset Mono.Runtime
-
-# call it if you want to use $(DOTNET_MONO) in this Makefile
-patch-mono-dotnet:
-	$(DOTNET) msbuild /t:PatchLocalMonoDotnet $(MONO_PROJ)
-
-# precompile (AOT) managed libs in .dotnet-mono
-patch-mono-dotnet-aot:
-	$(DOTNET) msbuild /t:PrecompileLocalMonoDotnetBcl $(MONO_PROJ)
 
 # copy mono runtime bits from artifacts to $(DST)
 copy-runtime-files-to:
@@ -71,17 +61,3 @@ run-tests-coreclr-all:
 # for `System.Runtime.Tests` (the rule builds both the lib and the test if needed)
 run-tests-corefx-%:
 	$(DOTNET) msbuild /t:RunLibrariesTest /p:LibraryToTest=$* $(MONO_PROJ)
-
-# precompile (AOT) all libraries' tests
-aot-tests-corefx:
-	$(DOTNET) msbuild /t:PrecompileLibrariesTests $(MONO_PROJ)
-
-# precompile (AOT) all libraries inside testhost (it's used for libraries' tests)
-aot-testhost-corefx:
-	$(DOTNET) msbuild /t:PrecompileTesthostLibraries $(MONO_PROJ)
-
-# run 'dotnet/performance' benchmarks
-# e.g. 'make run-benchmarks BenchmarksRepo=/prj/performance'
-# you can append BDN parameters at the end, e.g. ` -- --filter Burgers --keepFiles`
-run-benchmarks: patch-local-dotnet
-	$(DOTNET) msbuild /t:RunBenchmarks /p:BenchmarksRepo=$(BenchmarksRepo)

--- a/src/mono/netcore/Makefile
+++ b/src/mono/netcore/Makefile
@@ -3,8 +3,6 @@ ifeq ($(wildcard ../../../.dotnet),)
 endif
 
 DOTNET := $(shell bash init-tools.sh | tail -1)
-# DOTNET_MONO is a copy of DOTNET (local .dotnet) with Mono Runtime bits (see patch-mono-dotnet rule)
-DOTNET_MONO = ../../../.dotnet-mono/dotnet
 
 LIBRARIES_TESTS_CONFIG=Release
 CORECLR_TESTS_CONFIG=Release
@@ -60,4 +58,6 @@ run-tests-coreclr-all:
 #   make run-tests-corefx-System.Runtime 
 # for `System.Runtime.Tests` (the rule builds both the lib and the test if needed)
 run-tests-corefx-%:
-	$(DOTNET) msbuild /t:RunLibrariesTest /p:LibraryToTest=$* $(MONO_PROJ)
+	$(DOTNET) msbuild /t:PatchLibrariesTesthost $(MONO_PROJ)
+	$(DOTNET) build ../../../src/libraries/$*/tests -c $(LIBRARIES_TESTS_CONFIG) /p:RuntimeFlavor=mono /t:Test
+

--- a/src/mono/netcore/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/netcore/sample/HelloWorld/HelloWorld.csproj
@@ -1,10 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <OutputPath>bin</OutputPath>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <DebugType>full</DebugType>
+    <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
   </PropertyGroup>
 
+  <!-- Redirect 'dotnet publish' to in-tree runtime pack -->
+  <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
+    <ItemGroup>
+      <RuntimePack>
+        <PackageDirectory>$(ArtifactsBinDir)microsoft.netcore.app.runtime.$(RuntimeIdentifier)\$(Configuration)</PackageDirectory>
+      </RuntimePack>
+    </ItemGroup>
+    <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />
+  </Target>
 </Project>

--- a/src/mono/netcore/sample/HelloWorld/Makefile
+++ b/src/mono/netcore/sample/HelloWorld/Makefile
@@ -1,0 +1,23 @@
+TOP=../../../../../
+DOTNET:=$(TOP)./dotnet.sh
+DOTNET_Q_ARGS=--nologo -v:q -consoleloggerparameters:NoSummary
+
+MONO_CONFIG=Release
+MONO_ARCH=x64
+
+OS := $(shell uname -o)
+ifeq ($(OS),Darwin)
+	TARGET_OS=osx
+else
+	TARGET_OS=linux
+endif
+
+publish:
+	$(DOTNET) publish -c $(MONO_CONFIG) -r $(TARGET_OS)-$(MONO_ARCH)
+
+run: publish
+	MONO_ENV_OPTIONS="--llvm" \
+	$(TOP)artifacts/bin/HelloWorld/$(MONO_ARCH)/$(MONO_CONFIG)/$(TARGET_OS)-$(MONO_ARCH)/publish/HelloWorld
+
+clean:
+	rm -rf $(TOP)artifacts/bin/HelloWorld/

--- a/src/mono/netcore/sample/HelloWorld/Makefile
+++ b/src/mono/netcore/sample/HelloWorld/Makefile
@@ -16,6 +16,7 @@ publish:
 	$(DOTNET) publish -c $(MONO_CONFIG) -r $(TARGET_OS)-$(MONO_ARCH)
 
 run: publish
+	COMPlus_DebugWriteToStdErr=1 \
 	MONO_ENV_OPTIONS="--llvm" \
 	$(TOP)artifacts/bin/HelloWorld/$(MONO_ARCH)/$(MONO_CONFIG)/$(TARGET_OS)-$(MONO_ARCH)/publish/HelloWorld
 

--- a/src/mono/netcore/sample/HelloWorld/Program.cs
+++ b/src/mono/netcore/sample/HelloWorld/Program.cs
@@ -10,8 +10,9 @@ namespace HelloWorld
         private static void Main(string[] args)
         {
             bool isMono = typeof(object).Assembly.GetType("Mono.RuntimeStructs") != null;
-            Console.WriteLine(typeof(object).Assembly.FullName);
             Console.WriteLine($"Hello World {(isMono ? "from Mono!" : "from CoreCLR!")}");
+            Console.WriteLine(typeof(object).Assembly.FullName);
+            Console.WriteLine(System.Reflection.Assembly.GetEntryAssembly ());
             Console.WriteLine(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
         }
     }

--- a/src/mono/netcore/sample/HelloWorld/Program.cs
+++ b/src/mono/netcore/sample/HelloWorld/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 
 namespace HelloWorld
 {
@@ -7,10 +10,9 @@ namespace HelloWorld
         private static void Main(string[] args)
         {
             bool isMono = typeof(object).Assembly.GetType("Mono.RuntimeStructs") != null;
+            Console.WriteLine();
             Console.WriteLine("Hello World " + (isMono ? "from Mono!" : "from CoreCLR!"));
-            Console.WriteLine(typeof(object).Assembly.FullName);
-            Console.WriteLine(System.Reflection.Assembly.GetEntryAssembly ());
-            Console.WriteLine(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+            Console.WriteLine();
         }
     }
 }

--- a/src/mono/netcore/sample/HelloWorld/Program.cs
+++ b/src/mono/netcore/sample/HelloWorld/Program.cs
@@ -10,9 +10,9 @@ namespace HelloWorld
         private static void Main(string[] args)
         {
             bool isMono = typeof(object).Assembly.GetType("Mono.RuntimeStructs") != null;
-            Console.WriteLine();
-            Console.WriteLine("Hello World " + (isMono ? "from Mono!" : "from CoreCLR!"));
-            Console.WriteLine();
+            Console.WriteLine(typeof(object).Assembly.FullName);
+            Console.WriteLine($"Hello World {(isMono ? "from Mono!" : "from CoreCLR!")}");
+            Console.WriteLine(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
         }
     }
 }


### PR DESCRIPTION
Also, get rid of various ancient ".dotnet-mono" hacks.

https://github.com/dotnet/runtime/pull/42597 was a blocker for this.

Also, fixes https://github.com/dotnet/runtime/issues/40853