### PR TITLE
Add Array.GetMaxLength<T>

### DIFF
--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -344,9 +344,7 @@ void PublishObjectAndNotify(TObj* &orObject, GC_ALLOC_FLAGS flags)
 
 inline SIZE_T MaxArrayLength()
 {
-    // Impose limits on maximum array length in each dimension to allow efficient
-    // implementation of advanced range check elimination in future. We have to allow
-    // higher limit for array of bytes (or one byte structs) for backward compatibility.
+    // Impose limits on maximum array length to prevent corner case integer overflow bugs
     // Keep in sync with Array.MaxLength in BCL.
     return 0X7FFFFFC7;
 }

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -342,13 +342,13 @@ void PublishObjectAndNotify(TObj* &orObject, GC_ALLOC_FLAGS flags)
 #endif // FEATURE_EVENT_TRACE
 }
 
-inline SIZE_T MaxArrayLength(SIZE_T componentSize)
+inline SIZE_T MaxArrayLength()
 {
     // Impose limits on maximum array length in each dimension to allow efficient
     // implementation of advanced range check elimination in future. We have to allow
     // higher limit for array of bytes (or one byte structs) for backward compatibility.
-    // Keep in sync with Array.MaxArrayLength in BCL.
-    return (componentSize == 1) ? 0X7FFFFFC7 : 0X7FEFFFFF;
+    // Keep in sync with Array.MaxLength in BCL.
+    return 0X7FFFFFC7;
 }
 
 OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 cElements, GC_ALLOC_FLAGS flags)
@@ -388,11 +388,11 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
     if (cElements < 0)
         COMPlusThrow(kOverflowException);
 
-    SIZE_T componentSize = pArrayMT->GetComponentSize();
-    if ((SIZE_T)cElements > MaxArrayLength(componentSize))
+    if ((SIZE_T)cElements > MaxArrayLength())
         ThrowOutOfMemoryDimensionsExceeded();
 
     // Allocate the space from the GC heap
+    SIZE_T componentSize = pArrayMT->GetComponentSize();
 #ifdef TARGET_64BIT
     // POSITIVE_INT32 * UINT16 + SMALL_CONST
     // this cannot overflow on 64bit
@@ -568,7 +568,6 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
 
     // Calculate the total number of elements in the array
     UINT32 cElements;
-    SIZE_T componentSize = pArrayMT->GetComponentSize();
     bool maxArrayDimensionLengthOverflow = false;
     bool providedLowerBounds = false;
 
@@ -599,7 +598,7 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
             int length = pArgs[i];
             if (length < 0)
                 COMPlusThrow(kOverflowException);
-            if ((SIZE_T)length > MaxArrayLength(componentSize))
+            if ((SIZE_T)length > MaxArrayLength())
                 maxArrayDimensionLengthOverflow = true;
             if ((length > 0) && (lowerBound + (length - 1) < lowerBound))
                 COMPlusThrow(kArgumentOutOfRangeException, W("ArgumentOutOfRange_ArrayLBAndLength"));
@@ -615,7 +614,7 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
         int length = pArgs[0];
         if (length < 0)
             COMPlusThrow(kOverflowException);
-        if ((SIZE_T)length > MaxArrayLength(componentSize))
+        if ((SIZE_T)length > MaxArrayLength())
             maxArrayDimensionLengthOverflow = true;
         cElements = length;
     }
@@ -625,6 +624,7 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
         ThrowOutOfMemoryDimensionsExceeded();
 
     // Allocate the space from the GC heap
+    SIZE_T componentSize = pArrayMT->GetComponentSize();
 #ifdef TARGET_64BIT
     // POSITIVE_INT32 * UINT16 + SMALL_CONST
     // this cannot overflow on 64bit

