### PR TITLE
Fix  TimeZoneInfo to handle Yukon zone

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.AdjustmentRule.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.AdjustmentRule.cs
@@ -119,8 +119,7 @@ namespace System
             internal bool IsStartDateMarkerForBeginningOfYear() =>
                 !NoDaylightTransitions &&
                 DaylightTransitionStart.Month == 1 && DaylightTransitionStart.Day == 1 &&
-                DaylightTransitionStart.TimeOfDay.TimeOfDay.Ticks < TimeSpan.TicksPerSecond && // < 12:00:01 AM
-                _dateStart.Year == _dateEnd.Year;
+                DaylightTransitionStart.TimeOfDay.TimeOfDay.Ticks < TimeSpan.TicksPerSecond; // < 12:00:01 AM
 
             //
             // When Windows sets the daylight transition end Jan 1st at 12:00 AM, it means the year ends with the daylight saving on.
@@ -129,8 +128,7 @@ namespace System
             internal bool IsEndDateMarkerForEndOfYear() =>
                 !NoDaylightTransitions &&
                 DaylightTransitionEnd.Month == 1 && DaylightTransitionEnd.Day == 1 &&
-                DaylightTransitionEnd.TimeOfDay.TimeOfDay.Ticks < TimeSpan.TicksPerSecond && // < 12:00:01 AM
-                _dateStart.Year == _dateEnd.Year;
+                DaylightTransitionEnd.TimeOfDay.TimeOfDay.Ticks < TimeSpan.TicksPerSecond; // < 12:00:01 AM
 
             /// <summary>
             /// Helper function that performs all of the validation checks for the factory methods and deserialization callback.

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -122,7 +122,7 @@ namespace System.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public static void TestYukunTZ()
         {
-            var yukon = TimeZoneInfo.FindSystemTimeZoneById("Yukon Standard Time");
+            TimeZoneInfo yukon = TimeZoneInfo.FindSystemTimeZoneById("Yukon Standard Time");
 
             // First, ensure we have the updated data
             TimeZoneInfo.AdjustmentRule [] rules = yukon.GetAdjustmentRules();

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -119,6 +119,33 @@ namespace System.Tests
             Assert.True(libyaLocalTime.Equals(expectResult), string.Format("Expected {0} and got {1}", expectResult, libyaLocalTime));
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        public static void TestYukunTZ()
+        {
+            var yukon = TimeZoneInfo.FindSystemTimeZoneById("Yukon Standard Time");
+
+            // First, ensure we have the updated data
+            TimeZoneInfo.AdjustmentRule [] rules = yukon.GetAdjustmentRules();
+            if (rules.Length <= 0 || rules[rules.Length - 1].DateStart.Year != 2021 || rules[rules.Length - 1].DateEnd.Year != 9999)
+            {
+                return;
+            }
+
+            TimeSpan minus7HoursSpan = new TimeSpan(-7, 0, 0);
+
+            DateTimeOffset midnight = new DateTimeOffset(2021, 1, 1, 0, 0, 0, 0, minus7HoursSpan);
+            DateTimeOffset beforeMidnight = new DateTimeOffset(2020, 12, 31, 23, 59, 59, 999, minus7HoursSpan);
+            DateTimeOffset before1AM = new DateTimeOffset(2021, 1, 1, 0, 59, 59, 999, minus7HoursSpan);
+            DateTimeOffset at1AM = new DateTimeOffset(2021, 1, 1, 1, 0, 0, 0, minus7HoursSpan);
+            DateTimeOffset midnight2022 = new DateTimeOffset(2022, 1, 1, 0, 0, 0, 0, minus7HoursSpan);
+
+            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(midnight));
+            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(beforeMidnight));
+            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(before1AM));
+            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(at1AM));
+            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(midnight2022));
+       }
+
         [Fact]
         public static void RussianTimeZone()
         {

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -122,28 +122,35 @@ namespace System.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public static void TestYukunTZ()
         {
-            TimeZoneInfo yukon = TimeZoneInfo.FindSystemTimeZoneById("Yukon Standard Time");
-
-            // First, ensure we have the updated data
-            TimeZoneInfo.AdjustmentRule [] rules = yukon.GetAdjustmentRules();
-            if (rules.Length <= 0 || rules[rules.Length - 1].DateStart.Year != 2021 || rules[rules.Length - 1].DateEnd.Year != 9999)
+            try
             {
-                return;
+                TimeZoneInfo yukon = TimeZoneInfo.FindSystemTimeZoneById("Yukon Standard Time");
+
+                // First, ensure we have the updated data
+                TimeZoneInfo.AdjustmentRule [] rules = yukon.GetAdjustmentRules();
+                if (rules.Length <= 0 || rules[rules.Length - 1].DateStart.Year != 2021 || rules[rules.Length - 1].DateEnd.Year != 9999)
+                {
+                    return;
+                }
+
+                TimeSpan minus7HoursSpan = new TimeSpan(-7, 0, 0);
+
+                DateTimeOffset midnight = new DateTimeOffset(2021, 1, 1, 0, 0, 0, 0, minus7HoursSpan);
+                DateTimeOffset beforeMidnight = new DateTimeOffset(2020, 12, 31, 23, 59, 59, 999, minus7HoursSpan);
+                DateTimeOffset before1AM = new DateTimeOffset(2021, 1, 1, 0, 59, 59, 999, minus7HoursSpan);
+                DateTimeOffset at1AM = new DateTimeOffset(2021, 1, 1, 1, 0, 0, 0, minus7HoursSpan);
+                DateTimeOffset midnight2022 = new DateTimeOffset(2022, 1, 1, 0, 0, 0, 0, minus7HoursSpan);
+
+                Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(midnight));
+                Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(beforeMidnight));
+                Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(before1AM));
+                Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(at1AM));
+                Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(midnight2022));
             }
