### PR TITLE
Remove pr: none clause from several CoreCLR pipelines

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -24,9 +24,6 @@ trigger:
     - eng/pipelines/libraries/*
     - eng/pipelines/runtime.yml
 
-
-pr: none
-
 jobs:
 #
 # Checkout repository

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -25,6 +25,7 @@ trigger:
     - eng/pipelines/runtime.yml
 
 jobs:
+
 #
 # Checkout repository
 #

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 6 * * *"
   displayName: Mon through Sun at 10:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 6 * * 0,1"
   displayName: Sat and Sun at 10:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 7 * * 0,2,4"
   displayName: Sun, Tue, Thu at 11:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 6 * * *"
   displayName: Mon through Sun at 10:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/ilasm.yml
+++ b/eng/pipelines/coreclr/ilasm.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 19 * * 6"
   displayName: Sat at 11:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/jit-experimental.yml
+++ b/eng/pipelines/coreclr/jit-experimental.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 22 * * 0,6"
   displayName: Sun at 2:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/r2r-extra.yml
+++ b/eng/pipelines/coreclr/r2r-extra.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 2 * * 0,1"
   displayName: Sat and Sun at 6:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 5 * * *"
   displayName: Mon through Sun at 9:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/runincontext.yml
+++ b/eng/pipelines/coreclr/runincontext.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 13 * * 6,0"
   displayName: Sat and Sun at 5:00 AM (UTC-8:00)


### PR DESCRIPTION
I have updated the AzDO UI properties per Viktor's advice to enable these runs for <code>/asp run</code> runs. After verifying they work as expected we can expand the pipeline set. For now I have skipped the various stress runs that would be the most detrimental if they unexpectedly started to run as part of PR's as an unforeseen effect of the changes.

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 