### PR TITLE
Use unbounded connected streams in System.Net.Security tests

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamInvalidOperationTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamInvalidOperationTest.cs
@@ -25,7 +25,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task NegotiateStream_StreamContractTest_Success()
         {
-            (Stream clientStream, Stream serverStream) = ConnectedStreams.CreateBidirectional();
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
             using (clientStream)
             using (serverStream)
             using (var client = new NegotiateStream(clientStream))
@@ -61,7 +61,7 @@ namespace System.Net.Security.Tests
         public async Task NegotiateStream_EndReadEndWriteInvalidParameter_Throws()
         {
             byte[] recvBuf = new byte[s_sampleMsg.Length];
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -97,7 +97,7 @@ namespace System.Net.Security.Tests
         public void NegotiateStream_InvalidPolicy_Throws()
         {
             var policy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -109,7 +109,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task NegotiateStream_TokenImpersonationLevelRequirmentNotMatch_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -133,7 +133,7 @@ namespace System.Net.Security.Tests
             // PolicyEnforcement.Always will force clientSpn check.
             var policy = new ExtendedProtectionPolicy(PolicyEnforcement.Always, ProtectionScenario.TransportSelected, new ServiceNameCollection(snc));
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -146,7 +146,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public void NegotiateStream_DisposedState_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -158,7 +158,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task NegotiateStream_DoubleAuthentication_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -175,7 +175,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public void NegotiateStream_NullCredential_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -186,7 +186,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public void NegotiateStream_NullServicePrincipalName_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -197,7 +197,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task NegotiateStream_SecurityRequirmentNotMeet_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -217,7 +217,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task NegotiateStream_EndAuthenticateInvalidParameter_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -253,7 +253,7 @@ namespace System.Net.Security.Tests
             int offset = 0;
             int count = s_sampleMsg.Length;
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -38,7 +38,7 @@ namespace System.Net.Security.Tests
         [InlineData(1)]
         public async Task NegotiateStream_StreamToStream_Authentication_Success(int delay)
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
 
             using (var clientStream = new DelayStream(stream1, delay))
             using (var serverStream = new DelayStream(stream2, delay))
@@ -90,7 +90,7 @@ namespace System.Net.Security.Tests
         [InlineData(1)]
         public async Task NegotiateStream_StreamToStream_Authenticated_DisposeAsync(int delay)
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             await using (var client = new NegotiateStream(new DelayStream(stream1, delay)))
             await using (var server = new NegotiateStream(new DelayStream(stream2, delay)))
             {
@@ -127,7 +127,7 @@ namespace System.Net.Security.Tests
         {
             string targetName = "testTargetName";
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -186,7 +186,7 @@ namespace System.Net.Security.Tests
             Assert.NotEqual(emptyNetworkCredential, CredentialCache.DefaultCredentials);
             Assert.NotEqual(emptyNetworkCredential, CredentialCache.DefaultNetworkCredentials);
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(stream1))
             using (var server = new NegotiateStream(stream2))
             {
@@ -241,7 +241,7 @@ namespace System.Net.Security.Tests
             byte[] recvBuf = new byte[s_sampleMsg.Length];
             int bytesRead = 0;
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(new DelayStream(stream1, delay)))
             using (var server = new NegotiateStream(new DelayStream(stream2, delay)))
             {
@@ -280,7 +280,7 @@ namespace System.Net.Security.Tests
             byte[] recvBuf = new byte[s_longMsg.Length];
             int bytesRead = 0;
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional(4096, int.MaxValue);
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new NegotiateStream(new DelayStream(stream1, delay)))
             using (var server = new NegotiateStream(new DelayStream(stream2, delay)))
             {
@@ -302,7 +302,7 @@ namespace System.Net.Security.Tests
         [ConditionalFact(nameof(IsNtlmInstalled))]
         public void NegotiateStream_StreamToStream_Flush_Propagated()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var stream = new CallTrackingStream(stream1))
             using (var negotiateStream = new NegotiateStream(stream))
             using (stream2)
@@ -316,7 +316,7 @@ namespace System.Net.Security.Tests
         [ConditionalFact(nameof(IsNtlmInstalled))]
         public async Task NegotiateStream_StreamToStream_FlushAsync_Propagated()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             var tcs = new TaskCompletionSource();
 
             using (var stream = new DelegateDelegatingStream(stream1) { FlushAsyncFunc = async cancellationToken => { await tcs.Task.WithCancellation(cancellationToken); await stream1.FlushAsync(cancellationToken); } })
@@ -342,7 +342,7 @@ namespace System.Net.Security.Tests
 
             byte[] recvBuf = new byte[s_sampleMsg.Length];
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientStream = new DelayStream(stream1))
             using (var serverStream = new DelayStream(stream2))
             using (var client = new NegotiateStream(clientStream))

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
@@ -45,7 +45,7 @@ namespace System.Net.Security.Tests
                 RemoteCertificateValidationCallback serverRemoteCallback = new RemoteCertificateValidationCallback(delegate { return true; });
                 SslStreamCertificateContext certificateContext = SslStreamCertificateContext.Create(serverCert, null, false);
 
-                (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+                (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
                 using (var client = new SslStream(stream1))
                 using (var server = new SslStream(stream2))
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
@@ -24,7 +24,7 @@ namespace System.Net.Security.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/18837", TestPlatforms.AnyUnix)]
         public async Task SslStream_StreamToStream_HandshakeAlert_Ok()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1, true, AllowAnyServerCertificate))
             using (var server = new SslStream(stream2, true, FailClientCertificate))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
@@ -55,7 +55,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_ServerInitiatedCloseNotify_Ok()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1, true, AllowAnyServerCertificate))
             using (var server = new SslStream(stream2))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
@@ -125,7 +125,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_DataAfterShutdown_Fail()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1, true, AllowAnyServerCertificate))
             using (var server = new SslStream(stream2))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCredentialCacheTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCredentialCacheTest.cs
