### PR TITLE
Use Span-based CreateHMAC where possible

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.manual.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.manual.cs
@@ -52,8 +52,9 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
-            // Cannot use the ArrayPool or stackalloc here because CreateHMAC needs a properly bounded array.
-            byte[] derived = new byte[expectedOutputSize];
+            Debug.Assert(expectedOutputSize <= 64); // SHA512 is the largest digest size we know about
+            Span<byte> derived = stackalloc byte[expectedOutputSize];
+
 
             int iterationCount =
                 PasswordBasedEncryption.NormalizeIterationCount(MacData.Value.IterationCount);

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.manual.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.manual.cs
@@ -52,8 +52,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
+#if NETFRAMEWORK || NETCOREAPP3_0 || NETSTANDARD
+            byte[] derived = new byte[expectedOutputSize];
+#else
             Debug.Assert(expectedOutputSize <= 64); // SHA512 is the largest digest size we know about
             Span<byte> derived = stackalloc byte[expectedOutputSize];
+#endif
 
 
             int iterationCount =

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanDerivation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanDerivation.cs
@@ -191,67 +191,51 @@ namespace System.Security.Cryptography
             //
             // This is called via PRF, which turns (label || seed) into seed.
 
-            byte[] secretTmp = new byte[secret.Length];
+            Span<byte> retSpan = ret;
 
-            // Keep secretTmp pinned the whole time it has a secret in it, so it
-            // doesn't get copied around during heap compaction.
-            fixed (byte* pinnedSecretTmp = secretTmp)
+            using (IncrementalHash hasher = IncrementalHash.CreateHMAC(algorithmName, secret))
             {
-                secret.CopyTo(secretTmp);
+                Span<byte> a = stackalloc byte[hashOutputSize];
+                Span<byte> p = stackalloc byte[hashOutputSize];
 
-                try
+                // A(1)
+                hasher.AppendData(prfLabel);
+                hasher.AppendData(prfSeed);
+
+                if (!hasher.TryGetHashAndReset(a, out int bytesWritten) || bytesWritten != hashOutputSize)
                 {
-                    Span<byte> retSpan = ret;
-
-                    using (IncrementalHash hasher = IncrementalHash.CreateHMAC(algorithmName, secretTmp))
-                    {
-                        Span<byte> a = stackalloc byte[hashOutputSize];
-                        Span<byte> p = stackalloc byte[hashOutputSize];
-
-                        // A(1)
-                        hasher.AppendData(prfLabel);
-                        hasher.AppendData(prfSeed);
-
-                        if (!hasher.TryGetHashAndReset(a, out int bytesWritten) || bytesWritten != hashOutputSize)
-                        {
-                            throw new CryptographicException();
-                        }
-
-                        while (true)
-                        {
-                            // HMAC_hash(secret, A(i) || seed) => p
-                            hasher.AppendData(a);
-                            hasher.AppendData(prfLabel);
-                            hasher.AppendData(prfSeed);
-
-                            if (!hasher.TryGetHashAndReset(p, out bytesWritten) || bytesWritten != hashOutputSize)
-                            {
-                                throw new CryptographicException();
-                            }
-
-                            int len = Math.Min(p.Length, retSpan.Length);
-
-                            p.Slice(0, len).CopyTo(retSpan);
-                            retSpan = retSpan.Slice(len);
-
-                            if (retSpan.Length == 0)
-                            {
-                                return;
-                            }
-
-                            // Build the next A(i)
-                            hasher.AppendData(a);
-
-                            if (!hasher.TryGetHashAndReset(a, out bytesWritten) || bytesWritten != hashOutputSize)
-                            {
-                                throw new CryptographicException();
-                            }
-                        }
-                    }
+                    throw new CryptographicException();
                 }
-                finally
+
+                while (true)
                 {
-                    Array.Clear(secretTmp, 0, secretTmp.Length);
+                    // HMAC_hash(secret, A(i) || seed) => p
+                    hasher.AppendData(a);
+                    hasher.AppendData(prfLabel);
+                    hasher.AppendData(prfSeed);
+
+                    if (!hasher.TryGetHashAndReset(p, out bytesWritten) || bytesWritten != hashOutputSize)
+                    {
+                        throw new CryptographicException();
+                    }
+
+                    int len = Math.Min(p.Length, retSpan.Length);
+
+                    p.Slice(0, len).CopyTo(retSpan);
+                    retSpan = retSpan.Slice(len);
+
+                    if (retSpan.Length == 0)
+                    {
+                        return;
+                    }
+
+                    // Build the next A(i)
+                    hasher.AppendData(a);
+
+                    if (!hasher.TryGetHashAndReset(a, out bytesWritten) || bytesWritten != hashOutputSize)
+                    {
+                        throw new CryptographicException();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Since `CreateHMAC` accepts a span now, use it where applicable.

PR is much easier to review when ignoring white space differences.