### PR TITLE
arm64 osx: support byte sizes from lowering to codegen.

### DIFF
--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -241,7 +241,7 @@ void CodeGen::genPrologSaveRegPair(regNumber reg1,
     {
         // stp REG, REG + 1, [SP, #offset]
         // 64-bit STP offset range: -512 to 504, multiple of 8.
-        assert(spOffset <= 504);
+        assert((spOffset <= 504) && ((spOffset % 8) == 0));
         GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_PTRSIZE, reg1, reg2, REG_SPBASE, spOffset);
 
 #if defined(TARGET_UNIX)

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -241,7 +241,8 @@ void CodeGen::genPrologSaveRegPair(regNumber reg1,
     {
         // stp REG, REG + 1, [SP, #offset]
         // 64-bit STP offset range: -512 to 504, multiple of 8.
-        assert((spOffset <= 504) && ((spOffset % 8) == 0));
+        assert(spOffset <= 504);
+        assert((spOffset % 8) == 0);
         GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_PTRSIZE, reg1, reg2, REG_SPBASE, spOffset);
 
 #if defined(TARGET_UNIX)

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -665,9 +665,13 @@ void CodeGen::genIntrinsic(GenTree* treeNode)
 void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 {
     assert(treeNode->OperIs(GT_PUTARG_STK));
-    GenTree*  source     = treeNode->gtOp1;
+    GenTree* source = treeNode->gtOp1;
+#if !defined(OSX_ARM64_ABI)
     var_types targetType = genActualType(source->TypeGet());
-    emitter*  emit       = GetEmitter();
+#else
+    var_types targetType = source->TypeGet();
+#endif
+    emitter* emit = GetEmitter();
 
     // This is the varNum for our store operations,
     // typically this is the varNum for the Outgoing arg space
@@ -678,12 +682,12 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
     // Get argument offset to use with 'varNumOut'
     // Here we cross check that argument offset hasn't changed from lowering to codegen since
     // we are storing arg slot number in GT_PUTARG_STK node in lowering phase.
-    unsigned argOffsetOut = treeNode->gtSlotNum * TARGET_POINTER_SIZE;
+    unsigned argOffsetOut = treeNode->getArgOffset();
 
 #ifdef DEBUG
     fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(treeNode->gtCall, treeNode);
-    assert(curArgTabEntry);
-    assert(argOffsetOut == (curArgTabEntry->slotNum * TARGET_POINTER_SIZE));
+    assert(curArgTabEntry != nullptr);
+    DEBUG_ARG_SLOTS_ASSERT(argOffsetOut == (curArgTabEntry->slotNum * TARGET_POINTER_SIZE));
 #endif // DEBUG
 
     // Whether to setup stk arg in incoming or out-going arg area?
@@ -729,6 +733,23 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
             assert(argOffsetOut <= argOffsetMax); // We can't write beyound the outgoing area area
             return;
         }
+
+#if defined(OSX_ARM64_ABI)
+        const unsigned if (treeNode->GetStackByteSize() < 4)
+        {
+            switch (treeNode->GetStackByteSize())
+            {
+                case 1:
+                    targetType = TYP_BYTE;
+                    break;
+                case 2:
+                    targetType = TYP_SHORT;
+                    break;
+                default:
+                    unreached();
+            }
+        }
+#endif
 
         instruction storeIns  = ins_Store(targetType);
         emitAttr    storeAttr = emitTypeSize(targetType);
@@ -1161,7 +1182,7 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
     emitter* emit         = GetEmitter();
     unsigned varNumOut    = compiler->lvaOutgoingArgSpaceVar;
     unsigned argOffsetMax = compiler->lvaOutgoingArgSpaceSize;
-    unsigned argOffsetOut = treeNode->gtSlotNum * TARGET_POINTER_SIZE;
+    unsigned argOffsetOut = treeNode->getArgOffset();
 
     if (source->OperGet() == GT_FIELD_LIST)
     {
@@ -1292,7 +1313,7 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             assert(!compiler->IsHfa(source->AsObj()->GetLayout()->GetClassHandle()));
         }
 
-        int          structSize = treeNode->getArgSize();
+        unsigned     structSize = treeNode->GetStackByteSize();
         ClassLayout* layout     = source->AsObj()->GetLayout();
 
         // Put on stack first

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1313,13 +1313,12 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             assert(!compiler->IsHfa(source->AsObj()->GetLayout()->GetClassHandle()));
         }
 
-        unsigned     structSize = treeNode->GetStackByteSize();
-        ClassLayout* layout     = source->AsObj()->GetLayout();
+        ClassLayout* layout = source->AsObj()->GetLayout();
 
         // Put on stack first
         unsigned nextIndex     = treeNode->gtNumRegs;
         unsigned structOffset  = nextIndex * TARGET_POINTER_SIZE;
-        int      remainingSize = structSize - structOffset;
+        int      remainingSize = treeNode->GetStackByteSize();
 
         // remainingSize is always multiple of TARGET_POINTER_SIZE
         assert(remainingSize % TARGET_POINTER_SIZE == 0);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -735,19 +735,17 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         }
 
 #if defined(OSX_ARM64_ABI)
