### PR TITLE
Add TargetOS=Android back into the Android sample build

### DIFF
--- a/src/mono/netcore/sample/Android/Makefile
+++ b/src/mono/netcore/sample/Android/Makefile
@@ -10,6 +10,7 @@ runtimepack:
 run:
 	$(DOTNET) publish \
 	/p:TargetArchitecture=$(MONO_ARCH) \
+	/p:TargetOS=Android \
 	/p:Configuration=$(MONO_CONFIG) \
 	/p:DeployAndRun=true
 


### PR DESCRIPTION
This allows TargetsMobile to be set.