### PR TITLE
Update steps in debugging instruction of CLR

### DIFF
--- a/docs/workflow/debugging/coreclr/debugging.md
+++ b/docs/workflow/debugging/coreclr/debugging.md
@@ -19,10 +19,16 @@ Debugging CoreCLR on Windows
 7. Set Command Arguments=`<managed app you wish to run>` (e.g. HelloWorld.dll)
 8. Set Working Directory=`$(SolutionDir)\..\..\..\bin\coreclr\Windows_NT.$(Platform).$(Configuration)`
     1. This points to the folder containing CoreCLR binaries.
-9. Press F11 to start debugging at wmain in corerun (or set a breakpoint in source and press F5 to run to it)
+9. Set Environment=`CORE_LIBRARIES=$(SolutionDir)\..\..\..\bin\pkg\<current tfm>\runtime\Windows_NT-$(Configuration)-$(Platform)`,
+    where '\<current tfm\>' is the target framework of current branch, for example `netcoreapp3.1` `net5.0`.
+    1. This points to the folder containing core libraries except `System.Private.CoreLib`.
+10. Right-click the INSTALL project and choose 'Build'
+    1. This will load necessary information from cmake to Visual Studio.
+11. Press F11 to start debugging at wmain in corerun (or set a breakpoint in source and press F5 to run to it)
     1. As an example, set a breakpoint for the EEStartup function in ceemain.cpp to break into CoreCLR startup.
 
-Steps 1-8 only need to be done once, and then (9) can be repeated whenever you want to start debugging. The above can be done with Visual Studio 2013.
+Steps 1-10 only need to be done once, and then (11) can be repeated whenever you want to start debugging. The above can be done with Visual Studio 2019 as writing.
+Keeping with latest version of Visual Studio is recommended.
 
 ### Using SOS with windbg or cdb on Windows ###
 

--- a/docs/workflow/debugging/coreclr/debugging.md
+++ b/docs/workflow/debugging/coreclr/debugging.md
@@ -19,7 +19,7 @@ Debugging CoreCLR on Windows
 7. Set Command Arguments=`<managed app you wish to run>` (e.g. HelloWorld.dll)
 8. Set Working Directory=`$(SolutionDir)\..\..\..\bin\coreclr\Windows_NT.$(Platform).$(Configuration)`
     1. This points to the folder containing CoreCLR binaries.
-9. Set Environment=`CORE_LIBRARIES=$(SolutionDir)\..\..\..\bin\pkg\<current tfm>\runtime\Windows_NT-$(Configuration)-$(Platform)`,
+9. Set Environment=`CORE_LIBRARIES=$(SolutionDir)\..\..\..\bin\runtime\<current tfm>-Windows_NT-$(Configuration)-$(Platform)`,
     where '\<current tfm\>' is the target framework of current branch, for example `netcoreapp3.1` `net5.0`.
     1. This points to the folder containing core libraries except `System.Private.CoreLib`.
 10. Right-click the INSTALL project and choose 'Build'

--- a/docs/workflow/debugging/coreclr/debugging.md
+++ b/docs/workflow/debugging/coreclr/debugging.md
@@ -22,6 +22,8 @@ Debugging CoreCLR on Windows
 9. Set Environment=`CORE_LIBRARIES=$(SolutionDir)\..\..\..\bin\runtime\<current tfm>-Windows_NT-$(Configuration)-$(Platform)`,
     where '\<current tfm\>' is the target framework of current branch, for example `netcoreapp3.1` `net5.0`.
     1. This points to the folder containing core libraries except `System.Private.CoreLib`.
+    2. This step can be skipped if you are debugging CLR tests that references only `System.Private.CoreLib`.
+    Otherwise, it's required to debug a realworld application that references anything else, including `System.Runtime`.
 10. Right-click the INSTALL project and choose 'Build'
     1. This will load necessary information from cmake to Visual Studio.
 11. Press F11 to start debugging at wmain in corerun (or set a breakpoint in source and press F5 to run to it)


### PR DESCRIPTION
The missing steps costs 2 hours for me. I do have knowledge of CoreRun, and the repository layout, so I realized what I missed. For new beginners this is actually a contribution blocker.

Questions:
Is there an variable of `$(NetCoreAppCurrent)` available for C++?
Do I choose the suitable path for libraries? Its path contains `$(NetCoreAppCurrent)`. They are required for debugging with real world applications that references `System.Runtime`, not `System.Private.CoreLib`.