### PR TITLE
Fix async iterators to clear out state upon completion

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
@@ -405,8 +405,7 @@ namespace System.Runtime.CompilerServices
                 // Clear out the state machine and associated context to avoid keeping arbitrary state referenced by
                 // lifted locals.  We want to do this regardless of whether we end up caching the box or not, in case
                 // the caller keeps the box alive for an arbitrary period of time.
-                StateMachine = default;
-                Context = default;
+                ClearStateUponCompletion();
 
                 // Reset the MRVTSC.  We can either do this here, in which case we may be paying the (small) overhead
                 // to reset the box even if we're going to drop it, or we could do it while holding the lock, in which
@@ -441,6 +440,16 @@ namespace System.Runtime.CompilerServices
                     // Release the lock.
                     Volatile.Write(ref s_cacheLock, 0);
                 }
+            }
+
+            /// <summary>
+            /// Clear out the state machine and associated context to avoid keeping arbitrary state referenced by lifted locals.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ClearStateUponCompletion()
+            {
+                StateMachine = default;
+                Context = default;
             }
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IAsyncStateMachineBox.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IAsyncStateMachineBox.cs
@@ -19,5 +19,8 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>
         IAsyncStateMachine GetStateMachineObject();
+
+        /// <summary>Clears the state of the box.</summary>
+        void ClearStateUponCompletion();
     }
 }

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncIteratorMethodBuilderTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncIteratorMethodBuilderTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Threading.Tasks.Tests
+{
+    public class AsyncIteratorMethodBuilderTests
+    {
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void AsyncIteratorMethodBuilder_TaskCompleted()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                static async IAsyncEnumerable<int> Func(TaskCompletionSource tcs)
+                {
+                    await tcs.Task;
+                    yield return 1;
+                }
+
+                // NOTE: This depends on private implementation details generally only used by the debugger.
+                // If those ever change, this test will need to be updated as well.
+
+                typeof(Task).GetField("s_asyncDebuggingEnabled", BindingFlags.NonPublic | BindingFlags.Static).SetValue(null, true);
+
+                for (int i = 0; i < 1000; i++)
+                {
+                    TaskCompletionSource tcs = new();
+                    IAsyncEnumerator<int> e = Func(tcs).GetAsyncEnumerator();
+                    Task t = e.MoveNextAsync().AsTask();
+                    tcs.SetResult();
+                    t.Wait();
+                    e.MoveNextAsync().AsTask().Wait();
+                }
+
+                int activeCount = ((dynamic)typeof(Task).GetField("s_currentActiveTasks", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null)).Count;
+                Assert.InRange(activeCount, 0, 10); // some other tasks may be created by the runtime, so this is just using a reasonably small upper bound
+            }).Dispose();
+        }
+    }
+}

--- a/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -46,6 +46,7 @@
     <!-- TaskScheduler -->
     <Compile Include="TaskScheduler\TaskSchedulerTests.cs" />
     <!-- System.Runtime.CompilerServices -->
+    <Compile Include="System.Runtime.CompilerServices\AsyncIteratorMethodBuilderTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\AsyncTaskMethodBuilderTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredAsyncDisposable.cs" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredCancelableAsyncEnumerableTests.cs" />


### PR DESCRIPTION
AsyncIteratorMethodBuilder was only doing its clean-up for completion (e.g. zeroing out the state machine and context, removing the object from a debugger-incited tracking table) if the last call to the iterator was part of asynchronous completion; if the last MoveNextAsync completed synchronously, the used code path could miss that cleanup work.

Fixes https://github.com/dotnet/runtime/issues/41187
cc: @jcouv, @tarekgh, @benaadams 