### PR TITLE
[HTTP/3] detect frame/setting types reserved in draft 30.

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Frames/Http3FrameType.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Frames/Http3FrameType.cs
@@ -3,14 +3,27 @@
 
 namespace System.Net.Http
 {
+    /// <summary>
+    /// HTTP3 frame types.
+    /// </summary>
+    /// <remarks>
+    /// For frames that existed in HTTP/2, but either no longer exist or were delegated to QUIC, 7.2.8 states:
+    ///     "Frame types that were used in HTTP/2 where there is no corresponding HTTP/3 frame have also been
+    ///     reserved (Section 11.2.1). These frame types MUST NOT be sent, and their receipt MUST be treated
+    ///     as a connection error of type H3_FRAME_UNEXPECTED."
+    /// </remarks>
     internal enum Http3FrameType : long
     {
         Data = 0x0,
         Headers = 0x1,
+        ReservedHttp2Priority = 0x2,
         CancelPush = 0x3,
         Settings = 0x4,
         PushPromise = 0x5,
+        ReservedHttp2Ping = 0x6,
         GoAway = 0x7,
+        ReservedHttp2WindowUpdate = 0x8,
+        ReservedHttp2Continuation = 0x9,
         MaxPushId = 0xD,
         DuplicatePush = 0xE
     }

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Http3SettingType.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Http3SettingType.cs
@@ -12,6 +12,15 @@ namespace System.Net.Http
         /// </summary>
         QPackMaxTableCapacity = 0x1,
 
+        // Below are explicitly reserved and should never be sent, per
+        // https://tools.ietf.org/html/draft-ietf-quic-http-31#section-7.2.4.1
+        // and
+        // https://tools.ietf.org/html/draft-ietf-quic-http-31#section-11.2.2
+        ReservedHttp2EnablePush = 0x2,
+        ReservedHttp2MaxConcurrentStreams = 0x3,
+        ReservedHttp2InitialWindowSize = 0x4,
+        ReservedHttp2MaxFrameSize = 0x5,
+
         /// <summary>
         /// SETTINGS_MAX_HEADER_LIST_SIZE
         /// The maximum size of headers. The default is unlimited.

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -101,12 +101,7 @@ namespace System.Net.Test.Common
             return stream;
         }
 
-        public override async Task<byte[]> ReadRequestBodyAsync()
-        {
-            return await _currentStream.ReadRequestBodyAsync().ConfigureAwait(false);
-        }
-
-        public override async Task<HttpRequestData> ReadRequestDataAsync(bool readBody = true)
+        public async Task<Http3LoopbackStream> AcceptRequestStreamAsync()
         {
             Http3LoopbackStream stream;
 
@@ -116,62 +111,63 @@ namespace System.Net.Test.Common
             }
             while (!stream.CanWrite); // skip control stream.
 
+            return stream;
+        }
+
+        public async Task<(Http3LoopbackStream clientControlStream, Http3LoopbackStream requestStream)> AcceptControlAndRequestStreamAsync()
+        {
+            Http3LoopbackStream streamA = null, streamB = null;
+
+            try
+            {
+                streamA = await AcceptStreamAsync();
+                streamB = await AcceptStreamAsync();
+
+                return (streamA.CanWrite, streamB.CanWrite) switch
+                {
+                    (false, true) => (streamA, streamB),
+                    (true, false) => (streamB, streamA),
+                    _ => throw new Exception("Expected one unidirectional and one bidirectional stream; received something else.")
+                };
+            }
+            catch
+            {
+                streamA?.Dispose();
+                streamB?.Dispose();
+                throw;
+            }
+        }
+
+        public override async Task<byte[]> ReadRequestBodyAsync()
+        {
+            return await _currentStream.ReadRequestBodyAsync().ConfigureAwait(false);
+        }
+
+        public override async Task<HttpRequestData> ReadRequestDataAsync(bool readBody = true)
+        {
+            Http3LoopbackStream stream = await AcceptRequestStreamAsync().ConfigureAwait(false);
             return await stream.ReadRequestDataAsync(readBody).ConfigureAwait(false);
         }
 
