### PR TITLE
Add ability to parse command line switches without a value

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationExtensions.cs
@@ -23,21 +23,23 @@ namespace Microsoft.Extensions.Configuration
         ///   <para>
         ///     The values passed on the command line, in the <c>args</c> string array, should be a set
         ///     of keys prefixed with two dashes ("--") and then values, separate by either the
-        ///     equals sign ("=") or a space (" ").
+        ///     equals sign ("=") or a space (" "). If a value is omitted, the key is presumed to be
+        ///     a simple switch with the value "true" when evaluated.
         ///   </para>
         ///   <para>
         ///     A forward slash ("/") can be used as an alternative prefix, with either equals or space, and when using
         ///     an equals sign the prefix can be left out altogether.
         ///   </para>
         ///   <para>
-        ///     There are five basic alternative formats for arguments:
-        ///     <c>key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5</c>.
+        ///     There are seven basic alternative formats for arguments:
+        ///     <c>key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5 --key6 /key7</c>.
+        ///     The last two evaluate to the value "true".
         ///   </para>
         /// </remarks>
         /// <example>
-        ///   A simple console application that has five values.
+        ///   A simple console application that has seven values.
         ///   <code>
-        ///     // dotnet run key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5
+        ///     // dotnet run key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5 --key6 /key7
         ///
         ///     using Microsoft.Extensions.Configuration;
         ///     using System;
@@ -58,6 +60,8 @@ namespace Microsoft.Extensions.Configuration
         ///                Console.WriteLine($"Key3: '{config["Key3"]}'");
         ///                Console.WriteLine($"Key4: '{config["Key4"]}'");
         ///                Console.WriteLine($"Key5: '{config["Key5"]}'");
+        ///                Console.WriteLine($"Key6: '{config["Key6"]}'");
+        ///                Console.WriteLine($"Key7: '{config["Key7"]}'");
         ///            }
         ///        }
         ///     }

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationExtensions.cs
@@ -31,15 +31,15 @@ namespace Microsoft.Extensions.Configuration
         ///     an equals sign the prefix can be left out altogether.
         ///   </para>
         ///   <para>
-        ///     There are seven basic alternative formats for arguments:
-        ///     <c>key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5 --key6 /key7</c>.
-        ///     The last two evaluate to the value "true".
+        ///     There are eight basic alternative formats for arguments:
+        ///     <c>key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5 -key6 --key7 /key8</c>.
+        ///     The last three evaluate to the value "true".
         ///   </para>
         /// </remarks>
         /// <example>
-        ///   A simple console application that has seven values.
+        ///   A simple console application that has eight values.
         ///   <code>
-        ///     // dotnet run key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5 --key6 /key7
+        ///     // dotnet run key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5 -key6 --key7 /key8
         ///
         ///     using Microsoft.Extensions.Configuration;
         ///     using System;
@@ -62,6 +62,7 @@ namespace Microsoft.Extensions.Configuration
         ///                Console.WriteLine($"Key5: '{config["Key5"]}'");
         ///                Console.WriteLine($"Key6: '{config["Key6"]}'");
         ///                Console.WriteLine($"Key7: '{config["Key7"]}'");
+        ///                Console.WriteLine($"Key8: '{config["Key8"]}'");
         ///            }
         ///        }
         ///     }

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
@@ -126,9 +126,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                 keyStartIndex = 2;
             }
 
-            int separator = previousArg.IndexOf('=');
+            int separatorIndex = previousArg.IndexOf('=');
 
