### PR TITLE
Fix xunit analyzers to run on library test projects

### DIFF
--- a/eng/CodeAnalysis.test.ruleset
+++ b/eng/CodeAnalysis.test.ruleset
@@ -1,11 +1,11 @@
 ﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
   <Rules AnalyzerId="Microsoft.DotNet.CodeAnalysis" RuleNamespace="Microsoft.DotNet.CodeAnalysis.Analyzers">
-    <Rule Id="BCL0001" Action="Warning" />      <!-- Ensure minimum API surface is respected -->
-    <Rule Id="BCL0010" Action="Warning" />      <!-- AppContext default value expected to be true -->
-    <Rule Id="BCL0011" Action="Warning" />      <!-- AppContext default value defined in if statement with incorrect pattern -->
-    <Rule Id="BCL0012" Action="Warning" />      <!-- AppContext default value defined in if statement at root of switch case -->
+    <Rule Id="BCL0001" Action="None" />         <!-- Ensure minimum API surface is respected -->
+    <Rule Id="BCL0010" Action="None" />         <!-- AppContext default value expected to be true -->
+    <Rule Id="BCL0011" Action="None" />         <!-- AppContext default value defined in if statement with incorrect pattern -->
+    <Rule Id="BCL0012" Action="None" />         <!-- AppContext default value defined in if statement at root of switch case -->
     <Rule Id="BCL0015" Action="None" />         <!-- Invalid P/Invoke call -->
-    <Rule Id="BCL0020" Action="Warning" />      <!-- Invalid SR.Format call -->
+    <Rule Id="BCL0020" Action="None" />         <!-- Invalid SR.Format call -->
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
     <Rule Id="CA1000" Action="None" />          <!-- Do not declare static members on generic types -->
@@ -19,7 +19,7 @@
     <Rule Id="CA1014" Action="None" />          <!-- Mark assemblies with CLSCompliant -->
     <Rule Id="CA1016" Action="None" />          <!-- Mark assemblies with assembly version -->
     <Rule Id="CA1017" Action="None" />          <!-- Mark assemblies with ComVisible -->
-    <Rule Id="CA1018" Action="Warning" />       <!-- Mark attributes with AttributeUsageAttribute -->
+    <Rule Id="CA1018" Action="None" />          <!-- Mark attributes with AttributeUsageAttribute -->
     <Rule Id="CA1019" Action="None" />          <!-- Define accessors for attribute arguments -->
     <Rule Id="CA1021" Action="None" />          <!-- Avoid out parameters -->
     <Rule Id="CA1024" Action="None" />          <!-- Use properties where appropriate -->
@@ -37,8 +37,8 @@
     <Rule Id="CA1044" Action="None" />          <!-- Properties should not be write only -->
     <Rule Id="CA1045" Action="None" />          <!-- Do not pass types by reference -->
     <Rule Id="CA1046" Action="None" />          <!-- Do not overload equality operator on reference types -->
-    <Rule Id="CA1047" Action="Warning" />       <!-- Do not declare protected member in sealed type -->
-    <Rule Id="CA1050" Action="Warning" />       <!-- Declare types in namespaces -->
+    <Rule Id="CA1047" Action="None" />          <!-- Do not declare protected member in sealed type -->
+    <Rule Id="CA1050" Action="None" />          <!-- Declare types in namespaces -->
     <Rule Id="CA1051" Action="None" />          <!-- Do not declare visible instance fields -->
     <Rule Id="CA1052" Action="None" />          <!-- Static holder types should be Static or NotInheritable -->
     <Rule Id="CA1054" Action="None" />          <!-- Uri parameters should not be strings -->
@@ -55,22 +55,22 @@
     <Rule Id="CA1067" Action="None" />          <!-- Override Object.Equals(object) when implementing IEquatable<T> -->
     <Rule Id="CA1068" Action="None" />          <!-- CancellationToken parameters must come last -->
     <Rule Id="CA1069" Action="None" />          <!-- Enums values should not be duplicated -->
-    <Rule Id="CA1070" Action="Info" />          <!-- Do not declare event fields as virtual -->
-    <Rule Id="CA1200" Action="Warning" />       <!-- Avoid using cref tags with a prefix -->
+    <Rule Id="CA1070" Action="None" />          <!-- Do not declare event fields as virtual -->
+    <Rule Id="CA1200" Action="None" />          <!-- Avoid using cref tags with a prefix -->
     <Rule Id="CA1303" Action="None" />          <!-- Do not pass literals as localized parameters -->
     <Rule Id="CA1304" Action="None" />          <!-- Specify CultureInfo -->
     <Rule Id="CA1305" Action="None" />          <!-- Specify IFormatProvider -->
     <Rule Id="CA1307" Action="None" />          <!-- Specify StringComparison -->
     <Rule Id="CA1308" Action="None" />          <!-- Normalize strings to uppercase -->
     <Rule Id="CA1309" Action="None" />          <!-- Use ordinal stringcomparison -->
-    <Rule Id="CA1401" Action="Warning" />       <!-- P/Invokes should not be visible -->
-    <Rule Id="CA1416" Action="Warning" />       <!-- Validate platform compatibility -->
-    <Rule Id="CA1417" Action="Warning" />       <!-- Do not use 'OutAttribute' on string parameters for P/Invokes -->
+    <Rule Id="CA1401" Action="None" />          <!-- P/Invokes should not be visible -->
+    <Rule Id="CA1416" Action="None" />          <!-- Validate platform compatibility -->
+    <Rule Id="CA1417" Action="None" />          <!-- Do not use 'OutAttribute' on string parameters for P/Invokes -->
     <Rule Id="CA1501" Action="None" />          <!-- Avoid excessive inheritance -->
     <Rule Id="CA1502" Action="None" />          <!-- Avoid excessive complexity -->
     <Rule Id="CA1505" Action="None" />          <!-- Avoid unmaintainable code -->
     <Rule Id="CA1506" Action="None" />          <!-- Avoid excessive class coupling -->
-    <Rule Id="CA1507" Action="Warning" />       <!-- Use nameof to express symbol names -->
+    <Rule Id="CA1507" Action="None" />          <!-- Use nameof to express symbol names -->
     <Rule Id="CA1508" Action="None" />          <!-- Avoid dead conditional code -->
     <Rule Id="CA1509" Action="None" />          <!-- Invalid entry in code metrics rule specification file -->
     <Rule Id="CA1700" Action="None" />          <!-- Do not name enum values 'Reserved' -->
