### PR TITLE
Fix nullable field warnings in struct constructors

### DIFF
--- a/src/libraries/Common/src/System/Net/CookieParser.cs
+++ b/src/libraries/Common/src/System/Net/CookieParser.cs
@@ -59,6 +59,7 @@ namespace System.Net
         {
             _length = tokenStream.Length;
             _tokenStream = tokenStream;
+            _value = string.Empty;
         }
 
         internal bool EndOfCookie

--- a/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
@@ -15,7 +15,7 @@ namespace Internal.Cryptography
     internal struct CngAlgorithmCore
     {
         private readonly string _disposedName;
-        public CngAlgorithm DefaultKeyType;
+        public CngAlgorithm? DefaultKeyType;
         private CngKey? _lazyKey;
         private bool _disposed;
 


### PR DESCRIPTION
We'd like to fix the bug dotnet/roslyn#48574, which will add [new warnings](https://github.com/dotnet/roslyn/pull/48647#issuecomment-709625930) to the runtime. This PR resolves those warnings.