### PR TITLE
[mono] Fix HelloWorld sample for OSX

### DIFF
--- a/src/mono/netcore/sample/HelloWorld/Makefile
+++ b/src/mono/netcore/sample/HelloWorld/Makefile
@@ -5,7 +5,7 @@ DOTNET_Q_ARGS=--nologo -v:q -consoleloggerparameters:NoSummary
 MONO_CONFIG=Release
 MONO_ARCH=x64
 
-OS := $(shell uname -o)
+OS := $(shell uname -s)
 ifeq ($(OS),Darwin)
 	TARGET_OS=osx
 else


### PR DESCRIPTION
OSX `uname` doesn't have a `-o`