@@ -85,12 +85,12 @@
     <Rule Id="CA1720" Action="None" />          <!-- Identifier contains type name -->
     <Rule Id="CA1721" Action="None" />          <!-- Property names should not match get methods -->
     <Rule Id="CA1724" Action="None" />          <!-- Type names should not match namespaces -->
-    <Rule Id="CA1725" Action="Info" />          <!-- Parameter names should match base declaration -->
+    <Rule Id="CA1725" Action="None" />          <!-- Parameter names should match base declaration -->
     <Rule Id="CA1801" Action="None" />          <!-- Review unused parameters -->
-    <Rule Id="CA1802" Action="Warning" />       <!-- Use literals where appropriate -->
-    <Rule Id="CA1805" Action="Warning" />       <!-- Do not initialize unnecessarily -->
+    <Rule Id="CA1802" Action="None" />          <!-- Use literals where appropriate -->
+    <Rule Id="CA1805" Action="None" />          <!-- Do not initialize unnecessarily -->
     <Rule Id="CA1806" Action="None" />          <!-- Do not ignore method results -->
-    <Rule Id="CA1810" Action="Warning" />       <!-- Initialize reference type static fields inline -->
+    <Rule Id="CA1810" Action="None" />          <!-- Initialize reference type static fields inline -->
     <Rule Id="CA1812" Action="None" />          <!-- Avoid uninstantiated internal classes -->
     <Rule Id="CA1813" Action="None" />          <!-- Avoid unsealed attributes -->
     <Rule Id="CA1814" Action="None" />          <!-- Prefer jagged arrays over multidimensional -->
@@ -98,44 +98,44 @@
     <Rule Id="CA1816" Action="None" />          <!-- Dispose methods should call SuppressFinalize -->
     <Rule Id="CA1819" Action="None" />          <!-- Properties should not return arrays -->
     <Rule Id="CA1820" Action="None" />          <!-- Test for empty strings using string length -->
-    <Rule Id="CA1821" Action="Warning" />       <!-- Remove empty Finalizers -->
+    <Rule Id="CA1821" Action="None" />          <!-- Remove empty Finalizers -->
     <Rule Id="CA1822" Action="None" />          <!-- Mark members as static -->
-    <Rule Id="CA1823" Action="Warning" />       <!-- Avoid unused private fields -->
-    <Rule Id="CA1824" Action="Warning" />       <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
-    <Rule Id="CA1825" Action="Warning" />       <!-- Avoid zero-length array allocations. -->
-    <Rule Id="CA1826" Action="Warning" />       <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
-    <Rule Id="CA1827" Action="Warning" />       <!-- Do not use Count() or LongCount() when Any() can be used -->
-    <Rule Id="CA1828" Action="Warning" />       <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
-    <Rule Id="CA1829" Action="Warning" />       <!-- Use Length/Count property instead of Count() when available -->
-    <Rule Id="CA1830" Action="Warning" />       <!-- Prefer strongly-typed Append and Insert method overloads on StringBuilder. -->
-    <Rule Id="CA1831" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
-    <Rule Id="CA1832" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
-    <Rule Id="CA1833" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
-    <Rule Id="CA1834" Action="Warning" />       <!-- Consider using 'StringBuilder.Append(char)' when applicable. -->
-    <Rule Id="CA1835" Action="Warning" />       <!-- Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync' -->
-    <Rule Id="CA1836" Action="Warning" />       <!-- Prefer IsEmpty over Count -->
-    <Rule Id="CA1837" Action="Warning" />       <!-- Use 'Environment.ProcessId' -->
-    <Rule Id="CA1838" Action="Warning" />       <!-- Avoid 'StringBuilder' parameters for P/Invokes -->
+    <Rule Id="CA1823" Action="None" />          <!-- Avoid unused private fields -->
+    <Rule Id="CA1824" Action="None" />          <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
+    <Rule Id="CA1825" Action="None" />          <!-- Avoid zero-length array allocations. -->
+    <Rule Id="CA1826" Action="None" />          <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
+    <Rule Id="CA1827" Action="None" />          <!-- Do not use Count() or LongCount() when Any() can be used -->
+    <Rule Id="CA1828" Action="None" />          <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
+    <Rule Id="CA1829" Action="None" />          <!-- Use Length/Count property instead of Count() when available -->
+    <Rule Id="CA1830" Action="None" />          <!-- Prefer strongly-typed Append and Insert method overloads on StringBuilder. -->
+    <Rule Id="CA1831" Action="None" />          <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
+    <Rule Id="CA1832" Action="None" />          <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
+    <Rule Id="CA1833" Action="None" />          <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
+    <Rule Id="CA1834" Action="None" />          <!-- Consider using 'StringBuilder.Append(char)' when applicable. -->
+    <Rule Id="CA1835" Action="None" />          <!-- Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync' -->
+    <Rule Id="CA1836" Action="None" />          <!-- Prefer IsEmpty over Count -->
+    <Rule Id="CA1837" Action="None" />          <!-- Use 'Environment.ProcessId' -->
+    <Rule Id="CA1838" Action="None" />          <!-- Avoid 'StringBuilder' parameters for P/Invokes -->
     <Rule Id="CA2000" Action="None" />          <!-- Dispose objects before losing scope -->
     <Rule Id="CA2002" Action="None" />          <!-- Do not lock on objects with weak identity -->
