### PR TITLE
improve reliability of SslStream tests with failing certificate validation

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -362,7 +362,7 @@ namespace System.Net.Security
                         payload = message.Payload;
                         size = message.Size;
                     }
-                    else if (message.Failed && _lastFrame.Header.Type == TlsContentType.Handshake)
+                    else if (message.Failed && (_lastFrame.Header.Type == TlsContentType.Handshake || _lastFrame.Header.Type == TlsContentType.ChangeCipherSpec))
                     {
                         // If we failed without OS sending out alert, inject one here to be consistent across platforms.
                         payload = TlsFrameHelper.CreateAlertFrame(_lastFrame.Header.Version, TlsAlertDescription.ProtocolVersion);
@@ -563,7 +563,7 @@ namespace System.Net.Security
 
                     frameSize = nextHeader.Length + TlsFrameHelper.HeaderSize;
                     // Can process more handshake frames in single step, but we should avoid processing too much so as to preserve API boundary between handshake and I/O.
-                    if (nextHeader.Type != TlsContentType.Handshake || frameSize > _handshakeBuffer.ActiveLength)
+                    if ((nextHeader.Type != TlsContentType.Handshake && nextHeader.Type != TlsContentType.ChangeCipherSpec) || frameSize > _handshakeBuffer.ActiveLength)
                     {
                         // We don't have full frame left or we already have app data which needs to be processed by decrypt.
                         break;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -562,7 +562,7 @@ namespace System.Net.Security
                     }
 
                     frameSize = nextHeader.Length + TlsFrameHelper.HeaderSize;
-                    // Can can process more handshake frames in single step but we should avood processing too much re presreve API boundary between handshake and I/O.
+                    // Can process more handshake frames in single step, but we should avoid processing too much so as to preserve API boundary between handshake and I/O.
                     if (nextHeader.Type != TlsContentType.Handshake || frameSize > _handshakeBuffer.ActiveLength)
                     {
                         // We don't have full frame left or we already have app data which needs to be processed by decrypt.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -562,7 +562,8 @@ namespace System.Net.Security
                     }
 
                     frameSize = nextHeader.Length + TlsFrameHelper.HeaderSize;
-                    if (nextHeader.Type == TlsContentType.AppData || frameSize > _handshakeBuffer.ActiveLength)
+                    // Can can process more handshake frames in single step but we should avood processing too much re presreve API boundary between handshake and I/O.
+                    if (nextHeader.Type != TlsContentType.Handshake || frameSize > _handshakeBuffer.ActiveLength)
                     {
                         // We don't have full frame left or we already have app data which needs to be processed by decrypt.
                         break;


### PR DESCRIPTION
I'm not 100% sure why this start failing now. It feels like something changed but that can be just timing. 

I was able to reproduce this locally and it is similar to what I described in  #43475.
When remote certificate validation fails, TLS handshake succeed first and than it is immediately followed by TLS Alert to break the TLS session. (this is just side-effect how we do validation in managed code). Then depending on timing, this can surface in AuthenticaeAs* call or later as per of IO. While I was able to reproduce the hang with MemoryStream, I was not bale to reproduce it with NetworkStream on top of TCP. 

To make that more predictable and match better previous releases, logic processing multiple TLS frames if available will be limit to handshake message and Alerts will be alway processed in separate round. In may test runs, this was sufficient to stabilize this - somewhat brittle - test. 

Sine hanging tests are supper evil IMHO, I also added test update I had originally ready as mediation. 
It simply adds timeout to suspicious operations so if something happened we would fail just this particular test. 

This test is very Windows specific. In longer run, I would like to rework the test to be more portable to other platforms. 
I think testing for AuthenticationException as opposed to IOException should be sufficient IMHO to verify that TLS session was broken by TLS Alert instead of just closing connection by the peer.  Checking win32ex.NativeErrorCode will not really work on other platforms. 

fixes #43403
