### PR TITLE
[release/5.0] Extract bundled files when IncludeAllContentForSelfExtract is set

### DIFF
--- a/src/coreclr/src/binder/assemblybinder.cpp
+++ b/src/coreclr/src/binder/assemblybinder.cpp
@@ -22,6 +22,7 @@
 #include "utils.hpp"
 #include "variables.hpp"
 #include "stringarraylist.h"
+#include "configuration.h"
 
 #define APP_DOMAIN_LOCKED_UNLOCKED        0x02
 #define APP_DOMAIN_LOCKED_CONTEXT         0x04
@@ -401,13 +402,58 @@ namespace BINDER_SPACE
         sCoreLib.Set(systemDirectory);
         CombinePath(sCoreLib, sCoreLibName, sCoreLib);
 
-        IF_FAIL_GO(AssemblyBinder::GetAssembly(sCoreLib,
-                                               TRUE /* fIsInGAC */,
-                                               fBindToNativeImage,
-                                               &pSystemAssembly,
-                                               NULL /* szMDAssemblyPath */,
-                                               bundleFileLocation));
+        hr = AssemblyBinder::GetAssembly(sCoreLib,
+                                         TRUE /* fIsInGAC */,
+                                         fBindToNativeImage,
+                                         &pSystemAssembly,
+                                         NULL /* szMDAssemblyPath */,
+                                         bundleFileLocation);
         BinderTracing::PathProbed(sCoreLib, pathSource, hr);
+
+        if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+        {
+            // Try to find corelib in the TPA
+            StackSString sCoreLibSimpleName(CoreLibName_W);
+            StackSString sTrustedPlatformAssemblies = Configuration::GetKnobStringValue(W("TRUSTED_PLATFORM_ASSEMBLIES"));
+            sTrustedPlatformAssemblies.Normalize();
+
+            bool found = false;
+            for (SString::Iterator i = sTrustedPlatformAssemblies.Begin(); i != sTrustedPlatformAssemblies.End(); )
+            {
+                SString fileName;
+                SString simpleName;
+                bool isNativeImage = false;
+                HRESULT pathResult = S_OK;
+                IF_FAIL_GO(pathResult = GetNextTPAPath(sTrustedPlatformAssemblies, i, /*dllOnly*/ true, fileName, simpleName, isNativeImage));
+                if (pathResult == S_FALSE)
+                {
+                    break;
+                }
+
+                if (simpleName.EqualsCaseInsensitive(sCoreLibSimpleName))
+                {
+                    sCoreLib = fileName;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                GO_WITH_HRESULT(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+            }
+
+            hr = AssemblyBinder::GetAssembly(sCoreLib,
+                TRUE /* fIsInGAC */,
+                fBindToNativeImage,
+                &pSystemAssembly,
+                NULL /* szMDAssemblyPath */,
+                bundleFileLocation);
+
+            BinderTracing::PathProbed(sCoreLib, BinderTracing::PathSource::ApplicationAssemblies, hr);
+        }
+
+        IF_FAIL_GO(hr);
 
         *ppSystemAssembly = pSystemAssembly.Extract();
 

--- a/src/coreclr/src/binder/inc/utils.hpp
+++ b/src/coreclr/src/binder/inc/utils.hpp
@@ -39,6 +39,9 @@ namespace BINDER_SPACE
                                   SBuffer &publicKeyTokenBLOB);
 
     BOOL IsFileNotFound(HRESULT hr);
+
+    HRESULT GetNextPath(SString& paths, SString::Iterator& startPos, SString& outPath);
+    HRESULT GetNextTPAPath(SString& paths, SString::Iterator& startPos, bool dllOnly, SString& outPath, SString& simpleName, bool& isNativeImage);
 };
 
 #endif

--- a/src/installer/corehost/cli/bundle/file_entry.cpp
+++ b/src/installer/corehost/cli/bundle/file_entry.cpp
@@ -14,11 +14,11 @@ bool file_entry_t::is_valid() const
         static_cast<file_type_t>(m_type) < file_type_t::__last;
 }
 
