### PR TITLE
Fix nullable annotation on ISite.Container

### DIFF
--- a/src/libraries/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
+++ b/src/libraries/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
@@ -231,7 +231,7 @@ namespace System.ComponentModel
     public partial interface ISite : System.IServiceProvider
     {
         System.ComponentModel.IComponent Component { get; }
-        System.ComponentModel.IContainer Container { get; }
+        System.ComponentModel.IContainer? Container { get; }
         bool DesignMode { get; }
         string? Name { get; set; }
     }

--- a/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/ISite.cs
+++ b/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/ISite.cs
@@ -26,7 +26,7 @@ namespace System.ComponentModel
         /// When implemented by a class, gets the container associated with
         /// the <see cref='System.ComponentModel.ISite'/>.
         /// </summary>
-        IContainer Container { get; }
+        IContainer? Container { get; }
 
         /// <summary>
         /// When implemented by a class, determines whether the component is in design mode.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/42742

@buyaa-n, I only annotated Container as I'm not convinced Component should be nullable as well.  I suggest we wait to see if there's any feedback on it.  There's very few implementations / call sites to it / docs about it to go by.