### PR TITLE
Fix and test crossgen2 on arm and x86

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -22,6 +22,7 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - OSX_x64
+    - Windows_NT_x86
     - Windows_NT_x64
     - Windows_NT_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -47,6 +48,7 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - OSX_x64
+    - Windows_NT_x86
     - Windows_NT_x64
     - Windows_NT_arm64
     jobParameters:

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -19,6 +19,7 @@ jobs:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
     platforms:
+    - Linux_arm
     - Linux_x64
     - Linux_arm64
     - OSX_x64
@@ -45,6 +46,7 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     buildConfig: checked
     platforms:
+    - Linux_arm
     - Linux_x64
     - Linux_arm64
     - OSX_x64

--- a/src/coreclr/src/inc/readytorun.h
+++ b/src/coreclr/src/inc/readytorun.h
@@ -14,9 +14,12 @@
 
 #define READYTORUN_SIGNATURE 0x00525452 // 'RTR'
 
+// Keep these in sync with src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
 #define READYTORUN_MAJOR_VERSION 0x0004
-#define READYTORUN_MINOR_VERSION 0x0001
+#define READYTORUN_MINOR_VERSION 0x0002
+
 #define MINIMUM_READYTORUN_MAJOR_VERSION 0x003
+
 // R2R Version 2.1 adds the InliningInfo section
 // R2R Version 2.2 adds the ProfileDataInfo section
 // R2R Version 3.0 changes calling conventions to correctly handle explicit structures to spec.

--- a/src/coreclr/src/inc/readytorunhelpers.h
+++ b/src/coreclr/src/inc/readytorunhelpers.h
@@ -119,7 +119,7 @@ HELPER(READYTORUN_HELPER_ReversePInvokeExit,        CORINFO_HELP_JIT_REVERSE_PIN
 HELPER(READYTORUN_HELPER_MonitorEnter,              CORINFO_HELP_MON_ENTER,                         )
 HELPER(READYTORUN_HELPER_MonitorExit,               CORINFO_HELP_MON_EXIT,                          )
 
-#if defined(TARGET_X86) || defined(TARGET_AMD64)
+#ifndef TARGET_ARM64
 HELPER(READYTORUN_HELPER_StackProbe,                CORINFO_HELP_STACK_PROBE,                       )
 #endif
 

--- a/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -7,7 +7,7 @@ namespace Internal.Runtime
 {
     //
     // Please keep the data structures in this file in sync with the native version at
-    //  src/Native/Runtime/inc/ModuleHeaders.h
+    //  src/coreclr/src/inc/readytorun.h
     //
 
     internal struct ReadyToRunHeaderConstants
@@ -15,7 +15,7 @@ namespace Internal.Runtime
         public const uint Signature = 0x00525452; // 'RTR'
 
         public const ushort CurrentMajorVersion = 4;
-        public const ushort CurrentMinorVersion = 1;
+        public const ushort CurrentMinorVersion = 2;
     }
 
 #pragma warning disable 0169

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -172,7 +172,7 @@ namespace Internal.TypeSystem
             {
                 return ComputeExplicitFieldLayout(type, numInstanceFields);
             }
-            else if (type.IsSequentialLayout || type.Context.Target.Abi == TargetAbi.CppCodegen)
+            else if (type.IsSequentialLayout || type.IsEnum || type.Context.Target.Abi == TargetAbi.CppCodegen)
             {
                 return ComputeSequentialFieldLayout(type, numInstanceFields);
             }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             int pointerSize = type.Context.Target.PointerSize;
             int size = defType.InstanceFieldSize.AsInt;
-            int alignment = GetClassAlignmentRequirement(defType);
+            int alignment = Internal.JitInterface.CorInfoImpl.GetClassAlignmentRequirementStatic(defType);
             ReadyToRunTypeLayoutFlags flags = ReadyToRunTypeLayoutFlags.READYTORUN_LAYOUT_Alignment | ReadyToRunTypeLayoutFlags.READYTORUN_LAYOUT_GCLayout;
             if (alignment == pointerSize)
             {
@@ -117,37 +117,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 dataBuilder.EmitBytes(encodedGCRefMap);
             }
-        }
-
-        /// <summary>
-        /// Managed implementation of CEEInfo::getClassAlignmentRequirementStatic
-        /// </summary>
-        private static int GetClassAlignmentRequirement(MetadataType type)
-        {
-            int alignment = type.Context.Target.PointerSize;
-
-            if (type.HasLayout())
-            {
-                if (type.IsSequentialLayout || MarshalUtils.IsBlittableType(type))
-                {
-                    alignment = type.InstanceFieldAlignment.AsInt;
-                }
-            }
-
-            if (type.Context.Target.Architecture == TargetArchitecture.ARM &&
-                alignment < 8 && type.RequiresAlign8())
-            {
-                // If the structure contains 64-bit primitive fields and the platform requires 8-byte alignment for
-                // such fields then make sure we return at least 8-byte alignment. Note that it's technically possible
-                // to create unmanaged APIs that take unaligned structures containing such fields and this
-                // unconditional alignment bump would cause us to get the calling convention wrong on platforms such
-                // as ARM. If we see such cases in the future we'd need to add another control (such as an alignment
-                // property for the StructLayout attribute or a marshaling directive attribute for p/invoke arguments)
-                // that allows more precise control. For now we'll go with the likely scenario.
-                alignment = 8;
-            }
-
-            return alignment;
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -809,7 +809,7 @@ namespace ILCompiler
                 return ComputeExplicitFieldLayout(type, numInstanceFields);
             }
             else
