### PR TITLE
Allow passing entrypoint assembly to Android test app

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20502.4",
+      "version": "1.0.0-prerelease.20512.5",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -190,13 +190,13 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>41078a0e2fd80afc7b85048bf3fd9a3744a834b0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20505.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20512.5">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>66955fe68fa15cddf6def2a93239d01a5d90b514</Sha>
+      <Sha>8961af0d9f363a4023bc180eea7619f773e0d6e2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20505.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20512.5">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>66955fe68fa15cddf6def2a93239d01a5d90b514</Sha>
+      <Sha>8961af0d9f363a4023bc180eea7619f773e0d6e2</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -134,8 +134,8 @@
     <RefOnlyNugetPackagingVersion>4.9.4</RefOnlyNugetPackagingVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.8.0-release-20201009-01</MicrosoftNETTestSdkVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20505.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20505.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20512.5</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20512.5</MicrosoftDotNetXHarnessCLIVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -22,7 +22,6 @@ public class AndroidAppBuilderTask : Task
     /// <summary>
     /// This library will be used as an entry-point (e.g. TestRunner.dll)
     /// </summary>
-    [Required]
     public string MainLibraryFileName { get; set; } = ""!;
 
     /// <summary>

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -28,14 +28,22 @@ import java.util.zip.ZipInputStream;
 public class MonoRunner extends Instrumentation
 {
     static MonoRunner inst;
+    static String entryPointLibName = "%EntryPointLibName%";
 
     static {
         System.loadLibrary("monodroid");
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    public void onCreate(Bundle arguments) {
+        if (arguments != null) {
+            String lib = arguments.getString("entryPointLibName");
+            if (lib != null) {
+                entryPointLibName = lib;
+            }
+        }
+
+        super.onCreate(arguments);
         start();
     }
 
@@ -56,14 +64,25 @@ public class MonoRunner extends Instrumentation
         // unzip libs and test files to filesDir
         unzipAssets(context, filesDir, "assets.zip");
 
+        if (entryPointLibName == "") {
+            Log.e("DOTNET", "Missing entryPointLibName argument, pass '-e entryPointLibName <name.dll>' to adb to specify which program to run.");
+            finish(1, null);
+            return;
+        }
+
         Log.i("DOTNET", "initRuntime");
-        int retcode = initRuntime(filesDir, cacheDir, docsDir);
+        int retcode = initRuntime(filesDir, cacheDir, docsDir, entryPointLibName);
         runOnMainSync(new Runnable() {
             public void run() {
                 Bundle result = new Bundle();
                 result.putInt("return-code", retcode);
+
                 // Xharness cli expects "test-results-path" with test results
-                result.putString("test-results-path", docsDir + "/testResults.xml");
+                File testResults = new File(docsDir + "/testResults.xml");
+                if (testResults.exists()) {
+                    result.putString("test-results-path", testResults.getAbsolutePath());
+                }
+
                 finish(retcode, result);
             }
         });
@@ -103,5 +122,5 @@ public class MonoRunner extends Instrumentation
         }
     }
 
-    native int initRuntime(String libsDir, String cacheDir, String docsDir);
+    native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName);
 }


### PR DESCRIPTION
This allows packaging multiple assemblies with an entrypoint into the same app and select which one to run by passing an argument via adb/xharness.
Includes xharness bump for getting the expected exit code feature: https://github.com/dotnet/xharness/pull/331

/cc @fanyang-mono 