### PR TITLE
[wasm] Implement System.Console.Clear

### DIFF
--- a/src/libraries/System.Console/src/System.Console.csproj
+++ b/src/libraries/System.Console/src/System.Console.csproj
@@ -236,4 +236,7 @@
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsBrowser)' == 'true'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Private.Runtime.InteropServices.JavaScript\src\System.Private.Runtime.InteropServices.JavaScript.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
@@ -76,7 +76,8 @@ namespace System
 
     internal static class ConsolePal
     {
-        private static readonly JSObject? s_console = (JSObject)System.Runtime.InteropServices.JavaScript.Runtime.GetGlobalObject("console");
+        private static bool s_consoleInitialized;
+        private static JSObject? s_console;
 
         private static Encoding? s_outputEncoding;
 
@@ -167,7 +168,15 @@ namespace System
             char sourceChar, ConsoleColor sourceForeColor,
             ConsoleColor sourceBackColor) => throw new PlatformNotSupportedException();
 
-        public static void Clear() => s_console?.Invoke("clear");
+        public static void Clear()
+        {
+            if (!s_consoleInitialized)
+            {
+                s_console = (JSObject)System.Runtime.InteropServices.JavaScript.Runtime.GetGlobalObject("console");
+                s_consoleInitialized = true;
+            }
+            s_console?.Invoke("clear");
+        }
 
         public static void SetCursorPosition(int left, int top) => throw new PlatformNotSupportedException();
 

--- a/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
@@ -76,7 +76,7 @@ namespace System
 
     internal static class ConsolePal
     {
-        private static bool s_consoleInitialized;
+        private static volatile bool s_consoleInitialized;
         private static JSObject? s_console;
 
         private static Encoding? s_outputEncoding;
@@ -175,6 +175,7 @@ namespace System
                 s_console = (JSObject)System.Runtime.InteropServices.JavaScript.Runtime.GetGlobalObject("console");
                 s_consoleInitialized = true;
             }
+
             s_console?.Invoke("clear");
         }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
@@ -6,6 +6,8 @@ using System.Text;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
+using JSObject = System.Runtime.InteropServices.JavaScript.JSObject;
+
 namespace System
 {
     internal sealed class WasmConsoleStream : ConsoleStream
@@ -74,6 +76,8 @@ namespace System
 
     internal static class ConsolePal
     {
+        private static readonly JSObject? s_console = (JSObject)System.Runtime.InteropServices.JavaScript.Runtime.GetGlobalObject("console");
+
         private static Encoding? s_outputEncoding;
 
         internal static void EnsureConsoleInitialized() { }
@@ -163,7 +167,7 @@ namespace System
             char sourceChar, ConsoleColor sourceForeColor,
             ConsoleColor sourceBackColor) => throw new PlatformNotSupportedException();
 
-        public static void Clear() => throw new PlatformNotSupportedException();
+        public static void Clear() => s_console?.Invoke("clear");
 
         public static void SetCursorPosition(int left, int top) => throw new PlatformNotSupportedException();
 

--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -47,6 +47,7 @@ if (is_browser) {
 if (typeof console === "undefined") {
 	var Console = function () {
 		this.log = function(msg){ print(msg) };
+		this.clear = function() { };
 	};
 	console = new Console();
 }


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/41184#discussion_r477813798 it was mentioned that `System.Console.Clear` should be implemented since now it is not marked as `UnsupportedOSPlatformAttribute("browser")` but throws `PlatformNotSupportedException`.
https://github.com/dotnet/runtime/blob/271f008f0fe8168dacac45cd3ce1952e6e32bfbb/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs#L166

So this PR does that by using the same code pattern as in `BrowserHttpClient`:
https://github.com/dotnet/runtime/blob/271f008f0fe8168dacac45cd3ce1952e6e32bfbb/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs#L32

https://github.com/dotnet/runtime/blob/271f008f0fe8168dacac45cd3ce1952e6e32bfbb/src/libraries/System.Net.Http/src/System.Net.Http.csproj#L722-L724

Fixes https://github.com/mono/mono/issues/19825