--- a/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
+++ b/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
@@ -15,8 +15,8 @@ namespace System.Buffers
 #endif
     sealed class ArrayBufferWriter<T> : IBufferWriter<T>
     {
-        // Copy of Array.MaxArrayLength. For byte arrays the limit is slightly larger
-        private const int MaxArrayLength = 0X7FEFFFFF;
+        // Copy of Array.MaxLength.
+        private const int ArrayMaxLength = 0x7FFFFFC7;
 
         private const int DefaultInitialBufferSize = 256;
 
@@ -184,16 +184,16 @@ namespace System.Buffers
 
                 if ((uint)newSize > int.MaxValue)
                 {
-                    // Attempt to grow to MaxArrayLength.
+                    // Attempt to grow to ArrayMaxLength.
                     uint needed = (uint)(currentLength - FreeCapacity + sizeHint);
                     Debug.Assert(needed > currentLength);
 
-                    if (needed > MaxArrayLength)
+                    if (needed > ArrayMaxLength)
                     {
                         ThrowOutOfMemoryException(needed);
                     }
 
-                    newSize = MaxArrayLength;
+                    newSize = ArrayMaxLength;
                 }
 
                 Array.Resize(ref _buffer, newSize);

--- a/src/libraries/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -143,9 +143,9 @@ namespace System.Collections.Generic
             int capacity = Capacity;
             int nextCapacity = capacity == 0 ? DefaultCapacity : 2 * capacity;
 
-            if ((uint)nextCapacity > (uint)Array.GetMaxLength<T>())
+            if ((uint)nextCapacity > (uint)Array.MaxLength)
             {
-                nextCapacity = Math.Max(capacity + 1, Array.GetMaxLength<T>());
+                nextCapacity = Math.Max(capacity + 1, Array.MaxLength);
             }
 
             nextCapacity = Math.Max(nextCapacity, minimum);

--- a/src/libraries/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -12,7 +12,6 @@ namespace System.Collections.Generic
     internal struct ArrayBuilder<T>
     {
         private const int DefaultCapacity = 4;
-        private const int MaxCoreClrArrayLength = 0x7fefffff; // For byte arrays the limit is slightly larger
 
         private T[]? _array; // Starts out null, initialized on first Add.
         private int _count; // Number of items into _array we're using.
@@ -144,9 +143,9 @@ namespace System.Collections.Generic
             int capacity = Capacity;
             int nextCapacity = capacity == 0 ? DefaultCapacity : 2 * capacity;
 
-            if ((uint)nextCapacity > (uint)MaxCoreClrArrayLength)
+            if ((uint)nextCapacity > (uint)Array.GetMaxLength<T>())
             {
-                nextCapacity = Math.Max(capacity + 1, MaxCoreClrArrayLength);
+                nextCapacity = Math.Max(capacity + 1, Array.GetMaxLength<T>());
             }
 
             nextCapacity = Math.Max(nextCapacity, minimum);

--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -53,17 +53,12 @@ namespace System.Collections.Generic
                                 // If the array is currently empty, we make it a default size.  Otherwise, we attempt to
                                 // double the size of the array.  Doubling will overflow once the size of the array reaches
                                 // 2^30, since doubling to 2^31 is 1 larger than Int32.MaxValue.  In that case, we instead
-                                // constrain the length to be MaxArrayLength (this overflow check works because of the
-                                // cast to uint).  Because a slightly larger constant is used when T is one byte in size, we
-                                // could then end up in a situation where arr.Length is MaxArrayLength or slightly larger, such
-                                // that we constrain newLength to be MaxArrayLength but the needed number of elements is actually
-                                // larger than that.  For that case, we then ensure that the newLength is large enough to hold
-                                // the desired capacity.  This does mean that in the very rare case where we've grown to such a
-                                // large size, each new element added after MaxArrayLength will end up doing a resize.
+                                // constrain the length to be Array.MaxLength (this overflow check works because of the
+                                // cast to uint).
                                 int newLength = count << 1;
-                                if ((uint)newLength > Array.GetMaxLength<T>())
+                                if ((uint)newLength > Array.MaxLength)
                                 {
-                                    newLength = Array.GetMaxLength<T>() <= count ? count + 1 : Array.GetMaxLength<T>();
+                                    newLength = Array.MaxLength <= count ? count + 1 : Array.MaxLength;
                                 }
 
                                 Array.Resize(ref arr, newLength);

--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -49,12 +49,6 @@ namespace System.Collections.Generic
                         {
                             if (count == arr.Length)
                             {
-                                // MaxArrayLength is defined in Array.MaxArrayLength and in gchelpers in CoreCLR.
-                                // It represents the maximum number of elements that can be in an array where
-                                // the size of the element is greater than one byte; a separate, slightly larger constant,
-                                // is used when the size of the element is one.
-                                const int MaxArrayLength = 0x7FEFFFFF;
-
                                 // This is the same growth logic as in List<T>:
                                 // If the array is currently empty, we make it a default size.  Otherwise, we attempt to
                                 // double the size of the array.  Doubling will overflow once the size of the array reaches
@@ -67,9 +61,9 @@ namespace System.Collections.Generic
                                 // the desired capacity.  This does mean that in the very rare case where we've grown to such a
                                 // large size, each new element added after MaxArrayLength will end up doing a resize.
                                 int newLength = count << 1;
-                                if ((uint)newLength > MaxArrayLength)
+                                if ((uint)newLength > Array.GetMaxLength<T>())
                                 {
-                                    newLength = MaxArrayLength <= count ? count + 1 : MaxArrayLength;
+                                    newLength = Array.GetMaxLength<T>() <= count ? count + 1 : Array.GetMaxLength<T>();
                                 }
 
                                 Array.Resize(ref arr, newLength);

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1963,7 +1963,7 @@ namespace System.Collections.Concurrent
 
                         Debug.Assert(newLength % 2 != 0);
 
-                        if (newLength > Array.GetMaxLength<object>())
+                        if (newLength > Array.MaxLength)
                         {
                             maximizeTableSize = true;
                         }
@@ -1976,7 +1976,7 @@ namespace System.Collections.Concurrent
 
                 if (maximizeTableSize)
                 {
-                    newLength = Array.GetMaxLength<object>();
+                    newLength = Array.MaxLength;
 
                     // We want to make sure that GrowTable will not be called again, since table is at the maximum size.
                     // To achieve that, we set the budget to int.MaxValue.

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1908,7 +1908,6 @@ namespace System.Collections.Concurrent
         /// </summary>
         private void GrowTable(Tables tables)
         {
-            const int MaxArrayLength = 0X7FEFFFFF;
             int locksAcquired = 0;
             try
             {
@@ -1964,7 +1963,7 @@ namespace System.Collections.Concurrent
 
                         Debug.Assert(newLength % 2 != 0);
 
-                        if (newLength > MaxArrayLength)
+                        if (newLength > Array.GetMaxLength<object>())
                         {
                             maximizeTableSize = true;
                         }
@@ -1977,7 +1976,7 @@ namespace System.Collections.Concurrent
 
                 if (maximizeTableSize)
                 {
-                    newLength = MaxArrayLength;
+                    newLength = Array.GetMaxLength<object>();
 
                     // We want to make sure that GrowTable will not be called again, since table is at the maximum size.
                     // To achieve that, we set the budget to int.MaxValue.

--- a/src/libraries/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/libraries/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -375,7 +375,7 @@ namespace System.Collections
             int newCapacity = keys.Length == 0 ? 16 : keys.Length * 2;
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newCapacity > Array.GetMaxLength<object>()) newCapacity = Array.GetMaxLength<object>();
+            if ((uint)newCapacity > Array.MaxLength) newCapacity = Array.MaxLength;
             if (newCapacity < min) newCapacity = min;
             Capacity = newCapacity;
         }

--- a/src/libraries/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/libraries/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -70,9 +70,6 @@ namespace System.Collections
         private KeyList? keyList; // Do not rename (binary serialization)
         private ValueList? valueList; // Do not rename (binary serialization)
 
-        // Copy of Array.MaxArrayLength
-        internal const int MaxArrayLength = 0X7FEFFFFF;
-
         // Constructs a new sorted list. The sorted list is initially empty and has
         // a capacity of zero. Upon adding the first element to the sorted list the
         // capacity is increased to 16, and then increased in multiples of two as
@@ -378,7 +375,7 @@ namespace System.Collections
             int newCapacity = keys.Length == 0 ? 16 : keys.Length * 2;
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newCapacity > MaxArrayLength) newCapacity = MaxArrayLength;
+            if ((uint)newCapacity > Array.GetMaxLength<object>()) newCapacity = Array.GetMaxLength<object>();
             if (newCapacity < min) newCapacity = min;
             Capacity = newCapacity;
         }

--- a/src/libraries/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -255,7 +255,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public void EnsureCapacity_NewCapacityLessThanMin_CapsToMaxArrayLength()
+        public void EnsureCapacity_NewCapacityLessThanMin_CapsToArrayMaxLength()
         {
             // A situation like this occurs for very large lengths of SortedList.
             // To avoid allocating several GBs of memory and making this test run for a very

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -529,8 +529,6 @@ namespace System.Collections.Generic
         {
             Debug.Assert(_nodes.Length < minCapacity);
 
-            // Array.MaxArrayLength is internal to S.P.CoreLib, replicate here.
-            const int MaxArrayLength = 0X7FEFFFFF;
             const int GrowFactor = 2;
             const int MinimumGrow = 4;
 
@@ -538,13 +536,13 @@ namespace System.Collections.Generic
 
             // Allow the queue to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _nodes.Length overflowed thanks to the (uint) cast
-            if ((uint)newcapacity > MaxArrayLength) newcapacity = MaxArrayLength;
+            if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
 
             // Ensure minimum growth is respected.
             newcapacity = Math.Max(newcapacity, _nodes.Length + MinimumGrow);
 
             // If the computed capacity is still less than specified, set to the original argument.
-            // Capacities exceeding MaxArrayLength will be surfaced as OutOfMemoryException by Array.Resize.
+            // Capacities exceeding Array.MaxLength will be surfaced as OutOfMemoryException by Array.Resize.
             if (newcapacity < minCapacity) newcapacity = minCapacity;
 
             Array.Resize(ref _nodes, newcapacity);

--- a/src/libraries/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -400,8 +400,6 @@ namespace System.Collections.Generic
         {
             Debug.Assert(_array.Length < capacity);
 
-            // Array.MaxArrayLength is internal to S.P.CoreLib, replicate here.
-            const int MaxArrayLength = 0X7FEFFFFF;
             const int GrowFactor = 2;
             const int MinimumGrow = 4;
 
@@ -409,13 +407,13 @@ namespace System.Collections.Generic
 
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newcapacity > MaxArrayLength) newcapacity = MaxArrayLength;
+            if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
 
             // Ensure minimum growth is respected.
             newcapacity = Math.Max(newcapacity, _array.Length + MinimumGrow);
 
             // If the computed capacity is still less than specified, set to the original argument.
-            // Capacities exceeding MaxArrayLength will be surfaced as OutOfMemoryException by Array.Resize.
+            // Capacities exceeding Array.MaxLength will be surfaced as OutOfMemoryException by Array.Resize.
             if (newcapacity < capacity) newcapacity = capacity;
 
             SetCapacity(newcapacity);

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -530,7 +530,7 @@ namespace System.Collections.Generic
             int newCapacity = keys.Length == 0 ? DefaultCapacity : keys.Length * 2;
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newCapacity > Array.GetMaxLength<object>()) newCapacity = Array.GetMaxLength<object>();
+            if ((uint)newCapacity > Array.MaxLength) newCapacity = Array.MaxLength;
             if (newCapacity < min) newCapacity = min;
             Capacity = newCapacity;
         }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -522,8 +522,6 @@ namespace System.Collections.Generic
             }
         }
 
-        private const int MaxArrayLength = 0X7FEFFFFF;
-
         // Ensures that the capacity of this sorted list is at least the given
         // minimum value. The capacity is increased to twice the current capacity
         // or to min, whichever is larger.
@@ -532,7 +530,7 @@ namespace System.Collections.Generic
             int newCapacity = keys.Length == 0 ? DefaultCapacity : keys.Length * 2;
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newCapacity > MaxArrayLength) newCapacity = MaxArrayLength;
+            if ((uint)newCapacity > Array.GetMaxLength<object>()) newCapacity = Array.GetMaxLength<object>();
             if (newCapacity < min) newCapacity = min;
             Capacity = newCapacity;
         }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -315,17 +315,14 @@ namespace System.Collections.Generic
         {
             Debug.Assert(_array.Length < capacity);
 
-            // Array.MaxArrayLength is internal to S.P.CoreLib, replicate here.
-            const int MaxArrayLength = 0X7FEFFFFF;
-
             int newcapacity = _array.Length == 0 ? DefaultCapacity : 2 * _array.Length;
 
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast.
-            if ((uint)newcapacity > MaxArrayLength) newcapacity = MaxArrayLength;
+            if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
 
             // If computed capacity is still less than specified, set to the original argument.
-            // Capacities exceeding MaxArrayLength will be surfaced as OutOfMemoryException by Array.Resize.
+            // Capacities exceeding Array.MaxLength will be surfaced as OutOfMemoryException by Array.Resize.
             if (newcapacity < capacity) newcapacity = capacity;
 
             Array.Resize(ref _array, newcapacity);

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.EnsureCapacity.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.EnsureCapacity.cs
@@ -41,11 +41,14 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => list.EnsureCapacity(-1));
         }
 