-        public override async Task SendResponseAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "", bool isFinal = true, int requestId = 0)
+        public override Task SendResponseAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "", bool isFinal = true, int requestId = 0)
         {
-            IEnumerable<HttpHeaderData> newHeaders = headers ?? Enumerable.Empty<HttpHeaderData>();
-
-            if (content != null && !newHeaders.Any(x => x.Name == "Content-Length"))
-            {
-                newHeaders = newHeaders.Append(new HttpHeaderData("Content-Length", content.Length.ToString(CultureInfo.InvariantCulture)));
-            }
-
-            await SendResponseHeadersAsync(statusCode, newHeaders, requestId).ConfigureAwait(false);
-            await SendResponseBodyAsync(Encoding.UTF8.GetBytes(content ?? ""), isFinal, requestId).ConfigureAwait(false);
+            return GetOpenRequest(requestId).SendResponseAsync(statusCode, headers, content, isFinal);
         }
 
-        public override async Task SendResponseBodyAsync(byte[] content, bool isFinal = true, int requestId = 0)
+        public override Task SendResponseBodyAsync(byte[] content, bool isFinal = true, int requestId = 0)
         {
-            Http3LoopbackStream stream = GetOpenRequest(requestId);
-
-            if (content?.Length != 0)
-            {
-                await stream.SendDataFrameAsync(content).ConfigureAwait(false);
-            }
-
-            if (isFinal)
-            {
-                await stream.ShutdownSendAsync().ConfigureAwait(false);
-                stream.Dispose();
-            }
+            return GetOpenRequest(requestId).SendResponseBodyAsync(content, isFinal);
         }
 
         public override Task SendResponseHeadersAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, int requestId = 0)
         {
-            return SendResponseHeadersAsync(statusCode, headers, requestId);
-        }
-
-        private async Task SendResponseHeadersAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IEnumerable<HttpHeaderData> headers = null, int requestId = 0)
-        {
-            headers ??= Enumerable.Empty<HttpHeaderData>();
-
-            // Some tests use Content-Length with a null value to indicate Content-Length should not be set.
-            headers = headers.Where(x => x.Name != "Content-Length" || x.Value != null);
-
-            if (statusCode != null)
-            {
-                headers = headers.Prepend(new HttpHeaderData(":status", ((int)statusCode).ToString(CultureInfo.InvariantCulture)));
-            }
-
-            await GetOpenRequest(requestId).SendHeadersFrameAsync(headers).ConfigureAwait(false);
+            return GetOpenRequest(requestId).SendResponseHeadersAsync(statusCode, headers);
         }
 
         public override async Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "")
         {
-            HttpRequestData request = await ReadRequestDataAsync().ConfigureAwait(false);
-            await SendResponseAsync(statusCode, headers, content).ConfigureAwait(false);
+            Http3LoopbackStream stream = await AcceptRequestStreamAsync().ConfigureAwait(false);
+            HttpRequestData request = await stream.HandleRequestAsync(statusCode, headers, content);
 
             // closing the connection here causes bytes written to streams to go missing.
             //await CloseAsync(H3_NO_ERROR).ConfigureAwait(false);

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
@@ -29,7 +29,12 @@ namespace System.Net.Test.Common
             var sslOpts = new SslServerAuthenticationOptions
             {
                 EnabledSslProtocols = options.SslProtocols,
-                ApplicationProtocols = new List<SslApplicationProtocol> { new SslApplicationProtocol("h3-29") },
+                ApplicationProtocols = new List<SslApplicationProtocol>
+                {
+                    new SslApplicationProtocol("h3-31"),
+                    new SslApplicationProtocol("h3-30"),
+                    new SslApplicationProtocol("h3-29")
+                },
                 //ServerCertificate = _cert,
                 ClientCertificateRequired = false
             };

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -5,8 +5,11 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net.Quic;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace System.Net.Test.Common
@@ -21,6 +24,11 @@ namespace System.Net.Test.Common
         private const long HeadersFrame = 0x1;
         private const long SettingsFrame = 0x4;
 
+        public const long ControlStream = 0x0;
+        public const long PushStream = 0x1;
+
+        public const long MaxHeaderListSize = 0x6;
+
         private readonly QuicStream _stream;
 
         public bool CanRead => _stream.CanRead;
@@ -34,6 +42,12 @@ namespace System.Net.Test.Common
         public void Dispose()
         {
             _stream.Dispose();
+        }
+        public async Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "")
+        {
+            HttpRequestData request = await ReadRequestDataAsync().ConfigureAwait(false);
+            await SendResponseAsync(statusCode, headers, content).ConfigureAwait(false);
+            return request;
         }
 
         public async Task SendUnidirectionalStreamTypeAsync(long streamType)
@@ -175,6 +189,83 @@ namespace System.Net.Test.Common
             return requestData;
         }
 
