### PR TITLE
Use module initializer for WSAStartup in System.Net.Sockets on Windows

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -20,8 +20,6 @@ namespace System.Net.Sockets
         [SupportedOSPlatform("windows")]
         public Socket(SocketInformation socketInformation)
         {
-            InitializeSockets();
-
             SocketError errorCode = SocketPal.CreateSocket(socketInformation, out _handle,
                 ref _addressFamily, ref _socketType, ref _protocolType);
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -24,12 +24,6 @@ namespace System.Net.Sockets
 
         private static bool GetPlatformSupportsDualModeIPv4PacketInfo() =>
             Interop.Sys.PlatformSupportsDualModeIPv4PacketInfo() != 0;
-
-        public static void Initialize()
-        {
-            // nop.  No initialization required.
-        }
-
         public static SocketError GetSocketErrorForErrorCode(Interop.Error errorCode)
         {
             return SocketErrorPal.GetSocketErrorForNativeError(errorCode);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -18,19 +18,20 @@ namespace System.Net.Sockets
         public const bool SupportsMultipleConnectAttempts = true;
         public static readonly int MaximumAddressSize = UnixDomainSocketEndPoint.MaxAddressSize;
 
+        [ModuleInitializer]
+        internal static void Initialize()
+        {
+            // Ensure that WSAStartup has been called once per process.
+            // The System.Net.NameResolution contract is responsible for the initialization.
+            Dns.GetHostName();
+        }
+
         private static void MicrosecondsToTimeValue(long microseconds, ref Interop.Winsock.TimeValue socketTime)
         {
             const int microcnv = 1000000;
 
             socketTime.Seconds = (int)(microseconds / microcnv);
             socketTime.Microseconds = (int)(microseconds % microcnv);
-        }
-
-        public static void Initialize()
-        {
-            // Ensure that WSAStartup has been called once per process.
-            // The System.Net.NameResolution contract is responsible for the initialization.
-            Dns.GetHostName();
         }
 
         public static SocketError GetLastSocketError()

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/StartupTests.Windows.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/StartupTests.Windows.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipes;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public class StartupTests
+    {
+        // Socket functionality on Windows requires WSAStartup to have been called, and thus System.Net.Sockets
+        // is responsible for doing so prior to making relevant native calls; this tests entry points.
+        // RemoteExecutor is used so that the individual method is used as early in the process as possible.
+
+        [Fact]
+        public static void OSSupportsIPv4()
+        {
+            bool parentSupported = Socket.OSSupportsIPv4;
+            RemoteExecutor.Invoke(parentSupported =>
+            {
+                Assert.Equal(bool.Parse(parentSupported), Socket.OSSupportsIPv4);
+            }, parentSupported.ToString()).Dispose();
+        }
+
+        [Fact]
+        public static void OSSupportsIPv6()
+        {
+            bool parentSupported = Socket.OSSupportsIPv6;
+            RemoteExecutor.Invoke(parentSupported =>
+            {
+                Assert.Equal(bool.Parse(parentSupported), Socket.OSSupportsIPv6);
+            }, parentSupported.ToString()).Dispose();
+        }
+
+        [Fact]
+        public static void OSSupportsUnixDomainSockets()
+        {
+            bool parentSupported = Socket.OSSupportsUnixDomainSockets;
+            RemoteExecutor.Invoke(parentSupported =>
+            {
+                Assert.Equal(bool.Parse(parentSupported), Socket.OSSupportsUnixDomainSockets);
+            }, parentSupported.ToString()).Dispose();
+        }
+
+#pragma warning disable CS0618 // SupportsIPv4 and SupportsIPv6 are obsolete
+        [Fact]
+        public static void SupportsIPv4()
+        {
+            bool parentSupported = Socket.SupportsIPv4;
+            RemoteExecutor.Invoke(parentSupported =>
+            {
+                Assert.Equal(bool.Parse(parentSupported), Socket.SupportsIPv4);
+            }, parentSupported.ToString()).Dispose();
+        }
+
+        [Fact]
+        public static void SupportsIPv6()
+        {
+            bool parentSupported = Socket.SupportsIPv6;
+            RemoteExecutor.Invoke(parentSupported =>
+            {
+                Assert.Equal(bool.Parse(parentSupported), Socket.SupportsIPv6);
+            }, parentSupported.ToString()).Dispose();
+        }
+#pragma warning restore CS0618
+
+        [Fact]
+        public static void Ctor_SocketType_ProtocolType()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                new Socket(SocketType.Stream, ProtocolType.Tcp).Dispose();
+            }).Dispose();
+        }
+
+        [Fact]
+        public static void Ctor_AddressFamily_SocketType_ProtocolType()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp).Dispose();
+            }).Dispose();
+        }
+
+        [Fact]
+        public static void Ctor_SafeHandle() => RemoteExecutor.Invoke(() =>
+        {
+            using var pipe = new AnonymousPipeServerStream();
+            SocketException se = Assert.Throws<SocketException>(() => new Socket(new SafeSocketHandle(pipe.ClientSafePipeHandle.DangerousGetHandle(), ownsHandle: false)));
+            Assert.Equal(SocketError.NotSocket, se.SocketErrorCode);
+        }).Dispose();
+    }
+}

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="SocketTestHelper.cs" />
     <Compile Include="SelectAndPollTests.cs" />
     <Compile Include="SocketInformationTest.cs" />
+    <Compile Include="StartupTests.Windows.cs" />
     <Compile Include="TcpListenerTest.cs" />
     <Compile Include="TelemetryTest.cs" />
     <Compile Include="TimeoutTest.cs" />


### PR DESCRIPTION
@jkotas, this is what I mentioned to you.  Do you have concerns about this usage?  It seems to make sense, given that there's no reason to use System.Net.Sockets if you're not going to use one of the the things that requires this initialization, so from a trimming perspective it shouldn't matter.  And it helps to simplify the usage and make it less likely code paths would be added that need this initialization but don't get it (which would be easy to sneak through testing).

cc: @geoffkizer 