### PR TITLE
Port ComWrappers 5.0 diagnostic changes back to master and add stowed exception array to minidumps

### DIFF
--- a/src/coreclr/src/debug/daccess/dacimpl.h
+++ b/src/coreclr/src/debug/daccess/dacimpl.h
@@ -1482,6 +1482,7 @@ private:
 #endif
 
 #ifdef FEATURE_COMWRAPPERS
+    BOOL DACGetComWrappersCCWVTableQIAddress(CLRDATA_ADDRESS ccwPtr, TADDR *vTableAddress, TADDR *qiAddress);
     BOOL DACIsComWrappersCCW(CLRDATA_ADDRESS ccwPtr);
     TADDR DACGetManagedObjectWrapperFromCCW(CLRDATA_ADDRESS ccwPtr);
     HRESULT DACTryGetComWrappersObjectFromCCW(CLRDATA_ADDRESS ccwPtr, OBJECTREF* objRef);
@@ -4035,5 +4036,37 @@ extern unsigned __int64 g_nStackWalk;
 extern unsigned __int64 g_nFindStackTotalTime;
 
 #endif // #if defined(DAC_MEASURE_PERF)
+
+#ifdef FEATURE_COMWRAPPERS
+
+// Public contract for ExternalObjectContext, keep in sync with definition in
+// interoplibinterface.cpp
+struct ExternalObjectContextDACnterface
+{
+    PTR_VOID identity;
+    INT_PTR _padding1;
+    DWORD SyncBlockIndex;
+    INT64 _padding3;
+};
+
+typedef DPTR(ExternalObjectContextDACnterface) PTR_ExternalObjectContext;
+
+// Public contract for ManagedObjectWrapper, keep in sync with definition in
+// comwrappers.hpp
+struct ManagedObjectWrapperDACInterface
+{
+    PTR_VOID managedObject;
+    INT32 _padding1;
+    INT32 _padding2;
+    INT_PTR _padding3;
+    INT_PTR _padding4;
+    INT_PTR _padding6;
+    LONGLONG _refCount;
+    INT32 _padding7;
+};
+
+typedef DPTR(ManagedObjectWrapperDACInterface) PTR_ManagedObjectWrapper;
+
+#endif // FEATURE_COMWRAPPERS
 
 #endif // #ifndef __DACIMPL_H__

--- a/src/coreclr/src/debug/daccess/request.cpp
+++ b/src/coreclr/src/debug/daccess/request.cpp
@@ -5013,5 +5013,3 @@ HRESULT ClrDataAccess::GetComWrappersRCWData(CLRDATA_ADDRESS rcw, CLRDATA_ADDRES
     return E_NOTIMPL;
 #endif // FEATURE_COMWRAPPERS
 }
-
-#error You need to make !dumpobj on the stowedexception and !analyze in a minidump work!

--- a/src/coreclr/src/debug/daccess/request.cpp
+++ b/src/coreclr/src/debug/daccess/request.cpp
@@ -23,36 +23,6 @@
 #ifdef FEATURE_COMWRAPPERS
 #include <interoplibinterface.h>
 #include <interoplibabi.h>
-
-// Public contract for ExternalObjectContext, keep in sync with definition in
-// interoplibinterface.cpp
-struct ExternalObjectContextDACnterface
-{
-    INT_PTR sentinel;
-    PTR_VOID identity;
-    INT_PTR _padding1;
-    DWORD _padding2;
-    INT64 _padding3;
-};
-
-typedef DPTR(ExternalObjectContextDACnterface) PTR_ExternalObjectContext;
-
-// Public contract for ManagedObjectWrapper, keep in sync with definition in
-// comwrappers.hpp
-struct ManagedObjectWrapperDACInterface
-{
-    PTR_VOID managedObject;
-    INT32 _padding1;
-    INT32 _padding2;
-    INT_PTR _padding3;
-    INT_PTR _padding4;
-    INT_PTR _padding6;
-    LONGLONG _refCount;
-    INT32 _padding7;
-};
-
-typedef DPTR(ManagedObjectWrapperDACInterface) PTR_ManagedObjectWrapper;
-
 #endif // FEATURE_COMWRAPPERS
 
 #ifndef TARGET_UNIX
