### PR TITLE
Fix crash caused by GSCookie protection.

### DIFF
--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -507,7 +507,7 @@ void InitGSCookie()
 
 #ifdef TARGET_UNIX
     // PAL layer is unable to extract old protection for regions that were not allocated using VirtualAlloc
-    oldProtection = PAGE_READONLY;
+    oldProtection = PAGE_READWRITE;
 #endif // TARGET_UNIX
 
 #ifndef TARGET_UNIX


### PR DESCRIPTION
#### Backtrace:
```
Thread 1 "dotnet" received signal SIGSEGV, Segmentation fault.
0x00007ffff5927e3c in EEStartupHelper (fFlags=COINITEE_DEFAULT)
    at /home/heiher/exp/coreclr/src/vm/ceemain.cpp:727
727	            g_pStressLog = &StressLog::theLog;

(gdb) bt
#0  0x00007ffff5927e3c in EEStartupHelper (fFlags=COINITEE_DEFAULT)
    at /home/heiher/exp/coreclr/src/vm/ceemain.cpp:727
#1  0x00007ffff5928b3a in <lambda(COINITIEE*)>::operator()(COINITIEE *) const (__closure=0x7fffffffd7fa, 
    pfFlags=0x7fffffffd7ec) at /home/heiher/exp/coreclr/src/vm/ceemain.cpp:1152
#2  0x00007ffff5928c96 in EEStartup (fFlags=COINITEE_DEFAULT)
    at /home/heiher/exp/coreclr/src/vm/ceemain.cpp:1154
#3  0x00007ffff592754e in EnsureEEStarted (flags=COINITEE_DEFAULT)
    at /home/heiher/exp/coreclr/src/vm/ceemain.cpp:342
#4  0x00007ffff5927495 in InitializeEE (flags=COINITEE_DEFAULT)
    at /home/heiher/exp/coreclr/src/vm/ceemain.cpp:280
#5  0x00007ffff57dbe46 in CorRuntimeHostBase::Start (this=0x6626a8)
    at /home/heiher/exp/coreclr/src/vm/corhost.cpp:194
#6  0x00007ffff57dbd9f in CorHost2::Start (this=0x6626a0)
    at /home/heiher/exp/coreclr/src/vm/corhost.cpp:152
#7  0x00007ffff5791554 in coreclr_initialize (exePath=0x66dec0 "/home/heiher/exp/dotnet/dotnet", 
    appDomainFriendlyName=0x7ffff6813b1f "clrhost", propertyCount=10, propertyKeys=0x636240, 
    propertyValues=0x65f3e0, hostHandle=0x7fffffffdb18, domainId=0x7fffffffdb14)
    at /home/heiher/exp/coreclr/src/dlls/mscoree/unixinterface.cpp:217
#8  0x00007ffff67e1ee6 in coreclr_t::create (libcoreclr_path=..., exe_path=<optimized out>, 
    app_domain_friendly_name=<optimized out>, properties=..., inst=...)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/hostpolicy/coreclr.cpp:114
#9  0x00007ffff67ecf09 in (anonymous namespace)::create_coreclr ()
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/hostpolicy/hostpolicy.cpp:75
#10 0x00007ffff67eca52 in corehost_main (argc=3, argv=<optimized out>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/hostpolicy/hostpolicy.cpp:386
#11 0x00007ffff6a50f60 in execute_app (init=<optimized out>, impl_dll_dir=..., argc=<optimized out>, 
    argv=<optimized out>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/fxr/fx_muxer.cpp:146
#12 (anonymous namespace)::read_config_and_execute (host_command=..., host_info=..., app_candidate=..., 
    opts=..., new_argc=<optimized out>, new_argv=<optimized out>, mode=<optimized out>, 
    out_buffer=<optimized out>, buffer_size=<optimized out>, required_buffer_size=<optimized out>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/fxr/fx_muxer.cpp:502
#13 fx_muxer_t::handle_exec_host_command (host_command=..., host_info=..., app_candidate=..., opts=..., 
    argc=<optimized out>, argv=<optimized out>, argoff=<optimized out>, mode=<optimized out>, 
    result_buffer=<optimized out>, buffer_size=<optimized out>, required_buffer_size=<optimized out>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/fxr/fx_muxer.cpp:952
#14 0x00007ffff6a50627 in fx_muxer_t::handle_cli (host_info=..., argc=<optimized out>, 
    argv=<optimized out>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/fxr/fx_muxer.cpp:1032
#15 0x00007ffff6a4fdde in fx_muxer_t::execute (host_command=..., argc=2, argv=0x7fffffffe458, 
    host_info=..., result_buffer=<optimized out>, buffer_size=<optimized out>, 
    required_buffer_size=0x7ffff676da18 <g_pStressLog>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/fxr/fx_muxer.cpp:535
#16 0x00007ffff6a4b821 in hostfxr_main_startupinfo (argc=4194304, 
    argv=0x7ffff6784760 <StressLog::theLog>, host_path=<optimized out>, dotnet_root=<optimized out>, 
    app_path=<optimized out>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/cli/fxr/hostfxr.cpp:33
#17 0x000000000040cd23 in exe_start (argc=2, argv=0x7fffffffe458)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/corehost.cpp:220
#18 0x000000000040d06e in main (argc=<optimized out>, argv=<optimized out>)
    at /home/heiher/x64/source-build/artifacts/src/core-setup.368c23c6a623a75248e5eb852130055dc9cebec2/src/corehost/corehost.cpp:287

(gdb) x/20i $pc - 32
   0x7ffff5927e1c <EEStartupHelper(tagCOINITEE)+573>:	(bad)  
   0x7ffff5927e1d <EEStartupHelper(tagCOINITEE)+574>:	decl   -0xc77b(%rbx)
   0x7ffff5927e23 <EEStartupHelper(tagCOINITEE)+580>:	decl   -0x77(%rcx)
   0x7ffff5927e26 <EEStartupHelper(tagCOINITEE)+583>:	clc    
   0x7ffff5927e27 <EEStartupHelper(tagCOINITEE)+584>:	mov    %eax,%edi
   0x7ffff5927e29 <EEStartupHelper(tagCOINITEE)+586>:	callq  0x7ffff57ad336
     <StressLog::Initialize(unsigned int, unsigned int, unsigned int, unsigned int, void*)>
   0x7ffff5927e2e <EEStartupHelper(tagCOINITEE)+591>:	
    lea    0xe45be3(%rip),%rax        # 0x7ffff676da18 <g_pStressLog>
   0x7ffff5927e35 <EEStartupHelper(tagCOINITEE)+598>:	
    lea    0xe5c924(%rip),%rdx        # 0x7ffff6784760 <_ZN9StressLog6theLogE>
=> 0x7ffff5927e3c <EEStartupHelper(tagCOINITEE)+605>:	mov    %rdx,(%rax)
   0x7ffff5927e3f <EEStartupHelper(tagCOINITEE)+608>:	callq  0x7ffff579b9d2 <InitializeLogging()>
   0x7ffff5927e44 <EEStartupHelper(tagCOINITEE)+613>:	callq  0x7ffff58968d8 <PerfMap::Initialize()>
   0x7ffff5927e49 <EEStartupHelper(tagCOINITEE)+618>:	mov    $0x0,%esi
   0x7ffff5927e4e <EEStartupHelper(tagCOINITEE)+623>:	mov    $0x1000000,%edi
   0x7ffff5927e53 <EEStartupHelper(tagCOINITEE)+628>:	
    callq  0x7ffff57adfaa <StressLog::LogOn(unsigned int, unsigned int)>
   0x7ffff5927e58 <EEStartupHelper(tagCOINITEE)+633>:	test   %eax,%eax
   0x7ffff5927e5a <EEStartupHelper(tagCOINITEE)+635>:	setne  %al
   0x7ffff5927e5d <EEStartupHelper(tagCOINITEE)+638>:	test   %al,%al
   0x7ffff5927e5f <EEStartupHelper(tagCOINITEE)+640>:	
    je     0x7ffff5927e81 <EEStartupHelper(tagCOINITEE)+674>
   0x7ffff5927e61 <EEStartupHelper(tagCOINITEE)+642>:	lea    0x734f70(%rip),%rcx        # 0x7ffff605cdd8
   0x7ffff5927e68 <EEStartupHelper(tagCOINITEE)+649>:	mov    $0x0,%edx

```

