### PR TITLE
[mono] Fix constant folding for Math.Round

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -2620,7 +2620,7 @@ namespace System.Tests
         public static void Round_Double_Constant_Arg()
         {
             Assert.Equal( 0, Math.Round( 0.5));
-            Assert.Equal( 0, Math.Round( 0.5));
+            Assert.Equal( 0, Math.Round(-0.5));
             Assert.Equal( 2, Math.Round( 1.5));
             Assert.Equal(-2, Math.Round(-1.5));
             Assert.Equal( 2, Math.Round( 2.5));
@@ -2651,7 +2651,7 @@ namespace System.Tests
         public static void Round_Float_Constant_Arg()
         {
             Assert.Equal( 0, MathF.Round( 0.5f));
-            Assert.Equal( 0, MathF.Round( 0.5f));
+            Assert.Equal( 0, MathF.Round(-0.5f));
             Assert.Equal( 2, MathF.Round( 1.5f));
             Assert.Equal(-2, MathF.Round(-1.5f));
             Assert.Equal( 2, MathF.Round( 2.5f));

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -2621,28 +2621,46 @@ namespace System.Tests
         {
             Assert.Equal( 0, Math.Round( 0.5));
             Assert.Equal( 0, Math.Round(-0.5));
+            Assert.Equal( 1, Math.Round( 1.0));
+            Assert.Equal(-1, Math.Round(-1.0));
             Assert.Equal( 2, Math.Round( 1.5));
             Assert.Equal(-2, Math.Round(-1.5));
+            Assert.Equal( 2, Math.Round( 2.0));
+            Assert.Equal(-2, Math.Round(-2.0));
             Assert.Equal( 2, Math.Round( 2.5));
             Assert.Equal(-2, Math.Round(-2.5));
+            Assert.Equal( 3, Math.Round( 3.0));
+            Assert.Equal(-3, Math.Round(-3.0));
             Assert.Equal( 4, Math.Round( 3.5));
             Assert.Equal(-4, Math.Round(-3.5));
             
             Assert.Equal( 0, Math.Round( 0.5, MidpointRounding.ToZero));
             Assert.Equal( 0, Math.Round( 0.5, MidpointRounding.ToZero));
+            Assert.Equal( 1, Math.Round( 1.0, MidpointRounding.ToZero));
+            Assert.Equal(-1, Math.Round(-1.0, MidpointRounding.ToZero));
             Assert.Equal( 1, Math.Round( 1.5, MidpointRounding.ToZero));
             Assert.Equal(-1, Math.Round(-1.5, MidpointRounding.ToZero));
+            Assert.Equal( 2, Math.Round( 2.0, MidpointRounding.ToZero));
+            Assert.Equal(-2, Math.Round(-2.0, MidpointRounding.ToZero));
             Assert.Equal( 2, Math.Round( 2.5, MidpointRounding.ToZero));
             Assert.Equal(-2, Math.Round(-2.5, MidpointRounding.ToZero));
+            Assert.Equal( 3, Math.Round( 3.0, MidpointRounding.ToZero));
+            Assert.Equal(-3, Math.Round(-3.0, MidpointRounding.ToZero));
             Assert.Equal( 3, Math.Round( 3.5, MidpointRounding.ToZero));
             Assert.Equal(-3, Math.Round(-3.5, MidpointRounding.ToZero));
 
             Assert.Equal( 1, Math.Round( 0.5, MidpointRounding.AwayFromZero));
             Assert.Equal( 1, Math.Round( 0.5, MidpointRounding.AwayFromZero));
+            Assert.Equal( 1, Math.Round( 1.0, MidpointRounding.AwayFromZero));
+            Assert.Equal(-1, Math.Round(-1.0, MidpointRounding.AwayFromZero));
             Assert.Equal( 2, Math.Round( 1.5, MidpointRounding.AwayFromZero));
             Assert.Equal(-2, Math.Round(-1.5, MidpointRounding.AwayFromZero));
+            Assert.Equal( 2, Math.Round( 2.0, MidpointRounding.AwayFromZero));
+            Assert.Equal(-2, Math.Round(-2.0, MidpointRounding.AwayFromZero));
             Assert.Equal( 3, Math.Round( 2.5, MidpointRounding.AwayFromZero));
             Assert.Equal(-3, Math.Round(-2.5, MidpointRounding.AwayFromZero));
+            Assert.Equal( 3, Math.Round( 3.0, MidpointRounding.AwayFromZero));
+            Assert.Equal(-3, Math.Round(-3.0, MidpointRounding.AwayFromZero));
             Assert.Equal( 4, Math.Round( 3.5, MidpointRounding.AwayFromZero));
             Assert.Equal(-4, Math.Round(-3.5, MidpointRounding.AwayFromZero));
         }
@@ -2652,28 +2670,46 @@ namespace System.Tests
         {
             Assert.Equal( 0, MathF.Round( 0.5f));
             Assert.Equal( 0, MathF.Round(-0.5f));
+            Assert.Equal( 1, MathF.Round( 1.0f));
+            Assert.Equal(-1, MathF.Round(-1.0f));
             Assert.Equal( 2, MathF.Round( 1.5f));
             Assert.Equal(-2, MathF.Round(-1.5f));
+            Assert.Equal( 2, MathF.Round( 2.0f));
+            Assert.Equal(-2, MathF.Round(-2.0f));
             Assert.Equal( 2, MathF.Round( 2.5f));
             Assert.Equal(-2, MathF.Round(-2.5f));
+            Assert.Equal( 3, MathF.Round( 3.0f));
+            Assert.Equal(-3, MathF.Round(-3.0f));
             Assert.Equal( 4, MathF.Round( 3.5f));
             Assert.Equal(-4, MathF.Round(-3.5f));
             
             Assert.Equal( 0, MathF.Round( 0.5f, MidpointRounding.ToZero));
             Assert.Equal( 0, MathF.Round( 0.5f, MidpointRounding.ToZero));
+            Assert.Equal( 1, MathF.Round( 1.0f, MidpointRounding.ToZero));
+            Assert.Equal(-1, MathF.Round(-1.0f, MidpointRounding.ToZero));
             Assert.Equal( 1, MathF.Round( 1.5f, MidpointRounding.ToZero));
             Assert.Equal(-1, MathF.Round(-1.5f, MidpointRounding.ToZero));
+            Assert.Equal( 2, MathF.Round( 2.0f, MidpointRounding.ToZero));
+            Assert.Equal(-2, MathF.Round(-2.0f, MidpointRounding.ToZero));
             Assert.Equal( 2, MathF.Round( 2.5f, MidpointRounding.ToZero));
             Assert.Equal(-2, MathF.Round(-2.5f, MidpointRounding.ToZero));
+            Assert.Equal( 3, MathF.Round( 3.0f, MidpointRounding.ToZero));
+            Assert.Equal(-3, MathF.Round(-3.0f, MidpointRounding.ToZero));
             Assert.Equal( 3, MathF.Round( 3.5f, MidpointRounding.ToZero));
             Assert.Equal(-3, MathF.Round(-3.5f, MidpointRounding.ToZero));
 
             Assert.Equal( 1, MathF.Round( 0.5f, MidpointRounding.AwayFromZero));
             Assert.Equal( 1, MathF.Round( 0.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal( 1, MathF.Round( 1.0f, MidpointRounding.AwayFromZero));
+            Assert.Equal(-1, MathF.Round(-1.0f, MidpointRounding.AwayFromZero));
             Assert.Equal( 2, MathF.Round( 1.5f, MidpointRounding.AwayFromZero));
             Assert.Equal(-2, MathF.Round(-1.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal( 2, MathF.Round( 2.0f, MidpointRounding.AwayFromZero));
+            Assert.Equal(-2, MathF.Round(-2.0f, MidpointRounding.AwayFromZero));
             Assert.Equal( 3, MathF.Round( 2.5f, MidpointRounding.AwayFromZero));
             Assert.Equal(-3, MathF.Round(-2.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal( 3, MathF.Round( 3.0f, MidpointRounding.AwayFromZero));
+            Assert.Equal(-3, MathF.Round(-3.0f, MidpointRounding.AwayFromZero));
             Assert.Equal( 4, MathF.Round( 3.5f, MidpointRounding.AwayFromZero));
             Assert.Equal(-4, MathF.Round(-3.5f, MidpointRounding.AwayFromZero));
         }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -2615,5 +2615,67 @@ namespace System.Tests
             Assert.Equal(expected, Math.Round(x, 0, mode));
             Assert.Equal(expected, decimal.Round(x, 0, mode));
         }
+
+        [Fact]
+        public static void Round_Double_Constant_Arg()
+        {
+            Assert.Equal( 0, Math.Round( 0.5));
+            Assert.Equal( 0, Math.Round( 0.5));
+            Assert.Equal( 2, Math.Round( 1.5));
+            Assert.Equal(-2, Math.Round(-1.5));
+            Assert.Equal( 2, Math.Round( 2.5));
+            Assert.Equal(-2, Math.Round(-2.5));
+            Assert.Equal( 4, Math.Round( 3.5));
+            Assert.Equal(-4, Math.Round(-3.5));
+            
+            Assert.Equal( 0, Math.Round( 0.5, MidpointRounding.ToZero));
+            Assert.Equal( 0, Math.Round( 0.5, MidpointRounding.ToZero));
+            Assert.Equal( 1, Math.Round( 1.5, MidpointRounding.ToZero));
+            Assert.Equal(-1, Math.Round(-1.5, MidpointRounding.ToZero));
+            Assert.Equal( 2, Math.Round( 2.5, MidpointRounding.ToZero));
+            Assert.Equal(-2, Math.Round(-2.5, MidpointRounding.ToZero));
+            Assert.Equal( 3, Math.Round( 3.5, MidpointRounding.ToZero));
+            Assert.Equal(-3, Math.Round(-3.5, MidpointRounding.ToZero));
+
+            Assert.Equal( 1, Math.Round( 0.5, MidpointRounding.AwayFromZero));
+            Assert.Equal( 1, Math.Round( 0.5, MidpointRounding.AwayFromZero));
+            Assert.Equal( 2, Math.Round( 1.5, MidpointRounding.AwayFromZero));
+            Assert.Equal(-2, Math.Round(-1.5, MidpointRounding.AwayFromZero));
+            Assert.Equal( 3, Math.Round( 2.5, MidpointRounding.AwayFromZero));
+            Assert.Equal(-3, Math.Round(-2.5, MidpointRounding.AwayFromZero));
+            Assert.Equal( 4, Math.Round( 3.5, MidpointRounding.AwayFromZero));
+            Assert.Equal(-4, Math.Round(-3.5, MidpointRounding.AwayFromZero));
+        }
+
+        [Fact]
+        public static void Round_Float_Constant_Arg()
+        {
+            Assert.Equal( 0, MathF.Round( 0.5f));
+            Assert.Equal( 0, MathF.Round( 0.5f));
+            Assert.Equal( 2, MathF.Round( 1.5f));
+            Assert.Equal(-2, MathF.Round(-1.5f));
+            Assert.Equal( 2, MathF.Round( 2.5f));
+            Assert.Equal(-2, MathF.Round(-2.5f));
+            Assert.Equal( 4, MathF.Round( 3.5f));
+            Assert.Equal(-4, MathF.Round(-3.5f));
+            
+            Assert.Equal( 0, MathF.Round( 0.5f, MidpointRounding.ToZero));
+            Assert.Equal( 0, MathF.Round( 0.5f, MidpointRounding.ToZero));
+            Assert.Equal( 1, MathF.Round( 1.5f, MidpointRounding.ToZero));
+            Assert.Equal(-1, MathF.Round(-1.5f, MidpointRounding.ToZero));
+            Assert.Equal( 2, MathF.Round( 2.5f, MidpointRounding.ToZero));
+            Assert.Equal(-2, MathF.Round(-2.5f, MidpointRounding.ToZero));
+            Assert.Equal( 3, MathF.Round( 3.5f, MidpointRounding.ToZero));
+            Assert.Equal(-3, MathF.Round(-3.5f, MidpointRounding.ToZero));
+
+            Assert.Equal( 1, MathF.Round( 0.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal( 1, MathF.Round( 0.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal( 2, MathF.Round( 1.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal(-2, MathF.Round(-1.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal( 3, MathF.Round( 2.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal(-3, MathF.Round(-2.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal( 4, MathF.Round( 3.5f, MidpointRounding.AwayFromZero));
+            Assert.Equal(-4, MathF.Round(-3.5f, MidpointRounding.AwayFromZero));
+        }
     }
 }

--- a/src/mono/mono/metadata/sysmath.c
+++ b/src/mono/mono/metadata/sysmath.c
@@ -28,6 +28,7 @@
 
 #include "number-ms.h"
 #include "utils/mono-compiler.h"
+#include "utils/mono-math.h"
 #include "icalls.h"
 #include "icall-decl.h"
 
@@ -40,20 +41,7 @@ ves_icall_System_Math_Floor (gdouble x)
 gdouble
 ves_icall_System_Math_Round (gdouble x)
 {
-	gdouble floor_tmp;
-
-	/* If the number has no fractional part do nothing This shortcut is necessary
-	 * to workaround precision loss in borderline cases on some platforms */
-	if (x == (gdouble)(gint64) x)
-		return x;
-
-	floor_tmp = floor (x + 0.5);
-
-	if ((x == (floor (x) + 0.5)) && (fmod (floor_tmp, 2.0) != 0)) {
-		floor_tmp -= 1.0;
-	}
-
-	return copysign (floor_tmp, x);
+	return mono_round_to_even (x);
 }
 
 gdouble

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -1763,7 +1763,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 					result = cosh (source);
 					break;
 				case OP_ROUND:
-					result = round (source);
+					result = round (source * 0.5) * 2.0;
 					break;
 				case OP_SIN:
 					result = sin (source);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -1763,7 +1763,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 					result = cosh (source);
 					break;
 				case OP_ROUND:
-					result = round (source * 0.5) * 2.0;
+					result = mono_round_to_even (source);
 					break;
 				case OP_SIN:
 					result = sin (source);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -3,6 +3,7 @@
  */
 
 #include <config.h>
+#include <glib.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-math.h>
 #include <math.h>

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -4,6 +4,7 @@
 
 #include <config.h>
 #include <mono/utils/mono-compiler.h>
+#include <mono/utils/mono-math.h>
 #include <math.h>
 
 #ifndef DISABLE_JIT

--- a/src/mono/mono/utils/mono-math.h
+++ b/src/mono/mono/utils/mono-math.h
@@ -6,7 +6,6 @@
 #define __MONO_MATH_H__
 
 #include <math.h>
-#include <glib.h>
 #include <mono/utils/mono-publib.h>
 
 // Instead of isfinite, isinf, isnan, etc.,
@@ -81,14 +80,14 @@ inline double mono_trunc (double a)                 { return mono_trunc_double (
 
 #endif
 
-static inline gdouble
-mono_round_to_even (gdouble x)
+static inline double
+mono_round_to_even (double x)
 {
-	gdouble floor_tmp;
+	double floor_tmp;
 
 	/* If the number has no fractional part do nothing This shortcut is necessary
 	 * to workaround precision loss in borderline cases on some platforms */
-	if (x == (gdouble)(gint64) x)
+	if (x == (double)(int64_t) x)
 		return x;
 
 	floor_tmp = floor (x + 0.5);

--- a/src/mono/mono/utils/mono-math.h
+++ b/src/mono/mono/utils/mono-math.h
@@ -6,6 +6,7 @@
 #define __MONO_MATH_H__
 
 #include <math.h>
+#include <glib.h>
 #include <mono/utils/mono-publib.h>
 
 // Instead of isfinite, isinf, isnan, etc.,
@@ -79,5 +80,24 @@ inline double mono_trunc (double a)                 { return mono_trunc_double (
 #define mono_trunc           trunc
 
 #endif
+
+static inline gdouble
+mono_round_to_even (gdouble x)
+{
+	gdouble floor_tmp;
+
+	/* If the number has no fractional part do nothing This shortcut is necessary
+	 * to workaround precision loss in borderline cases on some platforms */
+	if (x == (gdouble)(gint64) x)
+		return x;
+
+	floor_tmp = floor (x + 0.5);
+
+	if ((x == (floor (x) + 0.5)) && (fmod (floor_tmp, 2.0) != 0)) {
+		floor_tmp -= 1.0;
+	}
+
+	return copysign (floor_tmp, x);
+}
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/20449

We have a logic to fold various Math* operators to constants (https://github.com/mono/mono/pull/9281) and it's slightly incorrect for `Math.Round(double)` which is "round to even".

Btw, we don't need this folding for LLVM since all math functions are LLVM-intrinsics so the folding is done there.