### PR TITLE
Fix crossbuild on CentOS

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -139,6 +139,10 @@ function(add_toolchain_linker_flag Flag)
   set("CMAKE_SHARED_LINKER_FLAGS${CONFIG_SUFFIX}" "${CMAKE_SHARED_LINKER_FLAGS${CONFIG_SUFFIX}} ${Flag}" PARENT_SCOPE)
 endfunction()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_toolchain_linker_flag("-Wl,--rpath-link=${CROSS_ROOTFS}/lib/${TOOLCHAIN}")
+  add_toolchain_linker_flag("-Wl,--rpath-link=${CROSS_ROOTFS}/usr/lib/${TOOLCHAIN}")
+endif()
 
 if(TARGET_ARCH_NAME STREQUAL "armel")
   if(DEFINED TIZEN_TOOLCHAIN) # For Tizen only

--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -43,7 +43,7 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
   locate_toolchain_exec(nm CMAKE_NM)
   locate_toolchain_exec(ranlib CMAKE_RANLIB)
 
-  if(NOT CMAKE_C_COMPILER_ID MATCHES "GNU")
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     locate_toolchain_exec(link CMAKE_LINKER)
   endif()
 

--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -41,10 +41,9 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER)
 
   locate_toolchain_exec(ar CMAKE_AR)
   locate_toolchain_exec(nm CMAKE_NM)
+  locate_toolchain_exec(ranlib CMAKE_RANLIB)
 
-  if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-    locate_toolchain_exec(ranlib CMAKE_RANLIB)
-  else()
+  if(NOT CMAKE_C_COMPILER_ID MATCHES "GNU")
     locate_toolchain_exec(link CMAKE_LINKER)
   endif()
 


### PR DESCRIPTION
This change fixes the crossbuilding to work on CentOS. Clang
frontend presets some of the compiler options based on the
host OS and I guess that's causing the need to add the
`--rpath-link`.
The ranlib change to use llvm ranlib fixed a problem where
cmake attempted to use ranlib from the rootfs for some
reason.

These changes have no effect on the cross build on Ubuntu.

The reason for fixing it is that we'd like to move our cross build to 
CentOS 7 from Ubuntu so that the cross tools generated during
the build can run on the same distros as natively built tools.
