### PR TITLE
Changing the free list from singly linked to doubly linked

### DIFF
--- a/src/coreclr/src/gc/env/gcenv.object.h
+++ b/src/coreclr/src/gc/env/gcenv.object.h
@@ -164,7 +164,11 @@ public:
 
     MethodTable * GetGCSafeMethodTable() const
     {
+#ifdef HOST_64BIT
+        return (MethodTable *)((uintptr_t)m_pMethTab & ~7);
+#else
         return (MethodTable *)((uintptr_t)m_pMethTab & ~3);
+#endif //HOST_64BIT
     }
 
     void RawSetMethodTable(MethodTable * pMT)

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -2298,6 +2298,9 @@ uint8_t*    gc_heap::background_saved_lowest_address = 0;
 uint8_t*    gc_heap::background_saved_highest_address = 0;
 uint8_t*    gc_heap::next_sweep_obj = 0;
 uint8_t*    gc_heap::current_sweep_pos = 0;
+#ifdef DOUBLY_LINKED_FL
+heap_segment* gc_heap::current_sweep_seg = 0;
+#endif //DOUBLY_LINKED_FL
 exclusive_sync* gc_heap::bgc_alloc_lock;
 #endif //BACKGROUND_GC
 
@@ -2609,6 +2612,11 @@ BOOL        gc_heap::heap_analyze_enabled = FALSE;
 alloc_list gc_heap::loh_alloc_list [NUM_LOH_ALIST-1];
 alloc_list gc_heap::gen2_alloc_list[NUM_GEN2_ALIST-1];
 alloc_list gc_heap::poh_alloc_list [NUM_POH_ALIST-1];
+
+#ifdef DOUBLY_LINKED_FL
+// size we removed with no undo; only for recording purpose
+size_t gc_heap::gen2_removed_no_undo = 0;
+#endif //DOUBLY_LINKED_FL
 
 dynamic_data gc_heap::dynamic_data_table [total_generation_count];
 gc_history_per_heap gc_heap::gc_data_per_heap;
@@ -3617,9 +3625,42 @@ heap_segment* seg_mapping_table_segment_of (uint8_t* o)
 size_t gcard_of ( uint8_t*);
 
 #define GC_MARKED       (size_t)0x1
+#ifdef DOUBLY_LINKED_FL
+// This bit indicates that we'll need to set the bgc mark bit for this object during an FGC.
+// We only do this when we decide to compact.
+#define BGC_MARKED_BY_FGC (size_t)0x2
+#define MAKE_FREE_OBJ_IN_COMPACT (size_t)0x4
+#endif //DOUBLY_LINKED_FL
+
 #define slot(i, j) ((uint8_t**)(i))[(j)+1]
 
 #define free_object_base_size (plug_skew + sizeof(ArrayBase))
+
+#define free_list_slot(x) ((uint8_t**)(x))[2]
+#define free_list_undo(x) ((uint8_t**)(x))[-1]
+#define UNDO_EMPTY ((uint8_t*)1)
+
+#ifdef DOUBLY_LINKED_FL
+#define free_list_prev(x) ((uint8_t**)(x))[3]
+#define PREV_EMPTY ((uint8_t*)1)
+
+void check_and_clear_in_free_list (uint8_t* o, size_t size)
+{
+    if (size >= min_free_list)
+    {
+        free_list_prev (o) = PREV_EMPTY;
+    }
+}
+// This is used when we need to clear the prev bit for a free object we made because we know 
+// it's not actually a free obj (it's just a temporary thing during allocation).
+void clear_prev_bit (uint8_t* o, size_t size)
+{
+    if (size >= min_free_list)
+    {
+        free_list_prev (o) = 0;
+    }
+}
+#endif //DOUBLY_LINKED_FL
 
 class CObjectHeader : public Object
 {
@@ -3691,7 +3732,11 @@ public:
 
     MethodTable    *GetMethodTable() const
     {
-        return( (MethodTable *) (((size_t) RawGetMethodTable()) & (~(GC_MARKED))));
+        return( (MethodTable *) (((size_t) RawGetMethodTable()) & (~(GC_MARKED
+#ifdef DOUBLY_LINKED_FL
+            | BGC_MARKED_BY_FGC | MAKE_FREE_OBJ_IN_COMPACT
+#endif //DOUBLY_LINKED_FL
+            ))));
     }
 
     void SetMarked()
@@ -3716,10 +3761,43 @@ public:
         return !!((((CObjectHeader*)this)->GetHeader()->GetBits()) & BIT_SBLK_GC_RESERVE);
     }
 
+    // Now we set more bits should actually only clear the mark bit
     void ClearMarked()
     {
-        RawSetMethodTable( GetMethodTable() );
+#ifdef DOUBLY_LINKED_FL
+        RawSetMethodTable ((MethodTable *)(((size_t) RawGetMethodTable()) & (~GC_MARKED)));
+#else
+        RawSetMethodTable (GetMethodTable());
+#endif //DOUBLY_LINKED_FL
     }
+
+#ifdef DOUBLY_LINKED_FL
+    void SetBGCMarkBit()
+    {
+        RawSetMethodTable((MethodTable *) (((size_t) RawGetMethodTable()) | BGC_MARKED_BY_FGC));
+    }
+    BOOL IsBGCMarkBitSet() const
+    {
+        return !!(((size_t)RawGetMethodTable()) & BGC_MARKED_BY_FGC);
+    }
+    void ClearBGCMarkBit()
+    {
+        RawSetMethodTable((MethodTable *)(((size_t) RawGetMethodTable()) & (~BGC_MARKED_BY_FGC)));
+    }
+
+    void SetFreeObjInCompactBit()
+    {
+        RawSetMethodTable((MethodTable *) (((size_t) RawGetMethodTable()) | MAKE_FREE_OBJ_IN_COMPACT));
+    }
+    BOOL IsFreeObjInCompactBitSet() const
+    {
+        return !!(((size_t)RawGetMethodTable()) & MAKE_FREE_OBJ_IN_COMPACT);
+    }
+    void ClearFreeObjInCompactBit()
+    {
+        RawSetMethodTable((MethodTable *)(((size_t) RawGetMethodTable()) & (~MAKE_FREE_OBJ_IN_COMPACT)));
+    }
+#endif //DOUBLY_LINKED_FL
 
     CGCDesc *GetSlotMap ()
     {
@@ -3743,8 +3821,26 @@ public:
         //((void**) this)[-1] = 0;    // clear the sync block,
         assert (*numComponentsPtr >= 0);
         if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
+        {
             memset (((uint8_t*)this)+sizeof(ArrayBase), 0xcc, *numComponentsPtr);
+#ifdef DOUBLY_LINKED_FL
+            // However, in this case we can't leave the Next field uncleared because no one will clear it
+            // so it remains 0xcc and that's not good for verification
+            if (*numComponentsPtr > 0)
+            {
+                free_list_slot (this) = 0;
+            }
+#endif //DOUBLY_LINKED_FL
+        }
 #endif //VERIFY_HEAP
+
+#ifdef DOUBLY_LINKED_FL
+        // For background GC, we need to distinguish between a free object that's not on the free list
+        // and one that is. So we always set its prev to PREV_EMPTY to indicate that it's a free
+        // object that's not on the free list. If it should be on the free list, it will be set to the
+        // appropriate non zero value.
+        check_and_clear_in_free_list ((uint8_t*)this, size);
+#endif //DOUBLY_LINKED_FL
     }
 
     void UnsetFree()
@@ -3795,9 +3891,57 @@ public:
 
 #define header(i) ((CObjectHeader*)(i))
 
-#define free_list_slot(x) ((uint8_t**)(x))[2]
-#define free_list_undo(x) ((uint8_t**)(x))[-1]
-#define UNDO_EMPTY ((uint8_t*)1)
+#ifdef DOUBLY_LINKED_FL
+inline
+BOOL is_on_free_list (uint8_t* o, size_t size)
+{
+    if (size >= min_free_list)
+    {
+        if (header(o)->GetMethodTable() == g_gc_pFreeObjectMethodTable)
+        {
+            return (free_list_prev (o) != PREV_EMPTY);
+        }
+    }
+
+    return FALSE;
+}
+
+inline
+void set_plug_bgc_mark_bit (uint8_t* node)
+{
+    header(node)->SetBGCMarkBit();
+}
+
+inline
+BOOL is_plug_bgc_mark_bit_set (uint8_t* node)
+{
+    return header(node)->IsBGCMarkBitSet();
+}
+
+inline
+void clear_plug_bgc_mark_bit (uint8_t* node)
+{
+    header(node)->ClearBGCMarkBit();
+}
+
+inline
+void set_free_obj_in_compact_bit (uint8_t* node)
+{
+    header(node)->SetFreeObjInCompactBit();
+}
+
+inline
+BOOL is_free_obj_in_compact_bit_set (uint8_t* node)
+{
+    return header(node)->IsFreeObjInCompactBitSet();
+}
+
+inline
+void clear_free_obj_in_compact_bit (uint8_t* node)
+{
+    header(node)->ClearFreeObjInCompactBit();
+}
+#endif //DOUBLY_LINKED_FL
 
 #ifdef SHORT_PLUGS
 inline
@@ -6116,8 +6260,13 @@ public:
     // We should think about whether it's really necessary to have to copy back the pre plug
     // info since it was already copied during compacting plugs. But if a plug doesn't move
     // by >= 3 ptr size (the size of gap_reloc_pair), it means we'd have to recover pre plug info.
-    void recover_plug_info()
+    size_t recover_plug_info() 
     {
+        // We need to calculate the size for sweep case in order to correctly record the 
+        // free_obj_space - sweep would've made these artifical gaps into free objects and
+        // we would need to deduct the size because now we are writing into those free objects.
+        size_t recovered_sweep_size = 0;
+
         if (saved_pre_p)
         {
             if (gc_heap::settings.compaction)
@@ -6135,6 +6284,7 @@ public:
                     &saved_pre_plug,
                     (first - sizeof (plug_and_gap))));
                 memcpy ((first - sizeof (plug_and_gap)), &saved_pre_plug, sizeof (saved_pre_plug));
+                recovered_sweep_size += sizeof (saved_pre_plug);
             }
         }
 
@@ -6155,8 +6305,11 @@ public:
                     &saved_post_plug,
                     saved_post_plug_info_start));
                 memcpy (saved_post_plug_info_start, &saved_post_plug, sizeof (saved_post_plug));
+                recovered_sweep_size += sizeof (saved_post_plug);
             }
         }
+
+        return recovered_sweep_size;
     }
 };
 
@@ -10262,6 +10415,10 @@ void gc_heap::make_generation (int gen_num, heap_segment* seg, uint8_t* start)
     gen->allocate_end_seg_p = FALSE;
     gen->free_list_allocator.clear();
 
+#ifdef DOUBLY_LINKED_FL
+    gen->set_bgc_mark_bit_p = FALSE;
+#endif //DOUBLY_LINKED_FL
+
 #ifdef FREE_USAGE_STATS
     memset (gen->gen_free_spaces, 0, sizeof (gen.gen_free_spaces));
     memset (gen->gen_current_pinned_free_spaces, 0, sizeof (gen.gen_current_pinned_free_spaces));
@@ -10294,9 +10451,10 @@ FILE* CreateLogFile(const GCConfigStringHolder& temp_logfile_name, bool is_confi
     }
 
     char logfile_name[MAX_LONGPATH+1];
-    uint32_t pid = GCToOSInterface::GetCurrentProcessId();
+    //uint32_t pid = GCToOSInterface::GetCurrentProcessId();
     const char* suffix = is_config ? ".config.log" : ".log";
