### PR TITLE
Add JitDasmWithAddress switch to print the process address of every instruction

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -2963,7 +2963,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
 
         // This one applies to both Ngen/Jit Disasm output: COMPlus_JitDasmWithAddress=1
-        if (JitConfig.DasmWithAddress() != 0)
+        if (JitConfig.JitDasmWithAddress() != 0)
         {
             opts.disAddr = true;
         }

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -2820,6 +2820,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disAsm          = false;
     opts.disAsmSpilled   = false;
     opts.disDiffable     = false;
+    opts.disAddr         = false;
     opts.dspCode         = false;
     opts.dspEHTable      = false;
     opts.dspDebugInfo    = false;
@@ -2960,6 +2961,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         {
             opts.disDiffable = true;
             opts.dspDiffable = true;
+        }
+
+        // This one applies to both Ngen/Jit Disasm output: COMPlus_JitDasmWithAddress=1
+        if (JitConfig.DasmWithAddress() != 0)
+        {
+            opts.disAddr = true;
         }
 
         if (JitConfig.JitLongAddress() != 0)

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -2813,7 +2813,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
 #ifdef DEBUG
     opts.dspInstrs       = false;
-    opts.dspEmit         = false;
     opts.dspLines        = false;
     opts.varNames        = false;
     opts.dmpHex          = false;
@@ -6097,7 +6096,7 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE classPtr,
 #ifdef DEBUG
     /* Give the function a unique number */
 
-    if (opts.disAsm || opts.dspEmit || verbose)
+    if (opts.disAsm || verbose)
     {
         compMethodID = ~info.compMethodHash() & 0xffff;
     }

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -8937,7 +8937,6 @@ public:
         bool dspEHTable;               // Display the EH table reported to the VM
         bool dspDebugInfo;             // Display the Debug info reported to the VM
         bool dspInstrs;                // Display the IL instructions intermixed with the native code output
-        bool dspEmit;                  // Display emitter output
         bool dspLines;                 // Display source-code lines intermixed with native code output
         bool dmpHex;                   // Display raw bytes in hex of native code output
         bool varNames;                 // Display variables names in native code output

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -8944,7 +8944,7 @@ public:
         bool disAsmSpilled;            // Display native code when any register spilling occurs
         bool disasmWithGC;             // Display GC info interleaved with disassembly.
         bool disDiffable;              // Makes the Disassembly code 'diff-able'
-        bool disAddr;                  // Display process address next to each instruction in Disassembly code
+        bool disAddr;                  // Display process address next to each instruction in disassembly code
         bool disAsm2;                  // Display native code after it is generated using external disassembler
         bool dspOrder;                 // Display names of each of the methods that we ngen/jit
         bool dspUnwind;                // Display the unwind info output

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -8945,6 +8945,7 @@ public:
         bool disAsmSpilled;            // Display native code when any register spilling occurs
         bool disasmWithGC;             // Display GC info interleaved with disassembly.
         bool disDiffable;              // Makes the Disassembly code 'diff-able'
+        bool disAddr;                  // Display process address next to each instruction in Disassembly code
         bool disAsm2;                  // Display native code after it is generated using external disassembler
         bool dspOrder;                 // Display names of each of the methods that we ngen/jit
         bool dspUnwind;                // Display the unwind info output

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5096,12 +5096,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\nG_M%03u_IG%02u:", emitComp->compMethodID, ig->igNum);
                 if (!emitComp->opts.disDiffable)
                 {
-#ifdef TARGET_XARCH
                     printf("              ;; offset=%04XH", ig->igOffs);
-#elif defined(TARGET_ARM64)
-                    // Only display for arm64 because offset is already displayed by default for arm
-                    printf("            ;; offset=%04XH", ig->igOffs);
-#endif
                 }
                 printf("\n");
             }

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -1211,13 +1211,16 @@ void emitter::appendToCurIG(instrDesc* id)
 
 #ifdef DEBUG
 
-void emitter::emitDispInsOffs(unsigned offs, bool doffs, BYTE* code)
+void emitter::emitDispInsAddr(BYTE* code)
 {
     if (emitComp->opts.disAddr)
     {
         printf(FMT_ADDR, DBG_ADDR(code));
     }
+}
 