-            if (separator < 0)
+            if (separatorIndex < 0)
             {
                 // If there is neither equal sign nor prefix in previous argument, it is an invalid format
                 if (keyStartIndex == 0)
@@ -174,7 +174,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine
             }
             else
             {
-                string keySegment = previousArg.Substring(0, separator);
+                string keySegment = previousArg.Substring(0, separatorIndex);
 
                 // If the switch is a key in given switch mappings, interpret it
                 if (_switchMappings != null
@@ -197,10 +197,10 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                 {
                     key = previousArg.Substring(
                         keyStartIndex,
-                        separator - keyStartIndex);
+                        separatorIndex - keyStartIndex);
                 }
 
-                value = previousArg.Substring(separator + 1);
+                value = previousArg.Substring(separatorIndex + 1);
             }
 
             pair = (key, value);

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Extensions.Configuration.CommandLine
 {
@@ -40,13 +39,13 @@ namespace Microsoft.Extensions.Configuration.CommandLine
         public override void Load()
         {
             var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var argArray = Args as string[] ?? Args.ToArray();
+            var argList = new List<string>(Args);
 
-            for (int i = 0; i < argArray.Length; i++)
+            for (int i = 0; i < argList.Count; i++)
             {
-                string currentArg = argArray[i];
+                string currentArg = argList[i];
                 string nextArg =
-                    i + 1 < argArray.Length ? argArray[i + 1] : null;
+                    i + 1 < argList.Count ? argList[i + 1] : null;
                 int keyStartIndex = 0;
 
                 if (currentArg.StartsWith("--"))

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                 string value;
                 if (separator < 0)
                 {
-                    // If there is neither equal sign nor prefix in current arugment, it is an invalid format
+                    // If there is neither equal sign nor prefix in current argument, it is an invalid format
                     if (keyStartIndex == 0)
                     {
                         // Ignore invalid formats
@@ -86,23 +86,21 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                     {
                         key = mappedKey;
                     }
-                    // If the switch starts with a single "-" and it isn't in given mappings , it is an invalid usage so ignore it
-                    else if (keyStartIndex == 1)
-                    {
-                        continue;
-                    }
-                    // Otherwise, use the switch name directly as a key
+                    // If the switch starts with a single "-" and it isn't in given mappings,
+                    // or in any other case, use the switch name directly as a key
                     else
                     {
                         key = currentArg.Substring(keyStartIndex);
                     }
 
-                    // If argument is last in list or next argument begins with
-                    // arg delimiter, treat as switch and record value of "true"
+                    // If the argument is last in list, the next argument begins
+                    // with an arg delimiter, or the next argument contains '=',
+                    // then treat argument as switch and record value of "true"
                     if (nextArg == null
                         || nextArg.StartsWith("--")
                         || nextArg.StartsWith("-")
-                        || nextArg.StartsWith("/"))
+                        || nextArg.StartsWith("/")
+                        || nextArg.Contains("="))
                     {
                         value = "true";
                     }

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                 if (keyStartIndex == 0)
                 {
                     // Ignore invalid formats
-                    pair = (null, null);
+                    pair = default;
                     return false;
                 }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
@@ -115,6 +115,33 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
         }
 
         [Fact]
+        public void CanEvalatePairsWithLinuxPathValues()
+        {
+            var args = new string[]
+            {
+                "-Key1",
+                "/Key2", "/path/to/value2/in/linux",
+                "--Key3",
+                "--Key4=Value4",
+                "/Key5",
+                "/Key6=Value6",
+                "/Key7", "Value7",
+            };
+            var cmdLineConfig = new CommandLineConfigurationProvider(args);
+
+            cmdLineConfig.Load();
+
+            Assert.Equal("true", cmdLineConfig.Get("Key1"));
+            Assert.Equal("/path/to/value2/in/linux", cmdLineConfig.Get("Key2"));
+            Assert.Equal("true", cmdLineConfig.Get("Key3"));
+            Assert.Equal("Value4", cmdLineConfig.Get("Key4"));
+            Assert.Equal("true", cmdLineConfig.Get("Key5"));
+            Assert.Equal("Value6", cmdLineConfig.Get("Key6"));
+            Assert.Equal("Value7", cmdLineConfig.Get("Key7"));
+            Assert.Equal(7, cmdLineConfig.GetChildKeys(new string[0], null).Count());
+        }
+
+        [Fact]
         public void LoadKeyValuePairsFromCommandLineArgumentsWithoutSwitchMappings()
         {
             var args = new string[]

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
                     "Bogus2",
                     "/Key5", "Value5",
                     "Bogus3",
-                    "--Key6",
-                    "/Key7"
+                    "-Key6",
+                    "--Key7",
+                    "/Key8"
                 };
             var cmdLineConfig = new CommandLineConfigurationProvider(args);
 
@@ -52,6 +53,34 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             Assert.Equal("Value5", cmdLineConfig.Get("Key5"));
             Assert.Equal("true", cmdLineConfig.Get("Key6"));
             Assert.Equal("true", cmdLineConfig.Get("Key7"));
+            Assert.Equal("true", cmdLineConfig.Get("Key8"));
+            Assert.Equal(8, cmdLineConfig.GetChildKeys(new string[0], null).Count());
+        }
+
+        [Fact]
+        public void CanEvalatePairsAfterSwitchesWithNoValues()
+        {
+            var args = new string[]
+            {
+                "-Key1",
+                "Key2=Value2",
+                "--Key3",
+                "--Key4=Value4",
+                "/Key5",
+                "/Key6=Value6",
+                "/Key7", "Value7",
+            };
+            var cmdLineConfig = new CommandLineConfigurationProvider(args);
+
+            cmdLineConfig.Load();
+
+            Assert.Equal("true", cmdLineConfig.Get("Key1"));
+            Assert.Equal("Value2", cmdLineConfig.Get("Key2"));
+            Assert.Equal("true", cmdLineConfig.Get("Key3"));
+            Assert.Equal("Value4", cmdLineConfig.Get("Key4"));
+            Assert.Equal("true", cmdLineConfig.Get("Key5"));
+            Assert.Equal("Value6", cmdLineConfig.Get("Key6"));
+            Assert.Equal("Value7", cmdLineConfig.Get("Key7"));
             Assert.Equal(7, cmdLineConfig.GetChildKeys(new string[0], null).Count());
         }
 
@@ -66,8 +95,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
                     "/Key3=Value3",
                     "--Key4", "Value4",
                     "/Key5", "Value5",
-                    "--Key6",
-                    "/Key7"
+                    "-Key6",
+                    "--Key7",
+                    "/Key8"
                 };
             var cmdLineConfig = new CommandLineConfigurationProvider(args);
 
@@ -80,6 +110,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             Assert.Equal("Value5", cmdLineConfig.Get("Key5"));
             Assert.Equal("true", cmdLineConfig.Get("Key6"));
             Assert.Equal("true", cmdLineConfig.Get("Key7"));
+            Assert.Equal("true", cmdLineConfig.Get("Key8"));
         }
 
         [Fact]
