### PR TITLE
Remove OSX arm64 from libraries outerloop build

### DIFF
--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -33,7 +33,6 @@ jobs:
           - Linux_arm64
           - Linux_musl_arm64
       - ${{ if eq(variables['includeOsxOuterloop'], true) }}:        
-        - OSX_arm64
         - OSX_x64
       jobParameters:
         testGroup: innerloop
@@ -57,7 +56,6 @@ jobs:
           - Linux_musl_x64
           - Linux_musl_arm64
       - ${{ if and(eq(variables['includeOsxOuterloop'], true), eq(variables['isFullMatrix'], true)) }}:
-        - OSX_arm64
         - OSX_x64
       helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
       jobParameters:
@@ -79,7 +77,6 @@ jobs:
           - Linux_x64
           - Linux_musl_x64
         - ${{ if eq(variables['includeOsxOuterloop'], true) }}:
-          - OSX_arm64
           - OSX_x64
         helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
         jobParameters:


### PR DESCRIPTION
This were added as part of the osx_arm64 runtime packs bring up but we don't yet have a helix queue to run this tests, so this will break the next coreclr-libraries outerloop build.


cc: @dotnet/runtime-infrastructure 