### PR TITLE
[Android] Add AndroidAppBuilder pkgproj for Android sample

### DIFF
--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.Android.Sample.Mono/Microsoft.NET.Runtime.Android.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.Android.Sample.Mono/Microsoft.NET.Runtime.Android.Sample.Mono.pkgproj
@@ -2,10 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-  <PropertyGroup>
-    <IsShipping>false</IsShipping>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AndroidAppBuilder\AndroidAppBuilder.csproj" />
   </ItemGroup>

--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.Android.Sample.Mono/Microsoft.NET.Runtime.Android.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.Android.Sample.Mono/Microsoft.NET.Runtime.Android.Sample.Mono.pkgproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <PropertyGroup>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoToolsLocalDir)tasks\mobile.tasks\AndroidAppBuilder\AndroidAppBuilder.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <_AndroidSampleFiles Include="$(ArtifactsDir)bin\AppleAppBuilder\$(Configuration)\net5.0\AppleAppBuilder.dll" />
+
+    <PackageFile Include="@(_AndroidSampleFiles)" TargetPath="tools\$(NetCoreAppCurrent)\" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.Android.Sample.Mono/Microsoft.NET.Runtime.Android.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.Android.Sample.Mono/Microsoft.NET.Runtime.Android.Sample.Mono.pkgproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_AndroidSampleFiles Include="$(ArtifactsDir)bin\AppleAppBuilder\$(Configuration)\net5.0\AppleAppBuilder.dll" />
+    <_AndroidSampleFiles Include="$(ArtifactsDir)bin\AndroidAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\AndroidAppBuilder.dll" />
 
     <PackageFile Include="@(_AndroidSampleFiles)" TargetPath="tools\$(NetCoreAppCurrent)\" />
   </ItemGroup>

--- a/src/mono/netcore/nuget/descriptions.json
+++ b/src/mono/netcore/nuget/descriptions.json
@@ -5,6 +5,11 @@
         "CommonTypes": [ ]
     },
     {
+        "Name": "Microsoft.NET.Runtime.Android.Sample.Mono",
+        "Description": "Internal package for sharing Android App Builder.",
+        "CommonTypes": [ ]
+    },
+    {
         "Name": "Microsoft.NETCore.BrowserDebugHost.Transport",
         "Description": "Internal package for sharing BrowserDebugHost.",
         "CommonTypes": [ ]

--- a/src/mono/netcore/nuget/mono-packages.proj
+++ b/src/mono/netcore/nuget/mono-packages.proj
@@ -1,6 +1,10 @@
 <Project>
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.props" />
 
+  <ItemGroup Condition="'$(TargetOS)' == 'Android'">
+    <ProjectReference Include="Microsoft.NET.Runtime.Android.Sample.Mono\Microsoft.NET.Runtime.Android.Sample.Mono.pkgproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <ProjectReference Include="Microsoft.NETCore.BrowserDebugHost.Transport\Microsoft.NETCore.BrowserDebugHost.Transport.pkgproj" />
   </ItemGroup>

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.csproj
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.csproj
@@ -25,4 +25,7 @@
   <Target Name="PublishBuilder"
           AfterTargets="Build"
           DependsOnTargets="Publish" />
+
+  <Target Name="GetFilesToPackage" />
+
 </Project>


### PR DESCRIPTION
In preparation to bring mono samples to `dotnet/samples`, files that are most likely to change will be packaged into a nuget package to be downloaded and consumed on the `dotnet/samples` end rather than mirroring changes.

This PR expands the process that created the NuGet package for `Microsoft.NETCore.BrowserDebugHost.Transport` to build a NuGet package for the Android sample.