@@ -19,7 +19,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_SameCertUsedForClientAndServer_Ok()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1, true, AllowAnyCertificate))
             using (var server = new SslStream(stream2, true, AllowAnyCertificate))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -28,7 +28,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task DisposeAsync_Connected_ClosesStream()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             var trackingStream1 = new CallTrackingStream(stream1);
             var trackingStream2 = new CallTrackingStream(stream2);
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -211,7 +211,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_NestedAuth_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var ssl = new SslStream(stream1))
             using (stream2)
             {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -70,7 +70,7 @@ namespace System.Net.Security.Tests
                 return true;
             });
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (SslStream server = new SslStream(stream1, false, null, selectionCallback),
                              client = new SslStream(stream2, leaveInnerStreamOpen: false, validationCallback))
             {
@@ -115,7 +115,7 @@ namespace System.Net.Security.Tests
                 return true;
             });
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (SslStream server = new SslStream(stream1, false, null, selectionCallback),
                              client = new SslStream(stream2, leaveInnerStreamOpen: false, validationCallback))
             {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -70,7 +70,7 @@ namespace System.Net.Security.Tests
         [MemberData(nameof(SslStream_StreamToStream_Authentication_Success_MemberData))]
         public async Task SslStream_StreamToStream_Authentication_Success(X509Certificate serverCert = null, X509Certificate clientCert = null)
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var server = new SslStream(stream2, false, delegate { return true; }))
             {
@@ -86,7 +86,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_Authentication_IncorrectServerName_Fail()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1))
             using (var server = new SslStream(stream2))
             using (var certificate = Configuration.Certificates.GetServerCertificate())
