### PR TITLE
Handle libunwind_xdac partial C11 support

### DIFF
--- a/src/coreclr/src/pal/src/libunwind/config.h.in
+++ b/src/coreclr/src/pal/src/libunwind/config.h.in
@@ -17,4 +17,13 @@
 
 #cmakedefine HAVE_ATOMIC_OPS_H
 
+#cmakedefine HAVE_STDALIGN_H
+#cmakedefine HAVE_STDALIGN_ALIGNAS
+
+#if defined(_MSC_VER) && defined(HAVE_STDALIGN_H) && !defined(HAVE_STDALIGN_ALIGNAS)
+// alignment is a performance optimization for the cross compile libunwind
+// Simply ignore it if it is not supported by the compiler
+#define alignas(x)
+#endif
+
 #endif

--- a/src/coreclr/src/pal/src/libunwind/configure.cmake
+++ b/src/coreclr/src/pal/src/libunwind/configure.cmake
@@ -59,6 +59,16 @@ int main(int argc, char **argv)
     return 0;
 }" HAVE__BUILTIN_UNREACHABLE)
 
+check_c_source_compiles("
+#include <stdalign.h>
+
+int main(void)
+{
+    alignas(128) char result = 0;
+
+    return result;
+}" HAVE_STDALIGN_ALIGNAS)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
 add_definitions(-DHAVE_CONFIG_H=1)
 


### PR DESCRIPTION
For newer Insider Windows SDKs, the stdalign.h header is present, but the alignas macro is not
defined unless the compiler command line adds the std:c11 or newer option.

Until we can set the std:c11 flag, work around the missing alignas macro using cmake config.

Fixes #39886