### PR TITLE
Update DataContractSerialization ILLink.Suppressions.xml

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Private.DataContractSerialization/src/ILLink/ILLink.Suppressions.xml
@@ -239,6 +239,12 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.ClassDataContract.IsNonAttributedTypeValidForSerialization(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:System.Runtime.Serialization.CodeGenerator.BeginMethod(System.String,System.Type,System.Boolean)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -257,13 +263,7 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Runtime.Serialization.Globals.GetConstructor(System.Type,System.Reflection.BindingFlags,System.Type[])</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Runtime.Serialization.Globals.GetMethod(System.Type,System.String,System.Reflection.BindingFlags,System.Type[])</property>
+      <property name="Target">M:System.Runtime.Serialization.DataContract.ImportKnownTypeAttributes(System.Type,System.Collections.Generic.Dictionary{System.Type,System.Type},System.Collections.Generic.Dictionary{System.Xml.XmlQualifiedName,System.Runtime.Serialization.DataContract}@)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -311,13 +311,19 @@
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.ClassDataContract.ClassDataContractCriticalHelper.GetNonAttributedTypeConstructor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:System.Runtime.Serialization.ClassDataContract.ClassDataContractCriticalHelper.ImportDataMembers</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Runtime.Serialization.CodeGenerator.get_ObjectEquals</property>
+      <property name="Target">M:System.Runtime.Serialization.CollectionDataContract.CollectionDataContractCriticalHelper.GetCollectionElementType</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -341,6 +347,12 @@
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.DataContract.DataContractCriticalHelper.get_ParseMethod</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:System.Runtime.Serialization.EnumDataContract.EnumDataContractCriticalHelper.ImportDataMembers</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -348,6 +360,12 @@
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Runtime.Serialization.Json.JsonFormatReaderGenerator.CriticalHelper.CreateObject(System.Runtime.Serialization.ClassDataContract)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.Json.JsonFormatReaderGenerator.CriticalHelper.ReadCollection(System.Runtime.Serialization.CollectionDataContract)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -383,7 +401,25 @@
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.XmlDataContract.GenerateCreateXmlSerializableDelegate</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.XmlDataContract.GetConstructor</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:System.Runtime.Serialization.XmlFormatGeneratorStatics.get_GetArrayLengthMethod</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.XmlFormatGeneratorStatics.get_HashtableCtor</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -395,7 +431,19 @@
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.XmlFormatReaderGenerator.CriticalHelper.ReadCollection(System.Runtime.Serialization.CollectionDataContract)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:System.Runtime.Serialization.XmlFormatReaderGenerator.CriticalHelper.WrapNullableObject(System.Reflection.Emit.LocalBuilder,System.Reflection.Emit.LocalBuilder,System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Runtime.Serialization.XmlFormatWriterGenerator.CriticalHelper.WriteCollection(System.Runtime.Serialization.CollectionDataContract)</property>
     </attribute>
   </assembly>
 </linker>


### PR DESCRIPTION
Changes #40691 and #42824 conflicted. One added a new ILLink suppress warnings file, while the other added more warnings. This causes the build to break.

The fix is to regenerate the suppressions file with the latest code.

Fix #42926