### PR TITLE
[release/5.0] Fix missing signatures for Cross bitness DAC symbols

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -50,12 +50,12 @@
     <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">
-    <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CrossTargetComponentFolder)/sharedFramework/*.dll" />
-    <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CrossTargetComponentFolder)/sharedFramework/*.exe" />
+  <ItemGroup Condition="'$(CoreCLRCrossTargetComponentDirName)' != ''">
+    <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CoreCLRCrossTargetComponentDirName)/sharedFramework/*.dll" />
+    <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CoreCLRCrossTargetComponentDirName)/sharedFramework/*.exe" />
   </ItemGroup>
 
-  <!-- When doing post build signing, the file containers (e.g. nupkg, msi, etc.) are 
+  <!-- When doing post build signing, the file containers (e.g. nupkg, msi, etc.) are
        processed for signing (opened up, individually signed, etc.) and these individual ItemsToSign
        elements are unnecessary. When signing within the build, we need to individually process
        dll's, exes, etc. that go into msi's because these containers are not able to be processed

--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -65,11 +65,6 @@
 
     <!-- We are only tracking Linux Distributions for Nuget RID mapping -->
     <DistroRid Condition="'$(TargetsLinux)' == 'true'">$(__DistroRid)</DistroRid>
-
-    <!-- Folder for cross target components -->
-    <CrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm64'">x64</CrossTargetComponentFolder>
-    <CrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CrossTargetComponentFolder>
-    <CrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CrossTargetComponentFolder>
   </PropertyGroup>
 
   <!-- Set the kind of PDB to Portable -->

--- a/src/installer/signing/Directory.Build.targets
+++ b/src/installer/signing/Directory.Build.targets
@@ -29,6 +29,7 @@
         ArtifactsPackagesDir=$(ArtifactsPackagesDir);
         TargetOS=$(TargetOS);
         TargetArchitecture=$(TargetArchitecture);
+        BuildArchitecture=$(BuildArchitecture);
         NetCoreAppCurrent=$(NetCoreAppCurrent)" />
 
     <PropertyGroup>

--- a/src/installer/signing/Directory.Build.targets
+++ b/src/installer/signing/Directory.Build.targets
@@ -28,6 +28,8 @@
         ArtifactsBinDir=$(ArtifactsBinDir);
         ArtifactsPackagesDir=$(ArtifactsPackagesDir);
         TargetOS=$(TargetOS);
+        TargetsLinux=$(TargetsLinux);
+        TargetsWindows=$(TargetsWindows);
         TargetArchitecture=$(TargetArchitecture);
         BuildArchitecture=$(BuildArchitecture);
         NetCoreAppCurrent=$(NetCoreAppCurrent)" />


### PR DESCRIPTION
5.0 fix for #43338. Adds signatures to the cross-bitness dacs on 

## Customer Impact
Dumps taken in ARM/ARM64 windows devices won't load in VS (x86/x64) as the downloaded debugging assets are unsigned and will fail trust checks. It's possible this also affects Watson in similar cross-bitness analysis scenarios.

## Testing
Manual inspection of packages produced by internal pipeline.

## Risk
Only changes paths that touch these files in the signing space, and they are already unsigned. So pretty low.
