### PR TITLE
Fix CG2 outerloop comparison runs and OSX leg warning

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -97,6 +97,8 @@ jobs:
       - ${{ if eq(parameters.compositeBuildMode, true) }}:
         - name: crossgenArg
           value: 'composite'
+        - name: LogNamePrefix
+          value: TestRunLogs_R2R_CG2_Composite
 
     # Set job timeouts
     #

--- a/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
@@ -76,7 +76,7 @@ jobs:
       - name: crossgen2location
         value: $(productDirectory)$(dir)$(targetFlavor)$(dir)x64$(dir)crossgen2$(dir)crossgen2.dll
     - name: librariesProductDllDir
-      value: $(Build.SourcesDirectory)$(dir)artifacts$(dir)bin$(dir)runtime$(dir)net5.0-$(osGroup)$(osSubgroup)-$(buildConfig)-$(archType)
+      value: $(Build.SourcesDirectory)$(dir)artifacts$(dir)bin$(dir)runtime$(dir)net6.0-$(osGroup)$(osSubgroup)-$(buildConfig)-$(archType)
 
     - ${{ parameters.variables }}
 
@@ -124,6 +124,7 @@ jobs:
           cp $(librariesProductDllDir)/* $(workItemDirectory)/dlls
           cp $(productDirectory)/$(targetFlavor)/IL/System.Private.CoreLib.dll $(workItemDirectory)/dlls
         displayName: Create directories
+        failOnStderr: true
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - script: |
           md $(workItemDirectory)\log
@@ -133,6 +134,7 @@ jobs:
           echo copy $(productDirectory)\$(targetFlavor)\IL\System.Private.CoreLib.dll $(workItemDirectory)\dlls
           copy $(productDirectory)\$(targetFlavor)\IL\System.Private.CoreLib.dll $(workItemDirectory)\dlls
         displayName: Create directories
+        failOnStderr: true
 
     # Create baseline output on the host (x64) machine
     - task: PythonScript@0


### PR DESCRIPTION
The crossgen2 comparison runs are failing to create the baseline crossgen'd framework because the live libraries zip's internal path has changed. .net5 has been replaced with .net6. The build should have failed when we tried to copy from the wrong folder but the error got eaten and we ended up with a malformed framework folder. Adjust the inline yml scripts so if they fail, it will fail that containing build task.

The outerloop run has OSX checked test runs for CG2 and CG2 composite modes. Currently both would use a log upload artifact with the same name (coreclr__TestRunLogs_R2R_CG2_OSX_x64_checked_outerloop). Disambiguate the two with a different `LogNamePrefix` for composite runs.

cc @dotnet/crossgen-contrib 