### PR TITLE
Fix RHEL7 socket dispose hang, and extend coverage

### DIFF
--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -38,9 +38,9 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        public static (Socket, Socket) CreateConnectedSocketPair() => CreateConnectedSocketPair(IPAddress.Loopback, false);
+        public static (Socket client, Socket server) CreateConnectedSocketPair() => CreateConnectedSocketPair(IPAddress.Loopback, false);
 
-        public static (Socket, Socket) CreateConnectedSocketPair(IPAddress serverAddress, bool dualModeClient)
+        public static (Socket client, Socket server) CreateConnectedSocketPair(IPAddress serverAddress, bool dualModeClient)
         {
             using Socket listener = new Socket(serverAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             listener.Bind(new IPEndPoint(serverAddress, 0));

--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -58,13 +58,6 @@ namespace System.Net.Sockets.Tests
             return (client, server);
         }
 
-        public static int GetUnusedPort(AddressFamily addressFamily, ProtocolType protocolType)
-        {
-            using Socket temp = new Socket(addressFamily, protocolType == ProtocolType.Tcp ? SocketType.Stream : SocketType.Dgram, protocolType);
-            IPAddress address = addressFamily == AddressFamily.InterNetwork ? IPAddress.Loopback : IPAddress.IPv6Loopback;
-            return temp.BindToAnonymousPort(address);
-        }
-
         // Tries to connect within the provided timeout interval
         // Useful to speed up "can not connect" assertions on Windows
         public static bool TryConnect(this Socket socket, EndPoint remoteEndpoint, int millisecondsTimeout)

--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -49,7 +49,6 @@ namespace System.Net.Sockets.Tests
             IPEndPoint connectTo = (IPEndPoint)listener.LocalEndPoint;
             if (dualModeClient) connectTo = new IPEndPoint(connectTo.Address.MapToIPv6(), connectTo.Port);
 
-
             Socket client = new Socket(connectTo.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             if (dualModeClient) client.DualMode = true;
             client.Connect(connectTo);

--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -58,6 +58,13 @@ namespace System.Net.Sockets.Tests
             return (client, server);
         }
 
+        public static int GetUnusedPort(AddressFamily addressFamily, ProtocolType protocolType)
+        {
+            using Socket temp = new Socket(addressFamily, protocolType == ProtocolType.Tcp ? SocketType.Stream : SocketType.Dgram, protocolType);
+            IPAddress address = addressFamily == AddressFamily.InterNetwork ? IPAddress.Loopback : IPAddress.IPv6Loopback;
+            return temp.BindToAnonymousPort(address);
+        }
+
         // Tries to connect within the provided timeout interval
         // Useful to speed up "can not connect" assertions on Windows
         public static bool TryConnect(this Socket socket, EndPoint remoteEndpoint, int millisecondsTimeout)

--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -38,10 +38,10 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        public static (Socket client, Socket server) CreateConnectedSocketPair() => CreateConnectedSocketPair(IPAddress.Loopback, false);
-
-        public static (Socket client, Socket server) CreateConnectedSocketPair(IPAddress serverAddress, bool dualModeClient)
+        public static (Socket client, Socket server) CreateConnectedSocketPair(bool ipv6 = false, bool dualModeClient = false)
         {
+            IPAddress serverAddress = ipv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
+
             using Socket listener = new Socket(serverAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             listener.Bind(new IPEndPoint(serverAddress, 0));
             listener.Listen(1);

--- a/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
@@ -16,6 +16,7 @@ namespace System
         /// <param name="maxAttempts">The maximum number of times to invoke <paramref name="test"/>.</param>
         /// <param name="test">The test to invoke.</param>
         /// <param name="backoffFunc">After a failure, invoked to determine how many milliseconds to wait before the next attempt.  It's passed the number of iterations attempted.</param>
+        /// <param name="retryWhen">Invoked to select the exceptions to retry on. If not set, any exception will trigger a retry.</param>
         public static void Execute(Action test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null)
         {
             // Validate arguments

--- a/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/RetryHelper.cs
@@ -10,12 +10,13 @@ namespace System
     public static partial class RetryHelper
     {
         private static readonly Func<int, int> s_defaultBackoffFunc = i => Math.Min(i * 100, 60_000);
+        private static readonly Predicate<Exception> s_defaultRetryWhenFunc = _ => true;
 
         /// <summary>Executes the <paramref name="test"/> action up to a maximum of <paramref name="maxAttempts"/> times.</summary>
         /// <param name="maxAttempts">The maximum number of times to invoke <paramref name="test"/>.</param>
         /// <param name="test">The test to invoke.</param>
         /// <param name="backoffFunc">After a failure, invoked to determine how many milliseconds to wait before the next attempt.  It's passed the number of iterations attempted.</param>
-        public static void Execute(Action test, int maxAttempts = 5, Func<int, int> backoffFunc = null)
+        public static void Execute(Action test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null)
         {
             // Validate arguments
             if (maxAttempts < 1)
@@ -27,6 +28,8 @@ namespace System
                 throw new ArgumentNullException(nameof(test));
             }
 
+            retryWhen ??= s_defaultRetryWhenFunc;
+
             // Execute the test until it either passes or we run it maxAttempts times
             var exceptions = new List<Exception>();
             for (int i = 1; i <= maxAttempts; i++)
@@ -36,7 +39,7 @@ namespace System
                     test();
                     return;
                 }
-                catch (Exception e)
+                catch (Exception e) when (retryWhen(e))
                 {
                     exceptions.Add(e);
                     if (i == maxAttempts)
@@ -53,7 +56,8 @@ namespace System
         /// <param name="maxAttempts">The maximum number of times to invoke <paramref name="test"/>.</param>
         /// <param name="test">The test to invoke.</param>
         /// <param name="backoffFunc">After a failure, invoked to determine how many milliseconds to wait before the next attempt.  It's passed the number of iterations attempted.</param>
-        public static async Task ExecuteAsync(Func<Task> test, int maxAttempts = 5, Func<int, int> backoffFunc = null)
+        /// <param name="retryWhen">Invoked to select the exceptions to retry on. If not set, any exception will trigger a retry.</param>
+        public static async Task ExecuteAsync(Func<Task> test, int maxAttempts = 5, Func<int, int> backoffFunc = null, Predicate<Exception> retryWhen = null)
         {
             // Validate arguments
             if (maxAttempts < 1)
@@ -65,6 +69,8 @@ namespace System
                 throw new ArgumentNullException(nameof(test));
             }
 
+            retryWhen ??= s_defaultRetryWhenFunc;
+
             // Execute the test until it either passes or we run it maxAttempts times
             var exceptions = new List<Exception>();
             for (int i = 1; i <= maxAttempts; i++)
@@ -74,7 +80,7 @@ namespace System
                     await test().ConfigureAwait(false);
                     return;
                 }
-                catch (Exception e)
+                catch (Exception e) when (retryWhen(e))
                 {
                     exceptions.Add(e);
                     if (i == maxAttempts)

--- a/src/libraries/Native/Unix/System.Native/pal_networking.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networking.c
@@ -3085,6 +3085,11 @@ int32_t SystemNative_Disconnect(intptr_t socket)
     addr.sa_family = AF_UNSPEC;
 
     err = connect(fd, &addr, sizeof(addr));
+    if (err != 0) 
+    {
+        // On some older kernels connect(AF_UNSPEC) may fail. Fall back to shutdown in these cases:
+        err = shutdown(fd, SHUT_RDWR);
+    } 
 #elif HAVE_DISCONNECTX
     // disconnectx causes a FIN close on OSX. It's the best we can do.
     err = disconnectx(fd, SAE_ASSOCID_ANY, SAE_CONNID_ANY);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 c_static_assert(PAL_SSL_ERROR_NONE == SSL_ERROR_NONE);
 c_static_assert(PAL_SSL_ERROR_SSL == SSL_ERROR_SSL);
@@ -118,6 +119,8 @@ static void DetectCiphersuiteConfiguration()
     g_config_specified_ciphersuites = 1;
 
 #endif
+    write(0, "config\n", 7);
+    write(0, g_config_specified_ciphersuites == 1 ? "1\n" : "0\n", 2);
 }
 
 void CryptoNative_EnsureLibSslInitialized()

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -11,7 +11,6 @@
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
-#include <unistd.h>
 
 c_static_assert(PAL_SSL_ERROR_NONE == SSL_ERROR_NONE);
 c_static_assert(PAL_SSL_ERROR_SSL == SSL_ERROR_SSL);
@@ -119,8 +118,6 @@ static void DetectCiphersuiteConfiguration()
     g_config_specified_ciphersuites = 1;
 
 #endif
-    write(0, "config\n", 7);
-    write(0, g_config_specified_ciphersuites == 1 ? "1\n" : "0\n", 2);
 }
 
 void CryptoNative_EnsureLibSslInitialized()

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -154,9 +154,6 @@ namespace System.Net.Sockets.Tests
                 }
                 catch (SocketException se)
                 {
-                    // On connection timeout, retry.
-                    Assert.NotEqual(SocketError.TimedOut, se.SocketErrorCode);
-
                     localSocketError = se.SocketErrorCode;
                 }
                 catch (ObjectDisposedException)
@@ -166,6 +163,9 @@ namespace System.Net.Sockets.Tests
 
                 try
                 {
+                    // On connection timeout, retry.
+                    Assert.NotEqual(SocketError.TimedOut, localSocketError);
+
                     if (UsesApm)
                     {
                         Assert.Null(localSocketError);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -122,12 +122,12 @@ namespace System.Net.Sockets.Tests
 
         public static readonly TheoryData<IPAddress> ConnectGetsCanceledByDispose_Data = new TheoryData<IPAddress>
         {
-            { IPAddress.Loopback },
-            { IPAddress.IPv6Loopback },
-            { IPAddress.Loopback.MapToIPv6() },
+            { IPAddress.Parse("1.1.1.1") },
+            { IPAddress.Parse("fd11:1:1:1:1:1:1:1") },
+            { IPAddress.Parse("1.1.1.1").MapToIPv6() },
         };
 
-        [Theory(Timeout = 30000)]
+        [Theory]
         [MemberData(nameof(ConnectGetsCanceledByDispose_Data))]
         [PlatformSpecific(~(TestPlatforms.OSX | TestPlatforms.FreeBSD))] // Not supported on BSD like OSes.
         public async Task ConnectGetsCanceledByDispose(IPAddress address)
@@ -140,8 +140,8 @@ namespace System.Net.Sockets.Tests
             {
                 var client = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
                 if (address.IsIPv4MappedToIPv6) client.DualMode = true;
-                int port = SocketTestExtensions.GetUnusedPort(address.AddressFamily, ProtocolType.Tcp);
-                Task connectTask = ConnectAsync(client, new IPEndPoint(address, port));
+
+                Task connectTask = ConnectAsync(client, new IPEndPoint(address, 23));
 
                 // Wait a little so the operation is started.
                 await Task.Delay(msDelay);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -127,6 +127,7 @@ namespace System.Net.Sockets.Tests
             { IPAddress.Parse("1.1.1.1").MapToIPv6() },
         };
 
+        [OuterLoop("Uses external server")]
         [Theory]
         [MemberData(nameof(ConnectGetsCanceledByDispose_Data))]
         [PlatformSpecific(~(TestPlatforms.OSX | TestPlatforms.FreeBSD))] // Not supported on BSD like OSes.

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -122,12 +122,12 @@ namespace System.Net.Sockets.Tests
 
         public static readonly TheoryData<IPAddress> ConnectGetsCanceledByDispose_Data = new TheoryData<IPAddress>
         {
-            { IPAddress.Parse("1.1.1.1") },
-            { IPAddress.Parse("fd11:1:1:1:1:1:1:1") },
-            { IPAddress.Parse("1.1.1.1").MapToIPv6() },
+            { IPAddress.Loopback },
+            { IPAddress.IPv6Loopback },
+            { IPAddress.Loopback.MapToIPv6() },
         };
 
-        [Theory]
+        [Theory(Timeout = 30000)]
         [MemberData(nameof(ConnectGetsCanceledByDispose_Data))]
         [PlatformSpecific(~(TestPlatforms.OSX | TestPlatforms.FreeBSD))] // Not supported on BSD like OSes.
         public async Task ConnectGetsCanceledByDispose(IPAddress address)
@@ -140,8 +140,8 @@ namespace System.Net.Sockets.Tests
             {
                 var client = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
                 if (address.IsIPv4MappedToIPv6) client.DualMode = true;
-
-                Task connectTask = ConnectAsync(client, new IPEndPoint(address, 23));
+                int port = SocketTestExtensions.GetUnusedPort(address.AddressFamily, ProtocolType.Tcp);
+                Task connectTask = ConnectAsync(client, new IPEndPoint(address, port));
 
                 // Wait a little so the operation is started.
                 await Task.Delay(msDelay);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -123,7 +123,7 @@ namespace System.Net.Sockets.Tests
         public static readonly TheoryData<IPAddress> ConnectGetsCanceledByDispose_Data = new TheoryData<IPAddress>
         {
             { IPAddress.Parse("1.1.1.1") },
-            { IPAddress.Parse("fd11:1:1:1:1:1:1:1") },
+            // TODO: Figure out how to test this with vanilla IPV6
             { IPAddress.Parse("1.1.1.1").MapToIPv6() },
         };
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/InlineCompletions.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/InlineCompletions.Unix.cs
@@ -31,8 +31,8 @@ namespace System.Net.Sockets.Tests
                 await new SendReceiveEap(null).SendRecv_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: false);
                 await new SendReceiveEap(null).SendRecv_Stream_TCP_MultipleConcurrentReceives(IPAddress.Loopback, useMultipleBuffers: false);
                 await new SendReceiveEap(null).SendRecv_Stream_TCP_MultipleConcurrentSends(IPAddress.Loopback, useMultipleBuffers: false);
-                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: true, serverAddress: IPAddress.Loopback, dualModeClient: false);
-                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: false, serverAddress: IPAddress.Loopback, dualModeClient: false);
+                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: true, ipv6Server: false, dualModeClient: false);
+                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: false, ipv6Server: false, dualModeClient: false);
             }, options).Dispose();
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/InlineCompletions.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/InlineCompletions.Unix.cs
@@ -31,8 +31,8 @@ namespace System.Net.Sockets.Tests
                 await new SendReceiveEap(null).SendRecv_Stream_TCP(IPAddress.Loopback, useMultipleBuffers: false);
                 await new SendReceiveEap(null).SendRecv_Stream_TCP_MultipleConcurrentReceives(IPAddress.Loopback, useMultipleBuffers: false);
                 await new SendReceiveEap(null).SendRecv_Stream_TCP_MultipleConcurrentSends(IPAddress.Loopback, useMultipleBuffers: false);