@@ -4105,22 +4075,23 @@ PTR_IUnknown ClrDataAccess::DACGetCOMIPFromCCW(PTR_ComCallWrapper pCCW, int vtab
 #endif
 
 #ifdef FEATURE_COMWRAPPERS
-BOOL ClrDataAccess::DACIsComWrappersCCW(CLRDATA_ADDRESS ccwPtr)
+BOOL ClrDataAccess::DACGetComWrappersCCWVTableQIAddress(CLRDATA_ADDRESS ccwPtr, TADDR *vTableAddress, TADDR *qiAddress)
 {
-    // Read CCWs QI address and compare it to the managed object wrapper's implementation.
+    _ASSERTE(vTableAddress != NULL && qiAddress != NULL);
+
     HRESULT hr = S_OK;
     ULONG32 bytesRead = 0;
     TADDR ccw = CLRDATA_ADDRESS_TO_TADDR(ccwPtr);
-    TADDR vTableAddress = NULL;
-    if (FAILED(m_pTarget->ReadVirtual(ccw, (PBYTE)&vTableAddress, sizeof(TADDR), &bytesRead))
+    *vTableAddress = NULL;
+    if (FAILED(m_pTarget->ReadVirtual(ccw, (PBYTE)vTableAddress, sizeof(TADDR), &bytesRead))
         || bytesRead != sizeof(TADDR)
         || vTableAddress == NULL)
     {
         return FALSE;
     }
 
-    TADDR qiAddress = NULL;
-    if (FAILED(m_pTarget->ReadVirtual(vTableAddress, (PBYTE)&qiAddress, sizeof(TADDR), &bytesRead))
+    *qiAddress = NULL;
+    if (FAILED(m_pTarget->ReadVirtual(*vTableAddress, (PBYTE)qiAddress, sizeof(TADDR), &bytesRead))
         || bytesRead != sizeof(TADDR)
         || qiAddress == NULL)
     {
@@ -4130,15 +4101,22 @@ BOOL ClrDataAccess::DACIsComWrappersCCW(CLRDATA_ADDRESS ccwPtr)
 
 #ifdef TARGET_ARM
     // clear the THUMB bit on qiAddress before comparing with known vtable entry
-    qiAddress &= ~THUMB_CODE;
+    *qiAddress &= ~THUMB_CODE;
 #endif
 
-    if (qiAddress != GetEEFuncEntryPoint(ManagedObjectWrapper_QueryInterface))
+    return TRUE;
+}
+
+BOOL ClrDataAccess::DACIsComWrappersCCW(CLRDATA_ADDRESS ccwPtr)
+{
+    TADDR vTableAddress = NULL;
+    TADDR qiAddress = NULL;
+    if (!DACGetComWrappersCCWVTableQIAddress(ccwPtr, &vTableAddress, &qiAddress))
     {
         return FALSE;
     }
 
-    return TRUE;
+    return qiAddress == GetEEFuncEntryPoint(ManagedObjectWrapper_QueryInterface);
 }
 
 TADDR ClrDataAccess::DACGetManagedObjectWrapperFromCCW(CLRDATA_ADDRESS ccwPtr)
@@ -4174,8 +4152,6 @@ HRESULT ClrDataAccess::DACTryGetComWrappersObjectFromCCW(CLRDATA_ADDRESS ccwPtr,
     }
 
     TADDR ccw = CLRDATA_ADDRESS_TO_TADDR(ccwPtr);
-    // Mask the "dispatch pointer" to get a double pointer to the ManagedObjectWrapper
-    TADDR managedObjectWrapperPtrPtr = ccw & InteropLib::ABI::DispatchThisPtrMask;
 
     // Return ManagedObjectWrapper as an OBJECTHANDLE. (The OBJECTHANDLE is guaranteed to live at offset 0).
     TADDR managedObjectWrapperPtr = DACGetManagedObjectWrapperFromCCW(ccwPtr);
@@ -4819,14 +4795,6 @@ HRESULT ClrDataAccess::GetObjectComWrappersData(CLRDATA_ADDRESS objAddr, CLRDATA
     }
 
     SOSDacEnter();
-    auto ComWrapperCallback = [](void *mocw, void *additionalData)
-    {
-        CQuickArrayList<CLRDATA_ADDRESS> *comWrappers = (CQuickArrayList<CLRDATA_ADDRESS>*)additionalData;
-
-        comWrappers->Push(TO_CDADDR(mocw));
-
-    };
-
     if (pNeeded != NULL)
     {
         *pNeeded = 0;
@@ -4845,11 +4813,24 @@ HRESULT ClrDataAccess::GetObjectComWrappersData(CLRDATA_ADDRESS objAddr, CLRDATA
         {
             if (rcw != NULL)
             {
-                *rcw = PTR_CDADDR(pInfo->m_externalComObjectContext);
+                *rcw = TO_TADDR(pInfo->m_externalComObjectContext);
             }
 
+            DPTR(NewHolder<ManagedObjectComWrapperByIdMap>) mapHolder(PTR_TO_MEMBER_TADDR(InteropSyncBlockInfo, pInfo, m_managedObjectComWrapperMap));
+            DPTR(ManagedObjectComWrapperByIdMap *)ppMap(PTR_TO_MEMBER_TADDR(NewHolder<ManagedObjectComWrapperByIdMap>, mapHolder, m_value));
+            DPTR(ManagedObjectComWrapperByIdMap) pMap(TO_TADDR(*ppMap));
+
             CQuickArrayList<CLRDATA_ADDRESS> comWrappers;
-            pInfo->IterateComWrappers(ComWrapperCallback, (void *)&comWrappers);
+            if (pMap != NULL)
+            {
+                ManagedObjectComWrapperByIdMap::Iterator iter = pMap->Begin();
+                while (iter != pMap->End())
+                {
+                    comWrappers.Push(TO_CDADDR(iter->Value()));
+                    ++iter;
+                
+                }
+            }
 
             if (pNeeded != NULL)
             {
@@ -4963,16 +4944,48 @@ HRESULT ClrDataAccess::IsComWrappersRCW(CLRDATA_ADDRESS rcw, BOOL *isComWrappers
     }
 
     SOSDacEnter();
-
-    PTR_ExternalObjectContext pEOC(TO_TADDR(rcw));
+    
     if (isComWrappersRCW != NULL)
     {
-        *isComWrappersRCW = pEOC->sentinel == ExternalObjectContextSentinelValue;
+        PTR_ExternalObjectContext pRCW(TO_TADDR(rcw));
+        BOOL stillValid = TRUE;
+        if(pRCW->SyncBlockIndex >= SyncBlockCache::s_pSyncBlockCache->m_SyncTableSize)
+        {
+            stillValid = FALSE;
+        }
+
+        PTR_SyncBlock pSyncBlk = NULL;
+        if (stillValid)
+        {
+            PTR_SyncTableEntry ste = PTR_SyncTableEntry(dac_cast<TADDR>(g_pSyncTable) + (sizeof(SyncTableEntry) * pRCW->SyncBlockIndex));
+            pSyncBlk = ste->m_SyncBlock;
+            if(pSyncBlk == NULL)
+            {
+                stillValid = FALSE;
+            }
+        }
+
+        PTR_InteropSyncBlockInfo pInfo = NULL;
+        if (stillValid)
+        {   
+            pInfo = pSyncBlk->GetInteropInfoNoCreate();
+            if(pInfo == NULL)
+            {
+                stillValid = FALSE;
+            }
+        }
+
+        if (stillValid)
+        {
+            stillValid = TO_TADDR(pInfo->m_externalComObjectContext) == PTR_HOST_TO_TADDR(pRCW);
+        }
+
+        *isComWrappersRCW = stillValid;
         hr = *isComWrappersRCW ? S_OK : S_FALSE; 
     }
 
     SOSDacLeave();
-    return hr;
+    return hr;    
 #else // FEATURE_COMWRAPPERS
     return E_NOTIMPL;
 #endif // FEATURE_COMWRAPPERS
@@ -4989,12 +5002,6 @@ HRESULT ClrDataAccess::GetComWrappersRCWData(CLRDATA_ADDRESS rcw, CLRDATA_ADDRES
     SOSDacEnter();
     
     PTR_ExternalObjectContext pEOC(TO_TADDR(rcw));
-    if (pEOC->sentinel != ExternalObjectContextSentinelValue)
-    {
-        // Not a ComWrappers RCW
-        hr = E_INVALIDARG;
-    }
-    
     if (identity != NULL)
     {
         *identity = PTR_CDADDR(pEOC->identity);
@@ -5006,3 +5013,5 @@ HRESULT ClrDataAccess::GetComWrappersRCWData(CLRDATA_ADDRESS rcw, CLRDATA_ADDRES
     return E_NOTIMPL;
 #endif // FEATURE_COMWRAPPERS
 }
+
+#error You need to make !dumpobj on the stowedexception and !analyze in a minidump work!

--- a/src/coreclr/src/inc/holder.h
+++ b/src/coreclr/src/inc/holder.h
@@ -115,6 +115,8 @@ struct AutoExpVisibleValue
 template <typename TYPE>
 class HolderBase
 {
+    friend class ClrDataAccess;
+
   protected:
     TYPE    m_value;
 
@@ -227,6 +229,7 @@ template
     >
 class BaseHolder : protected BASE
 {
+    friend class ClrDataAccess;
   protected:
     BOOL    m_acquired;      // Have we acquired the resource?
 
@@ -695,6 +698,7 @@ FORCEINLINE void SafeArrayDoNothing(SAFEARRAY* p)
 template <typename TYPE, void (*ACQUIREF)(TYPE), void (*RELEASEF)(TYPE)>
 class FunctionBase : protected HolderBase<TYPE>
 {
+    friend class ClrDataAccess;
   protected:
 
     FORCEINLINE FunctionBase(TYPE value)

--- a/src/coreclr/src/interop/comwrappers.hpp
+++ b/src/coreclr/src/interop/comwrappers.hpp
@@ -117,10 +117,9 @@ public: // Lifetime
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR * __RPC_FAR * ppvObject);
     ULONG AddRef(void);
     ULONG Release(void);
-
 };
 
-// These Sentinel and Identity are used by the DAC, any changes to the layout must be updated on the DAC side (request.cpp)
+// The Target and _refCount fields are used by the DAC, any changes to the layout must be updated on the DAC side (request.cpp)
 static constexpr size_t DACTargetOffset = 0;
 static_assert(offsetof(ManagedObjectWrapper, Target) == DACTargetOffset, "Keep in sync with DAC interfaces");
 static constexpr size_t DACRefCountOffset = (4 * sizeof(intptr_t)) + (2 * sizeof(int32_t));

--- a/src/coreclr/src/pal/prebuilt/inc/sospriv.h
+++ b/src/coreclr/src/pal/prebuilt/inc/sospriv.h
@@ -4,11 +4,13 @@
 
 
  /* File created by MIDL compiler version 8.01.0622 */
-/* Compiler settings for sospriv.idl:
-    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622 
+/* at Mon Jan 18 19:14:07 2038
+ */
+/* Compiler settings for C:/git/runtime/src/coreclr/src/inc/sospriv.idl:
+    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622
     protocol : dce , ms_ext, c_ext, robust
-    error checks: allocation ref bounds_check enum stub_data 
-    VC __declspec() decoration level: 
+    error checks: allocation ref bounds_check enum stub_data
+    VC __declspec() decoration level:
          __declspec(uuid()), __declspec(selectany), __declspec(novtable)
          DECLSPEC_UUID(), MIDL_INTERFACE()
 */
@@ -41,7 +43,7 @@
 #pragma once
 #endif
 
-/* Forward Declarations */ 
+/* Forward Declarations */
 
 #ifndef __ISOSEnum_FWD_DEFINED__
 #define __ISOSEnum_FWD_DEFINED__
@@ -147,11 +149,11 @@ typedef interface ISOSDacInterface10 ISOSDacInterface10;
 
 #ifdef __cplusplus
 extern "C"{
-#endif 
+#endif
 
 
 /* interface __MIDL_itf_sospriv_0000_0000 */
-/* [local] */ 
+/* [local] */
 
 
 
@@ -195,24 +197,24 @@ typedef int VCSHeapType;
 #endif
 typedef enum { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE } ModuleMapType;
 typedef enum {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap} VCSHeapType;
-typedef void ( *MODULEMAPTRAVERSE )( 
+typedef void ( *MODULEMAPTRAVERSE )(
     UINT index,
     CLRDATA_ADDRESS methodTable,
     LPVOID token);
 
-typedef void ( *VISITHEAP )( 
+typedef void ( *VISITHEAP )(
     CLRDATA_ADDRESS blockData,
     size_t blockSize,
     BOOL blockIsCurrentBlock);
 
-typedef BOOL ( *VISITRCWFORCLEANUP )( 
+typedef BOOL ( *VISITRCWFORCLEANUP )(
     CLRDATA_ADDRESS RCW,
     CLRDATA_ADDRESS Context,
     CLRDATA_ADDRESS Thread,
     BOOL bIsFreeThreaded,
     LPVOID token);
 
-typedef BOOL ( *DUMPEHINFO )( 
+typedef BOOL ( *DUMPEHINFO )(
     UINT clauseIndex,
     UINT totalClauses,
     struct DACEHInfo *pEHInfo,
@@ -242,57 +244,57 @@ extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0000_v0_0_s_ifspec;
 #define __ISOSEnum_INTERFACE_DEFINED__
 
 /* interface ISOSEnum */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSEnum;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("286CA186-E763-4F61-9760-487D43AE4341")
     ISOSEnum : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE Skip( 
+        virtual HRESULT STDMETHODCALLTYPE Skip(
             /* [in] */ unsigned int count) = 0;
-        
+
         virtual HRESULT STDMETHODCALLTYPE Reset( void) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetCount( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetCount(
             /* [out] */ unsigned int *pCount) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSEnumVtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSEnum * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSEnum * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *Skip )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Skip )(
             ISOSEnum * This,
             /* [in] */ unsigned int count);
-        
-        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Reset )(
             ISOSEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCount )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCount )(
             ISOSEnum * This,
             /* [out] */ unsigned int *pCount);
-        
+
         END_INTERFACE
     } ISOSEnumVtbl;
 
@@ -301,29 +303,29 @@ EXTERN_C const IID IID_ISOSEnum;
         CONST_VTBL struct ISOSEnumVtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSEnum_QueryInterface(This,riid,ppvObject)    \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSEnum_AddRef(This)   \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSEnum_Release(This)  \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSEnum_Skip(This,count)   \
-    ( (This)->lpVtbl -> Skip(This,count) ) 
+    ( (This)->lpVtbl -> Skip(This,count) )
 
 #define ISOSEnum_Reset(This)    \
-    ( (This)->lpVtbl -> Reset(This) ) 
+    ( (This)->lpVtbl -> Reset(This) )
 
 #define ISOSEnum_GetCount(This,pCount)  \
-    ( (This)->lpVtbl -> GetCount(This,pCount) ) 
+    ( (This)->lpVtbl -> GetCount(This,pCount) )
 
 #endif /* COBJMACROS */
 
@@ -340,60 +342,60 @@ EXTERN_C const IID IID_ISOSEnum;
 #define __ISOSHandleEnum_INTERFACE_DEFINED__
 
 /* interface ISOSHandleEnum */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSHandleEnum;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("3E269830-4A2B-4301-8EE2-D6805B29B2FA")
     ISOSHandleEnum : public ISOSEnum
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE Next( 
+        virtual HRESULT STDMETHODCALLTYPE Next(
             /* [in] */ unsigned int count,
             /* [length_is][size_is][out] */ SOSHandleData handles[  ],
             /* [out] */ unsigned int *pNeeded) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSHandleEnumVtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSHandleEnum * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSHandleEnum * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSHandleEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *Skip )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Skip )(
             ISOSHandleEnum * This,
             /* [in] */ unsigned int count);
-        
-        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Reset )(
             ISOSHandleEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCount )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCount )(
             ISOSHandleEnum * This,
             /* [out] */ unsigned int *pCount);
-        
-        HRESULT ( STDMETHODCALLTYPE *Next )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Next )(
             ISOSHandleEnum * This,
             /* [in] */ unsigned int count,
             /* [length_is][size_is][out] */ SOSHandleData handles[  ],
             /* [out] */ unsigned int *pNeeded);
-        
+
         END_INTERFACE
     } ISOSHandleEnumVtbl;
 
@@ -402,33 +404,33 @@ EXTERN_C const IID IID_ISOSHandleEnum;
         CONST_VTBL struct ISOSHandleEnumVtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSHandleEnum_QueryInterface(This,riid,ppvObject)  \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSHandleEnum_AddRef(This) \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSHandleEnum_Release(This)    \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSHandleEnum_Skip(This,count) \
-    ( (This)->lpVtbl -> Skip(This,count) ) 
+    ( (This)->lpVtbl -> Skip(This,count) )
 
 #define ISOSHandleEnum_Reset(This)  \
-    ( (This)->lpVtbl -> Reset(This) ) 
+    ( (This)->lpVtbl -> Reset(This) )
 
 #define ISOSHandleEnum_GetCount(This,pCount)    \
-    ( (This)->lpVtbl -> GetCount(This,pCount) ) 
+    ( (This)->lpVtbl -> GetCount(This,pCount) )
 
 
 #define ISOSHandleEnum_Next(This,count,handles,pNeeded) \
-    ( (This)->lpVtbl -> Next(This,count,handles,pNeeded) ) 
+    ( (This)->lpVtbl -> Next(This,count,handles,pNeeded) )
 
 #endif /* COBJMACROS */
 
@@ -442,18 +444,18 @@ EXTERN_C const IID IID_ISOSHandleEnum;
 
 
 /* interface __MIDL_itf_sospriv_0000_0002 */
-/* [local] */ 
+/* [local] */
 
 #ifndef _SOS_StackReference_
 #define _SOS_StackReference_
-typedef 
+typedef
 enum SOSStackSourceType
     {
         SOS_StackSourceIP   = 0,
-        SOS_StackSourceFrame    = ( SOS_StackSourceIP + 1 ) 
+        SOS_StackSourceFrame    = ( SOS_StackSourceIP + 1 )
     }   SOSStackSourceType;
 
-typedef 
+typedef
 enum SOSRefFlags
     {
         SOSRefInterior  = 1,
@@ -490,60 +492,60 @@ extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0002_v0_0_s_ifspec;
 #define __ISOSStackRefErrorEnum_INTERFACE_DEFINED__
 
 /* interface ISOSStackRefErrorEnum */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSStackRefErrorEnum;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("774F4E1B-FB7B-491B-976D-A8130FE355E9")
     ISOSStackRefErrorEnum : public ISOSEnum
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE Next( 
+        virtual HRESULT STDMETHODCALLTYPE Next(
             /* [in] */ unsigned int count,
             /* [length_is][size_is][out] */ SOSStackRefError ref[  ],
             /* [out] */ unsigned int *pFetched) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSStackRefErrorEnumVtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSStackRefErrorEnum * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSStackRefErrorEnum * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSStackRefErrorEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *Skip )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Skip )(
             ISOSStackRefErrorEnum * This,
             /* [in] */ unsigned int count);
-        
-        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Reset )(
             ISOSStackRefErrorEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCount )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCount )(
             ISOSStackRefErrorEnum * This,
             /* [out] */ unsigned int *pCount);
-        
-        HRESULT ( STDMETHODCALLTYPE *Next )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Next )(
             ISOSStackRefErrorEnum * This,
             /* [in] */ unsigned int count,
             /* [length_is][size_is][out] */ SOSStackRefError ref[  ],
             /* [out] */ unsigned int *pFetched);
-        
+
         END_INTERFACE
     } ISOSStackRefErrorEnumVtbl;
 
@@ -552,33 +554,33 @@ EXTERN_C const IID IID_ISOSStackRefErrorEnum;
         CONST_VTBL struct ISOSStackRefErrorEnumVtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSStackRefErrorEnum_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSStackRefErrorEnum_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSStackRefErrorEnum_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSStackRefErrorEnum_Skip(This,count)  \
-    ( (This)->lpVtbl -> Skip(This,count) ) 
+    ( (This)->lpVtbl -> Skip(This,count) )
 
 #define ISOSStackRefErrorEnum_Reset(This)   \
-    ( (This)->lpVtbl -> Reset(This) ) 
+    ( (This)->lpVtbl -> Reset(This) )
 
 #define ISOSStackRefErrorEnum_GetCount(This,pCount) \
-    ( (This)->lpVtbl -> GetCount(This,pCount) ) 
+    ( (This)->lpVtbl -> GetCount(This,pCount) )
 
 
 #define ISOSStackRefErrorEnum_Next(This,count,ref,pFetched) \
-    ( (This)->lpVtbl -> Next(This,count,ref,pFetched) ) 
+    ( (This)->lpVtbl -> Next(This,count,ref,pFetched) )
 
 #endif /* COBJMACROS */
 
@@ -595,67 +597,67 @@ EXTERN_C const IID IID_ISOSStackRefErrorEnum;
 #define __ISOSStackRefEnum_INTERFACE_DEFINED__
 
 /* interface ISOSStackRefEnum */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSStackRefEnum;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("8FA642BD-9F10-4799-9AA3-512AE78C77EE")
     ISOSStackRefEnum : public ISOSEnum
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE Next( 
+        virtual HRESULT STDMETHODCALLTYPE Next(
             /* [in] */ unsigned int count,
             /* [length_is][size_is][out] */ SOSStackRefData ref[  ],
             /* [out] */ unsigned int *pFetched) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE EnumerateErrors( 
+
+        virtual HRESULT STDMETHODCALLTYPE EnumerateErrors(
             /* [out] */ ISOSStackRefErrorEnum **ppEnum) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSStackRefEnumVtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSStackRefEnum * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSStackRefEnum * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSStackRefEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *Skip )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Skip )(
             ISOSStackRefEnum * This,
             /* [in] */ unsigned int count);
-        
-        HRESULT ( STDMETHODCALLTYPE *Reset )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Reset )(
             ISOSStackRefEnum * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCount )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCount )(
             ISOSStackRefEnum * This,
             /* [out] */ unsigned int *pCount);
-        
-        HRESULT ( STDMETHODCALLTYPE *Next )( 
+
+        HRESULT ( STDMETHODCALLTYPE *Next )(
             ISOSStackRefEnum * This,
             /* [in] */ unsigned int count,
             /* [length_is][size_is][out] */ SOSStackRefData ref[  ],
             /* [out] */ unsigned int *pFetched);
-        
-        HRESULT ( STDMETHODCALLTYPE *EnumerateErrors )( 
+
+        HRESULT ( STDMETHODCALLTYPE *EnumerateErrors )(
             ISOSStackRefEnum * This,
             /* [out] */ ISOSStackRefErrorEnum **ppEnum);
-        
+
         END_INTERFACE
     } ISOSStackRefEnumVtbl;
 
@@ -664,36 +666,36 @@ EXTERN_C const IID IID_ISOSStackRefEnum;
         CONST_VTBL struct ISOSStackRefEnumVtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSStackRefEnum_QueryInterface(This,riid,ppvObject)    \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSStackRefEnum_AddRef(This)   \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSStackRefEnum_Release(This)  \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSStackRefEnum_Skip(This,count)   \
-    ( (This)->lpVtbl -> Skip(This,count) ) 
+    ( (This)->lpVtbl -> Skip(This,count) )
 
 #define ISOSStackRefEnum_Reset(This)    \
-    ( (This)->lpVtbl -> Reset(This) ) 
+    ( (This)->lpVtbl -> Reset(This) )
 
 #define ISOSStackRefEnum_GetCount(This,pCount)  \
-    ( (This)->lpVtbl -> GetCount(This,pCount) ) 
+    ( (This)->lpVtbl -> GetCount(This,pCount) )
 
 
 #define ISOSStackRefEnum_Next(This,count,ref,pFetched)  \
-    ( (This)->lpVtbl -> Next(This,count,ref,pFetched) ) 
+    ( (This)->lpVtbl -> Next(This,count,ref,pFetched) )
 
 #define ISOSStackRefEnum_EnumerateErrors(This,ppEnum)   \
-    ( (This)->lpVtbl -> EnumerateErrors(This,ppEnum) ) 
+    ( (This)->lpVtbl -> EnumerateErrors(This,ppEnum) )
 
 #endif /* COBJMACROS */
 
@@ -710,546 +712,546 @@ EXTERN_C const IID IID_ISOSStackRefEnum;
 #define __ISOSDacInterface_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("436f00f2-b42a-4b9f-870c-e73db66ae930")
     ISOSDacInterface : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetThreadStoreData( 
+        virtual HRESULT STDMETHODCALLTYPE GetThreadStoreData(
             struct DacpThreadStoreData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAppDomainStoreData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAppDomainStoreData(
             struct DacpAppDomainStoreData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAppDomainList( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAppDomainList(
             unsigned int count,
             CLRDATA_ADDRESS values[  ],
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAppDomainData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAppDomainData(
             CLRDATA_ADDRESS addr,
             struct DacpAppDomainData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAppDomainName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAppDomainName(
             CLRDATA_ADDRESS addr,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetDomainFromContext( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetDomainFromContext(
             CLRDATA_ADDRESS context,
             CLRDATA_ADDRESS *domain) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAssemblyList( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAssemblyList(
             CLRDATA_ADDRESS appDomain,
             int count,
             CLRDATA_ADDRESS values[  ],
             int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAssemblyData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAssemblyData(
             CLRDATA_ADDRESS baseDomainPtr,
             CLRDATA_ADDRESS assembly,
             struct DacpAssemblyData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAssemblyName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAssemblyName(
             CLRDATA_ADDRESS assembly,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetModule( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetModule(
             CLRDATA_ADDRESS addr,
             IXCLRDataModule **mod) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetModuleData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetModuleData(
             CLRDATA_ADDRESS moduleAddr,
             struct DacpModuleData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE TraverseModuleMap( 
+
+        virtual HRESULT STDMETHODCALLTYPE TraverseModuleMap(
             ModuleMapType mmt,
             CLRDATA_ADDRESS moduleAddr,
             MODULEMAPTRAVERSE pCallback,
             LPVOID token) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAssemblyModuleList( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAssemblyModuleList(
             CLRDATA_ADDRESS assembly,
             unsigned int count,
             CLRDATA_ADDRESS modules[  ],
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetILForModule( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetILForModule(
             CLRDATA_ADDRESS moduleAddr,
             DWORD rva,
             CLRDATA_ADDRESS *il) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetThreadData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetThreadData(
             CLRDATA_ADDRESS thread,
             struct DacpThreadData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetThreadFromThinlockID( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetThreadFromThinlockID(
             UINT thinLockId,
             CLRDATA_ADDRESS *pThread) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetStackLimits( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetStackLimits(
             CLRDATA_ADDRESS threadPtr,
             CLRDATA_ADDRESS *lower,
             CLRDATA_ADDRESS *upper,
             CLRDATA_ADDRESS *fp) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodDescData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodDescData(
             CLRDATA_ADDRESS methodDesc,
             CLRDATA_ADDRESS ip,
             struct DacpMethodDescData *data,
             ULONG cRevertedRejitVersions,
             struct DacpReJitData *rgRevertedRejitData,
             ULONG *pcNeededRevertedRejitData) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodDescPtrFromIP( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodDescPtrFromIP(
             CLRDATA_ADDRESS ip,
             CLRDATA_ADDRESS *ppMD) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodDescName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodDescName(
             CLRDATA_ADDRESS methodDesc,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodDescPtrFromFrame( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodDescPtrFromFrame(
             CLRDATA_ADDRESS frameAddr,
             CLRDATA_ADDRESS *ppMD) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodDescFromToken( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodDescFromToken(
             CLRDATA_ADDRESS moduleAddr,
             mdToken token,
             CLRDATA_ADDRESS *methodDesc) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodDescTransparencyData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodDescTransparencyData(
             CLRDATA_ADDRESS methodDesc,
             struct DacpMethodDescTransparencyData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetCodeHeaderData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetCodeHeaderData(
             CLRDATA_ADDRESS ip,
             struct DacpCodeHeaderData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetJitManagerList( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetJitManagerList(
             unsigned int count,
             struct DacpJitManagerInfo *managers,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetJitHelperFunctionName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetJitHelperFunctionName(
             CLRDATA_ADDRESS ip,
             unsigned int count,
             char *name,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetJumpThunkTarget( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetJumpThunkTarget(
             T_CONTEXT *ctx,
             CLRDATA_ADDRESS *targetIP,
             CLRDATA_ADDRESS *targetMD) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetThreadpoolData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetThreadpoolData(
             struct DacpThreadpoolData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetWorkRequestData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetWorkRequestData(
             CLRDATA_ADDRESS addrWorkRequest,
             struct DacpWorkRequestData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHillClimbingLogEntry( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHillClimbingLogEntry(
             CLRDATA_ADDRESS addr,
             struct DacpHillClimbingLogEntry *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetObjectData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetObjectData(
             CLRDATA_ADDRESS objAddr,
             struct DacpObjectData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetObjectStringData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetObjectStringData(
             CLRDATA_ADDRESS obj,
             unsigned int count,
             WCHAR *stringData,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetObjectClassName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetObjectClassName(
             CLRDATA_ADDRESS obj,
             unsigned int count,
             WCHAR *className,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodTableName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodTableName(
             CLRDATA_ADDRESS mt,
             unsigned int count,
             WCHAR *mtName,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodTableData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodTableData(
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodTableSlot( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodTableSlot(
             CLRDATA_ADDRESS mt,
             unsigned int slot,
             CLRDATA_ADDRESS *value) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodTableFieldData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodTableFieldData(
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableFieldData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodTableTransparencyData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodTableTransparencyData(
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableTransparencyData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodTableForEEClass( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodTableForEEClass(
             CLRDATA_ADDRESS eeClass,
             CLRDATA_ADDRESS *value) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFieldDescData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFieldDescData(
             CLRDATA_ADDRESS fieldDesc,
             struct DacpFieldDescData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFrameName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFrameName(
             CLRDATA_ADDRESS vtable,
             unsigned int count,
             WCHAR *frameName,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetPEFileBase( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetPEFileBase(
             CLRDATA_ADDRESS addr,
             CLRDATA_ADDRESS *base) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetPEFileName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetPEFileName(
             CLRDATA_ADDRESS addr,
             unsigned int count,
             WCHAR *fileName,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGCHeapData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGCHeapData(
             struct DacpGcHeapData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGCHeapList( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGCHeapList(
             unsigned int count,
             CLRDATA_ADDRESS heaps[  ],
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGCHeapDetails( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGCHeapDetails(
             CLRDATA_ADDRESS heap,
             struct DacpGcHeapDetails *details) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGCHeapStaticData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGCHeapStaticData(
             struct DacpGcHeapDetails *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHeapSegmentData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHeapSegmentData(
             CLRDATA_ADDRESS seg,
             struct DacpHeapSegmentData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetOOMData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetOOMData(
             CLRDATA_ADDRESS oomAddr,
             struct DacpOomData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetOOMStaticData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetOOMStaticData(
             struct DacpOomData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHeapAnalyzeData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHeapAnalyzeData(
             CLRDATA_ADDRESS addr,
             struct DacpGcHeapAnalyzeData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHeapAnalyzeStaticData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHeapAnalyzeStaticData(
             struct DacpGcHeapAnalyzeData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetDomainLocalModuleData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetDomainLocalModuleData(
             CLRDATA_ADDRESS addr,
             struct DacpDomainLocalModuleData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetDomainLocalModuleDataFromAppDomain( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetDomainLocalModuleDataFromAppDomain(
             CLRDATA_ADDRESS appDomainAddr,
             int moduleID,
             struct DacpDomainLocalModuleData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetDomainLocalModuleDataFromModule( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetDomainLocalModuleDataFromModule(
             CLRDATA_ADDRESS moduleAddr,
             struct DacpDomainLocalModuleData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetThreadLocalModuleData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetThreadLocalModuleData(
             CLRDATA_ADDRESS thread,
             unsigned int index,
             struct DacpThreadLocalModuleData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetSyncBlockData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetSyncBlockData(
             unsigned int number,
             struct DacpSyncBlockData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetSyncBlockCleanupData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetSyncBlockCleanupData(
             CLRDATA_ADDRESS addr,
             struct DacpSyncBlockCleanupData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHandleEnum( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHandleEnum(
             ISOSHandleEnum **ppHandleEnum) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHandleEnumForTypes( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHandleEnumForTypes(
             unsigned int types[  ],
             unsigned int count,
             ISOSHandleEnum **ppHandleEnum) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHandleEnumForGC( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHandleEnumForGC(
             unsigned int gen,
             ISOSHandleEnum **ppHandleEnum) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE TraverseEHInfo( 
+
+        virtual HRESULT STDMETHODCALLTYPE TraverseEHInfo(
             CLRDATA_ADDRESS ip,
             DUMPEHINFO pCallback,
             LPVOID token) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetNestedExceptionData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetNestedExceptionData(
             CLRDATA_ADDRESS exception,
             CLRDATA_ADDRESS *exceptionObject,
             CLRDATA_ADDRESS *nextNestedException) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetStressLogAddress( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetStressLogAddress(
             CLRDATA_ADDRESS *stressLog) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE TraverseLoaderHeap( 
+
+        virtual HRESULT STDMETHODCALLTYPE TraverseLoaderHeap(
             CLRDATA_ADDRESS loaderHeapAddr,
             VISITHEAP pCallback) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetCodeHeapList( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetCodeHeapList(
             CLRDATA_ADDRESS jitManager,
             unsigned int count,
             struct DacpJitCodeHeapInfo *codeHeaps,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE TraverseVirtCallStubHeap( 
+
+        virtual HRESULT STDMETHODCALLTYPE TraverseVirtCallStubHeap(
             CLRDATA_ADDRESS pAppDomain,
             VCSHeapType heaptype,
             VISITHEAP pCallback) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetUsefulGlobals( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetUsefulGlobals(
             struct DacpUsefulGlobalsData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetClrWatsonBuckets( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetClrWatsonBuckets(
             CLRDATA_ADDRESS thread,
             void *pGenericModeBlock) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetTLSIndex( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetTLSIndex(
             ULONG *pIndex) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetDacModuleHandle( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetDacModuleHandle(
             HMODULE *phModule) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetRCWData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetRCWData(
             CLRDATA_ADDRESS addr,
             struct DacpRCWData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetRCWInterfaces( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetRCWInterfaces(
             CLRDATA_ADDRESS rcw,
             unsigned int count,
             struct DacpCOMInterfacePointerData *interfaces,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetCCWData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetCCWData(
             CLRDATA_ADDRESS ccw,
             struct DacpCCWData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetCCWInterfaces( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetCCWInterfaces(
             CLRDATA_ADDRESS ccw,
             unsigned int count,
             struct DacpCOMInterfacePointerData *interfaces,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE TraverseRCWCleanupList( 
+
+        virtual HRESULT STDMETHODCALLTYPE TraverseRCWCleanupList(
             CLRDATA_ADDRESS cleanupListPtr,
             VISITRCWFORCLEANUP pCallback,
             LPVOID token) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetStackReferences( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetStackReferences(
             /* [in] */ DWORD osThreadID,
             /* [out] */ ISOSStackRefEnum **ppEnum) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetRegisterName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetRegisterName(
             /* [in] */ int regName,
             /* [in] */ unsigned int count,
             /* [out] */ WCHAR *buffer,
             /* [out] */ unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetThreadAllocData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetThreadAllocData(
             CLRDATA_ADDRESS thread,
             struct DacpAllocData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetHeapAllocData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetHeapAllocData(
             unsigned int count,
             struct DacpGenerationAllocData *data,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyList( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyList(
             CLRDATA_ADDRESS appDomain,
             int count,
             CLRDATA_ADDRESS values[  ],
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetPrivateBinPaths( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetPrivateBinPaths(
             CLRDATA_ADDRESS appDomain,
             int count,
             WCHAR *paths,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAssemblyLocation( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAssemblyLocation(
             CLRDATA_ADDRESS assembly,
             int count,
             WCHAR *location,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAppDomainConfigFile( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAppDomainConfigFile(
             CLRDATA_ADDRESS appDomain,
             int count,
             WCHAR *configFile,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetApplicationBase( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetApplicationBase(
             CLRDATA_ADDRESS appDomain,
             int count,
             WCHAR *base,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyData(
             CLRDATA_ADDRESS assembly,
             unsigned int *pContext,
             HRESULT *pResult) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyLocation( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyLocation(
             CLRDATA_ADDRESS assesmbly,
             unsigned int count,
             WCHAR *location,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyDisplayName( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyDisplayName(
             CLRDATA_ADDRESS assembly,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterfaceVtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetThreadStoreData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetThreadStoreData )(
             ISOSDacInterface * This,
             struct DacpThreadStoreData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAppDomainStoreData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainStoreData )(
             ISOSDacInterface * This,
             struct DacpAppDomainStoreData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAppDomainList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainList )(
             ISOSDacInterface * This,
             unsigned int count,
             CLRDATA_ADDRESS values[  ],
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAppDomainData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             struct DacpAppDomainData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAppDomainName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetDomainFromContext )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetDomainFromContext )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS context,
             CLRDATA_ADDRESS *domain);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAssemblyList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyList )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
             CLRDATA_ADDRESS values[  ],
             int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAssemblyData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS baseDomainPtr,
             CLRDATA_ADDRESS assembly,
             struct DacpAssemblyData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAssemblyName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetModule )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetModule )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             IXCLRDataModule **mod);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetModuleData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetModuleData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS moduleAddr,
             struct DacpModuleData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *TraverseModuleMap )( 
+
+        HRESULT ( STDMETHODCALLTYPE *TraverseModuleMap )(
             ISOSDacInterface * This,
             ModuleMapType mmt,
             CLRDATA_ADDRESS moduleAddr,
             MODULEMAPTRAVERSE pCallback,
             LPVOID token);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAssemblyModuleList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyModuleList )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             unsigned int count,
             CLRDATA_ADDRESS modules[  ],
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetILForModule )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetILForModule )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS moduleAddr,
             DWORD rva,
             CLRDATA_ADDRESS *il);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetThreadData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetThreadData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS thread,
             struct DacpThreadData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetThreadFromThinlockID )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetThreadFromThinlockID )(
             ISOSDacInterface * This,
             UINT thinLockId,
             CLRDATA_ADDRESS *pThread);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetStackLimits )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetStackLimits )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS threadPtr,
             CLRDATA_ADDRESS *lower,
             CLRDATA_ADDRESS *upper,
             CLRDATA_ADDRESS *fp);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodDescData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodDescData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS methodDesc,
             CLRDATA_ADDRESS ip,
@@ -1257,397 +1259,397 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ULONG cRevertedRejitVersions,
             struct DacpReJitData *rgRevertedRejitData,
             ULONG *pcNeededRevertedRejitData);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodDescPtrFromIP )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodDescPtrFromIP )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS ip,
             CLRDATA_ADDRESS *ppMD);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodDescName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodDescName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS methodDesc,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodDescPtrFromFrame )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodDescPtrFromFrame )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS frameAddr,
             CLRDATA_ADDRESS *ppMD);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodDescFromToken )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodDescFromToken )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS moduleAddr,
             mdToken token,
             CLRDATA_ADDRESS *methodDesc);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodDescTransparencyData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodDescTransparencyData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS methodDesc,
             struct DacpMethodDescTransparencyData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCodeHeaderData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCodeHeaderData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS ip,
             struct DacpCodeHeaderData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetJitManagerList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetJitManagerList )(
             ISOSDacInterface * This,
             unsigned int count,
             struct DacpJitManagerInfo *managers,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetJitHelperFunctionName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetJitHelperFunctionName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS ip,
             unsigned int count,
             char *name,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetJumpThunkTarget )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetJumpThunkTarget )(
             ISOSDacInterface * This,
             T_CONTEXT *ctx,
             CLRDATA_ADDRESS *targetIP,
             CLRDATA_ADDRESS *targetMD);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetThreadpoolData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetThreadpoolData )(
             ISOSDacInterface * This,
             struct DacpThreadpoolData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetWorkRequestData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetWorkRequestData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addrWorkRequest,
             struct DacpWorkRequestData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHillClimbingLogEntry )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHillClimbingLogEntry )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             struct DacpHillClimbingLogEntry *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetObjectData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetObjectData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS objAddr,
             struct DacpObjectData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetObjectStringData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetObjectStringData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS obj,
             unsigned int count,
             WCHAR *stringData,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetObjectClassName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetObjectClassName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS obj,
             unsigned int count,
             WCHAR *className,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodTableName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodTableName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS mt,
             unsigned int count,
             WCHAR *mtName,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodTableData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodTableData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodTableSlot )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodTableSlot )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS mt,
             unsigned int slot,
             CLRDATA_ADDRESS *value);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodTableFieldData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodTableFieldData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableFieldData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodTableTransparencyData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodTableTransparencyData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableTransparencyData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodTableForEEClass )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodTableForEEClass )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS eeClass,
             CLRDATA_ADDRESS *value);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFieldDescData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFieldDescData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS fieldDesc,
             struct DacpFieldDescData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFrameName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFrameName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS vtable,
             unsigned int count,
             WCHAR *frameName,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetPEFileBase )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetPEFileBase )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             CLRDATA_ADDRESS *base);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetPEFileName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetPEFileName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             unsigned int count,
             WCHAR *fileName,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGCHeapData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGCHeapData )(
             ISOSDacInterface * This,
             struct DacpGcHeapData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGCHeapList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGCHeapList )(
             ISOSDacInterface * This,
             unsigned int count,
             CLRDATA_ADDRESS heaps[  ],
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGCHeapDetails )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGCHeapDetails )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS heap,
             struct DacpGcHeapDetails *details);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGCHeapStaticData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGCHeapStaticData )(
             ISOSDacInterface * This,
             struct DacpGcHeapDetails *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHeapSegmentData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHeapSegmentData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS seg,
             struct DacpHeapSegmentData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetOOMData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetOOMData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS oomAddr,
             struct DacpOomData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetOOMStaticData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetOOMStaticData )(
             ISOSDacInterface * This,
             struct DacpOomData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHeapAnalyzeData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHeapAnalyzeData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             struct DacpGcHeapAnalyzeData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHeapAnalyzeStaticData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHeapAnalyzeStaticData )(
             ISOSDacInterface * This,
             struct DacpGcHeapAnalyzeData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetDomainLocalModuleData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetDomainLocalModuleData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             struct DacpDomainLocalModuleData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetDomainLocalModuleDataFromAppDomain )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetDomainLocalModuleDataFromAppDomain )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomainAddr,
             int moduleID,
             struct DacpDomainLocalModuleData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetDomainLocalModuleDataFromModule )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetDomainLocalModuleDataFromModule )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS moduleAddr,
             struct DacpDomainLocalModuleData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetThreadLocalModuleData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetThreadLocalModuleData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS thread,
             unsigned int index,
             struct DacpThreadLocalModuleData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetSyncBlockData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetSyncBlockData )(
             ISOSDacInterface * This,
             unsigned int number,
             struct DacpSyncBlockData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetSyncBlockCleanupData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetSyncBlockCleanupData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             struct DacpSyncBlockCleanupData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHandleEnum )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHandleEnum )(
             ISOSDacInterface * This,
             ISOSHandleEnum **ppHandleEnum);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHandleEnumForTypes )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHandleEnumForTypes )(
             ISOSDacInterface * This,
             unsigned int types[  ],
             unsigned int count,
             ISOSHandleEnum **ppHandleEnum);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHandleEnumForGC )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHandleEnumForGC )(
             ISOSDacInterface * This,
             unsigned int gen,
             ISOSHandleEnum **ppHandleEnum);
-        
-        HRESULT ( STDMETHODCALLTYPE *TraverseEHInfo )( 
+
+        HRESULT ( STDMETHODCALLTYPE *TraverseEHInfo )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS ip,
             DUMPEHINFO pCallback,
             LPVOID token);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetNestedExceptionData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetNestedExceptionData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS exception,
             CLRDATA_ADDRESS *exceptionObject,
             CLRDATA_ADDRESS *nextNestedException);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetStressLogAddress )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetStressLogAddress )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS *stressLog);
-        
-        HRESULT ( STDMETHODCALLTYPE *TraverseLoaderHeap )( 
+
+        HRESULT ( STDMETHODCALLTYPE *TraverseLoaderHeap )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS loaderHeapAddr,
             VISITHEAP pCallback);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCodeHeapList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCodeHeapList )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS jitManager,
             unsigned int count,
             struct DacpJitCodeHeapInfo *codeHeaps,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *TraverseVirtCallStubHeap )( 
+
+        HRESULT ( STDMETHODCALLTYPE *TraverseVirtCallStubHeap )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS pAppDomain,
             VCSHeapType heaptype,
             VISITHEAP pCallback);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetUsefulGlobals )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetUsefulGlobals )(
             ISOSDacInterface * This,
             struct DacpUsefulGlobalsData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetClrWatsonBuckets )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetClrWatsonBuckets )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS thread,
             void *pGenericModeBlock);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetTLSIndex )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetTLSIndex )(
             ISOSDacInterface * This,
             ULONG *pIndex);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetDacModuleHandle )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetDacModuleHandle )(
             ISOSDacInterface * This,
             HMODULE *phModule);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetRCWData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetRCWData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             struct DacpRCWData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetRCWInterfaces )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetRCWInterfaces )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS rcw,
             unsigned int count,
             struct DacpCOMInterfacePointerData *interfaces,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCCWData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCCWData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS ccw,
             struct DacpCCWData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetCCWInterfaces )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetCCWInterfaces )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS ccw,
             unsigned int count,
             struct DacpCOMInterfacePointerData *interfaces,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *TraverseRCWCleanupList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *TraverseRCWCleanupList )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS cleanupListPtr,
             VISITRCWFORCLEANUP pCallback,
             LPVOID token);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetStackReferences )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetStackReferences )(
             ISOSDacInterface * This,
             /* [in] */ DWORD osThreadID,
             /* [out] */ ISOSStackRefEnum **ppEnum);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetRegisterName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetRegisterName )(
             ISOSDacInterface * This,
             /* [in] */ int regName,
             /* [in] */ unsigned int count,
             /* [out] */ WCHAR *buffer,
             /* [out] */ unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetThreadAllocData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetThreadAllocData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS thread,
             struct DacpAllocData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetHeapAllocData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetHeapAllocData )(
             ISOSDacInterface * This,
             unsigned int count,
             struct DacpGenerationAllocData *data,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyList )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyList )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
             CLRDATA_ADDRESS values[  ],
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetPrivateBinPaths )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetPrivateBinPaths )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
             WCHAR *paths,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAssemblyLocation )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyLocation )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             int count,
             WCHAR *location,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAppDomainConfigFile )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAppDomainConfigFile )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
             WCHAR *configFile,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetApplicationBase )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetApplicationBase )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
             WCHAR *base,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyData )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             unsigned int *pContext,
             HRESULT *pResult);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyLocation )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyLocation )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assesmbly,
             unsigned int count,
             WCHAR *location,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyDisplayName )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyDisplayName )(
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             unsigned int count,
             WCHAR *name,
             unsigned int *pNeeded);
-        
+
         END_INTERFACE
     } ISOSDacInterfaceVtbl;
 
@@ -1656,284 +1658,284 @@ EXTERN_C const IID IID_ISOSDacInterface;
         CONST_VTBL struct ISOSDacInterfaceVtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface_QueryInterface(This,riid,ppvObject)    \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface_AddRef(This)   \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface_Release(This)  \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface_GetThreadStoreData(This,data)  \
-    ( (This)->lpVtbl -> GetThreadStoreData(This,data) ) 
+    ( (This)->lpVtbl -> GetThreadStoreData(This,data) )
 
 #define ISOSDacInterface_GetAppDomainStoreData(This,data)   \
-    ( (This)->lpVtbl -> GetAppDomainStoreData(This,data) ) 
+    ( (This)->lpVtbl -> GetAppDomainStoreData(This,data) )
 
 #define ISOSDacInterface_GetAppDomainList(This,count,values,pNeeded)    \
-    ( (This)->lpVtbl -> GetAppDomainList(This,count,values,pNeeded) ) 
+    ( (This)->lpVtbl -> GetAppDomainList(This,count,values,pNeeded) )
 
 #define ISOSDacInterface_GetAppDomainData(This,addr,data)   \
-    ( (This)->lpVtbl -> GetAppDomainData(This,addr,data) ) 
+    ( (This)->lpVtbl -> GetAppDomainData(This,addr,data) )
 
 #define ISOSDacInterface_GetAppDomainName(This,addr,count,name,pNeeded) \
-    ( (This)->lpVtbl -> GetAppDomainName(This,addr,count,name,pNeeded) ) 
+    ( (This)->lpVtbl -> GetAppDomainName(This,addr,count,name,pNeeded) )
 
 #define ISOSDacInterface_GetDomainFromContext(This,context,domain)  \
-    ( (This)->lpVtbl -> GetDomainFromContext(This,context,domain) ) 
+    ( (This)->lpVtbl -> GetDomainFromContext(This,context,domain) )
 
 #define ISOSDacInterface_GetAssemblyList(This,appDomain,count,values,pNeeded)   \
-    ( (This)->lpVtbl -> GetAssemblyList(This,appDomain,count,values,pNeeded) ) 
+    ( (This)->lpVtbl -> GetAssemblyList(This,appDomain,count,values,pNeeded) )
 
 #define ISOSDacInterface_GetAssemblyData(This,baseDomainPtr,assembly,data)  \
-    ( (This)->lpVtbl -> GetAssemblyData(This,baseDomainPtr,assembly,data) ) 
+    ( (This)->lpVtbl -> GetAssemblyData(This,baseDomainPtr,assembly,data) )
 
 #define ISOSDacInterface_GetAssemblyName(This,assembly,count,name,pNeeded)  \
-    ( (This)->lpVtbl -> GetAssemblyName(This,assembly,count,name,pNeeded) ) 
+    ( (This)->lpVtbl -> GetAssemblyName(This,assembly,count,name,pNeeded) )
 
 #define ISOSDacInterface_GetModule(This,addr,mod)   \
-    ( (This)->lpVtbl -> GetModule(This,addr,mod) ) 
+    ( (This)->lpVtbl -> GetModule(This,addr,mod) )
 
 #define ISOSDacInterface_GetModuleData(This,moduleAddr,data)    \
-    ( (This)->lpVtbl -> GetModuleData(This,moduleAddr,data) ) 
+    ( (This)->lpVtbl -> GetModuleData(This,moduleAddr,data) )
 
 #define ISOSDacInterface_TraverseModuleMap(This,mmt,moduleAddr,pCallback,token) \
-    ( (This)->lpVtbl -> TraverseModuleMap(This,mmt,moduleAddr,pCallback,token) ) 
+    ( (This)->lpVtbl -> TraverseModuleMap(This,mmt,moduleAddr,pCallback,token) )
 
 #define ISOSDacInterface_GetAssemblyModuleList(This,assembly,count,modules,pNeeded) \
-    ( (This)->lpVtbl -> GetAssemblyModuleList(This,assembly,count,modules,pNeeded) ) 
+    ( (This)->lpVtbl -> GetAssemblyModuleList(This,assembly,count,modules,pNeeded) )
 
 #define ISOSDacInterface_GetILForModule(This,moduleAddr,rva,il) \
-    ( (This)->lpVtbl -> GetILForModule(This,moduleAddr,rva,il) ) 
+    ( (This)->lpVtbl -> GetILForModule(This,moduleAddr,rva,il) )
 
 #define ISOSDacInterface_GetThreadData(This,thread,data)    \
-    ( (This)->lpVtbl -> GetThreadData(This,thread,data) ) 
+    ( (This)->lpVtbl -> GetThreadData(This,thread,data) )
 
 #define ISOSDacInterface_GetThreadFromThinlockID(This,thinLockId,pThread)   \
-    ( (This)->lpVtbl -> GetThreadFromThinlockID(This,thinLockId,pThread) ) 
+    ( (This)->lpVtbl -> GetThreadFromThinlockID(This,thinLockId,pThread) )
 
 #define ISOSDacInterface_GetStackLimits(This,threadPtr,lower,upper,fp)  \
-    ( (This)->lpVtbl -> GetStackLimits(This,threadPtr,lower,upper,fp) ) 
+    ( (This)->lpVtbl -> GetStackLimits(This,threadPtr,lower,upper,fp) )
 
 #define ISOSDacInterface_GetMethodDescData(This,methodDesc,ip,data,cRevertedRejitVersions,rgRevertedRejitData,pcNeededRevertedRejitData)    \
-    ( (This)->lpVtbl -> GetMethodDescData(This,methodDesc,ip,data,cRevertedRejitVersions,rgRevertedRejitData,pcNeededRevertedRejitData) ) 
+    ( (This)->lpVtbl -> GetMethodDescData(This,methodDesc,ip,data,cRevertedRejitVersions,rgRevertedRejitData,pcNeededRevertedRejitData) )
 
 #define ISOSDacInterface_GetMethodDescPtrFromIP(This,ip,ppMD)   \
-    ( (This)->lpVtbl -> GetMethodDescPtrFromIP(This,ip,ppMD) ) 
+    ( (This)->lpVtbl -> GetMethodDescPtrFromIP(This,ip,ppMD) )
 
 #define ISOSDacInterface_GetMethodDescName(This,methodDesc,count,name,pNeeded)  \
-    ( (This)->lpVtbl -> GetMethodDescName(This,methodDesc,count,name,pNeeded) ) 
+    ( (This)->lpVtbl -> GetMethodDescName(This,methodDesc,count,name,pNeeded) )
 
 #define ISOSDacInterface_GetMethodDescPtrFromFrame(This,frameAddr,ppMD) \
-    ( (This)->lpVtbl -> GetMethodDescPtrFromFrame(This,frameAddr,ppMD) ) 
+    ( (This)->lpVtbl -> GetMethodDescPtrFromFrame(This,frameAddr,ppMD) )
 
 #define ISOSDacInterface_GetMethodDescFromToken(This,moduleAddr,token,methodDesc)   \
-    ( (This)->lpVtbl -> GetMethodDescFromToken(This,moduleAddr,token,methodDesc) ) 
+    ( (This)->lpVtbl -> GetMethodDescFromToken(This,moduleAddr,token,methodDesc) )
 
 #define ISOSDacInterface_GetMethodDescTransparencyData(This,methodDesc,data)    \
-    ( (This)->lpVtbl -> GetMethodDescTransparencyData(This,methodDesc,data) ) 
+    ( (This)->lpVtbl -> GetMethodDescTransparencyData(This,methodDesc,data) )
 
 #define ISOSDacInterface_GetCodeHeaderData(This,ip,data)    \
-    ( (This)->lpVtbl -> GetCodeHeaderData(This,ip,data) ) 
+    ( (This)->lpVtbl -> GetCodeHeaderData(This,ip,data) )
 
 #define ISOSDacInterface_GetJitManagerList(This,count,managers,pNeeded) \
-    ( (This)->lpVtbl -> GetJitManagerList(This,count,managers,pNeeded) ) 
+    ( (This)->lpVtbl -> GetJitManagerList(This,count,managers,pNeeded) )
 
 #define ISOSDacInterface_GetJitHelperFunctionName(This,ip,count,name,pNeeded)   \
-    ( (This)->lpVtbl -> GetJitHelperFunctionName(This,ip,count,name,pNeeded) ) 
+    ( (This)->lpVtbl -> GetJitHelperFunctionName(This,ip,count,name,pNeeded) )
 
 #define ISOSDacInterface_GetJumpThunkTarget(This,ctx,targetIP,targetMD) \
-    ( (This)->lpVtbl -> GetJumpThunkTarget(This,ctx,targetIP,targetMD) ) 
+    ( (This)->lpVtbl -> GetJumpThunkTarget(This,ctx,targetIP,targetMD) )
 
 #define ISOSDacInterface_GetThreadpoolData(This,data)   \
-    ( (This)->lpVtbl -> GetThreadpoolData(This,data) ) 
+    ( (This)->lpVtbl -> GetThreadpoolData(This,data) )
 
 #define ISOSDacInterface_GetWorkRequestData(This,addrWorkRequest,data)  \
-    ( (This)->lpVtbl -> GetWorkRequestData(This,addrWorkRequest,data) ) 
+    ( (This)->lpVtbl -> GetWorkRequestData(This,addrWorkRequest,data) )
 
 #define ISOSDacInterface_GetHillClimbingLogEntry(This,addr,data)    \
-    ( (This)->lpVtbl -> GetHillClimbingLogEntry(This,addr,data) ) 
+    ( (This)->lpVtbl -> GetHillClimbingLogEntry(This,addr,data) )
 
 #define ISOSDacInterface_GetObjectData(This,objAddr,data)   \
-    ( (This)->lpVtbl -> GetObjectData(This,objAddr,data) ) 
+    ( (This)->lpVtbl -> GetObjectData(This,objAddr,data) )
 
 #define ISOSDacInterface_GetObjectStringData(This,obj,count,stringData,pNeeded) \
-    ( (This)->lpVtbl -> GetObjectStringData(This,obj,count,stringData,pNeeded) ) 
+    ( (This)->lpVtbl -> GetObjectStringData(This,obj,count,stringData,pNeeded) )
 
 #define ISOSDacInterface_GetObjectClassName(This,obj,count,className,pNeeded)   \
-    ( (This)->lpVtbl -> GetObjectClassName(This,obj,count,className,pNeeded) ) 
+    ( (This)->lpVtbl -> GetObjectClassName(This,obj,count,className,pNeeded) )
 
 #define ISOSDacInterface_GetMethodTableName(This,mt,count,mtName,pNeeded)   \
-    ( (This)->lpVtbl -> GetMethodTableName(This,mt,count,mtName,pNeeded) ) 
+    ( (This)->lpVtbl -> GetMethodTableName(This,mt,count,mtName,pNeeded) )
 
 #define ISOSDacInterface_GetMethodTableData(This,mt,data)   \
-    ( (This)->lpVtbl -> GetMethodTableData(This,mt,data) ) 
+    ( (This)->lpVtbl -> GetMethodTableData(This,mt,data) )
 
 #define ISOSDacInterface_GetMethodTableSlot(This,mt,slot,value) \
-    ( (This)->lpVtbl -> GetMethodTableSlot(This,mt,slot,value) ) 
+    ( (This)->lpVtbl -> GetMethodTableSlot(This,mt,slot,value) )
 
 #define ISOSDacInterface_GetMethodTableFieldData(This,mt,data)  \
-    ( (This)->lpVtbl -> GetMethodTableFieldData(This,mt,data) ) 
+    ( (This)->lpVtbl -> GetMethodTableFieldData(This,mt,data) )
 
 #define ISOSDacInterface_GetMethodTableTransparencyData(This,mt,data)   \
-    ( (This)->lpVtbl -> GetMethodTableTransparencyData(This,mt,data) ) 
+    ( (This)->lpVtbl -> GetMethodTableTransparencyData(This,mt,data) )
 
 #define ISOSDacInterface_GetMethodTableForEEClass(This,eeClass,value)   \
-    ( (This)->lpVtbl -> GetMethodTableForEEClass(This,eeClass,value) ) 
+    ( (This)->lpVtbl -> GetMethodTableForEEClass(This,eeClass,value) )
 
 #define ISOSDacInterface_GetFieldDescData(This,fieldDesc,data)  \
-    ( (This)->lpVtbl -> GetFieldDescData(This,fieldDesc,data) ) 
+    ( (This)->lpVtbl -> GetFieldDescData(This,fieldDesc,data) )
 
 #define ISOSDacInterface_GetFrameName(This,vtable,count,frameName,pNeeded)  \
-    ( (This)->lpVtbl -> GetFrameName(This,vtable,count,frameName,pNeeded) ) 
+    ( (This)->lpVtbl -> GetFrameName(This,vtable,count,frameName,pNeeded) )
 
 #define ISOSDacInterface_GetPEFileBase(This,addr,base)  \
-    ( (This)->lpVtbl -> GetPEFileBase(This,addr,base) ) 
+    ( (This)->lpVtbl -> GetPEFileBase(This,addr,base) )
 
 #define ISOSDacInterface_GetPEFileName(This,addr,count,fileName,pNeeded)    \
-    ( (This)->lpVtbl -> GetPEFileName(This,addr,count,fileName,pNeeded) ) 
+    ( (This)->lpVtbl -> GetPEFileName(This,addr,count,fileName,pNeeded) )
 
 #define ISOSDacInterface_GetGCHeapData(This,data)   \
-    ( (This)->lpVtbl -> GetGCHeapData(This,data) ) 
+    ( (This)->lpVtbl -> GetGCHeapData(This,data) )
 
 #define ISOSDacInterface_GetGCHeapList(This,count,heaps,pNeeded)    \
-    ( (This)->lpVtbl -> GetGCHeapList(This,count,heaps,pNeeded) ) 
+    ( (This)->lpVtbl -> GetGCHeapList(This,count,heaps,pNeeded) )
 
 #define ISOSDacInterface_GetGCHeapDetails(This,heap,details)    \
-    ( (This)->lpVtbl -> GetGCHeapDetails(This,heap,details) ) 
+    ( (This)->lpVtbl -> GetGCHeapDetails(This,heap,details) )
 
 #define ISOSDacInterface_GetGCHeapStaticData(This,data) \
-    ( (This)->lpVtbl -> GetGCHeapStaticData(This,data) ) 
+    ( (This)->lpVtbl -> GetGCHeapStaticData(This,data) )
 
 #define ISOSDacInterface_GetHeapSegmentData(This,seg,data)  \
-    ( (This)->lpVtbl -> GetHeapSegmentData(This,seg,data) ) 
+    ( (This)->lpVtbl -> GetHeapSegmentData(This,seg,data) )
 
 #define ISOSDacInterface_GetOOMData(This,oomAddr,data)  \
-    ( (This)->lpVtbl -> GetOOMData(This,oomAddr,data) ) 
+    ( (This)->lpVtbl -> GetOOMData(This,oomAddr,data) )
 
 #define ISOSDacInterface_GetOOMStaticData(This,data)    \
-    ( (This)->lpVtbl -> GetOOMStaticData(This,data) ) 
+    ( (This)->lpVtbl -> GetOOMStaticData(This,data) )
 
 #define ISOSDacInterface_GetHeapAnalyzeData(This,addr,data) \
-    ( (This)->lpVtbl -> GetHeapAnalyzeData(This,addr,data) ) 
+    ( (This)->lpVtbl -> GetHeapAnalyzeData(This,addr,data) )
 
 #define ISOSDacInterface_GetHeapAnalyzeStaticData(This,data)    \
-    ( (This)->lpVtbl -> GetHeapAnalyzeStaticData(This,data) ) 
+    ( (This)->lpVtbl -> GetHeapAnalyzeStaticData(This,data) )
 
 #define ISOSDacInterface_GetDomainLocalModuleData(This,addr,data)   \
-    ( (This)->lpVtbl -> GetDomainLocalModuleData(This,addr,data) ) 
+    ( (This)->lpVtbl -> GetDomainLocalModuleData(This,addr,data) )
 
 #define ISOSDacInterface_GetDomainLocalModuleDataFromAppDomain(This,appDomainAddr,moduleID,data)    \
-    ( (This)->lpVtbl -> GetDomainLocalModuleDataFromAppDomain(This,appDomainAddr,moduleID,data) ) 
+    ( (This)->lpVtbl -> GetDomainLocalModuleDataFromAppDomain(This,appDomainAddr,moduleID,data) )
 
 #define ISOSDacInterface_GetDomainLocalModuleDataFromModule(This,moduleAddr,data)   \
-    ( (This)->lpVtbl -> GetDomainLocalModuleDataFromModule(This,moduleAddr,data) ) 
+    ( (This)->lpVtbl -> GetDomainLocalModuleDataFromModule(This,moduleAddr,data) )
 
 #define ISOSDacInterface_GetThreadLocalModuleData(This,thread,index,data)   \
-    ( (This)->lpVtbl -> GetThreadLocalModuleData(This,thread,index,data) ) 
+    ( (This)->lpVtbl -> GetThreadLocalModuleData(This,thread,index,data) )
 
 #define ISOSDacInterface_GetSyncBlockData(This,number,data) \
-    ( (This)->lpVtbl -> GetSyncBlockData(This,number,data) ) 
+    ( (This)->lpVtbl -> GetSyncBlockData(This,number,data) )
 
 #define ISOSDacInterface_GetSyncBlockCleanupData(This,addr,data)    \
-    ( (This)->lpVtbl -> GetSyncBlockCleanupData(This,addr,data) ) 
+    ( (This)->lpVtbl -> GetSyncBlockCleanupData(This,addr,data) )
 
 #define ISOSDacInterface_GetHandleEnum(This,ppHandleEnum)   \
-    ( (This)->lpVtbl -> GetHandleEnum(This,ppHandleEnum) ) 
+    ( (This)->lpVtbl -> GetHandleEnum(This,ppHandleEnum) )
 
 #define ISOSDacInterface_GetHandleEnumForTypes(This,types,count,ppHandleEnum)   \
-    ( (This)->lpVtbl -> GetHandleEnumForTypes(This,types,count,ppHandleEnum) ) 
+    ( (This)->lpVtbl -> GetHandleEnumForTypes(This,types,count,ppHandleEnum) )
 
 #define ISOSDacInterface_GetHandleEnumForGC(This,gen,ppHandleEnum)  \
-    ( (This)->lpVtbl -> GetHandleEnumForGC(This,gen,ppHandleEnum) ) 
+    ( (This)->lpVtbl -> GetHandleEnumForGC(This,gen,ppHandleEnum) )
 
 #define ISOSDacInterface_TraverseEHInfo(This,ip,pCallback,token)    \
-    ( (This)->lpVtbl -> TraverseEHInfo(This,ip,pCallback,token) ) 
+    ( (This)->lpVtbl -> TraverseEHInfo(This,ip,pCallback,token) )
 
 #define ISOSDacInterface_GetNestedExceptionData(This,exception,exceptionObject,nextNestedException) \
-    ( (This)->lpVtbl -> GetNestedExceptionData(This,exception,exceptionObject,nextNestedException) ) 
+    ( (This)->lpVtbl -> GetNestedExceptionData(This,exception,exceptionObject,nextNestedException) )
 
 #define ISOSDacInterface_GetStressLogAddress(This,stressLog)    \
-    ( (This)->lpVtbl -> GetStressLogAddress(This,stressLog) ) 
+    ( (This)->lpVtbl -> GetStressLogAddress(This,stressLog) )
 
 #define ISOSDacInterface_TraverseLoaderHeap(This,loaderHeapAddr,pCallback)  \
-    ( (This)->lpVtbl -> TraverseLoaderHeap(This,loaderHeapAddr,pCallback) ) 
+    ( (This)->lpVtbl -> TraverseLoaderHeap(This,loaderHeapAddr,pCallback) )
 
 #define ISOSDacInterface_GetCodeHeapList(This,jitManager,count,codeHeaps,pNeeded)   \
-    ( (This)->lpVtbl -> GetCodeHeapList(This,jitManager,count,codeHeaps,pNeeded) ) 
+    ( (This)->lpVtbl -> GetCodeHeapList(This,jitManager,count,codeHeaps,pNeeded) )
 
 #define ISOSDacInterface_TraverseVirtCallStubHeap(This,pAppDomain,heaptype,pCallback)   \
-    ( (This)->lpVtbl -> TraverseVirtCallStubHeap(This,pAppDomain,heaptype,pCallback) ) 
+    ( (This)->lpVtbl -> TraverseVirtCallStubHeap(This,pAppDomain,heaptype,pCallback) )
 
 #define ISOSDacInterface_GetUsefulGlobals(This,data)    \
-    ( (This)->lpVtbl -> GetUsefulGlobals(This,data) ) 
+    ( (This)->lpVtbl -> GetUsefulGlobals(This,data) )
 
 #define ISOSDacInterface_GetClrWatsonBuckets(This,thread,pGenericModeBlock) \
-    ( (This)->lpVtbl -> GetClrWatsonBuckets(This,thread,pGenericModeBlock) ) 
+    ( (This)->lpVtbl -> GetClrWatsonBuckets(This,thread,pGenericModeBlock) )
 
 #define ISOSDacInterface_GetTLSIndex(This,pIndex)   \
-    ( (This)->lpVtbl -> GetTLSIndex(This,pIndex) ) 
+    ( (This)->lpVtbl -> GetTLSIndex(This,pIndex) )
 
 #define ISOSDacInterface_GetDacModuleHandle(This,phModule)  \
-    ( (This)->lpVtbl -> GetDacModuleHandle(This,phModule) ) 
+    ( (This)->lpVtbl -> GetDacModuleHandle(This,phModule) )
 
 #define ISOSDacInterface_GetRCWData(This,addr,data) \
-    ( (This)->lpVtbl -> GetRCWData(This,addr,data) ) 
+    ( (This)->lpVtbl -> GetRCWData(This,addr,data) )
 
 #define ISOSDacInterface_GetRCWInterfaces(This,rcw,count,interfaces,pNeeded)    \
-    ( (This)->lpVtbl -> GetRCWInterfaces(This,rcw,count,interfaces,pNeeded) ) 
+    ( (This)->lpVtbl -> GetRCWInterfaces(This,rcw,count,interfaces,pNeeded) )
 
 #define ISOSDacInterface_GetCCWData(This,ccw,data)  \
-    ( (This)->lpVtbl -> GetCCWData(This,ccw,data) ) 
+    ( (This)->lpVtbl -> GetCCWData(This,ccw,data) )
 
 #define ISOSDacInterface_GetCCWInterfaces(This,ccw,count,interfaces,pNeeded)    \
-    ( (This)->lpVtbl -> GetCCWInterfaces(This,ccw,count,interfaces,pNeeded) ) 
+    ( (This)->lpVtbl -> GetCCWInterfaces(This,ccw,count,interfaces,pNeeded) )
 
 #define ISOSDacInterface_TraverseRCWCleanupList(This,cleanupListPtr,pCallback,token)    \
-    ( (This)->lpVtbl -> TraverseRCWCleanupList(This,cleanupListPtr,pCallback,token) ) 
+    ( (This)->lpVtbl -> TraverseRCWCleanupList(This,cleanupListPtr,pCallback,token) )
 
 #define ISOSDacInterface_GetStackReferences(This,osThreadID,ppEnum) \
-    ( (This)->lpVtbl -> GetStackReferences(This,osThreadID,ppEnum) ) 
+    ( (This)->lpVtbl -> GetStackReferences(This,osThreadID,ppEnum) )
 
 #define ISOSDacInterface_GetRegisterName(This,regName,count,buffer,pNeeded) \
-    ( (This)->lpVtbl -> GetRegisterName(This,regName,count,buffer,pNeeded) ) 
+    ( (This)->lpVtbl -> GetRegisterName(This,regName,count,buffer,pNeeded) )
 
 #define ISOSDacInterface_GetThreadAllocData(This,thread,data)   \
-    ( (This)->lpVtbl -> GetThreadAllocData(This,thread,data) ) 
+    ( (This)->lpVtbl -> GetThreadAllocData(This,thread,data) )
 
 #define ISOSDacInterface_GetHeapAllocData(This,count,data,pNeeded)  \
-    ( (This)->lpVtbl -> GetHeapAllocData(This,count,data,pNeeded) ) 
+    ( (This)->lpVtbl -> GetHeapAllocData(This,count,data,pNeeded) )
 
 #define ISOSDacInterface_GetFailedAssemblyList(This,appDomain,count,values,pNeeded) \
-    ( (This)->lpVtbl -> GetFailedAssemblyList(This,appDomain,count,values,pNeeded) ) 
+    ( (This)->lpVtbl -> GetFailedAssemblyList(This,appDomain,count,values,pNeeded) )
 
 #define ISOSDacInterface_GetPrivateBinPaths(This,appDomain,count,paths,pNeeded) \
-    ( (This)->lpVtbl -> GetPrivateBinPaths(This,appDomain,count,paths,pNeeded) ) 
+    ( (This)->lpVtbl -> GetPrivateBinPaths(This,appDomain,count,paths,pNeeded) )
 
 #define ISOSDacInterface_GetAssemblyLocation(This,assembly,count,location,pNeeded)  \
-    ( (This)->lpVtbl -> GetAssemblyLocation(This,assembly,count,location,pNeeded) ) 
+    ( (This)->lpVtbl -> GetAssemblyLocation(This,assembly,count,location,pNeeded) )
 
 #define ISOSDacInterface_GetAppDomainConfigFile(This,appDomain,count,configFile,pNeeded)    \
-    ( (This)->lpVtbl -> GetAppDomainConfigFile(This,appDomain,count,configFile,pNeeded) ) 
+    ( (This)->lpVtbl -> GetAppDomainConfigFile(This,appDomain,count,configFile,pNeeded) )
 
 #define ISOSDacInterface_GetApplicationBase(This,appDomain,count,base,pNeeded)  \
-    ( (This)->lpVtbl -> GetApplicationBase(This,appDomain,count,base,pNeeded) ) 
+    ( (This)->lpVtbl -> GetApplicationBase(This,appDomain,count,base,pNeeded) )
 
 #define ISOSDacInterface_GetFailedAssemblyData(This,assembly,pContext,pResult)  \
-    ( (This)->lpVtbl -> GetFailedAssemblyData(This,assembly,pContext,pResult) ) 
+    ( (This)->lpVtbl -> GetFailedAssemblyData(This,assembly,pContext,pResult) )
 
 #define ISOSDacInterface_GetFailedAssemblyLocation(This,assesmbly,count,location,pNeeded)   \
-    ( (This)->lpVtbl -> GetFailedAssemblyLocation(This,assesmbly,count,location,pNeeded) ) 
+    ( (This)->lpVtbl -> GetFailedAssemblyLocation(This,assesmbly,count,location,pNeeded) )
 
 #define ISOSDacInterface_GetFailedAssemblyDisplayName(This,assembly,count,name,pNeeded) \
-    ( (This)->lpVtbl -> GetFailedAssemblyDisplayName(This,assembly,count,name,pNeeded) ) 
+    ( (This)->lpVtbl -> GetFailedAssemblyDisplayName(This,assembly,count,name,pNeeded) )
 
 #endif /* COBJMACROS */
 
@@ -1950,56 +1952,56 @@ EXTERN_C const IID IID_ISOSDacInterface;
 #define __ISOSDacInterface2_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface2 */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface2;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("A16026EC-96F4-40BA-87FB-5575986FB7AF")
     ISOSDacInterface2 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetObjectExceptionData( 
+        virtual HRESULT STDMETHODCALLTYPE GetObjectExceptionData(
             CLRDATA_ADDRESS objAddr,
             struct DacpExceptionObjectData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE IsRCWDCOMProxy( 
+
+        virtual HRESULT STDMETHODCALLTYPE IsRCWDCOMProxy(
             CLRDATA_ADDRESS rcwAddr,
             BOOL *isDCOMProxy) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterface2Vtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface2 * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface2 * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface2 * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetObjectExceptionData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetObjectExceptionData )(
             ISOSDacInterface2 * This,
             CLRDATA_ADDRESS objAddr,
             struct DacpExceptionObjectData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *IsRCWDCOMProxy )( 
+
+        HRESULT ( STDMETHODCALLTYPE *IsRCWDCOMProxy )(
             ISOSDacInterface2 * This,
             CLRDATA_ADDRESS rcwAddr,
             BOOL *isDCOMProxy);
-        
+
         END_INTERFACE
     } ISOSDacInterface2Vtbl;
 
@@ -2008,26 +2010,26 @@ EXTERN_C const IID IID_ISOSDacInterface2;
         CONST_VTBL struct ISOSDacInterface2Vtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface2_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface2_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface2_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface2_GetObjectExceptionData(This,objAddr,data) \
-    ( (This)->lpVtbl -> GetObjectExceptionData(This,objAddr,data) ) 
+    ( (This)->lpVtbl -> GetObjectExceptionData(This,objAddr,data) )
 
 #define ISOSDacInterface2_IsRCWDCOMProxy(This,rcwAddr,isDCOMProxy)  \
-    ( (This)->lpVtbl -> IsRCWDCOMProxy(This,rcwAddr,isDCOMProxy) ) 
+    ( (This)->lpVtbl -> IsRCWDCOMProxy(This,rcwAddr,isDCOMProxy) )
 
 #endif /* COBJMACROS */
 
@@ -2044,61 +2046,61 @@ EXTERN_C const IID IID_ISOSDacInterface2;
 #define __ISOSDacInterface3_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface3 */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface3;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("B08C5CDC-FD8A-49C5-AB38-5FEEF35235B4")
     ISOSDacInterface3 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetGCInterestingInfoData( 
+        virtual HRESULT STDMETHODCALLTYPE GetGCInterestingInfoData(
             CLRDATA_ADDRESS interestingInfoAddr,
             struct DacpGCInterestingInfoData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGCInterestingInfoStaticData( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGCInterestingInfoStaticData(
             struct DacpGCInterestingInfoData *data) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGCGlobalMechanisms( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGCGlobalMechanisms(
             size_t *globalMechanisms) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterface3Vtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface3 * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface3 * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface3 * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGCInterestingInfoData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGCInterestingInfoData )(
             ISOSDacInterface3 * This,
             CLRDATA_ADDRESS interestingInfoAddr,
             struct DacpGCInterestingInfoData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGCInterestingInfoStaticData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGCInterestingInfoStaticData )(
             ISOSDacInterface3 * This,
             struct DacpGCInterestingInfoData *data);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGCGlobalMechanisms )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGCGlobalMechanisms )(
             ISOSDacInterface3 * This,
             size_t *globalMechanisms);
-        
+
         END_INTERFACE
     } ISOSDacInterface3Vtbl;
 
@@ -2107,29 +2109,29 @@ EXTERN_C const IID IID_ISOSDacInterface3;
         CONST_VTBL struct ISOSDacInterface3Vtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface3_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface3_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface3_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface3_GetGCInterestingInfoData(This,interestingInfoAddr,data)   \
-    ( (This)->lpVtbl -> GetGCInterestingInfoData(This,interestingInfoAddr,data) ) 
+    ( (This)->lpVtbl -> GetGCInterestingInfoData(This,interestingInfoAddr,data) )
 
 #define ISOSDacInterface3_GetGCInterestingInfoStaticData(This,data) \
-    ( (This)->lpVtbl -> GetGCInterestingInfoStaticData(This,data) ) 
+    ( (This)->lpVtbl -> GetGCInterestingInfoStaticData(This,data) )
 
 #define ISOSDacInterface3_GetGCGlobalMechanisms(This,globalMechanisms)  \
-    ( (This)->lpVtbl -> GetGCGlobalMechanisms(This,globalMechanisms) ) 
+    ( (This)->lpVtbl -> GetGCGlobalMechanisms(This,globalMechanisms) )
 
 #endif /* COBJMACROS */
 
@@ -2146,49 +2148,49 @@ EXTERN_C const IID IID_ISOSDacInterface3;
 #define __ISOSDacInterface4_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface4 */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface4;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("74B9D34C-A612-4B07-93DD-5462178FCE11")
     ISOSDacInterface4 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetClrNotification( 
+        virtual HRESULT STDMETHODCALLTYPE GetClrNotification(
             CLRDATA_ADDRESS arguments[  ],
             int count,
             int *pNeeded) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterface4Vtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface4 * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface4 * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface4 * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetClrNotification )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetClrNotification )(
             ISOSDacInterface4 * This,
             CLRDATA_ADDRESS arguments[  ],
             int count,
             int *pNeeded);
-        
+
         END_INTERFACE
     } ISOSDacInterface4Vtbl;
 
@@ -2197,23 +2199,23 @@ EXTERN_C const IID IID_ISOSDacInterface4;
         CONST_VTBL struct ISOSDacInterface4Vtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface4_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface4_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface4_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface4_GetClrNotification(This,arguments,count,pNeeded)  \
-    ( (This)->lpVtbl -> GetClrNotification(This,arguments,count,pNeeded) ) 
+    ( (This)->lpVtbl -> GetClrNotification(This,arguments,count,pNeeded) )
 
 #endif /* COBJMACROS */
 
@@ -2230,53 +2232,53 @@ EXTERN_C const IID IID_ISOSDacInterface4;
 #define __ISOSDacInterface5_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface5 */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface5;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("127d6abe-6c86-4e48-8e7b-220781c58101")
     ISOSDacInterface5 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetTieredVersions( 
+        virtual HRESULT STDMETHODCALLTYPE GetTieredVersions(
             CLRDATA_ADDRESS methodDesc,
             int rejitId,
             struct DacpTieredVersionData *nativeCodeAddrs,
             int cNativeCodeAddrs,
             int *pcNativeCodeAddrs) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterface5Vtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface5 * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface5 * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface5 * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetTieredVersions )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetTieredVersions )(
             ISOSDacInterface5 * This,
             CLRDATA_ADDRESS methodDesc,
             int rejitId,
             struct DacpTieredVersionData *nativeCodeAddrs,
             int cNativeCodeAddrs,
             int *pcNativeCodeAddrs);
-        
+
         END_INTERFACE
     } ISOSDacInterface5Vtbl;
 
@@ -2285,23 +2287,23 @@ EXTERN_C const IID IID_ISOSDacInterface5;
         CONST_VTBL struct ISOSDacInterface5Vtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface5_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface5_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface5_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface5_GetTieredVersions(This,methodDesc,rejitId,nativeCodeAddrs,cNativeCodeAddrs,pcNativeCodeAddrs) \
-    ( (This)->lpVtbl -> GetTieredVersions(This,methodDesc,rejitId,nativeCodeAddrs,cNativeCodeAddrs,pcNativeCodeAddrs) ) 
+    ( (This)->lpVtbl -> GetTieredVersions(This,methodDesc,rejitId,nativeCodeAddrs,cNativeCodeAddrs,pcNativeCodeAddrs) )
 
 #endif /* COBJMACROS */
 
@@ -2318,47 +2320,47 @@ EXTERN_C const IID IID_ISOSDacInterface5;
 #define __ISOSDacInterface6_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface6 */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface6;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("11206399-4B66-4EDB-98EA-85654E59AD45")
     ISOSDacInterface6 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetMethodTableCollectibleData( 
+        virtual HRESULT STDMETHODCALLTYPE GetMethodTableCollectibleData(
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableCollectibleData *data) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterface6Vtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface6 * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface6 * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface6 * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodTableCollectibleData )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodTableCollectibleData )(
             ISOSDacInterface6 * This,
             CLRDATA_ADDRESS mt,
             struct DacpMethodTableCollectibleData *data);
-        
+
         END_INTERFACE
     } ISOSDacInterface6Vtbl;
 
@@ -2367,23 +2369,23 @@ EXTERN_C const IID IID_ISOSDacInterface6;
         CONST_VTBL struct ISOSDacInterface6Vtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface6_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface6_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface6_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface6_GetMethodTableCollectibleData(This,mt,data)   \
-    ( (This)->lpVtbl -> GetMethodTableCollectibleData(This,mt,data) ) 
+    ( (This)->lpVtbl -> GetMethodTableCollectibleData(This,mt,data) )
 
 #endif /* COBJMACROS */
 
@@ -2400,80 +2402,80 @@ EXTERN_C const IID IID_ISOSDacInterface6;
 #define __ISOSDacInterface7_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface7 */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface7;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("c1020dde-fe98-4536-a53b-f35a74c327eb")
     ISOSDacInterface7 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetPendingReJITID( 
+        virtual HRESULT STDMETHODCALLTYPE GetPendingReJITID(
             CLRDATA_ADDRESS methodDesc,
             int *pRejitId) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetReJITInformation( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetReJITInformation(
             CLRDATA_ADDRESS methodDesc,
             int rejitId,
             struct DacpReJitData2 *pRejitData) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetProfilerModifiedILInformation( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetProfilerModifiedILInformation(
             CLRDATA_ADDRESS methodDesc,
             struct DacpProfilerILData *pILData) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetMethodsWithProfilerModifiedIL( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetMethodsWithProfilerModifiedIL(
             CLRDATA_ADDRESS mod,
             CLRDATA_ADDRESS *methodDescs,
             int cMethodDescs,
             int *pcMethodDescs) = 0;
-        
+
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterface7Vtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface7 * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface7 * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface7 * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetPendingReJITID )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetPendingReJITID )(
             ISOSDacInterface7 * This,
             CLRDATA_ADDRESS methodDesc,
             int *pRejitId);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetReJITInformation )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetReJITInformation )(
             ISOSDacInterface7 * This,
             CLRDATA_ADDRESS methodDesc,
             int rejitId,
             struct DacpReJitData2 *pRejitData);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetProfilerModifiedILInformation )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetProfilerModifiedILInformation )(
             ISOSDacInterface7 * This,
             CLRDATA_ADDRESS methodDesc,
             struct DacpProfilerILData *pILData);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetMethodsWithProfilerModifiedIL )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetMethodsWithProfilerModifiedIL )(
             ISOSDacInterface7 * This,
             CLRDATA_ADDRESS mod,
             CLRDATA_ADDRESS *methodDescs,
             int cMethodDescs,
             int *pcMethodDescs);
-        
+
         END_INTERFACE
     } ISOSDacInterface7Vtbl;
 
@@ -2482,32 +2484,32 @@ EXTERN_C const IID IID_ISOSDacInterface7;
         CONST_VTBL struct ISOSDacInterface7Vtbl *lpVtbl;
     };
 
-    
+
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface7_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface7_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface7_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface7_GetPendingReJITID(This,methodDesc,pRejitId)   \
-    ( (This)->lpVtbl -> GetPendingReJITID(This,methodDesc,pRejitId) ) 
+    ( (This)->lpVtbl -> GetPendingReJITID(This,methodDesc,pRejitId) )
 
 #define ISOSDacInterface7_GetReJITInformation(This,methodDesc,rejitId,pRejitData)   \
-    ( (This)->lpVtbl -> GetReJITInformation(This,methodDesc,rejitId,pRejitData) ) 
+    ( (This)->lpVtbl -> GetReJITInformation(This,methodDesc,rejitId,pRejitData) )
 
 #define ISOSDacInterface7_GetProfilerModifiedILInformation(This,methodDesc,pILData) \
-    ( (This)->lpVtbl -> GetProfilerModifiedILInformation(This,methodDesc,pILData) ) 
+    ( (This)->lpVtbl -> GetProfilerModifiedILInformation(This,methodDesc,pILData) )
 
 #define ISOSDacInterface7_GetMethodsWithProfilerModifiedIL(This,mod,methodDescs,cMethodDescs,pcMethodDescs) \
-    ( (This)->lpVtbl -> GetMethodsWithProfilerModifiedIL(This,mod,methodDescs,cMethodDescs,pcMethodDescs) ) 
+    ( (This)->lpVtbl -> GetMethodsWithProfilerModifiedIL(This,mod,methodDescs,cMethodDescs,pcMethodDescs) )
 
 #endif /* COBJMACROS */
 
@@ -2524,102 +2526,101 @@ EXTERN_C const IID IID_ISOSDacInterface7;
 #define __ISOSDacInterface8_INTERFACE_DEFINED__
 
 /* interface ISOSDacInterface8 */
-/* [uuid][local][object] */ 
+/* [uuid][local][object] */
 
 
 EXTERN_C const IID IID_ISOSDacInterface8;
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
-    
+
     MIDL_INTERFACE("c12f35a9-e55c-4520-a894-b3dc5165dfce")
     ISOSDacInterface8 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetNumberGenerations( 
+        virtual HRESULT STDMETHODCALLTYPE GetNumberGenerations(
             unsigned int *pGenerations) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGenerationTable( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGenerationTable(
             unsigned int cGenerations,
             struct DacpGenerationData *pGenerationData,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFinalizationFillPointers( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFinalizationFillPointers(
             unsigned int cFillPointers,
             CLRDATA_ADDRESS *pFinalizationFillPointers,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetGenerationTableSvr( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetGenerationTableSvr(
             CLRDATA_ADDRESS heapAddr,
             unsigned int cGenerations,
             struct DacpGenerationData *pGenerationData,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetFinalizationFillPointersSvr( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetFinalizationFillPointersSvr(
             CLRDATA_ADDRESS heapAddr,
             unsigned int cFillPointers,
             CLRDATA_ADDRESS *pFinalizationFillPointers,
             unsigned int *pNeeded) = 0;
-        
-        virtual HRESULT STDMETHODCALLTYPE GetAssemblyLoadContext( 
+
+        virtual HRESULT STDMETHODCALLTYPE GetAssemblyLoadContext(
             CLRDATA_ADDRESS methodTable,
-            CLRDATA_ADDRESS *assemblyLoadContext) = 0;
-        
+            CLRDATA_ADDRESS* assemblyLoadContext) = 0;
     };
-    
-    
+
+
 #else   /* C style interface */
 
     typedef struct ISOSDacInterface8Vtbl
     {
         BEGIN_INTERFACE
-        
-        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
             ISOSDacInterface8 * This,
             /* [in] */ REFIID riid,
-            /* [annotation][iid_is][out] */ 
+            /* [annotation][iid_is][out] */
             _COM_Outptr_  void **ppvObject);
-        
-        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
             ISOSDacInterface8 * This);
-        
-        ULONG ( STDMETHODCALLTYPE *Release )( 
+
+        ULONG ( STDMETHODCALLTYPE *Release )(
             ISOSDacInterface8 * This);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetNumberGenerations )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetNumberGenerations )(
             ISOSDacInterface8 * This,
             unsigned int *pGenerations);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGenerationTable )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGenerationTable )(
             ISOSDacInterface8 * This,
             unsigned int cGenerations,
             struct DacpGenerationData *pGenerationData,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFinalizationFillPointers )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFinalizationFillPointers )(
             ISOSDacInterface8 * This,
             unsigned int cFillPointers,
             CLRDATA_ADDRESS *pFinalizationFillPointers,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetGenerationTableSvr )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetGenerationTableSvr )(
             ISOSDacInterface8 * This,
             CLRDATA_ADDRESS heapAddr,
             unsigned int cGenerations,
             struct DacpGenerationData *pGenerationData,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetFinalizationFillPointersSvr )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetFinalizationFillPointersSvr )(
             ISOSDacInterface8 * This,
             CLRDATA_ADDRESS heapAddr,
             unsigned int cFillPointers,
             CLRDATA_ADDRESS *pFinalizationFillPointers,
             unsigned int *pNeeded);
-        
-        HRESULT ( STDMETHODCALLTYPE *GetAssemblyLoadContext )( 
+
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyLoadContext )(
             ISOSDacInterface8 * This,
             CLRDATA_ADDRESS methodTable,
             CLRDATA_ADDRESS *assemblyLoadContext);
-        
+           
         END_INTERFACE
     } ISOSDacInterface8Vtbl;
 
@@ -2628,38 +2629,37 @@ EXTERN_C const IID IID_ISOSDacInterface8;
         CONST_VTBL struct ISOSDacInterface8Vtbl *lpVtbl;
     };
 
-    
 
 #ifdef COBJMACROS
 
 
 #define ISOSDacInterface8_QueryInterface(This,riid,ppvObject)   \
-    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
 
 #define ISOSDacInterface8_AddRef(This)  \
-    ( (This)->lpVtbl -> AddRef(This) ) 
+    ( (This)->lpVtbl -> AddRef(This) )
 
 #define ISOSDacInterface8_Release(This) \
-    ( (This)->lpVtbl -> Release(This) ) 
+    ( (This)->lpVtbl -> Release(This) )
 
 
 #define ISOSDacInterface8_GetNumberGenerations(This,pGenerations)   \
-    ( (This)->lpVtbl -> GetNumberGenerations(This,pGenerations) ) 
+    ( (This)->lpVtbl -> GetNumberGenerations(This,pGenerations) )
 
 #define ISOSDacInterface8_GetGenerationTable(This,cGenerations,pGenerationData,pNeeded) \
-    ( (This)->lpVtbl -> GetGenerationTable(This,cGenerations,pGenerationData,pNeeded) ) 
+    ( (This)->lpVtbl -> GetGenerationTable(This,cGenerations,pGenerationData,pNeeded) )
 
 #define ISOSDacInterface8_GetFinalizationFillPointers(This,cFillPointers,pFinalizationFillPointers,pNeeded) \
-    ( (This)->lpVtbl -> GetFinalizationFillPointers(This,cFillPointers,pFinalizationFillPointers,pNeeded) ) 
+    ( (This)->lpVtbl -> GetFinalizationFillPointers(This,cFillPointers,pFinalizationFillPointers,pNeeded) )
 
 #define ISOSDacInterface8_GetGenerationTableSvr(This,heapAddr,cGenerations,pGenerationData,pNeeded) \
-    ( (This)->lpVtbl -> GetGenerationTableSvr(This,heapAddr,cGenerations,pGenerationData,pNeeded) ) 
+    ( (This)->lpVtbl -> GetGenerationTableSvr(This,heapAddr,cGenerations,pGenerationData,pNeeded) )
 
 #define ISOSDacInterface8_GetFinalizationFillPointersSvr(This,heapAddr,cFillPointers,pFinalizationFillPointers,pNeeded) \
-    ( (This)->lpVtbl -> GetFinalizationFillPointersSvr(This,heapAddr,cFillPointers,pFinalizationFillPointers,pNeeded) ) 
+    ( (This)->lpVtbl -> GetFinalizationFillPointersSvr(This,heapAddr,cFillPointers,pFinalizationFillPointers,pNeeded) )
 
-#define ISOSDacInterface8_GetAssemblyLoadContext(This,methodTable,assemblyLoadContext)  \
-    ( (This)->lpVtbl -> GetAssemblyLoadContext(This,methodTable,assemblyLoadContext) ) 
+#define ISOSDacInterface8_GetAssemblyLoadContext(This,methodTable,assemblyLoadContext) \
+    ( (This)->lpVtbl -> GetAssemblyLoadContext(This,methodTable,assemblyLoadContext) )
 
 #endif /* COBJMACROS */
 
@@ -2702,7 +2702,7 @@ EXTERN_C const IID IID_ISOSDacInterface9;
     };
     
     
-#else   /* C style interface */
+#else  /* C style interface */
 
     typedef struct ISOSDacInterface9Vtbl
     {
@@ -2737,25 +2737,23 @@ EXTERN_C const IID IID_ISOSDacInterface9;
 #ifdef COBJMACROS
 
 
-#define ISOSDacInterface9_QueryInterface(This,riid,ppvObject)   \
+#define ISOSDacInterface9_QueryInterface(This,riid,ppvObject) \
     ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
 
-#define ISOSDacInterface9_AddRef(This)  \
+#define ISOSDacInterface9_AddRef(This) \
     ( (This)->lpVtbl -> AddRef(This) ) 
 
 #define ISOSDacInterface9_Release(This) \
     ( (This)->lpVtbl -> Release(This) ) 
 
 
-#define ISOSDacInterface9_GetBreakingChangeVersion(This,pVersion)   \
+#define ISOSDacInterface9_GetBreakingChangeVersion(This,pVersion) \
     ( (This)->lpVtbl -> GetBreakingChangeVersion(This,pVersion) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif  /* C style interface */
-
-
 
 
 #endif  /* __ISOSDacInterface9_INTERFACE_DEFINED__ */
@@ -2908,5 +2906,4 @@ EXTERN_C const IID IID_ISOSDacInterface10;
 #endif
 
 #endif
-
 

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -12,7 +12,6 @@
 
 #include "interoplibinterface.h"
 
-
 using CreateObjectFlags = InteropLib::Com::CreateObjectFlags;
 using CreateComInterfaceFlags = InteropLib::Com::CreateComInterfaceFlags;
 
@@ -23,7 +22,6 @@ namespace
     {
         static const DWORD InvalidSyncBlockIndex;
 
-        INT_PTR Sentinel;
         void* Identity;
         void* ThreadContext;
         DWORD SyncBlockIndex;
@@ -57,7 +55,6 @@ namespace
             }
             CONTRACTL_END;
 
-            cxt->Sentinel = ExternalObjectContextSentinelValue; 
             cxt->Identity = (void*)identity;
             cxt->ThreadContext = threadContext;
             cxt->SyncBlockIndex = syncBlockIndex;
@@ -132,10 +129,8 @@ namespace
         }
     };
 
-    // These Sentinel and Identity are used by the DAC, any changes to the layout must be updated on the DAC side (request.cpp)
-    static constexpr size_t DACSentinelOffset = 0;
-    static constexpr size_t DACIdentityOffset = sizeof(INT_PTR);
-    static_assert(offsetof(ExternalObjectContext, Sentinel) == DACSentinelOffset, "Keep in sync with DAC interfaces");
+    // Identity is used by the DAC, any changes to the layout must be updated on the DAC side (request.cpp)
+    static constexpr size_t DACIdentityOffset = 0;
     static_assert(offsetof(ExternalObjectContext, Identity) == DACIdentityOffset, "Keep in sync with DAC interfaces");
 
     const DWORD ExternalObjectContext::InvalidSyncBlockIndex = 0; // See syncblk.h
@@ -1368,7 +1363,7 @@ void QCALLTYPE ComWrappersNative::GetIUnknownImpl(
     END_QCALL;
 }
 
-void ComWrappersNative::DestroyManagedObjectComWrapper(_In_ void* wrapper, void *unused)
+void ComWrappersNative::DestroyManagedObjectComWrapper(_In_ void* wrapper)
 {
     CONTRACTL
     {
@@ -1377,8 +1372,6 @@ void ComWrappersNative::DestroyManagedObjectComWrapper(_In_ void* wrapper, void 
         PRECONDITION(wrapper != NULL);
     }
     CONTRACTL_END;
-
-    _ASSERTE(unused == NULL && "Someone is passing data to this function but it is ignoring it.");
 
     STRESS_LOG1(LF_INTEROP, LL_INFO100, "Destroying MOW: 0x%p\n", wrapper);
     InteropLib::Com::DestroyWrapperForObject(wrapper);

--- a/src/coreclr/src/vm/interoplibinterface.h
+++ b/src/coreclr/src/vm/interoplibinterface.h
@@ -35,7 +35,7 @@ public: // Native QCalls for the abstract ComWrappers managed type.
         _Inout_ QCall::ObjectHandleOnStack retValue);
 
 public: // Lifetime management for COM Wrappers
-    static void DestroyManagedObjectComWrapper(_In_ void* wrapper, _Out_opt_ void *unused);
+    static void DestroyManagedObjectComWrapper(_In_ void* wrapper);
     static void DestroyExternalComObjectContext(_In_ void* context);
     static void MarkExternalComObjectContextCollected(_In_ void* context);
 
@@ -99,5 +99,3 @@ public:
     // Notify when GC finished
     static void OnGCFinished(_In_ int nCondemnedGeneration);
 };
-
-constexpr INT_PTR ExternalObjectContextSentinelValue = (INT_PTR)0xE0E0E0E0E0E0E0E0;


### PR DESCRIPTION
In the process of porting #42942 to 5.0 there were a couple changes that were originally intended to reduce code size, but actually made the change simpler and intruded less on runtime code:
- Using the sync block to round trip the RCW instead of adding a sentinel value
- Grabbing the CCW list and iterating through it instead of refactoring the ClearManagedObjectComWrappers code path

This also fixes #43082 by reporting the stowed exception array during minidump creation, so !analyze works as intended on stowed exceptions.