### PR TITLE
Don't autoupgrade homebrew formula in install-native-dependencies.sh

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -31,7 +31,7 @@ if [ "$1" = "Linux" ]; then
 elif [ "$1" = "OSX" ] || [ "$1" = "tvOS" ] || [ "$1" = "iOS" ]; then
     engdir=$(dirname "${BASH_SOURCE[0]}")
     brew update --preinstall
-    brew bundle --no-lock --file "${engdir}/Brewfile"
+    brew bundle --no-upgrade --no-lock --file "${engdir}/Brewfile"
     if [ "$?" != "0" ]; then
         exit 1;
     fi


### PR DESCRIPTION
Should workaround an issue we're seeing on AzDO while upgrading openssl@1.1 1.1.1g -> 1.1.1h: `Error: Not a directory @ dir_s_rmdir - /usr/local/Cellar/openssl`