### PR TITLE
Add MS_PLATFORM_CRYPTO_PROVIDER to CngProvider

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/ref/System.Security.Cryptography.Cng.cs
@@ -223,6 +223,7 @@ namespace System.Security.Cryptography
     public sealed partial class CngProvider : System.IEquatable<System.Security.Cryptography.CngProvider>
     {
         public CngProvider(string provider) { }
+        public static System.Security.Cryptography.CngProvider MicrosoftPlatformCryptoProvider { get { throw null; } }
         public static System.Security.Cryptography.CngProvider MicrosoftSmartCardKeyStorageProvider { get { throw null; } }
         public static System.Security.Cryptography.CngProvider MicrosoftSoftwareKeyStorageProvider { get { throw null; } }
         public string Provider { get { throw null; } }

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProvider.cs
@@ -86,6 +86,14 @@ namespace System.Security.Cryptography
         // Well known NCrypt KSPs
         //
 
+        public static CngProvider MicrosoftPlatformCryptoProvider
+        {
+            get
+            {
+                return s_msPlatformKsp ?? (s_msPlatformKsp = new CngProvider("Microsoft Platform Crypto Provider")); // MS_PLATFORM_CRYPTO_PROVIDER
+            }
+        }
+
         public static CngProvider MicrosoftSmartCardKeyStorageProvider
         {
             get
@@ -102,6 +110,7 @@ namespace System.Security.Cryptography
             }
         }
 
+        private static CngProvider? s_msPlatformKsp;
         private static CngProvider? s_msSmartCardKsp;
         private static CngProvider? s_msSoftwareKsp;
 

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProvider.cs
@@ -86,6 +86,10 @@ namespace System.Security.Cryptography
         // Well known NCrypt KSPs
         //
 
+        /// <summary>
+        /// Gets a <see cref="CngProvider" /> object that specifies the Microsoft Platform Crypto Storage Provider.
+        /// </summary>
+        /// <value>An object that specifies the Microsoft Platform Crypto Storage Provider.</value>
         public static CngProvider MicrosoftPlatformCryptoProvider
         {
             get


### PR DESCRIPTION
This PR adds MS_PLATFORM_CRYPTO_PROVIDER to CngProvider, resolves #42906

The Microsoft documentation page -- https://docs.microsoft.com/en-gb/windows/win32/api/ncrypt/nf-ncrypt-ncryptopenstorageprovider#parameters -- lists 3 built-in key storage providers, but only 2 were previously present on this class.  This PR adds the third.