### PR TITLE
Add `Crossgen2JitPath` to R2R test.

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildOptions.cs
@@ -34,6 +34,7 @@ namespace R2RTest
         public bool LargeBubble { get; set; }
         public bool Composite { get; set; }
         public int Crossgen2Parallelism { get; set; }
+        public FileInfo Crossgen2JitPath { get; set; }
         public int CompilationTimeoutMinutes { get; set; }
         public int ExecutionTimeoutMinutes { get; set; }
         public DirectoryInfo[] ReferencePath { get; set; }

--- a/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
@@ -61,6 +61,7 @@ namespace R2RTest
                         LargeBubble(),
                         Composite(),
                         Crossgen2Parallelism(),
+                        Crossgen2JitPath(),
                         ReferencePath(),
                         IssuesPath(),
                         CompilationTimeoutMinutes(),
@@ -97,6 +98,7 @@ namespace R2RTest
                         LargeBubble(),
                         Composite(),
                         Crossgen2Parallelism(),
+                        Crossgen2JitPath(),
                         ReferencePath(),
                         IssuesPath(),
                         CompilationTimeoutMinutes(),
@@ -118,6 +120,7 @@ namespace R2RTest
                         NoCrossgen2(),
                         NoCleanup(),
                         Crossgen2Parallelism(),
+                        Crossgen2JitPath(),
                         DegreeOfParallelism(),
                         Sequential(),
                         Release(),
@@ -238,6 +241,9 @@ namespace R2RTest
 
             Option Crossgen2Parallelism() =>
                 new Option<int>(new[] { "--crossgen2-parallelism" }, "Max number of threads to use in Crossgen2 (default = logical processor count)");
+            
+            Option Crossgen2JitPath() =>
+                new Option<FileInfo>(new[] { "--crossgen2-jitpath" }, "Jit path to use for crossgen2");
 
             Option IssuesPath() =>
                 new Option<FileInfo[]>(new[] { "--issues-path", "-ip" }, "Path to issues.targets")

--- a/src/coreclr/src/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/src/tools/r2rtest/Crossgen2Runner.cs
@@ -126,6 +126,11 @@ namespace R2RTest
                 yield return $"--parallelism={_options.Crossgen2Parallelism}";
             }
 
+            if (_options.Crossgen2JitPath != null)
+            {
+                yield return $"--jitpath={_options.Crossgen2JitPath}";
+            }
+
             string frameworkFolder = "";
             if (_options.Framework || _options.UseFramework)
             {


### PR DESCRIPTION
With the new option we can run SPMI collection for crossgen2 if you pass superpmi-shim-collector as your jit and set spmi shim to your real jit.

```
set SuperPMIShimLogPath=mc_drop_folder
set SuperPMIShimPath=YOUR_Core_Root\clrjit_win_x64_x64.dll
"RUNTIME\dotnet.cmd" "RUNTIME\artifacts\tests\coreclr\Windows_NT.x64.Checked\Tests\Core_Root\R2RTest\R2RTest.dll" compile-framework -cr "RUNTIME\artifacts\tests\coreclr\Windows_NT.x64.Checked\Tests\Core_Root" --output-directory "RUNTIME\artifacts\tests\coreclr\Windows_NT.x64.Checked\Tests\Core_Root\crossgen.out"  --large-bubble --release --target-arch x64 -dop 16 --verify-type-and-field-layout --crossgen2-parallelism 1 --crossgen2-path "RUNTIME\artifacts\bin\coreclr\Windows_NT.x64.Checked\crossgen2\crossgen2.dll" --crossgen2-jitpath "RUNTIME\artifacts\tests\coreclr\Windows_NT.x64.Checked\Tests\Core_Root\superpmi-shim-collector.dll"
```


Contributes to #41639.

cc @dotnet/jit-contrib 

Note: it generates 1.7Gb for CoreRun, there are 5 libraries that cause failures but they are SPMI errors and will be fixed separately. 