### PR TITLE
Keep response files used for crossgenning the framework

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildFolderSet.cs
@@ -239,6 +239,10 @@ namespace R2RTest
 
             if (_options.Composite)
             {
+                const string FrameworkOutputFileName = "framework-r2r.dll";
+
+                File.Delete(Path.Combine(_options.CoreRootDirectory.FullName, FrameworkOutputFileName));
+
                 var processes = new ProcessInfo[(int)CompilerIndex.Count];
                 foreach (CompilerRunner runner in frameworkRunners)
                 {
@@ -259,7 +263,7 @@ namespace R2RTest
 
                     if (inputFrameworkDlls.Count > 0)
                     {
-                        string outputFileName = runner.GetOutputFileName(_options.CoreRootDirectory.FullName, "framework-r2r.dll");
+                        string outputFileName = runner.GetOutputFileName(_options.CoreRootDirectory.FullName, FrameworkOutputFileName);
                         ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, outputFileName, inputFrameworkDlls));
                         compilationsToRun.Add(compilationProcess);
                         processes[(int)runner.Index] = compilationProcess;

--- a/src/coreclr/src/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildOptions.cs
@@ -120,7 +120,7 @@ namespace R2RTest
                 List<string> cpaotReferencePaths = new List<string>();
                 cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
                 cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new Crossgen2Runner(this, new Crossgen2RunnerOptions(), cpaotReferencePaths, overrideOutputPath));
+                runners.Add(new Crossgen2Runner(this, new Crossgen2RunnerOptions() { Composite = this.Composite }, cpaotReferencePaths, overrideOutputPath));
             }
 
             if (Crossgen)

--- a/src/coreclr/src/tools/r2rtest/CompilerRunner.cs
+++ b/src/coreclr/src/tools/r2rtest/CompilerRunner.cs
@@ -31,7 +31,6 @@ namespace R2RTest
         {
             new FrameworkExclusion(ExclusionType.Ignore, "CommandLine", "Not a framework assembly"),
             new FrameworkExclusion(ExclusionType.Ignore, "R2RDump", "Not a framework assembly"),
-            new FrameworkExclusion(ExclusionType.Ignore, "xunit.performance.api", "Not a framework assembly"),
 
             // TODO (DavidWr): IBC-related failures
             new FrameworkExclusion(ExclusionType.DontCrossgen2, "Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token"),
@@ -65,11 +64,15 @@ namespace R2RTest
                 reason = exclusion.Reason;
                 return true;
             }
-            else
+
+            if (simpleName.StartsWith("xunit.", StringComparison.OrdinalIgnoreCase))
             {
-                reason = null;
-                return false;
+                reason = "XUnit";
+                return true;
             }
+
+            reason = null;
+            return false;
         }
     }
 

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -629,7 +629,7 @@ exit /b 1
 
 :PrecompileFX
 
