### PR TITLE
Verify that OCSP and CRL checks fall back.

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
@@ -90,7 +90,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
             if (context != null)
             {
-                HandleRequest(context);
+                ThreadPool.QueueUserWorkItem(
+                    state => HandleRequest(state),
+                    context,
+                    true);
             }
         }
 
@@ -108,7 +111,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
             if (context != null)
             {
-                HandleRequest(context);
+                ThreadPool.QueueUserWorkItem(
+                    state => HandleRequest(state),
+                    context,
+                    true);
             }
         }
 
@@ -375,14 +381,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                 Console.WriteLine(trace);
             }
         }
+    }
 
-        internal enum DelayedActionsFlag : byte
-        {
-            None = 0,
-            Ocsp = 0b1,
-            Crl = 0b10,
-            Aia = 0b100,
-            All = 0b11111111
-        }
+    public enum DelayedActionsFlag : byte
+    {
+        None = 0,
+        Ocsp = 0b1,
+        Crl = 0b10,
+        Aia = 0b100,
+        All = 0b11111111
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                     X509Chain chain = holder.Chain;
                     responder.ResponseDelay = delay;
-                    responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+                    responder.DelayedActions = DelayedActionsFlag.All;
 
                     // This needs to be greater than delay, but less than 2x delay to ensure
                     // that the time is a timeout for individual fetches, not a running total.
@@ -90,7 +90,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                 X509Chain chain = holder.Chain;
                 responder.ResponseDelay = delay;
-                responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+                responder.DelayedActions = DelayedActionsFlag.All;
 
                 chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(1);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
@@ -148,7 +148,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                 X509Chain chain = holder.Chain;
                 responder.ResponseDelay = delay;
-                responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+                responder.DelayedActions = DelayedActionsFlag.All;
 
                 chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromMinutes(2);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
@@ -200,9 +200,50 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                     X509Chain chain = holder.Chain;
                     responder.ResponseDelay = delay;
-                    responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+                    responder.DelayedActions = DelayedActionsFlag.All;
 
                     chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromMinutes(-1);
+                    chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                    chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                    chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+                    chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+                    chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EndCertificateOnly;
+
+                    chain.ChainPolicy.DisableCertificateDownloads = true;
+
+                    Assert.True(chain.Build(endEntityCert), $"chain.Build; Chain status: {chain.AllStatusFlags()}");
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData(DelayedActionsFlag.Ocsp)]
+        [InlineData(DelayedActionsFlag.Crl)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        public static void RevocationCheckingTimeoutFallbackToOther(DelayedActionsFlag delayFlags)
+        {
+            RetryHelper.Execute(() => {
+                CertificateAuthority.BuildPrivatePki(
+                    PkiOptions.AllRevocation,
+                    out RevocationResponder responder,
+                    out CertificateAuthority rootAuthority,
+                    out CertificateAuthority intermediateAuthority,
+                    out X509Certificate2 endEntityCert,
+                    nameof(RevocationCheckingTimeoutFallbackToOther));
+
+                using (responder)
+                using (rootAuthority)
+                using (intermediateAuthority)
+                using (endEntityCert)
+                using (ChainHolder holder = new ChainHolder())
+                using (X509Certificate2 rootCert = rootAuthority.CloneIssuerCert())
+                using (X509Certificate2 intermediateCert = intermediateAuthority.CloneIssuerCert())
+                {
+                    X509Chain chain = holder.Chain;
+                    responder.ResponseDelay = TimeSpan.FromSeconds(8);
+                    responder.DelayedActions = delayFlags;
+
+                    chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(4);
                     chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
                     chain.ChainPolicy.CustomTrustStore.Add(rootCert);
                     chain.ChainPolicy.ExtraStore.Add(intermediateCert);
@@ -241,7 +282,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                     X509Chain chain = holder.Chain;
                     responder.ResponseDelay = delay;
-                    responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+                    responder.DelayedActions = DelayedActionsFlag.All;
 
                     chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(15);
                     chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
@@ -281,7 +322,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                 X509Chain chain = holder.Chain;
                 responder.ResponseDelay = delay;
-                responder.DelayedActions = RevocationResponder.DelayedActionsFlag.All;
+                responder.DelayedActions = DelayedActionsFlag.All;
 
                 chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(2);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;


### PR DESCRIPTION
Test that a CRL timeout chain build will use OCSP.
Test that a OCSP timeout chain build will use CRL.

This also changes the `RevocationResponder` to dispatch each request on the thread pool. Since we are simulating delays with sleeps, previously the sleep would span all requests for the responder.

Closes #38875