### PR TITLE
Suppress trim analysis warnings inside reflection implementation

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Associates.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Associates.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection
 {
@@ -31,6 +32,11 @@ namespace System.Reflection
             return false;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Module.ResolveMethod is marked as RequiresUnreferencedCode because it relies on tokens" +
+                            "which are not guaranteed to be stable across trimming. So if somebody harcodes a token it could break." +
+                            "The usage here is not like that as all these tokes come from existing metadata loaded from some IL" +
+                            "and so trimming has no effect (the tokens are read AFTER trimming occured).")]
         private static RuntimeMethodInfo? AssignAssociates(
             int tkMethod,
             RuntimeType declaredType,

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection
 {
@@ -289,6 +290,10 @@ namespace System.Reflection
         {
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "property setters and fiels which are accessed by any attribute instantiation which is present in the code linker has analyzed." +
+                            "As such enumerating all fields and properties may return different results fater trimming" +
+                            "but all those which are needed to actually have data should be there.")]
         private CustomAttributeData(RuntimeModule scope, MetadataToken caCtorToken, in ConstArray blob)
         {
             m_scope = scope;
@@ -1160,6 +1165,10 @@ namespace System.Reflection
             return result;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2065:UnrecognizedReflectionPattern",
+            Justification = "Linker guarantees presence of all the constructor parameters, property setters and fiels which are accessed by any " +
+                            "attribute instantiation which is present in the code linker has analyzed." +
+                            "As such the reflection usage in this method should never fail as those methods/fields should always be present.")]
         private static void AddCustomAttributes(
             ref RuntimeType.ListBuilder<object> attributes,
             RuntimeModule decoratedModule, int decoratedMetadataToken,
@@ -1294,6 +1303,11 @@ namespace System.Reflection
             }
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Module.ResolveMethod and Module.ResolveType are marked as RequiresUnreferencedCode because they rely on tokens" +
+                            "which are not guaranteed to be stable across trimming. So if somebody harcodes a token it could break." +
+                            "The usage here is not like that as all these tokes come from existing metadata loaded from some IL" +
+                            "and so trimming has no effect (the tokens are read AFTER trimming occured).")]
         private static bool FilterCustomAttributeRecord(
             MetadataToken caCtorToken,
             in MetadataImport scope,
@@ -1426,6 +1440,11 @@ namespace System.Reflection
             return true;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Module.ResolveType is marked as RequiresUnreferencedCode because it relies on tokens" +
+                            "which are not guaranteed to be stable across trimming. So if somebody harcodes a token it could break." +
+                            "The usage here is not like that as all these tokes come from existing metadata loaded from some IL" +
+                            "and so trimming has no effect (the tokens are read AFTER trimming occured).")]
         internal static AttributeUsageAttribute GetAttributeUsage(RuntimeType decoratedAttribute)
         {
             RuntimeModule decoratedModule = decoratedAttribute.GetRuntimeModule();

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -106,6 +106,11 @@ namespace System.Reflection.Emit
         public override string? FullName => m_strFullQualName ??= TypeNameBuilder.ToString(this, TypeNameBuilder.Format.FullName);
         public override string? Namespace => m_type.Namespace;
         public override string? AssemblyQualifiedName => TypeNameBuilder.ToString(this, TypeNameBuilder.Format.AssemblyQualifiedName);
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPatter",
+            Justification = "The entire TypeBuilderInstantiation is serving the MakeGenericType implementation. " +
+                            "Currently this is not supported by linker. Once it is supported the outercall (Type.MakeGenericType)" +
+                            "will validate that the types fullfill the necessary requirements of annotations on type parameters." +
+                            "As such the actual internals of the implementation are not interesting.")]
         private Type Substitute(Type[] substitutes)
         {
             Type[] inst = GetGenericArguments();

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -323,6 +323,7 @@ namespace System.Reflection
             return RuntimeMethodHandle.InvokeMethod(obj, null, sig, false, wrapExceptions);
         }
 
