### PR TITLE
Avoid throwing an Exception in ToString when a process has already exited

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1343,15 +1343,30 @@ namespace System.Diagnostics
 
         public override string ToString()
         {
-            if (Associated && !HasExited)
+            string result = base.ToString();
+
+            try
             {
-                string processName = ProcessName;
-                if (processName.Length != 0)
+                if (Associated)
                 {
-                    return string.Format(CultureInfo.CurrentCulture, "{0} ({1})", base.ToString(), processName);
+                    _processInfo ??= ProcessManager.GetProcessInfo(_processId, _machineName);
+                    if (_processInfo is not null)
+                    {
+                        string processName = _processInfo.ProcessName;
+                        if (processName.Length != 0)
+                        {
+                            result = $"{result} ({processName})";
+                        }
+                    }
                 }
             }
-            return base.ToString();
+            catch
+            {
+                // Handle cases where a process would exit straight after our checks
+                // and/or make ProcessManager throw an exception.
+            }
+
+            return result;
         }
 
         /// <devdoc>

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1343,7 +1343,7 @@ namespace System.Diagnostics
 
         public override string ToString()
         {
-            if (Associated)
+            if (Associated && !HasExited)
             {
                 string processName = ProcessName;
                 if (processName.Length != 0)

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -460,6 +460,20 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Fact]        
+        public void TestToString_OnExitedProcess()
+        {
+            var p = Process.Start("dotnet");
+            Assert.Equal("System.Diagnostics.Process (dotnet)", p.ToString());
+
+            p.Kill();
+
+            // Ensure ToString does not throw an exception, but still returns
+            // a representation of the object.
+            Assert.Equal("System.Diagnostics.Process", p.ToString());
+        }
+
+
         [Fact]
         public void HasExited_GetNotStarted_ThrowsInvalidOperationException()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -464,6 +464,7 @@ namespace System.Diagnostics.Tests
         public void TestToString_OnExitedProcess()
         {
             var p = CreateProcessLong();
+            p.Start();
             var name = p.ProcessName;
             Assert.Equal($"System.Diagnostics.Process ({name})", p.ToString());
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -460,20 +460,20 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact]        
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestToString_OnExitedProcess()
         {
-            var p = CreateProcessLong();
-            p.Start();
+            Process p = CreateDefaultProcess();
             var name = p.ProcessName;
             Assert.Equal($"System.Diagnostics.Process ({name})", p.ToString());
 
             p.Kill();
+            Assert.True(p.WaitForExit(WaitInMS));
+
             // Ensure ToString does not throw an exception, but still returns
             // a representation of the object.
             Assert.Equal("System.Diagnostics.Process", p.ToString());
         }
-
 
         [Fact]
         public void HasExited_GetNotStarted_ThrowsInvalidOperationException()

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -463,11 +463,11 @@ namespace System.Diagnostics.Tests
         [Fact]        
         public void TestToString_OnExitedProcess()
         {
-            var p = Process.Start("dotnet");
-            Assert.Equal("System.Diagnostics.Process (dotnet)", p.ToString());
+            var p = CreateProcessLong();
+            var name = p.ProcessName;
+            Assert.Equal($"System.Diagnostics.Process ({name})", p.ToString());
 
             p.Kill();
-
             // Ensure ToString does not throw an exception, but still returns
             // a representation of the object.
             Assert.Equal("System.Diagnostics.Process", p.ToString());


### PR DESCRIPTION
In cases where a process is killed, and `ToString` is called after that, an exception is thrown. This was due to the use of `ProcessName` which calls `EnsureState` - which in turn throws an exception. Instead, we now do a check for the state and fallback to the original `base.ToString`.

Fixes #1520