### PR TITLE
Delete OutDir after zipping test folder in CI

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -44,8 +44,8 @@
     <ZipDirectory SourceDirectory="$(_ZipSourceDirectory)"
                   DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))"
                   Overwrite="true" />
-    <!-- delete the BundleDir and PublishDir in CI builds to save disk space on build agents since they're no longer needed -->
-    <RemoveDir Condition="'$(ContinuousIntegrationBuild)' == 'true'" Directories="$(BundleDir);$(PublishDir)" />
+    <!-- delete the $(OutDir) in CI builds to save disk space on build agents since it's no longer needed after zipping -->
+    <RemoveDir Condition="'$(ContinuousIntegrationBuild)' == 'true'" Directories="$(OutDir)" />
   </Target>
 
   <UsingTask TaskName="GenerateRunScript" AssemblyFile="$(InstallerTasksAssemblyPath)"/>


### PR DESCRIPTION
We don't need it anymore and should help with the "no space left on device" issues during CI on e.g. the Browser wasm job.