### PR TITLE
R2RDump cleanup

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
@@ -93,7 +93,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                     }
                     else
                     {
-                        OpInfoStr += "Unknown";
+                        throw new BadImageFormatException();
                     }
                     break;
                 case UnwindOpCodes.UWOP_ALLOC_SMALL:

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
@@ -9,9 +9,12 @@ namespace ILCompiler.Reflection.ReadyToRun
     {
         IAssemblyMetadata FindAssembly(MetadataReader metadataReader, AssemblyReferenceHandle assemblyReferenceHandle, string parentFile);
         IAssemblyMetadata FindAssembly(string simpleName, string parentFile);
-        // TODO (refactoring) - signature formatting options should be independent of assembly resolver
-        bool Naked { get; }
-        bool SignatureBinary { get; }
-        bool InlineSignatureBinary { get; }
+    }
+
+    public class SignatureFormattingOptions
+    {
+        public bool Naked { get; set; }
+        public bool SignatureBinary { get; set;  }
+        public bool InlineSignatureBinary { get; set; }
     }
 }

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
@@ -21,14 +21,14 @@ namespace ILCompiler.Reflection.ReadyToRun
             public int StartRVA { get; set; }
             public long Section { get; set; }
             public uint SignatureRVA { get; set; }
-            public string Signature { get; set; }
+            public ReadyToRunSignature Signature { get; set; }
             public GCRefMap GCRefMap { get; set; }
 
             public ImportSectionEntry()
             {
             }
 
-            public ImportSectionEntry(int index, int startOffset, int startRVA, long section, uint signatureRVA, string signature)
+            public ImportSectionEntry(int index, int startOffset, int startRVA, long section, uint signatureRVA, ReadyToRunSignature signature)
             {
                 Index = index;
                 StartOffset = startOffset;

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -22,25 +22,25 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// </summary>
     public struct FixupCell
     {
-        public int Index { get; set; }
+        public int Index { get; }
 
         /// <summary>
         /// Zero-based index of the import table within the import tables section.
         /// </summary>
-        public uint TableIndex;
+        public uint TableIndex { get; }
 
         /// <summary>
         /// Zero-based offset of the entry in the import table; it must be a multiple
         /// of the target architecture pointer size.
         /// </summary>
-        public uint CellOffset;
+        public uint CellOffset { get; }
 
         /// <summary>
-        /// Fixup cell signature (textual representation of the typesystem object).
+        /// Fixup cell signature
         /// </summary>
-        public string Signature;
+        public ReadyToRunSignature Signature { get; }
 
-        public FixupCell(int index, uint tableIndex, uint cellOffset, string signature)
+        public FixupCell(int index, uint tableIndex, uint cellOffset, ReadyToRunSignature signature)
         {
             Index = index;
             TableIndex = tableIndex;

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -16,8 +16,23 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// <summary>
     /// This represents all possible signatures that is 
     /// </summary>
-    public class ReadyToRunSignature
+    public abstract class ReadyToRunSignature
     {
+        private SignatureDecoder _decoder;
+
+        public ReadyToRunSignature(SignatureDecoder decoder)
+        {
+            _decoder = decoder;
+        }
+
+        public string ToString(SignatureFormattingOptions options)
+        {
+            StringBuilder builder = new StringBuilder();
+            _decoder.Reset();
+            _decoder.Context.Options = options;
+            _decoder.ReadR2RSignature(builder);
+            return builder.ToString();
+        }
     }
 
     /// <summary>
@@ -25,16 +40,27 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// </summary>
     public class TodoSignature : ReadyToRunSignature
     {
+        public TodoSignature(SignatureDecoder decoder) : base(decoder)
+        {
+        }
     }
 
     public class MethodDefEntrySignature : ReadyToRunSignature
     {
         public uint MethodDefToken { get; set; }
+
+        public MethodDefEntrySignature(SignatureDecoder decoder) : base(decoder)
+        {
+        }
     }
 
     public class MethodRefEntrySignature : ReadyToRunSignature
     {
         public uint MethodRefToken { get; set; }
+
+        public MethodRefEntrySignature(SignatureDecoder decoder) : base(decoder)
+        {
+        }
     }
 
     /// <summary>
@@ -64,11 +90,12 @@ namespace ILCompiler.Reflection.ReadyToRun
             return formatter.EmitHandleName(handle, namespaceQualified, owningTypeOverride, signaturePrefix);
         }
 
-        public static string FormatSignature(IAssemblyResolver assemblyResolver, ReadyToRunReader r2rReader, int imageOffset, out ReadyToRunSignature result)
+        public static ReadyToRunSignature FormatSignature(IAssemblyResolver assemblyResolver, ReadyToRunReader r2rReader, int imageOffset)
         {
-            SignatureDecoder decoder = new SignatureDecoder(assemblyResolver, r2rReader.GetGlobalMetadata()?.MetadataReader, r2rReader, imageOffset);
-            string answer = decoder.ReadR2RSignature(out result);
-            return answer;
+            SignatureFormattingOptions dummyOptions = new SignatureFormattingOptions();
+            SignatureDecoder decoder = new SignatureDecoder(assemblyResolver, dummyOptions, r2rReader.GetGlobalMetadata()?.MetadataReader, r2rReader, imageOffset);
+            StringBuilder dummyBuilder = new StringBuilder();
+            return decoder.ReadR2RSignature(dummyBuilder);
         }
 
         /// <summary>
@@ -406,6 +433,11 @@ namespace ILCompiler.Reflection.ReadyToRun
         private int _offset;
 
         /// <summary>
+        /// Offset within the image file when the object is constructed.
+        /// </summary>
+        private readonly int _originalOffset;
+
+        /// <summary>
         /// Query signature parser for the current offset.
         /// </summary>
         public int Offset => _offset;
@@ -431,7 +463,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             Context = context;
             _provider = provider;
             _image = r2rReader.Image;
-            _offset = offset;
+            _originalOffset = _offset = offset;
             _contextReader = r2rReader;
         }
 
@@ -450,9 +482,17 @@ namespace ILCompiler.Reflection.ReadyToRun
             _provider = provider;
             _metadataReader = metadataReader;
             _image = signature;
-            _offset = offset;
+            _originalOffset = _offset = offset;
             _outerReader = outerReader;
             _contextReader = contextReader;
+        }
+
+        /// <summary>
+        /// Reset the offset back to the point where the decoder is constructed to allow re-decoding the same signature.
+        /// </summary>
+        internal void Reset()
+        {
+            this._offset = _originalOffset;
         }
 
         /// <summary>
