### PR TITLE
make CancelConnectAsync thread safe

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -565,7 +565,7 @@ namespace System.Net.Sockets
         {
             if (_operating == InProgress && _completedOperation == SocketAsyncOperation.Connect)
             {
-                var multipleConnect = _multipleConnect;
+                MultipleConnectAsync? multipleConnect = _multipleConnect;
                 if (multipleConnect != null)
                 {
                     // If a multiple connect is in progress, abort it.

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -565,22 +565,18 @@ namespace System.Net.Sockets
         {
             if (_operating == InProgress && _completedOperation == SocketAsyncOperation.Connect)
             {
-                if (_multipleConnect != null)
+                var multipleConnect = _multipleConnect;
+                if (multipleConnect != null)
                 {
                     // If a multiple connect is in progress, abort it.
-                    _multipleConnect.Cancel();
+                    multipleConnect.Cancel();
                 }
                 else
                 {
                     if (SocketsTelemetry.Log.IsEnabled()) SocketsTelemetry.Log.ConnectCanceledAndStop();
 
                     // Otherwise we're doing a normal ConnectAsync - cancel it by closing the socket.
-                    // _currentSocket will only be null if _multipleConnect was set, so we don't have to check.
-                    if (_currentSocket == null)
-                    {
-                        NetEventSource.Fail(this, "CurrentSocket and MultipleConnect both null!");
-                    }
-                    _currentSocket.Dispose();
+                    _currentSocket?.Dispose();
                 }
             }
         }


### PR DESCRIPTION
CancelConnectAsync uses global state which can change during execution of the function. That is clear from the core linked in #42085. We can hit Assert if connect finishes and both _multipleConnect and _currentSocket will be null or we can hit NRE. 

To make the function more thread safe this change captures _multipleConnect to local variable and add check to prevent NRE. 

I did ~ 1000 runs and I did not see any more failures where it it would fail in ~100ish iterations before.