### PR TITLE
[.NET 5.0] Add support for libicu67 and several more higher versions

### DIFF
--- a/src/installer/pkg/packaging/deb/package.targets
+++ b/src/installer/pkg/packaging/deb/package.targets
@@ -325,7 +325,7 @@
         Include="%SSL_DEPENDENCY_LIST%"
         ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
 
-      <KnownLibIcuVersion Include="68;67;66;65;63;60;57;55;52" />
+      <KnownLibIcuVersion Include="72;71;70;69;68;67;66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue
         Include="%LIBICU_DEPENDENCY_LIST%"
         ReplacementString="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />

--- a/src/installer/pkg/packaging/deb/package.targets
+++ b/src/installer/pkg/packaging/deb/package.targets
@@ -325,7 +325,7 @@
         Include="%SSL_DEPENDENCY_LIST%"
         ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
 
-      <KnownLibIcuVersion Include="66;65;63;60;57;55;52" />
+      <KnownLibIcuVersion Include="67;66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue
         Include="%LIBICU_DEPENDENCY_LIST%"
         ReplacementString="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />

--- a/src/installer/pkg/packaging/deb/package.targets
+++ b/src/installer/pkg/packaging/deb/package.targets
@@ -325,7 +325,7 @@
         Include="%SSL_DEPENDENCY_LIST%"
         ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
 
-      <KnownLibIcuVersion Include="67;66;65;63;60;57;55;52" />
+      <KnownLibIcuVersion Include="68;67;66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue
         Include="%LIBICU_DEPENDENCY_LIST%"
         ReplacementString="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/43417

Ubuntu 20.10 is releasing soon. It requires a change in our Debian deps package to add libicu67, which is the only version provided in Ubuntu 20.10.

Adding also all libicu versions from 68 to 72. Libicu68 will be released soon - this will future-proof it until we have a long-term fix