### PR TITLE
Expose BackgroundService.ExecuteTask

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.Hosting
     public abstract partial class BackgroundService : Microsoft.Extensions.Hosting.IHostedService, System.IDisposable
     {
         protected BackgroundService() { }
+        public virtual System.Threading.Tasks.Task ExecuteTask { get { throw null; } }
         public virtual void Dispose() { }
         protected abstract System.Threading.Tasks.Task ExecuteAsync(System.Threading.CancellationToken stoppingToken);
         public virtual System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Hosting/Microsoft.Extensions.Hosting.sln
+++ b/src/libraries/Microsoft.Extensions.Hosting/Microsoft.Extensions.Hosting.sln
@@ -25,7 +25,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Hostin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Hosting.Functional.Tests", "tests\FunctionalTests\Microsoft.Extensions.Hosting.Functional.Tests.csproj", "{49ED668A-7FCB-455B-B3B4-26C004172531}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{602F282E-2829-4C7D-B960-A8D31F326E9F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{602F282E-2829-4C7D-B960-A8D31F326E9F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Hosting.Abstractions", "..\Microsoft.Extensions.Hosting.Abstractions\ref\Microsoft.Extensions.Hosting.Abstractions.csproj", "{BAD57E10-C310-4BED-A4BF-7B02B1AC35BC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Hosting.Abstractions", "..\Microsoft.Extensions.Hosting.Abstractions\src\Microsoft.Extensions.Hosting.Abstractions.csproj", "{0468E166-54DE-4DB7-A2DF-42214A39C392}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +61,14 @@ Global
 		{602F282E-2829-4C7D-B960-A8D31F326E9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{602F282E-2829-4C7D-B960-A8D31F326E9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{602F282E-2829-4C7D-B960-A8D31F326E9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAD57E10-C310-4BED-A4BF-7B02B1AC35BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAD57E10-C310-4BED-A4BF-7B02B1AC35BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAD57E10-C310-4BED-A4BF-7B02B1AC35BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAD57E10-C310-4BED-A4BF-7B02B1AC35BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0468E166-54DE-4DB7-A2DF-42214A39C392}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0468E166-54DE-4DB7-A2DF-42214A39C392}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0468E166-54DE-4DB7-A2DF-42214A39C392}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0468E166-54DE-4DB7-A2DF-42214A39C392}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -71,6 +83,8 @@ Global
 		{4E52FAB8-83A4-4F81-AFED-072BF13D0F46} = {FE4AAEDA-1D08-4C9A-B61C-8A7156000E43}
 		{49ED668A-7FCB-455B-B3B4-26C004172531} = {EB3CB906-BAB0-4A90-BE2F-BBFE47B036C3}
 		{602F282E-2829-4C7D-B960-A8D31F326E9F} = {635786A7-1A3B-46BB-9367-DE57F7032900}
+		{BAD57E10-C310-4BED-A4BF-7B02B1AC35BC} = {23DF8E80-C5C7-4D64-B0D4-F4D33A9646A1}
+		{0468E166-54DE-4DB7-A2DF-42214A39C392} = {2BCD92F1-BA65-4145-A650-8BADD26EE5D9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {137EEE14-A353-4DA8-98CB-214FD8EBAF33}

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -55,10 +55,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
                 if (hostedService is BackgroundService backgroundService)
                 {
-                    _ = backgroundService.ExecuteTask.ContinueWith(t =>
-                    {
-                        _logger.BackgroundServiceFaulted(t.Exception);
-                    }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                    _ = HandleBackgroundException(backgroundService);
                 }
             }
 
@@ -66,6 +63,18 @@ namespace Microsoft.Extensions.Hosting.Internal
             _applicationLifetime.NotifyStarted();
 
             _logger.Started();
+        }
+
+        private async Task HandleBackgroundException(BackgroundService backgroundService)
+        {
+            try
+            {
+                await backgroundService.ExecuteTask.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.BackgroundServiceFaulted(ex);
+            }
         }
 
         public async Task StopAsync(CancellationToken cancellationToken = default)

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -52,6 +52,14 @@ namespace Microsoft.Extensions.Hosting.Internal
             {
                 // Fire IHostedService.Start
                 await hostedService.StartAsync(combinedCancellationToken).ConfigureAwait(false);
+
+                if (hostedService is BackgroundService backgroundService)
+                {
+                    _ = backgroundService.ExecuteTask.ContinueWith(t =>
+                    {
+                        _logger.BackgroundServiceFaulted(t.Exception);
+                    }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                }
             }
 
             // Fire IHostApplicationLifetime.Started

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 
@@ -77,6 +74,17 @@ namespace Microsoft.Extensions.Hosting.Internal
                     eventId: LoggerEventIds.StoppedWithException,
                     exception: ex,
                     message: "Hosting shutdown exception");
+            }
+        }
+
+        public static void BackgroundServiceFaulted(this ILogger logger, Exception ex)
+        {
+            if (logger.IsEnabled(LogLevel.Error))
+            {
+                logger.LogError(
+                    eventId: LoggerEventIds.BackgroundServiceFaulted,
+                    exception: ex,
+                    message: "BackgroundService failed");
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/LoggerEventIds.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/LoggerEventIds.cs
@@ -15,5 +15,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         public static readonly EventId ApplicationStartupException = new EventId(6, "ApplicationStartupException");
         public static readonly EventId ApplicationStoppingException = new EventId(7, "ApplicationStoppingException");
         public static readonly EventId ApplicationStoppedException = new EventId(8, "ApplicationStoppedException");
+        public static readonly EventId BackgroundServiceFaulted = new EventId(9, "BackgroundServiceFaulted");
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceTests.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Extensions.Hosting.Tests
 {
-    public class BackgroundHostedServiceTests
+    public class BackgroundServiceTests
     {
         [Fact]
         public void StartReturnsCompletedTaskIfLongRunningTaskIsIncomplete()
@@ -23,7 +21,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.True(task.IsCompleted);
             Assert.False(tcs.Task.IsCompleted);
 
-            // Complete the tsk
+            // Complete the task
             tcs.TrySetResult(null);
         }
 
@@ -37,6 +35,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             var task = service.StartAsync(CancellationToken.None);
 
             Assert.True(task.IsCompleted);
+            Assert.Same(task, service.ExecuteTask);
         }
 
         [Fact]
@@ -175,8 +174,6 @@ namespace Microsoft.Extensions.Hosting.Tests
         {
             private readonly Task _task;
 
-            public Task ExecuteTask { get; set; }
-
             public MyBackgroundService(Task task)
             {
                 _task = task;
@@ -184,8 +181,7 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
-                ExecuteTask = ExecuteCore(stoppingToken);
-                await ExecuteTask;
+                await ExecuteCore(stoppingToken);
             }
 
             private async Task ExecuteCore(CancellationToken stoppingToken)

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -13,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-namespace Microsoft.Extensions.Hosting
+namespace Microsoft.Extensions.Hosting.Tests
 {
     public class HostBuilderTests
     {

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -15,7 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
-namespace Microsoft.Extensions.Hosting
+namespace Microsoft.Extensions.Hosting.Tests
 {
     public partial class HostTests
     {
@@ -273,37 +271,6 @@ namespace Microsoft.Extensions.Hosting
                 public void Dispose()
                 {
                 }
-            }
-        }
-
-        private class TestEventListener : EventListener
-        {
-            private volatile bool _disposed;
-
-            private ConcurrentQueue<EventWrittenEventArgs> _events = new ConcurrentQueue<EventWrittenEventArgs>();
-
-            public IEnumerable<EventWrittenEventArgs> EventData => _events;
-
-            protected override void OnEventSourceCreated(EventSource eventSource)
-            {
-                if (eventSource.Name == "Microsoft-Extensions-Logging")
-                {
-                    EnableEvents(eventSource, EventLevel.Informational);
-                }
-            }
-
-            protected override void OnEventWritten(EventWrittenEventArgs eventData)
-            {
-                if (!_disposed)
-                {
-                    _events.Enqueue(eventData);
-                }
-            }
-
-            public override void Dispose()
-            {
-                _disposed = true;
-                base.Dispose();
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/TestEventListener.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/TestEventListener.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.Extensions.Hosting.Tests
+{
+    internal class TestEventListener : EventListener
+    {
+        private volatile bool _disposed;
+
+        private ConcurrentQueue<EventWrittenEventArgs> _events = new ConcurrentQueue<EventWrittenEventArgs>();
+
+        public IEnumerable<EventWrittenEventArgs> EventData => _events;
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == "Microsoft-Extensions-Logging")
+            {
+                EnableEvents(eventSource, EventLevel.Informational);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (!_disposed)
+            {
+                _events.Enqueue(eventData);
+            }
+        }
+
+        public override void Dispose()
+        {
+            _disposed = true;
+            base.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Expose the task that executes the background service, so consumers can check if it is running and/or has ran to competition or faulted.

Use the new ExecuteTask to log exceptions when a BackgroundService fails after await, instead of appearing to hang.

Fix #35991
Fix #36017