### PR TITLE
Correctly apply EventSourceSupport feature switch to NativeRuntimeEventSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -229,7 +229,7 @@ namespace System.Diagnostics.Tracing
 #pragma warning restore CA1823
 #endif //FEATURE_EVENTSOURCE_XPLAT
 
-        private static bool IsSupported { get; } = InitializeIsSupported();
+        internal static bool IsSupported { get; } = InitializeIsSupported();
 
         private static bool InitializeIsSupported() =>
             AppContext.TryGetSwitch("System.Diagnostics.Tracing.EventSource.IsSupported", out bool isSupported) ? isSupported : true;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
@@ -28,6 +28,11 @@ namespace System.Diagnostics.Tracing
         [NonEvent]
         internal unsafe void ProcessEvent(uint eventID, uint osThreadID, DateTime timeStamp, Guid activityId, Guid childActivityId, ReadOnlySpan<byte> payload)
         {
+            if (!IsSupported)
+            {
+                return;
+            }
+
             // Make sure the eventID is valid.
             if (eventID >= m_eventData!.Length)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
@@ -28,6 +28,8 @@ namespace System.Diagnostics.Tracing
         [NonEvent]
         internal unsafe void ProcessEvent(uint eventID, uint osThreadID, DateTime timeStamp, Guid activityId, Guid childActivityId, ReadOnlySpan<byte> payload)
         {
+            // A simple fix to avoid dependencies brought by this method if event source is disabled via a feature switch.
+            // Should be reconsidered when https://github.com/dotnet/runtime/issues/43657 is done.
             if (!IsSupported)
             {
                 return;


### PR DESCRIPTION
`NativeRuntimeEventSource.ProcessEvent` is called from native code in CoreCLR and as such is rooted in the descriptor. But if event source is disabled via feature switch it should not do anything.