### PR TITLE
Disable NamedPipeTests CurrentUserOnly on server core

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
@@ -125,7 +125,8 @@ namespace System.IO.Pipes.Tests
     {
         public static bool IsAdminOnSupportedWindowsVersions => PlatformDetection.IsWindowsAndElevated
             && !PlatformDetection.IsWindows7
-            && !PlatformDetection.IsWindowsNanoServer;
+            && !PlatformDetection.IsWindowsNanoServer
+            && !PlatformDetection.IsWindowsServerCore;
 
         private TestAccountImpersonator _testAccountImpersonator;
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/43209