### PR TITLE
RemoteExecutor FailureTest - NOT_FOR_MERGING

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -64,6 +64,7 @@ namespace System.Tests
         public void UnhandledException_Add_Remove()
         {
             RemoteExecutor.Invoke(() => {
+                Assert.True(false);
                 AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(MyHandler);
                 AppDomain.CurrentDomain.UnhandledException -= new UnhandledExceptionEventHandler(MyHandler);
             }).Dispose();


### PR DESCRIPTION
Exists purely to test a potentially major issue I am seeing in `RemoteExecutor` from the  dotnet/arcade repository where actions are not being invoked. 

https://github.com/dotnet/arcade/issues/6371

Didn't know of any other way to test this so sorry for hogging build infrastructure.