+        [RequiresUnreferencedCode("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         public override MethodBody? GetMethodBody()
         {
             RuntimeMethodBody? mb = RuntimeMethodHandle.GetMethodBody(this, ReflectedTypeInternal);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeExceptionHandlingClause.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeExceptionHandlingClause.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace System.Reflection
@@ -38,6 +39,11 @@ namespace System.Reflection
 
         public override Type? CatchType
         {
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                Justification = "Module.ResolveType is marked as RequiresUnreferencedCode because it relies on tokens" +
+                                "which are not guaranteed to be stable across trimming. So if somebody harcodes a token it could break." +
+                                "The usage here is not like that as all these tokes come from existing metadata loaded from some IL" +
+                                "and so trimming has no effect (the tokens are read AFTER trimming occured).")]
             get
             {
                 if (_flags != ExceptionHandlingClauseOptions.Clause)

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -318,6 +318,7 @@ namespace System.Reflection
 
         public override CallingConventions CallingConvention => Signature.CallingConvention;
 
+        [RequiresUnreferencedCode("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         public override MethodBody? GetMethodBody()
         {
             RuntimeMethodBody? mb = RuntimeMethodHandle.GetMethodBody(this, ReflectedTypeInternal);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1744,6 +1744,9 @@ namespace System
             return retval;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The code in this method looks up the method by name, but it always starts with a method handle." +
+                            "To get here something somwhere had to get the method handle and thus the method must exist.")]
         internal static MethodBase? GetMethodBase(RuntimeType? reflectedType, RuntimeMethodHandleInternal methodHandle)
         {
             Debug.Assert(!methodHandle.IsNullHandle());

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3564,11 +3564,13 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="method">The method to probe.</param>
         /// <returns>The literal value or -1 if the value could not be determined. </returns>
+#if !ES_BUILD_STANDALONE
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                    Justification = "The method calls MethodBase.GetMethodBody. Trimming application can change IL of various methods" +
                                    "which can lead to change of behavior. This method only uses this to validate usage of event source APIs." +
                                    "In the worst case it will not be able to determine the value it's looking for and will not perform" +
                                    "any validation.")]
+#endif
         private static int GetHelperCallFirstArg(MethodInfo method)
         {
             // Currently searches for the following pattern
@@ -4422,7 +4424,7 @@ namespace System.Diagnostics.Tracing
         /// Used to register AD/Process shutdown callbacks.
         /// </summary>
         private static bool s_EventSourceShutdownRegistered;
-        #endregion
+#endregion
     }
 
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -229,7 +229,7 @@ namespace System.Diagnostics.Tracing
 #pragma warning restore CA1823
 #endif //FEATURE_EVENTSOURCE_XPLAT
 
-        private static bool IsSupported { get; } = InitializeIsSupported();
+        internal static bool IsSupported { get; } = InitializeIsSupported();
 
         private static bool InitializeIsSupported() =>
             AppContext.TryGetSwitch("System.Diagnostics.Tracing.EventSource.IsSupported", out bool isSupported) ? isSupported : true;
@@ -3564,6 +3564,11 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="method">The method to probe.</param>
         /// <returns>The literal value or -1 if the value could not be determined. </returns>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                   Justification = "The method calls MethodBase.GetMethodBody. Trimming application can change IL of various methods" +
+                                   "which can lead to change of behavior. This method only uses this to validate usage of event source APIs." +
+                                   "In the worst case it will not be able to determine the value it's looking for and will not perform" +
+                                   "any validation.")]
         private static int GetHelperCallFirstArg(MethodInfo method)
         {
             // Currently searches for the following pattern

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -229,7 +229,7 @@ namespace System.Diagnostics.Tracing
 #pragma warning restore CA1823
 #endif //FEATURE_EVENTSOURCE_XPLAT
 
-        internal static bool IsSupported { get; } = InitializeIsSupported();
+        private static bool IsSupported { get; } = InitializeIsSupported();
 
         private static bool InitializeIsSupported() =>
             AppContext.TryGetSwitch("System.Diagnostics.Tracing.EventSource.IsSupported", out bool isSupported) ? isSupported : true;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -3,9 +3,9 @@
 
 using System.Globalization;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection
 {
@@ -16,7 +17,10 @@ namespace System.Reflection
         public abstract MethodAttributes Attributes { get; }
         public virtual MethodImplAttributes MethodImplementationFlags => GetMethodImplementationFlags();
         public abstract MethodImplAttributes GetMethodImplementationFlags();
+
+        [RequiresUnreferencedCode("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         public virtual MethodBody? GetMethodBody() { throw new InvalidOperationException(); }
+
         public virtual CallingConventions CallingConvention => CallingConventions.Standard;
 
         public bool IsAbstract => (Attributes & MethodAttributes.Abstract) != 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureTypeExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureTypeExtensions.cs
@@ -110,7 +110,7 @@ namespace System.Reflection
             return signatureType.TryResolve(genericMethod.GetGenericArguments());
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Used to find matching method overloads. Only used for assignability checks.")]
         private static Type? TryResolve(this SignatureType signatureType, Type[] genericMethodParameters)
         {
@@ -212,6 +212,7 @@ namespace System.Reflection
             }
         }
 
+        [RequiresUnreferencedCode("Wrapper around MakeGenericType which itself has RequiresUnreferencedCode")]
         private static Type? TryMakeGenericType(this Type type, Type[] instantiation)
         {
             try

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8335,6 +8335,7 @@ namespace System.Reflection
         public static System.Reflection.MethodBase? GetCurrentMethod() { throw null; }
         public virtual System.Type[] GetGenericArguments() { throw null; }
         public override int GetHashCode() { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         public virtual System.Reflection.MethodBody? GetMethodBody() { throw null; }
         public static System.Reflection.MethodBase? GetMethodFromHandle(System.RuntimeMethodHandle handle) { throw null; }
         public static System.Reflection.MethodBase? GetMethodFromHandle(System.RuntimeMethodHandle handle, System.RuntimeTypeHandle declaringType) { throw null; }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -233,6 +233,7 @@ namespace System.Reflection
         [DynamicDependency("#ctor(System.Reflection.ExceptionHandlingClause[],System.Reflection.LocalVariableInfo[],System.Byte[],System.Boolean,System.Int32,System.Int32)", typeof(RuntimeMethodBody))]
         internal static extern MethodBody GetMethodBodyInternal(IntPtr handle);
 
+        [RequiresUnreferencedCode("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         internal static MethodBody GetMethodBody(IntPtr handle)
         {
             return GetMethodBodyInternal(handle);
@@ -749,6 +750,7 @@ namespace System.Reflection
             }
         }
 
+        [RequiresUnreferencedCode("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         public override MethodBody GetMethodBody()
         {
             return GetMethodBody(mhandle);
@@ -972,6 +974,7 @@ namespace System.Reflection
             return CustomAttribute.GetCustomAttributes(this, attributeType, inherit);
         }
 
+        [RequiresUnreferencedCode("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         public override MethodBody GetMethodBody()
         {
             return RuntimeMethodInfo.GetMethodBody(mhandle);


### PR DESCRIPTION
See the Justification for each of the added suppressions.