### PR TITLE
Lock CoreDisTools package version in stress_dependencies.csproj

### DIFF
--- a/src/tests/Common/stress_dependencies/stress_dependencies.csproj
+++ b/src/tests/Common/stress_dependencies/stress_dependencies.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$(MicrosoftNETCoreCoreDisToolsPackageName)" GeneratePathProperty="True">
-      <Version>1.0.1-prerelease-*</Version>
+      <Version>1.0.1-prerelease-00005</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
So I can publish a newer version of coredistools from https://github.com/dotnet/jitutils without worrying to break anything in the repo.

R2RDump seems to be already doing this
https://github.com/dotnet/runtime/blob/3be4a5719a3a78c2a1e60c928c10aa48f2da69fd/src/coreclr/src/tools/r2rdump/R2RDump.csproj#L21-L23