+        public async Task SendResponseAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "", bool isFinal = true)
+        {
+            IEnumerable<HttpHeaderData> newHeaders = headers ?? Enumerable.Empty<HttpHeaderData>();
+
+            if (content != null && !newHeaders.Any(x => x.Name == "Content-Length"))
+            {
+                newHeaders = newHeaders.Append(new HttpHeaderData("Content-Length", content.Length.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            await SendResponseHeadersAsync(statusCode, newHeaders).ConfigureAwait(false);
+            await SendResponseBodyAsync(Encoding.UTF8.GetBytes(content ?? ""), isFinal).ConfigureAwait(false);
+        }
+
+        public async Task SendResponseHeadersAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IEnumerable<HttpHeaderData> headers = null)
+        {
+            headers ??= Enumerable.Empty<HttpHeaderData>();
+
+            // Some tests use Content-Length with a null value to indicate Content-Length should not be set.
+            headers = headers.Where(x => x.Name != "Content-Length" || x.Value != null);
+
+            if (statusCode != null)
+            {
+                headers = headers.Prepend(new HttpHeaderData(":status", ((int)statusCode).ToString(CultureInfo.InvariantCulture)));
+            }
+
+            await SendHeadersFrameAsync(headers).ConfigureAwait(false);
+        }
+
+        public async Task SendResponseBodyAsync(byte[] content, bool isFinal = true)
+        {
+            if (content?.Length != 0)
+            {
+                await SendDataFrameAsync(content).ConfigureAwait(false);
+            }
+
+            if (isFinal)
+            {
+                await ShutdownSendAsync().ConfigureAwait(false);
+                Dispose();
+            }
+        }
+
+        public async Task<List<(long settingId, long settingValue)>> ReadSettingsAsync()
+        {
+            (long? frameType, byte[] payload) = await ReadFrameAsync().ConfigureAwait(false);
+
+            if (frameType == null) throw new Exception("Unable to read settings; unexpected end of stream.");
+            if (frameType != SettingsFrame) throw new Exception($"Unable to read settings; received frame type 0x{frameType:x}.");
+
+            return ParseSettingsPayload(payload);
+        }
+
+        private List<(long settingId, long settingValue)> ParseSettingsPayload(ReadOnlySpan<byte> settingsPayload)
+        {
+            var settings = new List<(long settingId, long settingValue)>();
+
+            while (settingsPayload.Length != 0)
+            {
+                if (!TryDecodeHttpInteger(settingsPayload, out long settingId, out int bytesRead))
+                {
+                    throw new Exception("Unable to read setting ID; unexpected end of payload.");
+                }
+
+                settingsPayload = settingsPayload.Slice(bytesRead);
+
+                if (!TryDecodeHttpInteger(settingsPayload, out long settingValue, out bytesRead))
+                {
+                    throw new Exception($"Unable to read value for setting 0x{settingId:x}; unexpected end of payload.");
+                }
+
+                settingsPayload = settingsPayload.Slice(bytesRead);
+                settings.Add((settingId, settingValue));
+            }
+
+            return settings;
+        }
+
         private HttpRequestData ParseHeaders(ReadOnlySpan<byte> buffer)
         {
             HttpRequestData request = new HttpRequestData { RequestId = Http3LoopbackConnection.GetRequestId(_stream) };
@@ -228,10 +319,10 @@ namespace System.Net.Test.Common
 
         public async Task<(long? frameType, byte[] payload)> ReadFrameAsync()
         {
-            long? frameType = await ReadInteger().ConfigureAwait(false);
+            long? frameType = await ReadIntegerAsync().ConfigureAwait(false);
             if (frameType == null) return (null, null);
 
-            long? payloadLength = await ReadInteger().ConfigureAwait(false);
+            long? payloadLength = await ReadIntegerAsync().ConfigureAwait(false);
             if (payloadLength == null) throw new Exception("Unable to read frame; unexpected end of stream.");
 
             byte[] payload = new byte[checked((int)payloadLength)];
@@ -248,7 +339,7 @@ namespace System.Net.Test.Common
             return (frameType, payload);
         }
 
-        public async Task<long?> ReadInteger()
+        public async Task<long?> ReadIntegerAsync()
         {
             byte[] buffer = new byte[MaximumVarIntBytes];
             int bufferActiveLength = 0;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -753,10 +753,13 @@ namespace System.Net.Http
                     case Http3FrameType.Headers:
                     case Http3FrameType.Data:
                         return ((Http3FrameType)frameType, payloadLength);
-                    case Http3FrameType.Settings:
+                    case Http3FrameType.Settings: // These frames should only be received on a control stream, not a response stream.
                     case Http3FrameType.GoAway:
                     case Http3FrameType.MaxPushId:
-                        // These frames should only be received on a control stream, not a response stream.
+                    case Http3FrameType.ReservedHttp2Priority: // These frames are explicitly reserved and must never be sent.
+                    case Http3FrameType.ReservedHttp2Ping:
+                    case Http3FrameType.ReservedHttp2WindowUpdate:
+                    case Http3FrameType.ReservedHttp2Continuation:
                         throw new Http3ConnectionException(Http3ErrorCode.UnexpectedFrame);
                     case Http3FrameType.DuplicatePush:
                     case Http3FrameType.PushPromise:

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -257,7 +257,7 @@ namespace System.Net.Http
             if (NetEventSource.Log.IsEnabled()) Trace($"{this}");
         }
 
-        private static readonly List<SslApplicationProtocol> s_http3ApplicationProtocols = new List<SslApplicationProtocol>() { Http3Connection.Http3ApplicationProtocol };
+        private static readonly List<SslApplicationProtocol> s_http3ApplicationProtocols = new List<SslApplicationProtocol>() { Http3Connection.Http3ApplicationProtocol31, Http3Connection.Http3ApplicationProtocol30, Http3Connection.Http3ApplicationProtocol29 };
         private static readonly List<SslApplicationProtocol> s_http2ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
         private static readonly List<SslApplicationProtocol> s_http2OnlyApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http2 };
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
@@ -39,7 +39,7 @@ namespace System.Net.Http.Functional.Tests
                 };
 
             // The second request is expected to come in on this HTTP/3 server.
-            using var secondServer = new Http3LoopbackServer();
+            using Http3LoopbackServer secondServer = CreateHttp3LoopbackServer();
 
             using HttpClient client = CreateHttpClient();
 
@@ -68,7 +68,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task AltSvc_ConnectionFrame_UpgradeFrom20_Success()
         {
             using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
-            using Http3LoopbackServer secondServer = new Http3LoopbackServer();
+            using Http3LoopbackServer secondServer = CreateHttp3LoopbackServer();
             using HttpClient client = CreateHttpClient();
 
             Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
@@ -93,7 +93,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task AltSvc_ResponseFrame_UpgradeFrom20_Success()
         {
             using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
-            using Http3LoopbackServer secondServer = new Http3LoopbackServer();
+            using Http3LoopbackServer secondServer = CreateHttp3LoopbackServer();
             using HttpClient client = CreateHttpClient();
 
             Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Test.Common;
 using System.Text;
@@ -25,8 +26,101 @@ namespace System.Net.Http.Functional.Tests
         {
         }
 
-        [OuterLoop]
         [Theory]
+        [InlineData(10)] // 2 bytes settings value.
+        [InlineData(100)] // 4 bytes settings value.
+        [InlineData(10_000_000)] // 8 bytes settings value.
+        public async Task ClientSettingsReceived_Success(int headerSizeLimit)
+        {
+            using Http3LoopbackServer server = CreateHttp3LoopbackServer();
+
+            Task serverTask = Task.Run(async () =>
+            {
+                using Http3LoopbackConnection connection = (Http3LoopbackConnection)await server.EstablishGenericConnectionAsync();
+
+                (Http3LoopbackStream settingsStream, Http3LoopbackStream requestStream) = await connection.AcceptControlAndRequestStreamAsync();
+
+                using (settingsStream)
+                using (requestStream)
+                {
+                    Assert.False(settingsStream.CanWrite, "Expected unidirectional control stream.");
+
+                    long? streamType = await settingsStream.ReadIntegerAsync();
+                    Assert.Equal(Http3LoopbackStream.ControlStream, streamType);
+
+                    List<(long settingId, long settingValue)> settings = await settingsStream.ReadSettingsAsync();
+                    (long settingId, long settingValue) = Assert.Single(settings);
+
+                    Assert.Equal(Http3LoopbackStream.MaxHeaderListSize, settingId);
+                    Assert.Equal(headerSizeLimit * 1024L, settingValue);
+
+                    await requestStream.ReadRequestDataAsync();
+                    await requestStream.SendResponseAsync();
+                }
+            });
+
+            Task clientTask = Task.Run(async () =>
+            {
+                using HttpClientHandler handler = CreateHttpClientHandler();
+                handler.MaxResponseHeadersLength = headerSizeLimit;
+
+                using HttpClient client = CreateHttpClient(handler);
+                using HttpRequestMessage request = new()
+                {
+                    Method = HttpMethod.Get,
+                    RequestUri = server.Address,
+                    Version = HttpVersion30,
+                    VersionPolicy = HttpVersionPolicy.RequestVersionExact
+                };
+                using HttpResponseMessage response = await client.SendAsync(request);
+            });
+
+            await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(20_000);
+        }
+
+        [Fact]
+        public async Task ReservedFrameType_Throws()
+        {
+            const int ReservedHttp2PriorityFrameId = 0x2;
+            const long UnexpectedFrameErrorCode = 0x105;
+
+            using Http3LoopbackServer server = CreateHttp3LoopbackServer();
+
+            Task serverTask = Task.Run(async () =>
+            {
+                using Http3LoopbackConnection connection = (Http3LoopbackConnection)await server.EstablishGenericConnectionAsync();
+                using Http3LoopbackStream stream = await connection.AcceptRequestStreamAsync();
+
+                await stream.SendFrameAsync(ReservedHttp2PriorityFrameId, new byte[8]);
+
+                QuicConnectionAbortedException ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(async () =>
+                {
+                    await stream.HandleRequestAsync();
+                    using Http3LoopbackStream stream2 = await connection.AcceptRequestStreamAsync();
+                });
+
+                Assert.Equal(UnexpectedFrameErrorCode, ex.ErrorCode);
+            });
+
+            Task clientTask = Task.Run(async () =>
+            {
+                using HttpClient client = CreateHttpClient();
+                using HttpRequestMessage request = new()
+                {
+                    Method = HttpMethod.Get,
+                    RequestUri = server.Address,
+                    Version = HttpVersion30,
+                    VersionPolicy = HttpVersionPolicy.RequestVersionExact
+                };
+
+                await Assert.ThrowsAsync<HttpRequestException>(async () => await client.SendAsync(request));
+            });
+
+            await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(20_000);
+        }
+
+        [OuterLoop]
+        [ConditionalTheory(nameof(IsMsQuicSupported))]
         [MemberData(nameof(InteropUris))]
         public async Task Public_Interop_ExactVersion_Success(string uri)
         {
@@ -45,7 +139,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop]
-        [Theory]
+        [ConditionalTheory(nameof(IsMsQuicSupported))]
         [MemberData(nameof(InteropUris))]
         public async Task Public_Interop_Upgrade_Success(string uri)
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -38,6 +38,11 @@ namespace System.Net.Http.Functional.Tests
             return handler;
         }
 
+        protected Http3LoopbackServer CreateHttp3LoopbackServer()
+        {
+            return new Http3LoopbackServer(UseQuicImplementationProvider);
+        }
+
         protected HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion, UseQuicImplementationProvider);
 
         protected static HttpClientHandler CreateHttpClientHandler(string useVersionString) =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -3017,9 +3017,16 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsMsQuicSupported))]