-            if (MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type))
+            if (type.IsEnum || MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type))
             {
                 return ComputeSequentialFieldLayout(type, numInstanceFields);
             }

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ArchitectureSpecificFieldLayoutTests.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ArchitectureSpecificFieldLayoutTests.cs
@@ -82,5 +82,337 @@ namespace TypeSystemTests
             Assert.Equal(0x18, tARM.InstanceByteCount.AsInt);
             Assert.Equal(0x18, tX86.InstanceByteCount.AsInt);
         }
+
+        [Fact]
+        public void TestAlignmentBehavior_LongIntEnumStruct()
+        {
+            string _namespace = "EnumAlignment";
+            string _type = "LongIntEnumStruct";
+
+            MetadataType tX64 = _testModuleX64.GetType(_namespace, _type);
+            MetadataType tX86 = _testModuleX86.GetType(_namespace, _type);
+            MetadataType tARM = _testModuleARM.GetType(_namespace, _type);
+
+            Assert.Equal(0x8, tX64.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x8, tARM.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceByteAlignment.AsInt);
+
+            Assert.Equal(0x20, tX64.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x20, tARM.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x20, tX86.InstanceByteCountUnaligned.AsInt);
+
+            Assert.Equal(0x20, tX64.InstanceByteCount.AsInt);
+            Assert.Equal(0x20, tARM.InstanceByteCount.AsInt);
+            Assert.Equal(0x20, tX86.InstanceByteCount.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x8, tARM.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x8, tX86.InstanceFieldAlignment.AsInt);
+
+            Assert.Equal(0x20, tX64.InstanceFieldSize.AsInt);
+            Assert.Equal(0x20, tARM.InstanceFieldSize.AsInt);
+            Assert.Equal(0x20, tX86.InstanceFieldSize.AsInt);
+
+            Assert.Equal(0x0, tX64.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tARM.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tX86.GetField("_1").Offset.AsInt);
+
+            Assert.Equal(0x8, tX64.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x8, tARM.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x8, tX86.GetField("_2").Offset.AsInt);
+
+            Assert.Equal(0x10, tX64.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x10, tARM.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x10, tX86.GetField("_3").Offset.AsInt);
+
+            Assert.Equal(0x18, tX64.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x18, tARM.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x18, tX86.GetField("_4").Offset.AsInt);
+
+            MetadataType tX64FieldStruct = _testModuleX64.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tX86FieldStruct = _testModuleX86.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tARMFieldStruct = _testModuleARM.GetType(_namespace, _type + "FieldStruct");
+
+            Assert.Equal(0x8, tX64FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x8, tX86FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x8, tARMFieldStruct.GetField("_struct").Offset.AsInt);
+        }
+
+        [Fact]
+        public void TestAlignmentBehavior_IntShortEnumStruct()
+        {
+            string _namespace = "EnumAlignment";
+            string _type = "IntShortEnumStruct";
+
+            MetadataType tX64 = _testModuleX64.GetType(_namespace, _type);
+            MetadataType tX86 = _testModuleX86.GetType(_namespace, _type);
+            MetadataType tARM = _testModuleARM.GetType(_namespace, _type);
+
+            Assert.Equal(0x8, tX64.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tARM.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceByteAlignment.AsInt);
+
+            Assert.Equal(0x10, tX64.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x10, tARM.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x10, tX86.InstanceByteCountUnaligned.AsInt);
+
+            Assert.Equal(0x10, tX64.InstanceByteCount.AsInt);
+            Assert.Equal(0x10, tARM.InstanceByteCount.AsInt);
+            Assert.Equal(0x10, tX86.InstanceByteCount.AsInt);
+
+            Assert.Equal(0x4, tX64.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x4, tARM.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceFieldAlignment.AsInt);
+
+            Assert.Equal(0x10, tX64.InstanceFieldSize.AsInt);
+            Assert.Equal(0x10, tARM.InstanceFieldSize.AsInt);
+            Assert.Equal(0x10, tX86.InstanceFieldSize.AsInt);
+
+            Assert.Equal(0x0, tX64.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tARM.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tX86.GetField("_1").Offset.AsInt);
+
+            Assert.Equal(0x4, tX64.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x4, tARM.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x4, tX86.GetField("_2").Offset.AsInt);
+
+            Assert.Equal(0x8, tX64.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x8, tARM.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x8, tX86.GetField("_3").Offset.AsInt);
+
+            Assert.Equal(0xC, tX64.GetField("_4").Offset.AsInt);
+            Assert.Equal(0xC, tARM.GetField("_4").Offset.AsInt);
+            Assert.Equal(0xC, tX86.GetField("_4").Offset.AsInt);
+
+            MetadataType tX64FieldStruct = _testModuleX64.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tX86FieldStruct = _testModuleX86.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tARMFieldStruct = _testModuleARM.GetType(_namespace, _type + "FieldStruct");
+
+            Assert.Equal(0x4, tX64FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x4, tX86FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x4, tARMFieldStruct.GetField("_struct").Offset.AsInt);
+
+        }
+
+        [Fact]
+        public void TestAlignmentBehavior_ShortByteEnumStruct()
+        {
+            string _namespace = "EnumAlignment";
+            string _type = "ShortByteEnumStruct";
+
+            MetadataType tX64 = _testModuleX64.GetType(_namespace, _type);
+            MetadataType tX86 = _testModuleX86.GetType(_namespace, _type);
+            MetadataType tARM = _testModuleARM.GetType(_namespace, _type);
+
+            Assert.Equal(0x8, tX64.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tARM.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceByteAlignment.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x8, tARM.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x8, tX86.InstanceByteCountUnaligned.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceByteCount.AsInt);
+            Assert.Equal(0x8, tARM.InstanceByteCount.AsInt);
+            Assert.Equal(0x8, tX86.InstanceByteCount.AsInt);
+
+            Assert.Equal(0x2, tX64.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x2, tARM.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x2, tX86.InstanceFieldAlignment.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceFieldSize.AsInt);
+            Assert.Equal(0x8, tARM.InstanceFieldSize.AsInt);
+            Assert.Equal(0x8, tX86.InstanceFieldSize.AsInt);
+
+            Assert.Equal(0x0, tX64.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tARM.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tX86.GetField("_1").Offset.AsInt);
+
+            Assert.Equal(0x2, tX64.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x2, tARM.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x2, tX86.GetField("_2").Offset.AsInt);
+
+            Assert.Equal(0x4, tX64.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x4, tARM.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x4, tX86.GetField("_3").Offset.AsInt);
+
+            Assert.Equal(0x6, tX64.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x6, tARM.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x6, tX86.GetField("_4").Offset.AsInt);
+
+            MetadataType tX64FieldStruct = _testModuleX64.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tX86FieldStruct = _testModuleX86.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tARMFieldStruct = _testModuleARM.GetType(_namespace, _type + "FieldStruct");
+
+            Assert.Equal(0x2, tX64FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x2, tX86FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x2, tARMFieldStruct.GetField("_struct").Offset.AsInt);
+        }
+
+        [Fact]
+        public void TestAlignmentBehavior_LongIntEnumStructAuto()
+        {
+            string _namespace = "EnumAlignment";
+            string _type = "LongIntEnumStructAuto";
+
+            MetadataType tX64 = _testModuleX64.GetType(_namespace, _type);
+            MetadataType tX86 = _testModuleX86.GetType(_namespace, _type);
+            MetadataType tARM = _testModuleARM.GetType(_namespace, _type);
+
+            Assert.Equal(0x8, tX64.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x8, tARM.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceByteAlignment.AsInt);
+
+            Assert.Equal(0x18, tX64.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x18, tARM.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x18, tX86.InstanceByteCountUnaligned.AsInt);
+
+            Assert.Equal(0x18, tX64.InstanceByteCount.AsInt);
+            Assert.Equal(0x18, tARM.InstanceByteCount.AsInt);
+            Assert.Equal(0x18, tX86.InstanceByteCount.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x8, tARM.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceFieldAlignment.AsInt);
+
+            Assert.Equal(0x18, tX64.InstanceFieldSize.AsInt);
+            Assert.Equal(0x18, tARM.InstanceFieldSize.AsInt);
+            Assert.Equal(0x18, tX86.InstanceFieldSize.AsInt);
+
+            Assert.Equal(0x0, tX64.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tARM.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tX86.GetField("_1").Offset.AsInt);
+
+            Assert.Equal(0x10, tX64.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x10, tARM.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x10, tX86.GetField("_2").Offset.AsInt);
+
+            Assert.Equal(0x8, tX64.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x8, tARM.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x8, tX86.GetField("_3").Offset.AsInt);
+
+            Assert.Equal(0x14, tX64.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x14, tARM.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x14, tX86.GetField("_4").Offset.AsInt);
+
+            MetadataType tX64FieldStruct = _testModuleX64.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tX86FieldStruct = _testModuleX86.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tARMFieldStruct = _testModuleARM.GetType(_namespace, _type + "FieldStruct");
+
+            Assert.Equal(0x8, tX64FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x4, tX86FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x8, tARMFieldStruct.GetField("_struct").Offset.AsInt);
+        }
+
+        [Fact]
+        public void TestAlignmentBehavior_IntShortEnumStructAuto()
+        {
+            string _namespace = "EnumAlignment";
+            string _type = "IntShortEnumStructAuto";
+
+            MetadataType tX64 = _testModuleX64.GetType(_namespace, _type);
+            MetadataType tX86 = _testModuleX86.GetType(_namespace, _type);
+            MetadataType tARM = _testModuleARM.GetType(_namespace, _type);
+
+            Assert.Equal(0x8, tX64.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tARM.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceByteAlignment.AsInt);
+
+            Assert.Equal(0x10, tX64.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0xC,  tARM.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0xC,  tX86.InstanceByteCountUnaligned.AsInt);
+
+            Assert.Equal(0x10, tX64.InstanceByteCount.AsInt);
+            Assert.Equal(0xC,  tARM.InstanceByteCount.AsInt);
+            Assert.Equal(0xC,  tX86.InstanceByteCount.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x4, tARM.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceFieldAlignment.AsInt);
+
+            Assert.Equal(0x10, tX64.InstanceFieldSize.AsInt);
+            Assert.Equal(0xC,  tARM.InstanceFieldSize.AsInt);
+            Assert.Equal(0xC,  tX86.InstanceFieldSize.AsInt);
+
+            Assert.Equal(0x0, tX64.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tARM.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tX86.GetField("_1").Offset.AsInt);
+
+            Assert.Equal(0x8, tX64.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x8, tARM.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x8, tX86.GetField("_2").Offset.AsInt);
+
+            Assert.Equal(0x4, tX64.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x4, tARM.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x4, tX86.GetField("_3").Offset.AsInt);
+
+            Assert.Equal(0xA, tX64.GetField("_4").Offset.AsInt);
+            Assert.Equal(0xA, tARM.GetField("_4").Offset.AsInt);
+            Assert.Equal(0xA, tX86.GetField("_4").Offset.AsInt);
+
+            MetadataType tX64FieldStruct = _testModuleX64.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tX86FieldStruct = _testModuleX86.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tARMFieldStruct = _testModuleARM.GetType(_namespace, _type + "FieldStruct");
+
+            Assert.Equal(0x8, tX64FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x4, tX86FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x4, tARMFieldStruct.GetField("_struct").Offset.AsInt);
+
+        }
+
+        [Fact]
+        public void TestAlignmentBehavior_ShortByteEnumStructAuto()
+        {
+            string _namespace = "EnumAlignment";
+            string _type = "ShortByteEnumStructAuto";
+
+            MetadataType tX64 = _testModuleX64.GetType(_namespace, _type);
+            MetadataType tX86 = _testModuleX86.GetType(_namespace, _type);
+            MetadataType tARM = _testModuleARM.GetType(_namespace, _type);
+
+            Assert.Equal(0x8, tX64.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tARM.InstanceByteAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceByteAlignment.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x8, tARM.InstanceByteCountUnaligned.AsInt);
+            Assert.Equal(0x8, tX86.InstanceByteCountUnaligned.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceByteCount.AsInt);
+            Assert.Equal(0x8, tARM.InstanceByteCount.AsInt);
+            Assert.Equal(0x8, tX86.InstanceByteCount.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x4, tARM.InstanceFieldAlignment.AsInt);
+            Assert.Equal(0x4, tX86.InstanceFieldAlignment.AsInt);
+
+            Assert.Equal(0x8, tX64.InstanceFieldSize.AsInt);
+            Assert.Equal(0x8, tARM.InstanceFieldSize.AsInt);
+            Assert.Equal(0x8, tX86.InstanceFieldSize.AsInt);
+
+            Assert.Equal(0x0, tX64.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tARM.GetField("_1").Offset.AsInt);
+            Assert.Equal(0x0, tX86.GetField("_1").Offset.AsInt);
+
+            Assert.Equal(0x4, tX64.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x4, tARM.GetField("_2").Offset.AsInt);
+            Assert.Equal(0x4, tX86.GetField("_2").Offset.AsInt);
+
+            Assert.Equal(0x2, tX64.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x2, tARM.GetField("_3").Offset.AsInt);
+            Assert.Equal(0x2, tX86.GetField("_3").Offset.AsInt);
+
+            Assert.Equal(0x5, tX64.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x5, tARM.GetField("_4").Offset.AsInt);
+            Assert.Equal(0x5, tX86.GetField("_4").Offset.AsInt);
+
+            MetadataType tX64FieldStruct = _testModuleX64.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tX86FieldStruct = _testModuleX86.GetType(_namespace, _type + "FieldStruct");
+            MetadataType tARMFieldStruct = _testModuleARM.GetType(_namespace, _type + "FieldStruct");
+
+            Assert.Equal(0x8, tX64FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x4, tX86FieldStruct.GetField("_struct").Offset.AsInt);
+            Assert.Equal(0x4, tARMFieldStruct.GetField("_struct").Offset.AsInt);
+        }
     }
 }

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -304,3 +304,98 @@ namespace IsByRefLike
         int X;
     }
 }
