### PR TITLE
Fix issue #40112 and re-enable some tests

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -71,7 +71,16 @@ namespace System.Runtime.InteropServices.JavaScript
             WeakReference? reference;
             lock (_boundObjects)
             {
-                if (!_boundObjects.TryGetValue(jsId, out reference))
+                if (_boundObjects.TryGetValue(jsId, out reference))
+                {
+                    if ((reference.Target == null) || ((reference.Target as JSObject)?.IsDisposed == true))
+                    {
+                        _boundObjects.Remove(jsId);
+                        reference = null;
+                    }
+                }
+
+                if (reference == null)
                 {
                     IntPtr jsIntPtr = (IntPtr)jsId;
                     reference = new WeakReference(mappedType > 0 ? BindJSType(jsIntPtr, ownsHandle, mappedType) : new JSObject(jsIntPtr, ownsHandle), true);

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -316,6 +316,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         internal static int _sumValue = 0;
         private static void CallFunctionSum()
         {
+            if (_sumFunction == null)
+                throw new Exception("_sumFunction is null");
             _sumValue = (int)_sumFunction.Call(null, 3, 5);
         }
 
@@ -323,6 +325,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         private static void CreateFunctionApply()
         {
             var math = (JSObject)Runtime.GetGlobalObject("Math");
+            if (math == null)
+                throw new Exception("Runtime.GetGlobalObject(Math) returned null");
             _mathMinFunction = (Function)math.GetObjectProperty("min");
 
         }
@@ -330,6 +334,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         internal static int _minValue = 0;
         private static void CallFunctionApply()
         {
+            if (_mathMinFunction == null)
+                throw new Exception("_mathMinFunction is null");
             _minValue = (int)_mathMinFunction.Apply(null, new object[] { 5, 6, 2, 3, 7 });
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -92,14 +92,13 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void FunctionMath()
         {
             JSObject math = (JSObject)Runtime.GetGlobalObject("Math");
-            Assert.NotNull(math);
+            Assert.True(math != null, "math != null");
 
             Function mathMax = (Function)math.GetObjectProperty("max");
-            Assert.NotNull(mathMax);
+            Assert.True(mathMax != null, "math.max != null");
 
             var maxValue = (int)mathMax.Apply(null, new object[] { 5, 6, 2, 3, 7 });
             Assert.Equal(7, maxValue);
@@ -108,7 +107,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Equal(7, maxValue);
 
             Function mathMin = (Function)((JSObject)Runtime.GetGlobalObject("Math")).GetObjectProperty("min");
-            Assert.NotNull(mathMin);
+            Assert.True(mathMin != null, "math.min != null");
 
             var minValue = (int)mathMin.Apply(null, new object[] { 5, 6, 2, 3, 7 });
             Assert.Equal(2, minValue);

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -322,7 +322,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void MarshalTypedArray()
         {
             Runtime.InvokeJS(@"

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -454,7 +454,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void MarshalTypedArrayByte()
         {
             Runtime.InvokeJS(@"
@@ -462,7 +461,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 App.call_test_method (""SetTypedArrayByte"", [ obj ]);
                 App.call_test_method (""GetTypedArrayByte"", [ obj ]);
             ");
-            Assert.Equal(11, HelperMarshal._taSByte.Length);
+            Assert.Equal(17, HelperMarshal._taByte.Length);
             Assert.Equal(104, HelperMarshal._taByte[0]);
             Assert.Equal(115, HelperMarshal._taByte[HelperMarshal._taByte.Length - 1]);
             Assert.Equal("hic sunt dracones", System.Text.Encoding.Default.GetString(HelperMarshal._taByte));
@@ -558,7 +557,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/40112")]
         public static void TestFunctionApply()
         {
             HelperMarshal._minValue = 0;

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1198,8 +1198,7 @@ var BindingSupportLib = {
 			return BINDING.js_string_to_mono_string ("Global object '" + js_name + "' not found.");
 		}
 
-		var result = BINDING.js_to_mono_obj (globalObj);
-		return result;
+		return BINDING.js_to_mono_obj (globalObj);
 	},
 	mono_wasm_release_handle: function(js_handle, is_exception) {
 		BINDING.bindings_lazy_init ();

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -635,17 +635,28 @@ var BindingSupportLib = {
 		},
 
 		extract_mono_obj: function (js_obj) {
-
 			if (js_obj === null || typeof js_obj === "undefined")
 				return 0;
 
-			if (!js_obj.is_mono_bridged_obj) {
-				var gc_handle = this.mono_wasm_register_obj(js_obj);
-				return this.wasm_get_raw_obj (gc_handle);
+			var result = null;
+			var gc_handle = js_obj.__mono_gchandle__;
+			if (gc_handle) {
+				result = this.wasm_get_raw_obj (gc_handle);
+
+				// It's possible the managed object corresponding to this JS object was collected,
+				//  in which case we need to make a new one.
+				if (!result) {
+					delete js_obj.__mono_gchandle__;
+					delete js_obj.is_mono_bridged_obj;
+				}
 			}
 
+			if (!result) {
+				gc_handle = this.mono_wasm_register_obj(js_obj);
+				result = this.wasm_get_raw_obj (gc_handle);
+			}
 
-			return this.wasm_get_raw_obj (js_obj.__mono_gchandle__);
+			return result;
 		},
 
 		extract_js_obj: function (mono_obj) {
@@ -1173,13 +1184,13 @@ var BindingSupportLib = {
 
 		var js_name = BINDING.conv_string (global_name);
 
-		var globalObj = undefined;
+		var globalObj = BINDING.mono_wasm_get_global();
 
-		if (!js_name) {
-			globalObj = globalThis;
-		}
-		else {
-			globalObj = globalThis[js_name];
+		if (js_name === null) {
+			if (global_name !== 0)
+				throw new Error("conv_string failed to convert string");
+		} else {
+			globalObj = globalObj[js_name];
 		}
 
 		if (globalObj === null || typeof globalObj === undefined) {
@@ -1187,7 +1198,11 @@ var BindingSupportLib = {
 			return BINDING.js_string_to_mono_string ("Global object '" + js_name + "' not found.");
 		}
 
-		return BINDING.js_to_mono_obj (globalObj);
+		var result = BINDING.js_to_mono_obj (globalObj);
+		// FIXME
+		if (result === 0)
+			console.log("BINDING.js_to_mono_obj(", globalObj, ") result for", global_name, "was 0");
+		return result;
 	},
 	mono_wasm_release_handle: function(js_handle, is_exception) {
 		BINDING.bindings_lazy_init ();

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1184,7 +1184,7 @@ var BindingSupportLib = {
 
 		var js_name = BINDING.conv_string (global_name);
 
-		var globalObj = BINDING.mono_wasm_get_global();
+		var globalObj = BINDING.mono_wasm_get_global ();
 
 		if (js_name === null) {
 			if (global_name !== 0)
@@ -1199,9 +1199,6 @@ var BindingSupportLib = {
 		}
 
 		var result = BINDING.js_to_mono_obj (globalObj);
-		// FIXME
-		if (result === 0)
-			console.log("BINDING.js_to_mono_obj(", globalObj, ") result for", global_name, "was 0");
 		return result;
 	},
 	mono_wasm_release_handle: function(js_handle, is_exception) {


### PR DESCRIPTION
This turned out to be much less spooky than it appeared once I realized it was actually just a broken test with a hidden dependency on whether specific other tests ran before it did.
I can't tell why the other two tests were disabled under the same issue ID, as they seem to work fine and they don't seem like they could have possibly been affected by the error in the test in question, so I'm turning them back on while we're at it.