-
-            TimeSpan minus7HoursSpan = new TimeSpan(-7, 0, 0);
-
-            DateTimeOffset midnight = new DateTimeOffset(2021, 1, 1, 0, 0, 0, 0, minus7HoursSpan);
-            DateTimeOffset beforeMidnight = new DateTimeOffset(2020, 12, 31, 23, 59, 59, 999, minus7HoursSpan);
-            DateTimeOffset before1AM = new DateTimeOffset(2021, 1, 1, 0, 59, 59, 999, minus7HoursSpan);
-            DateTimeOffset at1AM = new DateTimeOffset(2021, 1, 1, 1, 0, 0, 0, minus7HoursSpan);
-            DateTimeOffset midnight2022 = new DateTimeOffset(2022, 1, 1, 0, 0, 0, 0, minus7HoursSpan);
-
-            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(midnight));
-            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(beforeMidnight));
-            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(before1AM));
-            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(at1AM));
-            Assert.Equal(minus7HoursSpan, yukon.GetUtcOffset(midnight2022));
+            catch (TimeZoneNotFoundException)
+            {
+                // Some Windows versions don't carry the complete TZ data. Ignore the tests on such versiosn.
+            }
        }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/43429

Windows changing the [Yukun](https://techcommunity.microsoft.com/t5/daylight-saving-time-time-zone/2020-time-zone-updates-for-yukon-now-available/ba-p/1598976) TZ data to move it from `(UTC-08:00) Pacific Time (US & Canada)` to `(UTC-07:00) Yukon`. Because of the TZ data limitation of Windows, the updated data has broken some of the TZ calculation around the end of the year of 2020 and the beginning of 2021.
The problem was, Windows sets the daylight transition begin/end to Jan 1st at 12:00 AM to mark the transition is starting from the beginning of the year or the transition continue to the end of the year. We have some code to detect these case. Our detection was assuming the rule always per year (i.e. the year of start date has to be same as the year of end date). This was a wrong assumption. Yukon new data now has a rule starts on 2021 and end on 9999 (i.e. this rule will be applied from next year and used to all subsequent years). Obviously, this rule broke our assumption and cause some calculations around the edge of 2020 and 2021 years calculated wrong. 
The fix here is simply removing the assumption and make our detection work again. 


 