### PR TITLE
build-commons.sh: check for OpenSSL 1.1 on macOS

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -55,7 +55,7 @@ check_prereqs()
         if ! pkg-config openssl ; then
             # We export the proper PKG_CONFIG_PATH where openssl was installed by Homebrew
             # It's important to _export_ it since build-commons.sh is sourced by other scripts such as build-native.sh
-            export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
+            export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig
             # We try again with the PKG_CONFIG_PATH in place, if pkg-config still can't find OpenSSL, exit with an error, cmake won't find OpenSSL either
             pkg-config openssl || { echo >&2 "Please install openssl before running this script, see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/macos-requirements.md"; exit 1; }
         fi


### PR DESCRIPTION
We're installing openssl@1.1 from Homebrew so we should check that version.
It looks like CI Macs don't set the /usr/local/opt/openssl symlink anymore:
```
Please install openssl before running this script, see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/macos-requirements.md
```