### PR TITLE
Fix libraries jitstress jobs

### DIFF
--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -129,7 +129,7 @@ jobs:
             # for clarity), and should remain in sync. This is only a subset; only the testGroups that are
             # used to test the libraries have been added here. More could be added if we decided to test the
             # libraries with more stress modes. The scenario tags are interpreted by
-            # src\coreclr\tests\testenvironment.proj.
+            # src\tests\Common\testenvironment.proj.
             #
             # The one difference here compared to eng/pipelines/common/templates/runtimes/run-test-job.yml is
             # that 'jitstress' contains 'no_tiered_compilation'. The 'normal' (default) test mode

--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -6,7 +6,7 @@
      is used to run the tests. If a set of comma-separated scenarios are specified in the `_Scenarios`
      property, then each test is run for each of the specified CoreCLR scenarios (e.g., COMPlus_JitStress=1;
      COMPlus_JitStressRegs=4; COMPlus_JitStress=2 + COMPlus_JitStressRegs=0x1000). The set of acceptable
-     scenario names is defined and interpreted by src\coreclr\tests\testenvironment.proj.
+     scenario names is defined and interpreted by src\tests\Common\testenvironment.proj.
 
     "RunInParallelForEachScenario" is the "root" target for this Project. It first creates the
     "correlation payload", which is the set of files used by all Helix submissions
@@ -105,7 +105,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_ProjectsToBuild Include="$(RepoRoot)\src\coreclr\tests\testenvironment.proj">
+      <_ProjectsToBuild Include="$(RepoRoot)\src\tests\Common\testenvironment.proj">
         <Properties>Scenario=$(Scenario);TestEnvFileName=$(TestEnvFilePath);TargetsWindows=$(TargetsWindows)</Properties>
       </_ProjectsToBuild>
     </ItemGroup>


### PR DESCRIPTION
PR #42386 moved testenvironment.proj, leading to pipeline failures in the libraries jitstress jobs.
This fixes up the references.