### PR TITLE
[corlib] ThreadAbortException protection for ArraySortHelper

### DIFF
--- a/src/mono/mono/tests/Makefile.am
+++ b/src/mono/mono/tests/Makefile.am
@@ -628,6 +628,7 @@ TESTS_CS_SRC=		\
 	bug-29585.cs	\
 	priority.cs	\
 	abort-cctor.cs	\
+	abort-sort.cs	\
 	abort-try-holes.cs \
 	abort-tests.cs \
 	thread-native-exit.cs \

--- a/src/mono/mono/tests/abort-sort.cs
+++ b/src/mono/mono/tests/abort-sort.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Collections.Generic;
+
+public struct J
+{
+	public int i;
+
+	public J(int i_) { i = i_; }
+}
+
+struct JComp : IComparer<J>
+{
+	public int Compare(J x, J y)
+	{
+		int val = 0;
+		Thread.Sleep (Timeout.Infinite);
+		return val;
+	}
+}
+
+public class Foo
+{
+	static ManualResetEventSlim mre;
+
+	public static void Main()
+	{
+		mre = new ManualResetEventSlim();
+		var t = new Thread(Run);
+		t.Start();
+		mre.Wait();
+		Thread.Sleep(400);
+		t.Abort();
+		t.Join();
+		Console.WriteLine("bye bye");
+
+	}
+
+	public static void Run()
+	{
+		int n = 10;
+		var a = new J[n];
+		for (int i = 0; i < n; ++i)
+		{
+			a[i] = new J(n - i);
+		}
+		mre.Set();
+		Array.Sort(a, 0, n, new JComp());
+	}
+}


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20467,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Bump `external/corert`

The ArraySortHelper catches all exceptions in the comparer.
If the sorting thread is aborted while it is running the comparer, the
ArraySortHelper will catch the TAE and propagate an InvalidOperationException
instead.

As a workaround, catch and rethrow TAEs separately.

Add regression test

Related to mono/mono#15418