-    <Rule Id="CA2007" Action="Warning" />       <!-- Consider calling ConfigureAwait on the awaited task -->
-    <Rule Id="CA2008" Action="Warning" />       <!-- Do not create tasks without passing a TaskScheduler -->
-    <Rule Id="CA2009" Action="Warning" />       <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
-    <Rule Id="CA2011" Action="Warning" />       <!-- Avoid infinite recursion -->
-    <Rule Id="CA2012" Action="Warning" />       <!-- Use ValueTasks correctly -->
-    <Rule Id="CA2013" Action="Warning" />       <!-- Do not use ReferenceEquals with value types -->
-    <Rule Id="CA2014" Action="Warning" />       <!-- Do not use stackalloc in loops. -->
-    <Rule Id="CA2015" Action="Warning" />       <!-- Do not define finalizers for types derived from MemoryManager<T> -->
-    <Rule Id="CA2016" Action="Warning" />       <!-- Forward the 'CancellationToken' parameter to methods that take one -->
+    <Rule Id="CA2007" Action="None" />          <!-- Consider calling ConfigureAwait on the awaited task -->
+    <Rule Id="CA2008" Action="None" />          <!-- Do not create tasks without passing a TaskScheduler -->
+    <Rule Id="CA2009" Action="None" />          <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
+    <Rule Id="CA2011" Action="None" />          <!-- Avoid infinite recursion -->
+    <Rule Id="CA2012" Action="None" />          <!-- Use ValueTasks correctly -->
+    <Rule Id="CA2013" Action="None" />          <!-- Do not use ReferenceEquals with value types -->
+    <Rule Id="CA2014" Action="None" />          <!-- Do not use stackalloc in loops. -->
+    <Rule Id="CA2015" Action="None" />          <!-- Do not define finalizers for types derived from MemoryManager<T> -->
+    <Rule Id="CA2016" Action="None" />          <!-- Forward the 'CancellationToken' parameter to methods that take one -->
     <Rule Id="CA2100" Action="None" />          <!-- Review SQL queries for security vulnerabilities -->
     <Rule Id="CA2101" Action="None" />          <!-- Specify marshaling for P/Invoke string arguments -->
     <Rule Id="CA2109" Action="None" />          <!-- Review visible event handlers -->
     <Rule Id="CA2119" Action="None" />          <!-- Seal methods that satisfy private interfaces -->
     <Rule Id="CA2153" Action="None" />          <!-- Do Not Catch Corrupted State Exceptions -->
-    <Rule Id="CA2200" Action="Warning" />       <!-- Rethrow to preserve stack details. -->
+    <Rule Id="CA2200" Action="None" />          <!-- Rethrow to preserve stack details. -->
     <Rule Id="CA2201" Action="None" />          <!-- Do not raise reserved exception types -->
-    <Rule Id="CA2207" Action="Warning" />       <!-- Initialize value type static fields inline -->
-    <Rule Id="CA2208" Action="Warning" />       <!-- Instantiate argument exceptions correctly -->
+    <Rule Id="CA2207" Action="None" />          <!-- Initialize value type static fields inline -->
+    <Rule Id="CA2208" Action="None" />          <!-- Instantiate argument exceptions correctly -->
     <Rule Id="CA2211" Action="None" />          <!-- Non-constant fields should not be visible -->
     <Rule Id="CA2213" Action="None" />          <!-- Disposable fields should be disposed -->
     <Rule Id="CA2214" Action="None" />          <!-- Do not call overridable methods in constructors -->
@@ -148,21 +148,20 @@
     <Rule Id="CA2225" Action="None" />          <!-- Operator overloads have named alternates -->
     <Rule Id="CA2226" Action="None" />          <!-- Operators should have symmetrical overloads -->
     <Rule Id="CA2227" Action="None" />          <!-- Collection properties should be read only -->
-    <Rule Id="CA2229" Action="Warning" />       <!-- Implement serialization constructors -->
+    <Rule Id="CA2229" Action="None" />          <!-- Implement serialization constructors -->
     <Rule Id="CA2231" Action="None" />          <!-- Overload operator equals on overriding value type Equals -->
     <Rule Id="CA2234" Action="None" />          <!-- Pass system uri objects instead of strings -->
     <Rule Id="CA2235" Action="None" />          <!-- Mark all non-serializable fields -->
     <Rule Id="CA2237" Action="None" />          <!-- Mark ISerializable types with serializable -->
-    <Rule Id="CA2241" Action="Warning" />       <!-- Provide correct arguments to formatting methods -->
-    <Rule Id="CA2242" Action="Warning" />       <!-- Test for NaN correctly -->
-    <!-- CA2243 temporarily disabled: https://github.com/dotnet/roslyn-analyzers/issues/3635 -->
+    <Rule Id="CA2241" Action="None" />          <!-- Provide correct arguments to formatting methods -->
+    <Rule Id="CA2242" Action="None" />          <!-- Test for NaN correctly -->
     <Rule Id="CA2243" Action="None" />          <!-- Attribute string literals should parse correctly -->
     <Rule Id="CA2244" Action="None" />          <!-- Do not duplicate indexed element initializations -->
-    <Rule Id="CA2245" Action="Warning" />       <!-- Do not assign a property to itself. -->
+    <Rule Id="CA2245" Action="None" />          <!-- Do not assign a property to itself. -->
     <Rule Id="CA2246" Action="None" />          <!-- Assigning symbol and its member in the same statement. -->
-    <Rule Id="CA2247" Action="Warning" />       <!-- Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum. -->
-    <Rule Id="CA2248" Action="Warning" />       <!-- Provide correct 'enum' argument to 'Enum.HasFlag' -->
-    <Rule Id="CA2249" Action="Warning" />       <!-- Consider using 'string.Contains' instead of 'string.IndexOf' -->
+    <Rule Id="CA2247" Action="None" />          <!-- Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum. -->
+    <Rule Id="CA2248" Action="None" />          <!-- Provide correct 'enum' argument to 'Enum.HasFlag' -->
+    <Rule Id="CA2249" Action="None" />          <!-- Consider using 'string.Contains' instead of 'string.IndexOf' -->
     <Rule Id="CA2300" Action="None" />          <!-- Do not use insecure deserializer BinaryFormatter -->
     <Rule Id="CA2301" Action="None" />          <!-- Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder -->
     <Rule Id="CA2302" Action="None" />          <!-- Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize -->
@@ -199,41 +198,41 @@
     <Rule Id="CA3010" Action="None" />          <!-- Review code for XAML injection vulnerabilities -->
     <Rule Id="CA3011" Action="None" />          <!-- Review code for DLL injection vulnerabilities -->
     <Rule Id="CA3012" Action="None" />          <!-- Review code for regex injection vulnerabilities -->