-        const unsigned if (treeNode->GetStackByteSize() < 4)
+        switch (treeNode->GetStackByteSize())
         {
-            switch (treeNode->GetStackByteSize())
-            {
-                case 1:
-                    targetType = TYP_BYTE;
-                    break;
-                case 2:
-                    targetType = TYP_SHORT;
-                    break;
-                default:
-                    unreached();
-            }
+            case 1:
+                targetType = TYP_BYTE;
+                break;
+            case 2:
+                targetType = TYP_SHORT;
+                break;
+            default:
+                assert(treeNode->GetStackByteSize() >= 4);
+                break;
         }
 #endif
 

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -2355,7 +2355,7 @@ void CodeGen::genEmitMachineCode()
     }
 #endif
 
-#if EMIT_TRACK_STACK_DEPTH && defined(DEBUG) && !defined(OSX_ARM64_ABI)
+#if EMIT_TRACK_STACK_DEPTH && defined(DEBUG_ARG_SLOTS)
     // Check our max stack level. Needed for fgAddCodeRef().
     // We need to relax the assert as our estimation won't include code-gen
     // stack changes (which we know don't affect fgAddCodeRef()).

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1704,8 +1704,6 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode,
     assert((src->gtOper == GT_OBJ) || ((src->gtOper == GT_IND && varTypeIsSIMD(src))));
     GenTree* srcAddr = src->gtGetOp1();
 
-    unsigned int size = putArgNode->getArgSize();
-
     assert(dstReg != REG_NA);
     assert(srcReg != REG_NA);
 
@@ -1757,6 +1755,7 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode,
 
     if (sizeReg != REG_NA)
     {
+        unsigned size = putArgNode->GetStackByteSize();
         inst_RV_IV(INS_mov, sizeReg, size, EA_PTRSIZE);
     }
 }

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1630,7 +1630,9 @@ public:
         return 0;
     }
 
-    // Get the number of bytes that this argument is occupying on the stack.
+    // Get the number of bytes that this argument is occupying on the stack,
+    // including padding up to the target pointer size for platforms
+    // where a stack argument can't take less.
     unsigned GetStackByteSize() const
     {
         if (!IsSplit() && numRegs > 0)
@@ -1642,7 +1644,10 @@ public:
 
         assert(GetByteSize() > TARGET_POINTER_SIZE * numRegs);
         unsigned stackByteSize = GetByteSize() - TARGET_POINTER_SIZE * numRegs;
-        return GetByteSize() - TARGET_POINTER_SIZE * numRegs;
+#if !defined(OSX_ARM64_ABI)
+        stackByteSize = roundUp(stackByteSize, TARGET_POINTER_SIZE);
+#endif
+        return stackByteSize;
     }
 
     var_types GetHfaType() const
@@ -1800,7 +1805,7 @@ public:
         return size;
     }
 
-#endif // DEBUG && !OSX_ARM64_ABI
+#endif // DEBUG_ARG_SLOTS
 
 private:
     unsigned m_byteOffset;

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -9807,6 +9807,8 @@ void Compiler::fgSimpleLowering()
         JITDUMP("Bumping outgoingArgSpaceSize to %u for localloc", outgoingArgSpaceSize);
     }
 
