### PR TITLE
Match BigInteger 8..15 hex formatting with int

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -512,7 +512,7 @@ namespace System.Numerics
             {
                 // [FF..F8] drop the high F as the two's complement negative number remains clear
                 // [F7..08] retain the high bits as the two's complement number is wrong without it
-                // [07..00] drop the high 0 as the two's complement positive number remains clear
+                // [09..00] drop the high 0 as the two's complement positive number remains clear
                 bool clearHighF = false;
                 byte head = bits[cur];
 
@@ -522,7 +522,7 @@ namespace System.Numerics
                     clearHighF = true;
                 }
 
-                if (head < 0x08 || clearHighF)
+                if (head < 0x08 || clearHighF || (head < 0x10 && cur == 0))
                 {
                     // {0xF8-0xFF} print as {8-F}
                     // {0x00-0x07} print as {0-7}


### PR DESCRIPTION
This delta aligns the output of
`BigInteger.Parse(value).ToString(format)` with
`int.Parse(value).ToString(format)` for `value ∈ [8..15]` and
`format ∈ { x, X }`.

Before:
| value | format | BigInteger | int |
|---|---|---|---|
| 8  | x | 08  | 8  |
| 8  | X  | 08 | 8 |
| 15  | x | 0f  | f  |
| 15  | X  | 0F | F |

After:
| value | format | BigInteger | int |
|---|---|---|---|
| 8  | x | <del>08</del> 8  | 8  |
| 8  | X  | <del>08</del> 8 | 8 |
| 15  | x | <del>0f</del> f  | f  |
| 15  | X  | <del>0F</del> F | F |