@@ -819,15 +859,21 @@ namespace ILCompiler.Reflection.ReadyToRun
     }
     public class TextSignatureDecoderContext
     {
-        public TextSignatureDecoderContext(IAssemblyResolver options)
+        public TextSignatureDecoderContext(IAssemblyResolver assemblyResolver, SignatureFormattingOptions options)
         {
+            AssemblyResolver = assemblyResolver;
             Options = options;
         }
 
         /// <summary>
-        /// Dump options are used to specify details of signature formatting.
+        /// AssemblyResolver is used to find where the dependent assembly are
         /// </summary>
-        public IAssemblyResolver Options { get; }
+        public IAssemblyResolver AssemblyResolver { get; }
+
+        /// <summary>
+        /// SignatureFormattingOptions are used to specify details of signature formatting.
+        /// </summary>
+        public SignatureFormattingOptions Options { get; set;  }
     }
 
     /// <summary>
@@ -924,25 +970,27 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// Construct the signature decoder by storing the image byte array and offset within the array.
         /// </summary>
-        /// <param name="options">Dump options and paths</param>
+        /// <param name="assemblyResolver">Assembly Resolver used to locate dependent assembly</param>
+        /// <param name="options">SignatureFormattingOptions for signature formatting</param>
         /// <param name="r2rReader">R2RReader object representing the PE file containing the ECMA metadata</param>
         /// <param name="offset">Signature offset within the PE file byte array</param>
-        public SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, ReadyToRunReader r2rReader, int offset) :
-            base(TextTypeProvider.Singleton, new TextSignatureDecoderContext(options), metadataReader, r2rReader, offset)
+        public SignatureDecoder(IAssemblyResolver assemblyResolver, SignatureFormattingOptions options, MetadataReader metadataReader, ReadyToRunReader r2rReader, int offset) :
+            base(TextTypeProvider.Singleton, new TextSignatureDecoderContext(assemblyResolver, options), metadataReader, r2rReader, offset)
         {
         }
 
         /// <summary>
         /// Construct the signature decoder by storing the image byte array and offset within the array.
         /// </summary>
