### PR TITLE
[RyuJIT] Propagate gtFlags in Vector.Create

### DIFF
--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -392,12 +392,14 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             {
                 assert(sig->numArgs >= 3);
 
-                GenTreeArgList* tmpList = nullptr;
+                GenTreeArgList* tmp = nullptr;
+
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
+                    tmp = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmp);
+                    op1 = tmp;
                 }
-                op1     = tmpList;
+
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -404,8 +404,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
                     }
                 }
-                op1 = tmpList;
-
+                op1     = tmpList;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -398,7 +398,11 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                 {
                     tmp        = gtNewArgList(impPopStack().val);
                     tmp->gtOp2 = op1;
-                    op1        = tmp;
+
+                    // propagate GTF_CALL if needed
+                    if ((op1 != nullptr) && (op1->gtFlags & GTF_CALL))
+                        tmp->gtFlags |= GTF_CALL;
+                    op1 = tmp;
                 }
 
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);

--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -392,18 +392,19 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             {
                 assert(sig->numArgs >= 3);
 
-                GenTreeArgList* tmp = nullptr;
-
+                GenTreeArgList* tmpList = nullptr;
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmp        = gtNewArgList(impPopStack().val);
-                    tmp->gtOp2 = op1;
-
-                    // propagate GTF_CALL if needed
-                    if ((op1 != nullptr) && (op1->gtFlags & GTF_CALL))
-                        tmp->gtFlags |= GTF_CALL;
-                    op1 = tmp;
+                    if (tmpList == nullptr)
+                    {
+                        tmpList = gtNewArgList(impPopStack().val);
+                    }
+                    else
+                    {
+                        tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
+                    }
                 }
+                op1 = tmpList;
 
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }

--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -395,14 +395,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                 GenTreeArgList* tmpList = nullptr;
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    if (tmpList == nullptr)
-                    {
-                        tmpList = gtNewArgList(impPopStack().val);
-                    }
-                    else
-                    {
-                        tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
-                    }
+                    tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
                 }
                 op1     = tmpList;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);

--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -396,10 +396,10 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmp = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmp);
-                    op1 = tmp;
+                    tmp = gtNewListNode(impPopStack().val, tmp);
                 }
 
+                op1     = tmp;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -773,14 +773,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                 GenTreeArgList* tmpList = nullptr;
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    if (tmpList == nullptr)
-                    {
-                        tmpList = gtNewArgList(impPopStack().val);
-                    }
-                    else
-                    {
-                        tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
-                    }
+                    tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
                 }
                 op1     = tmpList;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -782,8 +782,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                         tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
                     }
                 }
-                op1 = tmpList;
-
+                op1     = tmpList;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -770,18 +770,19 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
             {
                 assert(sig->numArgs >= 3);
 
-                GenTreeArgList* tmp = nullptr;
-
+                GenTreeArgList* tmpList = nullptr;
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmp        = gtNewArgList(impPopStack().val);
-                    tmp->gtOp2 = op1;
-
-                    // propagate GTF_CALL if needed
-                    if ((op1 != nullptr) && (op1->gtFlags & GTF_CALL))
-                        tmp->gtFlags |= GTF_CALL;
-                    op1 = tmp;
+                    if (tmpList == nullptr)
+                    {
+                        tmpList = gtNewArgList(impPopStack().val);
+                    }
+                    else
+                    {
+                        tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
+                    }
                 }
+                op1 = tmpList;
 
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -776,7 +776,11 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                 {
                     tmp        = gtNewArgList(impPopStack().val);
                     tmp->gtOp2 = op1;
-                    op1        = tmp;
+
+                    // propagate GTF_CALL if needed
+                    if ((op1 != nullptr) && (op1->gtFlags & GTF_CALL))
+                        tmp->gtFlags |= GTF_CALL;
+                    op1 = tmp;
                 }
 
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -770,12 +770,14 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
             {
                 assert(sig->numArgs >= 3);
 
-                GenTreeArgList* tmpList = nullptr;
+                GenTreeArgList* tmp = nullptr;
+
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmpList = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmpList);
+                    tmp = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmp);
+                    op1 = tmp;
                 }
-                op1     = tmpList;
+
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -774,10 +774,10 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
 
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmp = new (this, GT_LIST) GenTreeArgList(impPopStack().val, tmp);
-                    op1 = tmp;
+                    tmp = gtNewListNode(impPopStack().val, tmp);
                 }
 
+                op1     = tmp;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace GitHub_43569
+{
+    class Program
+    {
+        public static int Main()
+        {
+            if ((int)Vector64_Create_short(100) != 100)
+                return 1;
+            if ((int)Vector128_Create_float(100) != 100)
+                return 2;
+            if ((int)Vector128_Create_byte(100) != 100)
+                return 3;
+            if ((int)Vector256_Create_float(100) != 100)
+                return 4;
+            if ((int)Vector256_Create_double(100) != 100)
+                return 5;
+            return 100;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Inline<T>(T t) => t;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static short Vector64_Create_short(short a)
+        {
+            Vector64<short> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector64.Create(1, 2, 3, Inline(a));
+            return x.GetElement(3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static float Vector128_Create_float(float a)
+        {
+            Vector128<float> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector128.Create(1, 2, 3, Inline(a));
+            return x.GetElement(3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static byte Vector128_Create_byte(byte a)
+        {
+            Vector128<byte> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector128.Create(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, Inline(a));
+            return x.GetElement(15);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static float Vector256_Create_float(float a)
+        {
+            Vector256<float> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector256.Create(1, 2, 3, 4, 5, 6, 7, Inline(a));
+            return x.GetElement(7);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static double Vector256_Create_double(double a)
+        {
+            Vector256<double> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector256.Create(1, 2, 3, Inline(a));
+            return x.GetElement(3);
+        }
+    }
+}

--- a/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Embedded</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_43569.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -943,6 +943,9 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/**">
+            <Issue>https://github.com/dotnet/runtime/issues/43676</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
             <Issue>Tests features specific to coreclr</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/43569 bug

Current code used to ignore flags of arguments so we could get a tree like this:
```
[000010] ------------                    \--*  HWINTRINSIC simd16 float Create
[000009] ------------                       \--*  LIST      void
[000000] ------------                          +--*  CNS_DBL   float  1.0000000000000000
[000008] ------------                          \--*  LIST      void
[000001] ------------                             +--*  CNS_DBL   float  2.0000000000000000
[000007] ------------                             \--*  LIST      void
[000002] ------------                                +--*  CNS_DBL   float  3.0000000000000000
[000006] --C---------                                \--*  LIST      void
[000005] --C---------                                   \--*  RET_EXPR  float (inl return from call [000015])
```
As you can see `C` (stands for `GTF_CALL`) is not propagated to the top. That's why `fgUpdateInlineReturnExpressionPlaceHolder ` just gave up on the tree and didn't bother scanning it for `RET_EXPR` to replace with actual value.

/cc @dotnet/jit-contrib 

The bug doesn't reproduce on `netcoreapp3.1`. Worth back-porting to 5.0 ?