### PR TITLE
Block the runtime on ready to early bind breakpoints

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -26,13 +26,10 @@ namespace Microsoft.WebAssembly.Diagnostics
         private HashSet<SessionId> sessions = new HashSet<SessionId>();
         private Dictionary<SessionId, ExecutionContext> contexts = new Dictionary<SessionId, ExecutionContext>();
 
-        public MonoProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList, bool hideWebDriver = true) : base(loggerFactory)
+        public MonoProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList) : base(loggerFactory)
         {
-            this.hideWebDriver = hideWebDriver;
             this.urlSymbolServerList = urlSymbolServerList ?? new List<string>();
         }
-
-        private readonly bool hideWebDriver;
 
         internal ExecutionContext GetContext(SessionId sessionId)
         {
@@ -200,7 +197,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             // Inspector doesn't use the Target domain or sessions
             // so we try to init immediately
-            if (hideWebDriver && id == SessionId.Null)
+            if (id == SessionId.Null)
                 await DeleteWebDriver(id, token);
 
             if (!contexts.TryGetValue(id, out ExecutionContext context))
@@ -1175,7 +1172,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         private async Task DeleteWebDriver(SessionId sessionId, CancellationToken token)
         {
             // see https://github.com/mono/mono/issues/19549 for background
-            if (hideWebDriver && sessions.Add(sessionId))
+            if (sessions.Add(sessionId))
             {
                 await SendMonoCommand(sessionId, new MonoCommands("globalThis.dotnetDebugger = true"), token);
                 Result res = await SendCommand(sessionId,

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -170,7 +170,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Target.attachedToTarget":
                     {
                         if (args["targetInfo"]["type"]?.ToString() == "page")
-                            await DeleteWebDriver(new SessionId(args["sessionId"]?.ToString()), token);
+                            await AttachToTarget(new SessionId(args["sessionId"]?.ToString()), token);
                         break;
                     }
 
@@ -198,7 +198,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             // Inspector doesn't use the Target domain or sessions
             // so we try to init immediately
             if (id == SessionId.Null)
-                await DeleteWebDriver(id, token);
+                await AttachToTarget(id, token);
 
             if (!contexts.TryGetValue(id, out ExecutionContext context))
                 return false;
@@ -208,7 +208,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Target.attachToTarget":
                     {
                         Result resp = await SendCommand(id, method, args, token);
-                        await DeleteWebDriver(new SessionId(resp.Value["sessionId"]?.ToString()), token);
+                        await AttachToTarget(new SessionId(resp.Value["sessionId"]?.ToString()), token);
                         break;
                     }
 
@@ -1169,7 +1169,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             return true;
         }
 
-        private async Task DeleteWebDriver(SessionId sessionId, CancellationToken token)
+        private async Task AttachToTarget(SessionId sessionId, CancellationToken token)
         {
             // see https://github.com/mono/mono/issues/19549 for background
             if (sessions.Add(sessionId))

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -1299,9 +1299,6 @@ var MonoSupportLib = {
 
 		mono_wasm_runtime_ready: function () {
 			this.mono_wasm_runtime_is_ready = true;
-			// DO NOT REMOVE - magic debugger init function
-			console.debug ("mono_wasm_runtime_ready", "fe00e07a-5519-4dfe-b35a-f867dbaf2e28");
-
 			this._clear_per_step_state ();
 
 			// FIXME: where should this go?
@@ -1315,6 +1312,11 @@ var MonoSupportLib = {
 			this._register_c_var_fn ('mono_wasm_invoke_getter_on_value',  'bool', [ 'number', 'number', 'string' ]);
 			this._register_c_var_fn ('mono_wasm_get_local_vars',          'bool', [ 'number', 'number', 'number']);
 			this._register_c_var_fn ('mono_wasm_get_deref_ptr_value',     'bool', [ 'number', 'number']);
+			// DO NOT REMOVE - magic debugger init function
+			if (globalThis.dotnetDebugger)
+				debugger;
+			else
+				console.debug ("mono_wasm_runtime_ready", "fe00e07a-5519-4dfe-b35a-f867dbaf2e28");
 		},
 
 		mono_wasm_set_breakpoint: function (assembly, method_token, il_offset) {


### PR DESCRIPTION
Unless we pause at the ready point execution will continue while we figure out where the breakpoints are.  To fix this we initialize some state when we have a new session that indicates to the runtime it is safe to use a debugger statement to block while loading the pdbs.  This allows us to avoid a race in initialization when binding breakpoints at startup.

The debug proxy initially used something like this pattern but the `debugger` statement caused pauses when the inspector was used without the debug proxy and that was deemed problematic.