### PR TITLE
[release/5.0] Remove unneeded licenses ingested from dotnet/diagnostics repo

### DIFF
--- a/src/installer/pkg/THIRD-PARTY-NOTICES.TXT
+++ b/src/installer/pkg/THIRD-PARTY-NOTICES.TXT
@@ -1217,24 +1217,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
--------------------------------------------------
-
-Source in src/Microsoft.Diagnostics.TestHelpers/Xunit.Extensions/* is largely derived from source
-source found at https://github.com/xunit/samples.xunit.
-
-This set of code is covered by the following license:
-
-    Copyright (c) .NET Foundation and Contributors
-    All Rights Reserved
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/43042

Required for 5.0 release.

This PR follows the big TPN change in https://github.com/dotnet/runtime/pull/41851. A single license is not needed and should be removed, as its related to test-only assets.
