### PR TITLE
Add log for ILLinkSharedFramework target running in libraries build

### DIFF
--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -4,6 +4,8 @@
           AfterTargets="Build"
           DependsOnTargets="SetCommonILLinkArgs">
 
+    <Message Text="Trimming shared framework assemblies with ILLinker." Importance="high" />
+
     <PropertyGroup>
       <LibrariesTrimmedArtifactsPath>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'ILLinkTrimAssembly', '$(BuildSettings)', 'trimmed-runtimepack'))</LibrariesTrimmedArtifactsPath>
     </PropertyGroup>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -4,7 +4,7 @@
           AfterTargets="Build"
           DependsOnTargets="SetCommonILLinkArgs">
 
-    <Message Text="Trimming shared framework assemblies with ILLinker." Importance="high" />
+    <Message Text="Trimming shared framework assemblies with ILLinker..." Importance="high" />
 
     <PropertyGroup>
       <LibrariesTrimmedArtifactsPath>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'ILLinkTrimAssembly', '$(BuildSettings)', 'trimmed-runtimepack'))</LibrariesTrimmedArtifactsPath>


### PR DESCRIPTION
This is to aid figuring out what the issue is when new code that causes linker warnings is added. Currently folks would assume the errors come from running `ApiCompat`, like in https://github.com/dotnet/runtime/issues/42902.

A sample error log would go from this:

```
  System.Data -> D:\repos\dotnet_runtime\artifacts\bin\manual.System.Data\net5.0-Debug\System.Data.dll
  System.Xml -> D:\repos\dotnet_runtime\artifacts\bin\manual.System.Xml\net5.0-Debug\System.Xml.dll
  ApiCompat ->
D:\repos\dotnet_runtime\src\libraries\System.Text.Json\src\System\Text\Json\Serialization\Converters\Collection\IEnumerableConverterFactoryHelpers.cs(179,17): Trim analysis error IL2075: System.Text.Json.Serialization.IEnumerableConverterFactoryHelpers.GetImmutableDictionaryCreateRangeMethod(Type,Type,Type): The requirements declared via the 'DynamicallyAccessedMembersAttribute' on the return value of method 'System.Text.Json.Serialization.IEnumerableConverterFactoryHelpers.GetImmutableDictionaryConstructingType(Type)' don't match those on the implicit 'this' parameter of method 'System.Type.GetMethods()'. The source value must declare at least the same requirements as those declared on the target location it's assigned to [D:\repos\dotnet_runtime\src\libraries\src.proj]
D:\repos\dotnet_runtime\src\libraries\System.Text.Json\src\System\Text\Json\Serialization\Converters\Collection\IEnumerableConverterFactoryHelpers.cs(187,25): Trim analysis error IL2060: System.Text.Json.Serialization.IEnumerableConverterFactoryHelpers.GetImmutableDictionaryCreateRangeMethod(Type,Type,Type): Call to `System.Reflection.MethodInfo.MakeGenericMethod(Type[])` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method. [D:\repos\dotnet_runtime\src\libraries\src.proj]
  externals ->
  Microsoft.NETCore.Targets -> D:\repos\dotnet_runtime\artifacts\packages\Debug\Shipping\Microsoft.NETCore.Targets.6.0.0-dev.nupkg
  Microsoft.NETCore.Platforms -> D:\repos\dotnet_runtime\artifacts\packages\Debug\Shipping\Microsoft.NETCore.Platforms.6.0.0-dev.nupkg
  Microsoft.Extensions.Internal.Transport -> D:\repos\dotnet_runtime\artifacts\packages\Debug\NonShipping\Microsoft.Extensions.Internal.Transport.6.0.0-dev.nupkg
  runincontext -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\runincontext.dll
  R2RTest -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\R2RTest\R2RTest.dll
  ILCompiler.Reflection.ReadyToRun -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\ILCompiler.Reflection.ReadyToRun.dll
  R2RDump -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\R2RDump\R2RDump.dll
  dotnet-pgo -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\dotnet-pgo\dotnet-pgo.dll

Build FAILED.
```

to this:

```
  System.Data -> D:\repos\dotnet_runtime\artifacts\bin\manual.System.Data\net5.0-Debug\System.Data.dll
  System.Xml -> D:\repos\dotnet_runtime\artifacts\bin\manual.System.Xml\net5.0-Debug\System.Xml.dll
  ApiCompat ->
  Trimming shared framework assemblies with ILLinker...
D:\repos\dotnet_runtime\src\libraries\System.Text.Json\src\System\Text\Json\Serialization\Converters\Collection\IEnumerableConverterFactoryHelpers.cs(179,17): Trim analysis error IL2075: System.Text.Json.Serialization.IEnumerableConverterFactoryHelpers.GetImmutableDictionaryCreateRangeMethod(Type,Type,Type): The requirements declared via the 'DynamicallyAccessedMembersAttribute' on the return value of method 'System.Text.Json.Serialization.IEnumerableConverterFactoryHelpers.GetImmutableDictionaryConstructingType(Type)' don't match those on the implicit 'this' parameter of method 'System.Type.GetMethods()'. The source value must declare at least the same requirements as those declared on the target location it's assigned to [D:\repos\dotnet_runtime\src\libraries\src.proj]
D:\repos\dotnet_runtime\src\libraries\System.Text.Json\src\System\Text\Json\Serialization\Converters\Collection\IEnumerableConverterFactoryHelpers.cs(187,25): Trim analysis error IL2060: System.Text.Json.Serialization.IEnumerableConverterFactoryHelpers.GetImmutableDictionaryCreateRangeMethod(Type,Type,Type): Call to `System.Reflection.MethodInfo.MakeGenericMethod(Type[])` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method. [D:\repos\dotnet_runtime\src\libraries\src.proj]
  externals ->
  Microsoft.NETCore.Targets -> D:\repos\dotnet_runtime\artifacts\packages\Debug\Shipping\Microsoft.NETCore.Targets.6.0.0-dev.nupkg
  Microsoft.NETCore.Platforms -> D:\repos\dotnet_runtime\artifacts\packages\Debug\Shipping\Microsoft.NETCore.Platforms.6.0.0-dev.nupkg
  Microsoft.Extensions.Internal.Transport -> D:\repos\dotnet_runtime\artifacts\packages\Debug\NonShipping\Microsoft.Extensions.Internal.Transport.6.0.0-dev.nupkg
  runincontext -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\runincontext.dll
  R2RTest -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\R2RTest\R2RTest.dll
  ILCompiler.Reflection.ReadyToRun -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\ILCompiler.Reflection.ReadyToRun.dll
  R2RDump -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\R2RDump\R2RDump.dll
  dotnet-pgo -> D:\repos\dotnet_runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\dotnet-pgo\dotnet-pgo.dll

Build FAILED.
```