### PR TITLE
Add the release wildcard trigger in the release branch

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - master
+    - release/*
   paths:
     include:
     - '*'


### PR DESCRIPTION
This adds the release trigger in the release branch, which is required to have the trigger work properly