### PR TITLE
[browser][debugger] Clean up MessageId logic to prepare for sessions in the test harness

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
@@ -195,9 +195,9 @@ namespace Microsoft.WebAssembly.Diagnostics
             Log("protocol", $"browser: {msg}");
 
             if (res["id"] == null)
-                pending_ops.Add(OnEvent(new SessionId(res["sessionId"]?.Value<string>()), res["method"].Value<string>(), res["params"] as JObject, token));
+                pending_ops.Add(OnEvent(res.ToObject<SessionId>(), res["method"].Value<string>(), res["params"] as JObject, token));
             else
-                OnResponse(new MessageId(res["sessionId"]?.Value<string>(), res["id"].Value<int>()), Result.FromJson(res));
+                OnResponse(res.ToObject<MessageId>(), Result.FromJson(res));
         }
 
         private void ProcessIdeMessage(string msg, CancellationToken token)
@@ -206,8 +206,9 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (!string.IsNullOrEmpty(msg))
             {
                 var res = JObject.Parse(msg);
+                var id = res.ToObject<MessageId>();
                 pending_ops.Add(OnCommand(
-                    new MessageId(res["sessionId"]?.Value<string>(), res["id"].Value<int>()),
+                    id,
                     res["method"].Value<string>(),
                     res["params"] as JObject, token));
             }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DevToolsClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DevToolsClient.cs
@@ -19,7 +19,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         TaskCompletionSource<bool> side_exit = new TaskCompletionSource<bool>();
         List<byte[]> pending_writes = new List<byte[]>();
         Task current_write;
-        readonly ILogger logger;
+        protected readonly ILogger logger;
 
         public DevToolsClient(ILogger logger)
         {
@@ -157,11 +157,6 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
 
             return false;
-        }
-
-        protected virtual void Log(string priority, string msg)
-        {
-            //
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -46,7 +46,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
 
         public Task<Result> SendCommand(string method, JObject args, CancellationToken token)
-            => SendCommand (new SessionId (null), method, args, token);
+            => SendCommand(new SessionId(null), method, args, token);
 
         public Task<Result> SendCommand(SessionId sessionId, string method, JObject args, CancellationToken token)
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -13,7 +13,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 {
     internal class InspectorClient : DevToolsClient
     {
-        List<(int, TaskCompletionSource<Result>)> pending_cmds = new List<(int, TaskCompletionSource<Result>)>();
+        Dictionary<MessageId,TaskCompletionSource<Result>> pending_cmds = new Dictionary<MessageId, TaskCompletionSource<Result>>();
         Func<string, JObject, CancellationToken, Task> onEvent;
         int next_cmd_id;
 
@@ -22,18 +22,15 @@ namespace Microsoft.WebAssembly.Diagnostics
         Task HandleMessage(string msg, CancellationToken token)
         {
             var res = JObject.Parse(msg);
-            if (res["id"] == null)
-                DumpProtocol(string.Format("Event method: {0} params: {1}", res["method"], res["params"]));
-            else
-                DumpProtocol(string.Format("Response id: {0} res: {1}", res["id"], res));
 
             if (res["id"] == null)
                 return onEvent(res["method"].Value<string>(), res["params"] as JObject, token);
-            var id = res["id"].Value<int>();
-            var idx = pending_cmds.FindIndex(e => e.Item1 == id);
-            var item = pending_cmds[idx];
-            pending_cmds.RemoveAt(idx);
-            item.Item2.SetResult(Result.FromJson(res));
+
+            var id = res.ToObject<MessageId>();
+            if (!pending_cmds.Remove(id, out var item))
+                logger.LogError ($"Unable to find command {id}");
+
+            item.SetResult(Result.FromJson(res));
             return null;
         }
 
@@ -49,6 +46,9 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
 
         public Task<Result> SendCommand(string method, JObject args, CancellationToken token)
+            => SendCommand (new SessionId (null), method, args, token);
+
+        public Task<Result> SendCommand(SessionId sessionId, string method, JObject args, CancellationToken token)
         {
             int id = ++next_cmd_id;
             if (args == null)
@@ -62,20 +62,13 @@ namespace Microsoft.WebAssembly.Diagnostics
             });
 
             var tcs = new TaskCompletionSource<Result>();
-            pending_cmds.Add((id, tcs));
+            pending_cmds[new MessageId(sessionId.sessionId, id)] = tcs;
 
             var str = o.ToString();
-            //Log ("protocol", $"SendCommand: id: {id} method: {method} params: {args}");
 
             var bytes = Encoding.UTF8.GetBytes(str);
             Send(bytes, token);
             return tcs.Task;
-        }
-
-        protected virtual void DumpProtocol(string msg)
-        {
-            // Console.WriteLine (msg);
-            //XXX make logging not stupid
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -13,7 +13,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 {
     internal class InspectorClient : DevToolsClient
     {
-        Dictionary<MessageId,TaskCompletionSource<Result>> pending_cmds = new Dictionary<MessageId, TaskCompletionSource<Result>>();
+        Dictionary<MessageId, TaskCompletionSource<Result>> pending_cmds = new Dictionary<MessageId, TaskCompletionSource<Result>>();
         Func<string, JObject, CancellationToken, Task> onEvent;
         int next_cmd_id;
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -28,7 +28,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
             var id = res.ToObject<MessageId>();
             if (!pending_cmds.Remove(id, out var item))
-                logger.LogError ($"Unable to find command {id}");
+                logger.LogError($"Unable to find command {id}");
 
             item.SetResult(Result.FromJson(res));
             return null;


### PR DESCRIPTION
Use the same logic we use in the Proxy to clean up the Inspector and parse the MessageId directly.  Prevents id collisions across sessions.