### PR TITLE
Improve WASM test output via xharness

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20474.1",
+      "version": "1.0.0-prerelease.20502.4",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,9 +14,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>61cde6e8fb9d5c9790867b279deb41783a780cd8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20474.4">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20502.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>61cde6e8fb9d5c9790867b279deb41783a780cd8</Sha>
+      <Sha>baebe30c7969b4148a6a3b90cf5f4e3a96d4a11e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20474.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -190,13 +190,13 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>337f0c5c704c52fcd570fab3c69d7fc83c82e6e0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20476.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20502.4">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>e875c887915e47d1573a5000255f7f4057b954d5</Sha>
+      <Sha>68d8514065c4de0ae90ad0c30a4ceec08e46faa5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20476.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20502.4">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>e875c887915e47d1573a5000255f7f4057b954d5</Sha>
+      <Sha>68d8514065c4de0ae90ad0c30a4ceec08e46faa5</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -134,8 +134,8 @@
     <RefOnlyNugetPackagingVersion>4.9.4</RefOnlyNugetPackagingVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.8.0-release-20200924-01</MicrosoftNETTestSdkVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20476.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20476.2</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20502.4</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20502.4</MicrosoftDotNetXHarnessCLIVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -14,7 +14,7 @@
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
     <!-- We need to set this in order to get extensibility on xunit category traits and other arguments we pass down to xunit via MSBuild properties -->
-    <RunScriptCommand>$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js -v --output-directory=$XHARNESS_OUT --  $(RunTestsJSArguments) --run WasmTestRunner.dll $(AssemblyName).dll</RunScriptCommand>
+    <RunScriptCommand>$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js --output-directory=$XHARNESS_OUT --  $(RunTestsJSArguments) --run WasmTestRunner.dll $(AssemblyName).dll</RunScriptCommand>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20474.4",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20474.4",
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20474.4",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20474.4",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20502.2",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20359.4",
     "Microsoft.Build.NoTargets": "2.0.1",

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -98,6 +98,8 @@
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <HelixPreCommand Condition="'$(Scenario)' != 'WasmTestOnBrowser'" Include="export XHARNESS_COMMAND=test" />
     <HelixPreCommand Condition="'$(Scenario)' == 'WasmTestOnBrowser'" Include="export XHARNESS_COMMAND=test-browser" />
+    <HelixPreCommand Include="export XHARNESS_DISABLE_COLORED_OUTPUT=true" />
+    <HelixPreCommand Include="export XHARNESS_LOG_WITH_TIMESTAMPS=true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Scenario)' == 'WasmTestOnBrowser'">
@@ -153,6 +155,7 @@
 
   <ItemGroup>
     <HelixProperties Condition="'$(RuntimeFlavor)' != ''" Include="runtimeFlavor" Value="$(RuntimeFlavor)" />
+    <HelixProperties Condition="'$(Scenario)' != ''" Include="scenario" Value="$(Scenario)" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
With https://github.com/dotnet/xharness/pull/315 we can now make the test output similar to the regular xunit desktop runner.

It no longer prints the passed tests by default, only failing tests. To get the old behavior, add the `-v` flag back to xharness in tests.mobile.targets or check the new wasm-console.log file in the xharness-output folder.

```
  XHarness command issued: wasm test --app=. --engine=V8 --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=/Users/alexander/dev/runtime/artifacts/bin/System.Runtime.Handles.Tests/net5.0-Release/browser-wasm/AppBundle/xharness-output -- --run WasmTestRunner.dll System.Runtime.Handles.Tests.dll -notrait category=OuterLoop -notrait category=failing
  info: 21:57:45.3244690 v8 --expose_wasm --stack-trace-limit=1000 runtime.js -- --run WasmTestRunner.dll System.Runtime.Handles.Tests.dll -notrait category=OuterLoop -notrait category=failing
  info: Arguments: --run,WasmTestRunner.dll,System.Runtime.Handles.Tests.dll,-notrait,category=OuterLoop,-notrait,category=failing
  info: console.debug: MONO_WASM: Initializing mono runtime
  info: console.debug: MONO_WASM: ICU data archive(s) loaded, disabling invariant mode
  info: console.debug: mono_wasm_runtime_ready fe00e07a-5519-4dfe-b35a-f867dbaf2e28
  info: Initializing.....
  info: Discovering: System.Runtime.Handles.Tests.dll (method display = ClassAndMethod, method display options = None)
  info: Discovered:  System.Runtime.Handles.Tests.dll (found 14 of 15 test cases)
  info: Starting:    System.Runtime.Handles.Tests.dll
  fail: [FAIL] SafeWaitHandleTests.SafeWaitHandle_False
  info: Assert.False() Failure
  info: Expected: False
  info: Actual:   True
  info:    at SafeWaitHandleTests.SafeWaitHandle_False()
  info:    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  info: Finished:    System.Runtime.Handles.Tests.dll
  info:
  info: === TEST EXECUTION SUMMARY ===
  info: Total: 14, Errors: 0, Failed: 1, Skipped: 0, Time: 0.097211s
  info:
  info: 21:57:46.3323620 Process exited with 1
```

Fixes https://github.com/dotnet/runtime/issues/42746

/cc @CoffeeFlux @safern