### PR TITLE
[iOS] Add mono runtime and AppleAppBuilder pkgproj for iOS sample

### DIFF
--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
@@ -2,10 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-  <PropertyGroup>
-    <IsShipping>false</IsShipping>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\AppleAppBuilder.csproj" />
   </ItemGroup>

--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_iOSSampleFiles Include="$(ArtifactsDir)bin\AppleAppBuilder\$(Configuration)\net5.0\AppleAppBuilder.dll" />
+    <_iOSSampleFiles Include="$(ArtifactsDir)bin\AppleAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
     <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.m" />
     <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.h" />
     <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\main-simple.m" />

--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\AppleAppBuilder.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <_iOSSampleFiles Include="$(ArtifactsDir)bin\AppleAppBuilder\$(Configuration)\net5.0\AppleAppBuilder.dll" />
     <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.m" />
     <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.h" />

--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <PropertyGroup>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_iOSSampleFiles Include="$(ArtifactsDir)bin\AppleAppBuilder\$(Configuration)\net5.0\AppleAppBuilder.dll" />
+    <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.m" />
+    <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.h" />
+    <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\main-simple.m" />
+
+    <PackageFile Include="@(_iOSSampleFiles)" TargetPath="tools\$(NetCoreAppCurrent)\" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.iOS.Sample.Mono/Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj
@@ -14,7 +14,6 @@
     <_iOSSampleFiles Include="$(ArtifactsDir)bin\AppleAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
     <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.m" />
     <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\runtime.h" />
-    <_iOSSampleFiles Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AppleAppBuilder\Templates\main-simple.m" />
 
     <PackageFile Include="@(_iOSSampleFiles)" TargetPath="tools\$(NetCoreAppCurrent)\" />
   </ItemGroup>

--- a/src/mono/netcore/nuget/descriptions.json
+++ b/src/mono/netcore/nuget/descriptions.json
@@ -8,5 +8,10 @@
         "Name": "Microsoft.NETCore.BrowserDebugHost.Transport",
         "Description": "Internal package for sharing BrowserDebugHost.",
         "CommonTypes": [ ]
+    },
+    {
+        "Name": "Microsoft.NET.Runtime.iOS.Sample.Mono",
+        "Description": "Internal package for sharing embedded Mono runtime and iOS App Builder.",
+        "CommonTypes": [ ]
     }
 ]

--- a/src/mono/netcore/nuget/mono-packages.proj
+++ b/src/mono/netcore/nuget/mono-packages.proj
@@ -5,6 +5,10 @@
     <ProjectReference Include="Microsoft.NETCore.BrowserDebugHost.Transport\Microsoft.NETCore.BrowserDebugHost.Transport.pkgproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetOS)' == 'iOS'">
+    <ProjectReference Include="Microsoft.NET.Runtime.iOS.Sample.Mono\Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj" />
+  </ItemGroup>
+
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />
 
   <!-- Ordering matters! Overwriting the Pack target which should just invoke Build. -->

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.csproj
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.csproj
@@ -21,4 +21,7 @@
     <Compile Include="Utils.cs" />
     <Compile Include="Xcode.cs" />
   </ItemGroup>
+
+  <Target Name="GetFilesToPackage" />
+
 </Project>


### PR DESCRIPTION
In preparation to bring mono samples to `dotnet/samples`, files that are most likely to change will be packaged into a nuget package to be downloaded and consumed on the `dotnet/samples` end rather than mirroring changes.

This PR expands the process that created the NuGet package for `Microsoft.NETCore.BrowserDebugHost.Transport` to build a NuGet package for the iOS sample.