### PR TITLE
Remove alpine arm64 from mono outerloop build

### DIFF
--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -29,7 +29,6 @@ jobs:
         - Linux_x64
         - Linux_arm
         - Linux_musl_x64
-        - Linux_musl_arm64
         - OSX_x64
       jobParameters:
         testScope: outerloop


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/issues/43244

cc: @akoeplinger @ViktorHofer @directhex 