-        /// <param name="options">Dump options and paths</param>
+        /// <param name="assemblyResolver">Assembly Resolver used to locate dependent assembly</param>
+        /// <param name="options">SignatureFormattingOptions for signature formatting</param>
         /// <param name="metadataReader">Metadata reader for the R2R image</param>
         /// <param name="signature">Signature to parse</param>
         /// <param name="offset">Signature offset within the signature byte array</param>
         /// <param name="outerReader">Metadata reader representing the outer signature context</param>
         /// <param name="contextReader">Top-level signature context reader</param>
-        private SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, byte[] signature, int offset, MetadataReader outerReader, ReadyToRunReader contextReader) :
-            base(TextTypeProvider.Singleton, new TextSignatureDecoderContext(options), metadataReader, signature, offset, outerReader, contextReader)
+        private SignatureDecoder(IAssemblyResolver assemblyResolver, SignatureFormattingOptions options, MetadataReader metadataReader, byte[] signature, int offset, MetadataReader outerReader, ReadyToRunReader contextReader) :
+            base(TextTypeProvider.Singleton, new TextSignatureDecoderContext(assemblyResolver, options), metadataReader, signature, offset, outerReader, contextReader)
         {
         }
 
@@ -952,22 +1000,12 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// by custom encoding per fixup type.
         /// </summary>
         /// <returns></returns>
-        public string ReadR2RSignature(out ReadyToRunSignature result)
+        internal ReadyToRunSignature ReadR2RSignature(StringBuilder builder)
         {
-            result = null;
-            StringBuilder builder = new StringBuilder();
             int startOffset = Offset;
-            try
-            {
-                result = ParseSignature(builder);
-                EmitSignatureBinaryFrom(builder, startOffset);
-            }
-            catch (Exception ex)
-            {
-                builder.Append(" - ");
-                builder.Append(ex.Message);
-            }
-            return builder.ToString();
+            ReadyToRunSignature result = ParseSignature(builder);
+            EmitSignatureBinaryFrom(builder, startOffset);
+            return result;
         }
 
         public string ReadTypeSignature()
@@ -1066,7 +1104,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 fixupType &= ~(uint)ReadyToRunFixupKind.ModuleOverride;
                 int moduleIndex = (int)ReadUIntAndEmitInlineSignatureBinary(builder);
                 IAssemblyMetadata refAsmEcmaReader = _contextReader.OpenReferenceAssembly(moduleIndex);
-                moduleDecoder = new SignatureDecoder(Context.Options, refAsmEcmaReader.MetadataReader, _image, Offset, refAsmEcmaReader.MetadataReader, _contextReader);
+                moduleDecoder = new SignatureDecoder(Context.AssemblyResolver, Context.Options, refAsmEcmaReader.MetadataReader, _image, Offset, refAsmEcmaReader.MetadataReader, _contextReader);
             }
 
             ReadyToRunSignature result = moduleDecoder.ParseSignature((ReadyToRunFixupKind)fixupType, builder);
@@ -1081,7 +1119,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="builder">Output signature builder</param>
         private ReadyToRunSignature ParseSignature(ReadyToRunFixupKind fixupType, StringBuilder builder)
         {
-            ReadyToRunSignature result = new TodoSignature();
+            ReadyToRunSignature result = new TodoSignature(this);
             switch (fixupType)
             {
                 case ReadyToRunFixupKind.ThisObjDictionaryLookup:
@@ -1127,14 +1165,14 @@ namespace ILCompiler.Reflection.ReadyToRun
                     uint methodDefToken = ParseMethodDefToken(builder, owningTypeOverride: null);
                     builder.Append(" (METHOD_ENTRY");
                     builder.Append(Context.Options.Naked ? ")" : "_DEF_TOKEN)");
-                    result = new MethodDefEntrySignature { MethodDefToken = methodDefToken };
+                    result = new MethodDefEntrySignature(this) { MethodDefToken = methodDefToken };
                     break;
 
                 case ReadyToRunFixupKind.MethodEntry_RefToken:
                     uint methodRefToken = ParseMethodRefToken(builder, owningTypeOverride: null);
                     builder.Append(" (METHOD_ENTRY");
                     builder.Append(Context.Options.Naked ? ")" : "_REF_TOKEN)");
-                    result = new MethodRefEntrySignature { MethodRefToken = methodRefToken };
+                    result = new MethodRefEntrySignature(this) { MethodRefToken = methodRefToken };
                     break;
 
 
@@ -1341,8 +1379,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     break;
 
                 default:
-                    builder.Append(string.Format("Unknown fixup type: {0:X2}", fixupType));
-                    break;
+                    throw new BadImageFormatException();
             }
             return result;
         }
