### PR TITLE
Additional fixes to Windows log profiler.

### DIFF
--- a/src/mono/mono/metadata/profiler.c
+++ b/src/mono/mono/metadata/profiler.c
@@ -14,6 +14,7 @@
 #include <mono/utils/mono-dl.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-logger-internals.h>
+#include <mono/utils/w32subset.h>
 
 MonoProfilerState mono_profiler_state;
 
@@ -148,7 +149,11 @@ mono_profiler_load (const char *desc)
 	mname = libname = NULL;
 
 	if (!desc || !strcmp ("default", desc))
+#if HAVE_API_SUPPORT_WIN32_PIPE_OPEN_CLOSE && !defined (HOST_WIN32)
 		desc = "log:report";
+#else
+		desc = "log";
+#endif
 
 	if ((col = strchr (desc, ':')) != NULL) {
 		mname = (char *) g_memdup (desc, col - desc + 1);

--- a/src/mono/mono/profiler/helper.c
+++ b/src/mono/mono/profiler/helper.c
@@ -88,10 +88,12 @@ mono_profhelper_add_to_fd_set (fd_set *set, int fd, int *max_fd)
 	 * the profiler really can't function, and we're better off printing an
 	 * error and exiting.
 	 */
+#ifndef HOST_WIN32
 	if (fd >= FD_SETSIZE) {
 		mono_profiler_printf_err ("File descriptor is out of bounds for fd_set: %d", fd);
 		exit (1);
 	}
+#endif
 
 	FD_SET (fd, set);
 

--- a/src/mono/mono/profiler/log-args.c
+++ b/src/mono/mono/profiler/log-args.c
@@ -1,6 +1,7 @@
 #include <config.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-proclib.h>
+#include <mono/utils/w32subset.h>
 #include "log.h"
 
 #ifdef HAVE_UNISTD_H
@@ -80,7 +81,11 @@ parse_arg (const char *arg, ProfilerConfig *config)
 	} else if (match_option (arg, "nodefaults", NULL)) {
 		mono_profiler_printf_err ("The nodefaults option can only be used as the first argument.");
 	} else if (match_option (arg, "report", NULL)) {
+#if HAVE_API_SUPPORT_WIN32_PIPE_OPEN_CLOSE && !defined (HOST_WIN32)
 		config->do_report = TRUE;
+#else
+		mono_profiler_printf_err ("'report' argument not supported on platform.");
+#endif
 	} else if (match_option (arg, "debug", NULL)) {
 		config->do_debug = TRUE;
 	} else if (match_option (arg, "heapshot", &val)) {


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20464,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>* Disable popen/pclose.
* Disable reporting using |mprof-report on Windows due to limited piping support.
* Switch to inet_pton instead of deprecated inet_addr.
* Fix Windows socket server since FD is handle and can be bigger than FD_SETSIZE.