### PR TITLE
Disable GCExtendedTests.GetTotalAllocatedBytes

### DIFF
--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -870,6 +870,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/42883", TestRuntimes.Mono)]
         public static void GetTotalAllocatedBytes()
         {
             byte[] stash;


### PR DESCRIPTION
This test is failing intermittently on Mono; disabling until investigated and resolved. 

Issue: https://github.com/dotnet/runtime/issues/42883