-    <Rule Id="CA3061" Action="Warning" />       <!-- Do Not Add Schema By URL -->
-    <Rule Id="CA3075" Action="Warning" />       <!-- Insecure DTD processing in XML -->
-    <Rule Id="CA3076" Action="Warning" />       <!-- Insecure XSLT script processing. -->
-    <Rule Id="CA3077" Action="Warning" />       <!-- Insecure Processing in API Design, XmlDocument and XmlTextReader -->
-    <Rule Id="CA3147" Action="Warning" />       <!-- Mark Verb Handlers With Validate Antiforgery Token -->
-    <Rule Id="CA5350" Action="Warning" />       <!-- Do Not Use Weak Cryptographic Algorithms -->
-    <Rule Id="CA5351" Action="Warning" />       <!-- Do Not Use Broken Cryptographic Algorithms -->
+    <Rule Id="CA3061" Action="None" />          <!-- Do Not Add Schema By URL -->
+    <Rule Id="CA3075" Action="None" />          <!-- Insecure DTD processing in XML -->
+    <Rule Id="CA3076" Action="None" />          <!-- Insecure XSLT script processing. -->
+    <Rule Id="CA3077" Action="None" />          <!-- Insecure Processing in API Design, XmlDocument and XmlTextReader -->
+    <Rule Id="CA3147" Action="None" />          <!-- Mark Verb Handlers With Validate Antiforgery Token -->
+    <Rule Id="CA5350" Action="None" />          <!-- Do Not Use Weak Cryptographic Algorithms -->
+    <Rule Id="CA5351" Action="None" />          <!-- Do Not Use Broken Cryptographic Algorithms -->
     <Rule Id="CA5358" Action="None" />          <!-- Review cipher mode usage with cryptography experts -->
-    <Rule Id="CA5359" Action="Warning" />       <!-- Do Not Disable Certificate Validation -->
-    <Rule Id="CA5360" Action="Warning" />       <!-- Do Not Call Dangerous Methods In Deserialization -->
-    <Rule Id="CA5361" Action="Warning" />       <!-- Do Not Disable SChannel Use of Strong Crypto -->
+    <Rule Id="CA5359" Action="None" />          <!-- Do Not Disable Certificate Validation -->
+    <Rule Id="CA5360" Action="None" />          <!-- Do Not Call Dangerous Methods In Deserialization -->
+    <Rule Id="CA5361" Action="None" />          <!-- Do Not Disable SChannel Use of Strong Crypto -->
     <Rule Id="CA5362" Action="None" />          <!-- Potential reference cycle in deserialized object graph -->
-    <Rule Id="CA5363" Action="Warning" />       <!-- Do Not Disable Request Validation -->
-    <Rule Id="CA5364" Action="Warning" />       <!-- Do Not Use Deprecated Security Protocols -->
-    <Rule Id="CA5365" Action="Warning" />       <!-- Do Not Disable HTTP Header Checking -->
+    <Rule Id="CA5363" Action="None" />          <!-- Do Not Disable Request Validation -->
+    <Rule Id="CA5364" Action="None" />          <!-- Do Not Use Deprecated Security Protocols -->
+    <Rule Id="CA5365" Action="None" />          <!-- Do Not Disable HTTP Header Checking -->
     <Rule Id="CA5366" Action="None" />          <!-- Use XmlReader For DataSet Read Xml -->
     <Rule Id="CA5367" Action="None" />          <!-- Do Not Serialize Types With Pointer Fields -->
-    <Rule Id="CA5368" Action="Warning" />       <!-- Set ViewStateUserKey For Classes Derived From Page -->
+    <Rule Id="CA5368" Action="None" />          <!-- Set ViewStateUserKey For Classes Derived From Page -->
     <Rule Id="CA5369" Action="None" />          <!-- Use XmlReader For Deserialize -->
-    <Rule Id="CA5370" Action="Warning" />       <!-- Use XmlReader For Validating Reader -->
+    <Rule Id="CA5370" Action="None" />          <!-- Use XmlReader For Validating Reader -->
     <Rule Id="CA5371" Action="None" />          <!-- Use XmlReader For Schema Read -->
     <Rule Id="CA5372" Action="None" />          <!-- Use XmlReader For XPathDocument -->
-    <Rule Id="CA5373" Action="Warning" />       <!-- Do not use obsolete key derivation function -->
-    <Rule Id="CA5374" Action="Warning" />       <!-- Do Not Use XslTransform -->
+    <Rule Id="CA5373" Action="None" />          <!-- Do not use obsolete key derivation function -->
+    <Rule Id="CA5374" Action="None" />          <!-- Do Not Use XslTransform -->
     <Rule Id="CA5375" Action="None" />          <!-- Do Not Use Account Shared Access Signature -->
-    <Rule Id="CA5376" Action="Warning" />       <!-- Use SharedAccessProtocol HttpsOnly -->
-    <Rule Id="CA5377" Action="Warning" />       <!-- Use Container Level Access Policy -->
-    <Rule Id="CA5378" Action="Warning" />       <!-- Do not disable ServicePointManagerSecurityProtocols -->
-    <Rule Id="CA5379" Action="Warning" />       <!-- Do Not Use Weak Key Derivation Function Algorithm -->
-    <Rule Id="CA5380" Action="Warning" />       <!-- Do Not Add Certificates To Root Store -->
-    <Rule Id="CA5381" Action="Warning" />       <!-- Ensure Certificates Are Not Added To Root Store -->
+    <Rule Id="CA5376" Action="None" />          <!-- Use SharedAccessProtocol HttpsOnly -->
+    <Rule Id="CA5377" Action="None" />          <!-- Use Container Level Access Policy -->
+    <Rule Id="CA5378" Action="None" />          <!-- Do not disable ServicePointManagerSecurityProtocols -->
+    <Rule Id="CA5379" Action="None" />          <!-- Do Not Use Weak Key Derivation Function Algorithm -->
+    <Rule Id="CA5380" Action="None" />          <!-- Do Not Add Certificates To Root Store -->
+    <Rule Id="CA5381" Action="None" />          <!-- Ensure Certificates Are Not Added To Root Store -->
     <Rule Id="CA5382" Action="None" />          <!-- Use Secure Cookies In ASP.Net Core -->
     <Rule Id="CA5383" Action="None" />          <!-- Ensure Use Secure Cookies In ASP.Net Core -->
-    <Rule Id="CA5384" Action="Warning" />       <!-- Do Not Use Digital Signature Algorithm (DSA) -->
-    <Rule Id="CA5385" Action="Warning" />       <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size -->
+    <Rule Id="CA5384" Action="None" />          <!-- Do Not Use Digital Signature Algorithm (DSA) -->
+    <Rule Id="CA5385" Action="None" />          <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size -->
     <Rule Id="CA5386" Action="None" />          <!-- Avoid hardcoding SecurityProtocolType value -->
     <Rule Id="CA5387" Action="None" />          <!-- Do Not Use Weak Key Derivation Function With Insufficient Iteration Count -->
     <Rule Id="CA5388" Action="None" />          <!-- Ensure Sufficient Iteration Count When Using Weak Key Derivation Function -->
@@ -258,8 +257,8 @@
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" />          <!-- Analyzer threw an exception -->
     <Rule Id="SA0001" Action="None" />          <!-- XML comments -->
