### PR TITLE
[mono] Ensure MonoAssemblyName is in sync between managed and native

### DIFF
--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -170,7 +170,7 @@ struct _MonoAssemblyName {
 	uint32_t hash_len;
 	uint32_t flags;
 #ifdef ENABLE_NETCORE
-	int major, minor, build, revision, arch;
+	int32_t major, minor, build, revision, arch;
 #else
 	uint16_t major, minor, build, revision, arch;
 #endif

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -105,7 +105,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn),618,67</NoWarn>
 
-    <DefineConstants>NETCORE;DISABLE_REMOTING;MONO_FEATURE_SRE;$(DefineConstants)</DefineConstants>
+    <DefineConstants>MONO_FEATURE_SRE;$(DefineConstants)</DefineConstants>
 
     <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
     <FeatureManagedEtw>true</FeatureManagedEtw>

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
@@ -72,12 +72,7 @@ namespace Mono
         internal uint hash_alg;
         internal uint hash_len;
         internal uint flags;
-#if NETCORE
-        internal int major, minor, build, revision;
-#else
-		internal ushort major, minor, build, revision;
-#endif
-        internal ushort arch;
+        internal int major, minor, build, revision, arch;
     }
 
     // Used to implement generic sharing


### PR DESCRIPTION
We also no longer appear to need the NETCORE or DISABLE_REMOTING defines in msbuild, so remove them