-        const int MaxArraySize = 0X7FEFFFFF;
+        public static IEnumerable<object[]> EnsureCapacity_LargeCapacity_Throws_MemberData()
+        {
+            yield return new object[] { 5, Array.MaxLength + 1 };
+            yield return new object[] { 1, int.MaxValue };
+        }
 
         [Theory]
-        [InlineData(5, MaxArraySize + 1)]
-        [InlineData(1, int.MaxValue)]
+        [MemberData(nameof(EnsureCapacity_LargeCapacity_Throws_MemberData))]
         [SkipOnMono("mono forces no restrictions on array size.")]
         public void EnsureCapacity_LargeCapacity_Throws(int count, int requestCapacity)
         {

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.EnsureCapacity.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.EnsureCapacity.cs
@@ -49,7 +49,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(EnsureCapacity_LargeCapacity_Throws_MemberData))]
-        [SkipOnMono("mono forces no restrictions on array size.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51411", TestRuntimes.Mono)]
         public void EnsureCapacity_LargeCapacity_Throws(int count, int requestCapacity)
         {
             List<T> list = GenericListFactory(count);

--- a/src/libraries/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
@@ -356,7 +356,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(Queue_Generic_EnsureCapacity_LargeCapacityRequested_Throws_MemberData))]
-        [SkipOnMono("mono forces no restrictions on array size.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51411", TestRuntimes.Mono)]
         public void Queue_Generic_EnsureCapacity_LargeCapacityRequested_Throws(int requestedCapacity)
         {
             var queue = GenericQueueFactory();

--- a/src/libraries/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
@@ -348,11 +348,14 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => queue.EnsureCapacity(-1));
         }
 