@@ -92,13 +123,15 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
                     "/Key3=Value3",
                     "--Key4", "Value4",
                     "/Key5", "Value5",
-                    "/Key6=Value6"
+                    "/Key6=Value6",
+                    "/Key7"
                 };
             var switchMappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "-K1", "LongKey1" },
                     { "--Key2", "SuperLongKey2" },
-                    { "--Key6", "SuchALongKey6"}
+                    { "--Key6", "SuchALongKey6"},
+                    { "--Key7", "BoyWhatAKey7"}
                 };
             var cmdLineConfig = new CommandLineConfigurationProvider(args, switchMappings);
 
@@ -110,6 +143,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             Assert.Equal("Value4", cmdLineConfig.Get("Key4"));
             Assert.Equal("Value5", cmdLineConfig.Get("Key5"));
             Assert.Equal("Value6", cmdLineConfig.Get("SuchALongKey6"));
+            Assert.Equal("true", cmdLineConfig.Get("BoyWhatAKey7"));
         }
 
         [Fact]
@@ -200,13 +234,16 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             var args = new string[]
                 {
                     "/Key1=Value1",
-                    "--Key1=Value2"
+                    "--Key1=Value2",
+                    "-Key2", // As switch, evaluates "true"
+                    "/Key2=false" // Should be overridden to "false" here
                 };
             var cmdLineConfig = new CommandLineConfigurationProvider(args);
 
             cmdLineConfig.Load();
 
             Assert.Equal("Value2", cmdLineConfig.Get("Key1"));
+            Assert.Equal("false", cmdLineConfig.Get("Key2"));
         }
 
         [Fact]
@@ -215,16 +252,18 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             var args = new string[]
             {
                 "--Key1", "Value1",
-                "--Key2", /* The value for Key2 is missing here, so treat as a switch */
-                "/Key3"   /* The value for Key3 is missing here, so treat as a switch */
+                "-Key2", /* The value for Key2 is missing here, so treat as a switch */
+                "--Key3", /* The value for Key2 is missing here, so treat as a switch */
+                "/Key4"   /* The value for Key3 is missing here, so treat as a switch */
             };
 
             var cmdLineConfig = new CommandLineConfigurationProvider(args);
             cmdLineConfig.Load();
-            Assert.Equal(3, cmdLineConfig.GetChildKeys(new string[0], null).Count());
+            Assert.Equal(4, cmdLineConfig.GetChildKeys(new string[0], null).Count());
             Assert.Equal("Value1", cmdLineConfig.Get("Key1"));
             Assert.Equal("true", cmdLineConfig.Get("Key2"));
             Assert.Equal("true", cmdLineConfig.Get("Key3"));
+            Assert.Equal("true", cmdLineConfig.Get("Key4"));
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
                     "--Key4", "Value4",
                     "Bogus2",
                     "/Key5", "Value5",
-                    "Bogus3"
+                    "Bogus3",
+                    "--Key6",
+                    "/Key7"
                 };
             var cmdLineConfig = new CommandLineConfigurationProvider(args);
 
@@ -48,7 +50,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             Assert.Equal("Value3", cmdLineConfig.Get("Key3"));
             Assert.Equal("Value4", cmdLineConfig.Get("Key4"));
             Assert.Equal("Value5", cmdLineConfig.Get("Key5"));
-            Assert.Equal(5, cmdLineConfig.GetChildKeys(new string[0], null).Count());
+            Assert.Equal("true", cmdLineConfig.Get("Key6"));
+            Assert.Equal("true", cmdLineConfig.Get("Key7"));
+            Assert.Equal(7, cmdLineConfig.GetChildKeys(new string[0], null).Count());
         }
 
 