-    <Rule Id="SA1000" Action="Warning" />       <!-- Spacing around keywords -->
-    <Rule Id="SA1001" Action="Warning" />       <!-- Commas should not be preceded by whitespace -->
+    <Rule Id="SA1000" Action="None" />          <!-- Spacing around keywords -->
+    <Rule Id="SA1001" Action="None" />          <!-- Commas should not be preceded by whitespace -->
     <Rule Id="SA1002" Action="None" />          <!-- Semicolons should not be preceded by a space -->
     <Rule Id="SA1003" Action="None" />          <!-- Operator should not appear at the end of a line -->
     <Rule Id="SA1004" Action="None" />          <!-- Documentation line should begin with a space -->
@@ -270,42 +269,42 @@
     <Rule Id="SA1011" Action="None" />          <!-- Closing square bracket should be followed by a space -->
     <Rule Id="SA1012" Action="None" />          <!-- Opening brace should be followed by a space -->
     <Rule Id="SA1013" Action="None" />          <!-- Closing brace should be preceded by a space -->
-    <Rule Id="SA1014" Action="Warning" />       <!-- Opening generic brackets should not be preceded by a space -->
+    <Rule Id="SA1014" Action="None" />          <!-- Opening generic brackets should not be preceded by a space -->
     <Rule Id="SA1015" Action="None" />          <!-- Closing generic bracket should not be followed by a space -->
-    <Rule Id="SA1018" Action="Warning" />       <!-- Nullable type symbol should not be preceded by a space -->
-    <Rule Id="SA1020" Action="Warning" />       <!-- Increment symbol should not be preceded by a space -->
+    <Rule Id="SA1018" Action="None" />          <!-- Nullable type symbol should not be preceded by a space -->
+    <Rule Id="SA1020" Action="None" />          <!-- Increment symbol should not be preceded by a space -->
     <Rule Id="SA1021" Action="None" />          <!-- Negative sign should be preceded by a space -->
     <Rule Id="SA1023" Action="None" />          <!-- Dereference symbol '*' should not be preceded by a space." -->
     <Rule Id="SA1024" Action="None" />          <!-- Colon should be followed by a space -->
     <Rule Id="SA1025" Action="None" />          <!-- Code should not contain multiple whitespace characters in a row -->
-    <Rule Id="SA1026" Action="Warning" />       <!-- Keyword followed by span or blank line -->
-    <Rule Id="SA1027" Action="Warning" />       <!-- Tabs and spaces should be used correctly -->
-    <Rule Id="SA1028" Action="Warning" />       <!-- Code should not contain trailing whitespace -->
+    <Rule Id="SA1026" Action="None" />          <!-- Keyword followed by span or blank line -->
+    <Rule Id="SA1027" Action="None" />          <!-- Tabs and spaces should be used correctly -->
+    <Rule Id="SA1028" Action="None" />          <!-- Code should not contain trailing whitespace -->
     <Rule Id="SA1100" Action="None" />          <!-- Do not prefix calls with base unless local implementation exists -->
     <Rule Id="SA1101" Action="None" />          <!-- Prefix local calls with this -->
-    <Rule Id="SA1102" Action="Warning" />       <!-- Query clause should follow previous clause -->
-    <Rule Id="SA1105" Action="Warning" />       <!-- Query clauses spanning multiple lines should begin on own line -->
+    <Rule Id="SA1102" Action="None" />          <!-- Query clause should follow previous clause -->
+    <Rule Id="SA1105" Action="None" />          <!-- Query clauses spanning multiple lines should begin on own line -->
     <Rule Id="SA1106" Action="None" />          <!-- Code should not contain empty statements -->
     <Rule Id="SA1107" Action="None" />          <!-- Code should not contain multiple statements on one line -->
     <Rule Id="SA1108" Action="None" />          <!-- Block statements should not contain embedded comments -->
     <Rule Id="SA1110" Action="None" />          <!-- Opening parenthesis or bracket should be on declaration line -->
     <Rule Id="SA1111" Action="None" />          <!-- Closing parenthesis should be on line of last parameter -->
-    <Rule Id="SA1113" Action="Warning" />       <!-- Comma should be on the same line as previous parameter -->
+    <Rule Id="SA1113" Action="None" />          <!-- Comma should be on the same line as previous parameter -->
     <Rule Id="SA1114" Action="None" />          <!-- Parameter list should follow declaration -->
-    <Rule Id="SA1115" Action="Warning" />       <!-- Parameter should begin on the line after the previous parameter -->
+    <Rule Id="SA1115" Action="None" />          <!-- Parameter should begin on the line after the previous parameter -->
     <Rule Id="SA1116" Action="None" />          <!-- Split parameters should start on line after declaration -->
     <Rule Id="SA1117" Action="None" />          <!-- Parameters should be on same line or separate lines -->
     <Rule Id="SA1118" Action="None" />          <!-- Parameter should not span multiple lines -->
     <Rule Id="SA1119" Action="None" />          <!-- Statement should not use unnecessary parenthesis -->
     <Rule Id="SA1120" Action="None" />          <!-- Comments should contain text -->
-    <Rule Id="SA1121" Action="Warning" />       <!-- Use built-in type alias -->
+    <Rule Id="SA1121" Action="None" />          <!-- Use built-in type alias -->
     <Rule Id="SA1122" Action="None" />          <!-- Use string.Empty for empty strings -->
     <Rule Id="SA1123" Action="None" />          <!-- Region should not be located within a code element -->
     <Rule Id="SA1124" Action="None" />          <!-- Do not use regions -->
     <Rule Id="SA1125" Action="None" />          <!-- Use shorthand for nullable types -->
     <Rule Id="SA1127" Action="None" />          <!-- Generic type constraints should be on their own line -->
     <Rule Id="SA1128" Action="None" />          <!-- Put constructor initializers on their own line -->
-    <Rule Id="SA1129" Action="Warning" />       <!-- Do not use default value type constructor -->
+    <Rule Id="SA1129" Action="None" />          <!-- Do not use default value type constructor -->
     <Rule Id="SA1130" Action="None" />          <!-- Use lambda syntax -->
     <Rule Id="SA1131" Action="None" />          <!-- Constant values should appear on the right-hand side of comparisons -->
     <Rule Id="SA1132" Action="None" />          <!-- Do not combine fields -->
