### PR TITLE
Fix null reload token for ConfigurationProvider

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
@@ -786,9 +786,9 @@ namespace Microsoft.Extensions.Configuration.Test
 
         [Fact]
         public void SectionGetRequiredSectionNullThrowException()
-        {                      
+        {
             IConfigurationRoot config = null;
-            Assert.Throws<ArgumentNullException>(() => config.GetRequiredSection("Mem1"));           
+            Assert.Throws<ArgumentNullException>(() => config.GetRequiredSection("Mem1"));
         }
 
         [Fact]
@@ -888,6 +888,29 @@ namespace Microsoft.Extensions.Configuration.Test
 
             // Assert
             Assert.False(sectionExists);
+        }
+
+        internal class NullReloadTokenConfigSource : IConfigurationSource, IConfigurationProvider
+        {
+            public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string parentPath) => throw new NotImplementedException();
+            public Primitives.IChangeToken GetReloadToken() => null;
+            public void Load() { }
+            public void Set(string key, string value) => throw new NotImplementedException();
+            public bool TryGet(string key, out string value) => throw new NotImplementedException();
+            public IConfigurationProvider Build(IConfigurationBuilder builder) => this;
+        }
+
+        [Fact]
+        public void ProviderWithNullReloadToken()
+        {
+            // Arrange
+            var builder = new ConfigurationBuilder();
+            builder.Add(new NullReloadTokenConfigSource());
+
+            // Act
+            var config = builder.Build();
+
+            // Assert
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
@@ -911,6 +911,7 @@ namespace Microsoft.Extensions.Configuration.Test
             var config = builder.Build();
 
             // Assert
+            Assert.NotNull(config);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -95,6 +95,11 @@ namespace Microsoft.Extensions.Primitives
 
             private void RegisterChangeTokenCallback(IChangeToken token)
             {
+                if (token is null)
+                {
+                    return;
+                }
+
                 IDisposable registraton = token.RegisterChangeCallback(s => ((ChangeTokenRegistration<TState>)s).OnChangeTokenFired(), this);
 
                 SetDisposable(registraton);


### PR DESCRIPTION
Fixes #35996 (and fixes #36393)

I'm not sure if this is the best place to do the null check. Or if we want to check earlier.