### PR TITLE
[release/5.0] Use NetCorePublic-Pool pool instead of AzDO hosted pool for Browser jobs

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -103,12 +103,12 @@ jobs:
     ${{ if eq(parameters.jobParameters.pool, '') }}:
       pool:
         # Public Linux Build Pool
-        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD'), eq(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD', 'Browser'), eq(variables['System.TeamProject'], 'public')) }}:
           name:  NetCorePublic-Pool
           queue: BuildPool.Ubuntu.1604.Amd64.Open
 
         # Official Build Linux Pool
-        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD'), ne(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD', 'Browser'), ne(variables['System.TeamProject'], 'public')) }}:
           name: NetCoreInternal-Pool
           queue: BuildPool.Ubuntu.1604.Amd64
 


### PR DESCRIPTION
The hosted pool runs into disk space issues. Looks like AzDO provides less free space recently and we're hitting no free space when building Browser wasm tests.

Backport of #43589 to release/5.0

## Customer Impact

None, this impacts our CI only and allows us to build.

## Testing

Tested on the #43589 PR.

## Risk

Low, it just changes the build pool we're using for running the Browser wasm build (which runs in a Docker container anyway).