-                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: true);
-                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: false);
+                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: true, serverAddress: IPAddress.Loopback, dualModeClient: false);
+                await new SendReceiveEap(null).TcpReceiveSendGetsCanceledByDispose(receiveOrSend: false, serverAddress: IPAddress.Loopback, dualModeClient: false);
             }, options).Dispose();
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -311,11 +311,7 @@ namespace System.Net.Sockets.Tests
                     msDelay *= 2;
                     Task disposeTask = Task.Run(() => socket1.Dispose());
 
-                    var cts = new CancellationTokenSource();
-                    Task timeoutTask = Task.Delay(30000, cts.Token);
-                    Assert.NotSame(timeoutTask, await Task.WhenAny(disposeTask, socketOperation, timeoutTask));
-                    cts.Cancel();
-
+                    await Task.WhenAny(disposeTask, socketOperation).TimeoutAfter(30000);
                     await disposeTask;
 
                     SocketError? localSocketError = null;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1035,8 +1035,9 @@ namespace System.Net.Sockets.Tests
             if (UsesSync && PlatformDetection.IsRedHatFamily7 &&
                 receiveOrSend && (ipv6Server || dualModeClient))
             {
+                // The IPV6 synchronous Receive case times out on RedHat7 systems
                 // TODO: open a new issue for this case, if the PR gets accepted.
-                throw new SkipTestException("The IPV6 synchronous Receive case times out on RedHat7 systems");
+                return;
             }
 
             // We try this a couple of times to deal with a timing race: if the Dispose happens

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1129,13 +1129,13 @@ namespace System.Net.Sockets.Tests
                                     break;
                                 }
                             }