@@ -315,23 +314,23 @@
     <Rule Id="SA1136" Action="None" />          <!-- Enum values should be on separate lines -->
     <Rule Id="SA1137" Action="None" />          <!-- Elements should have the same indentation -->
     <Rule Id="SA1139" Action="None" />          <!-- Use literal suffix notation instead of casting -->
-    <Rule Id="SA1141" Action="Warning" />       <!-- Use tuple syntax -->
+    <Rule Id="SA1141" Action="None" />          <!-- Use tuple syntax -->
     <Rule Id="SA1200" Action="None" />          <!-- Using directive should appear within a namespace declaration -->
     <Rule Id="SA1201" Action="None" />          <!-- Elements should appear in the correct order -->
     <Rule Id="SA1202" Action="None" />          <!-- Elements should be ordered by access -->
     <Rule Id="SA1203" Action="None" />          <!-- Constants should appear before fields -->
     <Rule Id="SA1204" Action="None" />          <!-- Static elements should appear before instance elements -->
-    <Rule Id="SA1205" Action="Warning" />       <!-- Partial elements should declare an access modifier -->
-    <Rule Id="SA1206" Action="Warning" />       <!-- Keyword ordering -->
+    <Rule Id="SA1205" Action="None" />          <!-- Partial elements should declare an access modifier -->
+    <Rule Id="SA1206" Action="None" />          <!-- Keyword ordering -->
     <Rule Id="SA1208" Action="None" />          <!-- Using directive ordering -->
     <Rule Id="SA1209" Action="None" />          <!-- Using alias directives should be placed after all using namespace directives -->
     <Rule Id="SA1210" Action="None" />          <!-- Using directives should be ordered alphabetically by the namespaces -->
     <Rule Id="SA1211" Action="None" />          <!-- Using alias directive ordering -->
-    <Rule Id="SA1212" Action="Warning" />       <!-- A get accessor appears after a set accessor within a property or indexer -->
+    <Rule Id="SA1212" Action="None" />          <!-- A get accessor appears after a set accessor within a property or indexer -->
     <Rule Id="SA1214" Action="None" />          <!-- Readonly fields should appear before non-readonly fields -->
     <Rule Id="SA1216" Action="None" />          <!-- Using static directives should be placed at the correct location -->
     <Rule Id="SA1300" Action="None" />          <!-- Element should begin with an uppercase letter -->
-    <Rule Id="SA1302" Action="Warning" />       <!-- Interface names should begin with I -->
+    <Rule Id="SA1302" Action="None" />          <!-- Interface names should begin with I -->
     <Rule Id="SA1303" Action="None" />          <!-- Const field names should begin with upper-case letter -->
     <Rule Id="SA1304" Action="None" />          <!-- Non-private readonly fields should begin with upper-case letter -->
     <Rule Id="SA1306" Action="None" />          <!-- Field should begin with lower-case letter -->
@@ -344,16 +343,16 @@
     <Rule Id="SA1313" Action="None" />          <!-- Parameter should begin with lower-case letter -->
     <Rule Id="SA1314" Action="None" />          <!-- Type parameter names should begin with T -->
     <Rule Id="SA1316" Action="None" />          <!-- Tuple element names should use correct casing -->
-    <Rule Id="SA1400" Action="Warning" />       <!-- Member should declare an access modifer -->
+    <Rule Id="SA1400" Action="None" />          <!-- Member should declare an access modifer -->
     <Rule Id="SA1401" Action="None" />          <!-- Fields should be private -->
     <Rule Id="SA1402" Action="None" />          <!-- File may only contain a single type -->
     <Rule Id="SA1403" Action="None" />          <!-- File may only contain a single namespace -->
-    <Rule Id="SA1404" Action="Warning" />       <!-- Code analysis suppression should have justification -->
+    <Rule Id="SA1404" Action="None" />          <!-- Code analysis suppression should have justification -->
     <Rule Id="SA1405" Action="None" />          <!-- Debug.Assert should provide message text -->
     <Rule Id="SA1407" Action="None" />          <!-- Arithmetic expressions should declare precedence -->
     <Rule Id="SA1408" Action="None" />          <!-- Conditional expressions should declare precedence -->
-    <Rule Id="SA1410" Action="Warning" />       <!-- Remove delegate parens when possible -->
-    <Rule Id="SA1411" Action="Warning" />       <!-- Attribute constructor shouldn't use unnecessary parenthesis -->
+    <Rule Id="SA1410" Action="None" />          <!-- Remove delegate parens when possible -->
+    <Rule Id="SA1411" Action="None" />          <!-- Attribute constructor shouldn't use unnecessary parenthesis -->
     <Rule Id="SA1413" Action="None" />          <!-- Use trailing comma in multi-line initializers -->
     <Rule Id="SA1414" Action="None" />          <!-- Tuple types in signatures should have element names -->
     <Rule Id="SA1500" Action="None" />          <!-- Braces for multi-line statements should not share line -->
@@ -372,8 +371,8 @@
     <Rule Id="SA1514" Action="None" />          <!-- Element documentation header should be preceded by blank line -->
     <Rule Id="SA1515" Action="None" />          <!-- Single-line comment should be preceded by blank line -->
     <Rule Id="SA1516" Action="None" />          <!-- Elements should be separated by blank line -->
-    <Rule Id="SA1517" Action="Warning" />       <!-- Code should not contain blank lines at start of file -->
-    <Rule Id="SA1518" Action="Warning" />       <!-- Code should not contain blank lines at the end of the file -->
+    <Rule Id="SA1517" Action="None" />          <!-- Code should not contain blank lines at start of file -->
+    <Rule Id="SA1518" Action="None" />          <!-- Code should not contain blank lines at the end of the file -->
     <Rule Id="SA1519" Action="None" />          <!-- Braces should not be omitted from multi-line child statement -->
     <Rule Id="SA1520" Action="None" />          <!-- Use braces consistently -->
     <Rule Id="SA1600" Action="None" />          <!-- Elements should be documented -->
@@ -440,9 +439,9 @@
     <Rule Id="IDE0038" Action="Hidden" />       <!-- InlineIsTypeWithoutNameCheck -->
     <Rule Id="IDE0039" Action="Hidden" />       <!-- UseLocalFunction -->
     <Rule Id="IDE0040" Action="Hidden" />       <!-- AddAccessibilityModifiers -->
-    <Rule Id="IDE0041" Action="Warning" />      <!-- UseIsNullCheck -->
+    <Rule Id="IDE0041" Action="Hidden" />       <!-- UseIsNullCheck -->
     <Rule Id="IDE0042" Action="Hidden" />       <!-- UseDeconstruction -->
