### PR TITLE
Upgrade IL.SDK version, disable generating of generate dependency file & custom message for restore tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -17,7 +17,7 @@
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20506.7",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20506.7",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20359.4",
+    "Microsoft.NET.Sdk.IL": "6.0.0-alpha.1.20514.11",
     "Microsoft.Build.NoTargets": "2.0.1",
     "Microsoft.Build.Traversal": "2.1.1"
   }

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -285,4 +285,15 @@
     </When>
   </Choose>
 
+  <!-- The upfront vertical builds already generates the dependency file. -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' and Exists('$(ProjectDepsFilePath)')">
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+  </PropertyGroup>
+
+  <Target Name="CheckVSRestoreRequirements"
+          Condition="'$(BuildingInsideVisualStudio)' == 'true'"
+          BeforeTargets="ResolvePackageAssets" >
+    <Error Text="Please run dotnet restore from command line for $(MSBuildProjectName) because the project contains platform specific target frameworks." Condition="!Exists('$(ProjectAssetsFile)')" />
+  </Target>
+
 </Project>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -285,15 +285,10 @@
     </When>
   </Choose>
 
-  <!-- The upfront vertical builds already generates the dependency file. -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' and Exists('$(ProjectDepsFilePath)')">
-    <GenerateDependencyFile>false</GenerateDependencyFile>
-  </PropertyGroup>
-
   <Target Name="CheckVSRestoreRequirements"
           Condition="'$(BuildingInsideVisualStudio)' == 'true'"
           BeforeTargets="ResolvePackageAssets" >
-    <Error Text="Please run dotnet restore from command line for $(MSBuildProjectName) because the project contains platform specific target frameworks." Condition="!Exists('$(ProjectAssetsFile)')" />
+    <Error Text="Please run dotnet restore from command line for $(MSBuildProjectName)." Condition="!Exists('$(ProjectAssetsFile)')" />
   </Target>
 
 </Project>

--- a/src/libraries/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.sln
+++ b/src/libraries/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{4309CA21-32B5-46FB-BD91-7FD19C4D131B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{4309CA21-32B5-46FB-BD91-7FD19C4D131B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Win32.Registry", "..\Microsoft.Win32.Registry\src\Microsoft.Win32.Registry.csproj", "{88221928-2B78-469D-AB47-21755DBC2420}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{4309CA21-32B5-46FB-BD91-7FD19C4D131B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4309CA21-32B5-46FB-BD91-7FD19C4D131B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4309CA21-32B5-46FB-BD91-7FD19C4D131B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88221928-2B78-469D-AB47-21755DBC2420}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88221928-2B78-469D-AB47-21755DBC2420}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88221928-2B78-469D-AB47-21755DBC2420}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88221928-2B78-469D-AB47-21755DBC2420}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{0E23F29E-6BB0-4B94-A5DA-B5E50601E0F2} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{389CCAC2-E1C2-4185-AC01-2035CB99B5ED} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{4309CA21-32B5-46FB-BD91-7FD19C4D131B} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{88221928-2B78-469D-AB47-21755DBC2420} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E2062894-CBCC-49AF-9508-20D203AE3880}

--- a/src/libraries/System.Configuration.ConfigurationManager/System.Configuration.ConfigurationManager.sln
+++ b/src/libraries/System.Configuration.ConfigurationManager/System.Configuration.ConfigurationManager.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{10CD484E-5BF8-40EC-901E-2E4EB5609DB6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{10CD484E-5BF8-40EC-901E-2E4EB5609DB6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Permissions", "..\System.Security.Permissions\ref\System.Security.Permissions.csproj", "{911D6A7B-610A-45EE-AE2F-D23BBC6F7564}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{10CD484E-5BF8-40EC-901E-2E4EB5609DB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10CD484E-5BF8-40EC-901E-2E4EB5609DB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{10CD484E-5BF8-40EC-901E-2E4EB5609DB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{911D6A7B-610A-45EE-AE2F-D23BBC6F7564}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{911D6A7B-610A-45EE-AE2F-D23BBC6F7564}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{911D6A7B-610A-45EE-AE2F-D23BBC6F7564}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{911D6A7B-610A-45EE-AE2F-D23BBC6F7564}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{B7697463-7C98-4462-BA09-67B7BF3842B6} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{FD6AA2B9-56DB-4BCC-85E0-7727506562B0} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{10CD484E-5BF8-40EC-901E-2E4EB5609DB6} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{911D6A7B-610A-45EE-AE2F-D23BBC6F7564} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2A7070B4-C2EA-49C3-BEF1-E5BB001D99DF}

--- a/src/libraries/System.Console/System.Console.sln
+++ b/src/libraries/System.Console/System.Console.sln
@@ -25,7 +25,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{8261A605-FCBF-4D54-AC09-5248EBF93158}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{8261A605-FCBF-4D54-AC09-5248EBF93158}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Private.Runtime.InteropServices.JavaScript", "..\System.Private.Runtime.InteropServices.JavaScript\src\System.Private.Runtime.InteropServices.JavaScript.csproj", "{B9902401-3E49-4F00-A89B-A59AB29F8632}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +55,10 @@ Global
 		{8261A605-FCBF-4D54-AC09-5248EBF93158}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8261A605-FCBF-4D54-AC09-5248EBF93158}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8261A605-FCBF-4D54-AC09-5248EBF93158}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9902401-3E49-4F00-A89B-A59AB29F8632}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9902401-3E49-4F00-A89B-A59AB29F8632}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9902401-3E49-4F00-A89B-A59AB29F8632}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9902401-3E49-4F00-A89B-A59AB29F8632}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -63,6 +69,7 @@ Global
 		{F9DF2357-81B4-4317-908E-512DA9395583} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{9EB75B87-2BE5-48E5-8988-A0929CE6664E} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{8261A605-FCBF-4D54-AC09-5248EBF93158} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{B9902401-3E49-4F00-A89B-A59AB29F8632} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2BF05491-08EF-445E-ADBA-4D0DF54C0B6A}