-set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%CORE_ROOT%\crossgen.out"  --large-bubble --release --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS%
+set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%CORE_ROOT%\crossgen.out"  --large-bubble --release --nocleanup --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS%
 
 if defined __CompositeBuildMode (
     set __CrossgenCmd=%__CrossgenCmd% --composite
@@ -667,6 +667,5 @@ if %__exitCode% neq 0 (
 )
 
 move "%CORE_ROOT%\crossgen.out\*.dll" %CORE_ROOT% > nul
-del /q /s "%CORE_ROOT%\crossgen.out" > nul
 
 exit /b 0

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -154,9 +154,11 @@ set __msbuildArgs=/p:TargetOS=%__TargetOS% /p:Configuration=%__BuildType% /p:Tar
 
 echo %__MsgPrefix%Commencing CoreCLR test build
 
-set "__BinDir=%__RootBinDir%\bin\coreclr\%__TargetOS%.%__BuildArch%.%__BuildType%"
+set "__OSPlatformConfig=%__TargetOS%.%__BuildArch%.%__BuildType%"
+set "__BinDir=%__RootBinDir%\bin\coreclr\%__OSPlatformConfig%"
 set "__TestRootDir=%__RootBinDir%\tests\coreclr"
-set "__TestBinDir=%__TestRootDir%\%__TargetOS%.%__BuildArch%.%__BuildType%"
+set "__TestBinDir=%__TestRootDir%\%__OSPlatformConfig%"
+set "__TestIntermediatesDir=%__TestRootDir%\obj\%__OSPlatformConfig%"
 
 if not defined XunitTestBinBase set XunitTestBinBase=%__TestBinDir%\
 set "CORE_ROOT=%XunitTestBinBase%\Tests\Core_Root"
@@ -629,10 +631,14 @@ exit /b 1
 
 :PrecompileFX
 
-set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%CORE_ROOT%\crossgen.out"  --large-bubble --release --nocleanup --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS%
+set "__CrossgenOutputDir=%__TestIntermediatesDir%\crossgen.out"
+
+set __CrossgenCmd="%__RepoRootDir%\dotnet.cmd" "%CORE_ROOT%\R2RTest\R2RTest.dll" compile-framework -cr "%CORE_ROOT%" --output-directory "%__CrossgenOutputDir%" --release --nocleanup --target-arch %__BuildArch% -dop %NUMBER_OF_PROCESSORS%
 
 if defined __CompositeBuildMode (
     set __CrossgenCmd=%__CrossgenCmd% --composite
+) else (
+    set __CrossgenCmd=%__CrossgenCmd% --large-bubble
 )
 
 set __CrossgenDir=%__BinDir%
@@ -666,6 +672,6 @@ if %__exitCode% neq 0 (
     exit /b 1
 )
 
-move "%CORE_ROOT%\crossgen.out\*.dll" %CORE_ROOT% > nul
+move "%__CrossgenOutputDir%\*.dll" %CORE_ROOT% > nul
 
 exit /b 0

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -170,7 +170,7 @@ precompile_coreroot_fx()
         __NumProc=$(nproc --all)
     fi
 
-    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$CORE_ROOT/crossgen.out\" --target-arch $__BuildArch -dop $__NumProc"
+    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$CORE_ROOT/crossgen.out\" --large-bubble --release --target-arch $__BuildArch -dop $__NumProc"
 
     if [[ "$__CompositeBuildMode" != 0 ]]; then
         crossgenCmd="$crossgenCmd --composite"
@@ -197,7 +197,6 @@ precompile_coreroot_fx()
     fi
 
     mv "$CORE_ROOT"/crossgen.out/*.dll "$CORE_ROOT"
-    rm -r "$CORE_ROOT/crossgen.out"
 
     return 0
 }

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -170,7 +170,8 @@ precompile_coreroot_fx()
         __NumProc=$(nproc --all)
     fi
 
-    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$CORE_ROOT/crossgen.out\" --large-bubble --release --target-arch $__BuildArch -dop $__NumProc"
+    local outputDir="$__TestIntermediatesDir/crossgen.out"
+    local crossgenCmd="\"$__DotNetCli\" \"$CORE_ROOT/R2RTest/R2RTest.dll\" compile-framework -cr \"$CORE_ROOT\" --output-directory \"$outputDir\" --large-bubble --release --nocleanup --target-arch $__BuildArch -dop $__NumProc"
 
     if [[ "$__CompositeBuildMode" != 0 ]]; then
         crossgenCmd="$crossgenCmd --composite"
@@ -196,7 +197,7 @@ precompile_coreroot_fx()
         return 1
     fi
 
-    mv "$CORE_ROOT"/crossgen.out/*.dll "$CORE_ROOT"
+    mv "$outputDir"/*.dll "$CORE_ROOT"
 
     return 0
 }
@@ -625,13 +626,14 @@ __LogsDir="$__RootBinDir/log"
 __MsbuildDebugLogsDir="$__LogsDir/MsbuildDebugLogs"
 
 # Set the remaining variables based upon the determined build configuration
-__BinDir="$__RootBinDir/bin/coreclr/$__TargetOS.$__BuildArch.$__BuildType"
+__OSPlatformConfig="$__TargetOS.$__BuildArch.$__BuildType"
+__BinDir="$__RootBinDir/bin/coreclr/$__OSPlatformConfig"
 __PackagesBinDir="$__BinDir/.nuget"
 __TestDir="$__RepoRootDir/src/tests"
 __TryRunDir="$__RepoRootDir/src/coreclr"
-__TestWorkingDir="$__RootBinDir/tests/coreclr/$__TargetOS.$__BuildArch.$__BuildType"
-__IntermediatesDir="$__RootBinDir/obj/coreclr/$__TargetOS.$__BuildArch.$__BuildType"
-__TestIntermediatesDir="$__RootBinDir/tests/coreclr/obj/$__TargetOS.$__BuildArch.$__BuildType"
+__TestWorkingDir="$__RootBinDir/tests/coreclr/$__OSPlatformConfig"
+__IntermediatesDir="$__RootBinDir/obj/coreclr/$__OSPlatformConfig"
+__TestIntermediatesDir="$__RootBinDir/tests/coreclr/obj/$__OSPlatformConfig"
 __CrossComponentBinDir="$__BinDir"
 __CrossCompIntermediatesDir="$__IntermediatesDir/crossgen"
 


### PR DESCRIPTION
Response files are a very useful artifact for reproing various
Crossgen / Crossgen2 compilation errors. I propose modifying the
test build scripts to retain these artifacts by using the --nocleanup
option and by skipping deletion of the entire output folder upon
the end of framework compilation. The Crossgen output folder is not
listed among the artifacts transferred to Helix so it should be a
non-concern w.r.t. Helix throughput. I have also put the cmd and sh
versions of the script in sync by adding "large-bubble" and "release"
flags to the Unix version.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib 