### PR TITLE
[browser][crypto] Remove restraining not supported attribute Primitives

### DIFF
--- a/src/libraries/System.Security.Cryptography.Primitives/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Primitives/Directory.Build.props
@@ -3,6 +3,5 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
-    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Primitives/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Primitives/Directory.Build.props
@@ -2,6 +2,5 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The modules included within the System.Security.Cryptography.Primitives module should still be available for use outside of browser os.

The classes and enums included in this module do not provide an implementation and instead are used and implemented from and across the other System.Security.Cryptography.XXXX modules.

 close https://github.com/dotnet/runtime/issues/43380