@@ -1838,6 +1875,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     break;
 
                 default:
+                    // TODO: Something is wrong with helper signature parsing
                     builder.Append(string.Format("Unknown helper: {0:X2}", helperType));
                     break;
             }

--- a/src/coreclr/src/tools/dotnet-pgo/TraceTypeSystemContext.cs
+++ b/src/coreclr/src/tools/dotnet-pgo/TraceTypeSystemContext.cs
@@ -371,12 +371,5 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             EcmaAssembly ecmaAssembly = (EcmaAssembly)this.GetModuleForSimpleName(simpleName, false);
             return new StandaloneAssemblyMetadata(ecmaAssembly.PEReader);
         }
-        bool IAssemblyResolver.Naked => false;
-
-        bool IAssemblyResolver.SignatureBinary => false;
-
-        bool IAssemblyResolver.InlineSignatureBinary => false;
-
-
     }
 }

--- a/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
@@ -358,6 +358,18 @@ namespace R2RDump
             return instrSize;
         }
 
+        private bool TryGetImportCellName(int target, out string targetName)
+        {
+            targetName = null;
+            _reader.ImportSignatures.TryGetValue(target, out ReadyToRunSignature targetSignature);
+            if (targetSignature != null)
+            {
+                targetName = targetSignature.ToString(_options.GetSignatureFormattingOptions());
+                return true;
+            }
+            return false;
+        }
+
         const string RelIPTag = "[rip ";
 
         /// <summary>
@@ -379,7 +391,7 @@ namespace R2RDump
                 StringBuilder translated = new StringBuilder();
                 translated.Append(instruction, 0, leftBracket);
 
