### PR TITLE
CMake 3.16.4

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
     "dotnet": "5.0.100-rc.1.20454.5"
   },
   "native-tools": {
-    "cmake": "3.14.5",
+    "cmake": "3.16.4",
     "python3": "3.7.1"
   },
   "msbuild-sdks": {

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -318,7 +318,8 @@ if %__BuildNative%==0 if %__BuildCrossArchNative%==0 set __CMakeNeeded=0
 if %__CMakeNeeded%==1 (
     REM Eval the output from set-cmake-path.ps1
     for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& ""%__SourceDir%\pal\tools\set-cmake-path.ps1"""') do %%a
-    echo %__MsgPrefix%Using CMake from !CMakePath!
+    echo %__MsgPrefix%Using CMake from '!CMakePath!'
+    "!CMakePath!" --version
 )
 
 REM NumberOfCores is an WMI property providing number of physical cores on machine

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -225,7 +225,8 @@ REM Set the environment for the native build
 
 REM Eval the output from set-cmake-path.ps1
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& ""%__SourceDir%\pal\tools\set-cmake-path.ps1"""') do %%a
-echo %__MsgPrefix%Using CMake from !CMakePath!
+echo %__MsgPrefix%Using CMake from '!CMakePath!'
+"!CMakePath!" --version
 
 REM NumberOfCores is an WMI property providing number of physical cores on machine
 REM processor(s). It is used to set optimal level of CL parallelism during native build step


### PR DESCRIPTION
Scouting use of CMake 3.16.4 using native tool bootstrapping process, part of https://github.com/dotnet/core-eng/issues/11003 (follow-up for the Ninja effort).

cc @jkoritzinsky 