-    _snprintf_s(logfile_name, MAX_LONGPATH+1, _TRUNCATE, "%s.%d%s", temp_logfile_name.Get(), pid, suffix);
+    //_snprintf_s(logfile_name, MAX_LONGPATH+1, _TRUNCATE, "%s.%d%s", temp_logfile_name.Get(), pid, suffix);
+    _snprintf_s(logfile_name, MAX_LONGPATH+1, _TRUNCATE, "%s%s", temp_logfile_name.Get(), suffix);
     logFile = fopen(logfile_name, "wb");
     return logFile;
 }
@@ -11162,7 +11320,7 @@ gc_heap::init_gc_heap (int  h_number)
     heap_segment_allocated (pseg) = heap_segment_mem (pseg) + Align (min_obj_size, get_alignment_constant (FALSE));
     heap_segment_used (pseg) = heap_segment_allocated (pseg) - plug_skew;
 
-    generation_of (max_generation)->free_list_allocator = allocator(NUM_GEN2_ALIST, BASE_GEN2_ALIST_BITS, gen2_alloc_list);
+    generation_of (max_generation)->free_list_allocator = allocator(NUM_GEN2_ALIST, BASE_GEN2_ALIST_BITS, gen2_alloc_list, max_generation);
     generation_of (loh_generation)->free_list_allocator = allocator(NUM_LOH_ALIST, BASE_LOH_ALIST_BITS, loh_alloc_list);
     generation_of (poh_generation)->free_list_allocator = allocator(NUM_POH_ALIST, BASE_POH_ALIST_BITS, poh_alloc_list);
 
@@ -11313,6 +11471,11 @@ gc_heap::init_gc_heap (int  h_number)
     bgc_overflow_count = 0;
     end_loh_size = dd_min_size (dynamic_data_of (loh_generation));
     end_poh_size = dd_min_size (dynamic_data_of (poh_generation));
+
+    current_sweep_pos = 0;
+#ifdef DOUBLY_LINKED_FL
+    current_sweep_seg = 0;
+#endif //DOUBLY_LINKED_FL
 #endif //BACKGROUND_GC
 
 #ifdef GC_CONFIG_DRIVEN
@@ -11544,6 +11707,52 @@ int gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* allocated, uint8_t* 
 #endif // FEATURE_STRUCTALIGN
 }
 
+// thread this object to the front of gen's free list and update stats.
+void gc_heap::thread_free_item_front (generation* gen, uint8_t* free_start, size_t free_size)
+{
+    make_unused_array (free_start, free_size);
+    generation_free_list_space (gen) += free_size;
+    generation_allocator(gen)->thread_item_front (free_start, free_size);
+    add_gen_free (gen->gen_num, free_size);
+
+    if (gen->gen_num == max_generation)
+    {
+        dprintf (2, ("AO h%d: gen2F+: %Ix(%Id)->%Id, FO: %Id", 
+            heap_number, free_start, free_size,
+            generation_free_list_space (gen), generation_free_obj_space (gen)));
+    }
+}
+
+#ifdef DOUBLY_LINKED_FL
+void gc_heap::thread_item_front_added (generation* gen, uint8_t* free_start, size_t free_size)
+{
+    make_unused_array (free_start, free_size);
+    generation_free_list_space (gen) += free_size;
+    int bucket_index = generation_allocator(gen)->thread_item_front_added (free_start, free_size);
+
+    if (gen->gen_num == max_generation)
+    {
+        dprintf (2, ("AO [h%d] gen2FL+: %Ix(%Id)->%Id", 
+            heap_number, free_start, free_size, generation_free_list_space (gen)));
+    }
+
+    add_gen_free (gen->gen_num, free_size);
+}
+#endif //DOUBLY_LINKED_FL
+
+// this is for free objects that are not on the free list; also update stats.
+void gc_heap::make_free_obj (generation* gen, uint8_t* free_start, size_t free_size)
+{
+    make_unused_array (free_start, free_size);
+    generation_free_obj_space (gen) += free_size;
+
+    if (gen->gen_num == max_generation)
+    {
+        dprintf (2, ("AO [h%d] gen2FO+: %Ix(%Id)->%Id", 
+            heap_number, free_start, free_size, generation_free_obj_space (gen)));
+    }
+}
+
 //used only in older generation allocation (i.e during gc).
 void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen)
 {
@@ -11566,41 +11775,83 @@ void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen)
             {
                 dprintf (3, ("filling up hole: %Ix, size %Ix", hole, size));
                 size_t allocated_size = generation_allocation_pointer (gen) - generation_allocation_context_start_region (gen);
-                if (size >= Align (min_free_list))
+#ifdef DOUBLY_LINKED_FL
+                if (gen->gen_num == max_generation)
                 {
-                    if (allocated_size < min_free_list)
+                    // For BGC since we need to thread the max_gen's free list as a doubly linked list we need to preserve 5 ptr-sized
+                    // words: SB | MT | Len | Next | Prev
+                    // This means we cannot simply make a filler free object right after what's allocated in this alloc context if
+                    // that's < 5-ptr sized.
+                    //
+                    if (allocated_size < min_free_item_no_prev)
                     {
+                        // We can't make the free object just yet. Need to record the size.
+                        size_t* filler_free_obj_size_location = (size_t*)(generation_allocation_context_start_region (gen) + min_free_item_no_prev);
+                        size_t filler_free_obj_size = 0;
                         if (size >= (Align (min_free_list) + Align (min_obj_size)))
                         {
-                            //split hole into min obj + threadable free item
-                            make_unused_array (hole, min_obj_size);
-                            generation_free_obj_space (gen) += Align (min_obj_size);
-                            make_unused_array (hole + Align (min_obj_size), size - Align (min_obj_size));
-                            generation_free_list_space (gen) += size - Align (min_obj_size);
-                            generation_allocator(gen)->thread_item_front (hole + Align (min_obj_size),
-                                                                          size - Align (min_obj_size));
-                            add_gen_free (gen->gen_num, (size - Align (min_obj_size)));
+
+                            filler_free_obj_size = Align (min_obj_size);
+                            size_t fl_size = size - filler_free_obj_size;
+                            thread_item_front_added (gen, (hole + filler_free_obj_size), fl_size);
                         }
                         else
                         {
-                            dprintf (3, ("allocated size too small, can't put back rest on free list %Ix", allocated_size));
-                            make_unused_array (hole, size);
-                            generation_free_obj_space (gen) += size;
+                            filler_free_obj_size = size;
+                        }
+
+                        generation_free_obj_space (gen) += filler_free_obj_size;
+                        *filler_free_obj_size_location = filler_free_obj_size;
+                        uint8_t* old_loc = generation_last_free_list_allocated (gen);
+                        set_free_obj_in_compact_bit (old_loc);
+
+                        dprintf (3333, ("[h%d] ac: %Ix->%Ix((%Id < %Id), Pset %Ix s->%Id", heap_number, 
+                            generation_allocation_context_start_region (gen), generation_allocation_pointer (gen),
+                            allocated_size, min_free_item_no_prev, filler_free_obj_size_location, filler_free_obj_size));
+                    }
+                    else
+                    {
+                        if (size >= Align (min_free_list))
+                        {
+                            thread_item_front_added (gen, hole, size);
+                        }
+                        else
+                        {
+                            make_free_obj (gen, hole, size);
+                        }
+                    }
+                }
+                else
+#endif //DOUBLY_LINKED_FL
+                {
+                    // TODO: this should be written the same way as the above, ie, it should check allocated_size first,
+                    // but it doesn't need to do MAKE_FREE_OBJ_IN_COMPACT related things.
+                    if (size >= Align (min_free_list))
+                    {
+                        if (allocated_size < min_free_item_no_prev)
+                        {
+                            if (size >= (Align (min_free_list) + Align (min_obj_size)))
+                            {
+                                //split hole into min obj + threadable free item
+                                make_free_obj (gen, hole, min_obj_size);
+                                thread_free_item_front (gen, hole + Align (min_obj_size), size - Align (min_obj_size));
+                            }
+                            else
+                            {
+                                dprintf (3, ("allocated size too small, can't put back rest on free list %Ix", allocated_size));
+                                make_free_obj (gen, hole, size);
+                            }
+                        }
+                        else 
+                        {
+                            dprintf (3, ("threading hole in front of free list"));
+                            thread_free_item_front (gen, hole, size);
                         }
                     }
                     else
                     {
-                        dprintf (3, ("threading hole in front of free list"));
-                        make_unused_array (hole, size);
-                        generation_free_list_space (gen) += size;
-                        generation_allocator(gen)->thread_item_front (hole, size);
-                        add_gen_free (gen->gen_num, size);
+                        make_free_obj (gen, hole, size);
                     }
-                }
-                else
-                {
-                    make_unused_array (hole, size);
-                    generation_free_obj_space (gen) += size;
                 }
             }
         }
@@ -11739,12 +11990,13 @@ void gc_heap::check_batch_mark_array_bits (uint8_t* start, uint8_t* end)
 }
 #endif //VERIFY_HEAP && BACKGROUND_GC
 
-allocator::allocator (unsigned int num_b, int fbb, alloc_list* b)
+allocator::allocator (unsigned int num_b, int fbb, alloc_list* b, int gen)
 {
     assert (num_b < MAX_BUCKET_COUNT);
     num_buckets = num_b;
     first_bucket_bits = fbb;
     buckets = b;
+    gen_number = gen;
 }
 
 alloc_list& allocator::alloc_list_of (unsigned int bn)
@@ -11767,8 +12019,16 @@ size_t& allocator::alloc_list_damage_count_of (unsigned int bn)
 
 void allocator::unlink_item (unsigned int bn, uint8_t* item, uint8_t* prev_item, BOOL use_undo_p)
 {
-    //unlink the free_item
     alloc_list* al = &alloc_list_of (bn);
+    uint8_t* next_item = free_list_slot(item);
+
+#ifdef DOUBLY_LINKED_FL
+    // if repair_list is TRUE yet use_undo_p is FALSE, it means we do need to make sure
+    // this item does not look like it's on the free list as we will not have a chance to
+    // do that later.
+    BOOL repair_list = !discard_if_no_fit_p ();
+#endif //DOUBLY_LINKED_FL
+
     if (prev_item)
     {
         if (use_undo_p && (free_list_undo (prev_item) == UNDO_EMPTY))
@@ -11777,17 +12037,198 @@ void allocator::unlink_item (unsigned int bn, uint8_t* item, uint8_t* prev_item,
             free_list_undo (prev_item) = item;
             alloc_list_damage_count_of (bn)++;
         }
-        free_list_slot (prev_item) = free_list_slot(item);
+
+        free_list_slot (prev_item) = next_item;
     }
     else
     {
-        al->alloc_list_head() = (uint8_t*)free_list_slot(item);
+        al->alloc_list_head() = next_item;
     }
     if (al->alloc_list_tail() == item)
     {
         al->alloc_list_tail() = prev_item;
     }
+
+#ifdef DOUBLY_LINKED_FL
+    if (repair_list)
+    {
+        if (!use_undo_p)
+        {
+            free_list_prev (item) = PREV_EMPTY;
+        }
+    }
+
+    if (gen_number == max_generation)
+    {
+        dprintf (3, ("[g%2d, b%2d]UL: %Ix->%Ix->%Ix (h: %Ix, t: %Ix)",
+            gen_number, bn, free_list_prev (item), item, free_list_slot (item), 
+            al->alloc_list_head(), al->alloc_list_tail()));
+        dprintf (3, ("[g%2d, b%2d]UL: exit, h->N: %Ix, h->P: %Ix, t->N: %Ix, t->P: %Ix", 
+            gen_number, bn, 
+            (al->alloc_list_head() ? free_list_slot (al->alloc_list_head()) : 0),
+            (al->alloc_list_head() ? free_list_prev (al->alloc_list_head()) : 0),
+            (al->alloc_list_tail() ? free_list_slot (al->alloc_list_tail()) : 0),
+            (al->alloc_list_tail() ? free_list_prev (al->alloc_list_tail()) : 0)));
+    }
+#endif //DOUBLY_LINKED_FL
 }
