### PR TITLE
Mono: Clang bin path not added to PATH for VS2019 builds.

### DIFF
--- a/src/mono/msvc/setup-vs-msvcbuild-env.bat
+++ b/src/mono/msvc/setup-vs-msvcbuild-env.bat
@@ -83,7 +83,7 @@ set VS_2019_DEV_CMD=%VS_2019_VCINSTALL_DIR%Auxiliary\Build\%VS_2019_VCVARS_ARCH%
 
 :: Setup VS2019 VC development environment using VS installation.
 call :setup_build_env "%VS_2019_DEV_CMD%" "" "%CALLER_WD%" && (
-    set "VS_CLANG_TOOLS_BIN_PATH=%VS_2017_CLANG_TOOLS_BIN_PATH%"
+    set "VS_CLANG_TOOLS_BIN_PATH=%VS_2019_CLANG_TOOLS_BIN_PATH%"
     set VS_DEFAULT_PLATFORM_TOOL_SET=v142
     goto ON_EXIT
 )


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20487,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Building full AOT using CI scripts won't work when VS2019 IDE is present (not falling back to VS2019 build tools).

This happens due to a typo in setup-vs-msvcbuild-env.bat. Since CI doesn't install VS IDE, but using buildtools (where clan bin
path is added to PATH) problem only shows up on local development environment using VS2019 IDE.