+    assert((outgoingArgSpaceSize % TARGET_POINTER_SIZE) == 0);
+
     // Publish the final value and mark it as read only so any update
     // attempt later will cause an assert.
     lvaOutgoingArgSpaceSize = outgoingArgSpaceSize;

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -11529,7 +11529,6 @@ void Compiler::gtDispTree(GenTree*     tree,
 #else
             printf(" (%d slots), (%d stackByteSize), (%d slot), (%d byteOffset)", putArg->gtNumSlots,
                    putArg->GetStackByteSize(), putArg->gtSlotNum, putArg->getArgOffset());
-
 #endif
             if (putArg->gtPutArgStkKind != GenTreePutArgStk::Kind::Invalid)
             {
@@ -11552,6 +11551,19 @@ void Compiler::gtDispTree(GenTree*     tree,
                 }
             }
         }
+#if FEATURE_ARG_SPLIT
+        else if (tree->OperGet() == GT_PUTARG_SPLIT)
+        {
+            const GenTreePutArgSplit* putArg = tree->AsPutArgSplit();
+#if !defined(DEBUG_ARG_SLOTS)
+            printf(" (%d stackByteSize), (%d byteOffset), (%d numRegs)", putArg->GetStackByteSize(),
+                   putArg->getArgOffset(), putArg->gtNumRegs);
+#else
+            printf(" (%d slots), (%d stackByteSize), (%d slot), (%d byteOffset), (%d numRegs)", putArg->gtNumSlots,
+                   putArg->GetStackByteSize(), putArg->gtSlotNum, putArg->getArgOffset(), putArg->gtNumRegs);
+#endif
+        }
+#endif // FEATURE_ARG_SPLIT
 #endif // FEATURE_PUT_STRUCT_ARG_STK
 
         if (tree->gtOper == GT_INTRINSIC)

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -1206,7 +1206,7 @@ bool GenTreeCall::Equals(GenTreeCall* c1, GenTreeCall* c2)
 }
 
 #if !defined(FEATURE_PUT_STRUCT_ARG_STK)
-unsigned GenTreePutArgStk::getArgSize()
+unsigned GenTreePutArgStk::GetStackByteSize() const
 {
     return genTypeSize(genActualType(gtOp1->gtType));
 }
