### PR TITLE
JIT: some small profile related fixes

### DIFF
--- a/src/coreclr/src/jit/block.h
+++ b/src/coreclr/src/jit/block.h
@@ -565,9 +565,28 @@ struct BasicBlock : private LIR::Range
     }
 
     // this block will inherit the same weight and relevant bbFlags as bSrc
+    //
     void inheritWeight(BasicBlock* bSrc)
     {
-        this->bbWeight = bSrc->bbWeight;
+        inheritWeightPercentage(bSrc, 100);
+    }
+
+    // Similar to inheritWeight(), but we're splitting a block (such as creating blocks for qmark removal).
+    // So, specify a percentage (0 to 100) of the weight the block should inherit.
+    //
+    void inheritWeightPercentage(BasicBlock* bSrc, unsigned percentage)
+    {
+        assert(0 <= percentage && percentage <= 100);
+
+        // Check for overflow
+        if ((bSrc->bbWeight * 100) <= bSrc->bbWeight)
+        {
+            this->bbWeight = bSrc->bbWeight;
+        }
+        else
+        {
+            this->bbWeight = (bSrc->bbWeight * percentage) / 100;
+        }
 
         if (bSrc->hasProfileWeight())
         {
@@ -577,35 +596,6 @@ struct BasicBlock : private LIR::Range
         {
             this->bbFlags &= ~BBF_PROF_WEIGHT;
         }
-
-        if (this->bbWeight == 0)
-        {
-            this->bbFlags |= BBF_RUN_RARELY;
-        }
-        else
-        {
-            this->bbFlags &= ~BBF_RUN_RARELY;
-        }
-    }
-
-    // Similar to inheritWeight(), but we're splitting a block (such as creating blocks for qmark removal).
-    // So, specify a percentage (0 to 99; if it's 100, just use inheritWeight()) of the weight that we're
-    // going to inherit. Since the number isn't exact, clear the BBF_PROF_WEIGHT flag.
-    void inheritWeightPercentage(BasicBlock* bSrc, unsigned percentage)
-    {
-        assert(0 <= percentage && percentage < 100);
-
-        // Check for overflow
-        if (bSrc->bbWeight * 100 <= bSrc->bbWeight)
-        {
-            this->bbWeight = bSrc->bbWeight;
-        }
-        else
-        {
-            this->bbWeight = bSrc->bbWeight * percentage / 100;
-        }
-
-        this->bbFlags &= ~BBF_PROF_WEIGHT;
 
         if (this->bbWeight == 0)
         {

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4209,9 +4209,7 @@ void Compiler::EndPhase(Phases phase)
         pCompJitTimer->EndPhase(this, phase);
     }
 #endif
-#if DUMP_FLOWGRAPHS
-    fgDumpFlowGraph(phase);
-#endif // DUMP_FLOWGRAPHS
+
     mostRecentlyActivePhase = phase;
 }
 


### PR DESCRIPTION
1. If we're inheriting a fraction of the profile weight of a profiled block,
mark the inheriting block as profiled. This prevents methods like
`optSetBlockWeights` or `optMarkLoopBlocks` from coming along later and setting
the weights to something else. Since the full inheritance method has similar
logic, make it delegate to the fractional one, with a scale of 100 (no scaling).

2. If we switch from Tier0 to FullOpt, make sure to clear the BBINSTR flag,
else we'll put probes into optimized code.

3. Dump edge weights in the dot graph, if we have them.

4. Only dump the flow graph ~~twice~~ once per phase.