### PR TITLE
[mono] Copy image data with AssemblyLoadContext.LoadFromStream

### DIFF
--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -2832,7 +2832,7 @@ mono_alc_load_raw_bytes (MonoAssemblyLoadContext *alc, guint8 *assembly_data, gu
 {
 	MonoAssembly *ass = NULL;
 	MonoImageOpenStatus status;
-	MonoImage *image = mono_image_open_from_data_internal (alc, (char*)assembly_data, raw_assembly_len, FALSE, NULL, refonly, FALSE, NULL, NULL);
+	MonoImage *image = mono_image_open_from_data_internal (alc, (char*)assembly_data, raw_assembly_len, TRUE, NULL, refonly, FALSE, NULL, NULL);
 
 	if (!image) {
 		mono_error_set_bad_image_by_name (error, "In memory assembly", "0x%p", assembly_data);


### PR DESCRIPTION
We don't actually pin the byte array, so it must be copied or it can be overwritten once we run a GC on the LOH.

Fixes https://github.com/dotnet/runtime/issues/43402

Tested manually that it fixes the issue using the associated repro. This isn't really something that lends itself to a test, so that's the best I can do.