#### Maps:
```
# cat /proc/`pidof dotnet`/maps
7ffff56bc000-7ffff5aa9000 r-xp 00000000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
7ffff5aa9000-7ffff5aaa000 rwxp 003ed000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
7ffff5aaa000-7ffff650c000 r-xp 003ee000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
7ffff650c000-7ffff670c000 ---p 00e50000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
7ffff670c000-7ffff6769000 r--p 00e50000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
7ffff6769000-7ffff676d000 rw-p 00ead000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
7ffff676d000-7ffff676e000 r--p 00eb1000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
7ffff676e000-7ffff6784000 rw-p 00eb2000 00:32 14479273                   /home/heiher/exp/dotnet/shared/Microsoft.NETCore.App/3.1.6/libcoreclr.so
```

#### Section & Symbols:
```
# readelf -a libcoreclr.so
    79   [27] .data             PROGBITS         00000000010ad9c0  00ead9c0            
    80        0000000000012ca0  0000000000000000  WA       0     0     64   

# nm libcoreclr.so | grep -P "s_gsCookie|g_pStressLog"
00000000010b1918 d s_gsCookie
00000000010b1a18 d g_pStressLog
```
It seems that when assigning a value to `g_pStressLog`, the corresponding memory space is read-only. This issue occurs when `s_gsCookie` and `g_pStressLog` are linked in the same page, which is not found when compiling with clang, but it will happen when compiling with GCC. `s_gsCookie` is in the `.data` section, I think we should not restore to read-only protection without knowing that the old protection is read-only, and the `.data` section is usually readable and writable. 