+
+#ifdef DOUBLY_LINKED_FL
+void allocator::unlink_item_no_undo (unsigned int bn, uint8_t* item, size_t size)
+{
+    alloc_list* al = &alloc_list_of (bn);
+    
+    uint8_t* next_item = free_list_slot (item);
+    uint8_t* prev_item = free_list_prev (item);
+
+#ifdef FL_VERIFICATION
+    {
+        uint8_t* start = al->alloc_list_head();
+        BOOL found_p = FALSE;
+        while (start)
+        {
+            if (start == item)
+            {
+                found_p = TRUE;
+                break;
+            }
+
+            start = free_list_slot (start);
+        }
+
+        if (!found_p)
+        {
+            dprintf (1, ("could  not find %Ix in b%d!!!", item, a_l_number));
+            FATAL_GC_ERROR();
+        }
+    }
+#endif //FL_VERIFICATION
+
+    if (prev_item)
+    {
+        free_list_slot (prev_item) = next_item;
+    }
+    else
+    {
+        al->alloc_list_head() = next_item;
+    }
+
+    if (next_item)
+    {
+        free_list_prev (next_item) = prev_item;
+    }
+
+    if (al->alloc_list_tail() == item)
+    {
+        al->alloc_list_tail() = prev_item;
+    }
+
+    free_list_prev (item) = PREV_EMPTY;
+
+    if (gen_number == max_generation)
+    {
+        dprintf (3, ("[g%2d, b%2d]ULN: %Ix->%Ix->%Ix (h: %Ix, t: %Ix)",
+            gen_number, bn, free_list_prev (item), item, free_list_slot (item), 
+            al->alloc_list_head(), al->alloc_list_tail()));
+        dprintf (3, ("[g%2d, b%2d]ULN: exit: h->N: %Ix, h->P: %Ix, t->N: %Ix, t->P: %Ix", 
+            gen_number, bn, 
+            (al->alloc_list_head() ? free_list_slot (al->alloc_list_head()) : 0),
+            (al->alloc_list_head() ? free_list_prev (al->alloc_list_head()) : 0),
+            (al->alloc_list_tail() ? free_list_slot (al->alloc_list_tail()) : 0),
+            (al->alloc_list_tail() ? free_list_prev (al->alloc_list_tail()) : 0)));
+    }
+}
+
+void allocator::unlink_item_no_undo (uint8_t* item, size_t size)
+{
+    unsigned int bn = first_suitable_bucket (size);
+    unlink_item_no_undo (bn, item, size);
+}
+
+void allocator::unlink_item_no_undo_added (unsigned int bn, uint8_t* item, uint8_t* previous_item)
+{
+    alloc_list* al = &alloc_list_of (bn);
+    
+    uint8_t* next_item = free_list_slot (item);
+    uint8_t* prev_item = free_list_prev (item);
+
+    assert (prev_item == previous_item);
+
+    if (prev_item)
+    {
+        free_list_slot (prev_item) = next_item;
+    }
+    else
+    {
+        al->added_alloc_list_head() = next_item;
+    }
+
+    if (next_item)
+    {
+        free_list_prev (next_item) = prev_item;
+    }
+
+    if (al->added_alloc_list_tail() == item)
+    {
+        al->added_alloc_list_tail() = prev_item;
+    }
+
+    free_list_prev (item) = PREV_EMPTY;
+
+    if (gen_number == max_generation)
+    {
+        dprintf (3333, ("[g%2d, b%2d]ULNA: %Ix->%Ix->%Ix (h: %Ix, t: %Ix)",
+            gen_number, bn, free_list_prev (item), item, free_list_slot (item), 
+            al->added_alloc_list_head(), al->added_alloc_list_tail()));
+        dprintf (3333, ("[g%2d, b%2d]ULNA: exit: h->N: %Ix, h->P: %Ix, t->N: %Ix, t->P: %Ix", 
+            gen_number, bn, 
+            (al->added_alloc_list_head() ? free_list_slot (al->added_alloc_list_head()) : 0),
+            (al->added_alloc_list_head() ? free_list_prev (al->added_alloc_list_head()) : 0),
+            (al->added_alloc_list_tail() ? free_list_slot (al->added_alloc_list_tail()) : 0),
+            (al->added_alloc_list_tail() ? free_list_prev (al->added_alloc_list_tail()) : 0)));
+    }
+}
+
+int allocator::thread_item_front_added (uint8_t* item, size_t size)
+{
+    unsigned int a_l_number = first_suitable_bucket (size);
+    alloc_list* al = &alloc_list_of (a_l_number);
+
+    free_list_slot (item) = al->added_alloc_list_head();
+    free_list_prev (item) = 0;
+    // this list's UNDO is not useful.
+    free_list_undo (item) = UNDO_EMPTY;
+
+    if (al->added_alloc_list_head() != 0)
+    {
+        uint8_t* head_prev = free_list_prev (al->added_alloc_list_head());
+        free_list_prev (al->added_alloc_list_head()) = item;
+    }
+
+    al->added_alloc_list_head() = item;
+
+    if (al->added_alloc_list_tail() == 0)
+    {
+        al->added_alloc_list_tail() = item;
+    }
+
+    if (gen_number == max_generation)
+    {
+        dprintf (3333, ("[g%2d, b%2d]TFFA: exit: %Ix->%Ix->%Ix (h: %Ix, t: %Ix)",
+            gen_number, a_l_number, 
+            free_list_prev (item), item, free_list_slot (item), 
+            al->added_alloc_list_head(), al->added_alloc_list_tail()));
+        dprintf (3333, ("[g%2d, b%2d]TFFA: h->N: %Ix, h->P: %Ix, t->N: %Ix, t->P: %Ix", 
+            gen_number, a_l_number, 
+            (al->added_alloc_list_head() ? free_list_slot (al->added_alloc_list_head()) : 0),
+            (al->added_alloc_list_head() ? free_list_prev (al->added_alloc_list_head()) : 0),
+            (al->added_alloc_list_tail() ? free_list_slot (al->added_alloc_list_tail()) : 0),
+            (al->added_alloc_list_tail() ? free_list_prev (al->added_alloc_list_tail()) : 0)));
+    }
+
+    return a_l_number;
+}
+#endif //DOUBLY_LINKED_FL
 
 void allocator::clear()
 {
@@ -11801,7 +12242,7 @@ void allocator::clear()
 //always thread to the end.
 void allocator::thread_item (uint8_t* item, size_t size)
 {
-    unsigned int a_l_number = first_suitable_bucket(size);
+    unsigned int a_l_number = first_suitable_bucket (size);
     alloc_list* al = &alloc_list_of (a_l_number);
     uint8_t*& head = al->alloc_list_head();
     uint8_t*& tail = al->alloc_list_tail();
@@ -11809,6 +12250,13 @@ void allocator::thread_item (uint8_t* item, size_t size)
     free_list_slot (item) = 0;
     free_list_undo (item) = UNDO_EMPTY;
     assert (item != head);
+
+#ifdef DOUBLY_LINKED_FL
+    if (gen_number == max_generation)
+    {
+        free_list_prev (item) = tail;
+    }
+#endif //DOUBLY_LINKED_FL
 
     if (head == 0)
     {
@@ -11824,6 +12272,22 @@ void allocator::thread_item (uint8_t* item, size_t size)
     }
 
     tail = item;
+
+#ifdef DOUBLY_LINKED_FL
+    if (gen_number == max_generation)
+    {
+        dprintf (3333, ("[g%2d, b%2d]TFE: %Ix->%Ix->%Ix (h: %Ix, t: %Ix)", 
+            gen_number, a_l_number, 
+            free_list_prev (item), item, free_list_slot (item), 
+            al->alloc_list_head(), al->alloc_list_tail()));
+        dprintf (3333, ("[g%2d, b%2d]TFE: exit: h->N: %Ix, h->P: %Ix, t->N: %Ix, t->P: %Ix", 
+            gen_number, a_l_number, 
+            (al->alloc_list_head() ? free_list_slot (al->alloc_list_head()) : 0),
+            (al->alloc_list_head() ? free_list_prev (al->alloc_list_head()) : 0),
+            (al->alloc_list_tail() ? free_list_slot (al->alloc_list_tail()) : 0),
+            (al->alloc_list_tail() ? free_list_prev (al->alloc_list_tail()) : 0)));
+    }
+#endif //DOUBLY_LINKED_FL
 }
 
 void allocator::thread_item_front (uint8_t* item, size_t size)
@@ -11836,13 +12300,43 @@ void allocator::thread_item_front (uint8_t* item, size_t size)
 
     if (al->alloc_list_tail() == 0)
     {
+        assert (al->alloc_list_head() == 0);
         al->alloc_list_tail() = al->alloc_list_head();
     }
+
+#ifdef DOUBLY_LINKED_FL
+    if (gen_number == max_generation)
+    {
+        if (al->alloc_list_head() != 0)
+        {
+            free_list_prev (al->alloc_list_head()) = item;
+        }
+    }
+#endif //DOUBLY_LINKED_FL
+
     al->alloc_list_head() = item;
     if (al->alloc_list_tail() == 0)
     {
         al->alloc_list_tail() = item;
     }
+
+#ifdef DOUBLY_LINKED_FL
+    if (gen_number == max_generation)
+    {
+        free_list_prev (item) = 0;
+
+        dprintf (3333, ("[g%2d, b%2d]TFF: exit: %Ix->%Ix->%Ix (h: %Ix, t: %Ix)",
+            gen_number, a_l_number, 
+            free_list_prev (item), item, free_list_slot (item), 
+            al->alloc_list_head(), al->alloc_list_tail()));
+        dprintf (3333, ("[g%2d, b%2d]TFF: h->N: %Ix, h->P: %Ix, t->N: %Ix, t->P: %Ix", 
+            gen_number, a_l_number, 
+            (al->alloc_list_head() ? free_list_slot (al->alloc_list_head()) : 0),
+            (al->alloc_list_head() ? free_list_prev (al->alloc_list_head()) : 0),
+            (al->alloc_list_tail() ? free_list_slot (al->alloc_list_tail()) : 0),
+            (al->alloc_list_tail() ? free_list_prev (al->alloc_list_tail()) : 0)));
+    }
+#endif //DOUBLY_LINKED_FL
 }
 
 void allocator::copy_to_alloc_list (alloc_list* toalist)
