### PR TITLE
A couple of small LSRA modifications

### DIFF
--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -5824,6 +5824,7 @@ void LinearScan::allocateRegisters()
                 if (keepAssignment == false)
                 {
                     currentRefPosition->registerAssignment = allRegs(currentInterval->registerType);
+                    currentRefPosition->isFixedRegRef      = false;
                     unassignPhysRegNoSpill(physRegRecord);
 
                     // If the preferences are currently set to just this register, reset them to allRegs

--- a/src/coreclr/src/jit/lsra.h
+++ b/src/coreclr/src/jit/lsra.h
@@ -1551,7 +1551,7 @@ private:
 
     int BuildSimple(GenTree* tree);
     int BuildOperandUses(GenTree* node, regMaskTP candidates = RBM_NONE);
-    int BuildDelayFreeUses(GenTree* node, regMaskTP candidates = RBM_NONE);
+    int BuildDelayFreeUses(GenTree* node, GenTree* rmwNode = nullptr, regMaskTP candidates = RBM_NONE);
     int BuildIndirUses(GenTreeIndir* indirTree, regMaskTP candidates = RBM_NONE);
     int BuildAddrUses(GenTree* addr, regMaskTP candidates = RBM_NONE);
     void HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* callHasFloatRegArgs);

--- a/src/coreclr/src/jit/lsraarm64.cpp
+++ b/src/coreclr/src/jit/lsraarm64.cpp
@@ -1098,8 +1098,8 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree)
         {
             if (isRMW)
             {
-                srcCount += BuildDelayFreeUses(intrin.op2);
-                srcCount += BuildDelayFreeUses(intrin.op3, RBM_ASIMD_INDEXED_H_ELEMENT_ALLOWED_REGS);
+                srcCount += BuildDelayFreeUses(intrin.op2, nullptr);
+                srcCount += BuildDelayFreeUses(intrin.op3, nullptr, RBM_ASIMD_INDEXED_H_ELEMENT_ALLOWED_REGS);
             }
             else
             {

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3032,42 +3032,61 @@ void LinearScan::setDelayFree(RefPosition* use)
 //                     and which need to be marked delayRegFree
 //
 // Arguments:
-//    node      - The node of interest
+//    node       - The node of interest
+//    rmwNode    - The node that has RMW semantics (if applicable)
+//    candidates - The set of candidates for the uses
 //
 // Return Value:
 //    The number of source registers used by the *parent* of this node.
 //
-int LinearScan::BuildDelayFreeUses(GenTree* node, regMaskTP candidates)
+int LinearScan::BuildDelayFreeUses(GenTree* node, GenTree* rmwNode, regMaskTP candidates)
 {
-    RefPosition* use;
+    RefPosition* use          = nullptr;
+    Interval*    rmwInterval  = nullptr;
+    bool         rmwIsLastUse = false;
+    GenTree*     addr         = nullptr;
+    if ((rmwNode != nullptr) && isCandidateLocalRef(rmwNode))
+    {
+        rmwInterval = getIntervalForLocalVarNode(rmwNode->AsLclVar());
+        // Note: we don't handle multi-reg vars here. It's not clear that there are any cases
+        // where we'd encounter a multi-reg var in an RMW context.
+        rmwIsLastUse = rmwNode->AsLclVar()->IsLastUse(0);
+    }
     if (!node->isContained())
     {
         use = BuildUse(node, candidates);
-        setDelayFree(use);
-        return 1;
     }
-    if (node->OperIsHWIntrinsic())
+    else if (node->OperIsHWIntrinsic())
     {
         use = BuildUse(node->gtGetOp1(), candidates);
-        setDelayFree(use);
-        return 1;
     }
-    if (!node->OperIsIndir())
+    else if (!node->OperIsIndir())
     {
         return 0;
     }
-    GenTreeIndir* indirTree = node->AsIndir();
-    GenTree*      addr      = indirTree->gtOp1;
-    if (!addr->isContained())
+    else
     {
-        use = BuildUse(addr, candidates);
-        setDelayFree(use);
+        GenTreeIndir* indirTree = node->AsIndir();
+        addr                    = indirTree->gtOp1;
+        if (!addr->isContained())
+        {
+            use = BuildUse(addr, candidates);
+        }
+        else if (!addr->OperIs(GT_LEA))
+        {
+            return 0;
+        }
+    }
+    if (use != nullptr)
+    {
+        if ((use->getInterval() != rmwInterval) || (!rmwIsLastUse && !use->lastUse))
+        {
+            setDelayFree(use);
+        }
         return 1;
     }
-    if (!addr->OperIs(GT_LEA))
-    {
-        return 0;
-    }
+
+    // If we reach here we have a contained LEA in 'addr'.
 
     GenTreeAddrMode* const addrMode = addr->AsAddrMode();
 
@@ -3075,13 +3094,19 @@ int LinearScan::BuildDelayFreeUses(GenTree* node, regMaskTP candidates)
     if ((addrMode->Base() != nullptr) && !addrMode->Base()->isContained())
     {
         use = BuildUse(addrMode->Base(), candidates);
-        setDelayFree(use);
+        if ((use->getInterval() != rmwInterval) || (!rmwIsLastUse && !use->lastUse))
+        {
+            setDelayFree(use);
+        }
         srcCount++;
     }
     if ((addrMode->Index() != nullptr) && !addrMode->Index()->isContained())
     {
         use = BuildUse(addrMode->Index(), candidates);
-        setDelayFree(use);
+        if ((use->getInterval() != rmwInterval) || (!rmwIsLastUse && !use->lastUse))
+        {
+            setDelayFree(use);
+        }
         srcCount++;
     }
     return srcCount;

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -943,9 +943,9 @@ PhaseStatus Rationalizer::DoPhase()
         for (Statement* statement : StatementList(firstStatement))
         {
             assert(statement->GetTreeList() != nullptr);
-            assert(statement->GetTreeList()->gtPrev == nullptr);
+            noway_assert(statement->GetTreeList()->gtPrev == nullptr);
             assert(statement->GetRootNode() != nullptr);
-            assert(statement->GetRootNode()->gtNext == nullptr);
+            noway_assert(statement->GetRootNode()->gtNext == nullptr);
 
             BlockRange().InsertAtEnd(LIR::Range(statement->GetTreeList(), statement->GetRootNode()));
 

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -1288,7 +1288,7 @@ typedef unsigned char   regNumberSmall;
                                    REG_R6, REG_R7, REG_R8, REG_R9, REG_R10,        \
                                    REG_R11, REG_R13, REG_R14,                      \
                                    REG_R12, REG_R15, REG_IP0, REG_IP1,             \
-                                   REG_CALLEE_SAVED_ORDER
+                                   REG_CALLEE_SAVED_ORDER, REG_LR
 
   #define REG_VAR_ORDER_FLT        REG_V16, REG_V17, REG_V18, REG_V19, \
                                    REG_V20, REG_V21, REG_V22, REG_V23, \


### PR DESCRIPTION
- Fix an incorrect short-circuit for bestPossibleScore
- Don't set delayRegFree on an operand that is the same as the one in the RMW position, and one of them is a last use.
- Add REG_LR to the REG_VAR_ORDER

These changes have minor impact, but make it easier to achieve zero diffs when changing how the heuristics are computed.