### PR TITLE
Fixes failures in the diagnostics MacOS createdump testing 

### DIFF
--- a/src/coreclr/src/debug/createdump/datatarget.cpp
+++ b/src/coreclr/src/debug/createdump/datatarget.cpp
@@ -127,6 +127,7 @@ DumpDataTarget::ReadVirtual(
     size_t read = 0;
     if (!m_crashInfo.ReadProcessMemory((void*)(ULONG_PTR)address, buffer, size, &read))
     {
+        TRACE("DumpDataTarget::ReadVirtual %p %d FAILED\n", (void*)address, size);
         *done = 0;
         return E_FAIL;
     }

--- a/src/coreclr/src/debug/createdump/threadinfo.cpp
+++ b/src/coreclr/src/debug/createdump/threadinfo.cpp
@@ -57,7 +57,7 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
         if (ip == 0 || sp <= previousSp) {
             break;
         }
-        // Break out of the endless loop if the IP matches over a 100 times. This is a fallback
+        // Break out of the endless loop if the IP matches over a 1000 times. This is a fallback
         // behavior of libunwind when the module the IP is in doesn't have unwind info and for
         // simple stack overflows. The stack memory is added to the dump in GetThreadStack and
         // it isn't necessary to add the same IP page over and over again. The only place this
@@ -65,9 +65,9 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
         // over.
         if (ip == previousIp)
         {
-            if (ipMatchCount++ > 100)
+            if (ipMatchCount++ > 1000)
             {
-                TRACE("Unwind: same ip %" PRIA PRIx64 " over 100 times\n", ip);
+                TRACE("Unwind: same ip %" PRIA PRIx64 " over 1000 times\n", ip);
                 break;
             }
         }

--- a/src/coreclr/src/debug/createdump/threadinfo.cpp
+++ b/src/coreclr/src/debug/createdump/threadinfo.cpp
@@ -43,8 +43,11 @@ void
 ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
 {
     uint64_t previousSp = 0;
+    uint64_t previousIp = 0;
+    int ipMatchCount = 0;
 
-    // For each native frame
+    // For each native frame, add a page around the IP and any unwind info not already
+    // added in VisitProgramHeader (Linux) and VisitSection (MacOS) to the dump.
     while (true)
     {
         uint64_t ip = 0, sp = 0;
@@ -53,6 +56,24 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
         TRACE("Unwind: sp %" PRIA PRIx64 " ip %" PRIA PRIx64 "\n", sp, ip);
         if (ip == 0 || sp <= previousSp) {
             break;
+        }
+        // Break out of the endless loop if the IP matches over a 100 times. This is a fallback
+        // behavior of libunwind when the module the IP is in doesn't have unwind info and for
+        // simple stack overflows. The stack memory is added to the dump in GetThreadStack and
+        // it isn't necessary to add the same IP page over and over again. The only place this
+        // check won't catch is the stack overflow case that repeats a sequence of IPs over and
+        // over.
+        if (ip == previousIp)
+        {
+            if (ipMatchCount++ > 100)
+            {
+                TRACE("Unwind: same ip %" PRIA PRIx64 " over 100 times\n", ip);
+                break;
+            }
+        }
+        else
+        {
+            ipMatchCount = 0;
         }
 
         // Add two pages around the instruction pointer to the core dump
@@ -72,6 +93,7 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
             break;
         }
         previousSp = sp;
+        previousIp = ip;
     }
 }
 


### PR DESCRIPTION
1) The triage or heap MacOS coredumps generated with createdump can have the managed assembly
PE headers missing because they are artifically added to the module list but the header
may not end up in the coredump (except for full dumps).

2) ReadProcessMemory returns properly returns partial reads successfully

3) Apply same fixes to PAL_ReadProcessMemory

4) Add check to native unwind to limit endless loop issue (#42980)