### PR TITLE
Fix PAL test threading/WaitForMultipleObjectsEx/test2

### DIFF
--- a/src/coreclr/src/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
+++ b/src/coreclr/src/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
@@ -56,7 +56,7 @@ PALTEST(threading_WaitForMultipleObjectsEx_test2_paltest_waitformultipleobjectse
     // wait timeout
     if ( 
         ((ThreadWaitDelta_WFMO_test2 >= ChildThreadWaitTime) && (ThreadWaitDelta_WFMO_test2 - ChildThreadWaitTime) > TOLERANCE)
-        || (( ThreadWaitDelta_WFMO_test2 < InterruptTime) && (ThreadWaitDelta_WFMO_test2 - InterruptTime) > TOLERANCE)
+        || (( ThreadWaitDelta_WFMO_test2 < InterruptTime) && (InterruptTime - ThreadWaitDelta_WFMO_test2) > TOLERANCE)
         )
     {
         Fail("Expected thread to wait for %d ms (and get interrupted).\n"


### PR DESCRIPTION
This test was failing intermittently in the CI and I've been able
to reproduce the failure locally too in about 1 out of 2000 runs.
The problem was an incorrectly reverse subtraction in a condition
checking if the time after which a wait for interrupted by
APC matched the expected time with some tolerance.

Close #6327