### PR TITLE
improve detection of TLS13 on Windows

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -339,8 +339,10 @@ namespace System
                     }
                 }
                 catch { };
-                // assume no if key is missing or on error.
-                return false;
+                // assume no if positive entry is missing on older Windows
+                // Latest insider builds have TLS 1.3 enabled by default.
+                // The build number is approximation.
+                return IsWindows10Version2004Build19573OrGreater;
             }
             else if (IsOSX || IsiOS || IstvOS)
             {


### PR DESCRIPTION
Latest Insider builds have TLS 1.3 enabled by default. So it is on unless disabled by registry. 