### PR TITLE
Bump Intellisense version for main branch

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -145,7 +145,7 @@
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20200924.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>6.0.0-alpha.1.20509.3</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->


### PR DESCRIPTION
We generated [a new intellisense nuget package](https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=167131&view=results) that contains the latest API structure from RC2.
Nuget Package Version: 5.0.0-preview-20201009.2

I will also backport this change to the `release/5.0` branch.

@RussKie @merriemcgaw @AdamYoblick please make sure you bump the intellisense nuget package version in the WPF and WinForms repos, both in master and in your 5.0 branch.

