### PR TITLE
Fix test framework crossgening

### DIFF
--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -629,7 +629,7 @@ exit /b 1
 
 :PrecompileFX
 
-set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%CORE_ROOT%\crossgen.out" --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS%
+set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%CORE_ROOT%\crossgen.out"  --large-bubble --release --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS%
 
 if defined __CompositeBuildMode (
     set __CrossgenCmd=%__CrossgenCmd% --composite


### PR DESCRIPTION
The recent change that replaced direct invocation of crossgen and
crossgen2 for crossgening framework assemblies for coreclr tests by
r2rtest tool usage has ommited the --release and --large-bubble
arguments. These correspond to the former -O and --inputbubble crossgen2
commands and should be present.

This also fixes failures in running tests with the crossgened runtime.
Many tests were failing with the error `Could not execute the method
because either the method itself or the containing type is not fully
instantiated.`

So while there is a problem to investigate related to debug flavor of
crossgening, this PR fixes the options.