### PR TITLE
[System.Drawing.Common] In test, dispose of Metafile after Graphics

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
@@ -408,8 +408,8 @@ namespace MonoTests.System.Drawing.Imaging
                 RectangleF rect = new RectangleF(0, 0, size.Width, size.Height);
                 Region[] region = g.MeasureCharacterRanges(text, test_font, rect, sf);
                 Assert.Equal(2, region.Length);
-                mf.Dispose();
             }
+            mf.Dispose();
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37838

Verified using libgdiplus built with
https://github.com/mono/libgdiplus/pull/671