-    <Rule Id="IDE0043" Action="Warning" />      <!-- ValidateFormatString -->
+    <Rule Id="IDE0043" Action="Hidden" />       <!-- ValidateFormatString -->
     <Rule Id="IDE0044" Action="Hidden" />       <!-- MakeFieldReadonly -->
     <Rule Id="IDE0045" Action="Hidden" />       <!-- UseConditionalExpressionForAssignment -->
     <Rule Id="IDE0046" Action="Hidden" />       <!-- UseConditionalExpressionForReturn -->
@@ -461,7 +460,7 @@
     <Rule Id="IDE0059" Action="Hidden" />       <!-- ValueAssignedIsUnused -->
     <Rule Id="IDE0060" Action="Hidden" />       <!-- UnusedParameter -->
     <Rule Id="IDE0061" Action="Hidden" />       <!-- UseExpressionBodyForLocalFunctions -->
-    <Rule Id="IDE0062" Action="Warning" />      <!-- MakeLocalFunctionStatic -->
+    <Rule Id="IDE0062" Action="Hidden" />       <!-- MakeLocalFunctionStatic -->
     <Rule Id="IDE0063" Action="Hidden" />       <!-- UseSimpleUsingStatement -->
     <Rule Id="IDE0064" Action="Hidden" />       <!-- MakeStructFieldsWritable -->
     <Rule Id="IDE0065" Action="Hidden" />       <!-- MoveMisplacedUsingDirectives -->
@@ -472,16 +471,16 @@
     <Rule Id="IDE0070" Action="Hidden" />       <!-- UseSystemHashCode -->
     <Rule Id="IDE0071" Action="Hidden" />       <!-- SimplifyInterpolation -->
     <Rule Id="IDE0072" Action="Hidden" />       <!-- PopulateSwitchExpression -->
-    <Rule Id="IDE0073" Action="Warning" />      <!-- FileHeaderMismatch -->
+    <Rule Id="IDE0073" Action="Hidden" />       <!-- FileHeaderMismatch -->
     <Rule Id="IDE0074" Action="Hidden" />       <!-- UseCoalesceCompoundAssignment -->
     <Rule Id="IDE0075" Action="Hidden" />       <!-- SimplifyConditionalExpression -->
     <Rule Id="IDE0076" Action="Hidden" />       <!-- InvalidSuppressMessageAttribute -->
     <Rule Id="IDE0077" Action="Hidden" />       <!-- LegacyFormatSuppressMessageAttribute -->
     <Rule Id="IDE0078" Action="Hidden" />       <!-- UsePatternCombinators -->
-    <Rule Id="IDE0079" Action="Warning" />      <!-- RemoveUnnecessarySuppression -->
+    <Rule Id="IDE0079" Action="Hidden" />       <!-- RemoveUnnecessarySuppression -->
     <Rule Id="IDE0080" Action="Hidden" />       <!-- RemoveConfusingSuppressionForIsExpression -->
     <Rule Id="IDE0081" Action="Hidden" />       <!-- RemoveUnnecessaryByVal -->
-    <Rule Id="IDE0082" Action="Warning" />      <!-- ConvertTypeOfToNameOf -->
+    <Rule Id="IDE0082" Action="Hidden" />       <!-- ConvertTypeOfToNameOf -->
     <Rule Id="IDE0083" Action="Hidden" />       <!-- UseNotPattern -->
     <Rule Id="IDE0084" Action="Hidden" />       <!-- UseIsNotExpression -->
     <Rule Id="IDE1001" Action="Hidden" />       <!-- AnalyzerChanged -->
@@ -492,5 +491,56 @@
     <Rule Id="IDE1006" Action="Hidden" />       <!-- NamingRule -->
     <Rule Id="IDE1007" Action="Hidden" />       <!-- UnboundIdentifier -->
     <Rule Id="IDE1008" Action="Hidden" />       <!-- UnboundConstructor -->