@@ -11523,10 +11523,17 @@ void Compiler::gtDispTree(GenTree*     tree,
 #if FEATURE_PUT_STRUCT_ARG_STK
         else if (tree->OperGet() == GT_PUTARG_STK)
         {
-            printf(" (%d slots)", tree->AsPutArgStk()->gtNumSlots);
-            if (tree->AsPutArgStk()->gtPutArgStkKind != GenTreePutArgStk::Kind::Invalid)
+            const GenTreePutArgStk* putArg = tree->AsPutArgStk();
+#if !defined(DEBUG_ARG_SLOTS)
+            printf(" (%d stackByteSize), (%d byteOffset)", putArg->GetStackByteSize(), putArg->getArgOffset());
+#else
+            printf(" (%d slots), (%d stackByteSize), (%d slot), (%d byteOffset)", putArg->gtNumSlots,
+                   putArg->GetStackByteSize(), putArg->gtSlotNum, putArg->getArgOffset());
+
+#endif
+            if (putArg->gtPutArgStkKind != GenTreePutArgStk::Kind::Invalid)
             {
-                switch (tree->AsPutArgStk()->gtPutArgStkKind)
+                switch (putArg->gtPutArgStkKind)
                 {
                     case GenTreePutArgStk::Kind::RepInstr:
                         printf(" (RepInstr)");
@@ -12007,9 +12014,7 @@ void Compiler::gtGetArgMsg(GenTreeCall* call, GenTree* arg, unsigned argNum, cha
             }
 #endif // TARGET_ARM
 #if FEATURE_FIXED_OUT_ARGS
-
             sprintf_s(bufp, bufLength, "arg%d out+%02x%c", argNum, curArgTabEntry->slotNum * TARGET_POINTER_SIZE, 0);
-
 #else
             sprintf_s(bufp, bufLength, "arg%d on STK%c", argNum, 0);
 #endif
@@ -12052,8 +12057,7 @@ void Compiler::gtGetLateArgMsg(GenTreeCall* call, GenTree* argx, int lateArgInde
 #else
     if (argReg == REG_STK)
     {
-        sprintf_s(bufp, bufLength, "arg%d in out+%02x%c", curArgTabEntry->argNum,
-                  curArgTabEntry->slotNum * TARGET_POINTER_SIZE, 0);
+        sprintf_s(bufp, bufLength, "arg%d in out+%02x%c", curArgTabEntry->argNum, curArgTabEntry->GetByteOffset(), 0);
     }
     else
 #endif

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -11556,11 +11556,10 @@ void Compiler::gtDispTree(GenTree*     tree,
         {
             const GenTreePutArgSplit* putArg = tree->AsPutArgSplit();
 #if !defined(DEBUG_ARG_SLOTS)
-            printf(" (%d stackByteSize), (%d byteOffset), (%d numRegs)", putArg->GetStackByteSize(),
-                   putArg->getArgOffset(), putArg->gtNumRegs);
+            printf(" (%d stackByteSize), (%d numRegs)", putArg->GetStackByteSize(), putArg->gtNumRegs);
 #else
-            printf(" (%d slots), (%d stackByteSize), (%d slot), (%d byteOffset), (%d numRegs)", putArg->gtNumSlots,
-                   putArg->GetStackByteSize(), putArg->gtSlotNum, putArg->getArgOffset(), putArg->gtNumRegs);
+            printf(" (%d slots), (%d stackByteSize), (%d numRegs)", putArg->gtNumSlots, putArg->GetStackByteSize(),
+                   putArg->gtNumRegs);
 #endif
         }
 #endif // FEATURE_ARG_SPLIT

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -6032,21 +6032,32 @@ public:
     Kind gtPutArgStkKind;
 #endif
 
-#if defined(DEBUG_ARG_SLOTS) && defined(FEATURE_PUT_STRUCT_ARG_STK)
-    GenTreePutArgStk(genTreeOps   oper,
-                     var_types    type,
-                     GenTree*     op1,
-                     unsigned     stackByteOffset,
-                     unsigned     stackByteSize,
-                     unsigned     slotNum,
-                     unsigned     numSlots,
+    GenTreePutArgStk(genTreeOps oper,
+                     var_types  type,
+                     GenTree*   op1,
+                     unsigned   stackByteOffset,
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
+                     unsigned stackByteSize,
+#endif
+#if defined(DEBUG_ARG_SLOTS)
+                     unsigned slotNum,
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
+                     unsigned numSlots,
+#endif
+#endif
                      GenTreeCall* callNode,
                      bool         putInIncomingArgArea)
         : GenTreeUnOp(oper, type, op1 DEBUGARG(/*largeNode*/ false))
         , m_byteOffset(stackByteOffset)
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
         , m_byteSize(stackByteSize)
+#endif
+#if defined(DEBUG_ARG_SLOTS)
         , gtSlotNum(slotNum)
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
         , gtNumSlots(numSlots)
+#endif
+#endif
 #if defined(UNIX_X86_ABI)
         , gtPadAlign(0)
 #endif
@@ -6056,84 +6067,15 @@ public:
 #if FEATURE_FASTTAILCALL
         , gtPutInIncomingArgArea(putInIncomingArgArea)
 #endif // FEATURE_FASTTAILCALL
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
         , gtPutArgStkKind(Kind::Invalid)
-
+#endif
     {
         DEBUG_ARG_SLOTS_ASSERT(m_byteOffset == slotNum * TARGET_POINTER_SIZE);
+#if defined(FEATURE_PUT_STRUCT_ARG_STK)
         DEBUG_ARG_SLOTS_ASSERT(m_byteSize == gtNumSlots * TARGET_POINTER_SIZE);
+#endif
     }
-#elif defined(DEBUG_ARG_SLOTS) && !defined(FEATURE_PUT_STRUCT_ARG_STK)
-    GenTreePutArgStk(genTreeOps   oper,
-                     var_types    type,
-                     GenTree*     op1,
-                     unsigned     stackByteOffset,
-                     unsigned     slotNum,
-                     GenTreeCall* callNode,
-                     bool         putInIncomingArgArea)
-        : GenTreeUnOp(oper, type, op1 DEBUGARG(/*largeNode*/ false))
-        , m_byteOffset(stackByteOffset)
-        , gtSlotNum(slotNum)
-#if defined(UNIX_X86_ABI)
-        , gtPadAlign(0)
-#endif
-
-#if defined(DEBUG) || defined(UNIX_X86_ABI)
-        , gtCall(callNode)
-#endif
-#if FEATURE_FASTTAILCALL
-        , gtPutInIncomingArgArea(putInIncomingArgArea)
-#endif // FEATURE_FASTTAILCALL
-    {
-        DEBUG_ARG_SLOTS_ASSERT(m_byteOffset == slotNum * TARGET_POINTER_SIZE);
-    }
-#elif !defined(DEBUG_ARG_SLOTS) && defined(FEATURE_PUT_STRUCT_ARG_STK)
-    GenTreePutArgStk(genTreeOps   oper,
-                     var_types    type,
-                     GenTree*     op1,
-                     unsigned     stackByteOffset,
-                     unsigned     stackByteSize,
-                     GenTreeCall* callNode,
-                     bool         putInIncomingArgArea)
-        : GenTreeUnOp(oper, type, op1 DEBUGARG(/*largeNode*/ false))
-        , m_byteOffset(stackByteOffset)
-        , m_byteSize(stackByteSize)
-#if defined(UNIX_X86_ABI)
-        , gtPadAlign(0)
-#endif
-
-#if defined(DEBUG) || defined(UNIX_X86_ABI)
-        , gtCall(callNode)
-#endif
-#if FEATURE_FASTTAILCALL
-        , gtPutInIncomingArgArea(putInIncomingArgArea)
-#endif // FEATURE_FASTTAILCALL
-        , gtPutArgStkKind(Kind::Invalid)
-
-    {
-    }
-#elif !defined(DEBUG_ARG_SLOTS) && !defined(FEATURE_PUT_STRUCT_ARG_STK)
-    GenTreePutArgStk(genTreeOps   oper,
-                     var_types    type,
-                     GenTree*     op1,
-                     unsigned     stackByteOffset,
-                     GenTreeCall* callNode,
-                     bool         putInIncomingArgArea)
-        : GenTreeUnOp(oper, type, op1 DEBUGARG(/*largeNode*/ false))
-        , m_byteOffset(stackByteOffset)
-#if defined(UNIX_X86_ABI)
-        , gtPadAlign(0)
-#endif
-#if defined(DEBUG) || defined(UNIX_X86_ABI)
-        , gtCall(callNode)
-#endif
-#if FEATURE_FASTTAILCALL
-        , gtPutInIncomingArgArea(putInIncomingArgArea)
-#endif // FEATURE_FASTTAILCALL
-    {
-    }
-#else
-#error Unsupported set of defines.
-#endif
 
 #if FEATURE_FASTTAILCALL
     bool putInIncomingArgArea() const
@@ -6206,7 +6148,7 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
     GenTreePutArgSplit(GenTree* op1,
                        unsigned stackByteOffset,
 #if defined(FEATURE_PUT_STRUCT_ARG_STK)
-                       unsigned byteSize,
+                       unsigned stackByteSize,
 #endif
 #if defined(DEBUG_ARG_SLOTS)
                        unsigned slotNum,
@@ -6222,7 +6164,7 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
                            op1,
                            stackByteOffset,
 #if defined(FEATURE_PUT_STRUCT_ARG_STK)
-                           byteSize,
+                           stackByteSize,
 #endif
 #if defined(DEBUG_ARG_SLOTS)
                            slotNum,

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -6574,8 +6574,8 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
     {
 #if defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI) // No 4 slots for outgoing params on System V.
         noway_assert(lvaOutgoingArgSpaceSize >= (4 * TARGET_POINTER_SIZE));
-        noway_assert((lvaOutgoingArgSpaceSize % TARGET_POINTER_SIZE) == 0);
 #endif
+        noway_assert((lvaOutgoingArgSpaceSize % TARGET_POINTER_SIZE) == 0);
 
         // Give it a value so we can avoid asserts in CHK builds.
         // Since this will always use an SP relative offset of zero

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -605,11 +605,12 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
         // ARM softfp calling convention should affect only the floating point arguments.
         // Otherwise there appear too many surplus pre-spills and other memory operations
         // with the associated locations .
-        bool      isSoftFPPreSpill = opts.compUseSoftFP && varTypeIsFloating(varDsc->TypeGet());
-        unsigned  argSize          = eeGetArgSize(argLst, &info.compMethodInfo->args);
-        unsigned  cSlots           = argSize / TARGET_POINTER_SIZE; // the total number of slots of this argument
-        bool      isHfaArg         = false;
-        var_types hfaType          = TYP_UNDEF;
+        bool     isSoftFPPreSpill = opts.compUseSoftFP && varTypeIsFloating(varDsc->TypeGet());
+        unsigned argSize          = eeGetArgSize(argLst, &info.compMethodInfo->args);
+        unsigned cSlots =
+            (argSize + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE; // the total number of slots of this argument
+        bool      isHfaArg = false;
+        var_types hfaType  = TYP_UNDEF;
 
 #if defined(TARGET_ARM64) && defined(TARGET_UNIX)
         // Native varargs on arm64 unix use the regular calling convention.
@@ -1015,7 +1016,11 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 
 #if FEATURE_FASTTAILCALL
             varDsc->SetStackOffset(varDscInfo->stackArgSize);
+#if defined(OSX_ARM64_ABI)
+            varDscInfo->stackArgSize += argSize;
+#else
             varDscInfo->stackArgSize += roundUp(argSize, TARGET_POINTER_SIZE);
+#endif
 #endif // FEATURE_FASTTAILCALL
         }
 
@@ -5254,7 +5259,9 @@ void Compiler::lvaAssignVirtualFrameOffsetsToArgs()
     /* Update the argOffs to reflect arguments that are passed in registers */
 
     noway_assert(codeGen->intRegState.rsCalleeRegArgCount <= MAX_REG_ARG);
+#if !defined(OSX_ARM64_ABI)
     noway_assert(compArgSize >= codeGen->intRegState.rsCalleeRegArgCount * REGSIZE_BYTES);
+#endif
 
 #ifdef TARGET_X86
     argOffs -= codeGen->intRegState.rsCalleeRegArgCount * REGSIZE_BYTES;
@@ -6567,8 +6574,8 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
     {
 #if defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI) // No 4 slots for outgoing params on System V.
         noway_assert(lvaOutgoingArgSpaceSize >= (4 * TARGET_POINTER_SIZE));
-#endif
         noway_assert((lvaOutgoingArgSpaceSize % TARGET_POINTER_SIZE) == 0);
+#endif
 
         // Give it a value so we can avoid asserts in CHK builds.
         // Since this will always use an SP relative offset of zero

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -397,7 +397,7 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
 
         // Now that the fields have been sorted, the kind of code we will generate.
         bool     allFieldsAreSlots = true;
-        unsigned prevOffset        = putArgStk->getArgSize();
+        unsigned prevOffset        = putArgStk->GetStackByteSize();
         for (GenTreeFieldList::Use& use : fieldList->Uses())
         {
             GenTree* const  fieldNode   = use.GetNode();
@@ -520,7 +520,7 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
     // The cpyXXXX code is rather complex and this could cause it to be more complex, but
     // it might be the right thing to do.
 
-    ssize_t size = putArgStk->gtNumSlots * TARGET_POINTER_SIZE;
+    unsigned size = putArgStk->GetStackByteSize();
 
     // TODO-X86-CQ: The helper call either is not supported on x86 or required more work
     // (I don't know which).

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -1187,17 +1187,10 @@ void fgArgInfo::UpdateStkArg(fgArgTabEntry* curArgTabEntry, GenTree* node, bool 
     assert(curArgTabEntry->slotNum == nextSlotNum);
     nextSlotNum += curArgTabEntry->numSlots;
 #endif
+
     nextStackByteOffset = roundUp(nextStackByteOffset, curArgTabEntry->byteAlignment);
     assert(curArgTabEntry->GetByteOffset() == nextStackByteOffset);
-
-    if (!curArgTabEntry->IsSplit())
-    {
-        nextStackByteOffset += curArgTabEntry->GetByteSize();
-    }
-    else
-    {
-        nextStackByteOffset += curArgTabEntry->GetStackByteSize();
-    }
+    nextStackByteOffset += curArgTabEntry->GetStackByteSize();
 }
 
 void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)


### PR DESCRIPTION
Keep precise byte sizes and offsets for call arguments from lowering to codegen. It is a continuation of #42503.

Contributes to  #41130.

No diffs.