@@ -11851,6 +12345,11 @@ void allocator::copy_to_alloc_list (alloc_list* toalist)
     {
         toalist [i] = alloc_list_of (i);
 #ifdef FL_VERIFICATION
+        size_t damage_count = alloc_list_damage_count_of (i);
+        // We are only calling this method to copy to an empty list
+        // so damage count is always 0
+        assert (damage_count == 0);
+
         uint8_t* free_item = alloc_list_head_of (i);
         size_t count = 0;
         while (free_item)
@@ -11867,30 +12366,68 @@ void allocator::copy_to_alloc_list (alloc_list* toalist)
 void allocator::copy_from_alloc_list (alloc_list* fromalist)
 {
     BOOL repair_list = !discard_if_no_fit_p ();
-    for (unsigned int i = 0; i < num_buckets; i++)
+#ifdef DOUBLY_LINKED_FL
+    BOOL bgc_repair_p = FALSE;
+    if (gen_number == max_generation)
+    {
+        bgc_repair_p = TRUE;
+
+        if (alloc_list_damage_count_of (0) != 0)
+        {
+            GCToOSInterface::DebugBreak();
+        }
+
+        uint8_t* b0_head = alloc_list_head_of (0);
+        if (b0_head)
+        {
+            free_list_prev (b0_head) = 0;
+        }
+
+        added_alloc_list_head_of (0) = 0;
+        added_alloc_list_tail_of (0) = 0;
+    }
+
+    unsigned int start_index = (bgc_repair_p ? 1 : 0);
+#else
+    unsigned int start_index = 0;
+
+#endif //DOUBLY_LINKED_FL
+
+    for (unsigned int i = start_index; i < num_buckets; i++)
     {
         size_t count = alloc_list_damage_count_of (i);
+
         alloc_list_of (i) = fromalist [i];
         assert (alloc_list_damage_count_of (i) == 0);
 
         if (repair_list)
         {
             //repair the the list
-            //new items may have been added during the plan phase
-            //items may have been unlinked.
+            //new items may have been added during the plan phase 
+            //items may have been unlinked. 
             uint8_t* free_item = alloc_list_head_of (i);
+
             while (free_item && count)
             {
                 assert (((CObjectHeader*)free_item)->IsFree());
                 if ((free_list_undo (free_item) != UNDO_EMPTY))
                 {
                     count--;
+
                     free_list_slot (free_item) = free_list_undo (free_item);
                     free_list_undo (free_item) = UNDO_EMPTY;
                 }
 
                 free_item = free_list_slot (free_item);
             }
+
+#ifdef DOUBLY_LINKED_FL
+            if (bgc_repair_p)
+            {
+                added_alloc_list_head_of (i) = 0;
+                added_alloc_list_tail_of (i) = 0;
+            }
+#endif //DOUBLY_LINKED_FL
 
 #ifdef FL_VERIFICATION
             free_item = alloc_list_head_of (i);
@@ -11904,6 +12441,7 @@ void allocator::copy_from_alloc_list (alloc_list* fromalist)
             assert (item_count == alloc_list_of (i).item_count);
 #endif //FL_VERIFICATION
         }
+
 #ifdef DEBUG
         uint8_t* tail_item = alloc_list_tail_of (i);
         assert ((tail_item == 0) || (free_list_slot (tail_item) == 0));
@@ -11914,13 +12452,37 @@ void allocator::copy_from_alloc_list (alloc_list* fromalist)
 void allocator::commit_alloc_list_changes()
 {
     BOOL repair_list = !discard_if_no_fit_p ();
+#ifdef DOUBLY_LINKED_FL
+    BOOL bgc_repair_p = FALSE;
+    if (gen_number == max_generation)
+    {
+        bgc_repair_p = TRUE;
+    }
+#endif //DOUBLY_LINKED_FL
+
     if (repair_list)
     {
         for (unsigned int i = 0; i < num_buckets; i++)
         {
-            //remove the undo info from list.
+            //remove the undo info from list. 
             uint8_t* free_item = alloc_list_head_of (i);
+
+#ifdef DOUBLY_LINKED_FL
+            if (bgc_repair_p)
+            {
+                dprintf (3, ("C[b%2d] ENTRY: h: %Ix t: %Ix", i, 
+                    alloc_list_head_of (i), alloc_list_tail_of (i)));
+            }
+
+            if (free_item && bgc_repair_p)
+            {
+                if (free_list_prev (free_item) != 0)
+                    free_list_prev (free_item) = 0;
+            }
+#endif //DOUBLY_LINKED_FL
+
             size_t count = alloc_list_damage_count_of (i);
+
             while (free_item && count)
             {
                 assert (((CObjectHeader*)free_item)->IsFree());
@@ -11928,6 +12490,16 @@ void allocator::commit_alloc_list_changes()
                 if (free_list_undo (free_item) != UNDO_EMPTY)
                 {
                     free_list_undo (free_item) = UNDO_EMPTY;
+
+#ifdef DOUBLY_LINKED_FL
+                    if (bgc_repair_p)
+                    {
+                        uint8_t* next_item = free_list_slot (free_item);
+                        if (next_item && (free_list_prev (next_item) != free_item))
+                            free_list_prev (next_item) = free_item;
+                    }
+#endif //DOUBLY_LINKED_FL
+
                     count--;
                 }
 
@@ -11935,6 +12507,41 @@ void allocator::commit_alloc_list_changes()
             }
 
             alloc_list_damage_count_of (i) = 0;
+
+#ifdef DOUBLY_LINKED_FL
+            if (bgc_repair_p)
+            {
+                uint8_t* head = alloc_list_head_of (i);
+                uint8_t* tail_added = added_alloc_list_tail_of (i);
+
+                if (tail_added)
+                {
+                    assert (free_list_slot (tail_added) == 0);
+
+                    if (head)
+                    {
+                        free_list_slot (tail_added) = head;
+                        free_list_prev (head) = tail_added;
+                    }
+                }
+
+                uint8_t* head_added = added_alloc_list_head_of (i);
+                
+                if (head_added)
+                {
+                    alloc_list_head_of (i) = head_added;
+                    uint8_t* final_head = alloc_list_head_of (i);
+
+                    if (alloc_list_tail_of (i) == 0)
+                    {
+                        alloc_list_tail_of (i) = tail_added;
+                    }
+                }
+
+                added_alloc_list_head_of (i) = 0;
+                added_alloc_list_tail_of (i) = 0;
+            }
+#endif //DOUBLY_LINKED_FL
         }
     }
 }
@@ -12558,6 +13165,9 @@ void gc_heap::bgc_uoh_alloc_clr (uint8_t* alloc_start,
                                  heap_segment* seg)
 {
     make_unused_array (alloc_start, size);
+#ifdef DOUBLY_LINKED_FL
+    clear_prev_bit (alloc_start, size);
+#endif //DOUBLY_LINKED_FL
 
     size_t size_of_array_base = sizeof(ArrayBase);
 
@@ -12669,8 +13279,8 @@ BOOL gc_heap::a_fit_free_list_uoh_p (size_t size,
                 bgc_track_uoh_alloc();
 #endif //BACKGROUND_GC
 
-                //unlink the free_item
                 allocator->unlink_item (a_l_idx, free_list, prev_free_item, FALSE);
+                remove_gen_free (gen_number, free_list_size);
 
                 // Substract min obj size because limit_from_size adds it. Not needed for LOH
                 size_t limit = limit_from_size (size - Align(min_obj_size, align_const), flags, free_list_size,
@@ -12696,6 +13306,7 @@ BOOL gc_heap::a_fit_free_list_uoh_p (size_t size,
                 if (remain_size >= Align(min_free_list, align_const))
                 {
                     loh_thread_gap_front (remain, remain_size, gen);
+                    add_gen_free (gen_number, remain_size);
                     assert (remain_size >= Align (min_obj_size, align_const));
                 }
                 else
@@ -12703,6 +13314,8 @@ BOOL gc_heap::a_fit_free_list_uoh_p (size_t size,
                     generation_free_obj_space (gen) += remain_size;
                 }
                 generation_free_list_space (gen) -= free_list_size;
+                generation_free_list_allocated (gen) += limit;
+
                 dprintf (3, ("found fit on loh at %Ix", free_list));
 #ifdef BACKGROUND_GC
                 if (cookie != -1)
@@ -12883,7 +13496,9 @@ BOOL gc_heap::uoh_a_fit_segment_end_p (int gen_number,
                                        oom_reason* oom_r)
 {
     *commit_failed_p = FALSE;
-    heap_segment* seg = generation_allocation_segment (generation_of (gen_number));
+
+    generation* gen = generation_of (gen_number);
+    heap_segment* seg = generation_allocation_segment (gen);
     BOOL can_allocate_p = FALSE;
 
     while (seg)
@@ -12912,6 +13527,11 @@ BOOL gc_heap::uoh_a_fit_segment_end_p (int gen_number,
         }
 
         seg = heap_segment_next_rw (seg);
+    }
+
+    if (can_allocate_p)
+    {
+        generation_end_seg_allocated (gen) += size;
     }
 
     return can_allocate_p;
@@ -14536,10 +15156,17 @@ void  gc_heap::leave_allocation_segment (generation* gen)
 void gc_heap::init_free_and_plug()
 {
 #ifdef FREE_USAGE_STATS
-    for (int i = 0; i <= settings.condemned_generation; i++)
+    int i = (settings.concurrent ? max_generation : 0);
+
+    for (; i <= settings.condemned_generation; i++)
     {
         generation* gen = generation_of (i);
+#ifdef DOUBLY_LINKED_FL
+        print_free_and_plug ("BGC");
+#else
         memset (gen->gen_free_spaces, 0, sizeof (gen->gen_free_spaces));
+#endif //DOUBLY_LINKED_FL
+        memset (gen->gen_plugs_allocated_in_free, 0, sizeof (gen->gen_plugs_allocated_in_free));
         memset (gen->gen_plugs, 0, sizeof (gen->gen_plugs));
         memset (gen->gen_current_pinned_free_spaces, 0, sizeof (gen->gen_current_pinned_free_spaces));
     }
@@ -14581,22 +15208,31 @@ void gc_heap::print_free_and_plug (const char* msg)
 #endif //FREE_USAGE_STATS && SIMPLE_DPRINTF
 }
 
+// replace with allocator::first_suitable_bucket
+int gc_heap::find_bucket (size_t size)
+{
+    size_t sz = BASE_GEN_SIZE;
+    int i = 0;
+
+    for (; i < (NUM_GEN_POWER2 - 1); i++)
+    {
+        if (size < sz)
+        {
+            break;
+        }
+        sz = sz * 2;
+    }
+
+    return i;
+}
+
 void gc_heap::add_gen_plug (int gen_number, size_t plug_size)
 {
 #ifdef FREE_USAGE_STATS
     dprintf (3, ("adding plug size %Id to gen%d", plug_size, gen_number));
     generation* gen = generation_of (gen_number);
     size_t sz = BASE_GEN_SIZE;
-    int i = 0;
-
-    for (; i < NUM_GEN_POWER2; i++)
-    {
-        if (plug_size < sz)
-        {
-            break;
-        }
-        sz = sz * 2;
-    }
+    int i = find_bucket (plug_size);
 
     (gen->gen_plugs[i])++;
 #else
@@ -14610,16 +15246,7 @@ void gc_heap::add_item_to_current_pinned_free (int gen_number, size_t free_size)
 #ifdef FREE_USAGE_STATS
     generation* gen = generation_of (gen_number);
     size_t sz = BASE_GEN_SIZE;
-    int i = 0;
-
-    for (; i < NUM_GEN_POWER2; i++)
-    {
-        if (free_size < sz)
-        {
-            break;
-        }
-        sz = sz * 2;
-    }
+    int i = find_bucket (free_size);
 
     (gen->gen_current_pinned_free_spaces[i])++;
     generation_pinned_free_obj_space (gen) += free_size;
@@ -14633,24 +15260,25 @@ void gc_heap::add_item_to_current_pinned_free (int gen_number, size_t free_size)
 #endif //FREE_USAGE_STATS
 }
 
+// This is only for items large enough to be on the FL
+// Ideally we should keep track of smaller ones too but for now
+// it's easier to make the accounting right
 void gc_heap::add_gen_free (int gen_number, size_t free_size)
 {
 #ifdef FREE_USAGE_STATS
     dprintf (3, ("adding free size %Id to gen%d", free_size, gen_number));
+    if (free_size < min_free_list)
+        return;
+
     generation* gen = generation_of (gen_number);
     size_t sz = BASE_GEN_SIZE;
-    int i = 0;
-
-    for (; i < NUM_GEN_POWER2; i++)
-    {
-        if (free_size < sz)
-        {
-            break;
-        }
-        sz = sz * 2;
-    }
+    int i = find_bucket (free_size);
 
     (gen->gen_free_spaces[i])++;
+    if (gen_number == max_generation)
+    {
+        //dprintf (2, ("Mb b%d: f+ %Id (%Id->%Id)", i, free_size, (gen->gen_free_spaces[i]).num_items, (gen->gen_free_spaces[i]).total_size));
+    }
 #else
     UNREFERENCED_PARAMETER(gen_number);
     UNREFERENCED_PARAMETER(free_size);
@@ -14661,35 +15289,96 @@ void gc_heap::remove_gen_free (int gen_number, size_t free_size)
 {
 #ifdef FREE_USAGE_STATS
     dprintf (3, ("removing free %Id from gen%d", free_size, gen_number));
+    if (free_size < min_free_list)
+        return;
+
     generation* gen = generation_of (gen_number);
     size_t sz = BASE_GEN_SIZE;
-    int i = 0;
-
-    for (; i < NUM_GEN_POWER2; i++)
-    {
-        if (free_size < sz)
-        {
-            break;
-        }
-        sz = sz * 2;
-    }
+    int i = find_bucket (free_size);
 
     (gen->gen_free_spaces[i])--;
+    if (gen_number == max_generation)
+    {
+        //dprintf (2, ("Mb b%d: f- %Id (%Id->%Id)", i, free_size, (gen->gen_free_spaces[i]).num_items, (gen->gen_free_spaces[i]).total_size));
+    }
 #else
     UNREFERENCED_PARAMETER(gen_number);
     UNREFERENCED_PARAMETER(free_size);
 #endif //FREE_USAGE_STATS
 }
 
+#ifdef DOUBLY_LINKED_FL
+// This is only called on free spaces.
+BOOL gc_heap::should_set_bgc_mark_bit (uint8_t* o)
+{
+    if (!current_sweep_seg)
+    {
+        assert (current_bgc_state == bgc_not_in_process);
+        return FALSE;
+    }
+
+    // This is cheaper so I am doing this comparision first before having to get the seg for o.
+    if (in_range_for_segment (o, current_sweep_seg))
+    {
+        // The current sweep seg could have free spaces beyond its background_allocated so we need
+        // to check for that.
+        if ((o >= current_sweep_pos) && (o < heap_segment_background_allocated (current_sweep_seg)))
+        {
+            if (current_sweep_seg == saved_sweep_ephemeral_seg)
+                return (o < saved_sweep_ephemeral_start);
+            else
+                return TRUE;
+        }
+        else
+            return FALSE;
+    }
+    else
+    {
+        // We can have segments outside the BGC range that were allocated during mark - and we 
+        // wouldn't have committed the mark array for them and their background_allocated would be
+        // non-zero. Don't set mark bits for those.
+        // The ones allocated during BGC sweep would have their background_allocated as 0.
+        if ((o >= background_saved_lowest_address) && (o < background_saved_highest_address))
+        {
+            heap_segment* seg = seg_mapping_table_segment_of (o);
+            // if bgc_allocated is 0 it means it was allocated during bgc sweep, 
+            // and everything on it should be considered live.
+            uint8_t* background_allocated = heap_segment_background_allocated (seg);
+            if (background_allocated == 0)
+                return FALSE;
+            // During BGC sweep gen1 GCs could add some free spaces in gen2.
+            // If we use those, we should not set the mark bits on them.
+            // They could either be a newly allocated seg which is covered by the 
+            // above case; or they are on a seg that's seen but beyond what BGC mark
+            // saw.
+            else if (o >= background_allocated)
+                return FALSE;
+            else
+                return (!heap_segment_swept_p (seg));
+        }
+        else
+            return FALSE;
+    }
+}
+#endif //DOUBLY_LINKED_FL
+
 uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
-                                             int from_gen_number,
-                                             uint8_t* old_loc REQD_ALIGN_AND_OFFSET_DCL)
+                                                int from_gen_number,
+                                                uint8_t* old_loc REQD_ALIGN_AND_OFFSET_DCL)
 {
     size = Align (size);
     assert (size >= Align (min_obj_size));
     assert (from_gen_number < max_generation);
     assert (from_gen_number >= 0);
     assert (generation_of (from_gen_number + 1) == gen);
+
+#ifdef DOUBLY_LINKED_FL
+    BOOL consider_bgc_mark_p        = FALSE;
+    BOOL check_current_sweep_p      = FALSE;
+    BOOL check_saved_sweep_p        = FALSE;
+    BOOL try_added_list_p       = (gen->gen_num == max_generation);
+    BOOL record_free_list_allocated_p = ((gen->gen_num == max_generation) && (current_c_gc_state == c_gc_state_planning));
+#endif //DOUBLY_LINKED_FL
 
     allocator* gen_allocator = generation_allocator (gen);
     BOOL discard_p = gen_allocator->discard_if_no_fit_p ();
@@ -14712,8 +15401,71 @@ uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
     {
         for (unsigned int a_l_idx = gen_allocator->first_suitable_bucket(real_size * 2); a_l_idx < gen_allocator->number_of_buckets(); a_l_idx++)
         {
-            uint8_t* free_list = gen_allocator->alloc_list_head_of (a_l_idx);
+            uint8_t* free_list = 0;
             uint8_t* prev_free_item = 0;
+
+            BOOL use_undo_p = !discard_p;
+
+#ifdef DOUBLY_LINKED_FL
+            if (a_l_idx == 0)
+            {
+                use_undo_p = FALSE;
+            }
+
+            if (try_added_list_p)
+            {
+                free_list = gen_allocator->added_alloc_list_head_of (a_l_idx);
+                while (free_list != 0)
+                {
+                    dprintf (3, ("considering free list in added list%Ix", (size_t)free_list));
+
+                    size_t free_list_size = unused_array_size (free_list);
+
+                    if (size_fit_p (size REQD_ALIGN_AND_OFFSET_ARG, free_list, (free_list + free_list_size),
+                                    old_loc, USE_PADDING_TAIL | pad_in_front))
+                    {
+                        dprintf (4, ("F:%Ix-%Id",
+                                    (size_t)free_list, free_list_size));
+
+                        gen_allocator->unlink_item_no_undo_added (a_l_idx, free_list, prev_free_item);
+                        generation_free_list_space (gen) -= free_list_size;
+
+                        remove_gen_free (gen->gen_num, free_list_size);
+
+                        if (record_free_list_allocated_p)
+                        {
+                            generation_set_bgc_mark_bit_p (gen) = should_set_bgc_mark_bit (free_list);
+                            dprintf (3333, ("SFA: %Ix->%Ix(%d)", free_list, (free_list + free_list_size), 
+                                (generation_set_bgc_mark_bit_p (gen) ? 1 : 0)));
+                        }
+                        adjust_limit (free_list, free_list_size, gen);
+                        generation_allocate_end_seg_p (gen) = FALSE;
+
+                        goto finished;
+                    }
+                    // We do first fit on bucket 0 because we are not guaranteed to find a fit there.
+                    else if (a_l_idx == 0)
+                    {
+                        dprintf (3, ("couldn't use this free area, discarding"));
+                        generation_free_obj_space (gen) += free_list_size;
+
+                        gen_allocator->unlink_item_no_undo_added (a_l_idx, free_list, prev_free_item);
+                        generation_free_list_space (gen) -= free_list_size;
+
+                        remove_gen_free (gen->gen_num, free_list_size);
+                    }
+                    else
+                    {
+                        prev_free_item = free_list;
+                    }
+                    free_list = free_list_slot (free_list); 
+                }
+            }
+#endif //DOUBLY_LINKED_FL
+
+            free_list = gen_allocator->alloc_list_head_of (a_l_idx);
+            prev_free_item = 0;
+
             while (free_list != 0)
             {
                 dprintf (3, ("considering free list %Ix", (size_t)free_list));
@@ -14726,9 +15478,24 @@ uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
                     dprintf (4, ("F:%Ix-%Id",
                                     (size_t)free_list, free_list_size));
 
-                    gen_allocator->unlink_item (a_l_idx, free_list, prev_free_item, !discard_p);
+                    gen_allocator->unlink_item (a_l_idx, free_list, prev_free_item, use_undo_p);
                     generation_free_list_space (gen) -= free_list_size;
                     remove_gen_free (gen->gen_num, free_list_size);
+
+#ifdef DOUBLY_LINKED_FL
+                    if (!discard_p && !use_undo_p)
+                    {
+                        gen2_removed_no_undo += free_list_size;
+                        dprintf (3, ("h%d: remove with no undo %Id = %Id", 
+                            heap_number, free_list_size, gen2_removed_no_undo));
+                    }
+
+                    if (record_free_list_allocated_p)
+                    {
+                        generation_set_bgc_mark_bit_p (gen) = should_set_bgc_mark_bit (free_list);
+                        dprintf (3333, ("SF: %Ix(%d)", free_list, (generation_set_bgc_mark_bit_p (gen) ? 1 : 0)));
+                    }
+#endif //DOUBLY_LINKED_FL
 
                     adjust_limit (free_list, free_list_size, gen);
                     generation_allocate_end_seg_p (gen) = FALSE;
@@ -14743,6 +15510,15 @@ uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
                     gen_allocator->unlink_item (a_l_idx, free_list, prev_free_item, FALSE);
                     generation_free_list_space (gen) -= free_list_size;
                     remove_gen_free (gen->gen_num, free_list_size);
+
+#ifdef DOUBLY_LINKED_FL
+                    if (!discard_p)
+                    {
+                        gen2_removed_no_undo += free_list_size;
+                        dprintf (3, ("h%d: b0 remove with no undo %Id = %Id", 
+                            heap_number, free_list_size, gen2_removed_no_undo));
+                    }
+#endif //DOUBLY_LINKED_FL
                 }
                 else
                 {
@@ -14862,12 +15638,28 @@ uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
 
         generation_allocation_pointer (gen) += size + pad;
         assert (generation_allocation_pointer (gen) <= generation_allocation_limit (gen));
+
+        generation_free_obj_space (gen) += pad;
+
         if (generation_allocate_end_seg_p (gen))
         {
             generation_end_seg_allocated (gen) += size;
         }
         else
         {
+#ifdef DOUBLY_LINKED_FL
+            if (generation_set_bgc_mark_bit_p (gen))
+            {
+                dprintf (2, ("IOM: %Ix(->%Ix(%Id) (%Ix-%Ix)", old_loc, result, pad, 
+                        (size_t)(&mark_array [mark_word_of (result)]),
+                        (size_t)(mark_array [mark_word_of (result)])));
+                    
+                set_plug_bgc_mark_bit (old_loc);
+            }
+
+            generation_last_free_list_allocated (gen) = old_loc;
+#endif //DOUBLY_LINKED_FL
+
             generation_free_list_allocated (gen) += size;
         }
         generation_allocation_size (gen) += size;
@@ -14876,7 +15668,7 @@ uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
             generation_allocation_pointer (gen), generation_allocation_limit (gen),
             generation_allocation_context_start_region (gen)));
 
-        return result + pad;;
+        return (result + pad);
     }
 }
 
@@ -15401,6 +16193,11 @@ retry:
 
         generation_allocation_pointer (gen) += size + pad;
         assert (generation_allocation_pointer (gen) <= generation_allocation_limit (gen));
+
+        if ((pad > 0) && (to_gen_number >= 0))
+        {
+            generation_free_obj_space (generation_of (to_gen_number)) += pad;
+        }
 
 #ifdef FREE_USAGE_STATS
         generation_allocated_since_last_pin (gen) += size;
@@ -16486,6 +17283,10 @@ void gc_heap::init_background_gc ()
     generation_allocation_segment (gen) = heap_segment_rw (generation_start_segment (gen));
 
     PREFIX_ASSUME(generation_allocation_segment(gen) != NULL);
+
+#ifdef DOUBLY_LINKED_FL
+    generation_set_bgc_mark_bit_p (gen) = FALSE;
+#endif //DOUBLY_LINKED_FL
 
     //reset the plan allocation for each segment
     for (heap_segment* seg = generation_allocation_segment (gen); seg != ephemeral_heap_segment;
@@ -22785,6 +23586,15 @@ void gc_heap::plan_phase (int condemned_gen_number)
         memcpy (r_older_gen_free_space, older_gen->gen_free_spaces, sizeof (r_older_gen_free_space));
 #endif //FREE_USAGE_STATS
         generation_allocate_end_seg_p (older_gen) = FALSE;
+
+#ifdef DOUBLY_LINKED_FL
+        if (older_gen->gen_num == max_generation)
+        {
+            generation_set_bgc_mark_bit_p (older_gen) = FALSE;
+            generation_last_free_list_allocated (older_gen) = 0;
+        }
+#endif //DOUBLY_LINKED_FL
+
         r_older_gen_free_list_allocated = generation_free_list_allocated (older_gen);
         r_older_gen_condemned_allocated = generation_condemned_allocated (older_gen);
         r_older_gen_end_seg_allocated = generation_end_seg_allocated (older_gen);
@@ -22905,6 +23715,10 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
     BOOL fire_pinned_plug_events_p = EVENT_ENABLED(PinPlugAtGCTime);
     size_t last_plug_len = 0;
+
+#ifdef DOUBLY_LINKED_FL
+    gen2_removed_no_undo = 0;
+#endif //DOUBLY_LINKED_FL
 
     while (1)
     {
@@ -24059,9 +24873,28 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
         if ((condemned_gen_number < max_generation))
         {
+#ifdef FREE_USAGE_STATS
+            memcpy (older_gen->gen_free_spaces, r_older_gen_free_space, sizeof (r_older_gen_free_space));
+#endif //FREE_USAGE_STATS
             generation_allocator (older_gen)->copy_from_alloc_list (r_free_list);
             generation_free_list_space (older_gen) = r_free_list_space;
             generation_free_obj_space (older_gen) = r_free_obj_space;
+
+#ifdef DOUBLY_LINKED_FL
+            if (condemned_gen_number == (max_generation - 1))
+            {
+                dprintf (2, ("[h%d] no undo, FL %Id-%Id -> %Id, FO %Id+%Id=%Id", 
+                    heap_number, 
+                    generation_free_list_space (older_gen), gen2_removed_no_undo, 
+                    (generation_free_list_space (older_gen) - gen2_removed_no_undo),
+                    generation_free_obj_space (older_gen), gen2_removed_no_undo, 
+                    (generation_free_obj_space (older_gen) + gen2_removed_no_undo)));
+
+                generation_free_list_space (older_gen) -= gen2_removed_no_undo;
+                generation_free_obj_space (older_gen) += gen2_removed_no_undo;
+            }
+#endif //DOUBLY_LINKED_FL
+
             generation_free_list_allocated (older_gen) = r_older_gen_free_list_allocated;
             generation_end_seg_allocated (older_gen) = r_older_gen_end_seg_allocated;
             generation_condemned_allocated (older_gen) = r_older_gen_condemned_allocated;
@@ -24082,7 +24915,14 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
         gen0_big_free_spaces = 0;
         make_free_lists (condemned_gen_number);
-        recover_saved_pinned_info();
+        size_t total_recovered_sweep_size = recover_saved_pinned_info();
+        if (total_recovered_sweep_size > 0)
+        {
+            generation_free_obj_space (generation_of (max_generation)) -= total_recovered_sweep_size;
+            dprintf (2, ("h%d: deduct %Id for pin, fo->%Id", 
+                heap_number, total_recovered_sweep_size,
+                generation_free_obj_space (generation_of (max_generation))));
+        }
 
 #ifdef FEATURE_PREMORTEM_FINALIZATION
         finalize_queue->UpdatePromotedGenerations (condemned_gen_number, TRUE);
@@ -24161,8 +25001,13 @@ void gc_heap::fix_generation_bounds (int condemned_gen_number,
         dprintf(3,("Fixing generation pointers for %Ix", gen_number));
         if ((gen_number < max_generation) && ephemeral_promotion)
         {
+            size_t saved_eph_start_size = saved_ephemeral_plan_start_size[gen_number];
+
             make_unused_array (saved_ephemeral_plan_start[gen_number],
-                               saved_ephemeral_plan_start_size[gen_number]);
+                               saved_eph_start_size);
+            generation_free_obj_space (generation_of (max_generation)) += saved_eph_start_size;
+            dprintf (2, ("[h%d] EP %Ix(%Id)", heap_number, saved_ephemeral_plan_start[gen_number],
+                saved_ephemeral_plan_start_size[gen_number]));
         }
         reset_allocation_pointers (gen, generation_plan_allocation_start (gen));
         make_unused_array (generation_allocation_start (gen), generation_plan_allocation_start_size (gen));
@@ -24402,6 +25247,21 @@ void gc_heap::make_free_list_in_brick (uint8_t* tree, make_free_args* args)
                     clear_plug_padded (plug);
                 }
 #endif //SHORT_PLUGS
+
+#ifdef DOUBLY_LINKED_FL
+                // These 2 checks should really just be merged into one.
+                if (is_plug_bgc_mark_bit_set (plug))
+                {
+                    dprintf (3333, ("cbgcm: %Ix", plug));
+                    clear_plug_bgc_mark_bit (plug);
+                }
+                if (is_free_obj_in_compact_bit_set (plug))
+                {
+                    dprintf (3333, ("cfoc: %Ix", plug));
+                    clear_free_obj_in_compact_bit (plug);
+                }
+#endif //DOUBLY_LINKED_FL
+
             gen_crossing:
                 {
                     if ((args->current_gen_limit == MAX_PTR) ||
@@ -25737,9 +26597,61 @@ void  gc_heap::gcmemcopy (uint8_t* dest, uint8_t* src, size_t len, BOOL copy_car
             copy_mark_bits_for_addresses (dest, src, len);
         }
 #endif //BACKGROUND_GC
+
+#ifdef DOUBLY_LINKED_FL
+        BOOL set_bgc_mark_bits_p = is_plug_bgc_mark_bit_set (src);
+        if (set_bgc_mark_bits_p)
+        {
+            clear_plug_bgc_mark_bit (src);
+        }
+
+        BOOL make_free_obj_p = FALSE;
+        if (len < min_free_item_no_prev)
+        {
+            make_free_obj_p = is_free_obj_in_compact_bit_set (src);
+
+            if (make_free_obj_p)
+            {
+                clear_free_obj_in_compact_bit (src);
+            }
+        }
+#endif //DOUBLY_LINKED_FL
+
         //dprintf(3,(" Memcopy [%Ix->%Ix, %Ix->%Ix[", (size_t)src, (size_t)dest, (size_t)src+len, (size_t)dest+len));
         dprintf(3,(" mc: [%Ix->%Ix, %Ix->%Ix[", (size_t)src, (size_t)dest, (size_t)src+len, (size_t)dest+len));
         memcopy (dest - plug_skew, src - plug_skew, len);
+
+#ifdef DOUBLY_LINKED_FL
+        if (set_bgc_mark_bits_p)
+        {
+            uint8_t* dest_o = dest;
+            uint8_t* dest_end_o = dest + len;
+            while (dest_o < dest_end_o)
+            {
+                uint8_t* next_o = dest_o + Align (size (dest_o));
+                background_mark (dest_o, background_saved_lowest_address, background_saved_highest_address);
+
+                dest_o = next_o; 
+            }
+            dprintf (3333, ("[h%d] GM: %Ix(%Ix-%Ix)->%Ix(%Ix-%Ix)", 
+                heap_number, dest, 
+                (size_t)(&mark_array [mark_word_of (dest)]),
+                (size_t)(mark_array [mark_word_of (dest)]),
+                dest_end_o,
+                (size_t)(&mark_array [mark_word_of (dest_o)]),
+                (size_t)(mark_array [mark_word_of (dest_o)])));
+        }
+
+        if (make_free_obj_p)
+        {
+            size_t* filler_free_obj_size_location = (size_t*)(dest + min_free_item_no_prev);
+            size_t filler_free_obj_size = *filler_free_obj_size_location;
+            make_unused_array ((dest + len), filler_free_obj_size);
+            dprintf (3333, ("[h%d] smallobj, %Ix(%Id): %Ix->%Ix", heap_number,
+                filler_free_obj_size_location, filler_free_obj_size, (dest + len), (dest + len + filler_free_obj_size)));
+        }
+#endif //DOUBLY_LINKED_FL
+
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         if (SoftwareWriteWatch::IsEnabledForGCHeap())
         {
@@ -25985,14 +26897,27 @@ void gc_heap::compact_in_brick (uint8_t* tree, compact_args* args)
     }
 }
 
-void gc_heap::recover_saved_pinned_info()
+// This returns the recovered size for gen2 plugs as that's what we need
+// mostly - would be nice to make it work for all generations.
+size_t gc_heap::recover_saved_pinned_info()
 {
     reset_pinned_queue_bos();
+    size_t total_recovered_sweep_size = 0;
 
     while (!(pinned_plug_que_empty_p()))
     {
         mark* oldest_entry = oldest_pin();
-        oldest_entry->recover_plug_info();
+        size_t recovered_sweep_size = oldest_entry->recover_plug_info();
+
+        if (recovered_sweep_size > 0)
+        {
+            uint8_t* plug = pinned_plug (oldest_entry);
+            if (object_gennum (plug) == max_generation)
+            {
+                dprintf (3, ("recovered %Ix(%Id) from pin", plug, recovered_sweep_size));
+                total_recovered_sweep_size += recovered_sweep_size;
+            }
+        }
 #ifdef GC_CONFIG_DRIVEN
         if (oldest_entry->has_pre_plug_info() && oldest_entry->has_post_plug_info())
             record_interesting_data_point (idp_pre_and_post_pin);
@@ -26004,6 +26929,8 @@ void gc_heap::recover_saved_pinned_info()
 
         deque_pinned_plug();
     }
+
+    return total_recovered_sweep_size;
 }
 
 void gc_heap::compact_phase (int condemned_gen_number,
@@ -27293,9 +28220,10 @@ void gc_heap::background_mark_phase ()
             heap_segment_background_allocated (seg) = heap_segment_allocated (seg);
         }
 
-        dprintf (2, ("seg %Ix background allocated is %Ix",
-                      heap_segment_mem (seg),
-                      heap_segment_background_allocated (seg)));
+        dprintf (3333, ("h%d seg %Ix background allocated is %Ix", 
+                        heap_number,
+                        (size_t)(seg),
+                        heap_segment_background_allocated (seg)));
         seg = heap_segment_next_rw (seg);
     }
 
@@ -28114,7 +29042,9 @@ void gc_heap::bgc_thread_function()
 
         gc1();
 
+#ifndef DOUBLY_LINKED_FL
         current_bgc_state = bgc_not_in_process;
+#endif //!DOUBLY_LINKED_FL
 
         enable_preemptive ();
 #ifdef MULTIPLE_HEAPS
@@ -31695,6 +32625,23 @@ generation* gc_heap::expand_heap (int condemned_generation,
         get_gc_data_per_heap()->set_mechanism (gc_heap_expand, expand_new_seg_ep);
         dprintf (2, ("promoting ephemeral"));
         save_ephemeral_generation_starts();
+
+        // We also need to adjust free_obj_space (due to padding) here because now young gens' free_obj_space will
+        // belong to gen2.
+        generation* max_gen = generation_of (max_generation);
+        for (int i = 1; i < max_generation; i++)
+        {
+            generation_free_obj_space (max_gen) += 
+                generation_free_obj_space (generation_of (i));
+            dprintf (2, ("[h%d] maxgen freeobj + %Id=%Id",
+                heap_number, generation_free_obj_space (generation_of (i)),
+                generation_free_obj_space (max_gen)));
+        }
+        
+        // TODO: This is actually insufficient - if BACKGROUND_GC is not defined we'd need to commit more
+        // in order to accommodate eph gen starts. Also in the no_gc we should make sure used
+        // is updated correctly.
+        heap_segment_used (new_seg) = heap_segment_committed (new_seg);
     }
     else
     {
@@ -33378,12 +34325,14 @@ void gc_heap::generation_delete_heap_segment (generation* gen,
     }
     else
     {
-        if (seg == ephemeral_heap_segment)
-        {
-            FATAL_GC_ERROR();
-        }
+        assert (seg != ephemeral_heap_segment);
 
+#ifdef DOUBLY_LINKED_FL
+        // For doubly linked list we go forward for SOH
+        heap_segment_next (prev_seg) = next_seg;
+#else //DOUBLY_LINKED_FL
         heap_segment_next (next_seg) = prev_seg;
+#endif //DOUBLY_LINKED_FL
 
         dprintf (3, ("Preparing empty small segment %Ix for deletion", (size_t)seg));
         heap_segment_next (seg) = freeable_soh_segment;
@@ -33397,18 +34346,19 @@ void gc_heap::generation_delete_heap_segment (generation* gen,
 }
 
 void gc_heap::process_background_segment_end (heap_segment* seg,
-                                          generation* gen,
-                                          uint8_t* last_plug_end,
-                                          heap_segment* start_seg,
-                                          BOOL* delete_p)
+                                              generation* gen,
+                                              uint8_t* last_plug_end,
+                                              heap_segment* start_seg,
+                                              BOOL* delete_p, 
+                                              size_t free_obj_size_last_gap)
 {
     *delete_p = FALSE;
     uint8_t* allocated = heap_segment_allocated (seg);
     uint8_t* background_allocated = heap_segment_background_allocated (seg);
     BOOL uoh_p = heap_segment_uoh_p (seg);
 
-    dprintf (3, ("Processing end of background segment [%Ix, %Ix[(%Ix[)",
-                (size_t)heap_segment_mem (seg), background_allocated, allocated));
+    dprintf (3, ("EoS [%Ix, %Ix[(%Ix[), last: %Ix(%Id)", 
+                (size_t)heap_segment_mem (seg), background_allocated, allocated, last_plug_end, free_obj_size_last_gap));
 
     if (!uoh_p && (allocated != background_allocated))
     {
@@ -33416,15 +34366,20 @@ void gc_heap::process_background_segment_end (heap_segment* seg,
 
         dprintf (3, ("Make a free object before newly promoted objects [%Ix, %Ix[",
                     (size_t)last_plug_end, background_allocated));
-        thread_gap (last_plug_end, background_allocated - last_plug_end, generation_of (max_generation));
 
+        size_t last_gap = background_allocated - last_plug_end;
+        if (last_gap > 0)
+        {
+            thread_gap (last_plug_end, last_gap, generation_of (max_generation));
+            add_gen_free (max_generation, last_gap);
 
-        fix_brick_to_highest (last_plug_end, background_allocated);
+            fix_brick_to_highest (last_plug_end, background_allocated);
 
-        // When we allowed fgc's during going through gaps, we could have erased the brick
-        // that corresponds to bgc_allocated 'cause we had to update the brick there,
-        // recover it here.
-        fix_brick_to_highest (background_allocated, background_allocated);
+            // When we allowed fgc's during going through gaps, we could have erased the brick
+            // that corresponds to bgc_allocated 'cause we had to update the brick there, 
+            // recover it here.
+            fix_brick_to_highest (background_allocated, background_allocated);
+        }
     }
     else
     {
@@ -33455,12 +34410,22 @@ void gc_heap::process_background_segment_end (heap_segment* seg,
         }
         else
         {
-            dprintf (3, ("Trimming seg to %Ix[", (size_t)last_plug_end));
+            dprintf (3, ("[h%d] seg %Ix alloc %Ix->%Ix", 
+                heap_number, (size_t)seg, 
+                heap_segment_allocated (seg),
+                (size_t)last_plug_end));
             heap_segment_allocated (seg) = last_plug_end;
             set_mem_verify (heap_segment_allocated (seg) - plug_skew, heap_segment_used (seg), 0xbb);
 
             decommit_heap_segment_pages (seg, 0);
         }
+    }
+
+    if (free_obj_size_last_gap)
+    {
+        generation_free_obj_space (gen) -= free_obj_size_last_gap;
+        dprintf (2, ("[h%d] PS: gen2FO-: %Id->%Id", 
+            heap_number, free_obj_size_last_gap, generation_free_obj_space (gen)));
     }
 
     dprintf (3, ("verifying seg %Ix's mark array was completely cleared", seg));
@@ -33544,6 +34509,10 @@ void gc_heap::should_check_bgc_mark (heap_segment* seg,
         if ((seg->flags & heap_segment_flags_swept) || (current_sweep_pos == heap_segment_reserved (seg)))
         {
             dprintf (3, ("seg %Ix is already swept by bgc", seg));
+        }
+        else if (heap_segment_background_allocated (seg) == 0)
+        {
+            dprintf (3, ("seg %Ix newly alloc during bgc"));
         }
         else
         {
@@ -33701,9 +34670,22 @@ void gc_heap::background_sweep()
     for (int i = 0; i <= max_generation; i++)
     {
         generation* gen_to_reset = generation_of (i);
-        generation_allocator (gen_to_reset)->clear();
-        generation_free_list_space (gen_to_reset) = 0;
-        generation_free_obj_space (gen_to_reset) = 0;
+#ifdef DOUBLY_LINKED_FL
+        if (i == max_generation)
+        {
+            dprintf (2, ("h%d: gen2 still has FL: %Id, FO: %Id", 
+                heap_number, 
+                generation_free_list_space (gen_to_reset),
+                generation_free_obj_space (gen_to_reset)));
+        }
+        else
+#endif //DOUBLY_LINKED_FL
+        {
+            generation_allocator (gen_to_reset)->clear();
+            generation_free_list_space (gen_to_reset) = 0;
+            generation_free_obj_space (gen_to_reset) = 0;
+        }
+
         generation_free_list_allocated (gen_to_reset) = 0;
         generation_end_seg_allocated (gen_to_reset) = 0;
         generation_condemned_allocated (gen_to_reset) = 0;
@@ -33717,6 +34699,9 @@ void gc_heap::background_sweep()
     FIRE_EVENT(BGC2ndNonConEnd);
 
     uoh_alloc_thread_count = 0;
+
+    init_free_and_plug();
+
     current_bgc_state = bgc_sweep_soh;
     verify_soh_segment_list();
 
@@ -33729,7 +34714,6 @@ void gc_heap::background_sweep()
     }
 #endif // FEATURE_BASICFREEZE
 
-    //TODO BACKGROUND_GC: can we move this to where we switch to the LOH?
     if (current_c_gc_state != c_gc_state_planning)
     {
         current_c_gc_state = c_gc_state_planning;
@@ -33807,40 +34791,57 @@ void gc_heap::background_sweep()
         heap_segment* next_seg = 0;
         heap_segment* prev_seg;
         heap_segment* start_seg;
-        int align_const;
+        int align_const = get_alignment_constant (i == max_generation);
 
+#ifndef DOUBLY_LINKED_FL
         if (i == max_generation)
         {
             // start with saved ephemeral segment
             // we are no longer holding gc_lock, so a new ephemeral segment could be added, we want the saved one. 
             start_seg = saved_sweep_ephemeral_seg;
             prev_seg = heap_segment_next(start_seg);
-            align_const = get_alignment_constant (TRUE);
         }
         else
+#endif //!DOUBLY_LINKED_FL
         {
+            // If we use doubly linked FL we don't need to go backwards as we are maintaining the free list.
             start_seg = gen_start_seg;
             prev_seg = NULL;
-            align_const = get_alignment_constant (FALSE);
 
-            // UOH allocations are possible while sweeping SOH, so
-            // we defer clearing UOH free lists until we start sweeping them
-            generation_allocator (gen)->clear();
-            generation_free_list_space (gen) = 0;
-            generation_free_obj_space (gen) = 0;
-            generation_free_list_allocated (gen) = 0;
-            generation_end_seg_allocated (gen) = 0;
-            generation_condemned_allocated (gen) = 0;
-            generation_sweep_allocated (gen) = 0;
-            generation_allocation_pointer (gen)= 0;
-            generation_allocation_limit (gen) = 0;
-            generation_allocation_segment (gen) = heap_segment_rw (generation_start_segment (gen));
+            if (i > max_generation)
+            {
+                // UOH allocations are allowed while sweeping SOH, so
+                // we defer clearing UOH free lists until we start sweeping them
+                generation_allocator (gen)->clear();
+                generation_free_list_space (gen) = 0;
+                generation_free_obj_space (gen) = 0;
+                generation_free_list_allocated (gen) = 0;
+                generation_end_seg_allocated (gen) = 0;
+                generation_condemned_allocated (gen) = 0;
+                generation_sweep_allocated (gen) = 0;
+                generation_allocation_pointer (gen)= 0;
+                generation_allocation_limit (gen) = 0;
+                generation_allocation_segment (gen) = heap_segment_rw (generation_start_segment (gen));
+            }
+            else
+            {
+                dprintf (3333, ("h%d: SOH sweep start on seg %Ix: total FL: %Id, FO: %Id",
+                    heap_number, (size_t)start_seg,
+                    generation_free_list_space (gen),
+                    generation_free_obj_space (gen)));
+            }
         }
 
         PREFIX_ASSUME(start_seg != NULL);
         heap_segment* seg = start_seg;
         dprintf (2, ("bgs: sweeping gen %Ix objects", gen->gen_num));
-        while (seg)
+        while (seg
+#ifdef DOUBLY_LINKED_FL
+               // We no longer go backwards in segment list for SOH so we need to bail when we see
+               // segments newly allocated during bgc sweep.
+               && !((heap_segment_background_allocated (seg) == 0) && (gen != large_object_generation))
+#endif //DOUBLY_LINKED_FL
+                )
         {
             uint8_t* o = heap_segment_mem (seg);
             if (seg == gen_start_seg)
@@ -33853,10 +34854,18 @@ void gc_heap::background_sweep()
             uint8_t* plug_end = o;
             current_sweep_pos = o;
             next_sweep_obj = o;
+#ifdef DOUBLY_LINKED_FL
+            current_sweep_seg = seg;
+#endif //DOUBLY_LINKED_FL
+
+            // This records the total size of free objects (including the ones on and not on FL) 
+            // in the gap and it gets set to 0 when we encounter a plug. If the last gap we saw 
+            // on a seg is unmarked, we will process this in process_background_segment_end.
+            size_t free_obj_size_last_gap = 0;
 
             allow_fgc();
             uint8_t* end = background_next_end (seg, (i > max_generation));
-            dprintf (2, ("bgs: seg: %Ix, [%Ix, %Ix[%Ix", (size_t)seg,
+            dprintf (3333, ("bgs: seg: %Ix, [%Ix, %Ix[%Ix", (size_t)seg,
                             (size_t)heap_segment_mem (seg),
                             (size_t)heap_segment_allocated (seg),
                             (size_t)heap_segment_background_allocated (seg)));
@@ -33875,6 +34884,18 @@ void gc_heap::background_sweep()
                     if (i == max_generation)
                     {
                         add_gen_free (max_generation, plug_start-plug_end);
+
+#ifdef DOUBLY_LINKED_FL
+                        if (free_obj_size_last_gap)
+                        {
+                            generation_free_obj_space (gen) -= free_obj_size_last_gap;
+                            dprintf (3333, ("[h%d] LG: gen2FO-: %Id->%Id", 
+                                heap_number, free_obj_size_last_gap, generation_free_obj_space (gen)));
+
+                            free_obj_size_last_gap = 0;
+                        }
+#endif //DOUBLY_LINKED_FL
+
                         fix_brick_to_highest (plug_end, plug_start);
                         // we need to fix the brick for the next plug here 'cause an FGC can
                         // happen and can't read a stale brick.
@@ -33883,14 +34904,15 @@ void gc_heap::background_sweep()
 
                     do
                     {
-                        o = o + Align (size (o), align_const);
+                        next_sweep_obj = o + Align (size (o), align_const);
                         current_num_objs++;
                         if (current_num_objs >= num_objs)
                         {
-                            current_sweep_pos = o;
+                            current_sweep_pos = next_sweep_obj;
                             allow_fgc();
                             current_num_objs = 0;
                         }
+                        o = next_sweep_obj;
                     } while ((o < end) && background_object_marked(o, TRUE));
 
                     plug_end = o;
@@ -33904,7 +34926,50 @@ void gc_heap::background_sweep()
 
                 while ((o < end) && !background_object_marked (o, FALSE))
                 {
-                    o = o + Align (size (o), align_const);;
+                    size_t size_o = Align(size (o), align_const);
+                    next_sweep_obj = o + size_o;
+
+#ifdef DOUBLY_LINKED_FL
+                    if (gen != large_object_generation)
+                    {
+                        if (method_table (o) == g_gc_pFreeObjectMethodTable)
+                        {
+                            free_obj_size_last_gap += size_o;
+
+                            if (is_on_free_list (o, size_o))
+                            {
+                                generation_allocator (gen)->unlink_item_no_undo (o, size_o);
+                                generation_free_list_space (gen) -= size_o;
+                                generation_free_obj_space (gen) += size_o;
+                                
+                                dprintf (3333, ("[h%d] gen2F-: %Ix->%Ix(%Id) FL: %Id", 
+                                    heap_number, o, (o + size_o), size_o,
+                                    generation_free_list_space (gen)));
+                                dprintf (3333, ("h%d: gen2FO+: %Ix(%Id)->%Id (g: %Id)", 
+                                    heap_number, o, size_o,
+                                    generation_free_obj_space (gen),
+                                    free_obj_size_last_gap));
+                                remove_gen_free (max_generation, size_o);
+                            }
+                            else
+                            {
+                                // this was not on the free list so it was already part of 
+                                // free_obj_space, so no need to substract from it. However,
+                                // we do need to keep track in this gap's FO space.
+                                dprintf (3333, ("h%d: gen2FO: %Ix(%Id)->%Id (g: %Id)",
+                                    heap_number, o, size_o,
+                                    generation_free_obj_space (gen), free_obj_size_last_gap));
+                            }
+
+                            dprintf (3333, ("h%d: total FO: %Ix->%Ix FL: %Id, FO: %Id (g: %Id)",
+                                heap_number, plug_end, next_sweep_obj,
+                                generation_free_list_space (gen),
+                                generation_free_obj_space (gen),
+                                free_obj_size_last_gap));
+                        }
+                    }
+#endif //DOUBLY_LINKED_FL
+
                     current_num_objs++;
                     if (current_num_objs >= num_objs)
                     {
@@ -33913,9 +34978,14 @@ void gc_heap::background_sweep()
                         allow_fgc();
                         current_num_objs = 0;
                     }
+
+                    o = next_sweep_obj;
                 }
             }
 
+#ifdef DOUBLY_LINKED_FL
+            next_seg = heap_segment_next (seg);
+#else //DOUBLY_LINKED_FL
             if (i > max_generation)
             {
                 next_seg = heap_segment_next (seg);
@@ -33925,6 +34995,7 @@ void gc_heap::background_sweep()
                 // For SOH segments we go backwards.
                 next_seg = heap_segment_prev (gen_start_seg, seg);
             }
+#endif //DOUBLY_LINKED_FL
 
             BOOL delete_p = FALSE;
             if (!heap_segment_read_only_p (seg))
@@ -33936,13 +35007,13 @@ void gc_heap::background_sweep()
                     // because we don't allow UOH allocations during bgc
                     // sweep anyway - the UOH segments can't change.
                     process_background_segment_end (seg, gen, plug_end,
-                                                    start_seg, &delete_p);
+                                                    start_seg, &delete_p, 0);
                 }
                 else
                 {
                     assert (heap_segment_background_allocated (seg) != 0);
                     process_background_segment_end (seg, gen, plug_end,
-                                                    start_seg, &delete_p);
+                                                    start_seg, &delete_p, free_obj_size_last_gap);
 
                     assert (next_seg || !delete_p);
                 }
@@ -33960,6 +35031,14 @@ void gc_heap::background_sweep()
             }
 
             verify_soh_segment_list();
+
+#ifdef DOUBLY_LINKED_FL
+            while (next_seg && heap_segment_background_allocated (next_seg) == 0)
+            {
+                dprintf (2, ("[h%d] skip new %Ix ", heap_number, next_seg));
+                next_seg = heap_segment_next (next_seg);
+            }
+#endif //DOUBLY_LINKED_FL
 
             seg = next_seg;
             dprintf (GTC_LOG, ("seg: %Ix, next_seg: %Ix, prev_seg: %Ix", seg, next_seg, prev_seg));
@@ -34029,6 +35108,15 @@ void gc_heap::background_sweep()
     // be accurate.
     compute_new_dynamic_data (max_generation);
 
+#ifdef DOUBLY_LINKED_FL
+    current_bgc_state = bgc_not_in_process;
+
+    // We can have an FGC triggered before we set the global state to free
+    // so we need to not have left over current_sweep_seg that point to 
+    // a segment that might've been deleted at the beginning of an FGC.
+    current_sweep_seg = 0;
+#endif //DOUBLY_LINKED_FL
+
     enable_preemptive ();
 
 #ifdef MULTIPLE_HEAPS
@@ -34090,7 +35178,7 @@ void gc_heap::sweep_uoh_objects (int gen_num)
     generation_allocator (gen)->clear();
     generation_free_list_space (gen) = 0;
     generation_free_obj_space (gen) = 0;
-
+    generation_free_list_allocated (gen) = 0;
 
     dprintf (3, ("sweeping uoh objects"));
     dprintf (3, ("seg: %Ix, [%Ix, %Ix[, starting from %Ix", 
@@ -35153,6 +36241,18 @@ gc_heap::verify_free_lists ()
                                  (size_t)free_list));
                     FATAL_GC_ERROR();
                 }
+
+#ifdef DOUBLY_LINKED_FL
+                uint8_t* prev_free_item = free_list_prev (free_list);
+                if (gen_num == max_generation)
+                {
+                    if (prev_free_item != prev)
+                    {
+                        dprintf (1, ("%Ix prev should be: %Ix, actual: %Ix", free_list, prev_free_item, prev));
+                        FATAL_GC_ERROR();
+                    }
+                }
+#endif //DOUBLY_LINKED_FL
 
                 prev = free_list;
                 free_list = free_list_slot (free_list);

--- a/src/coreclr/src/vm/object.h
+++ b/src/coreclr/src/vm/object.h
@@ -441,8 +441,12 @@ class Object
         // A method table pointer should always be aligned.  During GC we set the least
         // significant bit for marked objects, and the second to least significant
         // bit is reserved.  So if we want the actual MT pointer during a GC
-        // we must zero out the lowest 2 bits.
+        // we must zero out the lowest 2 bits on 32-bit and 3 bits on 64-bit.
+#ifdef TARGET_64BIT
+        return dac_cast<PTR_MethodTable>((dac_cast<TADDR>(m_pMethTab)) & ~((UINT_PTR)7));
+#else 
         return dac_cast<PTR_MethodTable>((dac_cast<TADDR>(m_pMethTab)) & ~((UINT_PTR)3));
+#endif //TARGET_64BIT
     }
 
     // There are some cases where it is unsafe to get the type handle during a GC.


### PR DESCRIPTION
One of the problems with BGC sweep is it zeros out the gen2 FL at the beginning which means we might need to increase gen2 size before it builds up enough FL to accommodate gen1 survivors. To lift this limitation I'm changing this to a doubly linked list so we can easily take items off and thread new ones back on.

Note that this is the initial checkin for the feature - there needs to be more stress testing and perf testing done on this so I'm checking in with the feature DOUBLY_LINKED_FL undefined. I've done some stress testing but not a whole lot.

This is only used for gen2 FL, not UOH - we already don't allow UOH allocations while we are sweeping UOH (which should be quite quick). In the future we will make it work so UOH allocs are allowed while it's being swept but that's beyond the scope of this feature (it would require work in the synchronization between the allocator and BGC sweep).

2 new bits on the method table were introduced -

Previously we didn't need to care about bgc mark bits at all since we can't possibly compact into the part of the heap that hasn't been swept. But now we can. So if we compact into a free item that hasn't been swept, we need to set the mark bits correctly. So we introduce a new bit:

// This bit indicates that we'll need to set the bgc mark bit for this object during an FGC.
// We only do this when we decide to compact.
`#define BGC_MARKED_BY_FGC (size_t)0x2`

Also now we don't have the luxury to allocate a min obj in the plan phase if what's allocated in this alloc context is too short. Previously we have this situation:

SB|MT|L|N

and if we plan allocated a min obj in this free item, we can allocate a min free obj right after it because the min free obj will not overwrite anything of that free item:

SB|MT|L|N
min free:
        SB|MT|Payload

since we don't touch SB. But now we have this:

SB|MT|L|N|P

and if we only allocated 3 ptr size into this free item, and if we want to allocate a min free obj, we'd be over writing P (previous pointer of this free item):

SB|MT|L|N |P
        SB|MT|Payload

One note on this is that we check the "allocated size" with (alloc_ptr - start_region), but start_region is updated every time we pad in the same free item. And it's really only necessary for the actual alloc context start (because we just need to preserve that free item's prev). But this is saved by the fact that in gen2 we don't pad. If we do pad in gen2 it would be good to handle this.

This is handled by set_free_obj_in_compact_bit (which sets the new `MAKE_FREE_OBJ_IN_COMPACT` bit) in adjust_limit where we set the bit and record the size of the "filler object". and we'll actually make the filler obj in gcmemcopy. 

This means this feature is as of now ONLY FOR 64-bit as the bit we use to do this means we are taking up 3 bits in MT to do our bookkeeping. We could make it work for 32-bit by finding bits in the gap - I haven't done that.

Major areas changed were -
+ allocate_in_older_generation - this also has a complication wrt repair and commit. I introduced the new added list concept so we can repair and commit quickly, with one exception for bucket 0. For b0 since we do discard items, we do need to set prev of discarded items to PREV_EMPTY because we need to indicate that it's not the freelist anymore. However, we can still recover by going through the original head and set the prev of the discarded items one by one which wouldn't be fast so I choose to not do it - the discarded items are generally very small anyway.

+ gcmemcopy - this needs to care about the bits we added.

+ background_sweep - this takes items off of the FL and thread new ones back on. Since this never happens at the same time as the gen1 GCs using these items we don't need synchronization here.

+ allocator class - obviously this needs to care about the prev field now. The principle is we don't touch the prev field in unlink_item (except for the special b0 case) so when we repair we don't need to go repair the prev fields. When we commit, we do need to set the new prev field accordingly (unless for the added list which we would have already set the prev correctly).

---

Fixed some existing bugs -

The refactor change stopped updating next_sweep_obj but it's incorrect because it's used by the verification code in sos so brought that back.

More accounting to count free_list/obj spaces correctly.

---

TODO

Optimizations we can do in background_sweep -

+ Don't need to actually take items off if we are just going to thread back on the same one (and others from my design notes);

+ If there's a big item we may not want to remove, imagine this simplied scenario - we have 1 2-mb free item on the list and we just removed it. Now current_num_objs happens to be big enough so we left an FGC happen and this FGC is gen1 and now it doesn't find any free space and would have to grow gen2.

It's actually beneficial to switch to using the added list even for singly linked list so we could consider enabling it even when the feature is not on.