### PR TITLE
[5.0] Fix some issues with background thread compilation

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Reflection.Primitives" />	
     <Reference Include="System.Runtime" />	
     <Reference Include="System.Threading" />	
+    <Reference Include="System.Threading.ThreadPool" />	
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -20,11 +20,29 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             int callCount = 0;
             return scope =>
             {
+                // Resolve the result before we increment the call count, this ensures that singletons
+                // won't cause any side effects during the compilation of the resolve function.
+                var result = RuntimeResolver.Resolve(callSite, scope);
+
                 if (Interlocked.Increment(ref callCount) == 2)
                 {
-                    Task.Run(() => base.RealizeService(callSite));
+                    // Don't capture the ExecutionContext when forking to build the compiled version of the
+                    // resolve function
+                    ThreadPool.UnsafeQueueUserWorkItem(state =>
+                    {
+                        try
+                        {
+                            base.RealizeService(callSite);
+                        }
+                        catch
+                        {
+                            // Swallow the exception, we should log this via the event source in a non-patched release
+                        }
+                    },
+                    null);
                 }
-                return RuntimeResolver.Resolve(callSite, scope);
+
+                return result;
             };
         }
     }


### PR DESCRIPTION
Fixes Issue dotnet/extensions#3566

Master PR #42986

# Description

- Resolve dependencies before counting to avoid the race
where its possible for the background thread to run before
the main thread resulting in singletons being resolved during
compilation (it's meant to be side effect free).

- We also avoid capturing the ExecutionContext on the background thread
to avoid capture of async locals.

Simply a port taken from @davidfowl 's PR dotnet/extensions#3569 being submitted to `release/3.1` branch.

# Customer Impact

The patch 3.1.x PR is against the extensions repo, but this PR makes sure it goes into 5.0 GA as well. 
If 3.1.x goes through, but not this PR it could lead to a regressed behavior.

# Regression

Not a regression.

# Testing

Manually. Not a straightforward way to test the exact scenario.

# Risk

Low risk.