-                _reader.ImportCellNames.TryGetValue(target, out string targetName);
+                TryGetImportCellName(target, out string targetName);
 
                 if (_options.Naked)
                 {
@@ -432,7 +444,7 @@ namespace R2RDump
                 StringBuilder translated = new StringBuilder();
                 translated.Append(instruction, 0, leftBracket);
 
-                _reader.ImportCellNames.TryGetValue(target, out string targetName);
+                TryGetImportCellName(target, out string targetName);
 
                 if (_options.Naked)
                 {
@@ -495,7 +507,7 @@ namespace R2RDump
                 if (pointsOutsideRuntimeFunction && IsIntel2ByteIndirectJumpPCRelativeInstruction(targetImageOffset, out int instructionRelativeOffset))
                 {
                     int thunkTargetRVA = targetRVA + instructionRelativeOffset;
-                    bool haveImportCell = _reader.ImportCellNames.TryGetValue(thunkTargetRVA, out string importCellName);
+                    bool haveImportCell = TryGetImportCellName(thunkTargetRVA, out string importCellName); ;
 
                     if (_options.Naked && haveImportCell)
                     {
@@ -799,7 +811,7 @@ namespace R2RDump
                     var translated = new StringBuilder();
                     translated.Append(instruction, 0, hashPos);
 
-                    _reader.ImportCellNames.TryGetValue(target, out string targetName);
+                    TryGetImportCellName(target, out string targetName);
 
                     if (_options.Naked && (targetName != null))
                     {
@@ -824,7 +836,7 @@ namespace R2RDump
                 var translated = new StringBuilder();
                 translated.Append(instruction, 0, hashPos);
 
-                _reader.ImportCellNames.TryGetValue(target, out string targetName);
+                TryGetImportCellName(target, out string targetName);
 
                 if (_options.Naked && (targetName != null))
                 {
@@ -886,7 +898,7 @@ namespace R2RDump
                     {
                         int labelOffset = ldr1ImageOffset + ldr1Offset;
                         int target = checked((int)(BitConverter.ToUInt64(_reader.Image, labelOffset) - _reader.ImageBase));
-                        _reader.ImportCellNames.TryGetValue(target, out string targetName);
+                        TryGetImportCellName(target, out string targetName);
                         var translated = new StringBuilder();
 
                         if (_options.Naked && (targetName != null))

--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -117,7 +117,7 @@ namespace R2RDump
                 writer.Write($"  SignatureRVA: 0x{theThis.SignatureRVA:X8}");
                 writer.Write("   ");
             }
-            writer.Write(theThis.Signature);
+            writer.Write(theThis.Signature.ToString(options.GetSignatureFormattingOptions()));
             if (theThis.GCRefMap != null)
             {
                 writer.Write(" -- ");
@@ -152,7 +152,7 @@ namespace R2RDump
                 IEnumerable<FixupCell> fixups = theThis.Fixups;
                 if (options.Normalize)
                 {
-                    fixups = fixups.OrderBy((fc) => fc.Signature);
+                    fixups = fixups.OrderBy((fc) => fc.Signature.ToString(options.GetSignatureFormattingOptions()));
                 }
 
                 foreach (FixupCell cell in fixups)
@@ -162,7 +162,7 @@ namespace R2RDump
                     {
                         writer.Write($"TableIndex {cell.TableIndex}, Offset {cell.CellOffset:X4}: ");
                     }
-                    writer.WriteLine(cell.Signature);
+                    writer.WriteLine(cell.Signature.ToString(options.GetSignatureFormattingOptions()));
                 }
             }
         }

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -18,6 +18,7 @@ using ILCompiler.Reflection.ReadyToRun;
 using ILCompiler.PdbWriter;
 
 using Internal.Runtime;
+using System.Runtime.InteropServices;
 
 namespace R2RDump
 {
@@ -55,6 +56,8 @@ namespace R2RDump
 
         public bool SignatureBinary { get; set; }
         public bool InlineSignatureBinary { get; set; }
+
+        private SignatureFormattingOptions signatureFormattingOptions;
 
         /// <summary>
         /// Probing extensions to use when looking up assemblies under reference paths.
@@ -129,6 +132,20 @@ namespace R2RDump
             }
 
             return new StandaloneAssemblyMetadata(peReader);
+        }
+        
+        public SignatureFormattingOptions GetSignatureFormattingOptions()
+        {
+            if (signatureFormattingOptions == null)
+            {
+                signatureFormattingOptions = new SignatureFormattingOptions
+                {
+                    Naked = this.Naked,
+                    SignatureBinary = this.SignatureBinary,
+                    InlineSignatureBinary = this.InlineSignatureBinary,
+                };
+            }
+            return signatureFormattingOptions;
         }
     }
 
@@ -525,6 +542,19 @@ namespace R2RDump
             return null;
         }
 
+        private static bool InputArchitectureSupported(Machine machine)
+        {
+            return machine != Machine.ArmThumb2; // CoreDisTools often fails to decode when disassembling ARM images (see https://github.com/dotnet/runtime/issues/10959)
+        }
+
+        // TODO: Fix R2RDump issue where an R2R image cannot be dissassembled with the x86 CoreDisTools
+        // For the short term, we want to error out with a decent message explaining the unexpected error
+        // Issue https://github.com/dotnet/runtime/issues/10928
+        private static bool DisassemblerArchitectureSupported()
+        {
+            return RuntimeInformation.ProcessArchitecture != Architecture.X86;
+        }
+
         private int Run()
         {
             Disassembler disassembler = null;
@@ -551,7 +581,7 @@ namespace R2RDump
 
                     if (_options.Disasm)
                     {
-                        if (r2r.InputArchitectureSupported() && r2r.DisassemblerArchitectureSupported())
+                        if (InputArchitectureSupported(r2r.Machine) && DisassemblerArchitectureSupported())
                         {
                             disassembler = new Disassembler(r2r, _options);
                         }

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -462,7 +462,7 @@ namespace R2RDump
             {
                 entries.AddRange(importSection.Entries);
             }
-            entries.Sort((e1, e2) => e1.Signature.CompareTo(e2.Signature));
+            entries.Sort((e1, e2) => e1.Signature.ToString(_options.GetSignatureFormattingOptions()).CompareTo(e2.Signature.ToString(_options.GetSignatureFormattingOptions())));
             foreach (ReadyToRunImportSection.ImportSectionEntry entry in entries)
             {
                 entry.WriteTo(_writer, _options);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36219
Fixes https://github.com/dotnet/runtime/issues/13695

I have done some cleanup that I wanted for R2RDump:

- Throw exception instead of hiding error (I doubt we will ever notice the huge dump contained some `unknowns`), this fixes https://github.com/dotnet/runtime/issues/13695
- Avoid polluting the `IAssemblyResolver` with signature formatting options and avoided the dual return of both the string and the signature object (https://github.com/dotnet/runtime/issues/36219). The new design always expose `ReadyToRunSignature` objects from the `ReadyToRunReader`, and whenever a string representation is needed, we can call `ToString()` on it and that allows changing `SignatureFormattingOptions`.
- Moved a couple `R2RDump` specific methods out of `ReadyToRunReader`.
