### PR TITLE
[metadata] Getting the element size of array of fnptr types is ok

### DIFF
--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -4513,6 +4513,7 @@ handle_enum:
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
 	case MONO_TYPE_PTR:
+	case MONO_TYPE_FNPTR:
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_STRING:
 	case MONO_TYPE_OBJECT:


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/42917