### PR TITLE
Optimize the Linguistic String Search Operations

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -42,10 +42,10 @@ c_static_assert_msg(USEARCH_DONE == -1, "managed side requires -1 for not found"
 
 typedef struct { int32_t key; UCollator* UCollator; } TCollatorMap;
 
-typedef struct SEARCHNODE
+typedef struct SearchIteratorNode
 {
     UStringSearch* searchIterator;
-    struct SEARCHNODE* next;
+    struct SearchIteratorNode* next;
 } SearchIteratorNode;
 
 /*

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -449,10 +449,14 @@ static const int32_t GetSearchIteratorFromSortHandleUsingCollator(
         }
 
         UStringSearch* pNull = NULL;
-        if (!pal_atomic_cas_ptr((void* volatile*)&pSortHandle->searchIteratorPerOption[options], *pSearchIterator, pNull))
+        if (!pal_atomic_cas_ptr((void* volatile*)&pSortHandle->searchIteratorPerOption[options], USED_STRING_SEARCH, pNull))
         {
             usearch_close(*pSearchIterator);
             *pSearchIterator = pSortHandle->searchIteratorPerOption[options];
+        }
+        else
+        {
+            return options;
         }
     }
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -42,11 +42,11 @@ c_static_assert_msg(USEARCH_DONE == -1, "managed side requires -1 for not found"
 
 typedef struct { int32_t key; UCollator* UCollator; } TCollatorMap;
 
-struct SearchIteratorNode
+typedef struct SEARCHNODE
 {
     UStringSearch* searchIterator;
-    SearchIteratorNode* next;
-};
+    struct SEARCHNODE* next;
+} SearchIteratorNode;
 
 /*
  * For increased performance, we cache the UCollator objects for a locale and

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -515,7 +515,7 @@ static inline const int32_t GetSearchIteratorFromSortHandle(
                         pSearchIterator);
 }
 
-static inline void  ReleaseSeachHandle(SortHandle* pSortHandle, UStringSearch* pSearchIterator, int32_t searchCacheSlot)
+static inline void  ReleaseSearchHandle(SortHandle* pSortHandle, UStringSearch* pSearchIterator, int32_t searchCacheSlot)
 {
     if (searchCacheSlot < 0)
     {
@@ -630,7 +630,7 @@ int32_t GlobalizationNative_IndexOf(
         *pMatchedLength = usearch_getMatchedLength(pSearch);
     }
 
-    ReleaseSeachHandle(pSortHandle, pSearch, searchCacheSlot);
+    ReleaseSearchHandle(pSortHandle, pSearch, searchCacheSlot);
 
     return result;
 }
@@ -688,7 +688,7 @@ int32_t GlobalizationNative_LastIndexOf(
         *pMatchedLength = usearch_getMatchedLength(pSearch);
     }
 
-    ReleaseSeachHandle(pSortHandle, pSearch, searchCacheSlot);
+    ReleaseSearchHandle(pSortHandle, pSearch, searchCacheSlot);
 
     return result;
 }
@@ -858,7 +858,7 @@ static int32_t ComplexStartsWith(SortHandle* pSortHandle, const UChar* pPattern,
         }
     }
 
-    ReleaseSeachHandle(pSortHandle, pSearch, searchCacheSlot);
+    ReleaseSearchHandle(pSortHandle, pSearch, searchCacheSlot);
 
     return result;
 }
@@ -932,7 +932,7 @@ static int32_t ComplexEndsWith(SortHandle* pSortHandle, const UChar* pPattern, i
         }
     }
 
-    ReleaseSeachHandle(pSortHandle, pSearch, searchCacheSlot);
+    ReleaseSearchHandle(pSortHandle, pSearch, searchCacheSlot);
 
     return result;
 }

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -142,7 +142,9 @@
     PER_FUNCTION_BLOCK(usearch_first, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_getMatchedLength, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_last, libicui18n) \
-    PER_FUNCTION_BLOCK(usearch_openFromCollator, libicui18n)
+    PER_FUNCTION_BLOCK(usearch_openFromCollator, libicui18n) \
+    PER_FUNCTION_BLOCK(usearch_setPattern, libicui18n) \
+    PER_FUNCTION_BLOCK(usearch_setText, libicui18n)
 
 #if HAVE_SET_MAX_VARIABLE
 #define FOR_ALL_SET_VARIABLE_ICU_FUNCTIONS \
@@ -280,5 +282,8 @@ FOR_ALL_ICU_FUNCTIONS
 #define usearch_getMatchedLength(...) usearch_getMatchedLength_ptr(__VA_ARGS__)
 #define usearch_last(...) usearch_last_ptr(__VA_ARGS__)
 #define usearch_openFromCollator(...) usearch_openFromCollator_ptr(__VA_ARGS__)
+#define usearch_reset(...) usearch_reset_ptr(__VA_ARGS__)
+#define usearch_setPattern(...) usearch_setPattern_ptr(__VA_ARGS__)
+#define usearch_setText(...) usearch_setText_ptr(__VA_ARGS__)
 
 #endif // !defined(STATIC_ICU)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
@@ -513,4 +513,6 @@ int32_t usearch_first(UStringSearch * strsrch, UErrorCode * status);
 int32_t usearch_getMatchedLength(const UStringSearch * strsrch);
 int32_t usearch_last(UStringSearch * strsrch, UErrorCode * status);
 UStringSearch * usearch_openFromCollator(const UChar * pattern, int32_t patternlength, const UChar * text, int32_t textlength, const UCollator * collator, UBreakIterator * breakiter, UErrorCode * status);
+void usearch_setPattern(UStringSearch * strsrch, const UChar * pattern, int32_t patternlength, UErrorCode * status);
+void usearch_setText(UStringSearch * strsrch, const UChar * text, int32_t textlength, UErrorCode * status);
 void ucol_setMaxVariable(UCollator * coll, UColReorderCode group, UErrorCode * pErrorCode);


### PR DESCRIPTION
This change target optimizing the string search operations (e.g. IndexOf, LastIndexOf, StartsWith, EndsWith) when using ICU. We used to create a new ICU search handle using `usearch_openFromCollator` everytime we call any of the search operations. The change here is to cache the search handles same way we cached Collation handles. The search handles are a little bit different as it needs to include the source string we need to search in and the pattern string we need to search for. This require the search handle should be used exclusively and not be shared between 2 operations in same time. Everytime we use the handle we'll set the source and the patterns strings to the handle to be able perform the operation correctly.

Caching the search handles improved the performance for IndexOf and LastIndexOf. When searching in long strings and the match pattern near the other edge of the search direction or no match found, then it shows perf improvement ranges `13% ~ 20%`. With shorter source strings the perf improvement is almost doubled. Also StartsWith/EndsWith perf is almost doubled regardless of the source string length. 


# Before #
|                      Method |       Mean |      Error |     StdDev |
|---------------------------- |-----------:|-----------:|-----------:|
|      TestMultipleStartsWith | 903.234 us | 17.9408 us | 40.4955 us |
|        TestMultipleEndsWith | 968.899 us | 19.2996 us | 38.0956 us |
|              MixLongIndexOf |  25.768 us |  0.5439 us |  1.5693 us |
|          MixLongLastIndexOf |  25.358 us |  0.5027 us |  1.3505 us |
|             MixShortIndexOf |   7.761 us |  0.1544 us |  0.3959 us |
|         MixShortLastIndexOf |   8.092 us |  0.1546 us |  0.3551 us |


# After #
|                      Method |       Mean |     Error |     StdDev | 
|---------------------------- |-----------:|----------:|-----------:|
|      TestMultipleStartsWith | 370.672 us | 7.1230 us | 17.4729 us |
|        TestMultipleEndsWith | 412.960 us | 7.9043 us | 19.2402 us |
|              MixLongIndexOf |  20.691 us | 0.4134 us |  1.1928 us |
|          MixLongLastIndexOf |  21.982 us | 0.6489 us |  1.8929 us |
|             MixShortIndexOf |   3.564 us | 0.0840 us |  0.2451 us |
|         MixShortLastIndexOf |   3.541 us | 0.0701 us |  0.1810 us |
