### PR TITLE
Fix warnings revealed after enabling analyzer for projects not having access to RuntimeInformation, OSPlatofrm types

### DIFF
--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsSink.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsSink.cs
@@ -215,7 +215,9 @@ namespace System.Runtime.InteropServices
             // convert result to VARIANT
             if (pVarResult != IntPtr.Zero)
             {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                 Marshal.GetNativeVariantForObject(result, pVarResult);
+#pragma warning restore CA1416
             }
 
             // Now we need to marshal all the byrefs back
@@ -237,7 +239,9 @@ namespace System.Runtime.InteropServices
             ppv = IntPtr.Zero;
             if (iid == _iidSourceItf || iid == typeof(IDispatch).GUID)
             {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                 ppv = Marshal.GetComInterfaceForObject(this, typeof(IDispatch), CustomQueryInterfaceMode.Ignore);
+#pragma warning restore CA1416
                 return CustomQueryInterfaceResult.Handled;
             }
 
@@ -267,7 +271,9 @@ namespace System.Runtime.InteropServices
             try
             {
                 _connectionPoint.Unadvise(_cookie);
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                 Marshal.ReleaseComObject(_connectionPoint);
+#pragma warning restore CA1416
             }
             catch
             {

--- a/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
@@ -130,7 +130,7 @@ namespace System.Runtime.InteropServices
                 }
                 return;
             }
-
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
             if ((vt & VarEnum.VT_ARRAY) != 0)
             {
                 Variant vArray;
@@ -224,6 +224,7 @@ namespace System.Runtime.InteropServices
                 default:
                     throw new ArgumentException();
             }
+#pragma warning restore CA1416
         }
 
         /// <summary>
@@ -269,7 +270,9 @@ namespace System.Runtime.InteropServices
                     {
                         fixed (void* pThis = &this)
                         {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                             return Marshal.GetObjectForNativeVariant((System.IntPtr)pThis);
+#pragma warning restore CA1416
                         }
                     }
             }
@@ -645,6 +648,7 @@ namespace System.Runtime.InteropServices
 
         // VT_UNKNOWN
 
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
         public object? AsUnknown
         {
             get
@@ -698,6 +702,7 @@ namespace System.Runtime.InteropServices
                 }
             }
         }
+#pragma warning restore CA1416
 
         public IntPtr AsByRefVariant
         {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComEventSinksContainer.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComEventSinksContainer.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
         public static ComEventSinksContainer FromRuntimeCallableWrapper(object rcw, bool createIfNotFound)
         {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
             object data = Marshal.GetComObjectData(rcw, s_comObjectEventSinksKey);
             if (data != null || createIfNotFound == false)
             {
@@ -41,6 +42,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 {
                     throw Error.SetComObjectDataFailed();
                 }
+#pragma warning restore CA1416
 
                 return comEventSinks;
             }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComObject.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
         {
             Debug.Assert(ComBinder.IsComObject(rcw));
 
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
             object data = Marshal.GetComObjectData(rcw, s_comObjectInfoKey);
             if (data != null)
             {
@@ -53,6 +54,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 {
                     throw Error.SetComObjectDataFailed();
                 }
+#pragma warning restore CA1416
 
                 return comObjectInfo;
             }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
@@ -146,6 +146,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 Marshal.ThrowExceptionForHR(ComHresults.E_FAIL);
             }
 
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
             ComTypes.ITypeInfo typeInfo = null;
             try
             {
@@ -155,6 +156,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             {
                 Marshal.Release(typeInfoPtr);
             }
+#pragma warning restore CA1416
 
             return typeInfo;
         }
@@ -236,6 +238,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             return variant;
         }
 
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
         internal static void InitVariantForObject(object obj, ref Variant variant)
         {
             Debug.Assert(obj != null);
@@ -258,6 +261,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             IntPtr ptr = UnsafeMethods.ConvertVariantByrefToPtr(ref variant);
             return Marshal.GetObjectForNativeVariant(ptr);
         }
+#pragma warning restore CA1416
 
         // This method is intended for use through reflection and should only be used directly by IUnknownReleaseNotZero
         public static unsafe int IUnknownRelease(IntPtr interfacePointer)

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeClassDesc.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeClassDesc.cs
@@ -17,11 +17,13 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
         public object CreateInstance()
         {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
             if (_typeObj == null)
             {
                 _typeObj = Type.GetTypeFromCLSID(Guid);
             }
             return Activator.CreateInstance(Type.GetTypeFromCLSID(Guid));
+#pragma warning restore CA1416
         }
 
         internal ComTypeClassDesc(ComTypes.ITypeInfo typeInfo, ComTypeLibDesc typeLibDesc) :

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeEnumDesc.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeEnumDesc.cs
@@ -43,7 +43,9 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
                     if (varDesc.varkind == ComTypes.VARKIND.VAR_CONST)
                     {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                         memberValues[i] = Marshal.GetObjectForNativeVariant(varDesc.desc.lpvarValue);
+#pragma warning restore CA1416
                     }
                 }
                 finally

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DispatchArgBuilder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DispatchArgBuilder.cs
@@ -24,10 +24,12 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             // parameter.WrappedObject
             if (_isWrapper)
             {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                 parameter = Expression.Property(
                     Helpers.Convert(parameter, typeof(DispatchWrapper)),
                     typeof(DispatchWrapper).GetProperty(nameof(DispatchWrapper.WrappedObject))
                 );
+#pragma warning restore CA1416
             }
 
             return Helpers.Convert(parameter, typeof(object));

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
@@ -477,6 +477,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             if (rcw is IProvideClassInfo provideClassInfo)
             {
                 IntPtr typeInfoPtr = IntPtr.Zero;
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                 try
                 {
                     provideClassInfo.GetClassInfo(out typeInfoPtr);
@@ -492,6 +493,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                         Marshal.Release(typeInfoPtr);
                     }
                 }
