### PR TITLE
Remove some unnecessary unsafe usage

### DIFF
--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.ProtocolStatistics.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.ProtocolStatistics.cs
@@ -19,7 +19,7 @@ internal static partial class Interop
         }
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public readonly unsafe struct TcpGlobalStatistics
+        public readonly struct TcpGlobalStatistics
         {
             public readonly ulong ConnectionsAccepted;
             public readonly ulong ConnectionsInitiated;
@@ -34,10 +34,10 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTcpGlobalStatistics")]
-        public static extern unsafe int GetTcpGlobalStatistics(out TcpGlobalStatistics statistics);
+        public static extern int GetTcpGlobalStatistics(out TcpGlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public readonly unsafe struct IPv4GlobalStatistics
+        public readonly struct IPv4GlobalStatistics
         {
             public readonly ulong OutboundPackets;
             public readonly ulong OutputPacketsNoRoute;
@@ -56,10 +56,10 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4GlobalStatistics")]
-        public static extern unsafe int GetIPv4GlobalStatistics(out IPv4GlobalStatistics statistics);
+        public static extern int GetIPv4GlobalStatistics(out IPv4GlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public readonly unsafe struct UdpGlobalStatistics
+        public readonly struct UdpGlobalStatistics
         {
             public readonly ulong DatagramsReceived;
             public readonly ulong DatagramsSent;
@@ -69,10 +69,10 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetUdpGlobalStatistics")]
-        public static extern unsafe int GetUdpGlobalStatistics(out UdpGlobalStatistics statistics);
+        public static extern int GetUdpGlobalStatistics(out UdpGlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public readonly unsafe struct Icmpv4GlobalStatistics
+        public readonly struct Icmpv4GlobalStatistics
         {
             public readonly ulong AddressMaskRepliesReceived;
             public readonly ulong AddressMaskRepliesSent;
@@ -99,10 +99,10 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIcmpv4GlobalStatistics")]
-        public static extern unsafe int GetIcmpv4GlobalStatistics(out Icmpv4GlobalStatistics statistics);
+        public static extern int GetIcmpv4GlobalStatistics(out Icmpv4GlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        public readonly unsafe struct Icmpv6GlobalStatistics
+        public readonly struct Icmpv6GlobalStatistics
         {
             public readonly ulong DestinationUnreachableMessagesReceived;
             public readonly ulong DestinationUnreachableMessagesSent;
@@ -135,7 +135,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIcmpv6GlobalStatistics")]
-        public static extern unsafe int GetIcmpv6GlobalStatistics(out Icmpv6GlobalStatistics statistics);
+        public static extern int GetIcmpv6GlobalStatistics(out Icmpv6GlobalStatistics statistics);
 
         public readonly struct NativeIPInterfaceStatistics
         {
@@ -156,7 +156,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNativeIPInterfaceStatistics")]
-        public static extern unsafe int GetNativeIPInterfaceStatistics(string name, out NativeIPInterfaceStatistics stats);
+        public static extern int GetNativeIPInterfaceStatistics(string name, out NativeIPInterfaceStatistics stats);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNumRoutes")]
         public static extern int GetNumRoutes();

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.TcpConnectionInfo.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.TcpConnectionInfo.cs
@@ -26,13 +26,13 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetEstimatedTcpConnectionCount")]
-        public static extern unsafe int GetEstimatedTcpConnectionCount();
+        public static extern int GetEstimatedTcpConnectionCount();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetActiveTcpConnectionInfos")]
         public static extern unsafe int GetActiveTcpConnectionInfos(NativeTcpConnectionInformation* infos, int* infoCount);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetEstimatedUdpListenerCount")]
-        public static extern unsafe int GetEstimatedUdpListenerCount();
+        public static extern int GetEstimatedUdpListenerCount();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetActiveUdpListeners")]
         public static extern unsafe int GetActiveUdpListeners(IPEndPointInfo* infos, int* infoCount);

--- a/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.GetProcInfo.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.GetProcInfo.cs
@@ -64,7 +64,7 @@ internal static partial class Interop
 
         // sys/resource.h
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct rusage
+        internal struct rusage
         {
             public timeval ru_utime;        /* user time used */
             public timeval ru_stime;        /* system time used */

--- a/src/libraries/Common/src/Interop/Interop.Collation.cs
+++ b/src/libraries/Common/src/Interop/Interop.Collation.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static extern unsafe ResultCode GetSortHandle(string localeName, out IntPtr sortHandle);
 
         [DllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_CloseSortHandle")]
-        internal static extern unsafe void CloseSortHandle(IntPtr handle);
+        internal static extern void CloseSortHandle(IntPtr handle);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareString")]
         internal static extern unsafe int CompareString(IntPtr sortHandle, char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len, CompareOptions options);
@@ -34,11 +34,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_StartsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool StartsWith(IntPtr sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
+        internal static extern bool StartsWith(IntPtr sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EndsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool EndsWith(IntPtr sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
+        internal static extern bool EndsWith(IntPtr sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortKey")]
         internal static extern unsafe int GetSortKey(IntPtr sortHandle, char* str, int strLength, byte* sortKey, int sortKeyLength, CompareOptions options);

--- a/src/libraries/Common/src/Interop/Interop.Locale.cs
+++ b/src/libraries/Common/src/Interop/Interop.Locale.cs
@@ -21,7 +21,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsPredefinedLocale")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool IsPredefinedLocale(string localeName);
+        internal static extern bool IsPredefinedLocale(string localeName);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleTimeFormat")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/libraries/Common/src/Interop/OSX/Interop.libproc.GetProcessInfoById.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.libproc.GetProcessInfoById.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
 
         // From proc_info.h
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct proc_taskinfo
+        internal struct proc_taskinfo
         {
             internal ulong   pti_virtual_size;
             internal ulong   pti_resident_size;
@@ -72,7 +72,7 @@ internal static partial class Interop
 
         // From proc_info.h
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-        internal unsafe struct proc_taskallinfo
+        internal struct proc_taskallinfo
         {
             internal proc_bsdinfo    pbsd;
             internal proc_taskinfo   ptinfo;

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
         internal static extern SafeHmacHandle HmacCreate(PAL_HashAlgorithm algorithm, ref int cbDigest);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacInit")]
-        internal static extern unsafe int HmacInit(SafeHmacHandle ctx, [In] byte[] pbKey, int cbKey);
+        internal static extern int HmacInit(SafeHmacHandle ctx, [In] byte[] pbKey, int cbKey);
 
         internal static int HmacUpdate(SafeHmacHandle ctx, ReadOnlySpan<byte> data) =>
             HmacUpdate(ctx, ref MemoryMarshal.GetReference(data), data.Length);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ConfigureTerminalForChildProcess.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ConfigureTerminalForChildProcess.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConfigureTerminalForChildProcess")]
-        internal static extern unsafe void ConfigureTerminalForChildProcess(bool childUsesTerminal);
+        internal static extern void ConfigureTerminalForChildProcess(bool childUsesTerminal);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Disconnect.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Disconnect.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Disconnect")]
-        internal static extern unsafe Error Disconnect(IntPtr socket);
+        internal static extern Error Disconnect(IntPtr socket);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetCpuUtilization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetCpuUtilization.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal unsafe partial class Sys
+    internal partial class Sys
     {
         [StructLayout(LayoutKind.Sequential)]
         internal struct ProcessCpuInformation
@@ -16,6 +16,6 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetCpuUtilization")]
-        internal static extern unsafe int GetCpuUtilization(ref ProcessCpuInformation previousCpuInfo);
+        internal static extern int GetCpuUtilization(ref ProcessCpuInformation previousCpuInfo);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPeerID.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPeerID.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerID", SetLastError = true)]
-        internal static extern unsafe int GetPeerID(SafeHandle socket, out uint euid);
+        internal static extern int GetPeerID(SafeHandle socket, out uint euid);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPeerUserName.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPeerUserName.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerUserName", SetLastError = true)]
-        internal static extern unsafe string GetPeerUserName(SafeHandle socket);
+        internal static extern string GetPeerUserName(SafeHandle socket);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal unsafe partial class Sys
+    internal partial class Sys
     {
         [DllImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_GetNonCryptographicallySecureRandomBytes")]
         internal static extern unsafe void GetNonCryptographicallySecureRandomBytes(byte* buffer, int length);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetSystemTimeAsTicks.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetSystemTimeAsTicks.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal unsafe partial class Sys
+    internal partial class Sys
     {
         [DllImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_GetSystemTimeAsTicks")]
         internal static extern long GetSystemTimeAsTicks();

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.InterfaceNameToIndex.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.InterfaceNameToIndex.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InterfaceNameToIndex", SetLastError = true)]
-        public static extern unsafe uint InterfaceNameToIndex(string name);
+        public static extern uint InterfaceNameToIndex(string name);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MemAlloc.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MemAlloc.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal unsafe partial class Sys
+    internal partial class Sys
     {
         [DllImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_MemAlloc")]
         internal static extern IntPtr MemAlloc(nuint sizeInBytes);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
@@ -21,7 +21,7 @@ internal static partial class Interop
         /// Returns the number of bytes placed into the buffer on success; bufferSize if the buffer is too small; and -1 on error.
         /// </returns>
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadLink", SetLastError = true)]
-        private static extern unsafe int ReadLink(string path, byte[] buffer, int bufferSize);
+        private static extern int ReadLink(string path, byte[] buffer, int bufferSize);
 
         /// <summary>
         /// Takes a path to a symbolic link and returns the link target path.

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -12,9 +12,9 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0);
+        internal static extern void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
-        internal static extern unsafe void UninitializeConsoleAfterRead();
+        internal static extern void UninitializeConsoleAfterRead();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SendFile.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SendFile.cs
@@ -8,6 +8,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendFile", SetLastError = true)]
-        internal static extern unsafe Error SendFile(SafeHandle out_fd, SafeHandle in_fd, long offset, long count, out long sent);
+        internal static extern Error SendFile(SafeHandle out_fd, SafeHandle in_fd, long offset, long count, out long sent);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetEUid.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetEUid.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetEUid")]
-        internal static extern unsafe int SetEUid(uint euid);
+        internal static extern int SetEUid(uint euid);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout")]
-        internal static extern unsafe Error SetReceiveTimeout(SafeHandle socket, int millisecondsTimeout);
+        internal static extern Error SetReceiveTimeout(SafeHandle socket, int millisecondsTimeout);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout")]
-        internal static extern unsafe Error SetSendTimeout(SafeHandle socket, int millisecondsTimeout);
+        internal static extern Error SetSendTimeout(SafeHandle socket, int millisecondsTimeout);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -28,7 +28,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort")]
-        internal static extern unsafe Error CreateSocketEventPort(out IntPtr port);
+        internal static extern Error CreateSocketEventPort(out IntPtr port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort")]
         internal static extern Error CloseSocketEventPort(IntPtr port);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Stat.Span.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Stat.Span.cs
@@ -14,12 +14,11 @@ internal static partial class Interop
         private const int StackBufferSize = 256;
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", SetLastError = true)]
-        internal static extern unsafe int Stat(ref byte path, out FileStatus output);
+        internal static extern int Stat(ref byte path, out FileStatus output);
 
-        internal static unsafe int Stat(ReadOnlySpan<char> path, out FileStatus output)
+        internal static int Stat(ReadOnlySpan<char> path, out FileStatus output)
         {
-            byte* buffer = stackalloc byte[StackBufferSize];
-            var converter = new ValueUtf8Converter(new Span<byte>(buffer, StackBufferSize));
+            var converter = new ValueUtf8Converter(stackalloc byte[StackBufferSize]);
             int result = Stat(ref MemoryMarshal.GetReference(converter.ConvertAndTerminateString(path)), out output);
             converter.Dispose();
             return result;
@@ -28,10 +27,9 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", SetLastError = true)]
         internal static extern int LStat(ref byte path, out FileStatus output);
 
-        internal static unsafe int LStat(ReadOnlySpan<char> path, out FileStatus output)
+        internal static int LStat(ReadOnlySpan<char> path, out FileStatus output)
         {
-            byte* buffer = stackalloc byte[StackBufferSize];
-            var converter = new ValueUtf8Converter(new Span<byte>(buffer, StackBufferSize));
+            var converter = new ValueUtf8Converter(stackalloc byte[StackBufferSize]);
             int result = LStat(ref MemoryMarshal.GetReference(converter.ConvertAndTerminateString(path)), out output);
             converter.Dispose();
             return result;

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.StdinReady.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.StdinReady.cs
@@ -8,6 +8,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_StdinReady")]
-        internal static extern unsafe bool StdinReady();
+        internal static extern bool StdinReady();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -72,7 +72,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslWrite")]
-        internal static extern unsafe int SslWrite(SafeSslHandle ssl, ref byte buf, int num);
+        internal static extern int SslWrite(SafeSslHandle ssl, ref byte buf, int num);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslRead")]
         internal static extern unsafe int SslRead(SafeSslHandle ssl, byte* buf, int num);
@@ -102,7 +102,7 @@ internal static partial class Interop
         internal static extern unsafe int BioWrite(SafeBioHandle b, byte* data, int len);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioWrite")]
-        internal static extern unsafe int BioWrite(SafeBioHandle b, ref byte data, int len);
+        internal static extern int BioWrite(SafeBioHandle b, ref byte data, int len);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerCertificate")]
         internal static extern SafeX509Handle SslGetPeerCertificate(SafeSslHandle ssl);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
         internal static extern int SslCtxSetAlpnProtos(SafeSslContextHandle ctx, IntPtr protos, int len);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAlpnSelectCb")]
-        internal static extern unsafe void SslCtxSetAlpnSelectCb(SafeSslContextHandle ctx, SslCtxSetAlpnCallback callback, IntPtr arg);
+        internal static extern void SslCtxSetAlpnSelectCb(SafeSslContextHandle ctx, SslCtxSetAlpnCallback callback, IntPtr arg);
 
         internal static unsafe int SslCtxSetAlpnProtos(SafeSslContextHandle ctx, List<SslApplicationProtocol> protocols)
         {

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
@@ -10,7 +10,7 @@ internal partial class Interop
     internal partial class Advapi32
     {
         [DllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        internal static extern unsafe bool ConvertStringSecurityDescriptorToSecurityDescriptor(
+        internal static extern bool ConvertStringSecurityDescriptorToSecurityDescriptor(
                 string StringSecurityDescriptor,
                 int StringSDRevision,
                 out SafeLocalAllocHandle pSecurityDescriptor,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatus.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatus.cs
@@ -11,6 +11,5 @@ internal partial class Interop
     {
         [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern unsafe bool QueryServiceStatus(SafeServiceHandle serviceHandle, SERVICE_STATUS* pStatus);
-
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumKeyExW", ExactSpelling = true)]
-        internal static extern unsafe int RegEnumKeyEx(
+        internal static extern int RegEnumKeyEx(
             SafeRegistryHandle hKey,
             int dwIndex,
             char[] lpName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumValueW", ExactSpelling = true)]
-        internal static extern unsafe int RegEnumValue(
+        internal static extern int RegEnumValue(
             SafeRegistryHandle hKey,
             int dwIndex,
             char[] lpValueName,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -124,10 +124,10 @@ namespace Internal.NativeCrypto
             public static extern NTSTATUS BCryptOpenAlgorithmProvider(out SafeAlgorithmHandle phAlgorithm, string pszAlgId, string? pszImplementation, int dwFlags);
 
             [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-            public static extern unsafe NTSTATUS BCryptSetProperty(SafeAlgorithmHandle hObject, string pszProperty, string pbInput, int cbInput, int dwFlags);
+            public static extern NTSTATUS BCryptSetProperty(SafeAlgorithmHandle hObject, string pszProperty, string pbInput, int cbInput, int dwFlags);
 
             [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode, EntryPoint = "BCryptSetProperty")]
-            private static extern unsafe NTSTATUS BCryptSetIntPropertyPrivate(SafeBCryptHandle hObject, string pszProperty, ref int pdwInput, int cbInput, int dwFlags);
+            private static extern NTSTATUS BCryptSetIntPropertyPrivate(SafeBCryptHandle hObject, string pszProperty, ref int pdwInput, int cbInput, int dwFlags);
 
             public static unsafe NTSTATUS BCryptSetIntProperty(SafeBCryptHandle hObject, string pszProperty, ref int pdwInput, int dwFlags)
             {

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptImportKey.cs
@@ -11,32 +11,29 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
-        internal static SafeKeyHandle BCryptImportKey(SafeAlgorithmHandle hAlg, ReadOnlySpan<byte> key)
+        internal static unsafe SafeKeyHandle BCryptImportKey(SafeAlgorithmHandle hAlg, ReadOnlySpan<byte> key)
         {
-            unsafe
+            const string BCRYPT_KEY_DATA_BLOB = "KeyDataBlob";
+            int keySize = key.Length;
+            int blobSize = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + keySize;
+            byte[] blob = new byte[blobSize];
+            fixed (byte* pbBlob = blob)
             {
-                const string BCRYPT_KEY_DATA_BLOB = "KeyDataBlob";
-                int keySize = key.Length;
-                int blobSize = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + keySize;
-                byte[] blob = new byte[blobSize];
-                fixed (byte* pbBlob = blob)
-                {
-                    BCRYPT_KEY_DATA_BLOB_HEADER* pBlob = (BCRYPT_KEY_DATA_BLOB_HEADER*)pbBlob;
-                    pBlob->dwMagic = BCRYPT_KEY_DATA_BLOB_HEADER.BCRYPT_KEY_DATA_BLOB_MAGIC;
-                    pBlob->dwVersion = BCRYPT_KEY_DATA_BLOB_HEADER.BCRYPT_KEY_DATA_BLOB_VERSION1;
-                    pBlob->cbKeyData = (uint)keySize;
-                }
-
-                key.CopyTo(blob.AsSpan(sizeof(BCRYPT_KEY_DATA_BLOB_HEADER)));
-                SafeKeyHandle hKey;
-                NTSTATUS ntStatus = BCryptImportKey(hAlg, IntPtr.Zero, BCRYPT_KEY_DATA_BLOB, out hKey, IntPtr.Zero, 0, blob, blobSize, 0);
-                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-                {
-                    throw CreateCryptographicException(ntStatus);
-                }
-
-                return hKey;
+                BCRYPT_KEY_DATA_BLOB_HEADER* pBlob = (BCRYPT_KEY_DATA_BLOB_HEADER*)pbBlob;
+                pBlob->dwMagic = BCRYPT_KEY_DATA_BLOB_HEADER.BCRYPT_KEY_DATA_BLOB_MAGIC;
+                pBlob->dwVersion = BCRYPT_KEY_DATA_BLOB_HEADER.BCRYPT_KEY_DATA_BLOB_VERSION1;
+                pBlob->cbKeyData = (uint)keySize;
             }
+
+            key.CopyTo(blob.AsSpan(sizeof(BCRYPT_KEY_DATA_BLOB_HEADER)));
+            SafeKeyHandle hKey;
+            NTSTATUS ntStatus = BCryptImportKey(hAlg, IntPtr.Zero, BCRYPT_KEY_DATA_BLOB, out hKey, IntPtr.Zero, 0, blob, blobSize, 0);
+            if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+            {
+                throw CreateCryptographicException(ntStatus);
+            }
+
+            return hKey;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
+++ b/src/libraries/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
@@ -21,9 +21,9 @@ internal static partial class Interop
         internal const int IPv4AddressSize = 16;
         internal const int IPv6AddressSize = 28;
 
-        private static unsafe bool InitHttpApi(HTTPAPI_VERSION version)
+        private static bool InitHttpApi(HTTPAPI_VERSION version)
         {
-            uint statusCode = HttpInitialize(version, (uint)HTTP_FLAGS.HTTP_INITIALIZE_SERVER, null);
+            uint statusCode = HttpInitialize(version, (uint)HTTP_FLAGS.HTTP_INITIALIZE_SERVER, IntPtr.Zero);
             return statusCode == ERROR_SUCCESS;
         }
 
@@ -456,7 +456,7 @@ internal static partial class Interop
 
 
         [DllImport(Libraries.HttpApi, SetLastError = true)]
-        internal static extern unsafe uint HttpInitialize(HTTPAPI_VERSION version, uint flags, void* pReserved);
+        internal static extern uint HttpInitialize(HTTPAPI_VERSION version, uint flags, IntPtr pReserved);
 
         [DllImport(Libraries.HttpApi, SetLastError = true)]
         internal static extern uint HttpSetUrlGroupProperty(ulong urlGroupId, HTTP_SERVER_PROPERTY serverProperty, IntPtr pPropertyInfo, uint propertyInfoLength);
@@ -496,7 +496,7 @@ internal static partial class Interop
         internal static extern unsafe uint HttpSendResponseEntityBody(SafeHandle requestQueueHandle, ulong requestId, uint flags, ushort entityChunkCount, HTTP_DATA_CHUNK* pEntityChunks, uint* pBytesSent, SafeLocalAllocHandle pRequestBuffer, uint requestBufferLength, NativeOverlapped* pOverlapped, void* pLogData);
 
         [DllImport(Libraries.HttpApi, SetLastError = true)]
-        internal static extern unsafe uint HttpCloseRequestQueue(IntPtr pReqQueueHandle);
+        internal static extern uint HttpCloseRequestQueue(IntPtr pReqQueueHandle);
 
         [DllImport(Libraries.HttpApi, SetLastError = true)]
         internal static extern uint HttpCancelHttpRequest(SafeHandle requestQueueHandle, ulong requestId, IntPtr pOverlapped);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CompareStringOrdinal.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CompareStringOrdinal.cs
@@ -9,7 +9,7 @@ internal partial class Interop
     {
         // https://msdn.microsoft.com/en-us/library/windows/desktop/dd317762.aspx
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        public static extern unsafe int CompareStringOrdinal(
+        public static extern int CompareStringOrdinal(
             ref char lpString1,
             int cchCount1,
             ref char lpString2,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ConditionVariable.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ConditionVariable.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-internal static unsafe partial class Interop
+internal static partial class Interop
 {
     internal static partial class Kernel32
     {
@@ -15,12 +15,12 @@ internal static unsafe partial class Interop
         }
 
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        internal static extern void InitializeConditionVariable(CONDITION_VARIABLE* ConditionVariable);
+        internal static extern unsafe void InitializeConditionVariable(CONDITION_VARIABLE* ConditionVariable);
 
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        internal static extern void WakeConditionVariable(CONDITION_VARIABLE* ConditionVariable);
+        internal static extern unsafe void WakeConditionVariable(CONDITION_VARIABLE* ConditionVariable);
 
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        internal static extern bool SleepConditionVariableCS(CONDITION_VARIABLE* ConditionVariable, CRITICAL_SECTION* CriticalSection, int dwMilliseconds);
+        internal static extern unsafe bool SleepConditionVariableCS(CONDITION_VARIABLE* ConditionVariable, CRITICAL_SECTION* CriticalSection, int dwMilliseconds);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CriticalSection.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CriticalSection.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-internal static unsafe partial class Interop
+internal static partial class Interop
 {
     internal static partial class Kernel32
     {
@@ -20,15 +20,15 @@ internal static unsafe partial class Interop
         }
 
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        internal static extern void InitializeCriticalSection(CRITICAL_SECTION* lpCriticalSection);
+        internal static extern unsafe void InitializeCriticalSection(CRITICAL_SECTION* lpCriticalSection);
 
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        internal static extern void EnterCriticalSection(CRITICAL_SECTION* lpCriticalSection);
+        internal static extern unsafe void EnterCriticalSection(CRITICAL_SECTION* lpCriticalSection);
 
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        internal static extern void LeaveCriticalSection(CRITICAL_SECTION* lpCriticalSection);
+        internal static extern unsafe void LeaveCriticalSection(CRITICAL_SECTION* lpCriticalSection);
 
         [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        internal static extern void DeleteCriticalSection(CRITICAL_SECTION* lpCriticalSection);
+        internal static extern unsafe void DeleteCriticalSection(CRITICAL_SECTION* lpCriticalSection);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage_SafeLibraryHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage_SafeLibraryHandle.cs
@@ -14,7 +14,7 @@ internal partial class Interop
         public const int FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;
 
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = true)]
-        public static extern unsafe int FormatMessage(
+        public static extern int FormatMessage(
             int dwFlags,
             SafeLibraryHandle lpSource,
             uint dwMessageId,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
@@ -10,12 +10,12 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "GetComputerNameW", ExactSpelling = true)]
-        private static extern unsafe int GetComputerName(ref char lpBuffer, ref uint nSize);
+        private static extern int GetComputerName(ref char lpBuffer, ref uint nSize);
 
         // maximum length of the NETBIOS name (not including NULL)
         private const int MAX_COMPUTERNAME_LENGTH = 15;
 
-        internal static unsafe string? GetComputerName()
+        internal static string? GetComputerName()
         {
             Span<char> buffer = stackalloc char[MAX_COMPUTERNAME_LENGTH + 1];
             uint length = (uint)buffer.Length;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetEnvironmentVariable.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetEnvironmentVariable.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, EntryPoint = "GetEnvironmentVariableW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern unsafe uint GetEnvironmentVariable(string lpName, ref char lpBuffer, uint nSize);
+        internal static extern uint GetEnvironmentVariable(string lpName, ref char lpBuffer, uint nSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleFileName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleFileName.cs
@@ -8,7 +8,7 @@ using Microsoft.Win32;
 
 internal static partial class Interop
 {
-    internal static unsafe partial class Kernel32
+    internal static partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, EntryPoint = "GetModuleFileNameW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern uint GetModuleFileName(IntPtr hModule, ref char lpFilename, uint nSize);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static unsafe partial class Kernel32
+    internal static partial class Kernel32
     {
         // Under debug mode only, we'll want to check the error codes
         // of some of the p/invokes we make.
@@ -48,13 +48,13 @@ internal static partial class Interop
         internal const string LOCALE_NAME_SYSTEM_DEFAULT = "!x-sys-default-locale";
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern int LCIDToLocaleName(int locale, char* pLocaleName, int cchName, uint dwFlags);
+        internal static extern unsafe int LCIDToLocaleName(int locale, char* pLocaleName, int cchName, uint dwFlags);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern int LocaleNameToLCID(string lpName, uint dwFlags);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int LCMapStringEx(
+        internal static extern unsafe int LCMapStringEx(
                     string? lpLocaleName,
                     uint dwMapFlags,
                     char* lpSrcStr,
@@ -66,7 +66,7 @@ internal static partial class Interop
                     IntPtr sortHandle);
 
         [DllImport("kernel32.dll", EntryPoint = "FindNLSStringEx", SetLastError = SetLastErrorForDebug)]
-        internal static extern int FindNLSStringEx(
+        internal static extern unsafe int FindNLSStringEx(
                     char* lpLocaleName,
                     uint dwFindNLSStringFlags,
                     char* lpStringSource,
@@ -79,7 +79,7 @@ internal static partial class Interop
                     IntPtr sortHandle);
 
         [DllImport("kernel32.dll", EntryPoint = "CompareStringEx")]
-        internal static extern int CompareStringEx(
+        internal static extern unsafe int CompareStringEx(
                     char* lpLocaleName,
                     uint dwCmpFlags,
                     char* lpString1,
@@ -91,7 +91,7 @@ internal static partial class Interop
                     IntPtr lParam);
 
         [DllImport("kernel32.dll", EntryPoint = "CompareStringOrdinal")]
-        internal static extern int CompareStringOrdinal(
+        internal static extern unsafe int CompareStringOrdinal(
                     char* lpString1,
                     int cchCount1,
                     char* lpString2,
@@ -99,7 +99,7 @@ internal static partial class Interop
                     bool bIgnoreCase);
 
         [DllImport("kernel32.dll", EntryPoint = "FindStringOrdinal", SetLastError = SetLastErrorForDebug)]
-        internal static extern int FindStringOrdinal(
+        internal static extern unsafe int FindStringOrdinal(
                     uint dwFindStringOrdinalFlags,
                     char* lpStringSource,
                     int cchSource,
@@ -108,7 +108,7 @@ internal static partial class Interop
                     BOOL bIgnoreCase);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern bool IsNLSDefinedString(
+        internal static extern unsafe bool IsNLSDefinedString(
                     int Function,
                     uint dwFlags,
                     IntPtr lpVersionInformation,
@@ -116,16 +116,16 @@ internal static partial class Interop
                     int cchStr);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-        internal static extern Interop.BOOL GetUserPreferredUILanguages(uint dwFlags, uint* pulNumLanguages, char* pwszLanguagesBuffer, uint* pcchLanguagesBuffer);
+        internal static extern unsafe Interop.BOOL GetUserPreferredUILanguages(uint dwFlags, uint* pulNumLanguages, char* pwszLanguagesBuffer, uint* pcchLanguagesBuffer);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern int GetLocaleInfoEx(string lpLocaleName, uint LCType, void* lpLCData, int cchData);
+        internal static extern unsafe int GetLocaleInfoEx(string lpLocaleName, uint LCType, void* lpLCData, int cchData);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern bool EnumSystemLocalesEx(delegate* unmanaged<char*, uint, void*, BOOL> lpLocaleEnumProcEx, uint dwFlags, void* lParam, IntPtr reserved);
+        internal static extern unsafe bool EnumSystemLocalesEx(delegate* unmanaged<char*, uint, void*, BOOL> lpLocaleEnumProcEx, uint dwFlags, void* lParam, IntPtr reserved);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern bool EnumTimeFormatsEx(delegate* unmanaged<char*, void*, BOOL> lpTimeFmtEnumProcEx, string lpLocaleName, uint dwFlags, void* lParam);
+        internal static extern unsafe bool EnumTimeFormatsEx(delegate* unmanaged<char*, void*, BOOL> lpTimeFmtEnumProcEx, string lpLocaleName, uint dwFlags, void* lParam);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern int GetCalendarInfoEx(string? lpLocaleName, uint Calendar, IntPtr lpReserved, uint CalType, IntPtr lpCalData, int cchData, out int lpValue);
@@ -137,10 +137,10 @@ internal static partial class Interop
         internal static extern int GetUserGeoID(int geoClass);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern int GetGeoInfo(int location, int geoType, char* lpGeoData, int cchData, int LangId);
+        internal static extern unsafe int GetGeoInfo(int location, int geoType, char* lpGeoData, int cchData, int LangId);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern bool EnumCalendarInfoExEx(delegate* unmanaged<char*, uint, IntPtr, void*, BOOL> pCalInfoEnumProcExEx, string lpLocaleName, uint Calendar, string? lpReserved, uint CalType, void* lParam);
+        internal static extern unsafe bool EnumCalendarInfoExEx(delegate* unmanaged<char*, uint, IntPtr, void*, BOOL> pCalInfoEnumProcExEx, string lpLocaleName, uint Calendar, string? lpReserved, uint CalType, void* lParam);
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct NlsVersionInfoEx
@@ -153,6 +153,6 @@ internal static partial class Interop
         }
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern bool GetNLSVersionEx(int function, string localeName, NlsVersionInfoEx* lpVersionInformation);
+        internal static extern unsafe bool GetNLSVersionEx(int function, string localeName, NlsVersionInfoEx* lpVersionInformation);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileCompletionNotificationModes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileCompletionNotificationModes.cs
@@ -17,6 +17,6 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern unsafe bool SetFileCompletionNotificationModes(SafeHandle handle, FileCompletionNotificationModes flags);
+        internal static extern bool SetFileCompletionNotificationModes(SafeHandle handle, FileCompletionNotificationModes flags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
@@ -213,7 +213,7 @@ internal static partial class Interop
         /// <summary>
         ///     Derive key material from a secret agreement using the TLS KDF
         /// </summary>
-        internal static byte[] DeriveKeyMaterialTls(
+        internal static unsafe byte[] DeriveKeyMaterialTls(
             SafeNCryptSecretHandle secretAgreement,
             byte[] label,
             byte[] seed,
@@ -221,28 +221,25 @@ internal static partial class Interop
         {
             Span<NCryptBuffer> buffers = stackalloc NCryptBuffer[2];
 
-            unsafe
+            fixed (byte* pLabel = label, pSeed = seed)
             {
-                fixed (byte* pLabel = label, pSeed = seed)
-                {
-                    NCryptBuffer labelBuffer = default;
-                    labelBuffer.cbBuffer = label.Length;
-                    labelBuffer.BufferType = BufferType.KdfTlsLabel;
-                    labelBuffer.pvBuffer = new IntPtr(pLabel);
-                    buffers[0] = labelBuffer;
+                NCryptBuffer labelBuffer = default;
+                labelBuffer.cbBuffer = label.Length;
+                labelBuffer.BufferType = BufferType.KdfTlsLabel;
+                labelBuffer.pvBuffer = new IntPtr(pLabel);
+                buffers[0] = labelBuffer;
 
-                    NCryptBuffer seedBuffer = default;
-                    seedBuffer.cbBuffer = seed.Length;
-                    seedBuffer.BufferType = BufferType.KdfTlsSeed;
-                    seedBuffer.pvBuffer = new IntPtr(pSeed);
-                    buffers[1] = seedBuffer;
+                NCryptBuffer seedBuffer = default;
+                seedBuffer.cbBuffer = seed.Length;
+                seedBuffer.BufferType = BufferType.KdfTlsSeed;
+                seedBuffer.pvBuffer = new IntPtr(pSeed);
+                buffers[1] = seedBuffer;
 
-                    return DeriveKeyMaterial(
-                        secretAgreement,
-                        BCryptNative.KeyDerivationFunction.Tls,
-                        buffers,
-                        flags);
-                }
+                return DeriveKeyMaterial(
+                    secretAgreement,
+                    BCryptNative.KeyDerivationFunction.Tls,
+                    buffers,
+                    flags);
             }
         }
     }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.Properties.cs
@@ -20,62 +20,50 @@ internal static partial class Interop
         internal static extern unsafe ErrorCode NCryptSetProperty(SafeNCryptHandle hObject, string pszProperty, [In] void* pbInput, int cbInput, CngPropertyOptions dwFlags);
 
         [SupportedOSPlatform("windows")]
-        internal static ErrorCode NCryptGetByteProperty(SafeNCryptHandle hObject, string pszProperty, ref byte result, CngPropertyOptions options = CngPropertyOptions.None)
+        internal static unsafe ErrorCode NCryptGetByteProperty(SafeNCryptHandle hObject, string pszProperty, ref byte result, CngPropertyOptions options = CngPropertyOptions.None)
         {
-            int cbResult;
-            ErrorCode errorCode;
-
-            unsafe
+            fixed (byte* pResult = &result)
             {
-                fixed (byte* pResult = &result)
+                ErrorCode errorCode = Interop.NCrypt.NCryptGetProperty(
+                    hObject,
+                    pszProperty,
+                    pResult,
+                    sizeof(byte),
+                    out int cbResult,
+                    options);
+
+                if (errorCode == ErrorCode.ERROR_SUCCESS)
                 {
-                    errorCode = Interop.NCrypt.NCryptGetProperty(
-                        hObject,
-                        pszProperty,
-                        pResult,
-                        sizeof(byte),
-                        out cbResult,
-                        options);
+                    Debug.Assert(cbResult == sizeof(byte));
                 }
-            }
 
-            if (errorCode == ErrorCode.ERROR_SUCCESS)
-            {
-                Debug.Assert(cbResult == sizeof(byte));
+                return errorCode;
             }
-
-            return errorCode;
         }
 
-        internal static ErrorCode NCryptGetIntProperty(SafeNCryptHandle hObject, string pszProperty, ref int result)
+        internal static unsafe ErrorCode NCryptGetIntProperty(SafeNCryptHandle hObject, string pszProperty, ref int result)
         {
-            int cbResult;
-            ErrorCode errorCode;
-
-            unsafe
+            fixed (int* pResult = &result)
             {
-                fixed (int* pResult = &result)
-                {
 #if NETSTANDARD || NETCOREAPP
-                    Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+                Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 #endif
 
-                    errorCode = Interop.NCrypt.NCryptGetProperty(
-                        hObject,
-                        pszProperty,
-                        pResult,
-                        sizeof(int),
-                        out cbResult,
-                        CngPropertyOptions.None);
+                ErrorCode errorCode = Interop.NCrypt.NCryptGetProperty(
+                    hObject,
+                    pszProperty,
+                    pResult,
+                    sizeof(int),
+                    out int cbResult,
+                    CngPropertyOptions.None);
+
+                if (errorCode == ErrorCode.ERROR_SUCCESS)
+                {
+                    Debug.Assert(cbResult == sizeof(int));
                 }
-            }
 
-            if (errorCode == ErrorCode.ERROR_SUCCESS)
-            {
-                Debug.Assert(cbResult == sizeof(int));
+                return errorCode;
             }
-
-            return errorCode;
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_DIR_INFORMATION.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_DIR_INFORMATION.cs
@@ -15,7 +15,7 @@ internal partial class Interop
         /// Equivalent to <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/hh447298.aspx">FILE_FULL_DIR_INFO</a> structure.
         /// </summary>
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public unsafe struct FILE_FULL_DIR_INFORMATION
+        public struct FILE_FULL_DIR_INFORMATION
         {
             /// <summary>
             /// Offset in bytes of the next entry, if any.
@@ -54,7 +54,7 @@ internal partial class Interop
             public uint EaSize;
 
             private char _fileName;
-            public ReadOnlySpan<char> FileName { get { fixed (char* c = &_fileName) { return new ReadOnlySpan<char>(c, (int)FileNameLength / sizeof(char)); } } }
+            public unsafe ReadOnlySpan<char> FileName { get { fixed (char* c = &_fileName) { return new ReadOnlySpan<char>(c, (int)FileNameLength / sizeof(char)); } } }
 
             /// <summary>
             /// Gets the next info pointer or null if there are no more.

--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_EA_INFORMATION.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_EA_INFORMATION.cs
@@ -13,7 +13,7 @@ internal partial class Interop
         /// Provides extended attribute (EA) information. This structure is used primarily by network drivers.
         /// </summary>
         [StructLayoutAttribute(LayoutKind.Sequential)]
-        internal unsafe struct FILE_FULL_EA_INFORMATION
+        internal struct FILE_FULL_EA_INFORMATION
         {
             /// <summary>
             /// The offset of the next FILE_FULL_EA_INFORMATION-type entry. This member is zero if no other entries follow this one.

--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.RtlNtStatusToDosError.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.RtlNtStatusToDosError.cs
@@ -10,7 +10,6 @@ internal partial class Interop
     {
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680600(v=vs.85).aspx
         [DllImport(Libraries.NtDll, ExactSpelling = true)]
-        public static extern unsafe uint RtlNtStatusToDosError(
-            int Status);
+        public static extern uint RtlNtStatusToDosError(int Status);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Ole32/Interop.IStream.cs
+++ b/src/libraries/Common/src/Interop/Windows/Ole32/Interop.IStream.cs
@@ -18,21 +18,21 @@ internal static partial class Interop
         [ComImport,
             Guid("0000000C-0000-0000-C000-000000000046"),
             InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        internal unsafe interface IStream
+        internal interface IStream
         {
             // pcbRead is optional so it must be a pointer
-            void Read(byte* pv, uint cb, uint* pcbRead);
+            unsafe void Read(byte* pv, uint cb, uint* pcbRead);
 
             // pcbWritten is optional so it must be a pointer
-            void Write(byte* pv, uint cb, uint* pcbWritten);
+            unsafe void Write(byte* pv, uint cb, uint* pcbWritten);
 
             // SeekOrgin matches the native values, plibNewPosition is optional
-            void Seek(long dlibMove, SeekOrigin dwOrigin, ulong* plibNewPosition);
+            unsafe void Seek(long dlibMove, SeekOrigin dwOrigin, ulong* plibNewPosition);
 
             void SetSize(ulong libNewSize);
 
             // pcbRead and pcbWritten are optional
-            void CopyTo(
+            unsafe void CopyTo(
                 IStream pstm,
                 ulong cb,
                 ulong* pcbRead,

--- a/src/libraries/Common/src/Interop/Windows/PerfCounter/Interop.FormatFromRawValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/PerfCounter/Interop.FormatFromRawValue.cs
@@ -8,7 +8,7 @@ internal partial class Interop
     internal partial class PerfCounter
     {
         [DllImport(Libraries.PerfCounter, CharSet = CharSet.Unicode)]
-        public static extern unsafe int FormatFromRawValue(
+        public static extern int FormatFromRawValue(
             uint dwCounterType,
             uint dwFormat,
             ref long pTimeBase,

--- a/src/libraries/Common/src/Interop/Windows/PerfCounter/Interop.PerformanceData.cs
+++ b/src/libraries/Common/src/Interop/Windows/PerfCounter/Interop.PerformanceData.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal partial class PerfCounter
     {
         [DllImport(Libraries.Advapi32, ExactSpelling = true)]
-        internal static extern unsafe uint PerfStopProvider(
+        internal static extern uint PerfStopProvider(
             IntPtr hProvider
         );
 
@@ -54,7 +54,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.Advapi32, ExactSpelling = true)]
-        internal static extern unsafe uint PerfStartProvider(
+        internal static extern uint PerfStartProvider(
             ref Guid ProviderGuid,
             PERFLIBREQUEST ControlCallback,
             out SafePerfProviderHandle phProvider

--- a/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
@@ -8,9 +8,9 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net
 {
-    internal static unsafe partial class UnmanagedCertificateContext
+    internal static partial class UnmanagedCertificateContext
     {
-        internal static X509Certificate2Collection GetRemoteCertificatesFromStoreContext(IntPtr certContext)
+        internal static unsafe X509Certificate2Collection GetRemoteCertificatesFromStoreContext(IntPtr certContext)
         {
             X509Certificate2Collection result = new X509Certificate2Collection();
 
@@ -19,11 +19,7 @@ namespace System.Net
                 return result;
             }
 
-            Interop.Crypt32.CERT_CONTEXT context;
-            unsafe
-            {
-                context = *(Interop.Crypt32.CERT_CONTEXT*)certContext;
-            }
+            Interop.Crypt32.CERT_CONTEXT context = *(Interop.Crypt32.CERT_CONTEXT*)certContext;
 
             if (context.hCertStore != IntPtr.Zero)
             {

--- a/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net
 {
-    internal static unsafe partial class UnmanagedCertificateContext
+    internal static partial class UnmanagedCertificateContext
     {
         internal static X509Certificate2Collection GetRemoteCertificatesFromStoreContext(SafeFreeCertContext certContext)
         {

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -165,7 +165,7 @@ internal static partial class Interop
 
         // schannel.h
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct SecPkgContext_IssuerListInfoEx
+        internal struct SecPkgContext_IssuerListInfoEx
         {
             public IntPtr aIssuers;
             public uint cIssuers;
@@ -292,13 +292,13 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct SecBuffer
+        internal struct SecBuffer
         {
             public int cbBuffer;
             public SecurityBufferType BufferType;
             public IntPtr pvBuffer;
 
-            public static readonly int Size = sizeof(SecBuffer);
+            public static readonly unsafe int Size = sizeof(SecBuffer);
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -371,7 +371,7 @@ internal static partial class Interop
             [In] void* buffer);
 
         [DllImport(Interop.Libraries.SspiCli, ExactSpelling = true, SetLastError = true)]
-        internal static extern unsafe int SetContextAttributesW(
+        internal static extern int SetContextAttributesW(
             ref CredHandle contextHandle,
             [In] ContextAttribute attribute,
             [In] byte[] buffer,
@@ -464,11 +464,11 @@ internal static partial class Interop
           );
 
         [DllImport(Interop.Libraries.SspiCli, ExactSpelling = true, SetLastError = true)]
-        internal static extern unsafe SECURITY_STATUS SspiFreeAuthIdentity(
+        internal static extern SECURITY_STATUS SspiFreeAuthIdentity(
             [In] IntPtr authData);
 
         [DllImport(Interop.Libraries.SspiCli, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern unsafe SECURITY_STATUS SspiEncodeStringsAsAuthIdentity(
+        internal static extern SECURITY_STATUS SspiEncodeStringsAsAuthIdentity(
             [In] string userName,
             [In] string domainName,
             [In] string password,

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAStartup.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAStartup.cs
@@ -46,7 +46,7 @@ internal static partial class Interop
         private static extern SocketError WSACleanup();
 
         [StructLayout(LayoutKind.Sequential, Size = 408)]
-        private unsafe struct WSAData
+        private struct WSAData
         {
             // WSADATA is defined as follows:
             //

--- a/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
@@ -48,24 +48,21 @@ namespace System.Net.Sockets
             return true;
         }
 
-        private void FreeNativeOverlapped()
+        private unsafe void FreeNativeOverlapped()
         {
             // Do not call free during AppDomain shutdown, there may be an outstanding operation.
             // Overlapped will take care calling free when the native callback completes.
             IntPtr oldHandle = Interlocked.Exchange(ref handle, IntPtr.Zero);
             if (oldHandle != IntPtr.Zero && !Environment.HasShutdownStarted)
             {
-                unsafe
-                {
-                    Debug.Assert(OperatingSystem.IsWindows());
-                    Debug.Assert(_socketHandle != null, "_socketHandle is null.");
+                Debug.Assert(OperatingSystem.IsWindows());
+                Debug.Assert(_socketHandle != null, "_socketHandle is null.");
 
-                    ThreadPoolBoundHandle? boundHandle = _socketHandle.IOCPBoundHandle;
-                    Debug.Assert(boundHandle != null, "SafeNativeOverlapped::FreeNativeOverlapped - boundHandle is null");
+                ThreadPoolBoundHandle? boundHandle = _socketHandle.IOCPBoundHandle;
+                Debug.Assert(boundHandle != null, "SafeNativeOverlapped::FreeNativeOverlapped - boundHandle is null");
 
-                    // FreeNativeOverlapped will be called even if boundHandle was previously disposed.
-                    boundHandle?.FreeNativeOverlapped((NativeOverlapped*)oldHandle);
-                }
+                // FreeNativeOverlapped will be called even if boundHandle was previously disposed.
+                boundHandle?.FreeNativeOverlapped((NativeOverlapped*)oldHandle);
             }
         }
     }

--- a/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -640,7 +640,7 @@ namespace System.Globalization
                 }
             }
 
-            internal static unsafe char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
+            internal static char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
             {
                 char c = default;
                 if (format.Length > 0)

--- a/src/libraries/Common/src/System/Memory/FixedBufferExtensions.cs
+++ b/src/libraries/Common/src/System/Memory/FixedBufferExtensions.cs
@@ -21,7 +21,7 @@ namespace System
         /// <summary>
         /// Gets the null-terminated string length of the given span.
         /// </summary>
-        internal static unsafe int GetFixedBufferStringLength(this ReadOnlySpan<char> span)
+        internal static int GetFixedBufferStringLength(this ReadOnlySpan<char> span)
         {
             int length = span.IndexOf('\0');
             return length < 0 ? span.Length : length;
@@ -31,7 +31,7 @@ namespace System
         /// Returns true if the given string equals the given span.
         /// The span's logical length is to the first null if present.
         /// </summary>
-        internal static unsafe bool FixedBufferEqualsString(this ReadOnlySpan<char> span, string value)
+        internal static bool FixedBufferEqualsString(this ReadOnlySpan<char> span, string value)
         {
             if (value == null || value.Length > span.Length)
                 return false;

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/NetEventSource.Common.cs
@@ -350,7 +350,7 @@ namespace System.Net
         }
 
         [Event(DumpArrayEventId, Level = EventLevel.Verbose, Keywords = Keywords.Debug)]
-        private unsafe void DumpBuffer(string thisOrContextObject, string? memberName, byte[] buffer) =>
+        private void DumpBuffer(string thisOrContextObject, string? memberName, byte[] buffer) =>
             WriteEvent(DumpArrayEventId, thisOrContextObject, memberName ?? MissingMember, buffer);
         #endregion
 

--- a/src/libraries/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/libraries/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -13,8 +13,7 @@ namespace System
         // RFC 5952 Section 4.2.3
         // Longest consecutive sequence of zero segments, minimum 2.
         // On equal, first sequence wins. <-1, -1> for no compression.
-        internal static unsafe (int longestSequenceStart, int longestSequenceLength) FindCompressionRange(
-            ReadOnlySpan<ushort> numbers)
+        internal static (int longestSequenceStart, int longestSequenceLength) FindCompressionRange(ReadOnlySpan<ushort> numbers)
         {
             int longestSequenceLength = 0, longestSequenceStart = -1, currentSequenceLength = 0;
 
@@ -42,7 +41,7 @@ namespace System
 
         // Returns true if the IPv6 address should be formatted with an embedded IPv4 address:
         // ::192.168.1.1
-        internal static unsafe bool ShouldHaveIpv4Embedded(ReadOnlySpan<ushort> numbers)
+        internal static bool ShouldHaveIpv4Embedded(ReadOnlySpan<ushort> numbers)
         {
             // 0:0 : 0:0 : x:x : x.x.x.x
             if (numbers[0] == 0 && numbers[1] == 0 && numbers[2] == 0 && numbers[3] == 0 && numbers[6] != 0)

--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -287,7 +287,7 @@ namespace System.Net
         }
 
         [Event(DumpArrayEventId, Level = EventLevel.Verbose, Keywords = Keywords.Debug)]
-        private unsafe void DumpBuffer(string thisOrContextObject, string? memberName, byte[] buffer) =>
+        private void DumpBuffer(string thisOrContextObject, string? memberName, byte[] buffer) =>
             WriteEvent(DumpArrayEventId, thisOrContextObject, memberName ?? MissingMember, buffer);
         #endregion
 

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -37,7 +37,7 @@ namespace System.Net.NetworkInformation
         }
 
         // Check if found ping is symlink to busybox like alpine /bin/ping -> /bin/busybox
-        private static unsafe bool IsBusyboxPing(string? pingBinary)
+        private static bool IsBusyboxPing(string? pingBinary)
         {
             if (pingBinary != null)
             {

--- a/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -32,7 +32,7 @@ namespace System.Net.Security
                 (isServer ? Interop.SspiCli.CredentialUse.SECPKG_CRED_INBOUND : Interop.SspiCli.CredentialUse.SECPKG_CRED_OUTBOUND));
         }
 
-        internal static unsafe SafeFreeCredentials AcquireCredentialsHandle(string package, bool isServer, NetworkCredential credential)
+        internal static SafeFreeCredentials AcquireCredentialsHandle(string package, bool isServer, NetworkCredential credential)
         {
             SafeSspiAuthDataHandle? authData = null;
             try

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -10,12 +10,12 @@ namespace System.Net
         public const int IPv6AddressSize = 28;
         public const int IPv4AddressSize = 16;
 
-        public static unsafe AddressFamily GetAddressFamily(ReadOnlySpan<byte> buffer)
+        public static AddressFamily GetAddressFamily(ReadOnlySpan<byte> buffer)
         {
             return (AddressFamily)BitConverter.ToInt16(buffer);
         }
 
-        public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
+        public static void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
             if ((int)(family) > ushort.MaxValue)
             {
@@ -34,28 +34,17 @@ namespace System.Net
 #endif
         }
 
-        public static unsafe ushort GetPort(ReadOnlySpan<byte> buffer)
-        {
-            return buffer.NetworkBytesToHostUInt16(2);
-        }
+        public static ushort GetPort(ReadOnlySpan<byte> buffer) => buffer.NetworkBytesToHostUInt16(2);
 
-        public static unsafe void SetPort(byte[] buffer, ushort port)
-        {
-            port.HostToNetworkBytes(buffer, 2);
-        }
+        public static void SetPort(byte[] buffer, ushort port) => port.HostToNetworkBytes(buffer, 2);
 
-        public static unsafe uint GetIPv4Address(ReadOnlySpan<byte> buffer)
-        {
-            unchecked
-            {
-                return (uint)((buffer[4] & 0x000000FF) |
-                    (buffer[5] << 8 & 0x0000FF00) |
-                    (buffer[6] << 16 & 0x00FF0000) |
-                    (buffer[7] << 24));
-            }
-        }
+        public static uint GetIPv4Address(ReadOnlySpan<byte> buffer) =>
+            (uint)((buffer[4] & 0x000000FF) |
+                   (buffer[5] << 8 & 0x0000FF00) |
+                   (buffer[6] << 16 & 0x00FF0000) |
+                   (buffer[7] << 24));
 
-        public static unsafe void GetIPv6Address(ReadOnlySpan<byte> buffer, Span<byte> address, out uint scope)
+        public static void GetIPv6Address(ReadOnlySpan<byte> buffer, Span<byte> address, out uint scope)
         {
             for (int i = 0; i < address.Length; i++)
             {
@@ -69,7 +58,7 @@ namespace System.Net
                 (buffer[24])));
         }
 
-        public static unsafe void SetIPv4Address(byte[] buffer, uint address)
+        public static void SetIPv4Address(byte[] buffer, uint address)
         {
             // IPv4 Address serialization
             buffer[4] = unchecked((byte)(address));
@@ -78,7 +67,7 @@ namespace System.Net
             buffer[7] = unchecked((byte)(address >> 24));
         }
 
-        public static unsafe void SetIPv6Address(byte[] buffer, Span<byte> address, uint scope)
+        public static void SetIPv6Address(byte[] buffer, Span<byte> address, uint scope)
         {
             // No handling for Flow Information
             buffer[4] = (byte)0;
@@ -86,14 +75,11 @@ namespace System.Net
             buffer[6] = (byte)0;
             buffer[7] = (byte)0;
 
-            unchecked
-            {
-                // Scope serialization
-                buffer[24] = (byte)scope;
-                buffer[25] = (byte)(scope >> 8);
-                buffer[26] = (byte)(scope >> 16);
-                buffer[27] = (byte)(scope >> 24);
-            }
+            // Scope serialization
+            buffer[24] = (byte)scope;
+            buffer[25] = (byte)(scope >> 8);
+            buffer[26] = (byte)(scope >> 16);
+            buffer[27] = (byte)(scope >> 24);
 
             // Address serialization
             for (int i = 0; i < address.Length; i++)

--- a/src/libraries/Common/src/System/Net/WebHeaderEncoding.cs
+++ b/src/libraries/Common/src/System/Net/WebHeaderEncoding.cs
@@ -53,16 +53,15 @@ namespace System.Net
             });
         }
 
-        internal static int GetByteCount(string myString)
-        {
-            return myString.Length;
-        }
+        internal static int GetByteCount(string myString) => myString.Length;
+
         internal static unsafe void GetBytes(string myString, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (myString.Length == 0)
             {
                 return;
             }
+
             fixed (byte* bufferPointer = bytes)
             {
                 byte* newBufferPointer = bufferPointer + byteIndex;
@@ -73,7 +72,7 @@ namespace System.Net
                 }
             }
         }
-        internal static unsafe byte[] GetBytes(string myString)
+        internal static byte[] GetBytes(string myString)
         {
             byte[] bytes = new byte[myString.Length];
             if (myString.Length != 0)

--- a/src/libraries/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1287,7 +1287,7 @@ namespace System.Net.WebSockets
             }
         }
 
-        private static unsafe int CombineMaskBytes(Span<byte> buffer, int maskOffset) =>
+        private static int CombineMaskBytes(Span<byte> buffer, int maskOffset) =>
             BitConverter.ToInt32(buffer.Slice(maskOffset));
 
         /// <summary>Applies a mask to a portion of a byte array.</summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.cs
@@ -347,7 +347,7 @@ namespace System.Security.Cryptography
             return writer;
         }
 
-        internal static unsafe AsnWriter WriteEncryptedPkcs8(
+        internal static AsnWriter WriteEncryptedPkcs8(
             ReadOnlySpan<char> password,
             AsnWriter pkcs8Writer,
             PbeParameters pbeParameters)
@@ -371,7 +371,7 @@ namespace System.Security.Cryptography
                 pbeParameters);
         }
 
-        private static unsafe AsnWriter WriteEncryptedPkcs8(
+        private static AsnWriter WriteEncryptedPkcs8(
             ReadOnlySpan<char> password,
             ReadOnlySpan<byte> passwordBytes,
             AsnWriter pkcs8Writer,

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -21,11 +21,11 @@ namespace System.Security.Cryptography
         private const int StatusUnsuccessfulRetryCount = 1;
 
         /// <summary>Encrypts data using the public key.</summary>
-        public override unsafe byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
+        public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
             EncryptOrDecrypt(data, padding, encrypt: true);
 
         /// <summary>Decrypts data using the private key.</summary>
-        public override unsafe byte[] Decrypt(byte[] data, RSAEncryptionPadding padding) =>
+        public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding) =>
             EncryptOrDecrypt(data, padding, encrypt: false);
 
         /// <summary>Encrypts data using the public key.</summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -436,7 +436,7 @@ namespace System.Security.Cryptography
             ForceSetKeySize(BitsPerByte * Interop.Crypto.RsaSize(key));
         }
 
-        public override unsafe void ImportRSAPublicKey(ReadOnlySpan<byte> source, out int bytesRead)
+        public override void ImportRSAPublicKey(ReadOnlySpan<byte> source, out int bytesRead)
         {
             ThrowIfDisposed();
 

--- a/src/libraries/Common/src/System/Text/DBCSDecoder.cs
+++ b/src/libraries/Common/src/System/Text/DBCSDecoder.cs
@@ -40,7 +40,7 @@ namespace System.Text
             _leftOverLeadByte = 0;
         }
 
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return GetCharCount(bytes, index, count, false);
         }
@@ -121,7 +121,7 @@ namespace System.Text
             return ConvertWithLeftOverByte(bytes, count, null, 0);
         }
 
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                              char[] chars, int charIndex)
         {
             return GetChars(bytes, byteIndex, byteCount, chars, charIndex, false);

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.BSD.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.BSD.cs
@@ -40,7 +40,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Gets or sets which processors the threads in this process can be scheduled to run on.
         /// </summary>
-        private unsafe IntPtr ProcessorAffinityCore
+        private IntPtr ProcessorAffinityCore
         {
             get
             {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -170,7 +170,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Gets or sets which processors the threads in this process can be scheduled to run on.
         /// </summary>
-        private unsafe IntPtr ProcessorAffinityCore
+        private IntPtr ProcessorAffinityCore
         {
             get
             {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.UnknownUnix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.UnknownUnix.cs
@@ -52,7 +52,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Gets or sets which processors the threads in this process can be scheduled to run on.
         /// </summary>
-        private unsafe IntPtr ProcessorAffinityCore
+        private IntPtr ProcessorAffinityCore
         {
             get { throw new PlatformNotSupportedException(); }
             set { throw new PlatformNotSupportedException(); }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -151,19 +151,16 @@ namespace System.Diagnostics
                     if (int.TryParse(dirName, NumberStyles.Integer, CultureInfo.InvariantCulture, out tid) &&
                         Interop.procfs.TryReadStatFile(pid, tid, out stat))
                     {
-                        unsafe
+                        pi._threadInfoList.Add(new ThreadInfo()
                         {
-                            pi._threadInfoList.Add(new ThreadInfo()
-                            {
-                                _processId = pid,
-                                _threadId = (ulong)tid,
-                                _basePriority = pi.BasePriority,
-                                _currentPriority = (int)stat.nice,
-                                _startAddress = IntPtr.Zero,
-                                _threadState = ProcFsStateToThreadState(stat.state),
-                                _threadWaitReason = ThreadWaitReason.Unknown
-                            });
-                        }
+                            _processId = pid,
+                            _threadId = (ulong)tid,
+                            _basePriority = pi.BasePriority,
+                            _currentPriority = (int)stat.nice,
+                            _startAddress = IntPtr.Zero,
+                            _threadState = ProcFsStateToThreadState(stat.state),
+                            _threadWaitReason = ThreadWaitReason.Unknown
+                        });
                     }
                 }
             }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.Linux.cs
@@ -7,7 +7,7 @@ namespace System.DirectoryServices.Protocols
 {
     public static partial class BerConverter
     {
-        private static unsafe int DecodeBitStringHelper(ArrayList resultList, SafeBerHandle berElement)
+        private static int DecodeBitStringHelper(ArrayList resultList, SafeBerHandle berElement)
         {
             // Windows doesn't really decode BitStrings correctly, and wldap32 will internally treat it as 'O' Octet string.
             // In order to match behavior, in Linux we will interpret 'B' as 'O' when passing the call to libldap.

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.Windows.cs
@@ -9,7 +9,7 @@ namespace System.DirectoryServices.Protocols
 {
     public static partial class BerConverter
     {
-        private static unsafe int DecodeBitStringHelper(ArrayList resultList, SafeBerHandle berElement)
+        private static int DecodeBitStringHelper(ArrayList resultList, SafeBerHandle berElement)
         {
             int error;
             // return a bitstring and its length

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
@@ -250,7 +250,7 @@ namespace System.DirectoryServices.Interop
             };
         }
 
-        private unsafe void SetValue(object managedValue, AdsType adsType)
+        private void SetValue(object managedValue, AdsType adsType)
         {
             adsvalue = new AdsValue()
             {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 
 namespace System.Drawing
 {
-    internal static unsafe partial class SafeNativeMethods
+    internal static partial class SafeNativeMethods
     {
-        internal static partial class Gdip
+        internal static unsafe partial class Gdip
         {
             private const string LibraryName = "gdiplus.dll";
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -10,9 +10,9 @@ namespace System.Drawing
 {
     // Raw function imports for gdiplus
     // Functions are loaded manually in order to accomodate different shared library names on Unix.
-    internal static unsafe partial class SafeNativeMethods
+    internal static partial class SafeNativeMethods
     {
-        internal static partial class Gdip
+        internal static unsafe partial class Gdip
         {
             // Shared function imports (all platforms)
             [DllImport(LibraryName, ExactSpelling = true)]

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
@@ -89,18 +89,15 @@ namespace System.IO.Compression
             }
         }
 
-        public static bool TryDecompress(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        public static unsafe bool TryDecompress(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            unsafe
+            fixed (byte* inBytes = &MemoryMarshal.GetReference(source))
+            fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
             {
-                fixed (byte* inBytes = &MemoryMarshal.GetReference(source))
-                fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
-                {
-                    size_t availableOutput = (size_t)destination.Length;
-                    bool success = Interop.Brotli.BrotliDecoderDecompress((size_t)source.Length, inBytes, ref availableOutput, outBytes);
-                    bytesWritten = (int)availableOutput;
-                    return success;
-                }
+                size_t availableOutput = (size_t)destination.Length;
+                bool success = Interop.Brotli.BrotliDecoderDecompress((size_t)source.Length, inBytes, ref availableOutput, outBytes);
+                bytesWritten = (int)availableOutput;
+                return success;
             }
         }
     }

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
@@ -170,6 +170,7 @@ namespace System.IO.Compression
             {
                 throw new ArgumentOutOfRangeException(nameof(window), SR.Format(SR.BrotliEncoder_Window, window, BrotliUtils.WindowBits_Min, BrotliUtils.WindowBits_Max));
             }
+
             unsafe
             {
                 fixed (byte* inBytes = &MemoryMarshal.GetReference(source))

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -577,7 +577,7 @@ namespace System.IO
                 return _includeChildren || _fullDirectory.AsSpan().StartsWith(System.IO.Path.GetDirectoryName(eventPath), StringComparison.OrdinalIgnoreCase);
             }
 
-            private unsafe int? FindRenameChangePairedChange(
+            private int? FindRenameChangePairedChange(
                 int currentIndex,
                 Span<FSEventStreamEventFlags> flags, Span<FSEventStreamEventId> ids)
             {

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.Unix.cs
@@ -74,15 +74,8 @@ namespace Microsoft.Win32.SafeHandles
             base.Dispose(disposing);
         }
 
-        protected override unsafe bool ReleaseHandle()
-        {
-            // Nothing to clean up.  We unlinked immediately after creating the backing store.
-            return true;
-        }
+        protected override bool ReleaseHandle() => true; // Nothing to clean up.  We unlinked immediately after creating the backing store.
 
-        public override bool IsInvalid
-        {
-            get { return (long)handle <= 0; }
-        }
+        public override bool IsInvalid => (long)handle <= 0;
     }
 }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -52,7 +52,7 @@ namespace System.IO.MemoryMappedFiles
         /// memory mapped file should not be associated with an existing file on disk (i.e. start
         /// out empty).
         /// </summary>
-        private static unsafe SafeMemoryMappedFileHandle CreateCore(
+        private static SafeMemoryMappedFileHandle CreateCore(
             FileStream? fileStream, string? mapName,
             HandleInheritability inheritability, MemoryMappedFileAccess access,
             MemoryMappedFileOptions options, long capacity)

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs
@@ -8,7 +8,7 @@ namespace System.IO.MemoryMappedFiles
 {
     internal partial class MemoryMappedView
     {
-        public static unsafe MemoryMappedView CreateView(
+        public static MemoryMappedView CreateView(
             SafeMemoryMappedFileHandle memMappedFileHandle, MemoryMappedFileAccess access,
             long requestedOffset, long requestedSize)
         {

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
@@ -14,7 +14,7 @@ namespace System.IO.MemoryMappedFiles
         private const int MaxFlushWaits = 15;  // must be <=30
         private const int MaxFlushRetriesPerWait = 20;
 
-        public static unsafe MemoryMappedView CreateView(SafeMemoryMappedFileHandle memMappedFileHandle,
+        public static MemoryMappedView CreateView(SafeMemoryMappedFileHandle memMappedFileHandle,
                                             MemoryMappedFileAccess access, long offset, long size)
         {
             // MapViewOfFile can only create views that start at a multiple of the system memory allocation
@@ -93,57 +93,54 @@ namespace System.IO.MemoryMappedFiles
         // flush to the disk.
         // NOTE: This will flush all bytes before and after the view up until an offset that is a multiple
         //       of SystemPageSize.
-        public void Flush(UIntPtr capacity)
+        public unsafe void Flush(UIntPtr capacity)
         {
-            unsafe
+            byte* firstPagePtr = null;
+            try
             {
-                byte* firstPagePtr = null;
-                try
-                {
-                    _viewHandle.AcquirePointer(ref firstPagePtr);
+                _viewHandle.AcquirePointer(ref firstPagePtr);
 
-                    if (Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity))
-                        return;
+                if (Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity))
+                    return;
 
-                    // It is a known issue within the NTFS transaction log system that
-                    // causes FlushViewOfFile to intermittently fail with ERROR_LOCK_VIOLATION
-                    // As a workaround, we catch this particular error and retry the flush operation
-                    // a few milliseconds later. If it does not work, we give it a few more tries with
-                    // increasing intervals. Eventually, however, we need to give up. In ad-hoc tests
-                    // this strategy successfully flushed the view after no more than 3 retries.
+                // It is a known issue within the NTFS transaction log system that
+                // causes FlushViewOfFile to intermittently fail with ERROR_LOCK_VIOLATION
+                // As a workaround, we catch this particular error and retry the flush operation
+                // a few milliseconds later. If it does not work, we give it a few more tries with
+                // increasing intervals. Eventually, however, we need to give up. In ad-hoc tests
+                // this strategy successfully flushed the view after no more than 3 retries.
 
-                    int error = Marshal.GetLastWin32Error();
-                    if (error != Interop.Errors.ERROR_LOCK_VIOLATION)
-                        throw Win32Marshal.GetExceptionForWin32Error(error);
-
-                    SpinWait spinWait = default;
-                    for (int w = 0; w < MaxFlushWaits; w++)
-                    {
-                        int pause = (1 << w);  // MaxFlushRetries should never be over 30
-                        Thread.Sleep(pause);
-
-                        for (int r = 0; r < MaxFlushRetriesPerWait; r++)
-                        {
-                            if (Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity))
-                                return;
-
-                            error = Marshal.GetLastWin32Error();
-                            if (error != Interop.Errors.ERROR_LOCK_VIOLATION)
-                                throw Win32Marshal.GetExceptionForWin32Error(error);
-
-                            spinWait.SpinOnce();
-                        }
-                    }
-
-                    // We got to here, so there was no success:
+                int error = Marshal.GetLastWin32Error();
+                if (error != Interop.Errors.ERROR_LOCK_VIOLATION)
                     throw Win32Marshal.GetExceptionForWin32Error(error);
-                }
-                finally
+
+                SpinWait spinWait = default;
+                for (int w = 0; w < MaxFlushWaits; w++)
                 {
-                    if (firstPagePtr != null)
+                    int pause = (1 << w);  // MaxFlushRetries should never be over 30
+                    Thread.Sleep(pause);
+
+                    for (int r = 0; r < MaxFlushRetriesPerWait; r++)
                     {
-                        _viewHandle.ReleasePointer();
+                        if (Interop.Kernel32.FlushViewOfFile((IntPtr)firstPagePtr, capacity))
+                            return;
+
+                        error = Marshal.GetLastWin32Error();
+                        if (error != Interop.Errors.ERROR_LOCK_VIOLATION)
+                            throw Win32Marshal.GetExceptionForWin32Error(error);
+
+                        spinWait.SpinOnce();
                     }
+                }
+
+                // We got to here, so there was no success:
+                throw Win32Marshal.GetExceptionForWin32Error(error);
+            }
+            finally
+            {
+                if (firstPagePtr != null)
+                {
+                    _viewHandle.ReleasePointer();
                 }
             }
         }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.cs
@@ -13,8 +13,7 @@ namespace System.IO.MemoryMappedFiles
         private readonly long _size;
         private readonly MemoryMappedFileAccess _access;
 
-        private unsafe MemoryMappedView(SafeMemoryMappedViewHandle viewHandle, long pointerOffset,
-                                        long size, MemoryMappedFileAccess access)
+        private MemoryMappedView(SafeMemoryMappedViewHandle viewHandle, long pointerOffset, long size, MemoryMappedFileAccess access)
         {
             Debug.Assert(viewHandle != null);
 

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
@@ -64,10 +64,7 @@ namespace System.IO.MemoryMappedFiles
                 throw new ObjectDisposedException(nameof(MemoryMappedViewAccessor), SR.ObjectDisposed_ViewAccessorClosed);
             }
 
-            unsafe
-            {
-                _view.Flush((UIntPtr)Capacity);
-            }
+            _view.Flush((UIntPtr)Capacity);
         }
     }
 }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
@@ -10,7 +10,7 @@ namespace System.IO.MemoryMappedFiles
     {
         private readonly MemoryMappedView _view;
 
-        internal unsafe MemoryMappedViewStream(MemoryMappedView view)
+        internal MemoryMappedViewStream(MemoryMappedView view)
         {
             Debug.Assert(view != null, "view is null");
 

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
@@ -12,7 +12,7 @@ namespace System.IO.Pipes
     public sealed partial class AnonymousPipeServerStream : PipeStream
     {
         // Creates the anonymous pipe.
-        private unsafe void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
+        private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
         {
             Debug.Assert(direction != PipeDirection.InOut, "Anonymous pipe direction shouldn't be InOut");
             // Ignore bufferSize.  It's optional, and the fcntl F_SETPIPE_SZ for changing it is Linux specific.

--- a/src/libraries/System.IO.Pipes/tests/InteropTest.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/InteropTest.Unix.cs
@@ -36,7 +36,7 @@ namespace System.IO.Pipes.Tests
 
         // @todo: These are called by some Windows-specific tests. Those tests should really be split out into
         // partial classes and included only in Windows builds.
-        internal static unsafe bool CancelIoEx(SafeHandle handle) { throw new Exception("Should not call on Unix."); }
+        internal static bool CancelIoEx(SafeHandle handle) { throw new Exception("Should not call on Unix."); }
         internal static bool TryGetImpersonationUserName(SafePipeHandle handle, out string impersonationUserName) { throw new Exception("Should not call on Unix."); }
         internal static bool TryGetNumberOfServerInstances(SafePipeHandle handle, out uint numberOfServerInstances) { throw new Exception("Should not call on Unix."); }
     }

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -403,7 +403,7 @@ namespace System.IO.Ports
             return Read(array, offset, count, ReadTimeout);
         }
 
-        internal unsafe int Read(byte[] array, int offset, int count, int timeout)
+        internal int Read(byte[] array, int offset, int count, int timeout)
         {
             using (CancellationTokenSource cts = GetCancellationTokenSourceFromTimeout(timeout))
             {
@@ -786,7 +786,7 @@ namespace System.IO.Ports
             return 0;
         }
 
-        private unsafe void IOLoop()
+        private void IOLoop()
         {
             bool eofReceived = false;
             // we do not care about bytes we got before - only about changes

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -775,7 +775,7 @@ namespace System.Buffers
             return unread.Length < next.Length && IsNextSlow(next, advancePast);
         }
 
-        private unsafe bool IsNextSlow(ReadOnlySpan<T> next, bool advancePast)
+        private bool IsNextSlow(ReadOnlySpan<T> next, bool advancePast)
         {
             ReadOnlySpan<T> currentSpan = UnreadSpan;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -25,7 +25,7 @@ namespace System.Net
         }
 
         [Event(UriBaseAddressId, Keywords = Keywords.Debug, Level = EventLevel.Informational)]
-        private unsafe void UriBaseAddress(string? uriBaseAddress, string objName, int objHash) =>
+        private void UriBaseAddress(string? uriBaseAddress, string objName, int objHash) =>
             WriteEvent(UriBaseAddressId, uriBaseAddress, objName, objHash);
 
         [NonEvent]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -389,7 +389,7 @@ namespace System.Net.Http
                 return StringBuilderCache.GetStringAndRelease(sb);
             }
 
-            private unsafe void Parse(string challenge)
+            private void Parse(string challenge)
             {
                 int parsedIndex = 0;
                 while (parsedIndex < challenge.Length)

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
@@ -64,7 +64,8 @@ namespace System.Net.NetworkInformation
 
             return connectionInformations;
         }
-        public unsafe override TcpConnectionInformation[] GetActiveTcpConnections()
+
+        public override TcpConnectionInformation[] GetActiveTcpConnections()
         {
             return GetTcpConnections(listeners:false);
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -121,7 +121,7 @@ namespace System.Net.NetworkInformation
         }
 
         // Helper class for detecting address change events.
-        internal static unsafe class AddressChangeListener
+        internal static class AddressChangeListener
         {
             // Need to keep the reference so it isn't GC'd before the native call executes.
             private static bool s_isListening;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemTcpConnection.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemTcpConnection.cs
@@ -24,7 +24,7 @@ namespace System.Net.NetworkInformation
         }
 
         // IPV6 version of the Tcp row.
-        internal unsafe SystemTcpConnectionInformation(in Interop.IpHlpApi.MibTcp6RowOwnerPid row)
+        internal SystemTcpConnectionInformation(in Interop.IpHlpApi.MibTcp6RowOwnerPid row)
         {
             _state = row.state;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -11,7 +11,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal const ushort IPv4 = 2;
         internal const ushort IPv6 = 23;
 
-        internal static unsafe IPEndPoint INetToIPEndPoint(ref SOCKADDR_INET inetAddress)
+        internal static IPEndPoint INetToIPEndPoint(ref SOCKADDR_INET inetAddress)
         {
             if (inetAddress.si_family == IPv4)
             {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -237,7 +237,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             return MsQuicParameterHelpers.GetUShortParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.CONNECTION, (uint)QUIC_PARAM_CONN.PEER_BIDI_STREAM_COUNT);
         }
 
-        private unsafe void SetIdleTimeout(TimeSpan timeout)
+        private void SetIdleTimeout(TimeSpan timeout)
         {
             MsQuicParameterHelpers.SetULongParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.CONNECTION, (uint)QUIC_PARAM_CONN.IDLE_TIMEOUT, (ulong)timeout.TotalMilliseconds);
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -139,7 +139,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             MsQuicApi.Api.ListenerStopDelegate(_ptr);
         }
 
-        private unsafe void SetListenPort()
+        private void SetListenPort()
         {
             SOCKADDR_INET inetAddress = MsQuicParameterHelpers.GetINetParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.LISTENER, (uint)QUIC_PARAM_LISTENER.LOCAL_ADDRESS);
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -951,7 +951,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         }
 
         // This can fail if the stream isn't started.
-        private unsafe long GetStreamId()
+        private long GetStreamId()
         {
             return (long)MsQuicParameterHelpers.GetULongParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.STREAM, (uint)QUIC_PARAM_STREAM.ID);
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
@@ -87,7 +87,7 @@ namespace System.Net
         }
 
         [Event(SslStreamCtorId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
-        private unsafe void SslStreamCtor(string thisOrContextObject, string? localId, string? remoteId) =>
+        private void SslStreamCtor(string thisOrContextObject, string? localId, string? remoteId) =>
               WriteEvent(SslStreamCtorId, thisOrContextObject, localId, remoteId);
 
         [NonEvent]
@@ -100,7 +100,7 @@ namespace System.Net
         }
 
         [Event(SecureChannelCtorId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
-        private unsafe void SecureChannelCtor(string sslStream, string hostname, int secureChannelHash, int clientCertificatesCount, EncryptionPolicy encryptionPolicy) =>
+        private void SecureChannelCtor(string sslStream, string hostname, int secureChannelHash, int clientCertificatesCount, EncryptionPolicy encryptionPolicy) =>
             WriteEvent(SecureChannelCtorId, sslStream, hostname, secureChannelHash, clientCertificatesCount, (int)encryptionPolicy);
 
         [NonEvent]
@@ -284,7 +284,7 @@ namespace System.Net
             WriteEvent(UsingCachedCredentialId, secureChannelHash);
 
         [Event(SspiSelectedCipherSuitId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
-        public unsafe void SspiSelectedCipherSuite(
+        public void SspiSelectedCipherSuite(
             string process,
             SslProtocols sslProtocol,
             CipherAlgorithmType cipherAlgorithm,

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -396,7 +396,7 @@ namespace System.Net.Security
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromInterop(errorCode, attachException: true);
         }
 
-        public static unsafe SafeFreeContextBufferChannelBinding? QueryContextChannelBinding(SafeDeleteContext securityContext, ChannelBindingKind attribute)
+        public static SafeFreeContextBufferChannelBinding? QueryContextChannelBinding(SafeDeleteContext securityContext, ChannelBindingKind attribute)
         {
             return SSPIWrapper.QueryContextChannelBinding(GlobalSSPI.SSPISecureChannel, securityContext, (Interop.SspiCli.ContextAttribute)attribute);
         }


### PR DESCRIPTION
This is mostly removing `unsafe` from methods that don't actually need it.

In a handful of places, I removed an `unsafe` by also removing the pointer-based code.  I'll call those out with comments.

In a few places, I moved the `unsafe` around, e.g. from being an unsafe block surrounding the entire method body to being in the signature.

And in a few places, I cleaned up some formatting thing right around the other code being modified.

cc: @GrabYourPitchforks 
Related to https://github.com/dotnet/roslyn/issues/48031