### PR TITLE
[wasm][debugger][tests] Make `dotnet test DebuggerTestSuite.csproj` work

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -150,27 +150,15 @@ run-tests-jsc-%:
 run-tests-%:
 	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) $(MSBUILD_ARGS)
 
-build-debugger-test-app:
-	$(DOTNET) build --configuration debug --nologo /p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Configuration=Debug /p:RuntimeConfiguration=$(CONFIG) $(TOP)/src/mono/wasm/debugger/tests/debugger-test
-	$(DOTNET) build --configuration debug --nologo /p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Configuration=Debug /p:RuntimeConfiguration=$(CONFIG) $(TOP)/src/mono/wasm/debugger/tests/lazy-debugger-test
-	$(DOTNET) build --configuration debug --nologo /p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Configuration=Debug /p:RuntimeConfiguration=$(CONFIG) $(TOP)/src/mono/wasm/debugger/tests/lazy-debugger-test-embedded
-	cp $(TOP)/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html $(TOP)/src/mono/wasm/debugger/tests/debugger-test/bin/Debug/publish
-	cp $(TOP)/src/mono/wasm/debugger/tests/debugger-test/other.js $(TOP)/src/mono/wasm/debugger/tests/debugger-test/bin/Debug/publish
-	cp $(TOP)/src/mono/wasm/debugger/tests/debugger-test/runtime-debugger.js $(TOP)/src/mono/wasm/debugger/tests/debugger-test/bin/Debug/publish
-	cp $(TOP)/src/mono/wasm/debugger/tests/lazy-debugger-test/bin/Debug/publish/managed/* $(TOP)/src/mono/wasm/debugger/tests/debugger-test/bin/Debug/publish
-	cp $(TOP)/src/mono/wasm/debugger/tests/lazy-debugger-test-embedded/bin/Debug/publish/managed/* $(TOP)/src/mono/wasm/debugger/tests/debugger-test/bin/Debug/publish
-
-run-debugger-tests: build-debugger-test-app build-dbg-testsuite
+run-debugger-tests:
 	if [ ! -z "$(TEST_FILTER)" ]; then \
-		export TEST_SUITE_PATH=$(TOP)/src/mono/wasm/debugger/tests/debugger-test/bin/Debug/publish; \
 		export LC_ALL=en_US.UTF-8; \
 		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite --filter FullyQualifiedName~$(TEST_FILTER); \
-		unset TEST_SUITE_PATH LC_ALL; \
+		unset LC_ALL; \
 	else \
-		export TEST_SUITE_PATH=$(TOP)/src/mono/wasm/debugger/tests/debugger-test/bin/Debug/publish; \
 		export LC_ALL=en_US.UTF-8; \
 		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(TEST_ARGS); \
-		unset TEST_SUITE_PATH LC_ALL; \
+		unset LC_ALL; \
 	fi
 
 build-dbg-proxy:

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -4,12 +4,10 @@
     <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RunAnalyzers>false</RunAnalyzers>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-
     <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BrowserDebugHost\BrowserDebugHost.csproj" />
     <ProjectReference Include="..\BrowserDebugProxy\BrowserDebugProxy.csproj" />
+    <ProjectReference Include="..\tests\debugger-test\debugger-test.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Support.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Support.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.WebSockets;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -130,20 +131,12 @@ namespace DebuggerTests
 
         static protected string FindTestPath()
         {
-            //FIXME how would I locate it otherwise?
-            var test_path = Environment.GetEnvironmentVariable("TEST_SUITE_PATH");
-            //Lets try to guest
-            if (test_path != null && Directory.Exists(test_path))
-                return test_path;
+            var asm_dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var test_app_path = Path.Combine(asm_dir, "..", "..", "..", "debugger-test", "Debug", "publish");
+            if (File.Exists(Path.Combine(test_app_path, "debugger-driver.html")))
+                return test_app_path;
 
-            var cwd = Environment.CurrentDirectory;
-            Console.WriteLine("guessing from {0}", cwd);
-            //tests run from DebuggerTestSuite/bin/Debug/netcoreapp2.1
-            var new_path = Path.Combine(cwd, "../../../../bin/debugger-test-suite");
-            if (File.Exists(Path.Combine(new_path, "debugger-driver.html")))
-                return new_path;
-
-            throw new Exception("Missing TEST_SUITE_PATH env var and could not guess path from CWD");
+            throw new Exception($"Could not figure out debugger-test app path ({test_app_path}) based on the test suite location ({asm_dir})");
         }
 
         static string[] PROBE_LIST = {

--- a/src/mono/wasm/debugger/debugger.sln
+++ b/src/mono/wasm/debugger/debugger.sln
@@ -1,0 +1,73 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DebuggerTestSuite", "DebuggerTestSuite\DebuggerTestSuite.csproj", "{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lazy-debugger-test", "tests\lazy-debugger-test\lazy-debugger-test.csproj", "{BB824B8F-3E3B-48AB-86DB-168D15121372}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "debugger-test", "tests\debugger-test\debugger-test.csproj", "{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrowserDebugProxy", "BrowserDebugProxy\BrowserDebugProxy.csproj", "{532E9E35-D877-41A6-81F4-505AEA17AA04}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrowserDebugHost", "BrowserDebugHost\BrowserDebugHost.csproj", "{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lazy-debugger-test-embedded", "tests\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj", "{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Debug|x64.ActiveCfg = Debug|x64
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Debug|x64.Build.0 = Debug|x64
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Debug|x86.ActiveCfg = Debug|x86
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Debug|x86.Build.0 = Debug|x86
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Release|x64.ActiveCfg = Release|x64
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Release|x64.Build.0 = Release|x64
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Release|x86.ActiveCfg = Release|x86
+		{FF4CBDBF-EAC9-4531-A0F7-F3B834182862}.Release|x86.Build.0 = Release|x86
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Debug|x64.ActiveCfg = Debug|x64
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Debug|x64.Build.0 = Debug|x64
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Debug|x86.ActiveCfg = Debug|x86
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Debug|x86.Build.0 = Debug|x86
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Release|x64.ActiveCfg = Release|x64
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Release|x64.Build.0 = Release|x64
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Release|x86.ActiveCfg = Release|x86
+		{BB824B8F-3E3B-48AB-86DB-168D15121372}.Release|x86.Build.0 = Release|x86
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Debug|x64.ActiveCfg = Debug|x64
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Debug|x64.Build.0 = Debug|x64
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Debug|x86.ActiveCfg = Debug|x86
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Debug|x86.Build.0 = Debug|x86
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Release|x64.ActiveCfg = Release|x64
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Release|x64.Build.0 = Release|x64
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Release|x86.ActiveCfg = Release|x86
+		{6C3A70F3-12C1-457D-A8D7-1E0E335B1F66}.Release|x86.Build.0 = Release|x86
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Debug|x64.ActiveCfg = Debug|x64
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Debug|x64.Build.0 = Debug|x64
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Debug|x86.ActiveCfg = Debug|x86
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Debug|x86.Build.0 = Debug|x86
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Release|x64.ActiveCfg = Release|x64
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Release|x64.Build.0 = Release|x64
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Release|x86.ActiveCfg = Release|x86
+		{532E9E35-D877-41A6-81F4-505AEA17AA04}.Release|x86.Build.0 = Release|x86
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Debug|x64.ActiveCfg = Debug|x64
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Debug|x64.Build.0 = Debug|x64
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Debug|x86.ActiveCfg = Debug|x86
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Debug|x86.Build.0 = Debug|x86
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Release|x64.ActiveCfg = Release|x64
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Release|x64.Build.0 = Release|x64
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Release|x86.ActiveCfg = Release|x86
+		{E8A5E324-3FCD-4E3A-AC99-0C39037A8C1B}.Release|x86.Build.0 = Release|x86
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Debug|x64.ActiveCfg = Debug|x64
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Debug|x64.Build.0 = Debug|x64
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Debug|x86.ActiveCfg = Debug|x86
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Debug|x86.Build.0 = Debug|x86
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Release|x64.ActiveCfg = Release|x64
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Release|x64.Build.0 = Release|x64
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Release|x86.ActiveCfg = Release|x86
+		{1E2F50AA-DA21-4D71-AF07-F38B68026CAA}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/src/mono/wasm/debugger/tests/Directory.Build.props
+++ b/src/mono/wasm/debugger/tests/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\Directory.Build.props" />
+  <PropertyGroup>
+    <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
+    <TargetArchitecture>wasm</TargetArchitecture>
+    <TargetOS>Browser</TargetOS>
+    <OutputType>Library</OutputType>
+    <Configuration>Debug</Configuration>
+    <RuntimeBuildConfig Condition="'$(RuntimeBuildConfig)' == ''">$(Configuration)</RuntimeBuildConfig>
+
+    <AppDir>$(ArtifactsBinDir)debugger-test\$(Configuration)\publish</AppDir>
+    <OutDir>$(ArtifactsBinDir)debugger-test\$(Configuration)\wasm</OutDir>
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/Directory.Build.targets
+++ b/src/mono/wasm/debugger/tests/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <RuntimeConfiguration>Release</RuntimeConfiguration>
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -1,12 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="BuildApp">
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
-    <TargetArchitecture>wasm</TargetArchitecture>
-    <TargetOS>Browser</TargetOS>
-    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\Release\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
-    <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\wasm</BuildDir>
-    <AppDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\publish</AppDir>
-    <RuntimeBuildConfig Condition="'$(RuntimeBuildConfig)' == ''">$(Configuration)</RuntimeBuildConfig>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
     <NoWarn>219</NoWarn>
@@ -14,6 +7,16 @@
     <RunAnalyzers>false</RunAnalyzers>
     <DebugType>portable</DebugType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ExtraFileForPublish Include="debugger-driver.html" />
+    <ExtraFileForPublish Include="other.js" />
+    <ExtraFileForPublish Include="runtime-debugger.js" />
+
+    <!-- We want to bundle these assemblies, so build them first -->
+    <ProjectReference Include="..\lazy-debugger-test\lazy-debugger-test.csproj" Private="true"/>
+    <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" Private="true"/>
+  </ItemGroup>
 
   <Target Name="RebuildWasmAppBuilder">
     <ItemGroup>
@@ -33,19 +36,26 @@
              AssemblyFile="$(ArtifactsBinDir)WasmAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\publish\WasmAppBuilder.dll"/>
 
   <Target Name="BuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">
+    <PropertyGroup>
+      <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\Release\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
+    </PropertyGroup>
     <ItemGroup>
       <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)native"/>
       <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)"/>
+
+      <ExtraFileForPublish Include="@(ReferenceCopyLocalPaths)" />
     </ItemGroup>
+
     <WasmAppBuilder
       AppDir="$(AppDir)"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
-      MainAssembly="$(ArtifactsBinDir)debugger-test/wasm/Debug/debugger-test.dll"
+      MainAssembly="$(OutDir)debugger-test.dll"
       MainJS="$(MonoProjectRoot)wasm\runtime-test.js"
       DebugLevel="1"
       AssemblySearchPaths="@(AssemblySearchPaths)"
       ExtraAssemblies="$(ArtifactsBinDir)\System.Private.Runtime.InteropServices.JavaScript\$(NetCoreAppCurrent)-Browser-$(RuntimeConfiguration)\System.Private.Runtime.InteropServices.JavaScript.dll"/>
-    <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
+
+    <Copy SourceFiles="@(ExtraFileForPublish)" DestinationFolder="$(AppDir)" />
   </Target>
 
 </Project>

--- a/src/mono/wasm/debugger/tests/lazy-debugger-test-embedded/lazy-debugger-test-embedded.csproj
+++ b/src/mono/wasm/debugger/tests/lazy-debugger-test-embedded/lazy-debugger-test-embedded.csproj
@@ -1,50 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="BuildApp">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
-    <TargetArchitecture>wasm</TargetArchitecture>
-    <TargetOS>Browser</TargetOS>
-    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\Release\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
-    <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\wasm</BuildDir>
-    <AppDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\publish</AppDir>
-    <RuntimeBuildConfig Condition="'$(RuntimeBuildConfig)' == ''">$(Configuration)</RuntimeBuildConfig>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
     <NoWarn>219</NoWarn>
     <RunAnalyzers>false</RunAnalyzers>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
-
-  <Target Name="RebuildWasmAppBuilder">
-    <ItemGroup>
-      <WasmAppBuildProject Include="$(RepoTasksDir)mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj" />
-    </ItemGroup>
-
-    <MSBuild Projects="@(WasmAppBuildProject)"
-             Properties="Configuration=$(Configuration);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
-             Targets="Restore"/>
-
-    <MSBuild Projects="@(WasmAppBuildProject)"
-             Properties="Configuration=$(Configuration)"
-             Targets="Build;Publish"/>
-  </Target>
-
-  <UsingTask TaskName="WasmAppBuilder"
-             AssemblyFile="$(ArtifactsBinDir)WasmAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\publish\WasmAppBuilder.dll"/>
-
-  <Target Name="BuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">
-    <ItemGroup>
-      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)native"/>
-      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)"/>
-    </ItemGroup>
-    <WasmAppBuilder
-      AppDir="$(AppDir)"
-      MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
-      MainAssembly="$(ArtifactsBinDir)lazy-debugger-test-embedded/wasm/Debug/lazy-debugger-test-embedded.dll"
-      MainJS="$(MonoProjectRoot)wasm\runtime-test.js"
-      DebugLevel="1"
-      AssemblySearchPaths="@(AssemblySearchPaths)"
-      ExtraAssemblies="$(ArtifactsBinDir)\System.Private.Runtime.InteropServices.JavaScript\$(NetCoreAppCurrent)-Browser-$(RuntimeConfiguration)\System.Private.Runtime.InteropServices.JavaScript.dll"/>
-    <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
-  </Target>
-
 </Project>

--- a/src/mono/wasm/debugger/tests/lazy-debugger-test/lazy-debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/lazy-debugger-test/lazy-debugger-test.csproj
@@ -1,50 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="BuildApp">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
-    <TargetArchitecture>wasm</TargetArchitecture>
-    <TargetOS>Browser</TargetOS>
-    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\Release\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
-    <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\wasm</BuildDir>
-    <AppDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\publish</AppDir>
-    <RuntimeBuildConfig Condition="'$(RuntimeBuildConfig)' == ''">$(Configuration)</RuntimeBuildConfig>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
     <NoWarn>219</NoWarn>
     <RunAnalyzers>false</RunAnalyzers>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-
-  <Target Name="RebuildWasmAppBuilder">
-    <ItemGroup>
-      <WasmAppBuildProject Include="$(RepoTasksDir)mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj" />
-    </ItemGroup>
-
-    <MSBuild Projects="@(WasmAppBuildProject)"
-             Properties="Configuration=$(Configuration);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
-             Targets="Restore"/>
-
-    <MSBuild Projects="@(WasmAppBuildProject)"
-             Properties="Configuration=$(Configuration)"
-             Targets="Build;Publish"/>
-  </Target>
-
-  <UsingTask TaskName="WasmAppBuilder"
-             AssemblyFile="$(ArtifactsBinDir)WasmAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\publish\WasmAppBuilder.dll"/>
-
-  <Target Name="BuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">
-    <ItemGroup>
-      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)native"/>
-      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)"/>
-    </ItemGroup>
-    <WasmAppBuilder
-      AppDir="$(AppDir)"
-      MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
-      MainAssembly="$(ArtifactsBinDir)lazy-debugger-test/wasm/Debug/lazy-debugger-test.dll"
-      MainJS="$(MonoProjectRoot)wasm\runtime-test.js"
-      DebugLevel="1"
-      AssemblySearchPaths="@(AssemblySearchPaths)"
-      ExtraAssemblies="$(ArtifactsBinDir)\System.Private.Runtime.InteropServices.JavaScript\$(NetCoreAppCurrent)-Browser-$(RuntimeConfiguration)\System.Private.Runtime.InteropServices.JavaScript.dll"/>
-    <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
Now, the tests can be run with `dotnet test DebuggerTestSuite.csproj`.
and the existing `make run-debugger-tests` still works.

Changes:

- We don't need to use wasmAppBuilder for all the test projects, only
`debugger-test`.
	- Other assemblies just get bundled with `debugger-test`

- Move common properties to `Directory.Build.*`
- And move the settings being used for debugger-test in the Makefile to
msbuild:
	- RuntimeConfiguration defaults to Release, same as what the
	Makefile did

- build all the debugger-tests in artifacts dir
- And instead of `TEST_SUITE_PATH`, determine the debugger-tests path
based on the testsuite itself.

- We can then remove `build-debugger-test-app`