@@ -107,7 +107,7 @@ namespace System.Net.Security.Tests
                 return null;
             });
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var client = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var server = new SslStream(stream2, false, null, selectionCallback))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
@@ -121,7 +121,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task Read_CorrectlyUnlocksAfterFailure()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             var clientStream = new ThrowingDelegatingStream(stream1);
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
@@ -148,7 +148,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task Write_CorrectlyUnlocksAfterFailure()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             var clientStream = new ThrowingDelegatingStream(stream1);
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
@@ -172,7 +172,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task Read_InvokedSynchronously()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             var clientStream = new PreReadWriteActionDelegatingStream(stream1);
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
@@ -196,7 +196,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task Write_InvokedSynchronously()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             var clientStream = new PreReadWriteActionDelegatingStream(stream1);
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
@@ -221,7 +221,7 @@ namespace System.Net.Security.Tests
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -283,7 +283,7 @@ namespace System.Net.Security.Tests
         [InlineData(true)]
         public async Task SslStream_StreamToStream_LargeWrites_Success(bool randomizedData)
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -327,7 +327,7 @@ namespace System.Net.Security.Tests
         public async Task SslStream_StreamToStream_Successive_ClientWrite_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -362,7 +362,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_Write_ReadByte_Success()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -382,7 +382,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_WriteAsync_ReadByte_Success()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -408,7 +408,7 @@ namespace System.Net.Security.Tests
                 return;
             }
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -436,7 +436,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_ConcurrentBidirectionalReadsWrites_Success()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -487,7 +487,7 @@ namespace System.Net.Security.Tests
                 return;
             }
 
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(DelegateDelegatingStream.NopDispose(stream1), false, AllowAnyServerCertificate))
             {
                 var serverSslStream = new SslStream(DelegateDelegatingStream.NopDispose(stream2));
@@ -559,7 +559,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_EOFDuringFrameRead_ThrowsIOException()
         {
-            (Stream clientStream, Stream serverStream) = ConnectedStreams.CreateBidirectional();
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
             using (clientStream)
             using (serverStream)
             {
@@ -730,7 +730,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task ReadAsync_WriteAsync_Precanceled_ThrowsOperationCanceledException()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -743,7 +743,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task ReadAsync_CanceledAfterStart_ThrowsOperationCanceledException()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -844,7 +844,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_Handshake_DisposeClient_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -857,7 +857,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_Handshake_DisposeServer_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             {
@@ -870,7 +870,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_Handshake_DisposeClientSsl_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var serverSslStream = new SslStream(DelegateDelegatingStream.NopDispose(stream1)))
             {
                 var clientSslStream = new SslStream(DelegateDelegatingStream.NopDispose(stream2), false, AllowAnyServerCertificate);
@@ -883,7 +883,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_Handshake_DisposeServerSsl_Throws()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(DelegateDelegatingStream.NopDispose(stream1), false, AllowAnyServerCertificate))
             {
                 var serverSslStream = new SslStream(DelegateDelegatingStream.NopDispose(stream2));
@@ -954,7 +954,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task Authenticate_Precanceled_ThrowsOperationCanceledException()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
@@ -967,7 +967,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task AuthenticateAsClientAsync_MemoryBuffer_CanceledAfterStart_ThrowsOperationCanceledException()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
@@ -1000,7 +1000,7 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task AuthenticateAsServerAsync_VirtualNetwork_CanceledAfterStart_ThrowsOperationCanceledException()
         {
-            (Stream stream1, Stream stream2) = ConnectedStreams.CreateBidirectional();
+            (Stream stream1, Stream stream2) = TestHelper.GetConnectedStreams();
             using (var clientSslStream = new SslStream(stream1, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(stream2))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -49,7 +49,7 @@ namespace System.Net.Security.Tests
                 return GetConnectedTcpStreams();
             }
 
-            return ConnectedStreams.CreateBidirectional();
+            return ConnectedStreams.CreateBidirectional(initialBufferSize: 4096, maxBufferSize: int.MaxValue);
         }
 
         internal static (NetworkStream ClientStream, NetworkStream ServerStream) GetConnectedTcpStreams()


### PR DESCRIPTION
Recently there's been a rash of sporadic timeouts/hangs in System.Net.Security tests.  I don't _think_ it's related to hitting the maximum buffer size in ConnectedStreams (e.g. if the test is written in a way that it assumes a write will always complete synchronously and won't proceed to read until it does), but I'm removing the bound to see if that helps.  We can put it back later if desired: it's not what the tests are validating, and previous to my ConnectedStream change there was no bound, either.

cc: @geoffkizer 