+  </Rules>
+  <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
+    <Rule Id="xUnit1000" Action="Warning" />    <!-- Test classes must be public -->
+    <Rule Id="xUnit1001" Action="Warning" />    <!-- Fact methods cannot have parameters -->
+    <Rule Id="xUnit1002" Action="Warning" />    <!-- Test methods cannot have multiple Fact or Theory attributes -->
+    <Rule Id="xUnit1003" Action="Warning" />    <!-- Theory methods must have test data -->
+    <Rule Id="xUnit1004" Action="Warning" />    <!-- Test methods should not be skipped -->
+    <Rule Id="xUnit1005" Action="Warning" />    <!-- Fact methods should not have test data -->
+    <Rule Id="xUnit1006" Action="Warning" />    <!-- Theory methods should have parameters -->
+    <Rule Id="xUnit1007" Action="Warning" />    <!-- ClassData must point at a valid class -->
+    <Rule Id="xUnit1008" Action="Warning" />    <!-- Test data attribute should only be used on a Theory -->
+    <Rule Id="xUnit1009" Action="Warning" />    <!-- InlineData must match the number of method parameters -->
+    <Rule Id="xUnit1010" Action="Warning" />    <!-- The value is not convertible to the method parameter type -->
+    <Rule Id="xUnit1011" Action="Warning" />    <!-- There is no matching method parameter -->
+    <Rule Id="xUnit1012" Action="Warning" />    <!-- Null should not be used for value type parameters -->
+    <Rule Id="xUnit1013" Action="Warning" />    <!-- Public methods should be marked as test -->
+    <Rule Id="xUnit1014" Action="Warning" />    <!-- MemberData should use nameof operator for member name -->
+    <Rule Id="xUnit1015" Action="Warning" />    <!-- MemberData must reference an existing member -->
+    <Rule Id="xUnit1016" Action="Warning" />    <!-- MemberData must reference a public member -->
+    <Rule Id="xUnit1017" Action="Warning" />    <!-- MemberData must reference a static member -->
+    <Rule Id="xUnit1018" Action="Warning" />    <!-- MemberData must reference a valid member kind -->
+    <Rule Id="xUnit1019" Action="Warning" />    <!-- MemberData must reference a member providing a valid data type -->
+    <Rule Id="xUnit1020" Action="Warning" />    <!-- MemberData must reference a property with a getter -->
+    <Rule Id="xUnit1021" Action="Warning" />    <!-- MemberData should not have parameters if the referenced member is not a method -->
+    <Rule Id="xUnit1022" Action="Warning" />    <!-- Theory methods cannot have a parameter array -->
+    <Rule Id="xUnit1023" Action="Warning" />    <!-- Theory methods cannot have default parameter values -->
+    <Rule Id="xUnit1024" Action="Warning" />    <!-- Test methods cannot have overloads -->
+    <Rule Id="xUnit1025" Action="Warning" />    <!-- InlineData should be unique within the Theory it belongs to -->
+    <Rule Id="xUnit1026" Action="Warning" />    <!-- Theory methods should use all of their parameters -->
+    <Rule Id="xUnit2000" Action="Warning" />    <!-- Constants and literals should be the expected argument -->
+    <Rule Id="xUnit2001" Action="Warning" />    <!-- Do not use invalid equality check -->
+    <Rule Id="xUnit2002" Action="Warning" />    <!-- Do not use null check on value type -->
+    <Rule Id="xUnit2003" Action="Warning" />    <!-- Do not use equality check to test for null value -->
+    <Rule Id="xUnit2004" Action="Warning" />    <!-- Do not use equality check to test for boolean conditions -->
+    <Rule Id="xUnit2005" Action="Warning" />    <!-- Do not use identity check on value type -->
+    <Rule Id="xUnit2006" Action="Warning" />    <!-- Do not use invalid string equality check -->
+    <Rule Id="xUnit2007" Action="Warning" />    <!-- Do not use typeof expression to check the type -->
+    <Rule Id="xUnit2008" Action="Warning" />    <!-- Do not use boolean check to match on regular expressions -->
+    <Rule Id="xUnit2009" Action="Warning" />    <!-- Do not use boolean check to check for substrings -->
+    <Rule Id="xUnit2010" Action="Warning" />    <!-- Do not use boolean check to check for string equality -->
+    <Rule Id="xUnit2011" Action="Warning" />    <!-- Do not use empty collection check -->
+    <Rule Id="xUnit2012" Action="Warning" />    <!-- Do not use Enumerable.Any() to check if a value exists in a collection -->
+    <Rule Id="xUnit2013" Action="None" />       <!-- Do not use equality check to check for collection size. -->
+    <Rule Id="xUnit2014" Action="Warning" />    <!-- Do not use throws check to check for asynchronously thrown exception -->
+    <Rule Id="xUnit2015" Action="Warning" />    <!-- Do not use typeof expression to check the exception type -->
+    <Rule Id="xUnit2016" Action="Warning" />    <!-- Keep precision in the allowed range when asserting equality of doubles or decimals -->
+    <Rule Id="xUnit2017" Action="None" />       <!-- Do not use Contains() to check if a value exists in a collection -->
+    <Rule Id="xUnit2018" Action="Warning" />    <!-- Do not compare an object's exact type to an abstract class or interface -->
+    <Rule Id="xUnit2019" Action="Warning" />    <!-- Do not use obsolete throws check to check for asynchronously thrown exception -->
+    <Rule Id="xUnit3000" Action="Warning" />    <!-- Test case classes must derive directly or indirectly from Xunit.LongLivedMarshalByRefObject -->
+    <Rule Id="xUnit3001" Action="Warning" />    <!-- Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor -->
   </Rules>
 </RuleSet>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -225,7 +225,8 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
     <!-- Disable analyzers for tests and unsupported projects -->
-    <RunAnalyzers Condition="'$(IsSourceProject)' != 'true' or '$(MSBuildProjectExtension)' == '.ilproj'">false</RunAnalyzers>
+    <RunAnalyzers Condition="'$(IsTestProject)' != 'true' and '$(IsSourceProject)' != 'true'">false</RunAnalyzers>
+    <CodeAnalysisRuleset Condition="'$(IsTestProject)' == 'true'">$(RepositoryEngineeringDir)CodeAnalysis.test.ruleset</CodeAnalysisRuleset>
   </PropertyGroup>
 
   <!-- Set up common paths -->

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -845,7 +845,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var config = configurationBuilder.Build();
 
             var options = config.Get<ByteArrayOptions>();
-            Assert.Equal(null, options.MyByteArray);
+            Assert.Null(options.MyByteArray);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -265,7 +265,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.NotNull(provider.CreateScope());
         }
 
-        [Theory(Skip = "https://github.com/dotnet/runtime/issues/42160 - We don't support value task services currently")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/42160")] // We don't support value task services currently
+        [Theory]
         [InlineData(ServiceLifetime.Transient)]
         [InlineData(ServiceLifetime.Scoped)]
         [InlineData(ServiceLifetime.Singleton)]

--- a/src/libraries/System.Security.Cryptography.Csp/tests/CspParametersTests.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/CspParametersTests.cs
@@ -7,6 +7,8 @@ namespace System.Security.Cryptography.Csp.Tests
 {
     public static class CspParametersTests
     {
+        public static bool ManualTestsEnabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MANUAL_TESTS"));
+
         const int PROV_RSA_FULL = 1;
         const int PROV_RSA_AES = 24;
 
@@ -45,7 +47,7 @@ namespace System.Security.Cryptography.Csp.Tests
             }
         }
 
-        [Theory(Skip = "Manual test - requires Smart Card - read instructions")]
+        [ConditionalTheory(nameof(ManualTestsEnabled))] // requires Smart Card - read instructions
         [InlineData(true)]
         [InlineData(false)]
         public static void KeyPassword_SmartCard_Manual_Test(bool correctPassword)

--- a/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
@@ -817,9 +817,11 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("NaNa")]
         [InlineData("Infinitya")]
         [InlineData("-Infinitya")]
+#pragma warning disable xUnit1025 // Theory method 'FloatingPointConstants_Fail' on test class 'NumberHandlingTests' has InlineData duplicate(s)
         [InlineData("\u006EaN")] // "naN"
         [InlineData("\u0020Inf\u0069ni\u0074y")] // " Infinity"
         [InlineData("\u002BInf\u0069nity")] // "+Infinity"
+#pragma warning restore xUnit1025
         public static void FloatingPointConstants_Fail(string testString)
         {
             string testStringAsJson = $@"""{testString}""";


### PR DESCRIPTION
We don't want most analyzers running over our test code currently (some rules could be enabled with varying degrees of effort), but we do want the xunit analyzers running, and they haven't been.  Fix that by creating a new ruleset specific to library tests, and switching over to use it when building library test projects.

Fixes https://github.com/dotnet/runtime/issues/43456
cc: @ViktorHofer, @safern 