### PR TITLE
Fix stack overflow in BsdIPGlobalProperties

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
@@ -9,10 +9,13 @@ namespace System.Net.NetworkInformation
         {
             int realCount = Interop.Sys.GetEstimatedTcpConnectionCount();
             int infoCount = realCount * 2;
-            Interop.Sys.NativeTcpConnectionInformation* infos = stackalloc Interop.Sys.NativeTcpConnectionInformation[infoCount];
-            if (Interop.Sys.GetActiveTcpConnectionInfos(infos, &infoCount) == -1)
+            Interop.Sys.NativeTcpConnectionInformation[] infos = new Interop.Sys.NativeTcpConnectionInformation[infoCount];
+            fixed (Interop.Sys.NativeTcpConnectionInformation* infosPtr = infos)
             {
-                throw new NetworkInformationException(SR.net_PInvokeError);
+                if (Interop.Sys.GetActiveTcpConnectionInfos(infosPtr, &infoCount) == -1)
+                {
+                    throw new NetworkInformationException(SR.net_PInvokeError);
+                }
             }
 
             TcpConnectionInformation[] connectionInformations = new TcpConnectionInformation[infoCount];
@@ -81,10 +84,13 @@ namespace System.Net.NetworkInformation
         {
             int realCount = Interop.Sys.GetEstimatedUdpListenerCount();
             int infoCount = realCount * 2;
-            Interop.Sys.IPEndPointInfo* infos = stackalloc Interop.Sys.IPEndPointInfo[infoCount];
-            if (Interop.Sys.GetActiveUdpListeners(infos, &infoCount) == -1)
+            Interop.Sys.IPEndPointInfo[] infos = new Interop.Sys.IPEndPointInfo[infoCount];
+            fixed (Interop.Sys.IPEndPointInfo* infosPtr = infos)
             {
-                throw new NetworkInformationException(SR.net_PInvokeError);
+                if (Interop.Sys.GetActiveUdpListeners(infosPtr, &infoCount) == -1)
+                {
+                    throw new NetworkInformationException(SR.net_PInvokeError);
+                }
             }
 
             IPEndPoint[] endPoints = new IPEndPoint[infoCount];


### PR DESCRIPTION
Both the GetTcpConnections and GetActiveUdpListeners functions were
using stackalloc on unbounded arrays. As the objects in these arrays
are quite large, removed the stackalloc so the arrays are always on
the heap.

Fix #43286