@@ -61,7 +65,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
                     "--Key2=Value2",
                     "/Key3=Value3",
                     "--Key4", "Value4",
-                    "/Key5", "Value5"
+                    "/Key5", "Value5",
+                    "--Key6",
+                    "/Key7"
                 };
             var cmdLineConfig = new CommandLineConfigurationProvider(args);
 
@@ -72,6 +78,8 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             Assert.Equal("Value3", cmdLineConfig.Get("Key3"));
             Assert.Equal("Value4", cmdLineConfig.Get("Key4"));
             Assert.Equal("Value5", cmdLineConfig.Get("Key5"));
+            Assert.Equal("true", cmdLineConfig.Get("Key6"));
+            Assert.Equal("true", cmdLineConfig.Get("Key7"));
         }
 
         [Fact]
@@ -202,18 +210,21 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
         }
 
         [Fact]
-        public void IgnoreWhenValueForAKeyIsMissing()
+        public void EvaluateAsTrueWhenValueForAKeyIsMissing()
         {
             var args = new string[]
             {
                 "--Key1", "Value1",
-                "/Key2" /* The value for Key2 is missing here */
+                "--Key2", /* The value for Key2 is missing here, so treat as a switch */
+                "/Key3"   /* The value for Key3 is missing here, so treat as a switch */
             };
 
             var cmdLineConfig = new CommandLineConfigurationProvider(args);
             cmdLineConfig.Load();
-            Assert.Single(cmdLineConfig.GetChildKeys(new string[0], null));
+            Assert.Equal(3, cmdLineConfig.GetChildKeys(new string[0], null).Count());
             Assert.Equal("Value1", cmdLineConfig.Get("Key1"));
+            Assert.Equal("true", cmdLineConfig.Get("Key2"));
+            Assert.Equal("true", cmdLineConfig.Get("Key3"));
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
@@ -12,6 +12,36 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
     public class CommandLineTest
     {
         [Fact]
+        public void CanLoadSinglePair()
+        {
+            var args = new string[]
+            {
+                "--Key1=Value1"
+            };
+            var cmdLineConfig = new CommandLineConfigurationProvider(args);
+
+            cmdLineConfig.Load();
+
+            Assert.Equal("Value1", cmdLineConfig.Get("Key1"));
+            Assert.Single(cmdLineConfig.GetChildKeys(new string[0], null));
+        }
+
+        [Fact]
+        public void CanLoadSingleSwitch()
+        {
+            var args = new string[]
+            {
+                "--Key1"
+            };
+            var cmdLineConfig = new CommandLineConfigurationProvider(args);
+
+            cmdLineConfig.Load();
+
+            Assert.Equal("true", cmdLineConfig.Get("Key1"));
+            Assert.Single(cmdLineConfig.GetChildKeys(new string[0], null));
+        }
+
+        [Fact]
         public void IgnoresOnlyUnknownArgs()
         {
             var args = new string[]
@@ -83,7 +113,6 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
             Assert.Equal("Value7", cmdLineConfig.Get("Key7"));
             Assert.Equal(7, cmdLineConfig.GetChildKeys(new string[0], null).Count());
         }
-
 
         [Fact]
         public void LoadKeyValuePairsFromCommandLineArgumentsWithoutSwitchMappings()


### PR DESCRIPTION
This is in response to issue #36024 where I was asked by @maryamariyan to submit a pull request based on my demonstration.

Applying this PR will:

- Modify the `CommandLineConfigurationProvider` to allow for individual switches to be evaluated as having the value `"true"`, rather than be ignored altogether.
- Modify existing tests (one being commandeered entirely) to account for this change.

As an example, one can currently provide key-value pairs currently in the following formats:
```
.\myProgram.exe -help=true
.\myProgram.exe --help=true
.\myProgram.exe /help=true
.\myProgram.exe --help true
.\myProgram.exe help=true
```

Once this PR is merged, the following will also set the configuration key `"help"` to the value `"true"`, rather than be ignored completely:
```
.\myProgram.exe -help
.\myProgram.exe --help
.\myProgram.exe /help
```

~~A potential breaking change is the necessity to bring in `System.Linq` in `CommandLineConfigurationProvider` to easily transform an `IEnumerable<string>` into a `string[]`. However, this will likely never be needed, as the only type that `Args` will ever be is `string[]`, and `ToArray` will only be called if the safe cast to `string[]` fails.~~ This has been addressed; see below.

I have tried my best to adhere to the original coding style of the files modified. Please let me know if anything needs adjusting and I will happily accommodate.

Please see the original issue comments (#36024) for more details.