--- a/src/libraries/System.Data.Odbc/System.Data.Odbc.sln
+++ b/src/libraries/System.Data.Odbc/System.Data.Odbc.sln
@@ -20,7 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3B83B797-AB71-4C80-A21B-5D65D317A96C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3B83B797-AB71-4C80-A21B-5D65D317A96C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encoding.CodePages", "..\System.Text.Encoding.CodePages\src\System.Text.Encoding.CodePages.csproj", "{80F696C6-3D2C-44FD-8A22-A150FADB987A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encoding.CodePages", "..\System.Text.Encoding.CodePages\ref\System.Text.Encoding.CodePages.csproj", "{96AE799B-83AE-47F0-A5D8-C51E53A2037F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +48,14 @@ Global
 		{3B83B797-AB71-4C80-A21B-5D65D317A96C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B83B797-AB71-4C80-A21B-5D65D317A96C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B83B797-AB71-4C80-A21B-5D65D317A96C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80F696C6-3D2C-44FD-8A22-A150FADB987A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80F696C6-3D2C-44FD-8A22-A150FADB987A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80F696C6-3D2C-44FD-8A22-A150FADB987A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80F696C6-3D2C-44FD-8A22-A150FADB987A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96AE799B-83AE-47F0-A5D8-C51E53A2037F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96AE799B-83AE-47F0-A5D8-C51E53A2037F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96AE799B-83AE-47F0-A5D8-C51E53A2037F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96AE799B-83AE-47F0-A5D8-C51E53A2037F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +65,8 @@ Global
 		{7BAD100F-AD6B-490A-AF7C-8E3854E812C0} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{D589374B-3331-4660-8DFB-512D66F8EC63} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{3B83B797-AB71-4C80-A21B-5D65D317A96C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{80F696C6-3D2C-44FD-8A22-A150FADB987A} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{96AE799B-83AE-47F0-A5D8-C51E53A2037F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {57A3CDB1-B4C0-43A9-85CB-537EE69CD727}

--- a/src/libraries/System.Data.OleDb/System.Data.Oledb.sln
+++ b/src/libraries/System.Data.OleDb/System.Data.Oledb.sln
@@ -20,7 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{474DBDE9-7887-46D0-A2BF-EB531D16B958}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{474DBDE9-7887-46D0-A2BF-EB531D16B958}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{616D5A07-A066-4810-B42B-EA0C121F0006}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj", "{8F77937B-6B77-4709-ADC0-3D91104B792E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +48,14 @@ Global
 		{474DBDE9-7887-46D0-A2BF-EB531D16B958}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{474DBDE9-7887-46D0-A2BF-EB531D16B958}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{474DBDE9-7887-46D0-A2BF-EB531D16B958}.Release|Any CPU.Build.0 = Release|Any CPU
+		{616D5A07-A066-4810-B42B-EA0C121F0006}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{616D5A07-A066-4810-B42B-EA0C121F0006}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{616D5A07-A066-4810-B42B-EA0C121F0006}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{616D5A07-A066-4810-B42B-EA0C121F0006}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F77937B-6B77-4709-ADC0-3D91104B792E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F77937B-6B77-4709-ADC0-3D91104B792E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F77937B-6B77-4709-ADC0-3D91104B792E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F77937B-6B77-4709-ADC0-3D91104B792E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +65,8 @@ Global
 		{D909B69D-8F3B-4551-A355-8FFF6A308CF6} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{EF4F0844-7AAD-4B0C-A29C-37E1F92D2D78} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{474DBDE9-7887-46D0-A2BF-EB531D16B958} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{616D5A07-A066-4810-B42B-EA0C121F0006} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{8F77937B-6B77-4709-ADC0-3D91104B792E} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {04C9232C-0656-4BA5-9836-7DAE3DD4057C}

--- a/src/libraries/System.Diagnostics.EventLog/System.Diagnostics.EventLog.sln
+++ b/src/libraries/System.Diagnostics.EventLog/System.Diagnostics.EventLog.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3EC81942-75A3-4D56-A63C-2221337A0BB2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3EC81942-75A3-4D56-A63C-2221337A0BB2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{787E9E9A-EB04-4D1D-A99C-B17DF5952B97}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{3EC81942-75A3-4D56-A63C-2221337A0BB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EC81942-75A3-4D56-A63C-2221337A0BB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EC81942-75A3-4D56-A63C-2221337A0BB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{787E9E9A-EB04-4D1D-A99C-B17DF5952B97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{787E9E9A-EB04-4D1D-A99C-B17DF5952B97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{787E9E9A-EB04-4D1D-A99C-B17DF5952B97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{787E9E9A-EB04-4D1D-A99C-B17DF5952B97}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{432779B9-3CBD-4871-A7DC-D8A192319DBD} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{F405C42E-EF6F-4404-80FD-3B87E216707C} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{3EC81942-75A3-4D56-A63C-2221337A0BB2} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{787E9E9A-EB04-4D1D-A99C-B17DF5952B97} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DFF5A927-E889-4999-B4D2-E15E3B1B8E00}

--- a/src/libraries/System.Diagnostics.PerformanceCounter/System.Diagnostics.PerformanceCounter.sln
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/System.Diagnostics.PerformanceCounter.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{69B86C3B-8C7E-4B19-ADF9-931B1C17E7AC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{69B86C3B-8C7E-4B19-ADF9-931B1C17E7AC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{E2D3F10F-A9B7-4694-81CA-20D7F3AD6EEE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{69B86C3B-8C7E-4B19-ADF9-931B1C17E7AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69B86C3B-8C7E-4B19-ADF9-931B1C17E7AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69B86C3B-8C7E-4B19-ADF9-931B1C17E7AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2D3F10F-A9B7-4694-81CA-20D7F3AD6EEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2D3F10F-A9B7-4694-81CA-20D7F3AD6EEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2D3F10F-A9B7-4694-81CA-20D7F3AD6EEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2D3F10F-A9B7-4694-81CA-20D7F3AD6EEE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{9758106C-5D4E-475D-B5E7-B7ABC46B1DDA} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{5BDC8641-E3EE-47B5-BE7B-2D2275402412} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{69B86C3B-8C7E-4B19-ADF9-931B1C17E7AC} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{E2D3F10F-A9B7-4694-81CA-20D7F3AD6EEE} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E55827A2-8680-4A49-858D-70A4E41D2B9F}

--- a/src/libraries/System.Diagnostics.Process/System.Diagnostics.Process.sln
+++ b/src/libraries/System.Diagnostics.Process/System.Diagnostics.Process.sln
@@ -20,7 +20,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{C1978154-3C91-4097-BEC4-027BDCF986B2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{C1978154-3C91-4097-BEC4-027BDCF986B2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Win32.Registry", "..\Microsoft.Win32.Registry\src\Microsoft.Win32.Registry.csproj", "{10384A0E-0C35-4418-86B7-5AD310C4045D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.DirectoryServices", "..\System.DirectoryServices\src\System.DirectoryServices.csproj", "{002BE7CB-4484-4681-8443-433333468546}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{F672F2EB-5B8C-41F6-BF11-6774EAE715A2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\src\System.Security.AccessControl.csproj", "{26A982C2-BEB0-4F23-9ACE-BDA2344D3E62}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj", "{0A7A6B71-9212-4756-B0C1-EE3154A0BDA7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +54,26 @@ Global
 		{C1978154-3C91-4097-BEC4-027BDCF986B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C1978154-3C91-4097-BEC4-027BDCF986B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C1978154-3C91-4097-BEC4-027BDCF986B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10384A0E-0C35-4418-86B7-5AD310C4045D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10384A0E-0C35-4418-86B7-5AD310C4045D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10384A0E-0C35-4418-86B7-5AD310C4045D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10384A0E-0C35-4418-86B7-5AD310C4045D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{002BE7CB-4484-4681-8443-433333468546}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{002BE7CB-4484-4681-8443-433333468546}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{002BE7CB-4484-4681-8443-433333468546}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{002BE7CB-4484-4681-8443-433333468546}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F672F2EB-5B8C-41F6-BF11-6774EAE715A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F672F2EB-5B8C-41F6-BF11-6774EAE715A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F672F2EB-5B8C-41F6-BF11-6774EAE715A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F672F2EB-5B8C-41F6-BF11-6774EAE715A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26A982C2-BEB0-4F23-9ACE-BDA2344D3E62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26A982C2-BEB0-4F23-9ACE-BDA2344D3E62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26A982C2-BEB0-4F23-9ACE-BDA2344D3E62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26A982C2-BEB0-4F23-9ACE-BDA2344D3E62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A7A6B71-9212-4756-B0C1-EE3154A0BDA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A7A6B71-9212-4756-B0C1-EE3154A0BDA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A7A6B71-9212-4756-B0C1-EE3154A0BDA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A7A6B71-9212-4756-B0C1-EE3154A0BDA7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +83,11 @@ Global
 		{F55047F8-E47B-46E3-B221-C23595AFE168} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{98B33275-39D8-4997-867D-04C69C69885E} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{C1978154-3C91-4097-BEC4-027BDCF986B2} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{10384A0E-0C35-4418-86B7-5AD310C4045D} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{002BE7CB-4484-4681-8443-433333468546} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{F672F2EB-5B8C-41F6-BF11-6774EAE715A2} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{26A982C2-BEB0-4F23-9ACE-BDA2344D3E62} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{0A7A6B71-9212-4756-B0C1-EE3154A0BDA7} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {80AB55A3-9829-474C-B17D-CC239ECC04CE}

--- a/src/libraries/System.DirectoryServices.AccountManagement/System.DirectoryServices.AccountManagement.sln
+++ b/src/libraries/System.DirectoryServices.AccountManagement/System.DirectoryServices.AccountManagement.sln
@@ -20,7 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{481EC106-6480-409E-93E3-DF8FE0F401C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{481EC106-6480-409E-93E3-DF8FE0F401C8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\src\System.Security.AccessControl.csproj", "{25086586-A4AF-48C6-829C-BEB064B70704}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj", "{E5423545-B56C-4DCA-B41E-325F2F3D4197}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +48,14 @@ Global
 		{481EC106-6480-409E-93E3-DF8FE0F401C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{481EC106-6480-409E-93E3-DF8FE0F401C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{481EC106-6480-409E-93E3-DF8FE0F401C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25086586-A4AF-48C6-829C-BEB064B70704}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25086586-A4AF-48C6-829C-BEB064B70704}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25086586-A4AF-48C6-829C-BEB064B70704}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25086586-A4AF-48C6-829C-BEB064B70704}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5423545-B56C-4DCA-B41E-325F2F3D4197}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5423545-B56C-4DCA-B41E-325F2F3D4197}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5423545-B56C-4DCA-B41E-325F2F3D4197}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5423545-B56C-4DCA-B41E-325F2F3D4197}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +65,8 @@ Global
 		{879C23DC-D828-4DFB-8E92-ABBC11B71035} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{404455B6-466C-4F78-9DCC-C37DCC0B75DA} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{481EC106-6480-409E-93E3-DF8FE0F401C8} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{25086586-A4AF-48C6-829C-BEB064B70704} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{E5423545-B56C-4DCA-B41E-325F2F3D4197} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D2C151C-899E-483D-9E18-F1E22EB5425C}

--- a/src/libraries/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols.sln
+++ b/src/libraries/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols.sln
@@ -17,10 +17,15 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
+	ProjectSection(SolutionItems) = preProject
+		..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj = ..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{B71108C0-4466-472C-880D-B54081E7E16A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{B71108C0-4466-472C-880D-B54081E7E16A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj", "{D83F1C43-072E-49BE-93E5-C3ADF904611E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +49,10 @@ Global
 		{B71108C0-4466-472C-880D-B54081E7E16A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B71108C0-4466-472C-880D-B54081E7E16A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B71108C0-4466-472C-880D-B54081E7E16A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D83F1C43-072E-49BE-93E5-C3ADF904611E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D83F1C43-072E-49BE-93E5-C3ADF904611E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D83F1C43-072E-49BE-93E5-C3ADF904611E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D83F1C43-072E-49BE-93E5-C3ADF904611E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +62,7 @@ Global
 		{135980AC-4583-44EC-894E-CB3B1A481920} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{7DEA4539-9A0D-4801-B229-3824710EBCEE} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{B71108C0-4466-472C-880D-B54081E7E16A} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{D83F1C43-072E-49BE-93E5-C3ADF904611E} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DBE446A9-A8D4-47DC-AF12-E8FA5BF9685C}

--- a/src/libraries/System.DirectoryServices/System.DirectoryServices.sln
+++ b/src/libraries/System.DirectoryServices/System.DirectoryServices.sln
@@ -20,7 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{7140F6A9-8DBB-4D3C-87D4-0DCF5181B3E2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{7140F6A9-8DBB-4D3C-87D4-0DCF5181B3E2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\src\System.Security.AccessControl.csproj", "{0A2B3166-6D7A-4561-B663-A0029CF10231}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{E6D3A629-3F73-4A23-87BD-67F1E213F5EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +48,14 @@ Global
 		{7140F6A9-8DBB-4D3C-87D4-0DCF5181B3E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7140F6A9-8DBB-4D3C-87D4-0DCF5181B3E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7140F6A9-8DBB-4D3C-87D4-0DCF5181B3E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A2B3166-6D7A-4561-B663-A0029CF10231}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A2B3166-6D7A-4561-B663-A0029CF10231}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A2B3166-6D7A-4561-B663-A0029CF10231}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A2B3166-6D7A-4561-B663-A0029CF10231}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6D3A629-3F73-4A23-87BD-67F1E213F5EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6D3A629-3F73-4A23-87BD-67F1E213F5EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6D3A629-3F73-4A23-87BD-67F1E213F5EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6D3A629-3F73-4A23-87BD-67F1E213F5EE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +65,8 @@ Global
 		{EC9B0FBC-C3A2-44E6-BFC6-51E565061C28} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{CBCDA53B-4C01-4267-B08C-413205FE4D8D} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{7140F6A9-8DBB-4D3C-87D4-0DCF5181B3E2} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{0A2B3166-6D7A-4561-B663-A0029CF10231} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{E6D3A629-3F73-4A23-87BD-67F1E213F5EE} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {88FABF55-3145-4BBD-908F-BDB2AEB4742B}

--- a/src/libraries/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
+++ b/src/libraries/System.IO.IsolatedStorage/System.IO.IsolatedStorage.sln
@@ -20,7 +20,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{BA259C30-B614-48A6-B980-848FA2F86795}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{BA259C30-B614-48A6-B980-848FA2F86795}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.DirectoryServices", "..\System.DirectoryServices\src\System.DirectoryServices.csproj", "{AFDD997A-47C0-403E-A56E-1E4CAF012D86}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\src\System.Security.AccessControl.csproj", "{B4B92CA4-0B26-4BBA-861B-4DB16BB85716}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj", "{BBA3A492-29C3-494A-8529-EB3E55E21188}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +50,18 @@ Global
 		{BA259C30-B614-48A6-B980-848FA2F86795}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA259C30-B614-48A6-B980-848FA2F86795}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA259C30-B614-48A6-B980-848FA2F86795}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFDD997A-47C0-403E-A56E-1E4CAF012D86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFDD997A-47C0-403E-A56E-1E4CAF012D86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFDD997A-47C0-403E-A56E-1E4CAF012D86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFDD997A-47C0-403E-A56E-1E4CAF012D86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4B92CA4-0B26-4BBA-861B-4DB16BB85716}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4B92CA4-0B26-4BBA-861B-4DB16BB85716}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4B92CA4-0B26-4BBA-861B-4DB16BB85716}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4B92CA4-0B26-4BBA-861B-4DB16BB85716}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBA3A492-29C3-494A-8529-EB3E55E21188}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBA3A492-29C3-494A-8529-EB3E55E21188}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBA3A492-29C3-494A-8529-EB3E55E21188}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBA3A492-29C3-494A-8529-EB3E55E21188}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +71,9 @@ Global
 		{FAF5D1E4-BA43-4663-8429-C069066D75CB} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{750200D5-661A-42AA-9E1F-2A151F5AEE74} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{BA259C30-B614-48A6-B980-848FA2F86795} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{AFDD997A-47C0-403E-A56E-1E4CAF012D86} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{B4B92CA4-0B26-4BBA-861B-4DB16BB85716} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{BBA3A492-29C3-494A-8529-EB3E55E21188} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B771C8B1-8D0C-4DF8-95F5-9CFD75660C47}

--- a/src/libraries/System.IO.Pipes.AccessControl/System.IO.Pipes.AccessControl.sln
+++ b/src/libraries/System.IO.Pipes.AccessControl/System.IO.Pipes.AccessControl.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Pipes", "..\Syste
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\src\System.Security.AccessControl.csproj", "{7C35E697-38D0-4A2C-BC25-816732BA2D91}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{9FF89FBB-D353-490B-8AB8-FD22D9F7078F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{7C35E697-38D0-4A2C-BC25-816732BA2D91}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C35E697-38D0-4A2C-BC25-816732BA2D91}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C35E697-38D0-4A2C-BC25-816732BA2D91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FF89FBB-D353-490B-8AB8-FD22D9F7078F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FF89FBB-D353-490B-8AB8-FD22D9F7078F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FF89FBB-D353-490B-8AB8-FD22D9F7078F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FF89FBB-D353-490B-8AB8-FD22D9F7078F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,6 +73,7 @@ Global
 		{3B8D8597-DC68-4915-8C2A-1DC33E78E607} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{D0711B56-E234-45DB-A620-2F43041826BB} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{7C35E697-38D0-4A2C-BC25-816732BA2D91} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{9FF89FBB-D353-490B-8AB8-FD22D9F7078F} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AFD36AE1-C562-46E4-8D24-6F36C0F106B1}

--- a/src/libraries/System.IO.Pipes/System.IO.Pipes.sln
+++ b/src/libraries/System.IO.Pipes/System.IO.Pipes.sln
@@ -20,7 +20,21 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{CBDA9624-90C8-4236-8883-EDFA0D92C724}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{CBDA9624-90C8-4236-8883-EDFA0D92C724}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.DirectoryServices", "..\System.DirectoryServices\src\System.DirectoryServices.csproj", "{561A78B7-BBD8-43F1-8676-6BB2B8EE3117}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.DirectoryServices.AccountManagement", "..\System.DirectoryServices.AccountManagement\src\System.DirectoryServices.AccountManagement.csproj", "{3B54F94E-638F-48D4-87CB-724F606A74C6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\src\System.Security.AccessControl.csproj", "{A2540E63-E78D-464C-86A7-C2164ED35C0C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.AccessControl", "..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj", "{071A9F4C-4D02-4B1B-9CD3-B70F1DA9EAA4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{C5ADCD8C-B77A-4442-8472-69B4D3A57D4F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj", "{8B5631FB-6CD7-4CBD-A7D9-37FC73ACB362}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.DirectoryServices.Protocols", "..\System.DirectoryServices.Protocols\src\System.DirectoryServices.Protocols.csproj", "{50C55A28-BA79-4CC3-A140-FA280954CBE7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +58,34 @@ Global
 		{CBDA9624-90C8-4236-8883-EDFA0D92C724}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBDA9624-90C8-4236-8883-EDFA0D92C724}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBDA9624-90C8-4236-8883-EDFA0D92C724}.Release|Any CPU.Build.0 = Release|Any CPU
+		{561A78B7-BBD8-43F1-8676-6BB2B8EE3117}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{561A78B7-BBD8-43F1-8676-6BB2B8EE3117}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{561A78B7-BBD8-43F1-8676-6BB2B8EE3117}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{561A78B7-BBD8-43F1-8676-6BB2B8EE3117}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B54F94E-638F-48D4-87CB-724F606A74C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B54F94E-638F-48D4-87CB-724F606A74C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B54F94E-638F-48D4-87CB-724F606A74C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B54F94E-638F-48D4-87CB-724F606A74C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2540E63-E78D-464C-86A7-C2164ED35C0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2540E63-E78D-464C-86A7-C2164ED35C0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2540E63-E78D-464C-86A7-C2164ED35C0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2540E63-E78D-464C-86A7-C2164ED35C0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{071A9F4C-4D02-4B1B-9CD3-B70F1DA9EAA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{071A9F4C-4D02-4B1B-9CD3-B70F1DA9EAA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{071A9F4C-4D02-4B1B-9CD3-B70F1DA9EAA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{071A9F4C-4D02-4B1B-9CD3-B70F1DA9EAA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5ADCD8C-B77A-4442-8472-69B4D3A57D4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5ADCD8C-B77A-4442-8472-69B4D3A57D4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5ADCD8C-B77A-4442-8472-69B4D3A57D4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5ADCD8C-B77A-4442-8472-69B4D3A57D4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B5631FB-6CD7-4CBD-A7D9-37FC73ACB362}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B5631FB-6CD7-4CBD-A7D9-37FC73ACB362}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B5631FB-6CD7-4CBD-A7D9-37FC73ACB362}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B5631FB-6CD7-4CBD-A7D9-37FC73ACB362}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50C55A28-BA79-4CC3-A140-FA280954CBE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50C55A28-BA79-4CC3-A140-FA280954CBE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50C55A28-BA79-4CC3-A140-FA280954CBE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50C55A28-BA79-4CC3-A140-FA280954CBE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +95,13 @@ Global
 		{D293A0E4-AE6C-4DF7-99AE-CC1A37BF4918} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{38B2B275-FB29-45C6-9E68-9ECEBC6BD874} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{CBDA9624-90C8-4236-8883-EDFA0D92C724} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{561A78B7-BBD8-43F1-8676-6BB2B8EE3117} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{3B54F94E-638F-48D4-87CB-724F606A74C6} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{A2540E63-E78D-464C-86A7-C2164ED35C0C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{071A9F4C-4D02-4B1B-9CD3-B70F1DA9EAA4} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{C5ADCD8C-B77A-4442-8472-69B4D3A57D4F} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{8B5631FB-6CD7-4CBD-A7D9-37FC73ACB362} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{50C55A28-BA79-4CC3-A140-FA280954CBE7} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F531A2FC-20AC-4B49-8C87-B9D69F2F2055}

--- a/src/libraries/System.IO.Ports/System.IO.Ports.sln
+++ b/src/libraries/System.IO.Ports/System.IO.Ports.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{5D4A4B8C-7DC1-4BAA-BE24-868664E8ECCA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{5D4A4B8C-7DC1-4BAA-BE24-868664E8ECCA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encoding.CodePages", "..\System.Text.Encoding.CodePages\src\System.Text.Encoding.CodePages.csproj", "{1FFC7E45-A4A6-4658-BDC0-1D9AD22FDC1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{5D4A4B8C-7DC1-4BAA-BE24-868664E8ECCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D4A4B8C-7DC1-4BAA-BE24-868664E8ECCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D4A4B8C-7DC1-4BAA-BE24-868664E8ECCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FFC7E45-A4A6-4658-BDC0-1D9AD22FDC1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FFC7E45-A4A6-4658-BDC0-1D9AD22FDC1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FFC7E45-A4A6-4658-BDC0-1D9AD22FDC1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FFC7E45-A4A6-4658-BDC0-1D9AD22FDC1B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{187503F4-BEF9-4369-A1B2-E3DC5D564E4E} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{75DE4259-43BB-4067-9F30-3AC920D51AEC} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{5D4A4B8C-7DC1-4BAA-BE24-868664E8ECCA} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{1FFC7E45-A4A6-4658-BDC0-1D9AD22FDC1B} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6245C4C2-9217-41E3-A9FA-8118DA599D2B}

--- a/src/libraries/System.Net.Http/System.Net.Http.sln
+++ b/src/libraries/System.Net.Http/System.Net.Http.sln
@@ -25,7 +25,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{9448438C-CF47-4242-9D82-77FCCFCCA1AB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{9448438C-CF47-4242-9D82-77FCCFCCA1AB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Private.Runtime.InteropServices.JavaScript", "..\System.Private.Runtime.InteropServices.JavaScript\src\System.Private.Runtime.InteropServices.JavaScript.csproj", "{F961BB0E-7498-49B8-A170-8F1DA2D087E6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{57B70EA9-DE3A-4DA6-B3BF-09591D0ED6E1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.DirectoryServices.Protocols", "..\System.DirectoryServices.Protocols\src\System.DirectoryServices.Protocols.csproj", "{60FA26B9-8BE2-4ACB-8DE2-AD467A75AE53}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +59,18 @@ Global
 		{9448438C-CF47-4242-9D82-77FCCFCCA1AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9448438C-CF47-4242-9D82-77FCCFCCA1AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9448438C-CF47-4242-9D82-77FCCFCCA1AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F961BB0E-7498-49B8-A170-8F1DA2D087E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F961BB0E-7498-49B8-A170-8F1DA2D087E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F961BB0E-7498-49B8-A170-8F1DA2D087E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F961BB0E-7498-49B8-A170-8F1DA2D087E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57B70EA9-DE3A-4DA6-B3BF-09591D0ED6E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57B70EA9-DE3A-4DA6-B3BF-09591D0ED6E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57B70EA9-DE3A-4DA6-B3BF-09591D0ED6E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57B70EA9-DE3A-4DA6-B3BF-09591D0ED6E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60FA26B9-8BE2-4ACB-8DE2-AD467A75AE53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60FA26B9-8BE2-4ACB-8DE2-AD467A75AE53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60FA26B9-8BE2-4ACB-8DE2-AD467A75AE53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60FA26B9-8BE2-4ACB-8DE2-AD467A75AE53}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -63,6 +81,9 @@ Global
 		{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{132BF813-FC40-4D39-8B6F-E55D7633F0ED} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{9448438C-CF47-4242-9D82-77FCCFCCA1AB} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{F961BB0E-7498-49B8-A170-8F1DA2D087E6} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{57B70EA9-DE3A-4DA6-B3BF-09591D0ED6E1} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{60FA26B9-8BE2-4ACB-8DE2-AD467A75AE53} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5100F629-0FAB-4C6F-9A54-95AE9565EE0D}

--- a/src/libraries/System.Net.Requests/System.Net.Requests.sln
+++ b/src/libraries/System.Net.Requests/System.Net.Requests.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{B0F5B1D3-AD4E-4FB4-B35C-414BEB5B1D9E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{B0F5B1D3-AD4E-4FB4-B35C-414BEB5B1D9E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{7EA95C68-6FBC-424B-985F-F6FABEE52277}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{B0F5B1D3-AD4E-4FB4-B35C-414BEB5B1D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0F5B1D3-AD4E-4FB4-B35C-414BEB5B1D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0F5B1D3-AD4E-4FB4-B35C-414BEB5B1D9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EA95C68-6FBC-424B-985F-F6FABEE52277}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EA95C68-6FBC-424B-985F-F6FABEE52277}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EA95C68-6FBC-424B-985F-F6FABEE52277}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EA95C68-6FBC-424B-985F-F6FABEE52277}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{5EE76DCC-9FD5-47FD-AB45-BD0F0857740F} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{F86C715C-E37B-4853-869E-D696AB3DB057} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{B0F5B1D3-AD4E-4FB4-B35C-414BEB5B1D9E} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{7EA95C68-6FBC-424B-985F-F6FABEE52277} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {05B55060-524A-407F-A69E-BD06F6EBCFF3}

--- a/src/libraries/System.Net.Security/System.Net.Security.sln
+++ b/src/libraries/System.Net.Security/System.Net.Security.sln
@@ -25,7 +25,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3C4504D2-95D0-4F41-9BC7-8335C3A0CF59}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3C4504D2-95D0-4F41-9BC7-8335C3A0CF59}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{F7989D79-2F16-413E-A070-353E95CB7CFD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj", "{47104C68-B3D1-42FA-AD78-C9C7EB534764}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +57,14 @@ Global
 		{3C4504D2-95D0-4F41-9BC7-8335C3A0CF59}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C4504D2-95D0-4F41-9BC7-8335C3A0CF59}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C4504D2-95D0-4F41-9BC7-8335C3A0CF59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7989D79-2F16-413E-A070-353E95CB7CFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7989D79-2F16-413E-A070-353E95CB7CFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7989D79-2F16-413E-A070-353E95CB7CFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7989D79-2F16-413E-A070-353E95CB7CFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47104C68-B3D1-42FA-AD78-C9C7EB534764}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47104C68-B3D1-42FA-AD78-C9C7EB534764}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47104C68-B3D1-42FA-AD78-C9C7EB534764}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47104C68-B3D1-42FA-AD78-C9C7EB534764}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -63,6 +75,8 @@ Global
 		{89F37791-6254-4D60-AB96-ACD3CCA0E771} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{A7488FC0-9A8F-4EF9-BC3E-C5EBA47E13F8} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{3C4504D2-95D0-4F41-9BC7-8335C3A0CF59} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{F7989D79-2F16-413E-A070-353E95CB7CFD} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{47104C68-B3D1-42FA-AD78-C9C7EB534764} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5681D01F-0E3B-4BB3-9251-B78F91819933}

--- a/src/libraries/System.Net.Sockets/System.Net.Sockets.sln
+++ b/src/libraries/System.Net.Sockets/System.Net.Sockets.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{5BE7D6FF-0B45-4D54-B831-7EEA1EBAF40E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{5BE7D6FF-0B45-4D54-B831-7EEA1EBAF40E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{B66FC459-DC02-4F00-8542-D7F829354FE2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{5BE7D6FF-0B45-4D54-B831-7EEA1EBAF40E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5BE7D6FF-0B45-4D54-B831-7EEA1EBAF40E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5BE7D6FF-0B45-4D54-B831-7EEA1EBAF40E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B66FC459-DC02-4F00-8542-D7F829354FE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B66FC459-DC02-4F00-8542-D7F829354FE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B66FC459-DC02-4F00-8542-D7F829354FE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B66FC459-DC02-4F00-8542-D7F829354FE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{834E3534-6A11-4A8D-923F-35C1E71CCEC3} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{5BE7D6FF-0B45-4D54-B831-7EEA1EBAF40E} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{B66FC459-DC02-4F00-8542-D7F829354FE2} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E33D5E2-B9BF-49D1-99FA-3C9AC3412636}

--- a/src/libraries/System.Net.WebSockets.Client/System.Net.WebSockets.Client.sln
+++ b/src/libraries/System.Net.WebSockets.Client/System.Net.WebSockets.Client.sln
@@ -20,7 +20,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{7E207B06-C3D0-4F00-A061-7E9C45C9EC13}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{7E207B06-C3D0-4F00-A061-7E9C45C9EC13}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Private.Runtime.InteropServices.JavaScript", "..\System.Private.Runtime.InteropServices.JavaScript\src\System.Private.Runtime.InteropServices.JavaScript.csproj", "{58F172DB-B19E-44DD-9F53-8F165DC70FF1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{7E207B06-C3D0-4F00-A061-7E9C45C9EC13}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E207B06-C3D0-4F00-A061-7E9C45C9EC13}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E207B06-C3D0-4F00-A061-7E9C45C9EC13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58F172DB-B19E-44DD-9F53-8F165DC70FF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58F172DB-B19E-44DD-9F53-8F165DC70FF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58F172DB-B19E-44DD-9F53-8F165DC70FF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58F172DB-B19E-44DD-9F53-8F165DC70FF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{B8AD98AE-84C3-4313-B3F1-EE8BD5BFF69B} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{F282B57E-2E1E-422B-8AC2-88145E37B809} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{7E207B06-C3D0-4F00-A061-7E9C45C9EC13} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{58F172DB-B19E-44DD-9F53-8F165DC70FF1} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0998F457-1A03-4825-96F4-9B6EFC1F08EF}

--- a/src/libraries/System.Reflection.MetadataLoadContext/System.Reflection.MetadataLoadContext.sln
+++ b/src/libraries/System.Reflection.MetadataLoadContext/System.Reflection.MetadataLoadContext.sln
@@ -20,7 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{74668CA1-2F2C-4B5C-85DD-15AA365F3B80}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{74668CA1-2F2C-4B5C-85DD-15AA365F3B80}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Collections.Immutable", "..\System.Collections.Immutable\src\System.Collections.Immutable.csproj", "{FC9B8AAE-D10B-449D-BF2A-FEC52A06B35C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Collections.Immutable", "..\System.Collections.Immutable\ref\System.Collections.Immutable.csproj", "{32081058-2274-4539-9CA5-38B5D7C5E672}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +48,14 @@ Global
 		{74668CA1-2F2C-4B5C-85DD-15AA365F3B80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74668CA1-2F2C-4B5C-85DD-15AA365F3B80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74668CA1-2F2C-4B5C-85DD-15AA365F3B80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC9B8AAE-D10B-449D-BF2A-FEC52A06B35C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC9B8AAE-D10B-449D-BF2A-FEC52A06B35C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC9B8AAE-D10B-449D-BF2A-FEC52A06B35C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC9B8AAE-D10B-449D-BF2A-FEC52A06B35C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32081058-2274-4539-9CA5-38B5D7C5E672}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32081058-2274-4539-9CA5-38B5D7C5E672}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32081058-2274-4539-9CA5-38B5D7C5E672}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32081058-2274-4539-9CA5-38B5D7C5E672}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +65,8 @@ Global
 		{DBB18588-DD89-4F41-9852-484FD4726F0F} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{EC84D608-71BC-4FE4-86C8-CA30F3B0CC7D} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{74668CA1-2F2C-4B5C-85DD-15AA365F3B80} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{FC9B8AAE-D10B-449D-BF2A-FEC52A06B35C} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{32081058-2274-4539-9CA5-38B5D7C5E672} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {34BA9CE0-95B8-42D8-B2E1-84D1EB36A8DD}

--- a/src/libraries/System.Runtime/System.Runtime.sln
+++ b/src/libraries/System.Runtime/System.Runtime.sln
@@ -45,9 +45,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{9EE64AF5-E04D-4E0E-8D87-F263E3CAF247}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{9EE64AF5-E04D-4E0E-8D87-F263E3CAF247}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities.Unicode", "..\Common\tests\TestUtilities.Unicode\TestUtilities.Unicode.csproj", "{D7833CAD-D4DB-4E60-8F77-A8EFF4B2D86B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities.Unicode", "..\Common\tests\TestUtilities.Unicode\TestUtilities.Unicode.csproj", "{D7833CAD-D4DB-4E60-8F77-A8EFF4B2D86B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Threading.AccessControl", "..\System.Threading.AccessControl\src\System.Threading.AccessControl.csproj", "{3F03994E-1DC1-4E4C-85A7-959DD2E0DF77}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Threading.AccessControl", "..\System.Threading.AccessControl\ref\System.Threading.AccessControl.csproj", "{BF625DC7-6F53-42F4-9642-DDFBCE37A198}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{0AB1DC13-8721-40D8-BD85-F4BA9CEBB04D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj", "{F4F3BD8B-FFA7-4982-8316-F98543688F48}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -95,6 +103,22 @@ Global
 		{D7833CAD-D4DB-4E60-8F77-A8EFF4B2D86B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7833CAD-D4DB-4E60-8F77-A8EFF4B2D86B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D7833CAD-D4DB-4E60-8F77-A8EFF4B2D86B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F03994E-1DC1-4E4C-85A7-959DD2E0DF77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F03994E-1DC1-4E4C-85A7-959DD2E0DF77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F03994E-1DC1-4E4C-85A7-959DD2E0DF77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F03994E-1DC1-4E4C-85A7-959DD2E0DF77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF625DC7-6F53-42F4-9642-DDFBCE37A198}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF625DC7-6F53-42F4-9642-DDFBCE37A198}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF625DC7-6F53-42F4-9642-DDFBCE37A198}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF625DC7-6F53-42F4-9642-DDFBCE37A198}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AB1DC13-8721-40D8-BD85-F4BA9CEBB04D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AB1DC13-8721-40D8-BD85-F4BA9CEBB04D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AB1DC13-8721-40D8-BD85-F4BA9CEBB04D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AB1DC13-8721-40D8-BD85-F4BA9CEBB04D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4F3BD8B-FFA7-4982-8316-F98543688F48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4F3BD8B-FFA7-4982-8316-F98543688F48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4F3BD8B-FFA7-4982-8316-F98543688F48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4F3BD8B-FFA7-4982-8316-F98543688F48}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +134,10 @@ Global
 		{ADBCF120-3454-4A3C-9D1D-AC4293E795D6} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{9EE64AF5-E04D-4E0E-8D87-F263E3CAF247} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{D7833CAD-D4DB-4E60-8F77-A8EFF4B2D86B} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{3F03994E-1DC1-4E4C-85A7-959DD2E0DF77} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{BF625DC7-6F53-42F4-9642-DDFBCE37A198} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{0AB1DC13-8721-40D8-BD85-F4BA9CEBB04D} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{F4F3BD8B-FFA7-4982-8316-F98543688F48} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBD1A5A2-A6F0-444D-9D7D-86D77604F1F5}

--- a/src/libraries/System.Security.AccessControl/System.Security.AccessControl.sln
+++ b/src/libraries/System.Security.AccessControl/System.Security.AccessControl.sln
@@ -20,7 +20,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{7BC2D7E9-03C7-4577-A895-6EB91B6A7EA3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{7BC2D7E9-03C7-4577-A895-6EB91B6A7EA3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Principal.Windows", "..\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj", "{63FBCE4E-F0C3-47C3-B81D-B36DF90E863E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.FileSystem.AccessControl", "..\System.IO.FileSystem.AccessControl\src\System.IO.FileSystem.AccessControl.csproj", "{558BD942-0BD3-47F7-9157-7DD44A9AB680}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.FileSystem.AccessControl", "..\System.IO.FileSystem.AccessControl\ref\System.IO.FileSystem.AccessControl.csproj", "{CDE508D9-64AA-4FF0-BFCC-34E5833E9EF7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +50,18 @@ Global
 		{7BC2D7E9-03C7-4577-A895-6EB91B6A7EA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BC2D7E9-03C7-4577-A895-6EB91B6A7EA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BC2D7E9-03C7-4577-A895-6EB91B6A7EA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63FBCE4E-F0C3-47C3-B81D-B36DF90E863E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63FBCE4E-F0C3-47C3-B81D-B36DF90E863E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63FBCE4E-F0C3-47C3-B81D-B36DF90E863E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63FBCE4E-F0C3-47C3-B81D-B36DF90E863E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{558BD942-0BD3-47F7-9157-7DD44A9AB680}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{558BD942-0BD3-47F7-9157-7DD44A9AB680}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{558BD942-0BD3-47F7-9157-7DD44A9AB680}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{558BD942-0BD3-47F7-9157-7DD44A9AB680}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDE508D9-64AA-4FF0-BFCC-34E5833E9EF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDE508D9-64AA-4FF0-BFCC-34E5833E9EF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDE508D9-64AA-4FF0-BFCC-34E5833E9EF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDE508D9-64AA-4FF0-BFCC-34E5833E9EF7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +71,9 @@ Global
 		{D27FFA1F-B446-4D24-B60A-1F88385CDB6D} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{7BC2D7E9-03C7-4577-A895-6EB91B6A7EA3} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{63FBCE4E-F0C3-47C3-B81D-B36DF90E863E} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{558BD942-0BD3-47F7-9157-7DD44A9AB680} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{CDE508D9-64AA-4FF0-BFCC-34E5833E9EF7} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB302CDD-C173-44F3-B0F3-C9C36248368E}

--- a/src/libraries/System.Security.Cryptography.Algorithms/System.Security.Cryptography.Algorithms.sln
+++ b/src/libraries/System.Security.Cryptography.Algorithms/System.Security.Cryptography.Algorithms.sln
@@ -20,7 +20,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3F87192A-32C0-4D92-A28C-D104FB86CBFB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{3F87192A-32C0-4D92-A28C-D104FB86CBFB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Cryptography.Pkcs", "..\System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj", "{6AFF5C9C-E124-4601-B878-AAC6C2492D91}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Cryptography.Cng", "..\System.Security.Cryptography.Cng\src\System.Security.Cryptography.Cng.csproj", "{5476420A-39F1-4C56-B7F5-E3F471C939E3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Cryptography.Cng", "..\System.Security.Cryptography.Cng\ref\System.Security.Cryptography.Cng.csproj", "{EF32F89B-40FC-4A96-83B4-2EBC6069331B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Formats.Asn1", "..\System.Formats.Asn1\src\System.Formats.Asn1.csproj", "{45E3EFF0-CA94-4DD3-984D-FF6556E11314}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Formats.Asn1", "..\System.Formats.Asn1\ref\System.Formats.Asn1.csproj", "{ED755DCE-D1BC-49AB-998D-9C70A7682D29}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +54,26 @@ Global
 		{3F87192A-32C0-4D92-A28C-D104FB86CBFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F87192A-32C0-4D92-A28C-D104FB86CBFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F87192A-32C0-4D92-A28C-D104FB86CBFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AFF5C9C-E124-4601-B878-AAC6C2492D91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AFF5C9C-E124-4601-B878-AAC6C2492D91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AFF5C9C-E124-4601-B878-AAC6C2492D91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AFF5C9C-E124-4601-B878-AAC6C2492D91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5476420A-39F1-4C56-B7F5-E3F471C939E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5476420A-39F1-4C56-B7F5-E3F471C939E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5476420A-39F1-4C56-B7F5-E3F471C939E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5476420A-39F1-4C56-B7F5-E3F471C939E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF32F89B-40FC-4A96-83B4-2EBC6069331B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF32F89B-40FC-4A96-83B4-2EBC6069331B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF32F89B-40FC-4A96-83B4-2EBC6069331B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF32F89B-40FC-4A96-83B4-2EBC6069331B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45E3EFF0-CA94-4DD3-984D-FF6556E11314}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45E3EFF0-CA94-4DD3-984D-FF6556E11314}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45E3EFF0-CA94-4DD3-984D-FF6556E11314}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45E3EFF0-CA94-4DD3-984D-FF6556E11314}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED755DCE-D1BC-49AB-998D-9C70A7682D29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED755DCE-D1BC-49AB-998D-9C70A7682D29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED755DCE-D1BC-49AB-998D-9C70A7682D29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED755DCE-D1BC-49AB-998D-9C70A7682D29}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +83,11 @@ Global
 		{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{102247C1-3DB9-4DB5-80B3-EE9F80DD4E8F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{3F87192A-32C0-4D92-A28C-D104FB86CBFB} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{6AFF5C9C-E124-4601-B878-AAC6C2492D91} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{5476420A-39F1-4C56-B7F5-E3F471C939E3} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{EF32F89B-40FC-4A96-83B4-2EBC6069331B} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{45E3EFF0-CA94-4DD3-984D-FF6556E11314} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{ED755DCE-D1BC-49AB-998D-9C70A7682D29} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CC136687-FDBD-4E35-9849-99D64A0D816B}

--- a/src/libraries/System.Security.Cryptography.Cng/System.Security.Cryptography.Cng.sln
+++ b/src/libraries/System.Security.Cryptography.Cng/System.Security.Cryptography.Cng.sln
@@ -20,7 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{2E55E921-96F9-409F-8C35-9822C7479E18}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{2E55E921-96F9-409F-8C35-9822C7479E18}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Formats.Asn1", "..\System.Formats.Asn1\src\System.Formats.Asn1.csproj", "{8BCD3F52-16B5-417D-8297-C072F0B43AC4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Formats.Asn1", "..\System.Formats.Asn1\ref\System.Formats.Asn1.csproj", "{2992D6A4-3B63-455D-AABB-5FFFA56508DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +48,14 @@ Global
 		{2E55E921-96F9-409F-8C35-9822C7479E18}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E55E921-96F9-409F-8C35-9822C7479E18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E55E921-96F9-409F-8C35-9822C7479E18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BCD3F52-16B5-417D-8297-C072F0B43AC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BCD3F52-16B5-417D-8297-C072F0B43AC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BCD3F52-16B5-417D-8297-C072F0B43AC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BCD3F52-16B5-417D-8297-C072F0B43AC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2992D6A4-3B63-455D-AABB-5FFFA56508DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2992D6A4-3B63-455D-AABB-5FFFA56508DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2992D6A4-3B63-455D-AABB-5FFFA56508DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2992D6A4-3B63-455D-AABB-5FFFA56508DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +65,8 @@ Global
 		{4C1BD451-6A99-45E7-9339-79C77C42EE9E} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{9FD12550-3A7C-49D3-9A1E-C4B7410989DD} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{2E55E921-96F9-409F-8C35-9822C7479E18} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{8BCD3F52-16B5-417D-8297-C072F0B43AC4} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{2992D6A4-3B63-455D-AABB-5FFFA56508DE} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {946D0BC8-AC86-4941-8E28-FC386E071E93}

--- a/src/libraries/System.Security.Cryptography.OpenSsl/System.Security.Cryptography.OpenSsl.sln
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/System.Security.Cryptography.OpenSsl.sln
@@ -20,7 +20,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{42A6795A-8E6D-4328-B41E-6B1414043CEF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{42A6795A-8E6D-4328-B41E-6B1414043CEF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Formats.Asn1", "..\System.Formats.Asn1\src\System.Formats.Asn1.csproj", "{BE18F993-0BEE-4AA8-8AD1-44E9A81A810C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Formats.Asn1", "..\System.Formats.Asn1\ref\System.Formats.Asn1.csproj", "{03B20A7B-341D-4B2E-9B0F-4FF1DF61F497}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Security.Cryptography.Cng", "..\System.Security.Cryptography.Cng\src\System.Security.Cryptography.Cng.csproj", "{32356F97-5DF7-4808-B3CE-67E931159780}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +50,18 @@ Global
 		{42A6795A-8E6D-4328-B41E-6B1414043CEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42A6795A-8E6D-4328-B41E-6B1414043CEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42A6795A-8E6D-4328-B41E-6B1414043CEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE18F993-0BEE-4AA8-8AD1-44E9A81A810C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE18F993-0BEE-4AA8-8AD1-44E9A81A810C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE18F993-0BEE-4AA8-8AD1-44E9A81A810C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE18F993-0BEE-4AA8-8AD1-44E9A81A810C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B20A7B-341D-4B2E-9B0F-4FF1DF61F497}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B20A7B-341D-4B2E-9B0F-4FF1DF61F497}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B20A7B-341D-4B2E-9B0F-4FF1DF61F497}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B20A7B-341D-4B2E-9B0F-4FF1DF61F497}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32356F97-5DF7-4808-B3CE-67E931159780}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32356F97-5DF7-4808-B3CE-67E931159780}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32356F97-5DF7-4808-B3CE-67E931159780}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32356F97-5DF7-4808-B3CE-67E931159780}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +71,9 @@ Global
 		{78452F3E-BA91-47E7-BB0F-02E8A5C116C4} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{8DEA82EF-2214-4295-8CC1-9FFB9B18838F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 		{42A6795A-8E6D-4328-B41E-6B1414043CEF} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{BE18F993-0BEE-4AA8-8AD1-44E9A81A810C} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{03B20A7B-341D-4B2E-9B0F-4FF1DF61F497} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{32356F97-5DF7-4808-B3CE-67E931159780} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {43A2E052-7F63-42D1-B22E-47C2A06358F4}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/40159
Fixes https://github.com/dotnet/runtime/issues/32205

- Upgrade Microsoft.NET.Sdk.IL to get CompileDesignTime target.
- Added CheckVSRestoreRequirements for build being failing due to restore not being done correctly for tfms with platforms. For all other projects restore from the VS will succeed and error wont be triggered.
- setting GenerateDependencyFile to false. A couple of projects were failing in this target due to some references being not set properly for unix configurations. The design time build provide some information but it was not enough to drill into. However, just adding this condition resolve this error, and we are able to run and build all the projects.
- closing the duplicate runtime issue because the message needs to be fixed by the nuget. We have added the suitable features so that this error does not have any effect on the vs experience. As the restore is not run as a part of target, we cannot edit the error message.