-        const int MaxArraySize = 0X7FEFFFFF;
+        public static IEnumerable<object[]> Queue_Generic_EnsureCapacity_LargeCapacityRequested_Throws_MemberData()
+        {
+            yield return new object[] { Array.MaxLength + 1 };
+            yield return new object[] { int.MaxValue };
+        }
 
         [Theory]
-        [InlineData(MaxArraySize + 1)]
-        [InlineData(int.MaxValue)]
+        [MemberData(nameof(Queue_Generic_EnsureCapacity_LargeCapacityRequested_Throws_MemberData))]
         [SkipOnMono("mono forces no restrictions on array size.")]
         public void Queue_Generic_EnsureCapacity_LargeCapacityRequested_Throws(int requestedCapacity)
         {

--- a/src/libraries/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -314,11 +314,14 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => stack.EnsureCapacity(-1));
         }
 
-        const int MaxArraySize = 0X7FEFFFFF;
+        public static IEnumerable<object[]> Stack_Generic_EnsureCapacity_LargeCapacityRequested_Throws_MemberData()
+        {
+            yield return new object[] { Array.MaxLength + 1 };
+            yield return new object[] { int.MaxValue };
+        }
 
         [Theory]
-        [InlineData(MaxArraySize + 1)]
-        [InlineData(int.MaxValue)]
+        [MemberData(nameof(Stack_Generic_EnsureCapacity_LargeCapacityRequested_Throws_MemberData))]
         [SkipOnMono("mono forces no restrictions on array size.")]
         public void Stack_Generic_EnsureCapacity_LargeCapacityRequested_Throws(int requestedCapacity)
         {

--- a/src/libraries/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -322,7 +322,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(Stack_Generic_EnsureCapacity_LargeCapacityRequested_Throws_MemberData))]
-        [SkipOnMono("mono forces no restrictions on array size.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51411", TestRuntimes.Mono)]
         public void Stack_Generic_EnsureCapacity_LargeCapacityRequested_Throws(int requestedCapacity)
         {
             var stack = GenericStackFactory();

--- a/src/libraries/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions.Tests
             {
                 Assert.Throws<OverflowException>(() => func());
             }
-            else if (size > Array.GetMaxLength<object>())
+            else if (size > Array.MaxLength)
             {
                 Assert.Throws<OutOfMemoryException>(() => func());
             }

--- a/src/libraries/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Array/NewArrayBoundsTests.cs
@@ -10,8 +10,6 @@ namespace System.Linq.Expressions.Tests
 {
     public static class ArrayBoundsTests
     {
-        private const int MaxArraySize = 0X7FEFFFFF;
-
         private class BogusCollection<T> : IList<T>
         {
             public T this[int index]
@@ -168,7 +166,7 @@ namespace System.Linq.Expressions.Tests
             {
                 Assert.Throws<OverflowException>(() => func());
             }
-            else if (size > MaxArraySize)
+            else if (size > Array.GetMaxLength<object>())
             {
                 Assert.Throws<OutOfMemoryException>(() => func());
             }

--- a/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.Byte.cs
+++ b/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.Byte.cs
@@ -98,7 +98,6 @@ namespace System.Buffers.Tests
         [OuterLoop]
         public void GetMemory_ExceedMaximumBufferSize()
         {
-            const int MaxArrayLength = 0X7FEFFFFF;
             int initialCapacity = int.MaxValue / 2 + 1;
 
             try
@@ -111,8 +110,8 @@ namespace System.Buffers.Tests
                 memory = output.GetMemory(1);
 
                 // The buffer should grow more than the 1 byte requested otherwise performance will not be usable
-                // between 1GB and 2GB. The current implementation maxes out the buffer size to MaxArrayLength.
-                Assert.Equal(MaxArrayLength - initialCapacity, memory.Length);
+                // between 1GB and 2GB. The current implementation maxes out the buffer size to Array.MaxLength.
+                Assert.Equal(Array.MaxLength - initialCapacity, memory.Length);
                 Assert.Throws<OutOfMemoryException>(() => output.GetMemory(int.MaxValue));
             }
             catch (OutOfMemoryException)

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -20,11 +20,12 @@ namespace System
     {
         // We impose limits on maximum array length in each dimension to allow efficient
         // implementation of advanced range check elimination in future.
-        // Keep in sync with vm\gcscan.cpp and HashHelpers.MaxPrimeArrayLength.
-        // The constants are defined in this method: inline SIZE_T MaxArrayLength(SIZE_T componentSize) from gcscan
+        // Keep in sync with vm\gchelpers.cpp and HashHelpers.MaxPrimeArrayLength.
+        // The constants are defined in this method: inline SIZE_T MaxArrayLength(SIZE_T componentSize) from gchelpers
         // We have different max sizes for arrays with elements of size 1 for backwards compatibility
-        internal const int MaxArrayLength = 0X7FEFFFFF;
-        internal const int MaxByteArrayLength = 0x7FFFFFC7;
+        // Wrapped by GetMaxLength<T>()
+        private const int MaxArrayLength = 0X7FEFFFFF;
+        private const int MaxByteArrayLength = 0x7FFFFFC7;
 
         // This is the threshold where Introspective sort switches to Insertion sort.
         // Empirically, 16 seems to speed up most cases without slowing down others, at least for integers.
@@ -1871,6 +1872,20 @@ namespace System
             }
             return true;
         }
+
+        /// <summary>
+        /// Gets the maximum number of elements that may be contained in an array of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of array element.</typeparam>
+        /// <returns>The maximum count of elements allowed of array of the given type.</returns>
+        /// <remarks>
+        /// This methods returns runtime limitation.
+        /// The limitation is counted in elements, not bytes.
+        /// There's no guarantee that allocation under the size would succeed.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetMaxLength<T>() =>
+            Unsafe.SizeOf<T>() == 1 ? MaxByteArrayLength : MaxArrayLength;
 
         // Private value type used by the Sort methods.
         private readonly struct SorterObjectArray

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -18,15 +18,6 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract partial class Array : ICloneable, IList, IStructuralComparable, IStructuralEquatable
     {
-        // We impose limits on maximum array length in each dimension to allow efficient
-        // implementation of advanced range check elimination in future.
-        // Keep in sync with vm\gchelpers.cpp and HashHelpers.MaxPrimeArrayLength.
-        // The constants are defined in this method: inline SIZE_T MaxArrayLength(SIZE_T componentSize) from gchelpers
-        // We have different max sizes for arrays with elements of size 1 for backwards compatibility
-        // Wrapped by GetMaxLength<T>()
-        private const int MaxArrayLength = 0X7FEFFFFF;
-        private const int MaxByteArrayLength = 0x7FFFFFC7;
-
         // This is the threshold where Introspective sort switches to Insertion sort.
         // Empirically, 16 seems to speed up most cases without slowing down others, at least for integers.
         // Large value types may benefit from a smaller number.
@@ -1873,19 +1864,16 @@ namespace System
             return true;
         }
 
-        /// <summary>
-        /// Gets the maximum number of elements that may be contained in an array of the specified type.
-        /// </summary>
-        /// <typeparam name="T">The type of array element.</typeparam>
-        /// <returns>The maximum count of elements allowed of array of the given type.</returns>
+        /// <summary>Gets the maximum number of elements that may be contained in an array.</summary>
+        /// <returns>The maximum count of elements allowed in any array.</returns>
         /// <remarks>
-        /// This methods returns runtime limitation.
-        /// The limitation is counted in elements, not bytes.
-        /// There's no guarantee that allocation under the size would succeed.
+        /// This property represents a runtime limitation, the maximum number of elements (not bytes)
+        /// the runtime will allow in an array. There is no guarantee that an allocation under this length
+        /// will succeed, but all attempts to allocate a larger array will fail.
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetMaxLength<T>() =>
-            Unsafe.SizeOf<T>() == 1 ? MaxByteArrayLength : MaxArrayLength;
+        public static int MaxLength =>
+            // Keep in sync with `inline SIZE_T MaxArrayLength()` from gchelpers and HashHelpers.MaxPrimeArrayLength.
+            0X7FFFFFC7;
 
         // Private value type used by the Sort methods.
         private readonly struct SorterObjectArray

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
@@ -314,7 +314,7 @@ namespace System.Collections
                 int newCapacity = _items.Length == 0 ? _defaultCapacity : _items.Length * 2;
                 // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
                 // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-                if ((uint)newCapacity > Array.GetMaxLength<object>()) newCapacity = Array.GetMaxLength<object>();
+                if ((uint)newCapacity > Array.MaxLength) newCapacity = Array.MaxLength;
                 if (newCapacity < min) newCapacity = min;
                 Capacity = newCapacity;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
@@ -314,7 +314,7 @@ namespace System.Collections
                 int newCapacity = _items.Length == 0 ? _defaultCapacity : _items.Length * 2;
                 // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
                 // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-                if ((uint)newCapacity > Array.MaxArrayLength) newCapacity = Array.MaxArrayLength;
+                if ((uint)newCapacity > Array.GetMaxLength<object>()) newCapacity = Array.GetMaxLength<object>();
                 if (newCapacity < min) newCapacity = min;
                 Capacity = newCapacity;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -428,7 +428,7 @@ namespace System.Collections.Generic
             if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
 
             // If the computed capacity is still less than specified, set to the original argument.
-            // Capacities exceeding MaxArrayLength will be surfaced as OutOfMemoryException by Array.Resize.
+            // Capacities exceeding Array.MaxLength will be surfaced as OutOfMemoryException by Array.Resize.
             if (newcapacity < capacity) newcapacity = capacity;
 
             Capacity = newcapacity;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -425,7 +425,7 @@ namespace System.Collections.Generic
 
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newcapacity > Array.MaxArrayLength) newcapacity = Array.MaxArrayLength;
+            if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
 
             // If the computed capacity is still less than specified, set to the original argument.
             // Capacities exceeding MaxArrayLength will be surfaced as OutOfMemoryException by Array.Resize.

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
@@ -10,7 +10,7 @@ namespace System.Collections
     {
         public const uint HashCollisionThreshold = 100;
 
-        // This is the maximum prime smaller than Array.MaxArrayLength
+        // This is the maximum prime smaller than Array.MaxLength.
         public const int MaxPrimeArrayLength = 0x7FEFFFFD;
 
         public const int HashPrime = 101;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
@@ -11,7 +11,7 @@ namespace System.Collections
         public const uint HashCollisionThreshold = 100;
 
         // This is the maximum prime smaller than Array.MaxLength.
-        public const int MaxPrimeArrayLength = 0x7FEFFFFD;
+        public const int MaxPrimeArrayLength = 0x7FFFFFC3;
 
         public const int HashPrime = 101;
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -155,11 +155,11 @@ namespace System.IO
                     newCapacity = _capacity * 2;
                 }
 
-                // We want to expand the array up to Array.MaxByteArrayLength
+                // We want to expand the array up to Array.GetMaxLength<byte>()
                 // And we want to give the user the value that they asked for
-                if ((uint)(_capacity * 2) > Array.MaxByteArrayLength)
+                if ((uint)(_capacity * 2) > Array.GetMaxLength<byte>())
                 {
-                    newCapacity = Math.Max(value, Array.MaxByteArrayLength);
+                    newCapacity = Math.Max(value, Array.GetMaxLength<byte>());
                 }
 
                 Capacity = newCapacity;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -155,11 +155,11 @@ namespace System.IO
                     newCapacity = _capacity * 2;
                 }
 
-                // We want to expand the array up to Array.GetMaxLength<byte>()
+                // We want to expand the array up to Array.MaxLength.
                 // And we want to give the user the value that they asked for
-                if ((uint)(_capacity * 2) > Array.GetMaxLength<byte>())
+                if ((uint)(_capacity * 2) > Array.MaxLength)
                 {
-                    newCapacity = Math.Max(value, Array.GetMaxLength<byte>());
+                    newCapacity = Math.Max(value, Array.MaxLength);
                 }
 
                 Capacity = newCapacity;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -588,7 +588,7 @@ namespace System.Threading
         /// </summary>
         private static int GetNewTableSize(int minSize)
         {
-            if ((uint)minSize > Array.GetMaxLength<object>())
+            if ((uint)minSize > Array.MaxLength)
             {
                 // Intentionally return a value that will result in an OutOfMemoryException
                 return int.MaxValue;
@@ -623,9 +623,9 @@ namespace System.Threading
             newSize++;
 
             // Don't set newSize to more than Array.MaxArrayLength
-            if ((uint)newSize > Array.GetMaxLength<object>())
+            if ((uint)newSize > Array.MaxLength)
             {
-                newSize = Array.GetMaxLength<object>();
+                newSize = Array.MaxLength;
             }
 
             return newSize;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -588,7 +588,7 @@ namespace System.Threading
         /// </summary>
         private static int GetNewTableSize(int minSize)
         {
-            if ((uint)minSize > Array.MaxArrayLength)
+            if ((uint)minSize > Array.GetMaxLength<object>())
             {
                 // Intentionally return a value that will result in an OutOfMemoryException
                 return int.MaxValue;
@@ -623,9 +623,9 @@ namespace System.Threading
             newSize++;
 
             // Don't set newSize to more than Array.MaxArrayLength
-            if ((uint)newSize > Array.MaxArrayLength)
+            if ((uint)newSize > Array.GetMaxLength<object>())
             {
-                newSize = Array.MaxArrayLength;
+                newSize = Array.GetMaxLength<object>();
             }
 
             return newSize;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
@@ -175,7 +175,10 @@ namespace System.Runtime.Serialization
             3, 7, 17, 37, 89, 197, 431, 919, 1931, 4049, 8419, 17519, 36353,
             75431, 156437, 324449, 672827, 1395263, 2893249, 5999471,
             11998949, 23997907, 47995853, 95991737, 191983481, 383966977, 767933981, 1535867969,
-            2146435069, Array.MaxLength // Array.MaxLength is not prime, but it is the largest possible array size. There's nowhere to go from here.
+            2146435069, 0x7FFFFFC7
+            // 0x7FFFFFC7 == Array.MaxLength is not prime, but it is the largest possible array size.
+            // There's nowhere to go from here. Using a const rather than the MaxLength property
+            // so that the array contains only const values.
         };
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
@@ -175,8 +175,7 @@ namespace System.Runtime.Serialization
             3, 7, 17, 37, 89, 197, 431, 919, 1931, 4049, 8419, 17519, 36353,
             75431, 156437, 324449, 672827, 1395263, 2893249, 5999471,
             11998949, 23997907, 47995853, 95991737, 191983481, 383966977, 767933981, 1535867969,
-            2146435069, Array.GetMaxLength<object>()
-            // 0X7FEFFFFF is not prime, but it is the largest possible array size. There's nowhere to go from here.
+            2146435069, Array.MaxLength // Array.MaxLength is not prime, but it is the largest possible array size. There's nowhere to go from here.
         };
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
@@ -175,7 +175,7 @@ namespace System.Runtime.Serialization
             3, 7, 17, 37, 89, 197, 431, 919, 1931, 4049, 8419, 17519, 36353,
             75431, 156437, 324449, 672827, 1395263, 2893249, 5999471,
             11998949, 23997907, 47995853, 95991737, 191983481, 383966977, 767933981, 1535867969,
-            2146435069, 0X7FEFFFFF
+            2146435069, Array.GetMaxLength<object>()
             // 0X7FEFFFFF is not prime, but it is the largest possible array size. There's nowhere to go from here.
         };
     }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -305,6 +305,7 @@ namespace System
         public bool IsSynchronized { get { throw null; } }
         public int Length { get { throw null; } }
         public long LongLength { get { throw null; } }
+        public static int MaxLength { get { throw null; } }
         public int Rank { get { throw null; } }
         public object SyncRoot { get { throw null; } }
         int System.Collections.ICollection.Count { get { throw null; } }
@@ -352,7 +353,6 @@ namespace System
         public int GetLength(int dimension) { throw null; }
         public long GetLongLength(int dimension) { throw null; }
         public int GetLowerBound(int dimension) { throw null; }
-        public static int GetMaxLength<T>() { throw null; }
         public int GetUpperBound(int dimension) { throw null; }
         public object? GetValue(int index) { throw null; }
         public object? GetValue(int index1, int index2) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -352,6 +352,7 @@ namespace System
         public int GetLength(int dimension) { throw null; }
         public long GetLongLength(int dimension) { throw null; }
         public int GetLowerBound(int dimension) { throw null; }
+        public static int GetMaxLength<T>() { throw null; }
         public int GetUpperBound(int dimension) { throw null; }
         public object? GetValue(int index) { throw null; }
         public object? GetValue(int index1, int index2) { throw null; }

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -4325,12 +4325,7 @@ namespace System.Tests
         [Fact]
         public static void MaxSizes()
         {
-            Assert.Equal(0x7FFFFFC7, Array.GetMaxLength<byte>());
-            Assert.Equal(0x7FFFFFC7, Array.GetMaxLength<SByteEnum>());
-
-            Assert.Equal(0X7FEFFFFF, Array.GetMaxLength<int>());
-            Assert.Equal(0X7FEFFFFF, Array.GetMaxLength<object>());
-            Assert.Equal(0X7FEFFFFF, Array.GetMaxLength<string>());
+            Assert.Equal(0x7FFFFFC7, Array.MaxLength);
         }
 
         private static void VerifyArray(Array array, Type elementType, int[] lengths, int[] lowerBounds, object repeatedValue)

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -4322,6 +4322,17 @@ namespace System.Tests
             Reverse(array, int.MinValue, 2, new int[] { 2, 1, 3 });
         }
 
