### PR TITLE
Changed mono exception type from execution engine to not supported.

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -7172,7 +7172,7 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 	g_assert (value != NULL);
 	if (G_UNLIKELY (m_class_is_byreflike (klass))) {
 		char *full_name = mono_type_get_full_name (klass);
-		mono_error_set_execution_engine (error, "Cannot box IsByRefLike type %s", full_name);
+		mono_error_set_not_supported (error, "Cannot box IsByRefLike type %s", full_name);
 		g_free (full_name);
 		return NULL_HANDLE;
 	}


### PR DESCRIPTION
This PR fixes this issue. #40738. 
Whereas the fix is simple, we need to throw `mono_error_set_not_supported` instead of `mono_error_set_execution_engine`.