### PR TITLE
CoreDisTools and R2RDump support Arm Thumb2 disassembling

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -465,6 +465,12 @@ namespace ILCompiler.Reflection.ReadyToRun
             for (int i = 0; i < RuntimeFunctionCount; i++)
             {
                 int startRva = NativeReader.ReadInt32(_readyToRunReader.Image, ref curOffset);
+                if (_readyToRunReader.Machine == Machine.ArmThumb2)
+                {
+                    // The low bit of this address is set since the function contains thumb code.
+                    // Clear this bit in order to get the "real" RVA of the start of the function.
+                    startRva = (int)(startRva & ~1);
+                }
                 int endRva = -1;
                 if (_readyToRunReader.Machine == Machine.Amd64)
                 {

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -542,11 +542,6 @@ namespace R2RDump
             return null;
         }
 
-        private static bool InputArchitectureSupported(Machine machine)
-        {
-            return machine != Machine.ArmThumb2; // CoreDisTools often fails to decode when disassembling ARM images (see https://github.com/dotnet/runtime/issues/10959)
-        }
-
         // TODO: Fix R2RDump issue where an R2R image cannot be dissassembled with the x86 CoreDisTools
         // For the short term, we want to error out with a decent message explaining the unexpected error
         // Issue https://github.com/dotnet/runtime/issues/10928
@@ -581,7 +576,7 @@ namespace R2RDump
 
                     if (_options.Disasm)
                     {
-                        if (InputArchitectureSupported(r2r.Machine) && DisassemblerArchitectureSupported())
+                        if (DisassemblerArchitectureSupported())
                         {
                             disassembler = new Disassembler(r2r, _options);
                         }


### PR DESCRIPTION
With the new version of coredistools produced by [jitutils-coredistools](https://dev.azure.com/dnceng/public/_build?definitionId=900) pipeline and changes in this PR and https://github.com/dotnet/jitutils/pull/295 I was able to run R2RDump locally on windows-x64 machine and successfully disassemble all of the flavors of the System.Private.CoreLib R2R images.

```
D:\>for %A in (x64 x86 arm arm64) do (C:\git\runtime1\.dotnet\dotnet.exe C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.x64.Checked\R2RDump\R2RDump.dll --in C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.%A.Checked\System.Private.CoreLib.dll --disasm --out System.Private.CoreLib.%A.disasm)

D:\>(C:\git\runtime1\.dotnet\dotnet.exe C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.x64.Checked\R2RDump\R2RDump.dll --in C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.x64.Checked\System.Private.CoreLib.dll --disasm --out System.Private.CoreLib.x64.disasm )

D:\>(C:\git\runtime1\.dotnet\dotnet.exe C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.x64.Checked\R2RDump\R2RDump.dll --in C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.x86.Checked\System.Private.CoreLib.dll --disasm --out System.Private.CoreLib.x86.disasm )

D:\>(C:\git\runtime1\.dotnet\dotnet.exe C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.x64.Checked\R2RDump\R2RDump.dll --in C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.arm.Checked\System.Private.CoreLib.dll --disasm --out System.Private.CoreLib.arm.disasm )

D:\>(C:\git\runtime1\.dotnet\dotnet.exe C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.x64.Checked\R2RDump\R2RDump.dll --in C:\git\runtime1\artifacts\bin\coreclr\Windows_NT.arm64.Checked\System.Private.CoreLib.dll --disasm --out System.Private.CoreLib.arm64.disasm )
```

It seems that this issue we observed with Arm disassembler (https://github.com/dotnet/runtime/issues/10959) was due to a wrong address of the instruction passed to coredistools during `DumpInstruction` call. Since the function contains thumb code its low bit was set and the disassembler attempted to decode instruction at the next position than where it should've. 

@trylek @janvorli PTAL I was not sure if I should've adjusted the address of an instruction *"closer"* to `DumpInstruction` call or clearing the bit in `startRva` seems fine.

cc @dotnet/jit-contrib 