### PR TITLE
Fix xml doc comment for SimpleConsoleFormatterOptions.SingleLine

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Logging.Console
         public LoggerColorBehavior ColorBehavior { get; set; }
 
         /// <summary>
-        /// When <see langword="false" />, the entire message gets logged in a single line.
+        /// When <see langword="true" />, the entire message gets logged in a single line.
         /// </summary>
         public bool SingleLine { get; set; }
     }


### PR DESCRIPTION
Setting it to `true` forces the single line, not `false` :)
