### PR TITLE
Jit: Dont remove parent commas of bound checks

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -4917,8 +4917,15 @@ GenTree* Compiler::optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test)
         Statement* newStmt;
         if (sideEffList->OperGet() == GT_COMMA)
         {
-            newStmt     = fgNewStmtNearEnd(block, sideEffList->gtGetOp1());
-            sideEffList = sideEffList->gtGetOp2();
+            GenTree* op1      = sideEffList->gtGetOp1();
+            GenTree* nextNode = sideEffList->gtGetOp2();
+            if (op1->OperIsBoundsCheck())
+            {
+                op1                = sideEffList;
+                op1->AsOp()->gtOp2 = gtNewNothingNode();
+            }
+            newStmt     = fgNewStmtNearEnd(block, op1);
+            sideEffList = nextNode;
         }
         else
         {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16001,6 +16001,11 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
             {
                 if (m_compiler->gtNodeHasSideEffects(node, m_flags))
                 {
+                    if (node->OperIs(GT_ARR_BOUNDS_CHECK))
+                    {
+                        node = m_compiler->gtNewOperNode(GT_COMMA, TYP_VOID, node, m_compiler->gtNewNothingNode());
+                    }
+
                     m_sideEffects.Push(node);
                     if (node->OperIsBlk() && !node->OperIsStoreBlk())
                     {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -14233,8 +14233,9 @@ DONE_MORPHING_CHILDREN:
                     return op2;
                 }
 
-                /* If the right operand is just a void nop node, throw it away */
-                if (op2->IsNothingNode() && op1->gtType == TYP_VOID)
+                // If the right operand is just a void nop node, throw it away
+                // unless it has a bounds check node, as we expect those as a parent of bounds checks
+                if (op2->IsNothingNode() && (op1->gtType == TYP_VOID) && !op1->OperIsBoundsCheck())
                 {
                     op1->gtFlags |= (tree->gtFlags & (GTF_DONT_CSE | GTF_LATE_ARG));
                     DEBUG_DESTROY_NODE(tree);

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -189,11 +189,23 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTree* upper)
 
 void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree* treeParent)
 {
+#ifdef DEBUG
+    // range check only expects bound check nodes under a comma,
+    // check that that's the case
+    if (treeParent->OperIsBoundsCheck())
+    {
+        GenTree* parent = treeParent->gtGetParent(nullptr);
+        assert((parent != nullptr) && parent->OperIs(GT_COMMA));
+    }
+#endif
+
     // Check if we are dealing with a bounds check node.
     if (treeParent->OperGet() != GT_COMMA)
     {
         return;
     }
+
+    assert(!treeParent->AsOp()->gtGetOp2()->OperIsBoundsCheck());
 
     // If we are not looking at array bounds check, bail.
     GenTree* tree = treeParent->AsOp()->gtOp1;


### PR DESCRIPTION
If anyone is curious, but needs more investigation:

<pre>Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for x64 default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 31822434
Total bytes of diff: 31763272
Total bytes of delta: -59162 (-0.186% of base)
    diff is an improvement.

Top file regressions (bytes):
          72 : System.Reflection.Metadata.dasm (0.022% of base)
          58 : System.Resources.Extensions.dasm (0.182% of base)
          58 : System.Resources.Writer.dasm (0.733% of base)
          30 : System.Configuration.ConfigurationManager.dasm (0.010% of base)
          26 : Microsoft.Extensions.Primitives.dasm (0.164% of base)
          24 : System.Private.Uri.dasm (0.029% of base)
          21 : System.Threading.Tasks.Dataflow.dasm (0.015% of base)
          13 : System.CodeDom.dasm (0.008% of base)
          11 : CommandLine.dasm (0.007% of base)
           4 : System.Text.Encodings.Web.dasm (0.029% of base)
           3 : System.Numerics.Tensors.dasm (0.010% of base)
           3 : Newtonsoft.Json.Bson.dasm (0.004% of base)

Top file improvements (bytes):
      -14584 : System.Private.CoreLib.dasm (-0.450% of base)
       -5104 : System.Private.Xml.dasm (-0.159% of base)
       -4933 : System.Data.Common.dasm (-0.444% of base)
       -4915 : System.Reflection.MetadataLoadContext.dasm (-2.668% of base)
       -3049 : FSharp.Core.dasm (-0.362% of base)
       -2388 : Microsoft.CodeAnalysis.CSharp.dasm (-0.115% of base)
       -1966 : System.Private.DataContractSerialization.dasm (-0.276% of base)
       -1864 : Microsoft.CSharp.dasm (-0.697% of base)
       -1697 : System.Runtime.Serialization.Formatters.dasm (-1.744% of base)
       -1664 : System.Linq.Expressions.dasm (-0.057% of base)
       -1636 : System.Linq.Parallel.dasm (-0.286% of base)
       -1524 : Microsoft.VisualBasic.Core.dasm (-0.359% of base)
       -1436 : xunit.execution.dotnet.dasm (-0.786% of base)
       -1354 : Microsoft.CodeAnalysis.dasm (-0.176% of base)
        -926 : System.Web.HttpUtility.dasm (-7.237% of base)
        -897 : System.Drawing.Common.dasm (-0.322% of base)
        -860 : System.Data.Odbc.dasm (-0.479% of base)
        -715 : ILCompiler.Reflection.ReadyToRun.dasm (-0.629% of base)
        -587 : System.ComponentModel.Composition.dasm (-0.271% of base)
        -551 : Newtonsoft.Json.dasm (-0.088% of base)

64 total files with Code Size differences (52 improved, 12 regressed), 203 unchanged.

Top method regressions (bytes):
          88 (2.532% of base) : System.DirectoryServices.Protocols.dasm - LdapConnection:SendRequestHelper(DirectoryRequest,byref):int:this
          74 (2.979% of base) : System.Reflection.Metadata.dasm - &lt;OrderBy&gt;d__3`1:MoveNext():bool:this (7 methods)
          67 (4.417% of base) : System.Private.Xml.dasm - XmlSerializationReaderILGen:WriteMemberEnd(ref,bool):this
          60 (3.645% of base) : System.Private.Xml.dasm - XmlQueryStaticData:GetObjectData(byref,byref):this
          58 (2.317% of base) : System.Resources.Extensions.dasm - PreserializedResourceWriter:Generate():this
          58 (2.303% of base) : System.Resources.Writer.dasm - ResourceWriter:Generate():this
          55 (1.201% of base) : System.Private.CoreLib.dasm - ManifestBuilder:CreateManifestString():String:this
          30 (0.997% of base) : System.Configuration.ConfigurationManager.dasm - MgmtConfigurationRecord:CopyConfigDefinitionsRecursive(ConfigDefinitionUpdates,XmlUtil,XmlUtilWriter,bool,LocationUpdates,SectionUpdates,bool,String,int,int):bool:this
          29 (8.192% of base) : System.Reflection.MetadataLoadContext.dasm - Assignability:ProvablyAGcReferenceTypeHelper(Type,CoreTypes):bool
          28 (1.251% of base) : System.Private.Xml.dasm - XmlSerializationReaderILGen:WriteEnumMethod(EnumMapping):this
          27 (11.345% of base) : System.Data.Common.dasm - Scope:IsAllowedType(Type):bool:this
          25 (1.958% of base) : System.Private.CoreLib.dasm - MemberInfoCache`1:PopulateInterfaces(Filter):ref:this
          24 (9.524% of base) : System.Data.Odbc.dasm - DBConnectionString:IsSupersetOf(DBConnectionString):bool:this
          23 (0.515% of base) : System.Private.CoreLib.dasm - EventSource:CreateManifestAndDescriptors(Type,String,EventSource,int):ref
          23 (8.647% of base) : System.Private.Uri.dasm - DomainNameHelper:IdnEquivalent(String):String
          22 (1.756% of base) : System.ComponentModel.TypeConverter.dasm - ReflectPropertyDescriptor:FillAttributes(IList):this
          21 (4.421% of base) : System.Threading.Tasks.Dataflow.dasm - SourceCore`1:AddMessages(IEnumerable`1):this
          21 (7.749% of base) : System.Private.CoreLib.dasm - RuntimeType:IsAssignableFrom(Type):bool:this
          21 (7.394% of base) : System.Private.CoreLib.dasm - Type:IsAssignableFrom(Type):bool:this
          21 (4.167% of base) : System.Drawing.Common.dasm - Pen:set_DashPattern(ref):this

Top method improvements (bytes):
       -4428 (-42.402% of base) : System.Private.CoreLib.dasm - DefaultBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
       -1636 (-11.524% of base) : System.Linq.Parallel.dasm - ExchangeUtilities:PartitionDataSource(IEnumerable`1,int,bool):PartitionedStream`2 (26 methods)
       -1053 (-22.876% of base) : System.Private.Xml.dasm - XmlUntypedStringConverter:ToArray(ref,IXmlNamespaceResolver):ref:this (16 methods)
       -1032 (-41.496% of base) : Microsoft.CSharp.dasm - ErrorHandling:Error(int,ref):RuntimeBinderException
       -1020 (-39.596% of base) : System.Reflection.MetadataLoadContext.dasm - DefaultBinder:SelectMethod(int,ref,ref,ref):MethodBase:this
        -950 (-13.875% of base) : System.Private.DataContractSerialization.dasm - ArrayHelper`2:ReadArray(XmlDictionaryReader,__Canon,__Canon,int):ref:this (12 methods)
        -794 (-32.042% of base) : System.Reflection.MetadataLoadContext.dasm - DefaultBinder:SelectProperty(int,ref,Type,ref,ref):PropertyInfo:this
        -731 (-36.789% of base) : System.Private.CoreLib.dasm - DefaultBinder:SelectMethod(int,ref,ref,ref):MethodBase:this
        -670 (-30.819% of base) : System.Private.CoreLib.dasm - DefaultBinder:SelectProperty(int,ref,Type,ref,ref):PropertyInfo:this
        -660 (-28.796% of base) : Microsoft.VisualBasic.Core.dasm - OverloadResolution:MoreSpecificProcedure(Method,Method,ref,ref,int,byref,bool):Method
        -644 (-47.598% of base) : System.Private.Xml.dasm - XsltCompileContext:FindBestMethod(ref,bool,bool,String,ref):MethodInfo:this
        -560 (-33.058% of base) : System.Private.Xml.dasm - ParticleContentValidator:BuildTransitionTable(BitSet,ref,int):ref:this
        -536 (-33.626% of base) : ILCompiler.Reflection.ReadyToRun.dasm - PEExportTable:.ctor(PEReader):this
        -511 (-42.336% of base) : System.Reflection.MetadataLoadContext.dasm - DefaultBinder:FindMostSpecific(ref,ref,Type,ref,ref,Type,ref,ref):int
        -510 (-43.404% of base) : System.Private.CoreLib.dasm - Type:GetEnumData(byref,byref):this
        -506 (-42.272% of base) : System.Private.CoreLib.dasm - DefaultBinder:FindMostSpecific(ref,ref,Type,ref,ref,Type,ref,ref):int
        -502 (-18.958% of base) : Microsoft.VisualBasic.Core.dasm - OverloadResolution:CanMatchArguments(Method,ref,ref,ref,bool,List`1):bool
        -456 (-34.730% of base) : xunit.execution.dotnet.dasm - TestClassRunner`1:CreateTestClassConstructorArguments():ref:this
        -454 (-39.104% of base) : System.Reflection.MetadataLoadContext.dasm - Assignability:MatchesWithVariance(Type,Type,CoreTypes):bool
        -451 (-12.140% of base) : System.Private.Xml.dasm - TempAssembly:GenerateSerializerToStream(ref,ref,String,Assembly,Hashtable,Stream):bool

Top method regressions (percentages):
          21 (14.094% of base) : Microsoft.Extensions.Primitives.dasm - StringValues:IndexOf(String):int:this (2 methods)
          27 (11.345% of base) : System.Data.Common.dasm - Scope:IsAllowedType(Type):bool:this
          20 (10.000% of base) : System.Runtime.Serialization.Formatters.dasm - HashHelpers:GetPrime(int):int
          20 (9.852% of base) : System.Private.CoreLib.dasm - HashHelpers:GetPrime(int):int
          24 (9.524% of base) : System.Data.Odbc.dasm - DBConnectionString:IsSupersetOf(DBConnectionString):bool:this
          23 (8.647% of base) : System.Private.Uri.dasm - DomainNameHelper:IdnEquivalent(String):String
          29 (8.192% of base) : System.Reflection.MetadataLoadContext.dasm - Assignability:ProvablyAGcReferenceTypeHelper(Type,CoreTypes):bool
          21 (7.749% of base) : System.Private.CoreLib.dasm - RuntimeType:IsAssignableFrom(Type):bool:this
          13 (7.692% of base) : System.DirectoryServices.Protocols.dasm - DirectoryAttributeCollection:AddRange(ref):this
          13 (7.692% of base) : System.DirectoryServices.Protocols.dasm - DirectoryAttributeModificationCollection:AddRange(ref):this
          14 (7.609% of base) : System.DirectoryServices.Protocols.dasm - DirectoryControlCollection:AddRange(ref):this
          21 (7.394% of base) : System.Private.CoreLib.dasm - Type:IsAssignableFrom(Type):bool:this
          13 (6.599% of base) : System.Net.HttpListener.dasm - HttpListenerResponse:set_StatusDescription(String):this
          17 (5.519% of base) : System.Private.CoreLib.dasm - SignatureConstructedGenericType:.ctor(Type,ref):this
          14 (5.469% of base) : System.Private.CoreLib.dasm - PathInternal:NormalizeDirectorySeparators(String):String
           9 (5.294% of base) : System.Private.CoreLib.dasm - String:TrimHelper(long,int,int):String:this
          15 (5.051% of base) : System.CodeDom.dasm - Indentation:get_IndentationString():String:this
           8 (4.762% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Parser:ElementNameIsOneFromTheList(XmlNodeSyntax,ref):bool:this
          21 (4.421% of base) : System.Threading.Tasks.Dataflow.dasm - SourceCore`1:AddMessages(IEnumerable`1):this
          67 (4.417% of base) : System.Private.Xml.dasm - XmlSerializationReaderILGen:WriteMemberEnd(ref,bool):this

Top method improvements (percentages):
        -152 (-55.474% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,ushort,int,int):int:this (4 methods)
         -98 (-54.749% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,float,int,int):int:this (2 methods)
         -76 (-54.676% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,short,int,int):int:this (2 methods)
        -101 (-54.595% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,double,int,int):int:this (2 methods)
        -132 (-54.545% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,int,int,int):int:this (4 methods)
        -204 (-54.400% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,long,int,int):int:this (6 methods)
         -63 (-53.846% of base) : Microsoft.CodeAnalysis.dasm - Hash:GetFNVHashCode(ref,int,int):int
        -238 (-53.846% of base) : System.Text.RegularExpressions.dasm - Match:TidyBalancing():this
         -62 (-51.667% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MethodSymbol:TypeParametersMatchTypeArguments(ImmutableArray`1,ImmutableArray`1):bool
        -333 (-51.548% of base) : System.Data.Common.dasm - DataTableCollection:BaseGroupSwitch(ref,int,ref,int):this
        -413 (-51.241% of base) : System.Data.Common.dasm - DataColumnCollection:BaseGroupSwitch(ref,int,ref,int):this
        -342 (-50.742% of base) : System.Data.Common.dasm - ConstraintCollection:BaseGroupSwitch(ref,int,ref,int):this
         -54 (-50.000% of base) : System.Private.CoreLib.dasm - EnumEqualityComparer`1:IndexOf(ref,int,int,int):int:this (2 methods)
        -217 (-49.431% of base) : System.Data.Common.dasm - SqlString:CompareBinary2(SqlString,SqlString):int
         -96 (-47.761% of base) : System.Private.DataContractSerialization.dasm - XmlBufferReader:GetChars(int,int,ref):int:this
        -644 (-47.598% of base) : System.Private.Xml.dasm - XsltCompileContext:FindBestMethod(ref,bool,bool,String,ref):MethodInfo:this
        -170 (-47.486% of base) : Microsoft.CSharp.dasm - RuntimeBinder:CreateArgumentListEXPR(ref,ref,int,int):Expr:this
        -174 (-47.154% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Binder:BindAttributeTypes(ImmutableArray`1,ImmutableArray`1,Symbol,ref,DiagnosticBag)
        -247 (-45.488% of base) : System.Reflection.MetadataLoadContext.dasm - PropertyPolicies:IsSuppressedByMoreDerivedMember(PropertyInfo,ref,int,int):bool:this
        -118 (-45.211% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - GCPerHeapHistoryTraceData:GetIntPtrArray(int,int):ref:this

524 total methods with Code Size differences (430 improved, 94 regressed), 189503 unchanged.

</pre>