### PR TITLE
Fix for 'not fully instantiated' Crossgen2 issue bucket

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (!_method.Unboxing && !_isInstantiatingStub && _method.ConstrainedType == null &&
                 fixupKind == ReadyToRunFixupKind.MethodEntry)
             {
-                if (!_method.Method.OwningType.HasInstantiation && !_method.Method.OwningType.IsArray)
+                if (!_method.Method.HasInstantiation && !_method.Method.OwningType.HasInstantiation && !_method.Method.OwningType.IsArray)
                 {
                     if (_method.Token.TokenType == CorTokenType.mdtMethodDef)
                     {


### PR DESCRIPTION
Around September 25 several dozens of Crossgen2 tests started
failing with a runtime error around incomplete instantiation of
GetArrayDataReference. I believe that for generic methods we
should skip the METHOD_ENTRY_DEF_TOKEN shortcut, otherwise we
lose the instantiation information and cause the runtime problem.

I originally thought this may be related to JanK's function
pointer changes but I no longer believe it is the case
(my apologies to Jan for the false accusation). I rather think
that some ambient code change caused a subtle difference in IL
encoding of access to the method that started tripping the
"shortcut" code path.

Thanks

Tomas

P.S. I'm running a Crossgen2 private run to validate the change.
Thankfully this still reproduces on Linux / OSX as JanV forgot to
fix the --release option for r2rtest in the .sh version of the build
script.

/cc @dotnet/crossgen-contrib 