### PR TITLE
Fix ArrayList.GetRange().GetRange().ToArray()

### DIFF
--- a/src/libraries/System.Collections.NonGeneric/tests/ArrayListTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/ArrayListTests.cs
@@ -1319,6 +1319,32 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        public static void GetRange_OnAnotherRange_YieldsProperSubset()
+        {
+            var list = new ArrayList() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+            ArrayList range1 = list.GetRange(2, 6);
+            Assert.Equal(6, range1.Count);
+            Assert.Equal(3, range1[0]);
+            Assert.Equal(8, range1[5]);
+            Assert.Equal(new object[] { 3, 4, 5, 6, 7, 8 }, range1.ToArray());
+
+            ArrayList range2 = range1.GetRange(3, 2);
+            Assert.Equal(2, range2.Count);
+            Assert.Equal(6, range2[0]);
+            Assert.Equal(7, range2[1]);
+            Assert.Equal(new object[] { 6, 7 }, range2.ToArray());
+
+            ArrayList range3 = range2.GetRange(0, 1);
+            Assert.Equal(1, range3.Count);
+            Assert.Equal(6, range3[0]);
+            Assert.Equal(new object[] { 6 }, range3.ToArray());
+
+            range3[0] = 42;
+            Assert.Equal(42, range1[3]);
+        }
+
+        [Fact]
         public static void SetRange()
         {
             int index = 3;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
@@ -2574,7 +2574,7 @@ namespace System.Collections
                 if (_baseSize == 0)
                     return Array.Empty<object?>();
                 object[] array = new object[_baseSize];
-                Array.Copy(_baseList._items, _baseIndex, array, 0, _baseSize);
+                _baseList.CopyTo(_baseIndex, array, 0, _baseSize);
                 return array;
             }
 


### PR DESCRIPTION
The range created by the second GetRange call has an empty _items array that should be ignored, but ToArray on it was trying to copy from that _items directly rather than going through the source's CopyTo method.

Fixes https://github.com/dotnet/runtime/issues/43047