### PR TITLE
Minor Type.IsPrimitive improvement

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -126,10 +126,7 @@ namespace System
 
         internal static bool IsPrimitive(RuntimeType type)
         {
-            CorElementType corElemType = GetCorElementType(type);
-            return (corElemType >= CorElementType.ELEMENT_TYPE_BOOLEAN && corElemType <= CorElementType.ELEMENT_TYPE_R8) ||
-                    corElemType == CorElementType.ELEMENT_TYPE_I ||
-                    corElemType == CorElementType.ELEMENT_TYPE_U;
+            return RuntimeHelpers.IsPrimitiveType(GetCorElementType(type));
         }
 
         internal static bool IsByRef(RuntimeType type)


### PR DESCRIPTION
Re-use [branch-free version](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs#L132-L134) in RuntimeHelpers instead.
It makes `Type.IsPrimitive` property a bit faster and removes duplicated code:
```csharp
[Benchmark]
[Arguments(typeof(string))]
[Arguments(typeof(Program))]
[Arguments(typeof(sbyte))]
[Arguments(typeof(int))]
[Arguments(typeof(UIntPtr))]
public bool IsPrimitive(Type type) => type.IsPrimitive;
```
```
Before:
|      Method |    type |     Mean |     Error |    StdDev |
|------------ |-------- |---------:|----------:|----------:|
| IsPrimitive | Program | 2.022 ns | 0.0047 ns | 0.0042 ns |
| IsPrimitive |   Int32 | 2.396 ns | 0.0038 ns | 0.0032 ns |
| IsPrimitive |   SByte | 2.406 ns | 0.0053 ns | 0.0047 ns |
| IsPrimitive |  String | 1.986 ns | 0.0007 ns | 0.0006 ns |
| IsPrimitive | UIntPtr | 2.192 ns | 0.0015 ns | 0.0012 ns |

After:
|      Method |    type |     Mean |     Error |    StdDev |
|------------ |-------- |---------:|----------:|----------:|
| IsPrimitive | Program | 1.714 ns | 0.0062 ns | 0.0051 ns |
| IsPrimitive |   Int32 | 1.927 ns | 0.0047 ns | 0.0041 ns |
| IsPrimitive |   SByte | 1.947 ns | 0.0060 ns | 0.0053 ns |
| IsPrimitive |  String | 1.737 ns | 0.0186 ns | 0.0174 ns |
| IsPrimitive | UIntPtr | 1.923 ns | 0.0023 ns | 0.0020 ns |
```