### PR TITLE
Teach coreclr/src/tools about Checked configuration

### DIFF
--- a/src/coreclr/src/tools/Directory.Build.props
+++ b/src/coreclr/src/tools/Directory.Build.props
@@ -5,4 +5,10 @@
     <SignAssembly>false</SignAssembly>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
+  
+  <!-- MSBuild doesn't understand the Checked configuration -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Checked'">
+    <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
We never test managed tools in Debug configuration because we never build the runtime partition in the Debug configuration - we only build Checked.

But managed tools don't know what Checked means because it's not an MSBuild concept. So we never run the tools with asserts turned on.