### PR TITLE
[Mono] enable tests that seem to pass

### DIFF
--- a/src/libraries/System.ComponentModel.Composition/tests/AssemblyInfo.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/AssemblyInfo.cs
@@ -3,4 +3,3 @@
 
 using Xunit;
 
-[assembly: ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)] // flaky tests

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AdvancedValueComposition.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AdvancedValueComposition.cs
@@ -23,7 +23,6 @@ namespace System.ComponentModel.Composition
     public class AdvancedValueComposition
     {
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void RepeatedContainerUse()
         {
             var container = ContainerFactory.Create();
@@ -41,7 +40,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void FunctionsFieldsAndProperties()
         {
             Consumer c;
@@ -56,7 +54,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void FunctionsFieldsAndProperties2()
         {
             Consumer c;
@@ -254,7 +251,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportIntoDerivationOfExportException()
         {
             var container = ContainerFactory.Create();
@@ -272,7 +268,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportIntoDerivationOfExportsException()
         {
             var container = ContainerFactory.Create();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AllowNonPublicCompositionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AllowNonPublicCompositionTests.cs
@@ -10,7 +10,6 @@ namespace System.ComponentModel.Composition
     public class AllowNonPublicCompositionTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PublicFromPublic()
         {
             var container = ContainerFactory.Create();
@@ -25,7 +24,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PublicToSelf()
         {
             var container = ContainerFactory.Create();
@@ -39,7 +37,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PublicFromPrivate()
         {
             var container = ContainerFactory.Create();
@@ -54,7 +51,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PrivateFromPublic()
         {
             var container = ContainerFactory.Create();
@@ -69,7 +65,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PrivateToSelf()
         {
             var container = ContainerFactory.Create();
@@ -83,7 +78,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PrivateData()
         {
             var container = ContainerFactory.Create();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelCompositionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelCompositionTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.ComponentModel.Composition.AttributedModel
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class AttributedModelCompositionTests
     {
         [Fact]

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelDiscoveryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelDiscoveryTests.cs
@@ -15,7 +15,6 @@ namespace System.ComponentModel.Composition.AttributedModel
     public class AttributedModelDiscoveryTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void CreatePartDefinition_TypeWithExports_ShouldHaveMultipleExports()
         {
             var definition = CreateDefinition(typeof(PublicComponentWithPublicExports));
@@ -34,7 +33,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void CreatePartDefinition_TypeWithImports_ShouldHaveMultipleImports()
         {
             var definition = CreateDefinition(typeof(PublicImportsExpectingPublicExports));
@@ -157,7 +155,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void CreatePartDefinition_OneMarkedConstructorsAsPartTypeArgument_ShouldSetConstructorToMarked()
         {
             var definition = CreateDefinition(typeof(SimpleConstructorInjectedObject));
@@ -169,7 +166,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void CreatePartDefinition_OneDefaultConstructorAsPartTypeArgument_ShouldSetConstructorToDefault()
         {
             var definition = CreateDefinition(typeof(PublicComponentWithPublicExports));
@@ -182,7 +178,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void CreatePartDefinition_OneMarkedAndOneDefaultConstructorsAsPartTypeArgument_ShouldSetConstructorToMarked()
         {
             var definition = CreateDefinition(typeof(ClassWithOneMarkedAndOneDefaultConstructor));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/INotifyImportTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/INotifyImportTests.cs
@@ -22,7 +22,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportsSatisfiedOnComponentWithoutImports()
         {
             CompositionContainer container = ContainerFactory.CreateWithAttributedCatalog(typeof(PartWithoutImports));
@@ -35,7 +34,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportCompletedTest()
         {
             var container = ContainerFactory.Create();
@@ -57,7 +55,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportCompletedWithRecomposing()
         {
             var container = ContainerFactory.Create();
@@ -96,7 +93,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportCompletedAddPartAndBindComponent()
         {
             var container = ContainerFactory.Create();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModelServicesTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModelServicesTests.cs
@@ -144,7 +144,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Imports()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();
@@ -158,7 +157,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Imports_CardinalityIgnored_WhenNotSpecified()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();
@@ -171,7 +169,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Imports_CardinalityNotIgnored_WhenSpecified()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();
@@ -202,7 +199,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportsGeneric()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();
@@ -216,7 +212,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportsGeneric_CardinalityIgnored_WhenNotSpecified()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();
@@ -229,7 +224,6 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportsGeneric_CardinalityNotIgnored_WhenSpecified()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ComponentServicesTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ComponentServicesTests.cs
@@ -73,7 +73,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void NoResolverExceptionTest()
         {
             var container = ContainerFactory.Create();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerCollectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerCollectionTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace System.ComponentModel.Composition
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class CompositionContainerCollectionTests
     {
         public class SupportedImportCollectionAssignments<T>

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerImportTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerImportTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace System.ComponentModel.Composition
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class CompositionContainerImportTests
     {
         // Exporting collectin values is not supported

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerTests.cs
@@ -1726,7 +1726,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportsOfTTMetadataView1_TypeAsMetadataViewTypeArgument_IsUsedAsMetadataConstraint()
         {
             var metadata = new Dictionary<string, object>();
@@ -1751,7 +1750,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportsOfTTMetadataView2_TypeAsMetadataViewTypeArgument_IsUsedAsMetadataConstraint()
         {
             var metadata = new Dictionary<string, object>();
@@ -1872,7 +1870,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void TryComposeSimple()
         {
             var container = CreateCompositionContainer();
@@ -1886,7 +1883,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void TryComposeSimpleFail()
         {
             var container = CreateCompositionContainer();
@@ -1904,7 +1900,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ComposeDisposableChildContainer()
         {
             var outerContainer = CreateCompositionContainer();
@@ -1964,7 +1959,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Trait("Type", "Integration")]
         public void OptionalImportsOfValueTypeBoundToDefaultValueShouldNotAffectAvailableValues()
         {
@@ -1984,7 +1978,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Trait("Type", "Integration")]
         public void OptionalImportsOfNullableValueTypeBoundToDefaultValueShouldNotAffectAvailableValues()
         {
@@ -2004,7 +1997,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Trait("Type", "Integration")]
         public void OptionalImportsOfReferenceTypeBoundToDefaultValueShouldNotAffectAvailableValues()
         {
@@ -2413,7 +2405,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void TryGetExportedValueWhileLockedForNotify()
         {
             var container = CreateCompositionContainer();
@@ -2489,7 +2480,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Trait("Type", "Integration")]
         public void AddPartSimple()
         {
@@ -2504,7 +2494,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Trait("Type", "Integration")]
         public void AddPart()
         {
@@ -2519,7 +2508,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ComposeReentrantChildContainerDisposed()
         {
             var container = CreateCompositionContainer();
@@ -2549,7 +2537,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ComposeSimple()
         {
             var container = CreateCompositionContainer();
@@ -2563,7 +2550,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ComposeSimpleFail()
         {
             var container = CreateCompositionContainer();
@@ -2581,7 +2567,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ExceptionDuringNotify()
         {
             var container = CreateCompositionContainer();
@@ -2599,7 +2584,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void NeutralComposeWhileNotified()
         {
             var container = CreateCompositionContainer();
@@ -2657,7 +2641,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ThreadSafeCompositionContainer()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SimpleExporter));
@@ -2677,7 +2660,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ThreadSafeCompositionOptionsCompositionContainer()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SimpleExporter));
@@ -2696,7 +2678,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void DisableSilentRejectionCompositionOptionsCompositionContainer()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SimpleExporter));
@@ -2715,7 +2696,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void DisableSilentRejectionThreadSafeCompositionOptionsCompositionContainer()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SimpleExporter));
@@ -2967,7 +2947,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void TestExportedValueCachesNullValue()
         {
             var container = ContainerFactory.Create();
@@ -2981,7 +2960,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void TestExportedValueUsingWhereClause_ExportSuccessful()
         {
             CompositionContainer container = new CompositionContainer(new TypeCatalog(typeof(MefCollection<,>)));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionServiceExportFactoryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionServiceExportFactoryTests.cs
@@ -41,7 +41,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Description("Verifies CompositionServices.SatisfyImportsOne with Scoped ExportFactories")]
         public void ComposeAppInNewScopeChildrenInRoot_ShouldSucceed()
         {
@@ -66,7 +65,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Description("Verifies CompositionServices.SatisfyImportsOne with Scoped ExportFactories")]
         public void ComposeAppInNewScopeChildrenInScope_ShouldSucceed()
         {
@@ -91,7 +89,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Description("Verifies CompositionServices.SatisfyImportsOne with Scoped ExportFactories")]
         public void ComposeAppInNewScopeChildrenInBoth_ShouldSucceed()
         {
@@ -116,7 +113,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         [Description("Verifies CompositionServices.SatisfyImportsOne with NonScoped ExportFactories")]
         public void ComposeAppInRootScope_ShouldSucceed()
         {

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/DynamicMetadata.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/DynamicMetadata.cs
@@ -12,7 +12,6 @@ namespace System.ComponentModel.Composition
     public class DynamicMetadata : IDisposable
     {
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SimpleAttachment()
         {
             MetadataStore.Container = new CompositionContainer();
@@ -34,7 +33,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void LocalContainer()
         {
             var container1 = new CompositionContainer();
@@ -61,7 +59,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void DualContainers()
         {
             var container1 = new CompositionContainer();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportAttributeTests.cs
@@ -70,7 +70,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ExportIndexers_ShouldThrowSomething()
         {
             var con = new CompositionContainer(

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportFactoryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportFactoryTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Tests.Integration
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class ExportFactoryTests
     {
         public interface IId

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/GenericsTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/GenericsTests.cs
@@ -303,7 +303,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithClosedGenericImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfImport<>), typeof(OpenGenericPartWithClosedGenericImport<>));
@@ -331,7 +330,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PropertyExportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(PropertyExport<,>));
@@ -345,7 +343,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PropertyExportWithContractInferredTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(PropertyExportWithContractInferred<,>));
@@ -359,7 +356,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithPropertyImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithPropertyImport<,>), typeof(SelfImport<,>));
@@ -374,7 +370,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithLazyPropertyImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithLazyPropertyImport<,>), typeof(SelfImport<,>));
@@ -389,7 +384,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithNakedLazyPropertyImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithNakedLazyPropertyImport<>), typeof(Foo));
@@ -404,7 +398,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithExportFactoryPropertyImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithExportFactoryPropertyImport<,>), typeof(SelfImport<,>));
@@ -426,7 +419,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithNakedExportFactoryPropertyImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithNakedExportFactoryPropertyImport<>), typeof(Foo));
@@ -448,7 +440,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithExportFactoryParameterImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithExportFactoryParameterImport<,>), typeof(SelfImport<,>));
@@ -470,7 +461,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithCollectionPropertyImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithCollectionPropertyImport<,>), typeof(SelfImport<,>));
@@ -485,7 +475,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithLazyCollectionPropertyImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithLazyCollectionPropertyImport<,>), typeof(SelfImport<,>));
@@ -500,7 +489,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithPropertyImportWithContractInferredTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithPropertyImportWithContractInferred<,>), typeof(SelfImport<,>));
@@ -515,7 +503,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithParameterImportTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithParameterImport<,>), typeof(SelfImport<,>));
@@ -530,7 +517,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SelfExportWithMultipleGenericImportsTest()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SelfExportWithMultipleGenericImports<,>), typeof(SelfImport<,>), typeof(SelfImport<>), typeof(Foo));
@@ -562,7 +548,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SingletonBehavior()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(SingletonExport<,>));
@@ -721,7 +706,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PartWithExportParametersInReverseOrder()
         {
             TypeCatalog catalog = new TypeCatalog(typeof(PropertyExportWithChangedParameterOrder<,>));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/CatalogExportProviderTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/CatalogExportProviderTests.cs
@@ -338,7 +338,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void RemovingAndReAddingMultipleDefinitionsFromCatalog()
         {
             var fixedParts = new TypeCatalog(typeof(RootMultipleImporter), typeof(ExportedService));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/CompositionBatchTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/CompositionBatchTests.cs
@@ -802,7 +802,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void AddPart_ReturnedComposablePart_ExportsArrayWithNullElementAsExportsArgumentToSetImports_ShouldThrowArgument()
         {
             CompositionBatch batch = new CompositionBatch();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
@@ -126,6 +126,7 @@ namespace System.ComponentModel.Composition.Primitives
         }
 
         [Fact]
+	[PlatformSpecific(~TestPlatforms.Browser)]
         public void LoadedFiles_ContainsMultipleDllsAndSomeNonDll_ShouldOnlyContainDlls()
         {
             string directoryPath = GetTemporaryDirectory();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
@@ -325,7 +325,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-	[PlatformSpecific(~TestPlatforms.Browser)]
+        [PlatformSpecific(~TestPlatforms.Browser)]
         public void LoadedFiles_ContainsMultipleDllsAndSomeNonDll_ShouldOnlyContainDlls()
         {
                 // Add one text file

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
@@ -325,6 +325,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
+	[PlatformSpecific(~TestPlatforms.Browser)]
         public void LoadedFiles_ContainsMultipleDllsAndSomeNonDll_ShouldOnlyContainDlls()
         {
                 // Add one text file

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/FilteredCatalogTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/FilteredCatalogTests.cs
@@ -80,7 +80,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportsWithGenerics()
         {
             var originalCatalog = new TypeCatalog(typeof(GenericExporter<,>), typeof(Exporter11), typeof(Exporter22));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/FilteredCatalogTransitiveClosureTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/FilteredCatalogTransitiveClosureTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace System.ComponentModel.Composition.Hosting
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class FilteredCatalogTransitiveClosureTests
     {
         public interface IContract1 { }

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/ScopeExtensionsTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/ScopeExtensionsTests.cs
@@ -67,7 +67,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Imports()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();
@@ -81,7 +80,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Imports_CardinalityIgnored_WhenNotSpecified()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();
@@ -94,7 +92,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Imports_CardinalityNotIgnored_WhenSpecified()
         {
             ComposablePartDefinition part1 = typeof(PartImportingContract1).AsPart();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ImportAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ImportAttributeTests.cs
@@ -168,7 +168,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportIndexers_ShouldThrowSomething()
         {
             var con = new CompositionContainer(

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/MetadataTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/MetadataTests.cs
@@ -272,7 +272,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void InvalidDuplicateMetadataOnMember_ShouldThrow()
         {
             var part = AttributedModelServices.CreatePart(new ClassWithInvalidDuplicateMetadataOnMember());
@@ -319,7 +318,6 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ValidDuplicateMetadataOnMember_ShouldDiscoverAllMetadata()
         {
             var container = ContainerFactory.Create();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Primitives/CompositionScopeDefinitionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Primitives/CompositionScopeDefinitionTests.cs
@@ -132,7 +132,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Constructor_PublicSurface()
         {
             var catalog = new TypeCatalog(typeof(FooImpl), typeof(FooImpl2), typeof(FooImpl2));
@@ -152,7 +151,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExports_DelegateToCatalog()
         {
             var parts = new TypeCatalog(typeof(FooImpl), typeof(FooImpl2), typeof(FooImpl2)).Parts;
@@ -215,7 +213,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Dispose()
         {
             var parts = new TypeCatalog(typeof(FooImpl), typeof(FooImpl2), typeof(FooImpl2)).Parts;
@@ -252,7 +249,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SimpleComposition()
         {
             var catalog = new TypeCatalog(typeof(FooImpl), typeof(FooImpl2), typeof(FooImpl2));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartTests.cs
@@ -140,7 +140,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void OnComposed_MissingPostImportsOnInstance_ShouldThrowComposition()
         {
             var part = CreatePart(new MySharedPartExport());
@@ -153,7 +152,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void OnComposed_ProperlyComposed_ShouldSucceed()
         {
             var import = new TrivialImporter();
@@ -168,7 +166,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void OnComposed_UnhandledExceptionThrowInOnImportsSatisfied_ShouldThrowComposablePart()
         {
             var part = CreatePart(typeof(ExceptionDuringINotifyImport));
@@ -182,7 +179,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_WhenDisposed_ShouldThrowObjectDisposed()
         {
             var part = CreateDefaultDisposablePart();
@@ -208,7 +204,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_NullAsExportsArgument_ShouldThrowArgumentNull()
         {
             var part = CreatePart(typeof(MySharedPartExport));
@@ -221,7 +216,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_ExportsArrayWithNullElementAsExportsArgument_ShouldThrowArgument()
         {
             var part = CreatePart(typeof(MySharedPartExport));
@@ -247,7 +241,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_SetNonRecomposableDefinitionAsDefinitionArgumentAfterOnComposed_ShouldThrowInvalidOperation()
         {
             var part = CreatePartWithNonRecomposableImport();
@@ -263,7 +256,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_ZeroOrOneDefinitionAsDefinitionArgumentAndTwoExportsAsExportsArgument_ShouldThrowArgument()
         {
             var part = CreatePartWithZeroOrOneImport();
@@ -278,7 +270,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_ExactlyOneDefinitionAsDefinitionArgumentAndTwoExportsAsExportsArgument_ShouldThrowArgument()
         {
             var part = CreatePartWithExactlyOneImport();
@@ -293,7 +284,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_ExactlyOneDefinitionAsDefinitionArgumentAndEmptyExportsAsExportsArgument_ShouldThrowArgument()
         {
             var part = CreatePartWithExactlyOneImport();
@@ -308,7 +298,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_WrongTypeExportGiven_ShouldThrowComposablePart()
         {
             var part = CreatePart(new MySharedPartExport());
@@ -321,7 +310,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SetImport_SetPostValueAndSetAgainOnInstance_ShouldSetProperty()
         {
             var import = new MySharedPartExport();
@@ -345,7 +333,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedValue_WhenDisposed_ShouldThrowObjectDisposed()
         {
             var part = CreateDefaultDisposablePart();
@@ -383,7 +370,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedValue_MissingPrerequisiteImport_ShouldThrowInvalidOperation()
         {
             var part = CreatePart(typeof(SimpleConstructorInjectedObject));
@@ -422,7 +408,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedValue_GetObjectAfterSetPreImport_ShouldGetValue()
         {
             var part = CreatePart(typeof(SimpleConstructorInjectedObject));
@@ -439,7 +424,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedValue_GetObjectAfterSetPostImport_ShouldGetValue()
         {
             var part = CreatePart(typeof(MySharedPartExport));
@@ -457,7 +441,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedValue_CallMultipleTimes_ShouldReturnSame()
         {
             var part = CreatePart(typeof(MySharedPartExport));
@@ -487,7 +470,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedValue_OptionalPostNotGiven_ShouldReturnValidObject()
         {
             var part = CreatePart(typeof(ClassWithOptionalPostImport));
@@ -500,7 +482,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedValue_OptionalPreNotGiven_ShouldReturnValidObject()
         {
             var part = CreatePart(typeof(ClassWithOptionalPreImport));
@@ -566,7 +547,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedObjectAlwaysReturnsSameReference_ForProperty()
         {
             var cp = CreatePart(new PropertyExporter());
@@ -577,7 +557,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportedObjectAlwaysReturnsSameReference_ForField()
         {
             var exporter = new FieldExporter();
@@ -648,7 +627,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportDefinitions_ImportWithCustomAttributeImports()
         {
             var part = CreatePart(typeof(ImportWithCustomImport));
@@ -682,7 +660,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportDefinitions_ImportManyWithCustomAttributeImportManys()
         {
             var part = CreatePart(typeof(ImportManyWithCustomImportMany));
@@ -751,7 +728,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportDefinitions_ImportingConstructorWithCustomAttributeImportingConstructors()
         {
             var part = CreatePart(typeof(ImportingConstructorWithCustomImportingConstructor));
@@ -764,7 +740,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportDefinitions_ImportingConstructorWithCustomAttributeImportingConstructorsWithAllowMultiple_ShouldNotThrowInvalidOperation()
         {
             var part = CreatePart(typeof(ImportingConstructorWithCustomImportingConstructorAllowMultiple));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ScopeExportFactoryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ScopeExportFactoryTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace System.ComponentModel.Composition
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class ScopeExportFactoryTests
     {
         public interface IFooContract
@@ -269,7 +268,6 @@ namespace System.ComponentModel.Composition
         }
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class ScopeExportFactoryWithPublicSurface
     {
         [Export] public class ClassA { }
@@ -312,7 +310,6 @@ namespace System.ComponentModel.Composition
         }
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class ScopeFactoryAutoResolveFromAncestorScope
     {
         [Export] public class Root { }
@@ -370,7 +367,6 @@ namespace System.ComponentModel.Composition
         }
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class DeeplyNestedCatalog
     {
         [Export]
@@ -449,7 +445,6 @@ namespace System.ComponentModel.Composition
         }
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class LocalSharedNonLocalInSameContainer
     {
         [Export]
@@ -546,7 +541,6 @@ namespace System.ComponentModel.Composition
         }
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class ScopeBridgingAdaptersConstructorInjection
     {
         [Export]
@@ -635,7 +629,6 @@ namespace System.ComponentModel.Composition
         }
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class ScopeBridgingAdaptersImportExportProperty
     {
         [Export]
@@ -719,7 +712,6 @@ namespace System.ComponentModel.Composition
         }
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class SelfExportFromExportFactory
     {
         [Export]

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ScopedCompositionServicetests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ScopedCompositionServicetests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace System.ComponentModel.Composition
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class ScopedCompositionServiceTests
     {
         [Export]

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/AdaptingCollectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/AdaptingCollectionTests.cs
@@ -154,7 +154,6 @@ namespace System.ComponentModel.Composition
         #endregion
     }
 
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class AdaptingCollectionTests
     {
         public interface IContract { }

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CatalogFilteringTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CatalogFilteringTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace System.ComponentModel.Composition
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class CatalogFilteringTests
     {
         [Fact]

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CompositionContainerAttributedModelCycleTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CompositionContainerAttributedModelCycleTests.cs
@@ -29,7 +29,6 @@ namespace Tests.Integration
         //
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void APrerequisiteDependsOnBPrerequisite_ShouldThrowComposition()
         {
             AssertCycle(typeof(APrerequisiteDependsOnBPrerequisite),
@@ -37,7 +36,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void APrerequisiteDependsOnBPost_ShouldThrowComposition()
         {
             AssertCycle(typeof(APrerequisiteDependsOnBPost),
@@ -53,7 +51,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void APostDependsOnBPrerequisite_ShouldThrowComposition()
         {
             AssertCycle(typeof(APostDependsOnBPrerequisite),

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/ConstructorInjectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/ConstructorInjectionTests.cs
@@ -12,7 +12,6 @@ namespace Tests.Integration
     public class ConstructorInjectionTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SimpleConstructorInjection()
         {
             var container = ContainerFactory.Create();
@@ -177,7 +176,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ImportMany_ConstructorParameter_OnNonAssiganbleType_ShouldThrowCompositionException()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(InvalidImportManyCI));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DelayLoadingTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DelayLoadingTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Tests.Integration
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class DelayLoadingTests
     {
         [Fact]

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DelegateCompositionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DelegateCompositionTests.cs
@@ -174,7 +174,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void CustomExportedDelegate_ShouldWork()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
@@ -71,7 +71,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Import_PrivateOnClass_ShouldSetImport()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(BaseWithNonPublicImportAndExport));
@@ -82,7 +81,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Import_PrivateOnBase_ShouldSetImport()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(DerivedBaseWithNonPublicImportAndExport));
@@ -121,7 +119,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Import_InheritImportFromInterface_ShouldExposeImport()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -170,7 +167,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Export_BaseAndDerivedShouldAmountInTwoExports()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -306,7 +302,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Export_Plugin1()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -331,7 +326,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Export_Plugin2()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -359,7 +353,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Export_Plugin3()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -392,7 +385,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Export_Plugin4()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -413,7 +405,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Export_MyPlugin()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -449,7 +440,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void TestInterfaces()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(
@@ -508,7 +498,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Import_VirtualPropertyOverrideWithSameContract_ShouldSucceed()
         {
             var container = ContainerFactory.Create();
@@ -540,7 +529,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Import_VirtualPropertyOverrideWithDifferentContract_ShouldSucceed()
         {
             var container = ContainerFactory.Create();
@@ -668,7 +656,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void DiscoverAddinsWithCombinedCustomExportAndMetadataAttribute()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(Addin1), typeof(Addin2), typeof(Addin3));
@@ -727,7 +714,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Test_CustomInheritedExportAttribute_OnInterface()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(UsesCustomInheritedExportOnInterface));
@@ -750,7 +736,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void Test_CustomInheritedExportAttribute_OnBaseClass()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(DerivedFromBaseWithCustomInheritedExport));
@@ -786,6 +771,7 @@ namespace Tests.Integration
         public class FooWithTwoFoos : IFoo1, IFoo2 { }
 
         [Fact]
+	[ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void InheritedExport_TwoInterfaces()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(FooWithTwoFoos));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
@@ -771,7 +771,7 @@ namespace Tests.Integration
         public class FooWithTwoFoos : IFoo1, IFoo2 { }
 
         [Fact]
-	[ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void InheritedExport_TwoInterfaces()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(FooWithTwoFoos));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/LifetimeTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/LifetimeTests.cs
@@ -54,7 +54,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PartAddedViaAddExportedValue_ShouldNotBeDisposedWithContainer()
         {
             var container = new CompositionContainer();
@@ -68,7 +67,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void PartAddedTwice_AppearsTwice()
         {
             //  You probably shouldn't be adding a part to the container twice, but it's not something we're going to check for and throw an exception on
@@ -106,7 +104,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void AnyPart_Disposable_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(AnyPartDisposable));
@@ -121,7 +118,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void AnyPart_Disposable_ShouldBeDisposedWithContainer()
         {
             var catalog = new TypeCatalog(typeof(AnyPartDisposable));
@@ -137,7 +133,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void AnyPart_RecomposabeImport_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(AnyPartRecomposable));
@@ -169,7 +164,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void AnyPart_DisposableRecomposabeImport_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(AnyPartDisposableRecomposable));
@@ -264,7 +258,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SharedPart_Disposable_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(SharedPartDisposable));
@@ -281,7 +274,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SharedPart_Disposable_ShouldBeDisposedWithContainer()
         {
             var catalog = new TypeCatalog(typeof(SharedPartDisposable));
@@ -297,7 +289,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SharedPart_RecomposabeImport_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(SharedPartRecomposable));
@@ -330,7 +321,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void SharedPart_DisposableRecomposabeImport_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(SharedPartDisposableRecomposable));
@@ -423,7 +413,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void NonSharedPart_Disposable_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartDisposable));
@@ -440,7 +429,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void NonSharedPart_Disposable_ShouldBeDisposedWithContainer()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartDisposable));
@@ -456,7 +444,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void NonSharedPart_RecomposableImport_WithReference_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartRecomposable));
@@ -489,7 +476,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void NonSharedPart_DisposableRecomposabeImport_NoReference_ShouldNotBeCollected()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartDisposableRecomposable));
@@ -544,7 +530,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void NonSharedPart_TwoRecomposablePartsSameExportedValue()
         {
             // This test is primarily used to ensure that we allow for multiple parts to be associated
@@ -604,7 +589,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetReleaseExport_SharedRoot_ShouldNotDisposeChain()
         {
             var container = GetContainer();
@@ -619,7 +603,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void AddRemovePart_SharedRoot_ShouldNotDisposeChain()
         {
             var container = GetContainer();
@@ -639,7 +622,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ContainerDispose_SharedRoot_ShouldDisposeChain()
         {
             var container = GetContainer();
@@ -654,7 +636,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetReleaseExport_NonSharedRoot_ShouldDisposeChain()
         {
             var container = GetContainer();
@@ -685,7 +666,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetReleaseExport_NonSharedRoot_ShouldDisposeChain_WithMetadata()
         {
             var container = GetContainer();
@@ -716,7 +696,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ReleaseExports_ShouldDispose_NonSharedParts()
         {
             var container = GetContainer();
@@ -737,7 +716,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void AddRemovePart_NonSharedRoot_ShouldDisposeChain()
         {
             var container = GetContainer();
@@ -757,7 +735,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ContainerDispose_NonSharedRoot_ShouldNotDisposeChain()
         {
             var container = GetContainer();
@@ -772,7 +749,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetReleaseExport_NonSharedPart_ShouldNotRecomposeAfterRelease()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartRecomposable));
@@ -800,7 +776,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void GetExportManualDisposeThenRecompose_NonSharedDisposableRecomposablePart_ShouldThrowComposition()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartDisposableRecomposable));
@@ -841,7 +816,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void RecomposeCausesOldImportedValuesToBeDisposed()
         {
             var cat = new AggregateCatalog();
@@ -884,7 +858,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ChildContainerGetReleaseExport_NonSharedRoot_ShouldDisposeChain()
         {
             var child = CreateParentChildContainerWithNonSharedImporter();
@@ -899,7 +872,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ChildContainerAddRemovePart_NonSharedRoot_ShouldDisposeChain()
         {
             var child = CreateParentChildContainerWithNonSharedImporter();
@@ -919,7 +891,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ChildContainerAddRemovePart_NonSharedRoot_ShouldNotDisposeChain()
         {
             var child = CreateParentChildContainerWithNonSharedImporter();
@@ -1290,7 +1261,6 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
         public void ReleaseExports_ShouldWorkWithExportCollection()
         {
             var container = GetContainer();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RecompositionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RecompositionTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Tests.Integration
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class RecompositionTests
     {
         public class Class_OptIn_AllowRecompositionImports

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RejectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RejectionTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Tests.Integration
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class RejectionTests
     {
         public interface IExtension

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RequiredCreationPolicyTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RequiredCreationPolicyTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Tests.Integration
 {
-    [ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)]
     public class RequiredCreationPolicyTests
     {
         // Matrix that details which policy to use for a given part to satisfy a given import.

--- a/src/libraries/System.Linq.Parallel/tests/PlinqModesTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/PlinqModesTests.cs
@@ -158,7 +158,6 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/mono/mono/issues/14956", TestRuntimes.Mono)]
         [MemberData(nameof(AllExecutionModes_Multiple))]
         public static void WithExecutionMode_Multiple(ParallelExecutionMode first, ParallelExecutionMode second)
         {

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -445,13 +445,10 @@ namespace System.Numerics.Tests
         #region Tests for constructors using unsupported types
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/15190", TestRuntimes.Mono)]
         public void ConstructorWithUnsupportedTypes_Guid() => TestConstructorWithUnsupportedTypes<Guid>();
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/15190", TestRuntimes.Mono)]
         public void ConstructorWithUnsupportedTypes_DateTime() => TestConstructorWithUnsupportedTypes<DateTime>();
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/15190", TestRuntimes.Mono)]
         public void ConstructorWithUnsupportedTypes_Char() => TestConstructorWithUnsupportedTypes<Char>();
 
         private void TestConstructorWithUnsupportedTypes<T>() where T : struct

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -473,7 +473,6 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
-        [ActiveIssue("https://github.com/mono/mono/issues/15353", TestRuntimes.Mono)]
         public void TC_AbsolutePath_Transform(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             TestUsingTemporaryCopyOfResolverDocument(() =>
@@ -2097,7 +2096,6 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
-        [ActiveIssue("https://github.com/mono/mono/issues/15353", TestRuntimes.Mono)]
         public void TC_AbsolutePath_Transform(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             TestUsingTemporaryCopyOfResolverDocument(() =>

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -733,6 +733,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/mono/mono/issues/15029", TestRuntimes.Mono)]
         public static void FindMembers()
         {
             MemberInfo[] members = typeof(MembersClass).GetTypeInfo().FindMembers(MemberTypes.All, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, (MemberInfo memberInfo, object c) => true, "notused");
@@ -816,6 +817,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/mono/mono/issues/15029", TestRuntimes.Mono)]
         public void GetMethod()
         {
             MethodInfo[] methods = typeof(MembersClass).GetTypeInfo().GetMethods();
@@ -834,6 +836,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/mono/mono/issues/15029", TestRuntimes.Mono)]
         [InlineData(BindingFlags.Default, 9)]
         [InlineData(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, 16)]
         public void GetMethods(BindingFlags bindingAttributes, int length)
@@ -900,6 +903,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/mono/mono/issues/15029", TestRuntimes.Mono)]
         [InlineData(BindingFlags.Default, 15)]
         [InlineData(BindingFlags.NonPublic | BindingFlags.Instance, 13)]
         [InlineData(BindingFlags.Public | BindingFlags.Instance, 15)]


### PR DESCRIPTION
These tests have`ActiveIssue` attributes that link to https://github.com/mono/mono issues.  They appear to pass now.

| Test project | Issue |
|----------------|-----------|
| `System.Numerics.Vectors` | Fixes https://github.com/mono/mono/issues/15190 |
| `System.ComponentModel.Composition` | Possibly addresses https://github.com/mono/mono/issues/16417 |
| `System.Private.Xml` | Fixes https://github.com/mono/mono/issues/15353 |
| `System.Linq.Parallel` | Fixes https://github.com/mono/mono/issues/14956 |

Note there are a number of remaining `ActiveIssue` attributes that link to issues in `mono/mono`  see gist https://gist.github.com/lambdageek/dd9b7872d446a16589529f0c562c4123
