### PR TITLE
Add additional URI scheme fields (#35180)

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -18,14 +18,18 @@ namespace System
     {
         public static readonly string UriSchemeFile = UriParser.FileUri.SchemeName;
         public static readonly string UriSchemeFtp = UriParser.FtpUri.SchemeName;
+        public static readonly string UriSchemeSftp = "sftp";
+        public static readonly string UriSchemeFtps = "ftps";
         public static readonly string UriSchemeGopher = UriParser.GopherUri.SchemeName;
         public static readonly string UriSchemeHttp = UriParser.HttpUri.SchemeName;
         public static readonly string UriSchemeHttps = UriParser.HttpsUri.SchemeName;
-        internal static readonly string UriSchemeWs = UriParser.WsUri.SchemeName;
-        internal static readonly string UriSchemeWss = UriParser.WssUri.SchemeName;
+        public static readonly string UriSchemeWs = UriParser.WsUri.SchemeName;
+        public static readonly string UriSchemeWss = UriParser.WssUri.SchemeName;
         public static readonly string UriSchemeMailto = UriParser.MailToUri.SchemeName;
         public static readonly string UriSchemeNews = UriParser.NewsUri.SchemeName;
         public static readonly string UriSchemeNntp = UriParser.NntpUri.SchemeName;
+        public static readonly string UriSchemeSsh = "ssh";
+        public static readonly string UriSchemeTelnet = UriParser.TelnetUri.SchemeName;
         public static readonly string UriSchemeNetTcp = UriParser.NetTcpUri.SchemeName;
         public static readonly string UriSchemeNetPipe = UriParser.NetPipeUri.SchemeName;
         public static readonly string SchemeDelimiter = "://";

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4629,6 +4629,7 @@ namespace System
         public static readonly string SchemeDelimiter;
         public static readonly string UriSchemeFile;
         public static readonly string UriSchemeFtp;
+        public static readonly string UriSchemeFtps;
         public static readonly string UriSchemeGopher;
         public static readonly string UriSchemeHttp;
         public static readonly string UriSchemeHttps;
@@ -4637,6 +4638,11 @@ namespace System
         public static readonly string UriSchemeNetTcp;
         public static readonly string UriSchemeNews;
         public static readonly string UriSchemeNntp;
+        public static readonly string UriSchemeSftp;
+        public static readonly string UriSchemeSsh;
+        public static readonly string UriSchemeTelnet;
+        public static readonly string UriSchemeWs;
+        public static readonly string UriSchemeWss;
         protected Uri(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public Uri(string uriString) { }
         [System.ObsoleteAttribute("The constructor has been deprecated. Please use new Uri(string). The dontEscape parameter is deprecated and is always false. https://go.microsoft.com/fwlink/?linkid=14202")]


### PR DESCRIPTION
This PR addresses #35180 and adds public fields for the following schemes: WS, WSS, SSH, Telnet, SFTP and FTPS.

This is the first draft which should add all required functionality. I still plan to add some tests to verify the parsing logic in `CheckKnownSchemes` but since this is my first contribution to the new mono repo, I am struggling a bit with the tooling to get everything building properly.

Until then, I hope I didn’t miss something that also needs to be added to add proper support for those protocols. I would also be happy to get some feedback on the UriParser flags since I wasn’t perfectly sure which flags would be appropriate for the new protocols.