### PR TITLE
Update the targeting SDK version to RC2 final

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-rc.1.20454.5"
+    "dotnet": "5.0.100-rc.2.20479.15"
   },
   "native-tools": {
     "cmake": "3.14.5",


### PR DESCRIPTION
Manually porting https://github.com/dotnet/arcade/commit/65bb4cb39c95cdb6c7577af855dfe79d2e211b2a into dotnet/runtime to avoid dependency flow hops close to shipping.

cc @ericstj