-file_entry_t file_entry_t::read(reader_t &reader)
+file_entry_t file_entry_t::read(reader_t &reader, bool force_extraction)
 {
     // First read the fixed-sized portion of file-entry
     const file_entry_fixed_t* fixed_data = reinterpret_cast<const file_entry_fixed_t*>(reader.read_direct(sizeof(file_entry_fixed_t)));
-    file_entry_t entry(fixed_data);
+    file_entry_t entry(fixed_data, force_extraction);
 
     if (!entry.is_valid())
     {
@@ -35,6 +35,9 @@ file_entry_t file_entry_t::read(reader_t &reader)
 
 bool file_entry_t::needs_extraction() const
 {
+    if (m_force_extraction)
+        return true;
+
     switch (m_type)
     {
     case file_type_t::deps_json:

--- a/src/installer/corehost/cli/bundle/file_entry.h
+++ b/src/installer/corehost/cli/bundle/file_entry.h
@@ -10,13 +10,13 @@
 namespace bundle
 {
     // FileEntry: Records information about embedded files.
-    // 
-    // The bundle manifest records the following meta-data for each 
+    //
+    // The bundle manifest records the following meta-data for each
     // file embedded in the bundle:
     // Fixed size portion (file_entry_fixed_t)
-    //   - Offset     
-    //   - Size       
-    //   - File Entry Type       
+    //   - Offset
+    //   - Size
+    //   - File Entry Type
     // Variable Size portion
     //   - relative path (7-bit extension encoded length prefixed string)
 
@@ -37,15 +37,19 @@ namespace bundle
             , m_size(0)
             , m_type(file_type_t::__last)
             , m_relative_path()
+            , m_force_extraction(false)
         {
         }
 
-        file_entry_t(const file_entry_fixed_t *fixed_data)
-            :m_relative_path()
+        file_entry_t(
+            const file_entry_fixed_t *fixed_data,
+            const bool force_extraction = false)
+            : m_relative_path()
+            , m_force_extraction(force_extraction)
         {
-            // File_entries in the bundle-manifest are expected to be used 
+            // File_entries in the bundle-manifest are expected to be used
             // beyond startup (for loading files directly from bundle, lazy extraction, etc.).
-            // The contents of fixed_data are copied on to file_entry in order to 
+            // The contents of fixed_data are copied on to file_entry in order to
             // avoid memory mapped IO later.
 
             m_offset = fixed_data->offset;
@@ -59,13 +63,14 @@ namespace bundle
         file_type_t type() const { return m_type; }
         bool needs_extraction() const;
 
-        static file_entry_t read(reader_t &reader);
+        static file_entry_t read(reader_t &reader, bool force_extraction);
 
     private:
         int64_t m_offset;
         int64_t m_size;
         file_type_t m_type;
         pal::string_t m_relative_path; // Path of an embedded file, relative to the extraction directory.
+        bool m_force_extraction;
         bool is_valid() const;
     };
 }

--- a/src/installer/corehost/cli/bundle/manifest.cpp
+++ b/src/installer/corehost/cli/bundle/manifest.cpp
@@ -5,15 +5,15 @@
 
 using namespace bundle;
 
-manifest_t manifest_t::read(reader_t& reader, int32_t num_files)
+manifest_t manifest_t::read(reader_t& reader, const header_t& header)
 {
     manifest_t manifest;
 
-    for (int32_t i = 0; i < num_files; i++)
+    for (int32_t i = 0; i < header.num_embedded_files(); i++)
     {
-        file_entry_t entry = file_entry_t::read(reader);
+        file_entry_t entry = file_entry_t::read(reader, header.is_netcoreapp3_compat_mode());
         manifest.files.push_back(std::move(entry));
-        manifest.m_need_extraction |= entry.needs_extraction();
+        manifest.m_files_need_extraction |= entry.needs_extraction();
     }
 
     return manifest;

--- a/src/installer/corehost/cli/bundle/manifest.h
+++ b/src/installer/corehost/cli/bundle/manifest.h
@@ -6,6 +6,7 @@
 
 #include <list>
 #include "file_entry.h"
+#include "header.h"
 
 namespace bundle
 {
@@ -16,16 +17,21 @@ namespace bundle
     {
     public:
         manifest_t()
-            : m_need_extraction(false) {}
+            : m_files_need_extraction(false)
+        {
+        }
 
         std::vector<file_entry_t> files;
 
-        static manifest_t read(reader_t &reader, int32_t num_files);
+        static manifest_t read(reader_t &reader, const header_t &header);
 
-        bool files_need_extraction() { return m_need_extraction; }
+        bool files_need_extraction() const
+        {
+            return m_files_need_extraction;
+        }
 
     private:
-        bool m_need_extraction;
+        bool m_files_need_extraction;
     };
 }
 #endif // __MANIFEST_H__

--- a/src/installer/corehost/cli/bundle/runner.cpp
+++ b/src/installer/corehost/cli/bundle/runner.cpp
@@ -28,7 +28,7 @@ StatusCode runner_t::extract()
         m_runtimeconfig_json.set_location(&m_header.runtimeconfig_json_location());
 
         // Read the bundle manifest
-        m_manifest = manifest_t::read(reader, m_header.num_embedded_files());
+        m_manifest = manifest_t::read(reader, m_header);
 
         // Extract the files if necessary
         if (m_manifest.files_need_extraction())
@@ -64,7 +64,8 @@ bool runner_t::probe(const pal::string_t& relative_path, int64_t* offset, int64_
 {
     const bundle::file_entry_t* entry = probe(relative_path);
 
-    if (entry == nullptr)
+    // Do not report extracted entries - those should be reported through either TPA or resource paths
+    if (entry == nullptr || entry->needs_extraction())
     {
         return false;
     }

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -877,6 +877,19 @@ bool deps_resolver_t::resolve_probe_dirs(
         }
     }
 
+    // If this is a single-file app, add the app's dir to the native search directories.
+    if (bundle::info_t::is_single_file_bundle() && !is_resources)
+    {
+        auto bundle = bundle::runner_t::app();
+        add_unique_path(asset_type, bundle->base_path(), &items, output, &non_serviced, core_servicing);
+
+        // Add the extraction path if it exists.
+        if (pal::directory_exists(bundle->extraction_path()))
+        {
+            add_unique_path(asset_type, bundle->extraction_path(), &items, output, &non_serviced, core_servicing);
+        }
+    }
+
     output->append(non_serviced);
 
     return true;

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -736,7 +736,8 @@ void deps_resolver_t::get_app_context_deps_files_range(fx_definition_vector_t::i
     auto begin_iter = m_fx_definitions.begin();
     auto end_iter = m_fx_definitions.end();
 
-    if ((m_host_mode == host_mode_t::libhost || bundle::info_t::is_single_file_bundle())
+    if ((m_host_mode == host_mode_t::libhost
+        || (bundle::info_t::is_single_file_bundle() && !bundle::runner_t::app()->is_netcoreapp3_compat_mode()))
         && begin_iter != end_iter)
     {
         // Neither in a libhost scenario nor in a bundled app

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.h
@@ -172,13 +172,15 @@ public:
         return m_is_framework_dependent;
     }
 
-    const pal::string_t &get_app_dir() const
+    void get_app_dir(pal::string_t *app_dir) const
     {
         if (m_host_mode == host_mode_t::libhost)
         {
             static const pal::string_t s_empty;
-            return s_empty;
+            *app_dir = s_empty;
+            return;
         }
+        *app_dir = m_app_dir;
         if (m_host_mode == host_mode_t::apphost)
         {
             if (bundle::info_t::is_single_file_bundle())
@@ -186,12 +188,18 @@ public:
                 const bundle::runner_t* app = bundle::runner_t::app();
                 if (app->is_netcoreapp3_compat_mode())
                 {
-                    return app->extraction_path();
+                    *app_dir = app->extraction_path();
                 }
             }
         }
 
-        return m_app_dir;
+        // Make sure the path ends with a directory separator
+        // This has been the behavior for a long time, and we should make it consistent
+        // for all cases.
+        if (app_dir->back() != DIR_SEPARATOR)
+        {
+            app_dir->append(1, DIR_SEPARATOR);
+        }
     }
 
 private:

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -369,10 +369,20 @@ int corehost_main_init(
 
     if (bundle::info_t::is_single_file_bundle())
     {
-        StatusCode status = bundle::runner_t::process_manifest_and_extract();
+        const bundle::runner_t* bundle = bundle::runner_t::app();
+        StatusCode status = bundle->process_manifest_and_extract();
         if (status != StatusCode::Success)
         {
             return status;
+        }
+
+        if (bundle->is_netcoreapp3_compat_mode())
+        {
+            auto extracted_assembly = bundle->extraction_path();
+            auto app_name = hostpolicy_init.host_info.get_app_name() + _X(".dll");
+            append_path(&extracted_assembly, app_name.c_str());
+            assert(pal::file_exists(extracted_assembly));
+            hostpolicy_init.host_info.app_path = extracted_assembly;
         }
     }
 

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -161,12 +161,26 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         if (fx_curr != fx_begin)
             app_context_deps_str += _X(';');
 
-        app_context_deps_str += (*fx_curr)->get_deps_file();
+        // For the application's .deps.json if this is single file, 3.1 backward compat
+        // then the path used internally is the bundle path, but externally we need to report
+        // the path to the extraction folder.
+        if (fx_curr == fx_begin && bundle::info_t::is_single_file_bundle() && bundle::runner_t::app()->is_netcoreapp3_compat_mode())
+        {
+            pal::string_t deps_path = bundle::runner_t::app()->extraction_path();
+            append_path(&deps_path, get_filename((*fx_curr)->get_deps_file()).c_str());
+            app_context_deps_str += deps_path;
+        }
+        else
+        {
+            app_context_deps_str += (*fx_curr)->get_deps_file();
+        }
+
         ++fx_curr;
     }
 
     // Build properties for CoreCLR instantiation
-    pal::string_t app_base = resolver.get_app_dir();
+    pal::string_t app_base;
+    resolver.get_app_dir(&app_base);
     coreclr_properties.add(common_property::TrustedPlatformAssemblies, probe_paths.tpa.c_str());
     coreclr_properties.add(common_property::NativeDllSearchDirectories, probe_paths.native.c_str());
     coreclr_properties.add(common_property::PlatformResourceRoots, probe_paths.resources.c_str());

--- a/src/installer/tests/Assets/TestProjects/AppWithSubDirs/AppWithSubDirs.csproj
+++ b/src/installer/tests/Assets/TestProjects/AppWithSubDirs/AppWithSubDirs.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
     <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+    <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
   </PropertyGroup>
 
   <Target Name="CopyFiles" AfterTargets="Publish">

--- a/src/installer/tests/Assets/TestProjects/AppWithSubDirs/Directory.Build.props
+++ b/src/installer/tests/Assets/TestProjects/AppWithSubDirs/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseMicrosoftNETCoreAppInternalWorkaround>false</UseMicrosoftNETCoreAppInternalWorkaround>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+</Project>

--- a/src/installer/tests/Assets/TestProjects/AppWithWait/Directory.Build.props
+++ b/src/installer/tests/Assets/TestProjects/AppWithWait/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseMicrosoftNETCoreAppInternalWorkaround>false</UseMicrosoftNETCoreAppInternalWorkaround>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+</Project>

--- a/src/installer/tests/Assets/TestProjects/Directory.Build.targets
+++ b/src/installer/tests/Assets/TestProjects/Directory.Build.targets
@@ -8,7 +8,10 @@
   <Target Name="RemoveUpstackKnownFrameworkReferences"
           BeforeTargets="ProcessFrameworkReferences">
     <ItemGroup>
-      <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
+    <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
+    <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />
+    <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WPF" />
+    <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />
     </ItemGroup>
   </Target>
 

--- a/src/installer/tests/Assets/TestProjects/SingleFileApiTests/Directory.Build.props
+++ b/src/installer/tests/Assets/TestProjects/SingleFileApiTests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseMicrosoftNETCoreAppInternalWorkaround>false</UseMicrosoftNETCoreAppInternalWorkaround>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+</Project>

--- a/src/installer/tests/Assets/TestProjects/SingleFileApiTests/Program.cs
+++ b/src/installer/tests/Assets/TestProjects/SingleFileApiTests/Program.cs
@@ -71,6 +71,11 @@ namespace SingleFileApiTests
                         Console.WriteLine("AppContext.BaseDirectory: " + AppContext.BaseDirectory);
                         break;
 
+                    case "native_search_dirs":
+                        var native_search_dirs = AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES");
+                        Console.WriteLine("NATIVE_DLL_SEARCH_DIRECTORIES: " + native_search_dirs);
+                        break;
+
                     default:
                         Console.WriteLine("test failure");
                         return -1;

--- a/src/installer/tests/Assets/TestProjects/SingleFileApiTests/SingleFileApiTests.csproj
+++ b/src/installer/tests/Assets/TestProjects/SingleFileApiTests/SingleFileApiTests.csproj
@@ -7,4 +7,10 @@
     <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Condition="'$(AddFile)' != ''" Include="$(AddFile)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class BundleExtractToSpecificPath : IClassFixture<BundleExtractToSpecificPath.SharedTestState>
+    public class BundleExtractToSpecificPath : BundleTestBase, IClassFixture<BundleExtractToSpecificPath.SharedTestState>
     {
         private SharedTestState sharedTestState;
 
@@ -28,8 +28,8 @@ namespace AppHost.Bundle.Tests
             var hostName = BundleHelper.GetHostName(fixture);
 
             // Publish the bundle
-            string singleFile;
-            Bundler bundler = BundleHelper.BundleApp(fixture, out singleFile, options: BundleOptions.BundleNativeBinaries);
+            UseSingleFileSelfContainedHost(fixture);
+            Bundler bundler = BundleHelper.BundleApp(fixture, out string singleFile, options: BundleOptions.BundleNativeBinaries);
 
             // Verify expected files in the bundle directory
             var bundleDir = BundleHelper.GetBundleDir(fixture);
@@ -65,7 +65,7 @@ namespace AppHost.Bundle.Tests
         private void Bundle_Extraction_To_Relative_Path_Succeeds (string relativePath)
         {
             var fixture = sharedTestState.TestFixture.Copy();
-            var singleFile = BundleHelper.BundleApp(fixture, BundleOptions.None);
+            var singleFile = BundleSelfContainedApp(fixture, BundleOptions.None);
 
             // Run the bundled app (extract files to <path>)
             Command.Create(singleFile)
@@ -85,8 +85,8 @@ namespace AppHost.Bundle.Tests
             var fixture = sharedTestState.TestFixture.Copy();
 
             // Publish the bundle
-            string singleFile;
-            Bundler bundler = BundleHelper.BundleApp(fixture, out singleFile, BundleOptions.BundleNativeBinaries);
+            UseSingleFileSelfContainedHost(fixture);
+            Bundler bundler = BundleHelper.BundleApp(fixture, out string singleFile, BundleOptions.BundleNativeBinaries);
 
             // Create a directory for extraction.
             var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
@@ -103,7 +103,6 @@ namespace AppHost.Bundle.Tests
                 .And
                 .HaveStdOutContaining("Hello World");
 
-            var appBaseName = BundleHelper.GetAppBaseName(fixture);
             var extractDir = BundleHelper.GetExtractionDir(fixture, bundler);
 
             extractDir.Refresh();
@@ -136,8 +135,8 @@ namespace AppHost.Bundle.Tests
             var appName = Path.GetFileNameWithoutExtension(hostName);
 
             // Publish the bundle
-            string singleFile;
-            Bundler bundler = BundleHelper.BundleApp(fixture, out singleFile, BundleOptions.BundleNativeBinaries);
+            UseSingleFileSelfContainedHost(fixture);
+            Bundler bundler = BundleHelper.BundleApp(fixture, out string singleFile, BundleOptions.BundleNativeBinaries);
 
             // Create a directory for extraction.
             var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
@@ -178,19 +177,13 @@ namespace AppHost.Bundle.Tests
             extractDir.Should().HaveFiles(extractedFiles);
         }
 
-        public class SharedTestState : IDisposable
+        public class SharedTestState : SharedTestStateBase, IDisposable
         {
             public TestProjectFixture TestFixture { get; set; }
-            public RepoDirectoriesProvider RepoDirectories { get; set; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-                TestFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
-                TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                    .PublishProject(runtime: TestFixture.CurrentRid, 
-                                    outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+                TestFixture = PreparePublishedSelfContainedTestProject("StandaloneApp");
             }
 
             public void Dispose()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleLocalizedApp.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleLocalizedApp.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class BundleLocalizedApp : IClassFixture<BundleLocalizedApp.SharedTestState>
+    public class BundleLocalizedApp : BundleTestBase, IClassFixture<BundleLocalizedApp.SharedTestState>
     {
         private SharedTestState sharedTestState;
 
@@ -24,7 +24,7 @@ namespace AppHost.Bundle.Tests
         public void Bundled_Localized_App_Run_Succeeds()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-            var singleFile = BundleHelper.BundleApp(fixture);
+            var singleFile = BundleSelfContainedApp(fixture);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -42,20 +42,13 @@ namespace AppHost.Bundle.Tests
                 .HaveStdOutContaining("ನಮಸ್ಕಾರ! வணக்கம்! Hello!");
         }
 
-        public class SharedTestState : IDisposable
+        public class SharedTestState : SharedTestStateBase, IDisposable
         {
             public TestProjectFixture TestFixture { get; set; }
-            public RepoDirectoriesProvider RepoDirectories { get; set; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-
-                TestFixture = new TestProjectFixture("LocalizedApp", RepoDirectories);
-                TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                    .PublishProject(runtime: TestFixture.CurrentRid,
-                                    outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+                TestFixture = PreparePublishedSelfContainedTestProject("LocalizedApp");
             }
 
             public void Dispose()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleProbe.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleProbe.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
-using Xunit;
+using BundleTests.Helpers;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
-using BundleTests.Helpers;
-using System.Threading;
+using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class BundleProbe : IClassFixture<BundleProbe.SharedTestState>
+    public class BundleProbe : BundleTestBase, IClassFixture<BundleProbe.SharedTestState>
     {
         private SharedTestState sharedTestState;
 
@@ -40,7 +38,7 @@ namespace AppHost.Bundle.Tests
         private void Bundle_Probe_Passed_For_Single_File_App()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-            string singleFile = BundleHelper.BundleApp(fixture);
+            string singleFile = BundleSelfContainedApp(fixture);
 
             Command.Create(singleFile, "SingleFile")
                 .CaptureStdErr()
@@ -52,19 +50,13 @@ namespace AppHost.Bundle.Tests
                 .HaveStdOutContaining("BUNDLE_PROBE OK");
         }
 
-        public class SharedTestState : IDisposable
+        public class SharedTestState : SharedTestStateBase, IDisposable
         {
             public TestProjectFixture TestFixture { get; set; }
-            public RepoDirectoriesProvider RepoDirectories { get; set; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-                TestFixture = new TestProjectFixture("BundleProbeTester", RepoDirectories);
-                TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                    .PublishProject(runtime: TestFixture.CurrentRid,
-                                    outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+                TestFixture = PreparePublishedSelfContainedTestProject("BundleProbeTester");
             }
 
             public void Dispose()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
@@ -59,13 +59,14 @@ namespace AppHost.Bundle.Tests
                 RepoDirectories = new RepoDirectoriesProvider();
             }
 
-            public TestProjectFixture PreparePublishedSelfContainedTestProject(string projectName)
+            public TestProjectFixture PreparePublishedSelfContainedTestProject(string projectName, params string[] extraArgs)
             {
                 var testFixture = new TestProjectFixture(projectName, RepoDirectories);
                 testFixture
                     .EnsureRestoredForRid(testFixture.CurrentRid, RepoDirectories.CorehostPackages)
                     .PublishProject(runtime: testFixture.CurrentRid,
-                                    outputDirectory: BundleHelper.GetPublishPath(testFixture));
+                                    outputDirectory: BundleHelper.GetPublishPath(testFixture),
+                                    extraArgs: extraArgs);
 
                 return testFixture;
             }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.IO;
+using BundleTests.Helpers;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.NET.HostModel.AppHost;
+using Microsoft.NET.HostModel.Bundle;
+
+namespace AppHost.Bundle.Tests
+{
+    public abstract class BundleTestBase
+    {
+        // This helper is used in lieu of SDK support for publishing apps using the singlefilehost.
+        // It replaces the apphost with singlefilehost, and along with appropriate app.dll updates in the host.
+        // For now, we leave behind the hostpolicy and hostfxr DLLs in the publish directory, because
+        // removing them requires deps.json update.
+        public static string UseSingleFileSelfContainedHost(TestProjectFixture testFixture)
+        {
+            var singleFileHost = Path.Combine(
+                testFixture.RepoDirProvider.HostArtifacts,
+                RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("singlefilehost"));
+            var publishedHostPath = BundleHelper.GetHostPath(testFixture);
+            HostWriter.CreateAppHost(singleFileHost,
+                                     publishedHostPath,
+                                     BundleHelper.GetAppPath(testFixture));
+            return publishedHostPath;
+        }
+
+        public static string UseFrameworkDependentHost(TestProjectFixture testFixture)
+        {
+            var appHost = Path.Combine(
+                testFixture.RepoDirProvider.HostArtifacts,
+                RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("apphost"));
+            var publishedHostPath = BundleHelper.GetHostPath(testFixture);
+            HostWriter.CreateAppHost(appHost,
+                                     publishedHostPath,
+                                     BundleHelper.GetAppPath(testFixture));
+            return publishedHostPath;
+        }
+
+        public static string BundleSelfContainedApp(
+            TestProjectFixture testFixture,
+            BundleOptions options = BundleOptions.None,
+            Version targetFrameworkVersion = null)
+        {
+            UseSingleFileSelfContainedHost(testFixture);
+            return BundleHelper.BundleApp(testFixture, options, targetFrameworkVersion);
+        }
+
+        public abstract class SharedTestStateBase
+        {
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+
+            public SharedTestStateBase()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+            }
+
+            public TestProjectFixture PreparePublishedSelfContainedTestProject(string projectName)
+            {
+                var testFixture = new TestProjectFixture(projectName, RepoDirectories);
+                testFixture
+                    .EnsureRestoredForRid(testFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .PublishProject(runtime: testFixture.CurrentRid,
+                                    outputDirectory: BundleHelper.GetPublishPath(testFixture));
+
+                return testFixture;
+            }
+        }
+    }
+}

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.IO;
+using System.Linq;
+using BundleTests.Helpers;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.NET.HostModel.Bundle;
+using Xunit;
+
+namespace AppHost.Bundle.Tests
+{
+    public class NetCoreApp3CompatModeTests : BundleTestBase, IClassFixture<NetCoreApp3CompatModeTests.SharedTestState>
+    {
+        private SharedTestState sharedTestState;
+
+        public NetCoreApp3CompatModeTests(SharedTestState fixture)
+        {
+            sharedTestState = fixture;
+        }
+
+        [Fact]
+        public void Bundle_Is_Extracted()
+        {
+            var fixture = sharedTestState.SingleFileTestFixture.Copy();
+            UseSingleFileSelfContainedHost(fixture);
+            Bundler bundler = BundleHelper.BundleApp(fixture, out string singleFile, BundleOptions.BundleAllContent);
+            var extractionBaseDir = BundleHelper.GetExtractionRootDir(fixture);
+
+            Command.Create(singleFile, "executing_assembly_location trusted_platform_assemblies assembly_location System.Console")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractionBaseDir.FullName)
+                .Execute()
+                .Should()
+                .Pass()
+                // Validate that the main assembly is running from disk (and not from bundle)
+                .And.HaveStdOutContaining("ExecutingAssembly.Location: " + extractionBaseDir.FullName)
+                // Validate that TPA contains at least one framework assembly from the extraction directory
+                .And.HaveStdOutContaining("System.Runtime.dll")
+                // Validate that framework assembly is actually loaded from the extraction directory
+                .And.HaveStdOutContaining("System.Console location: " + extractionBaseDir.FullName);
+
+            var extractionDir = BundleHelper.GetExtractionDir(fixture, bundler);
+            var bundleFiles = BundleHelper.GetBundleDir(fixture).GetFiles().Select(file => file.Name).ToArray();
+            var publishedFiles = Directory.GetFiles(BundleHelper.GetPublishPath(fixture), searchPattern: "*", searchOption: SearchOption.AllDirectories)
+                .Select(file => Path.GetFileName(file))
+                .Except(bundleFiles)
+                .ToArray();
+            extractionDir.Should().HaveFiles(publishedFiles);
+        }
+
+        public class SharedTestState : SharedTestStateBase, IDisposable
+        {
+            public TestProjectFixture SingleFileTestFixture { get; set; }
+
+            public SharedTestState()
+            {
+                SingleFileTestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests");
+            }
+
+            public void Dispose()
+            {
+                SingleFileTestFixture.Dispose();
+            }
+        }
+    }
+}

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -1,12 +1,14 @@
 ﻿using System;
+using System.IO;
 using BundleTests.Helpers;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.NET.HostModel.Bundle;
 using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class SingleFileApiTests : IClassFixture<SingleFileApiTests.SharedTestState>
+    public class SingleFileApiTests : BundleTestBase, IClassFixture<SingleFileApiTests.SharedTestState>
     {
         private SharedTestState sharedTestState;
 
@@ -16,77 +18,56 @@ namespace AppHost.Bundle.Tests
         }
 
         [Fact]
-        public void FullyQualifiedName()
+        public void SelfContained_SingleFile_APITests()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-            var singleFile = BundleHelper.BundleApp(fixture);
+            var singleFile = BundleSelfContainedApp(fixture);
 
-            Command.Create(singleFile, "fullyqualifiedname")
+            Command.Create(singleFile, "fullyqualifiedname codebase appcontext cmdlineargs executing_assembly_location basedirectory")
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
                 .Should()
                 .Pass()
-                .And
-                .HaveStdOutContaining("FullyQualifiedName: <Unknown>" +
-                    Environment.NewLine +
-                    "Name: <Unknown>");
+                .And.HaveStdOutContaining("FullyQualifiedName: <Unknown>")
+                .And.HaveStdOutContaining("Name: <Unknown>")
+                .And.HaveStdOutContaining("CodeBase NotSupported")
+                .And.NotHaveStdOutContaining("SingleFileApiTests.deps.json")
+                .And.NotHaveStdOutContaining("Microsoft.NETCore.App.deps.json")
+                // For single-file, Environment.GetCommandLineArgs[0] should return the file path of the host.
+                .And.HaveStdOutContaining("Command line args: " + singleFile)
+                .And.HaveStdOutContaining("ExecutingAssembly.Location: " + Environment.NewLine)
+                .And.HaveStdOutContaining("AppContext.BaseDirectory: " + Path.GetDirectoryName(singleFile));
         }
 
         [Fact]
-        public void CodeBaseThrows()
+        public void SelfContained_NetCoreApp3_CompatMode_SingleFile_APITests()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-            var singleFile = BundleHelper.BundleApp(fixture);
+            var singleFile = BundleSelfContainedApp(fixture, BundleOptions.BundleAllContent);
+            var extractionBaseDir = BundleHelper.GetExtractionRootDir(fixture);
 
-            Command.Create(singleFile, "codebase")
+            Command.Create(singleFile, "fullyqualifiedname codebase appcontext cmdlineargs executing_assembly_location basedirectory")
                 .CaptureStdErr()
                 .CaptureStdOut()
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractionBaseDir.FullName)
                 .Execute()
                 .Should()
                 .Pass()
-                .And
-                .HaveStdOutContaining("CodeBase NotSupported");
+                .And.HaveStdOutContaining(Path.DirectorySeparatorChar + "System.Private.CoreLib.dll") // In extraction directory
+                .And.HaveStdOutContaining("System.Private.CoreLib.dll") // In extraction directory
+                .And.NotHaveStdOutContaining("CodeBase NotSupported") // CodeBase should point to extraction directory
+                .And.HaveStdOutContaining("SingleFileApiTests.dll")
+                .And.HaveStdOutContaining("SingleFileApiTests.deps.json") // The app's .deps.json should be available
+                .And.NotHaveStdOutContaining("Microsoft.NETCore.App.deps.json") // No framework - it's self-contained
+                // For single-file, Environment.GetCommandLineArgs[0] should return the file path of the host.
+                .And.HaveStdOutContaining("Command line args: " + singleFile)
+                .And.HaveStdOutContaining("ExecutingAssembly.Location: " + extractionBaseDir.FullName) // Should point to the app's dll
+                .And.HaveStdOutContaining("AppContext.BaseDirectory: " + extractionBaseDir.FullName); // Should point to the extraction directory
         }
 
         [Fact]
-        public void AppContext_Deps_Files_Bundled_Self_Contained()
-        {
-            var fixture = sharedTestState.TestFixture.Copy();
-            var singleFile = BundleHelper.BundleApp(fixture);
-
-            Command.Create(singleFile, "appcontext")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .NotHaveStdOutContaining("SingleFileApiTests.deps.json")
-                .And
-                .NotHaveStdOutContaining("Microsoft.NETCore.App.deps.json");
-        }
-
-        [Fact]
-        public void GetEnvironmentArgs_0_Returns_Bundled_Executable_Path()
-        {
-            var fixture = sharedTestState.TestFixture.Copy();
-            var singleFile = BundleHelper.BundleApp(fixture);
-
-            // For single-file, Environment.GetCommandLineArgs[0]
-            // should return the file path of the host.
-            Command.Create(singleFile, "cmdlineargs")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining(singleFile);
-        }
-
-        [Fact]
-        public void GetEnvironmentArgs_0_Non_Bundled_App()
+        public void GetCommandLineArgs_0_Non_Bundled_App()
         {
             var fixture = sharedTestState.TestFixture.Copy();
             var dotnet = fixture.BuiltDotnet;
@@ -104,18 +85,13 @@ namespace AppHost.Bundle.Tests
                 .HaveStdOutContaining(appPath);
         }
 
-        public class SharedTestState : IDisposable
+        public class SharedTestState : SharedTestStateBase, IDisposable
         {
             public TestProjectFixture TestFixture { get; set; }
-            public RepoDirectoriesProvider RepoDirectories { get; set; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-                TestFixture = new TestProjectFixture("SingleFileApiTests", RepoDirectories);
-                TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                    .PublishProject(runtime: TestFixture.CurrentRid, outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+                TestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests");
             }
 
             public void Dispose()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/StaticHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/StaticHost.cs
@@ -1,19 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using BundleTests.Helpers;
+using System;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
-using Microsoft.NET.HostModel.AppHost;
-using Microsoft.NET.HostModel.Bundle;
-using System;
-using System.IO;
-using System.Threading;
 using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class StaticHost : IClassFixture<StaticHost.SharedTestState>
+    public class StaticHost : BundleTestBase, IClassFixture<StaticHost.SharedTestState>
     {
         private SharedTestState sharedTestState;
 
@@ -22,27 +17,12 @@ namespace AppHost.Bundle.Tests
             sharedTestState = fixture;
         }
 
-        // This helper is used in lieu of SDK support for publishing apps using the singlefilehost.
-        // It replaces the apphost with singlefilehost, and along with appropriate app.dll updates in the host.
-        // For now, we leave behind the hostpolicy and hostfxr DLLs in the publish directory, because
-        // removing them requires deps.json update.
-        void ReplaceApphostWithStaticHost(TestProjectFixture fixture)
-        {
-            var staticHost = Path.Combine(fixture.RepoDirProvider.HostArtifacts,
-                                          RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("singlefilehost"));
-            HostWriter.CreateAppHost(staticHost,
-                                     BundleHelper.GetHostPath(fixture),
-                                     BundleHelper.GetAppPath(fixture));
-
-        }
-
         [Fact]
         private void Can_Run_App_With_StatiHost()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-            var appExe = BundleHelper.GetHostPath(fixture);
 
-            ReplaceApphostWithStaticHost(fixture);
+            var appExe = UseSingleFileSelfContainedHost(fixture);
 
             Command.Create(appExe)
                 .CaptureStdErr()
@@ -59,9 +39,7 @@ namespace AppHost.Bundle.Tests
         {
             var fixture = sharedTestState.TestFixture.Copy();
 
-            ReplaceApphostWithStaticHost(fixture);
-
-            string singleFile = BundleHelper.BundleApp(fixture);
+            string singleFile = BundleSelfContainedApp(fixture);
 
             Command.Create(singleFile)
                 .CaptureStdErr()
@@ -73,19 +51,13 @@ namespace AppHost.Bundle.Tests
                 .HaveStdOutContaining("Hello World");
         }
 
-        public class SharedTestState : IDisposable
+        public class SharedTestState : SharedTestStateBase, IDisposable
         {
             public TestProjectFixture TestFixture { get; set; }
-            public RepoDirectoriesProvider RepoDirectories { get; set; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-                TestFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
-                TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                    .PublishProject(runtime: TestFixture.CurrentRid, 
-                                    outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+                TestFixture = PreparePublishedSelfContainedTestProject("StandaloneApp");
             }
 
             public void Dispose()

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -257,7 +257,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
             bool? selfContained = null,
             string outputDirectory = null,
             bool singleFile = false,
-            bool restore = false)
+            bool restore = false,
+            params string[] extraArgs)
         {
             dotnet = dotnet ?? SdkDotnet;
             outputDirectory = outputDirectory ?? TestProject.OutputDirectory;
@@ -307,6 +308,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             publishArgs.Add($"/p:TestTargetRid={RepoDirProvider.TargetRID}");
             publishArgs.Add($"/p:MNAVersion={RepoDirProvider.MicrosoftNETCoreAppVersion}");
+
+            foreach (var arg in extraArgs)
+            {
+                publishArgs.Add(arg);
+            }
 
             dotnet.Publish(publishArgs.ToArray())
                 .WorkingDirectory(TestProject.ProjectDirectory)


### PR DESCRIPTION
## Description

Backport of #42435 to release/5.0.

This change fixes the "3.1 compat mode" for single-file. This flag allows people to return to the previous "extraction" behavior of single-file that was available in 3.1. 

## Customer impact

In certain scenarios, like use of changed APIs in a dependent library, this may be the only workaround for users who were previously using the 3.1 version of single-file. In compat testing, we found as many as half of the applications which worked with single-file were broken with the 5.0 changes.

## Regression

The 3.1 -> 5.0 mode was an intentional breaking change, and this mode was intended to be present to mitigate the break.

## Testing

Manual testing of all of the app compat libraries, both in the compat scenario, and in 5.0 after the compat fix.

## Risk

This change is entirely in single-file. It is a large change and bares moderate risk, but the risk would be isolated to single-file publishing.

(cherry picked from commit 0be66cbac680adc6ae1ec4c84adc028b2c340413)