+        [Fact]
+        public static void MaxSizes()
+        {
+            Assert.Equal(0x7FFFFFC7, Array.GetMaxLength<byte>());
+            Assert.Equal(0x7FFFFFC7, Array.GetMaxLength<SByteEnum>());
+
+            Assert.Equal(0X7FEFFFFF, Array.GetMaxLength<int>());
+            Assert.Equal(0X7FEFFFFF, Array.GetMaxLength<object>());
+            Assert.Equal(0X7FEFFFFF, Array.GetMaxLength<string>());
+        }
+
         private static void VerifyArray(Array array, Type elementType, int[] lengths, int[] lowerBounds, object repeatedValue)
         {
             VerifyArray(array, elementType, lengths, lowerBounds);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -12,9 +12,6 @@ namespace System.Text.Json
 {
     internal static partial class JsonHelpers
     {
-        // Copy of Array.MaxArrayLength. For byte arrays the limit is slightly larger
-        private const int MaxArrayLength = 0X7FEFFFFF;
-
         // Members accessed by the serializer when deserializing.
         public const DynamicallyAccessedMemberTypes MembersAccessedOnRead =
             DynamicallyAccessedMemberTypes.PublicConstructors |
@@ -157,7 +154,11 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ValidateInt32MaxArrayLength(uint length)
         {
-            if (length > MaxArrayLength)
+#if BUILDING_INBOX_LIBRARY
+            if (length > Array.MaxLength)
+#else
+            if (length > 0X7FEFFFFF) // prior to .NET 6, max array length for sizeof(T) != 1 (size == 1 is larger)
+#endif
             {
                 ThrowHelper.ThrowOutOfMemoryException(length);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -154,11 +154,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ValidateInt32MaxArrayLength(uint length)
         {
-#if BUILDING_INBOX_LIBRARY
-            if (length > Array.MaxLength)
-#else
             if (length > 0X7FEFFFFF) // prior to .NET 6, max array length for sizeof(T) != 1 (size == 1 is larger)
-#endif
             {
                 ThrowHelper.ThrowOutOfMemoryException(length);
             }

--- a/src/tests/GC/Performance/Tests/Allocation.cs
+++ b/src/tests/GC/Performance/Tests/Allocation.cs
@@ -55,11 +55,12 @@ class Allocation
         UInt64 objCount = MaxBytes / (UInt64)byteArraySize;
 
         Console.WriteLine("Creating a list of {0} objects", objCount);
-        if (objCount > 0X7FEFFFFF)
+        UInt64 maxArrayLength = (UInt64)Array.GetMaxLength<object>();
+        if (objCount > maxArrayLength)
         {
             Console.WriteLine("Exceeded the max number of objects in a list");
-            Console.WriteLine("Creating a list with {0} objects", 0X7FEFFFFF);
-            objCount = 0X7FEFFFFF;
+            Console.WriteLine("Creating a list with {0} objects", maxArrayLength);
+            objCount = maxArrayLength;
         }
 
         Console.WriteLine("Byte array size is " + byteArraySize);

--- a/src/tests/GC/Performance/Tests/Allocation.cs
+++ b/src/tests/GC/Performance/Tests/Allocation.cs
@@ -55,7 +55,7 @@ class Allocation
         UInt64 objCount = MaxBytes / (UInt64)byteArraySize;
 
         Console.WriteLine("Creating a list of {0} objects", objCount);
-        UInt64 maxArrayLength = (UInt64)Array.GetMaxLength<object>();
+        UInt64 maxArrayLength = (UInt64)Array.MaxLength;
         if (objCount > maxArrayLength)
         {
             Console.WriteLine("Exceeded the max number of objects in a list");


### PR DESCRIPTION
Closes #31366

Not encountering the complexity of dividing with object size under 32bit, because that limit shouldn't be meaningful in real world.

Replaces usages of the magic constant with the new api.