-                            if (expectGracefulShutdown)
+                            if (!expectGracefulShutdown)
                             {
                                 Assert.Equal(SocketError.ConnectionReset, peerSocketError);
                             }
                             else
                             {
-                                Assert.Equal(null, peerSocketError);
+                                Assert.Null(peerSocketError);
                             }
                             
                         }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1027,7 +1027,7 @@ namespace System.Net.Sockets.Tests
             { false, IPAddress.IPv6Loopback, false },
         };
 
-        [Theory]
+        [Theory(Timeout = 30000)]
         [MemberData(nameof(TcpReceiveSendGetsCanceledByDispose_Data))]
         public async Task TcpReceiveSendGetsCanceledByDispose(bool receiveOrSend, IPAddress serverAddress, bool dualModeClient)
         {
@@ -1064,7 +1064,7 @@ namespace System.Net.Sockets.Tests
                     Task disposeTask = Task.Run(() => socket1.Dispose());
 
                     var cts = new CancellationTokenSource();
-                    Task timeoutTask = Task.Delay(30000, cts.Token);
+                    Task timeoutTask = Task.Delay(15000, cts.Token);
                     Assert.NotSame(timeoutTask, await Task.WhenAny(disposeTask, socketOperation, timeoutTask));
                     cts.Cancel();
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1032,13 +1032,13 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(TcpReceiveSendGetsCanceledByDispose_Data))]
         public async Task TcpReceiveSendGetsCanceledByDispose(bool receiveOrSend, bool ipv6Server, bool dualModeClient)
         {
-            if (UsesSync && PlatformDetection.IsRedHatFamily7 &&
-                receiveOrSend && (ipv6Server || dualModeClient))
-            {
-                // The IPV6 synchronous Receive case times out on RedHat7 systems
-                // TODO: open a new issue for this case, if the PR gets accepted.
-                return;
-            }
+            //if (UsesSync && PlatformDetection.IsRedHatFamily7 &&
+            //    receiveOrSend && (ipv6Server || dualModeClient))
+            //{
+            //    // The IPV6 synchronous Receive case times out on RedHat7 systems
+            //    // TODO: open a new issue for this case, if the PR gets accepted.
+            //    return;
+            //}
 
             // We try this a couple of times to deal with a timing race: if the Dispose happens
             // before the operation is started, the peer won't see a ConnectionReset SocketException and we won't
@@ -1077,12 +1077,15 @@ namespace System.Net.Sockets.Tests
                     Assert.NotSame(timeoutTask, await Task.WhenAny(disposeTask, socketOperation, timeoutTask));
                     cts.Cancel();
 
+                    _output.WriteLine("awaiting disposeTask...");
                     await disposeTask;
+                    _output.WriteLine("disposeTask completed.");
 
                     SocketError? localSocketError = null;
                     bool disposedException = false;
                     try
                     {
+                        _output.WriteLine("awaiting socketOperation...");
                         await socketOperation;
                     }
                     catch (SocketException se)
@@ -1093,6 +1096,7 @@ namespace System.Net.Sockets.Tests
                     {
                         disposedException = true;
                     }
+                    _output.WriteLine("socketOperation completed or failed");
 
                     try
                     {
@@ -1120,7 +1124,9 @@ namespace System.Net.Sockets.Tests
                             {
                                 try
                                 {
+                                    _output.WriteLine("awaiting ReceiveAsync(socket2) ...");
                                     int received = await ReceiveAsync(socket2, receiveBuffer);
+                                    _output.WriteLine("ReceiveAsync(socket2) done.");
                                     if (received == 0)
                                     {
                                         break;
@@ -1129,6 +1135,7 @@ namespace System.Net.Sockets.Tests
                                 catch (SocketException se)
                                 {
                                     peerSocketError = se.SocketErrorCode;
+                                    _output.WriteLine("ReceiveAsync(socket2) thrown: " + peerSocketError);
                                     break;
                                 }
                             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1018,22 +1018,22 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        public static readonly TheoryData<bool, IPAddress, bool> TcpReceiveSendGetsCanceledByDispose_Data = new TheoryData<bool, IPAddress, bool>
+        public static readonly TheoryData<bool, bool, bool> TcpReceiveSendGetsCanceledByDispose_Data = new TheoryData<bool, bool, bool>
         {
-            { true, IPAddress.Loopback, false },
-            { true, IPAddress.Loopback, true },
-            { true, IPAddress.IPv6Loopback, false },
-            { false, IPAddress.Loopback, false },
-            { false, IPAddress.Loopback, true },
-            { false, IPAddress.IPv6Loopback, false },
+            { true, false, false },
+            { true, false, true },
+            { true, true, false },
+            { false, false, false },
+            { false, false, true },
+            { false, true, false },
         };
 
         [Theory(Timeout = 40000)]
         [MemberData(nameof(TcpReceiveSendGetsCanceledByDispose_Data))]
-        public async Task TcpReceiveSendGetsCanceledByDispose(bool receiveOrSend, IPAddress serverAddress, bool dualModeClient)
+        public async Task TcpReceiveSendGetsCanceledByDispose(bool receiveOrSend, bool ipv6Server, bool dualModeClient)
         {
             if (UsesSync && PlatformDetection.IsRedHatFamily7 &&
-                receiveOrSend && (serverAddress.AddressFamily == AddressFamily.InterNetworkV6 || dualModeClient))
+                receiveOrSend && (ipv6Server || dualModeClient))
             {
                 // TODO: open a new issue for this case, if the PR gets accepted.
                 throw new SkipTestException("The IPV6 synchronous Receive case times out on RedHat7 systems");
@@ -1046,7 +1046,7 @@ namespace System.Net.Sockets.Tests
             int retries = 10;
             while (true)
             {
-                (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair(serverAddress, dualModeClient);
+                (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair(ipv6Server, dualModeClient);
                 using (socket2)
                 {
                     Task socketOperation;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -954,9 +954,6 @@ namespace System.Net.Sockets.Tests
             // We try this a couple of times to deal with a timing race: if the Dispose happens
             // before the operation is started, we won't see a SocketException.
             int msDelay = 100;
-            // We try this a couple of times to deal with a timing race: if the Dispose happens
-            // before the operation is started, we won't see a SocketException.
-            int msDelay = 100;
             await RetryHelper.ExecuteAsync(async () =>
             {
                 var socket = new Socket(address.AddressFamily, SocketType.Dgram, ProtocolType.Udp);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -168,12 +168,6 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(SocketMethods_WithBools_MemberData))]
         public void EventSource_SocketConnectFailure_LogsConnectFailed(string connectMethod, bool useDnsEndPoint)
         {
-            if (connectMethod == "Sync" && PlatformDetection.IsRedHatFamily7)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/42686")]
-                throw new SkipTestException("Disposing a Socket performing a sync operation can hang on RedHat7 systems");
-            }
-
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);


### PR DESCRIPTION
The PR:
- Fixes  #42686 by doing a graceful close in case if the abortive `connect(AF_UNSPEC)` call fails on Linux.
- Includes test improvements from #42725 making sure that we don't mask failed cancellations by our retry logic.
- Extends Tom's tests so Connect, Accept, Send and Receive cancellations are also tested with IPV6 and DualMode sockets

~Unfortunately, my new IPV6 Receive cancellation test keeps failing on RHEL7, even with the change in `pal_networking.c`. So far I was not able to reproduce this in native code, `shutdown(s, SHUT_RDWR)` seems to work nicely with raw sockets. I suggest to disable that test case for now, open a new issue, and do a separate investigation.~

@tmds @geoffkizer PTAL