+#pragma warning restore CA1416
             }
 
             // retrieving class information through IPCI has failed -

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/Variant.Extended.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/Variant.Extended.cs
@@ -157,7 +157,9 @@ namespace System.Runtime.InteropServices
         {
             get
             {
+#pragma warning disable CA1416 // Validate platform compatibility, cannot use any of guard methods
                 return Marshal.GetObjectForNativeVariant(UnsafeMethods.ConvertVariantByrefToPtr(ref this));
+#pragma warning restore CA1416
             }
 
             set

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -94,6 +94,7 @@ namespace System.Diagnostics
             Dictionary<int, string> stringTable;
             RegistryKey libraryKey;
 
+            Debug.Assert(OperatingSystem.IsWindows());
             libraryKey = Registry.PerformanceData;
 
             try
@@ -208,6 +209,7 @@ namespace System.Diagnostics
             [MemberNotNull(nameof(_perfDataKey))]
             private void Init()
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 if (ProcessManager.IsRemoteMachine(_machineName))
                 {
                     _perfDataKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.PerformanceData, _machineName);
@@ -236,6 +238,7 @@ namespace System.Diagnostics
                 byte[]? data = null;
                 int error = 0;
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 while (waitRetries > 0)
                 {
                     try

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -28,6 +28,7 @@ namespace System.Diagnostics
 
         private unsafe bool StartWithShellExecuteEx(ProcessStartInfo startInfo)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             if (!string.IsNullOrEmpty(startInfo.UserName) || startInfo.Password != null)
                 throw new InvalidOperationException(SR.CantStartAsUser);
 
@@ -166,6 +167,7 @@ namespace System.Diagnostics
                 {
                     ThreadStart threadStart = new ThreadStart(ShellExecuteFunction);
                     Thread executionThread = new Thread(threadStart) { IsBackground = true };
+                    Debug.Assert(OperatingSystem.IsWindows());
                     executionThread.SetApartmentState(ApartmentState.STA);
                     executionThread.Start();
                     executionThread.Join();

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -541,6 +541,7 @@ namespace System.Diagnostics
 
                     if (startInfo.UserName.Length != 0)
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
                         if (startInfo.Password != null && startInfo.PasswordInClearText != null)
                         {
                             throw new ArgumentException(SR.CantSetDuplicatePassword);

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Win32.cs
@@ -17,6 +17,7 @@ namespace System.Diagnostics
                 if (string.IsNullOrEmpty(extension))
                     return Array.Empty<string>();
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 using (RegistryKey? key = Registry.ClassesRoot.OpenSubKey(extension))
                 {
                     if (key == null)

--- a/src/libraries/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
@@ -469,7 +469,9 @@ namespace System.DirectoryServices.Protocols
     public partial class QuotaControl : System.DirectoryServices.Protocols.DirectoryControl
     {
         public QuotaControl() : base (default(string), default(byte[]), default(bool), default(bool)) { }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public QuotaControl(System.Security.Principal.SecurityIdentifier querySid) : base (default(string), default(byte[]), default(bool), default(bool)) { }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public System.Security.Principal.SecurityIdentifier QuerySid { get { throw null; } set { } }
         public override byte[] GetValue() { throw null; }
     }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using System.Runtime.Versioning;
 
 namespace System.DirectoryServices.Protocols
 {
@@ -1026,11 +1027,13 @@ namespace System.DirectoryServices.Protocols
 
         public QuotaControl() : base("1.2.840.113556.1.4.1852", null, true, true) { }
 
+        [SupportedOSPlatform("windows")]
         public QuotaControl(SecurityIdentifier querySid) : this()
         {
             QuerySid = querySid;
         }
 
+        [SupportedOSPlatform("windows")]
         public SecurityIdentifier QuerySid
         {
             get => _sid == null ? null : new SecurityIdentifier(_sid, 0);

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -51,6 +51,7 @@ namespace System.IO
                 int session = Interlocked.Increment(ref _currentSession);
                 byte[] buffer = AllocateBuffer();
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 // Store all state, including a preallocated overlapped, into the state object that'll be
                 // passed from iteration to iteration during the lifetime of the operation.  The buffer will be pinned
                 // from now until the end of the operation.
@@ -59,6 +60,7 @@ namespace System.IO
                 {
                     state.PreAllocatedOverlapped = new PreAllocatedOverlapped((errorCode, numBytes, overlappedPointer) =>
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
                         AsyncReadState state = (AsyncReadState)ThreadPoolBoundHandle.GetNativeOverlappedState(overlappedPointer)!;
                         state.ThreadPoolBinding.FreeNativeOverlapped(overlappedPointer);
                         if (state.WeakWatcher.TryGetTarget(out FileSystemWatcher? watcher))
@@ -153,6 +155,7 @@ namespace System.IO
                 if (!_enabled || IsHandleInvalid(state.DirectoryHandle))
                     return;
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 // Get the overlapped pointer to use for this iteration.
                 overlappedPointer = state.ThreadPoolBinding.AllocateNativeOverlapped(state.PreAllocatedOverlapped);
                 continueExecuting = Interop.Kernel32.ReadDirectoryChangesW(

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Security.AccessControl;
 using System.Security.Principal;
 
@@ -35,6 +36,7 @@ namespace System.IO.IsolatedStorage
                 // (But applies CREATOR OWNER as expected for items and subdirectories.) Setting up front when creating the directory
                 // doesn't exhibit this behavior, but as we can't currently do that we'll take the rough equivalent for now.
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 DirectorySecurity security = new DirectorySecurity();
 
                 // Don't inherit the existing rules

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
@@ -27,23 +27,27 @@ namespace System.IO.Pipes
         FullControl = 2032031,
         AccessSystemSecurity = 16777216,
     }
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
     public sealed partial class PipeAccessRule : System.Security.AccessControl.AccessRule
     {
         public PipeAccessRule(System.Security.Principal.IdentityReference identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AccessControlType type) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public PipeAccessRule(string identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AccessControlType type) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
         public System.IO.Pipes.PipeAccessRights PipeAccessRights { get { throw null; } }
     }
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
     public sealed partial class PipeAuditRule : System.Security.AccessControl.AuditRule
     {
         public PipeAuditRule(System.Security.Principal.IdentityReference identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AuditFlags flags) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
         public PipeAuditRule(string identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AuditFlags flags) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
         public System.IO.Pipes.PipeAccessRights PipeAccessRights { get { throw null; } }
     }
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
     public static partial class PipesAclExtensions
     {
         public static System.IO.Pipes.PipeSecurity GetAccessControl(this System.IO.Pipes.PipeStream stream) { throw null; }
         public static void SetAccessControl(this System.IO.Pipes.PipeStream stream, System.IO.Pipes.PipeSecurity pipeSecurity) { }
     }
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
     public partial class PipeSecurity : System.Security.AccessControl.NativeObjectSecurity
     {
         public PipeSecurity() : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/ConnectionCompletionSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.ExceptionServices;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace System.IO.Pipes

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -7,6 +7,7 @@ using System.Security.Principal;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.Versioning;
+using System.Diagnostics;
 
 namespace System.IO.Pipes
 {
@@ -135,6 +136,7 @@ namespace System.IO.Pipes
             if (!IsCurrentUserOnly)
                 return;
 
+            Debug.Assert(OperatingSystem.IsWindows());
             PipeSecurity accessControl = this.GetAccessControl();
             IdentityReference? remoteOwnerSid = accessControl.GetOwner(typeof(SecurityIdentifier));
             using (WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent())

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -72,6 +72,7 @@ namespace System.IO.Pipes
             if (IsCurrentUserOnly)
             {
                 Debug.Assert(pipeSecurity == null);
+                Debug.Assert(OperatingSystem.IsWindows());
 
                 using (WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent())
                 {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeAccessRule.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeAccessRule.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using System.Security.Principal;
 
 namespace System.IO.Pipes
 {
+    [SupportedOSPlatform("windows")]
     public sealed class PipeAccessRule : AccessRule
     {
         //

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeAuditRule.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeAuditRule.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using System.Security.Principal;
 
 namespace System.IO.Pipes
 {
+    [SupportedOSPlatform("windows")]
     public sealed class PipeAuditRule : AuditRule
     {
         public PipeAuditRule(

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeCompletionSource.cs
@@ -30,6 +30,7 @@ namespace System.IO.Pipes
 #if DEBUG
         private bool _cancellationHasBeenRegistered;
 #endif
+
         // Using RunContinuationsAsynchronously for compat reasons (old API used ThreadPool.QueueUserWorkItem for continuations)
         protected PipeCompletionSource(ThreadPoolBoundHandle handle, ReadOnlyMemory<byte> bufferToPin)
             : base(TaskCreationOptions.RunContinuationsAsynchronously)

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeSecurity.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeSecurity.cs
@@ -5,9 +5,11 @@ using Microsoft.Win32.SafeHandles;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.IO.Pipes
 {
+    [SupportedOSPlatform("windows")]
     public class PipeSecurity : NativeObjectSecurity
     {
         public PipeSecurity()

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -41,6 +41,7 @@ namespace System.IO.Pipes
         /// <param name="handle">The handle.</param>
         private void InitializeAsyncHandle(SafePipeHandle handle)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             // If the handle is of async type, bind the handle to the ThreadPool so that we can use
             // the async operations (it's needed so that our native callbacks get called).
             _threadPoolBinding = ThreadPoolBoundHandle.BindHandle(handle);
@@ -50,6 +51,7 @@ namespace System.IO.Pipes
         {
             if (disposing)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 _threadPoolBinding?.Dispose();
             }
         }
@@ -113,6 +115,7 @@ namespace System.IO.Pipes
 
                         unsafe
                         {
+                            Debug.Assert(OperatingSystem.IsWindows());
                             // Clear the overlapped status bit for this special case. Failure to do so looks
                             // like we are freeing a pending overlapped.
                             completionSource.Overlapped->InternalLow = IntPtr.Zero;
@@ -212,6 +215,7 @@ namespace System.IO.Pipes
                     }
                     if ((pipeFlags & Interop.Kernel32.PipeOptions.PIPE_TYPE_MESSAGE) != 0)
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
                         return PipeTransmissionMode.Message;
                     }
                     else
@@ -407,6 +411,7 @@ namespace System.IO.Pipes
 
             if (pipeSecurity != null)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 byte[] securityDescriptor = pipeSecurity.GetSecurityDescriptorBinaryForm();
                 pinningHandle = GCHandle.Alloc(securityDescriptor, GCHandleType.Pinned);
                 fixed (byte* pSecurityDescriptor = securityDescriptor)
@@ -433,6 +438,7 @@ namespace System.IO.Pipes
 
             if ((flags & Interop.Kernel32.PipeOptions.PIPE_READMODE_MESSAGE) != 0)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 _readMode = PipeTransmissionMode.Message;
             }
             else

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipesAclExtensions.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipesAclExtensions.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Runtime.Versioning;
 using System.Security.AccessControl;
 
 namespace System.IO.Pipes
 {
+    [SupportedOSPlatform("windows")]
     public static class PipesAclExtensions
     {
         public static PipeSecurity GetAccessControl(this PipeStream stream)

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.ExceptionServices;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace System.IO.Pipes

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/ReadWriteCompletionSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.ExceptionServices;
-using System.Runtime.Versioning;
 using System.Threading;
 
 namespace System.IO.Pipes

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Windows.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Security.Principal;
 
 namespace System.Net.Http
@@ -9,6 +10,7 @@ namespace System.Net.Http
     {
         public static string GetIdentity()
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             using WindowsIdentity identity = WindowsIdentity.GetCurrent();
             return identity.Name;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -748,7 +748,7 @@ namespace System.Net.Http
                         // Map the exception the same way as we normally do.
                         catch (Exception ex) when (MapSendException(ex, cancellationToken, out Exception mappedEx))
                         {
-                            throw;
+                            throw mappedEx;
                         }
                     }
                     LogExceptions(sendRequestContentTask);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -748,7 +748,7 @@ namespace System.Net.Http
                         // Map the exception the same way as we normally do.
                         catch (Exception ex) when (MapSendException(ex, cancellationToken, out Exception mappedEx))
                         {
-                            throw mappedEx;
+                            throw;
                         }
                     }
                     LogExceptions(sendRequestContentTask);

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/AsyncRequestContext.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/AsyncRequestContext.cs
@@ -37,6 +37,7 @@ namespace System.Net
 
         private Interop.HttpApi.HTTP_REQUEST* Allocate(ThreadPoolBoundHandle boundHandle, uint size)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             uint newSize = size != 0 ? size : RequestBuffer == IntPtr.Zero ? 4096 : Size;
             if (_nativeOverlapped != null)
             {
@@ -75,6 +76,7 @@ namespace System.Net
 
                 NativeOverlapped* nativeOverlapped = _nativeOverlapped;
                 _nativeOverlapped = null;
+                Debug.Assert(OperatingSystem.IsWindows());
                 _boundHandle!.FreeNativeOverlapped(nativeOverlapped);
             }
         }
@@ -89,6 +91,7 @@ namespace System.Net
 #if DEBUG
                     DebugRefCountReleaseNativeOverlapped();
 #endif
+                    Debug.Assert(OperatingSystem.IsWindows());
                     _boundHandle!.FreeNativeOverlapped(_nativeOverlapped);
                 }
             }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -703,6 +703,7 @@ namespace System.Net
                     WindowsPrincipal? principal = disconnectResult?.AuthenticatedConnection;
                     if (principal != null)
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
                         if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Principal: {principal} principal.Identity.Name: {principal.Identity.Name} creating request");
                         stoleBlob = true;
                         HttpListenerContext ntlmContext = new HttpListenerContext(session, memoryBlob);
@@ -967,6 +968,7 @@ namespace System.Net
                                                         $"HandleAuthentication creating new WindowsIdentity from user context: {userContext.DangerousGetHandle().ToString("x8")}");
                                                 }
 
+                                                Debug.Assert(OperatingSystem.IsWindows());
                                                 WindowsPrincipal windowsPrincipal = new WindowsPrincipal(
                                                     new WindowsIdentity(userContext.DangerousGetHandle(), context.ProtocolName));
 
@@ -1836,6 +1838,7 @@ namespace System.Net
                 _listenerSession = session;
                 _connectionId = connectionId;
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 // we can call the Unsafe API here, we won't ever call user code
                 _nativeOverlapped = session.RequestQueueBoundHandle.AllocateNativeOverlapped(s_IOCallback, state: this, pinData: null);
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"DisconnectAsyncResult: ThreadPoolBoundHandle.AllocateNativeOverlapped({session.RequestQueueBoundHandle}) -> {_nativeOverlapped->GetHashCode()}");
@@ -1874,6 +1877,7 @@ namespace System.Net
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "_connectionId:" + asyncResult._connectionId);
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 asyncResult._listenerSession.RequestQueueBoundHandle.FreeNativeOverlapped(nativeOverlapped);
                 if (Interlocked.Exchange(ref asyncResult._ownershipState, 2) == 0)
                 {
@@ -1884,6 +1888,7 @@ namespace System.Net
             private static unsafe void WaitCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"errorCode: {errorCode}, numBytes: {numBytes}, nativeOverlapped: {((IntPtr)nativeOverlapped).ToString("x")}");
+                Debug.Assert(OperatingSystem.IsWindows());
                 // take the DisconnectAsyncResult object from the state
                 DisconnectAsyncResult asyncResult = (DisconnectAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
                 IOCompleted(asyncResult, errorCode, numBytes, nativeOverlapped);
@@ -1903,6 +1908,7 @@ namespace System.Net
                 // Clean up the identity. This is for scenarios where identity was not cleaned up before due to
                 // identity caching for unsafe ntlm authentication
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 IDisposable? identity = _authenticatedConnection == null ? null : _authenticatedConnection.Identity as IDisposable;
                 if ((identity != null) &&
                     (_authenticatedConnection!.Identity.AuthenticationType == AuthenticationTypes.NTLM) &&

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerSession.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerSession.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -22,6 +23,7 @@ namespace System.Net
                     {
                         if (_requestQueueBoundHandle == null)
                         {
+                            Debug.Assert(OperatingSystem.IsWindows());
                             _requestQueueBoundHandle = ThreadPoolBoundHandle.BindHandle(RequestQueueHandle);
                             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"ThreadPoolBoundHandle.BindHandle({RequestQueueHandle}) -> {_requestQueueBoundHandle}");
                         }
@@ -65,6 +67,7 @@ namespace System.Net
                 if (!RequestQueueHandle.IsInvalid)
                 {
                     if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"Dispose ThreadPoolBoundHandle: {_requestQueueBoundHandle}");
+                    Debug.Assert(OperatingSystem.IsWindows());
                     _requestQueueBoundHandle?.Dispose();
                     RequestQueueHandle.Dispose();
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
@@ -295,6 +296,7 @@ namespace System.Net
             {
                 _dataAlreadyRead = dataAlreadyRead;
                 _boundHandle = boundHandle;
+                Debug.Assert(OperatingSystem.IsWindows());
                 _pOverlapped = boundHandle.AllocateNativeOverlapped(s_IOCallback, state: this, pinData: buffer);
                 _pPinnedBuffer = (void*)(Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset));
             }
@@ -331,6 +333,7 @@ namespace System.Net
 
             private static unsafe void Callback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 HttpRequestStreamAsyncResult asyncResult = (HttpRequestStreamAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
 
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"asyncResult: {asyncResult} errorCode:0x {errorCode.ToString("x8")} numBytes: {numBytes} nativeOverlapped:0x {((IntPtr)nativeOverlapped).ToString("x8")}");
@@ -344,6 +347,7 @@ namespace System.Net
                 base.Cleanup();
                 if (_pOverlapped != null)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     _boundHandle!.FreeNativeOverlapped(_pOverlapped);
                 }
             }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStreamAsyncResult.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStreamAsyncResult.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -114,6 +115,7 @@ namespace System.Net
             _boundHandle = boundHandle;
             _sentHeaders = sentHeaders;
 
+            Debug.Assert(OperatingSystem.IsWindows());
             if (size == 0)
             {
                 _dataChunks = null;
@@ -219,6 +221,7 @@ namespace System.Net
 
         private static unsafe void Callback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             object state = ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
             HttpResponseStreamAsyncResult asyncResult = (state as HttpResponseStreamAsyncResult)!;
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "errorCode:0x" + errorCode.ToString("x8") + " numBytes:" + numBytes + " nativeOverlapped:0x" + ((IntPtr)nativeOverlapped).ToString("x8"));
@@ -232,6 +235,7 @@ namespace System.Net
             base.Cleanup();
             if (_pOverlapped != null)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 _boundHandle!.FreeNativeOverlapped(_pOverlapped);
             }
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerAsyncResult.Windows.cs
@@ -96,6 +96,7 @@ namespace System.Net
 
         private static unsafe void WaitCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             ListenerAsyncResult asyncResult = (ListenerAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
             IOCompleted(asyncResult, errorCode, numBytes);
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography;
@@ -49,6 +50,7 @@ namespace System.Net
             {
                 return;
             }
+            Debug.Assert(OperatingSystem.IsWindows());
             if (_size != 0)
             {
                 _boundHandle!.FreeNativeOverlapped(_pOverlapped);
@@ -162,6 +164,7 @@ namespace System.Net
 
         private static unsafe void WaitCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             ListenerClientCertAsyncResult asyncResult = (ListenerClientCertAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"errorCode:[{errorCode}] numBytes:[{numBytes}] nativeOverlapped:[{((long)nativeOverlapped)}]");
             IOCompleted(asyncResult, errorCode, numBytes);
@@ -173,6 +176,7 @@ namespace System.Net
             if (_pOverlapped != null)
             {
                 _memoryBlob = null;
+                Debug.Assert(OperatingSystem.IsWindows());
                 _boundHandle!.FreeNativeOverlapped(_pOverlapped);
                 _pOverlapped = null;
                 _boundHandle = null;
@@ -185,6 +189,7 @@ namespace System.Net
         {
             if (_pOverlapped != null && !Environment.HasShutdownStarted)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 _boundHandle!.FreeNativeOverlapped(_pOverlapped);
                 _pOverlapped = null;  // Must do this in case application calls GC.ReRegisterForFinalize().
                 _boundHandle = null;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
@@ -908,6 +908,7 @@ namespace System.Net.WebSockets
                 DebugRefCountAllocNativeOverlapped();
 #endif
                 _boundHandle = boundHandle;
+                Debug.Assert(OperatingSystem.IsWindows());
                 _ptrNativeOverlapped = boundHandle.AllocateNativeOverlapped(CompletionPortCallback, null, null);
             }
 
@@ -922,6 +923,7 @@ namespace System.Net.WebSockets
 #if DEBUG
                         DebugRefCountReleaseNativeOverlapped();
 #endif
+                        Debug.Assert(OperatingSystem.IsWindows());
                         _boundHandle!.FreeNativeOverlapped(_ptrNativeOverlapped);
                         _ptrNativeOverlapped = null;
                     }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -4,6 +4,7 @@
 using Microsoft.Win32.SafeHandles;
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
 
@@ -229,6 +230,8 @@ namespace System.Net.NetworkInformation
 
                     if (!s_isPending)
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
+
                         if (Socket.OSSupportsIPv4 && (startIPOptions & StartIPOptions.StartIPv4) != 0)
                         {
                             ThreadPool.RegisterWaitForSingleObject(

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -175,6 +176,7 @@ namespace System.Net
             // For app-compat We want to ensure the store is opened under the **process** account.
             try
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 WindowsIdentity.RunImpersonated(SafeAccessTokenHandle.InvalidHandle, () =>
                 {
                     store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -48,6 +48,7 @@ namespace System.Net.Security
                     }
                     string authtype = context.ProtocolName;
 
+                    Debug.Assert(OperatingSystem.IsWindows());
                     // The following call was also specifying WindowsAccountType.Normal, true.
                     // WindowsIdentity.IsAuthenticated is no longer supported in .NET Core
                     result = new WindowsIdentity(token.DangerousGetHandle(), authtype);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -506,6 +506,7 @@ namespace System.Net.Security
                 //
                 // For app-compat we want to ensure the credential are accessed under >>process<< account.
                 //
+                Debug.Assert(OperatingSystem.IsWindows());
                 return WindowsIdentity.RunImpersonated<SafeFreeCredentials>(SafeAccessTokenHandle.InvalidHandle, () =>
                 {
                     return SSPIWrapper.AcquireCredentialsHandle(GlobalSSPI.SSPISecureChannel, SecurityPackage, credUsage, secureCredential);
@@ -526,6 +527,7 @@ namespace System.Net.Security
                 //
                 // For app-compat we want to ensure the credential are accessed under >>process<< account.
                 //
+                Debug.Assert(OperatingSystem.IsWindows());
                 return WindowsIdentity.RunImpersonated<SafeFreeCredentials>(SafeAccessTokenHandle.InvalidHandle, () =>
                 {
                     return SSPIWrapper.AcquireCredentialsHandle(GlobalSSPI.SSPISecureChannel, SecurityPackage, credUsage, secureCredential);

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -80,6 +80,7 @@ namespace System.Runtime.CompilerServices
     public sealed partial class IDispatchConstantAttribute : System.Runtime.CompilerServices.CustomConstantAttribute
     {
         public IDispatchConstantAttribute() { }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public override object Value { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter, Inherited=false)]

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/CompilerServices/IDispatchConstantAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/CompilerServices/IDispatchConstantAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Runtime.CompilerServices
 {
@@ -10,6 +11,7 @@ namespace System.Runtime.CompilerServices
     {
         public IDispatchConstantAttribute() { }
 
+        [SupportedOSPlatform("windows")]
         public override object Value => new DispatchWrapper(null);
     }
 }

--- a/src/libraries/System.Security.Cryptography.Csp/src/Internal/Cryptography/BasicSymmetricCipherCsp.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/Internal/Cryptography/BasicSymmetricCipherCsp.cs
@@ -122,6 +122,7 @@ namespace Internal.Cryptography
         private static SafeProvHandle AcquireSafeProviderHandle()
         {
             SafeProvHandle safeProvHandle;
+            Debug.Assert(OperatingSystem.IsWindows());
             var cspParams = new CspParameters((int)ProviderType.PROV_RSA_FULL);
             CapiHelper.AcquireCsp(cspParams, out safeProvHandle);
             return safeProvHandle;

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -176,7 +176,7 @@ namespace Internal.NativeCrypto
         internal static void AcquireCsp(CspParameters cspParameters, out SafeProvHandle safeProvHandle)
         {
             Debug.Assert(cspParameters != null);
-            Debug.Assert(cspParameters.KeyContainerName == null);
+            Debug.Assert(OperatingSystem.IsWindows() && cspParameters.KeyContainerName == null);
 
             SafeProvHandle hProv;
             //
@@ -205,6 +205,7 @@ namespace Internal.NativeCrypto
                 throw new ArgumentException(SR.Format(SR.CspParameter_invalid, nameof(cspParameters)));
             }
 
+            Debug.Assert(OperatingSystem.IsWindows());
             //look for provider type in the cspParameters
             int providerType = cspParameters.ProviderType;
 
@@ -274,6 +275,7 @@ namespace Internal.NativeCrypto
             SafeProvHandle safeProvHandle;
             uint flag = 0;
             uint hr = unchecked((uint)OpenCSP(parameters, flag, out safeProvHandle));
+            Debug.Assert(OperatingSystem.IsWindows());
             //Open container failed
             if (hr != S_OK)
             {
@@ -664,6 +666,7 @@ namespace Internal.NativeCrypto
             out bool randomKeyContainer)
         {
             CspParameters parameters;
+            Debug.Assert(OperatingSystem.IsWindows());
             if (userParameters == null)
             {
                 parameters = new CspParameters(keyType == CspAlgorithmType.Dss ?
@@ -732,6 +735,7 @@ namespace Internal.NativeCrypto
         {
             // If the key already exists, use it, else generate a new one
             SafeKeyHandle hKey;
+            Debug.Assert(OperatingSystem.IsWindows());
             int hr = CapiHelper.GetUserKey(safeProvHandle, parameters.KeyNumber, out hKey);
             if (hr != S_OK)
             {

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -176,7 +176,8 @@ namespace Internal.NativeCrypto
         internal static void AcquireCsp(CspParameters cspParameters, out SafeProvHandle safeProvHandle)
         {
             Debug.Assert(cspParameters != null);
-            Debug.Assert(OperatingSystem.IsWindows() && cspParameters.KeyContainerName == null);
+            Debug.Assert(OperatingSystem.IsWindows());
+            Debug.Assert(cspParameters.KeyContainerName == null);
 
             SafeProvHandle hProv;
             //

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Windows.cs
@@ -24,11 +24,13 @@ namespace System.Security.Cryptography
         /// Initializes a new instance of the DSACryptoServiceProvider class.
         /// </summary>
         public DSACryptoServiceProvider()
+#pragma warning disable CA1416 // Validate platform compatibility
             : this(
                   new CspParameters(CapiHelper.DefaultDssProviderType,
                       null,
                       null,
                       s_useMachineKeyStore))
+#pragma warning restore CA1416 //
         {
         }
 
@@ -37,11 +39,13 @@ namespace System.Security.Cryptography
         /// </summary>
         /// <param name="dwKeySize">The size of the key for the asymmetric algorithm in bits.</param>
         public DSACryptoServiceProvider(int dwKeySize)
+#pragma warning disable CA1416 // Validate platform compatibility
             : this(dwKeySize,
                   new CspParameters(CapiHelper.DefaultDssProviderType,
                       null,
                       null,
                       s_useMachineKeyStore))
+#pragma warning restore CA1416 // Validate platform compatibility
         {
         }
 
@@ -324,6 +328,7 @@ namespace System.Security.Cryptography
         private SafeProvHandle AcquireSafeProviderHandle()
         {
             SafeProvHandle safeProvHandle;
+            Debug.Assert(OperatingSystem.IsWindows());
             CapiHelper.AcquireCsp(new CspParameters(CapiHelper.DefaultDssProviderType), out safeProvHandle);
             return safeProvHandle;
         }
@@ -348,6 +353,7 @@ namespace System.Security.Cryptography
             }
             else
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 CapiHelper.ImportKeyBlob(SafeProvHandle, _parameters.Flags, false, keyBlob, out safeKeyHandle);
             }
 
@@ -489,6 +495,7 @@ namespace System.Security.Cryptography
             if (rgbHash.Length != _sha1.HashSize / 8)
                 throw new CryptographicException(SR.Format(SR.Cryptography_InvalidHashSize, "SHA1", _sha1.HashSize / 8));
 
+            Debug.Assert(OperatingSystem.IsWindows());
             return CapiHelper.SignValue(
                 SafeProvHandle,
                 SafeKeyHandle,

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/PasswordDeriveBytes.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/PasswordDeriveBytes.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Internal.NativeCrypto;
+using System.Diagnostics;
 using System.Runtime.Versioning;
 
 #pragma warning disable CA5373 // Call to obsolete key derivation function PasswordDeriveBytes.*
@@ -58,6 +59,7 @@ namespace System.Security.Cryptography
         {
             if (cspParams == null)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 cspParams = new CspParameters(CapiHelper.DefaultRsaProviderType);
             }
 

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/PasswordDeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/PasswordDeriveBytes.cs
@@ -25,6 +25,7 @@ namespace System.Security.Cryptography
         private HashAlgorithm? _hash;
         private readonly CspParameters? _cspParams;
 
+#pragma warning disable CA1416 // Validate platform compatibility, CspParametersis windows only, this is feels wrong suppressing for now
         public PasswordDeriveBytes(string strPassword, byte[]? rgbSalt) : this(strPassword, rgbSalt, new CspParameters()) { }
 
         public PasswordDeriveBytes(byte[] password, byte[]? salt) : this(password, salt, new CspParameters()) { }
@@ -34,6 +35,7 @@ namespace System.Security.Cryptography
 
         public PasswordDeriveBytes(byte[] password, byte[]? salt, string hashName, int iterations) :
             this(password, salt, hashName, iterations, new CspParameters()) { }
+#pragma warning restore CA1416
 
         public PasswordDeriveBytes(string strPassword, byte[]? rgbSalt, CspParameters? cspParams) :
             this(strPassword, rgbSalt, "SHA1", 100, cspParams) { }

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography
         private static volatile CspProviderFlags s_useMachineKeyStore;
         private bool _disposed;
 
+#pragma warning disable CA1416 // Validate platform compatibility
         public RSACryptoServiceProvider()
             : this(0, new CspParameters(CapiHelper.DefaultRsaProviderType,
                                        null,
@@ -39,6 +40,7 @@ namespace System.Security.Cryptography
                   s_useMachineKeyStore), false)
         {
         }
+#pragma warning restore CA1416
 
         [SupportedOSPlatform("windows")]
         public RSACryptoServiceProvider(int dwKeySize, CspParameters? parameters)
@@ -374,6 +376,7 @@ namespace System.Security.Cryptography
         private SafeProvHandle AcquireSafeProviderHandle()
         {
             SafeProvHandle safeProvHandle;
+            Debug.Assert(OperatingSystem.IsWindows());
             CapiHelper.AcquireCsp(new CspParameters(CapiHelper.DefaultRsaProviderType), out safeProvHandle);
             return safeProvHandle;
         }
@@ -397,6 +400,7 @@ namespace System.Security.Cryptography
             }
             else
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 CapiHelper.ImportKeyBlob(SafeProvHandle, _parameters.Flags, false, keyBlob, out safeKeyHandle);
             }
 
@@ -507,6 +511,7 @@ namespace System.Security.Cryptography
         private byte[] SignHash(byte[] rgbHash, int calgHash)
         {
             Debug.Assert(rgbHash != null);
+            Debug.Assert(OperatingSystem.IsWindows());
 
             return CapiHelper.SignValue(
                 SafeProvHandle,
@@ -714,6 +719,7 @@ namespace System.Security.Cryptography
         {
             get
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 if (_parameters.KeyNumber == (int)Interop.Advapi32.KeySpec.AT_KEYEXCHANGE)
                 {
                     return "RSA-PKCS1-KeyEx";

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.PrivateKey.cs
@@ -28,10 +28,12 @@ namespace Internal.Cryptography.Pal
             return GetPrivateKey<RSA>(
                 delegate (CspParameters csp)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     return new RSACryptoServiceProvider(csp);
                 },
                 delegate (CngKey cngKey)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     return new RSACng(cngKey);
                 }
             );
@@ -42,10 +44,12 @@ namespace Internal.Cryptography.Pal
             return GetPrivateKey<DSA>(
                 delegate (CspParameters csp)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     return new DSACryptoServiceProvider(csp);
                 },
                 delegate (CngKey cngKey)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     return new DSACng(cngKey);
                 }
             );
@@ -60,6 +64,7 @@ namespace Internal.Cryptography.Pal
                 },
                 delegate (CngKey cngKey)
                 {
+                    Debug.Assert(OperatingSystem.IsWindows());
                     return new ECDsaCng(cngKey);
                 }
             );
@@ -69,7 +74,9 @@ namespace Internal.Cryptography.Pal
         {
             return GetPrivateKey<ECDiffieHellman>(
                 csp => throw new NotSupportedException(SR.NotSupported_ECDiffieHellman_Csp),
+#pragma warning disable CA1416 // Validate platform compatibility
                 cngKey => new ECDiffieHellmanCng(cngKey)
+#pragma warning restore CA1416 // Validate platform compatibility
             );
         }
 
@@ -78,6 +85,7 @@ namespace Internal.Cryptography.Pal
             DSACng? dsaCng = dsa as DSACng;
             ICertificatePal? clone = null;
 
+            Debug.Assert(OperatingSystem.IsWindows());
             if (dsaCng != null)
             {
                 clone = CopyWithPersistedCngKey(dsaCng.Key);
@@ -115,6 +123,7 @@ namespace Internal.Cryptography.Pal
         {
             ECDsaCng? ecdsaCng = ecdsa as ECDsaCng;
 
+            Debug.Assert(OperatingSystem.IsWindows());
             if (ecdsaCng != null)
             {
                 ICertificatePal? clone = CopyWithPersistedCngKey(ecdsaCng.Key);
@@ -140,6 +149,7 @@ namespace Internal.Cryptography.Pal
         {
             ECDiffieHellmanCng? ecdhCng = ecdh as ECDiffieHellmanCng;
 
+            Debug.Assert(OperatingSystem.IsWindows());
             if (ecdhCng != null)
             {
                 ICertificatePal? clone = CopyWithPersistedCngKey(ecdhCng.Key);
@@ -166,6 +176,7 @@ namespace Internal.Cryptography.Pal
             RSACng? rsaCng = rsa as RSACng;
             ICertificatePal? clone = null;
 
+            Debug.Assert(OperatingSystem.IsWindows());
             if (rsaCng != null)
             {
                 clone = CopyWithPersistedCngKey(rsaCng.Key);
@@ -208,6 +219,7 @@ namespace Internal.Cryptography.Pal
         {
             CngKeyHandleOpenOptions cngHandleOptions;
             SafeNCryptKeyHandle? ncryptKey = TryAcquireCngPrivateKey(CertContext, out cngHandleOptions);
+            Debug.Assert(OperatingSystem.IsWindows());
             if (ncryptKey != null)
             {
                 CngKey cngKey = CngKey.Open(ncryptKey, cngHandleOptions);
@@ -244,6 +256,7 @@ namespace Internal.Cryptography.Pal
             Debug.Assert(certificateContext != null, "certificateContext != null");
             Debug.Assert(!certificateContext.IsClosed && !certificateContext.IsInvalid,
                          "!certificateContext.IsClosed && !certificateContext.IsInvalid");
+            Debug.Assert(OperatingSystem.IsWindows());
 
             IntPtr privateKeyPtr;
 
@@ -345,6 +358,7 @@ namespace Internal.Cryptography.Pal
                         throw Marshal.GetLastWin32Error().ToCryptographicException();
                     CRYPT_KEY_PROV_INFO* pKeyProvInfo = (CRYPT_KEY_PROV_INFO*)pPrivateKey;
 
+                    Debug.Assert(OperatingSystem.IsWindows());
                     CspParameters cspParameters = new CspParameters();
                     cspParameters.ProviderName = Marshal.PtrToStringUni((IntPtr)(pKeyProvInfo->pwszProvName));
                     cspParameters.KeyContainerName = Marshal.PtrToStringUni((IntPtr)(pKeyProvInfo->pwszContainerName));
@@ -358,6 +372,7 @@ namespace Internal.Cryptography.Pal
 
         private unsafe ICertificatePal? CopyWithPersistedCngKey(CngKey cngKey)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             if (string.IsNullOrEmpty(cngKey.KeyName))
             {
                 return null;
@@ -404,6 +419,7 @@ namespace Internal.Cryptography.Pal
             bool machineKey,
             CngAlgorithmGroup? algorithmGroup)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             if (provider == CngProvider.MicrosoftSoftwareKeyStorageProvider ||
                 provider == CngProvider.MicrosoftSmartCardKeyStorageProvider)
             {
@@ -457,6 +473,7 @@ namespace Internal.Cryptography.Pal
             CngAlgorithmGroup? algorithmGroup,
             out int keySpec)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             if (algorithmGroup == CngAlgorithmGroup.Rsa)
             {
                 return TryGuessRsaKeySpec(cspParameters, out keySpec);
@@ -493,6 +510,7 @@ namespace Internal.Cryptography.Pal
                 PROV_RSA_SIG,
             };
 
+            Debug.Assert(OperatingSystem.IsWindows());
             foreach (int provType in provTypes)
             {
                 cspParameters.ProviderType = provType;
@@ -528,6 +546,7 @@ namespace Internal.Cryptography.Pal
                 PROV_DSS,
             };
 
+            Debug.Assert(OperatingSystem.IsWindows());
             foreach (int provType in provTypes)
             {
                 cspParameters.ProviderType = provType;
@@ -554,6 +573,7 @@ namespace Internal.Cryptography.Pal
 
         private unsafe ICertificatePal? CopyWithPersistedCapiKey(CspKeyContainerInfo keyContainerInfo)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             if (string.IsNullOrEmpty(keyContainerInfo.KeyContainerName))
             {
                 return null;
@@ -588,6 +608,7 @@ namespace Internal.Cryptography.Pal
 
         private ICertificatePal CopyWithEphemeralKey(CngKey cngKey)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             Debug.Assert(string.IsNullOrEmpty(cngKey.KeyName));
 
             SafeNCryptKeyHandle handle = cngKey.Handle;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -410,6 +410,7 @@ namespace Internal.Cryptography.Pal
             sb.AppendLine();
             sb.AppendLine("[Private Key]");
 
+            Debug.Assert(OperatingSystem.IsWindows());
             CspKeyContainerInfo? cspKeyContainerInfo = null;
             try
             {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
@@ -169,6 +169,7 @@ namespace Internal.Cryptography.Pal.Native
 
                         try
                         {
+                            Debug.Assert(OperatingSystem.IsWindows());
                             using (CngKey cngKey = CngKey.Open(keyContainerName, new CngProvider(providerName)))
                             {
                                 cngKey.Delete();

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
@@ -30,8 +30,10 @@ namespace Internal.Cryptography.Pal
             {
                 return DecodeECPublicKey(
                     pal,
+#pragma warning disable CA1416 // Validate platform compatibility, flow analysis bug
                     factory: cngKey => new ECDsaCng(cngKey),
                     import: (algorithm, ecParams) => algorithm.ImportParameters(ecParams));
+#pragma warning restore CA1416
             }
 
             throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
@@ -41,10 +43,13 @@ namespace Internal.Cryptography.Pal
         {
             if (certificatePal is CertificatePal pal)
             {
+                Debug.Assert(OperatingSystem.IsWindows());
                 return DecodeECPublicKey(
                     pal,
+#pragma warning disable CA1416 // Validate platform compatibility
                     factory: cngKey => new ECDiffieHellmanCng(cngKey),
                     import: (algorithm, ecParams) => algorithm.ImportParameters(ecParams),
+#pragma warning restore CA1416
                     importFlags: CryptImportPublicKeyInfoFlags.CRYPT_OID_INFO_PUBKEY_ENCRYPT_KEY_FLAG);
             }
 
@@ -59,6 +64,7 @@ namespace Internal.Cryptography.Pal
                 case AlgId.CALG_RSA_KEYX:
                 case AlgId.CALG_RSA_SIGN:
                     {
+                        Debug.Assert(OperatingSystem.IsWindows());
                         byte[] keyBlob = DecodeKeyBlob(CryptDecodeObjectStructType.CNG_RSA_PUBLIC_KEY_BLOB, encodedKeyValue);
                         CngKey cngKey = CngKey.Import(keyBlob, CngKeyBlobFormat.GenericPublicBlob);
                         return new RSACng(cngKey);
@@ -90,6 +96,7 @@ namespace Internal.Cryptography.Pal
                 byte[] keyBlob;
                 string? curveName = GetCurveName(bCryptKeyHandle);
 
+                Debug.Assert(OperatingSystem.IsWindows());
                 if (curveName == null)
                 {
                     if (HasExplicitParameters(bCryptKeyHandle))
@@ -149,6 +156,7 @@ namespace Internal.Cryptography.Pal
 
         private static byte[] ExportKeyBlob(SafeBCryptKeyHandle bCryptKeyHandle, CngKeyBlobFormat blobFormat)
         {
+            Debug.Assert(OperatingSystem.IsWindows());
             string blobFormatString = blobFormat.Format;
 
             int numBytesNeeded = 0;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
@@ -43,7 +43,6 @@ namespace Internal.Cryptography.Pal
         {
             if (certificatePal is CertificatePal pal)
             {
-                Debug.Assert(OperatingSystem.IsWindows());
                 return DecodeECPublicKey(
                     pal,
 #pragma warning disable CA1416 // Validate platform compatibility


### PR DESCRIPTION
Fix Platform Compatibility warnings revealed after enabling analyzer for projects not having access to System.Runtime.InteropServices.RuntimeInformation, System.Runtime.InteropServices.OSPlatofrm types

Related to [Ensure that each of those projects can produce warnings/errors from the analyzer during a normal build task of #42335 ]( https://github.com/dotnet/runtime/issues/42335)