+
+namespace EnumAlignment
+{
+    public enum ByteEnum : byte {}
+    public enum ShortEnum : short {}
+    public enum IntEnum : int {}
+    public enum LongEnum : long {}
+
+    public struct LongIntEnumStruct
+    {
+        public LongEnum _1;
+        public IntEnum _2;
+        public LongEnum _3;
+        public IntEnum _4;
+    }
+
+    public struct LongIntEnumStructFieldStruct
+    {
+        public byte _0;
+        public LongIntEnumStruct _struct;
+    }
+
+    public struct IntShortEnumStruct
+    {
+        public IntEnum _1;
+        public ShortEnum _2;
+        public IntEnum _3;
+        public ShortEnum _4;
+    }
+
+    public struct IntShortEnumStructFieldStruct
+    {
+        public byte _0;
+        public IntShortEnumStruct _struct;
+    }
+
+    public struct ShortByteEnumStruct
+    {
+        public ShortEnum _1;
+        public ByteEnum _2;
+        public ShortEnum _3;
+        public ByteEnum _4;
+    }
+
+    public struct ShortByteEnumStructFieldStruct
+    {
+        public byte _0;
+        public ShortByteEnumStruct _struct;
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct LongIntEnumStructAuto
+    {
+        public LongEnum _1;
+        public IntEnum _2;
+        public LongEnum _3;
+        public IntEnum _4;
+    }
+
+    public struct LongIntEnumStructAutoFieldStruct
+    {
+        public byte _0;
+        public LongIntEnumStructAuto _struct;
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct IntShortEnumStructAuto
+    {
+        public IntEnum _1;
+        public ShortEnum _2;
+        public IntEnum _3;
+        public ShortEnum _4;
+    }
+
+    public struct IntShortEnumStructAutoFieldStruct
+    {
+        public byte _0;
+        public IntShortEnumStructAuto _struct;
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct ShortByteEnumStructAuto
+    {
+        public ShortEnum _1;
+        public ByteEnum _2;
+        public ShortEnum _3;
+        public ByteEnum _4;
+    }
+
+    public struct ShortByteEnumStructAutoFieldStruct
+    {
+        public byte _0;
+        public ShortByteEnumStructAuto _struct;
+    }
+}

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -13790,6 +13790,15 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
                     fatalErrorString.Printf(W("Verify_TypeLayout '%s' failed to verify type layout"), 
                         GetFullyQualifiedNameForClassW(pMT));
 
+#ifdef _DEBUG
+                    {
+                        StackScratchBuffer buf;
+                        _ASSERTE_MSG(false, fatalErrorString.GetUTF8(buf));
+                        // Run through the type layout logic again, after the assert, makes debugging easy
+                        TypeLayoutCheck(pMT, pBlob);
+                    }
+#endif
+
                     EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(-1, fatalErrorString.GetUnicode());
                     return FALSE;
                 }
@@ -13845,13 +13854,20 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
                 SString ssFieldName(SString::Utf8, pField->GetName());
 
                 SString fatalErrorString;
-                fatalErrorString.Printf(W("Verify_FieldOffset '%s.%s' %d!=%d || %d!=%d"), 
+                fatalErrorString.Printf(W("Verify_FieldOffset '%s.%s' Field offset %d!=%d(actual) || baseOffset %d!=%d(actual)"), 
                     GetFullyQualifiedNameForClassW(pEnclosingMT),
                     ssFieldName.GetUnicode(),
                     fieldOffset,
                     actualFieldOffset,
                     baseOffset,
                     actualBaseOffset);
+
+#ifdef _DEBUG
+                {
+                    StackScratchBuffer buf;
+                    _ASSERTE_MSG(false, fatalErrorString.GetUTF8(buf));
+                }
+#endif
 
                 EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(-1, fatalErrorString.GetUnicode());
                 return FALSE;

--- a/src/tests/readytorun/crossgen2/Program.cs
+++ b/src/tests/readytorun/crossgen2/Program.cs
@@ -956,7 +956,7 @@ internal class Program
         return success;
     }
 
-    private enum ByteEnum : byte
+    public enum ByteEnum : byte
     {
         Value0,
         Value1,
@@ -964,7 +964,7 @@ internal class Program
         Value3,
     }
     
-    private enum IntEnum : int
+    public enum IntEnum : int
     {
         Value0,
         Value1,
@@ -1932,6 +1932,231 @@ internal class Program
         return true;
     }
 
+    public enum ShortEnum : short
+    {
+    }
+    public enum LongEnum : long
+    {
+    }
+
+    public struct LongIntEnumStruct
+    {
+        public LongEnum _1;
+        public IntEnum _2;
+        public LongEnum _3;
+        public IntEnum _4;
+    }
+
+    public struct LongIntEnumStructFieldStruct
+    {
+        public byte _0;
+        public LongIntEnumStruct _struct;
+    }
+
+    public struct IntShortEnumStruct
+    {
+        public IntEnum _1;
+        public ShortEnum _2;
+        public IntEnum _3;
+        public ShortEnum _4;
+    }
+
+    public struct IntShortEnumStructFieldStruct
+    {
+        public byte _0;
+        public IntShortEnumStruct _struct;
+    }
+
+    public struct ShortByteEnumStruct
+    {
+        public ShortEnum _1;
+        public ByteEnum _2;
+        public ShortEnum _3;
+        public ByteEnum _4;
+    }
+
+    public struct ShortByteEnumStructFieldStruct
+    {
+        public byte _0;
+        public ShortByteEnumStruct _struct;
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct LongIntEnumStructAuto
+    {
+        public LongEnum _1;
+        public IntEnum _2;
+        public LongEnum _3;
+        public IntEnum _4;
+    }
+
+    public struct LongIntEnumStructAutoFieldStruct
+    {
+        public byte _0;
+        public LongIntEnumStructAuto _struct;
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct IntShortEnumStructAuto
+    {
+        public IntEnum _1;
+        public ShortEnum _2;
+        public IntEnum _3;
+        public ShortEnum _4;
+    }
+
+    public struct IntShortEnumStructAutoFieldStruct
+    {
+        public byte _0;
+        public IntShortEnumStructAuto _struct;
+    }
+
+    [StructLayout(LayoutKind.Auto)]
+    public struct ShortByteEnumStructAuto
+    {
+        public ShortEnum _1;
+        public ByteEnum _2;
+        public ShortEnum _3;
+        public ByteEnum _4;
+    }
+
+    public struct ShortByteEnumStructAutoFieldStruct
+    {
+        public byte _0;
+        public ShortByteEnumStructAuto _struct;
+    }
+
+    public static void SetFieldOnStruct<T>(object obj, string name, int value)
+    {
+        var field = typeof(T).GetField(name);
+        object setValueObject = value;
+        if (Marshal.SizeOf(field.FieldType.GetEnumUnderlyingType()) == 1)
+        {
+            setValueObject = (byte)value;
+        }
+        if (Marshal.SizeOf(field.FieldType.GetEnumUnderlyingType()) == 2)
+        {
+            setValueObject = (short)value;
+        }
+        if (Marshal.SizeOf(field.FieldType.GetEnumUnderlyingType()) == 8)
+        {
+            setValueObject = (long)value;
+        }
+
+        field.SetValue(obj, setValueObject);
+    }
+
+    public static T GetStructWithValues<T>()
+    {
+        object obj = Activator.CreateInstance(typeof(T));
+        SetFieldOnStruct<T>(obj, "_1", 1);
+        SetFieldOnStruct<T>(obj, "_2", 2);
+        SetFieldOnStruct<T>(obj, "_3", 3);
+        SetFieldOnStruct<T>(obj, "_4", 4);
+        return (T)obj;
+    }
+
+    public static bool TestEnumLayoutAlignments()
+    {
+        {
+            var val = GetStructWithValues<LongIntEnumStruct>();
+            if (((int)val._1) != 1)
+                throw new Exception();
+            if (((int)val._2) != 2)
+                throw new Exception();
+            if (((int)val._3) != 3)
+                throw new Exception();
+            if (((int)val._4) != 4)
+                throw new Exception();
+
+            var valStruct = default(LongIntEnumStructFieldStruct);
+            valStruct._struct = val;
+            Console.WriteLine(valStruct.ToString());
+        }
+
+        {
+            var val = GetStructWithValues<IntShortEnumStruct>();
+            if (((int)val._1) != 1)
+                throw new Exception();
+            if (((int)val._2) != 2)
+                throw new Exception();
+            if (((int)val._3) != 3)
+                throw new Exception();
+            if (((int)val._4) != 4)
+                throw new Exception();
+
+            var valStruct = default(IntShortEnumStructFieldStruct);
+            valStruct._struct = val;
+            Console.WriteLine(valStruct.ToString());
+        }
+
+        {
+            var val = GetStructWithValues<ShortByteEnumStruct>();
+            if (((int)val._1) != 1)
+                throw new Exception();
+            if (((int)val._2) != 2)
+                throw new Exception();
+            if (((int)val._3) != 3)
+                throw new Exception();
+            if (((int)val._4) != 4)
+                throw new Exception();
+
+            var valStruct = default(ShortByteEnumStructFieldStruct);
+            valStruct._struct = val;
+            Console.WriteLine(valStruct.ToString());
+        }
+
+        {
+            var val = GetStructWithValues<LongIntEnumStructAuto>();
+            if (((int)val._1) != 1)
+                throw new Exception();
+            if (((int)val._2) != 2)
+                throw new Exception();
+            if (((int)val._3) != 3)
+                throw new Exception();
+            if (((int)val._4) != 4)
+                throw new Exception();
+
+            var valStruct = default(LongIntEnumStructAutoFieldStruct);
+            valStruct._struct = val;
+            Console.WriteLine(valStruct.ToString());
+        }
+
+        {
+            var val = GetStructWithValues<IntShortEnumStructAuto>();
+            if (((int)val._1) != 1)
+                throw new Exception();
+            if (((int)val._2) != 2)
+                throw new Exception();
+            if (((int)val._3) != 3)
+                throw new Exception();
+            if (((int)val._4) != 4)
+                throw new Exception();
+
+            var valStruct = default(IntShortEnumStructAutoFieldStruct);
+            valStruct._struct = val;
+            Console.WriteLine(valStruct.ToString());
+        }
+
+        {
+            var val = GetStructWithValues<ShortByteEnumStructAuto>();
+            if (((int)val._1) != 1)
+                throw new Exception();
+            if (((int)val._2) != 2)
+                throw new Exception();
+            if (((int)val._3) != 3)
+                throw new Exception();
+            if (((int)val._4) != 4)
+                throw new Exception();
+
+            var valStruct = default(ShortByteEnumStructAutoFieldStruct);
+            valStruct._struct = val;
+            Console.WriteLine(valStruct.ToString());
+        }
+
+        return true;
+    }
+
     public static int Main(string[] args)
     {
         _passedTests = new List<string>();
@@ -2001,6 +2226,7 @@ internal class Program
         RunTest("TestGenericMDArrayBehavior", TestGenericMDArrayBehavior());
         RunTest("TestWithStructureNonBlittableFieldDueToGenerics", TestWithStructureNonBlittableFieldDueToGenerics());
         RunTest("TestSingleElementStructABI", TestSingleElementStructABI());
+        RunTest("TestEnumLayoutAlignments", TestEnumLayoutAlignments());
 
         File.Delete(TextFileName);
 


### PR DESCRIPTION
Fix last issues preventing the Pri0 tests from passing under crossgen2 for arm and x86
- Add support for stackprobe helper on arm32
- Fix field layout for x86 structures that contain long enums
  - Add test suite for these enum scenarios 
- Report the same alignment info to the jit for crossgen2 based compilation as was done in the core runtime

Also enable testing targetting x86 and arm