### PR TITLE
Fix condition to align methods to 32 bytes boundary

### DIFF
--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -4771,10 +4771,11 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #endif
 
 #ifdef TARGET_XARCH
-    // For x64/x86, align Tier1 methods to 32 byte boundaries if
+    // For x64/x86, align methods that are "optimizations enabled" to 32 byte boundaries if
     // they are larger than 16 bytes and contain a loop.
     //
-    if (emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1) && (emitTotalHotCodeSize > 16) && emitComp->fgHasLoops)
+    if (emitComp->opts.OptimizationEnabled() && !emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) &&
+        (emitTotalHotCodeSize > 16) && emitComp->fgHasLoops)
     {
         allocMemFlag = CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN;
     }


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/2249, we started doing alignment of methods to 32-byte boundary for `Tier1`. However, a method having loops bypass tiering and hence this condition was never executed. Fixed it to make sure we do the alignment for optimized methods only and don't do it for prejitted methods.

