### PR TITLE
Remove unnecessary code from ConsoleLogger

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
@@ -51,11 +51,6 @@ namespace Microsoft.Extensions.Logging.Console
                 return;
             }
             string computedAnsiString = sb.ToString();
-            sb.Clear();
-            if (sb.Capacity > 1024)
-            {
-                sb.Capacity = 1024;
-            }
             _queueProcessor.EnqueueMessage(new LogMessageEntry(computedAnsiString, logAsError: logLevel >= Options.LogToStandardErrorThreshold));
         }
 


### PR DESCRIPTION
I guess this was left behind after https://github.com/dotnet/runtime/pull/38616 which was re-using one `StringBuilder`
