### PR TITLE
Issue 42839

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -59,6 +59,7 @@ namespace System.Text.Json
         public System.Text.Json.JsonElement GetProperty(System.ReadOnlySpan<char> propertyName) { throw null; }
         public System.Text.Json.JsonElement GetProperty(string propertyName) { throw null; }
         public string GetRawText() { throw null; }
+        public System.ReadOnlyMemory<byte> GetRawValue() { throw null; }
         [System.CLSCompliantAttribute(false)]
         public sbyte GetSByte() { throw null; }
         public float GetSingle() { throw null; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -747,6 +747,12 @@ namespace System.Text.Json
             return false;
         }
 
+        internal ReadOnlyMemory<byte> GetRawValue(int index)
+        {
+            ReadOnlyMemory<byte> segment = GetRawValue(index, includeQuotes: true);
+            return segment;
+        }
+
         internal string GetRawValueAsString(int index)
         {
             ReadOnlyMemory<byte> segment = GetRawValue(index, includeQuotes: true);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1169,6 +1169,22 @@ namespace System.Text.Json
             return _parent.GetRawValueAsString(_idx);
         }
 
+        /// <summary>
+        ///   Gets the original input data backing this value, returning it as a <see cref="ReadOnlyMemory{T}"/> of <see cref="byte"/>.
+        /// </summary>
+        /// <returns>
+        ///   The original input data backing this value, returning it as a <see cref="ReadOnlyMemory{T}"/> of <see cref="byte"/>.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        public ReadOnlyMemory<byte> GetRawValue()
+        {
+            CheckValidInstance();
+
+            return _parent.GetRawValue(_idx);
+        }
+
         internal string GetPropertyRawText()
         {
             CheckValidInstance();

--- a/src/libraries/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/JsonTestHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.Json.Tests;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -144,6 +145,34 @@ namespace System.Text.Json
             var state = new JsonReaderState(new JsonReaderOptions { CommentHandling = commentHandling, MaxDepth = maxDepth });
             var reader = new Utf8JsonReader(sequence, true, state);
             return ReaderLoop(data.Length, out length, ref reader);
+        }
+
+        public static void AssertContainsSequence<T>(IEnumerable<T> outerEnumerable, IEnumerable<T> innerEnumerable)
+        {
+            var outer = outerEnumerable.ToArray();
+            var inner = innerEnumerable.ToArray();
+            int outerCount = outer.Length;
+            int innerCount = inner.Length;
+            Assert.True(outerCount > innerCount);
+
+            for(int i = 0; i < outerCount - innerCount; ++i)
+            {
+                bool found = true;
+                for(int j = 0; j < innerCount; ++j)
+                {
+                    if (!outer[i + j].Equals(inner[j]))
+                    {
+                        found = false;
+                        break;
+                    }
+                }
+                if (found)
+                {
+                    return;
+                }
+            }
+
+            Assert.True(false, "Expected outer sequence to contain inner sequence");
         }
 
         public static ReadOnlySequence<byte> CreateSegments(byte[] data)

--- a/src/libraries/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/JsonTestHelper.cs
@@ -155,7 +155,7 @@ namespace System.Text.Json
             int innerCount = inner.Length;
             Assert.True(outerCount > innerCount);
 
-            for(int i = 0; i < outerCount - innerCount; ++i)
+            for(int i = 0; i <= outerCount - innerCount; ++i)
             {
                 bool found = true;
                 for(int j = 0; j < innerCount; ++j)


### PR DESCRIPTION
Adds System.Text.Json.JsonElement.GetRawValue() and tests.

Adds an API to JsonElement to retrieve the raw Utf8 byte stream for a JsonElement equivalent to GetRawText().

Adds the corresponding internal method to JsonDocument to support that.

Adds a test equivalent to the test for GetRawText().

Adds a test to validate the correct exception is thrown for a disposed JsonDocument.

Adds a test to validate that GetRawValue() can safely retrieve invalid UTF8 byte sequences that would cause GetRawText() to fail.

Fix #42839    