+void emitter::emitDispInsOffs(unsigned offs, bool doffs)
+{
     if (doffs)
     {
         printf("%06X", offs);
@@ -5091,9 +5094,14 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             else
             {
                 printf("\nG_M%03u_IG%02u:", emitComp->compMethodID, ig->igNum);
-                if (emitComp->opts.disAddr)
+                if (!emitComp->opts.disDiffable)
                 {
-                    printf("\t\t;; offset=%04XH", ig->igOffs);
+#ifdef TARGET_XARCH
+                    printf("              ;; offset=%04XH", ig->igOffs);
+#elif defined(TARGET_ARM64)
+                    // Only display for arm64 because offset is already displayed by default for arm
+                    printf("            ;; offset=%04XH", ig->igOffs);
+#endif
                 }
                 printf("\n");
             }

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -1215,7 +1215,7 @@ void emitter::emitDispInsOffs(unsigned offs, bool doffs, BYTE* code)
 {
     if (emitComp->opts.disAddr)
     {
-        printf("[" FMT_ADDR "] ", DBG_ADDR(code));
+        printf(FMT_ADDR, DBG_ADDR(code));
     }
 
     if (doffs)

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -1211,8 +1211,13 @@ void emitter::appendToCurIG(instrDesc* id)
 
 #ifdef DEBUG
 
-void emitter::emitDispInsOffs(unsigned offs, bool doffs)
+void emitter::emitDispInsOffs(unsigned offs, bool doffs, BYTE* code)
 {
+    if (emitComp->opts.disAddr)
+    {
+        printf("[" FMT_ADDR "] ", DBG_ADDR(code));
+    }
+
     if (doffs)
     {
         printf("%06X", offs);
@@ -5085,7 +5090,12 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             }
             else
             {
-                printf("\nG_M%03u_IG%02u:\n", emitComp->compMethodID, ig->igNum);
+                printf("\nG_M%03u_IG%02u:", emitComp->compMethodID, ig->igNum);
+                if (emitComp->opts.disAddr)
+                {
+                    printf("\t\t;; offset=%04XH", ig->igOffs);
+                }
+                printf("\n");
             }
         }
 #endif // DEBUG

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5058,7 +5058,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             assert(coldCodeBlock);
             cp = coldCodeBlock;
 #ifdef DEBUG
-            if (emitComp->opts.disAsm || emitComp->opts.dspEmit || emitComp->verbose)
+            if (emitComp->opts.disAsm || emitComp->verbose)
             {
                 printf("\n************** Beginning of cold code **************\n");
             }
@@ -5081,7 +5081,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #ifdef DEBUG
         /* Print the IG label, but only if it is a branch label */
 
-        if (emitComp->opts.disAsm || emitComp->opts.dspEmit || emitComp->verbose)
+        if (emitComp->opts.disAsm || emitComp->verbose)
         {
             if (emitComp->verbose || emitComp->opts.disasmWithGC)
             {
@@ -5193,7 +5193,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
         }
 
 #ifdef DEBUG
-        if (emitComp->opts.disAsm || emitComp->opts.dspEmit || emitComp->verbose)
+        if (emitComp->opts.disAsm || emitComp->verbose)
         {
             printf("\t\t\t\t\t\t;; bbWeight=%s PerfScore %.2f", refCntWtd2str(ig->igWeight), ig->igPerfScore);
         }
@@ -6481,10 +6481,6 @@ unsigned char emitter::emitOutputByte(BYTE* dst, ssize_t val)
     *castto(dst, unsigned char*) = (unsigned char)val;
 
 #ifdef DEBUG
-    if (emitComp->opts.dspEmit)
-    {
-        printf("; emit_byte 0%02XH\n", val & 0xFF);
-    }
 #ifdef TARGET_AMD64
     // if we're emitting code bytes, ensure that we've already emitted the rex prefix!
     assert(((val & 0xFF00000000LL) == 0) || ((val & 0xFFFFFFFF00000000LL) == 0xFFFFFFFF00000000LL));
@@ -6504,10 +6500,6 @@ unsigned char emitter::emitOutputWord(BYTE* dst, ssize_t val)
     MISALIGNED_WR_I2(dst, (short)val);
 
 #ifdef DEBUG
-    if (emitComp->opts.dspEmit)
-    {
-        printf("; emit_word 0%02XH,0%02XH\n", (val & 0xFF), (val >> 8) & 0xFF);
-    }
 #ifdef TARGET_AMD64
     // if we're emitting code bytes, ensure that we've already emitted the rex prefix!
     assert(((val & 0xFF00000000LL) == 0) || ((val & 0xFFFFFFFF00000000LL) == 0xFFFFFFFF00000000LL));
@@ -6527,10 +6519,6 @@ unsigned char emitter::emitOutputLong(BYTE* dst, ssize_t val)
     MISALIGNED_WR_I4(dst, (int)val);
 
 #ifdef DEBUG
-    if (emitComp->opts.dspEmit)
-    {
-        printf("; emit_long 0%08XH\n", (int)val);
-    }
 #ifdef TARGET_AMD64
     // if we're emitting code bytes, ensure that we've already emitted the rex prefix!
     assert(((val & 0xFF00000000LL) == 0) || ((val & 0xFFFFFFFF00000000LL) == 0xFFFFFFFF00000000LL));
@@ -6552,17 +6540,6 @@ unsigned char emitter::emitOutputSizeT(BYTE* dst, ssize_t val)
 #else
     MISALIGNED_WR_ST(dst, val);
 #endif
-
-#ifdef DEBUG
-    if (emitComp->opts.dspEmit)
-    {
-#ifdef TARGET_AMD64
-        printf("; emit_size_t 0%016llXH\n", val);
-#else  // TARGET_AMD64
-        printf("; emit_size_t 0%08XH\n", val);
-#endif // TARGET_AMD64
-    }
-#endif // DEBUG
 
     return TARGET_POINTER_SIZE;
 }

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -1508,7 +1508,8 @@ protected:
     void emitDispGCinfo();
     void emitDispClsVar(CORINFO_FIELD_HANDLE fldHnd, ssize_t offs, bool reloc = false);
     void emitDispFrameRef(int varx, int disp, int offs, bool asmfm);
-    void emitDispInsOffs(unsigned offs, bool doffs, BYTE* code);
+    void emitDispInsAddr(BYTE* code);
+    void emitDispInsOffs(unsigned offs, bool doffs);
     void emitDispInsHex(instrDesc* id, BYTE* code, size_t sz);
 
 #else // !DEBUG

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -1508,7 +1508,7 @@ protected:
     void emitDispGCinfo();
     void emitDispClsVar(CORINFO_FIELD_HANDLE fldHnd, ssize_t offs, bool reloc = false);
     void emitDispFrameRef(int varx, int disp, int offs, bool asmfm);
-    void emitDispInsOffs(unsigned offs, bool doffs);
+    void emitDispInsOffs(unsigned offs, bool doffs, BYTE* code);
     void emitDispInsHex(instrDesc* id, BYTE* code, size_t sz);
 
 #else // !DEBUG

--- a/src/coreclr/src/jit/emitarm.cpp
+++ b/src/coreclr/src/jit/emitarm.cpp
@@ -6981,9 +6981,13 @@ void emitter::emitDispInsHelp(
         doffs = true;
     }
 
+    /* Display the instruction address */
+
+    emitDispInsAddr(code);
+
     /* Display the instruction offset */
 
-    emitDispInsOffs(offset, doffs, code);
+    emitDispInsOffs(offset, doffs);
 
     /* Display the instruction hex code */
 

--- a/src/coreclr/src/jit/emitarm.cpp
+++ b/src/coreclr/src/jit/emitarm.cpp
@@ -6977,11 +6977,13 @@ void emitter::emitDispInsHelp(
         sz = 0;
 
     if (!emitComp->opts.dspEmit && !isNew && !asmfm && sz)
+    {
         doffs = true;
+    }
 
     /* Display the instruction offset */
 
-    emitDispInsOffs(offset, doffs);
+    emitDispInsOffs(offset, doffs, code);
 
     /* Display the instruction hex code */
 

--- a/src/coreclr/src/jit/emitarm.cpp
+++ b/src/coreclr/src/jit/emitarm.cpp
@@ -6530,7 +6530,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     size_t expected = emitSizeOfInsDsc(id);
     assert(sz == expected);
 
-    if (emitComp->opts.disAsm || emitComp->opts.dspEmit || emitComp->verbose)
+    if (emitComp->opts.disAsm || emitComp->verbose)
     {
         emitDispIns(id, false, dspOffs, true, emitCurCodeOffs(odst), *dp, (dst - *dp), ig);
     }
@@ -6976,7 +6976,7 @@ void emitter::emitDispInsHelp(
     if (code == NULL)
         sz = 0;
 
-    if (!emitComp->opts.dspEmit && !isNew && !asmfm && sz)
+    if (!isNew && !asmfm && sz)
     {
         doffs = true;
     }

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -11462,7 +11462,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     size_t expected = emitSizeOfInsDsc(id);
     assert(sz == expected);
 
-    if (emitComp->opts.disAsm || emitComp->opts.dspEmit || emitComp->verbose)
+    if (emitComp->opts.disAsm || emitComp->verbose)
     {
         emitDispIns(id, false, dspOffs, true, emitCurCodeOffs(odst), *dp, (dst - *dp), ig);
     }
@@ -12107,7 +12107,7 @@ void emitter::emitDispIns(
     if (pCode == NULL)
         sz = 0;
 
-    if (!emitComp->opts.dspEmit && !isNew && !asmfm && sz)
+    if (!isNew && !asmfm && sz)
     {
         doffs = true;
     }

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12112,9 +12112,13 @@ void emitter::emitDispIns(
         doffs = true;
     }
 
+    /* Display the instruction address */
+
+    emitDispInsAddr(pCode);
+
     /* Display the instruction offset */
 
-    emitDispInsOffs(offset, doffs, pCode);
+    emitDispInsOffs(offset, doffs);
 
     /* Display the instruction hex code */
 

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12108,11 +12108,13 @@ void emitter::emitDispIns(
         sz = 0;
 
     if (!emitComp->opts.dspEmit && !isNew && !asmfm && sz)
+    {
         doffs = true;
+    }
 
     /* Display the instruction offset */
 
-    emitDispInsOffs(offset, doffs);
+    emitDispInsOffs(offset, doffs, pCode);
 
     /* Display the instruction hex code */
 

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -8243,9 +8243,13 @@ void emitter::emitDispIns(
         doffs = true;
     }
 
+    /* Display the instruction address */
+
+    emitDispInsAddr(code);
+
     /* Display the instruction offset */
 
-    emitDispInsOffs(offset, doffs, code);
+    emitDispInsOffs(offset, doffs);
 
     if (code != nullptr)
     {

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -8238,7 +8238,7 @@ void emitter::emitDispIns(
     // printf("[A=%08X] " , emitSimpleByrefStkMask);
     // printf("[L=%02u] " , id->idCodeSize());
 
-    if (!emitComp->opts.dspEmit && !isNew && !asmfm)
+    if (!isNew && !asmfm)
     {
         doffs = true;
     }
@@ -13680,7 +13680,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     assert(*dp != dst || emitInstHasNoCode(ins));
 
 #ifdef DEBUG
-    if (emitComp->opts.disAsm || emitComp->opts.dspEmit || emitComp->verbose)
+    if (emitComp->opts.disAsm || emitComp->verbose)
     {
         emitDispIns(id, false, dspOffs, true, emitCurCodeOffs(*dp), *dp, (dst - *dp));
     }

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -8245,7 +8245,7 @@ void emitter::emitDispIns(
 
     /* Display the instruction offset */
 
-    emitDispInsOffs(offset, doffs);
+    emitDispInsOffs(offset, doffs, code);
 
     if (code != nullptr)
     {
@@ -13985,6 +13985,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
 
     switch (ins)
     {
+        case INS_align:
         case INS_nop:
         case INS_int3:
             assert(memFmt == IF_NONE);

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -21,8 +21,9 @@ CONFIG_INTEGER(BreakOnDumpToken, W("BreakOnDumpToken"), 0xffffffff) // Breaks wh
                                                                     // particular token value.
 CONFIG_INTEGER(DebugBreakOnVerificationFailure, W("DebugBreakOnVerificationFailure"), 0) // Halts the jit on
                                                                                          // verification failure
-CONFIG_INTEGER(DiffableDasm, W("JitDiffableDasm"), 0)            // Make the disassembly diff-able
-CONFIG_INTEGER(DasmWithAddress, W("JitDasmWithAddress"), 0)      // Print the process address next to each instruction of the disassembly
+CONFIG_INTEGER(DiffableDasm, W("JitDiffableDasm"), 0)          // Make the disassembly diff-able
+CONFIG_INTEGER(JitDasmWithAddress, W("JitDasmWithAddress"), 0) // Print the process address next to each instruction of
+                                                               // the disassembly
 CONFIG_INTEGER(DisplayLoopHoistStats, W("JitLoopHoistStats"), 0) // Display JIT loop hoisting statistics
 CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0)       // Display JIT Linear Scan Register Allocator statistics
 CONFIG_INTEGER(DumpJittedMethods, W("DumpJittedMethods"), 0) // Prints all jitted methods to the console

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -22,6 +22,7 @@ CONFIG_INTEGER(BreakOnDumpToken, W("BreakOnDumpToken"), 0xffffffff) // Breaks wh
 CONFIG_INTEGER(DebugBreakOnVerificationFailure, W("DebugBreakOnVerificationFailure"), 0) // Halts the jit on
                                                                                          // verification failure
 CONFIG_INTEGER(DiffableDasm, W("JitDiffableDasm"), 0)            // Make the disassembly diff-able
+CONFIG_INTEGER(DasmWithAddress, W("JitDasmWithAddress"), 0)      // Print the process address next to each instruction of the disassembly
 CONFIG_INTEGER(DisplayLoopHoistStats, W("JitLoopHoistStats"), 0) // Display JIT loop hoisting statistics
 CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0)       // Display JIT Linear Scan Register Allocator statistics
 CONFIG_INTEGER(DumpJittedMethods, W("DumpJittedMethods"), 0) // Prints all jitted methods to the console


### PR DESCRIPTION
In order to do alignment related investigation, it will be good to have a way to print the process address where JIT code is inserted into. Added `COMPlus_JitDasmWithAddress` switch to enable printing it. If this switch is set, it will also print the offset at the top of every block. Also I noticed that `opts.dspEmit` was never getting used, so I deleted it and its usage.

Sample output of x64:

```asm
G_M3239_IG01:           ;; offset=0000H
[ 00007ff8`1ba29390 ]        4883EC18             sub      rsp, 24
[ 00007ff8`1ba29394 ]        33C0                 xor      rax, rax
[ 00007ff8`1ba29396 ]        4889442410           mov      qword ptr [rsp+10H], rax
[ 00007ff8`1ba2939b ]        4889442408           mov      qword ptr [rsp+08H], rax
                                                ;; bbWeight=1    PerfScore 2.50
G_M3239_IG02:           ;; offset=0010H
[ 00007ff8`1ba293a0 ]        8B4108               mov      eax, dword ptr [rcx+8]
[ 00007ff8`1ba293a3 ]        4883C10C             add      rcx, 12
[ 00007ff8`1ba293a7 ]        48894C2410           mov      bword ptr [rsp+10H], rcx
[ 00007ff8`1ba293ac ]        488B4C2410           mov      rcx, bword ptr [rsp+10H]
[ 00007ff8`1ba293b1 ]        4885D2               test     rdx, rdx
[ 00007ff8`1ba293b4 ]        7505                 jne      SHORT G_M3239_IG04
                                                ;; bbWeight=1    PerfScore 5.50
```

x86 output:

```asm
G_M3239_IG01:           ;; offset=0000H
[ 08b189c0 ]       55           push     ebp
[ 08b189c1 ]       8BEC         mov      ebp, esp
[ 08b189c3 ]       57           push     edi
[ 08b189c4 ]       56           push     esi
[ 08b189c5 ]       83EC08       sub      esp, 8
[ 08b189c8 ]       33C0         xor      eax, eax
[ 08b189ca ]       8945F4       mov      dword ptr [ebp-0CH], eax
[ 08b189cd ]       8945F0       mov      dword ptr [ebp-10H], eax
                                                ;; bbWeight=1    PerfScore 5.75
G_M3239_IG02:           ;; offset=0010H
[ 08b189d0 ]       8B4104       mov      eax, dword ptr [ecx+4]
[ 08b189d3 ]       83C108       add      ecx, 8
[ 08b189d6 ]       894DF4       mov      bword ptr [ebp-0CH], ecx
[ 08b189d9 ]       8B4DF4       mov      ecx, bword ptr [ebp-0CH]
[ 08b189dc ]       85D2         test     edx, edx
[ 08b189de ]       7504         jne      SHORT G_M3239_IG04
                                                ;; bbWeight=1    PerfScore 5.50
```