-    public sealed class SocketsHttpHandlerTest_Http3 : HttpClientHandlerTest_Http3
+    public sealed class SocketsHttpHandlerTest_Http3_MsQuic : HttpClientHandlerTest_Http3
     {
-        public SocketsHttpHandlerTest_Http3(ITestOutputHelper output) : base(output) { }
+        public SocketsHttpHandlerTest_Http3_MsQuic(ITestOutputHelper output) : base(output) { }
+        protected override QuicImplementationProvider UseQuicImplementationProvider => QuicImplementationProviders.MsQuic;
+    }
+
+    public sealed class SocketsHttpHandlerTest_Http3_Mock : HttpClientHandlerTest_Http3
+    {
+        public SocketsHttpHandlerTest_Http3_Mock(ITestOutputHelper output) : base(output) { }
+        protected override QuicImplementationProvider UseQuicImplementationProvider => QuicImplementationProviders.Mock;
     }
 
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsMsQuicSupported))]


### PR DESCRIPTION
Resolves #42650

Cause a connection abort when HTTP/2-only frame and settings types are received in HTTP/3. (Progress toward HTTP/3 draft 31 compat)
Send h3-29 through h3-31 for ALPN as we are compatible with all of them.
Move some of the loopback test code into the stream class rather than connection class.
Add a basic test for SETTINGS frame receipt.
Fix some tests that were explicitly using Http3LoopbackServer and did not see the new "Mock" QUIC setting introduced in https://github.com/dotnet/runtime/pull/43076