### PR TITLE
Remove EBS.Never from CipherMode.CFB.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -46,7 +46,6 @@ namespace System.Security.Cryptography
         ECB = 2,
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         OFB = 3,
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         CFB = 4,
         CTS = 5,
     }


### PR DESCRIPTION
This was removed from src/ but ref/ was not updated to match.

Fixes #43256 