### PR TITLE
Fix aot compiler execute_system on all HOST_WIN32.

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -9937,16 +9937,12 @@ mono_aot_patch_info_dup (MonoJumpInfo* ji)
 	return res;
 }
 
-#ifdef HOST_WIN32
-#include <mono/utils/w32subset.h>
-#endif
-
 static int
 execute_system (const char * command)
 {
 	int status = 0;
 
-#if defined (HOST_WIN32) && defined (HAVE_SYSTEM)
+#if defined (HOST_WIN32)
 	// We need an extra set of quotes around the whole command to properly handle commands 
 	// with spaces since internally the command is called through "cmd /c.
 	char * quoted_command = g_strdup_printf ("\"%s\"", command);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20476,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>HAVE_SYSTEM is not defined on all HOST_WIN32 where building the AOT compiler makes sense (like cygwin). Make sure this works on all HOST_WIN32 independent of HAVE_SYSTEM.