### PR TITLE
make sure we process PhysicalAddress on Linux

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -88,6 +88,11 @@ namespace System.Net.NetworkInformation
                     lni._mtu = nii->Mtu;
                     lni._supportsMulticast = nii->SupportsMulticast != 0;
 
+                    if (nii->NumAddressBytes > 0)
+                    {
+                        lni._physicalAddress = new PhysicalAddress(new ReadOnlySpan<byte>(nii->AddressBytes, nii->NumAddressBytes).ToArray());
+                    }
+
                     interfaces[i] = lni;
                     interfacesByIndex.Add(nii->InterfaceIndex, lni);
                     nii++;

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -47,6 +47,11 @@ namespace System.Net.NetworkInformation.Tests
 
                 _log.WriteLine("SupportsMulticast: " + nic.SupportsMulticast);
                 _log.WriteLine("GetPhysicalAddress(): " + nic.GetPhysicalAddress());
+
+                if (nic.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+                {
+                    Assert.Equal(6, nic.GetPhysicalAddress().GetAddressBytes().Length);
+                }
             }
         }
 
@@ -81,6 +86,11 @@ namespace System.Net.NetworkInformation.Tests
 
                 _log.WriteLine("SupportsMulticast: " + nic.SupportsMulticast);
                 _log.WriteLine("GetPhysicalAddress(): " + nic.GetPhysicalAddress());
+
+                if (nic.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+                {
+                    Assert.Equal(6, nic.GetPhysicalAddress().GetAddressBytes().Length);
+                }
             }
         }
 
@@ -111,6 +121,11 @@ namespace System.Net.NetworkInformation.Tests
                 {
                     // Ethernet, WIFI and loopback should have known status.
                     Assert.True((nic.OperationalStatus == OperationalStatus.Up) || (nic.OperationalStatus == OperationalStatus.Down));
+                }
+
+                if (nic.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+                {
+                    Assert.Equal(6, nic.GetPhysicalAddress().GetAddressBytes().Length);
                 }
             }
         }


### PR DESCRIPTION
This is regression to 3.1 caused by https://github.com/dotnet/corefx/pull/41490. Somehow the lack of MAC address got unnoticed as GetPhysicalAddress() simple returns empty address instead of failing. 

I modified tests to ensure valid length at least for Ethernet type.  
Provided repro now shows correct output:
```
Selected interface:enp0s5
MAC:001C42E4302E
False
Bytes:6
Hash code:-465423824
```

fixes #42870