### PR TITLE
Display the real offset after branch tightening

### DIFF
--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5048,7 +5048,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #define DEFAULT_CODE_BUFFER_INIT 0xcc
 
 #ifdef DEBUG
-    *instrCount = 0;
+    *instrCount      = 0;
+    bool isColdBlock = false;
 #endif
     for (insGroup* ig = emitIGlist; ig != nullptr; ig = ig->igNext)
     {
@@ -5060,7 +5061,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             assert(emitCurCodeOffs(cp) == emitTotalHotCodeSize);
 
             assert(coldCodeBlock);
-            cp = coldCodeBlock;
+            cp          = coldCodeBlock;
+            isColdBlock = true;
 #ifdef DEBUG
             if (emitComp->opts.disAsm || emitComp->verbose)
             {
@@ -5097,7 +5099,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\nG_M%03u_IG%02u:", emitComp->compMethodID, ig->igNum);
                 if (!emitComp->opts.disDiffable)
                 {
-                    printf("              ;; offset=%04XH", (cp - codeBlock));
+                    printf("              ;; offset=%04XH", (cp - (isColdBlock ? coldCodeBlock : codeBlock)));
                 }
                 printf("\n");
             }

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5097,7 +5097,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\nG_M%03u_IG%02u:", emitComp->compMethodID, ig->igNum);
                 if (!emitComp->opts.disDiffable)
                 {
-                    printf("              ;; offset=%04XH", ig->igOffs);
+                    printf("              ;; offset=%04XH", (cp - codeBlock));
                 }
                 printf("\n");
             }

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5062,8 +5062,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
             assert(coldCodeBlock);
             cp          = coldCodeBlock;
-#ifdef DEBUG
             isColdBlock = true;
+#ifdef DEBUG
             if (emitComp->opts.disAsm || emitComp->verbose)
             {
                 printf("\n************** Beginning of cold code **************\n");

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5061,7 +5061,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             assert(emitCurCodeOffs(cp) == emitTotalHotCodeSize);
 
             assert(coldCodeBlock);
-            cp          = coldCodeBlock;
+            cp = coldCodeBlock;
 #ifdef DEBUG
             isColdBlock = true;
             if (emitComp->opts.disAsm || emitComp->verbose)

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5048,8 +5048,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #define DEFAULT_CODE_BUFFER_INIT 0xcc
 
 #ifdef DEBUG
-    *instrCount      = 0;
-    bool isColdBlock = false;
+    *instrCount = 0;
 #endif
     for (insGroup* ig = emitIGlist; ig != nullptr; ig = ig->igNext)
     {
@@ -5061,8 +5060,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             assert(emitCurCodeOffs(cp) == emitTotalHotCodeSize);
 
             assert(coldCodeBlock);
-            cp          = coldCodeBlock;
-            isColdBlock = true;
+            cp = coldCodeBlock;
 #ifdef DEBUG
             if (emitComp->opts.disAsm || emitComp->verbose)
             {
@@ -5099,7 +5097,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\nG_M%03u_IG%02u:", emitComp->compMethodID, ig->igNum);
                 if (!emitComp->opts.disDiffable)
                 {
-                    printf("              ;; offset=%04XH", (cp - (isColdBlock ? coldCodeBlock : codeBlock)));
+                    printf("              ;; offset=%04XH", (cp - codeBlock));
                 }
                 printf("\n");
             }

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5062,8 +5062,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
             assert(coldCodeBlock);
             cp          = coldCodeBlock;
-            isColdBlock = true;
 #ifdef DEBUG
+            isColdBlock = true;
             if (emitComp->opts.disAsm || emitComp->verbose)
             {
                 printf("\n************** Beginning of cold code **************\n");

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5061,7 +5061,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             assert(emitCurCodeOffs(cp) == emitTotalHotCodeSize);
 
             assert(coldCodeBlock);
-            cp = coldCodeBlock;
+            cp          = coldCodeBlock;
 #ifdef DEBUG
             isColdBlock = true;
             if (emitComp->opts.disAsm || emitComp->verbose)

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5097,7 +5097,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\nG_M%03u_IG%02u:", emitComp->compMethodID, ig->igNum);
                 if (!emitComp->opts.disDiffable)
                 {
-                    printf("              ;; offset=%04XH", (cp - codeBlock));
+                    printf("              ;; offset=%04XH", emitCurCodeOffs(cp));
                 }
                 printf("\n");
             }


### PR DESCRIPTION
The offset displaying logic I added https://github.com/dotnet/runtime/pull/43120 doesn't take into account the compaction to the code that can happen after branch tightening. So instead, just use the code address to calculate the address.