### PR TITLE
Add CSV map file generation for compiler diagnostics

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -53,6 +53,14 @@ namespace ILCompiler.DependencyAnalysis
         /// Set to non-null when the executable generator should output a map file.
         /// </summary>
         private readonly MapFileBuilder _mapFileBuilder;
+        /// <summary>
+        /// True when the map file builder should emit a textual map file
+        /// </summary>
+        private bool _generateMapFile;
+        /// <summary>
+        /// True when the map file builder should emit a CSV formatted map file
+        /// </summary>
+        private bool _generateMapCsvFile;
 
         /// <summary>
         /// If non-null, the PE file will be laid out such that it can naturally be mapped with a higher alignment than 4KB
@@ -79,15 +87,17 @@ namespace ILCompiler.DependencyAnalysis
         Dictionary<string, NodeInfo> _previouslyWrittenNodeNames = new Dictionary<string, NodeInfo>();
 #endif
 
-        public ReadyToRunObjectWriter(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, int? customPESectionAlignment)
+        public ReadyToRunObjectWriter(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, bool generateMapCsvFile, int? customPESectionAlignment)
         {
             _objectFilePath = objectFilePath;
             _componentModule = componentModule;
             _nodes = nodes;
             _nodeFactory = factory;
             _customPESectionAlignment = customPESectionAlignment;
-
-            if (generateMapFile)
+            _generateMapFile = generateMapFile;
+            _generateMapCsvFile = generateMapCsvFile;
+            
+            if (generateMapFile || generateMapCsvFile)
             {
                 _mapFileBuilder = new MapFileBuilder();
             }
@@ -241,8 +251,18 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     r2rPeBuilder.AddSections(_mapFileBuilder);
 
-                    string mapFileName = Path.ChangeExtension(_objectFilePath, ".map");
-                    _mapFileBuilder.Save(mapFileName);
+                    if (_generateMapFile)
+                    {
+                        string mapFileName = Path.ChangeExtension(_objectFilePath, ".map");
+                        _mapFileBuilder.SaveMap(mapFileName);
+                    }
+
+                    if (_generateMapCsvFile)
+                    {
+                        string nodeStatsCsvFileName = Path.ChangeExtension(_objectFilePath, ".nodestats.csv");
+                        string mapCsvFileName = Path.ChangeExtension(_objectFilePath, ".map.csv");
+                        _mapFileBuilder.SaveCsv(nodeStatsCsvFileName, mapCsvFileName);
+                    }
                 }
 
                 succeeded = true;
@@ -302,10 +322,10 @@ namespace ILCompiler.DependencyAnalysis
             r2rPeBuilder.AddObjectData(data, section, name, mapFileBuilder);
         }
 
-        public static void EmitObject(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, int? customPESectionAlignment)
+        public static void EmitObject(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, bool generateMapCsvFile, int? customPESectionAlignment)
         {
             Console.WriteLine($@"Emitting R2R PE file: {objectFilePath}");
-            ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(objectFilePath, componentModule, nodes, factory, generateMapFile, customPESectionAlignment);
+            ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(objectFilePath, componentModule, nodes, factory, generateMapFile, generateMapCsvFile, customPESectionAlignment);
             objectWriter.EmitPortableExecutable();
         }
     }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -230,6 +230,7 @@ namespace ILCompiler
         private int _parallelism;
 
         private bool _generateMapFile;
+        private bool _generateMapCsvFile;
 
         private ProfileDataManager _profileData;
         private ReadyToRunFileLayoutOptimizer _fileLayoutOptimizer;
@@ -255,6 +256,7 @@ namespace ILCompiler
             InstructionSetSupport instructionSetSupport,
             bool resilient,
             bool generateMapFile,
+            bool generateMapCsvFile,
             int parallelism,
             ProfileDataManager profileData,
             ReadyToRunMethodLayoutAlgorithm methodLayoutAlgorithm,
@@ -274,6 +276,7 @@ namespace ILCompiler
             _resilient = resilient;
             _parallelism = parallelism;
             _generateMapFile = generateMapFile;
+            _generateMapCsvFile = generateMapCsvFile;
             _customPESectionAlignment = customPESectionAlignment;
             SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory, verifyTypeAndFieldLayout);
             _corInfoImpls = new ConditionalWeakTable<Thread, CorInfoImpl>();
@@ -304,7 +307,7 @@ namespace ILCompiler
             using (PerfEventSource.StartStopEvents.EmittingEvents())
             {
                 NodeFactory.SetMarkingComplete();
-                ReadyToRunObjectWriter.EmitObject(outputFile, componentModule: null, nodes, NodeFactory, _generateMapFile, _customPESectionAlignment);
+                ReadyToRunObjectWriter.EmitObject(outputFile, componentModule: null, nodes, NodeFactory, _generateMapFile, _generateMapCsvFile, _customPESectionAlignment);
                 CompilationModuleGroup moduleGroup = _nodeFactory.CompilationModuleGroup;
 
                 if (moduleGroup.IsCompositeBuildMode)
@@ -369,7 +372,7 @@ namespace ILCompiler
             }
             componentGraph.ComputeMarkedNodes();
             componentFactory.Header.Add(Internal.Runtime.ReadyToRunSectionType.OwnerCompositeExecutable, ownerExecutableNode, ownerExecutableNode);
-            ReadyToRunObjectWriter.EmitObject(outputFile, componentModule: inputModule, componentGraph.MarkedNodeList, componentFactory, generateMapFile: false, customPESectionAlignment: null);
+            ReadyToRunObjectWriter.EmitObject(outputFile, componentModule: inputModule, componentGraph.MarkedNodeList, componentFactory, generateMapFile: false, generateMapCsvFile: false, customPESectionAlignment: null);
         }
 
         public override void WriteDependencyLog(string outputFileName)

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -23,6 +23,7 @@ namespace ILCompiler
         private bool _ibcTuning;
         private bool _resilient;
         private bool _generateMapFile;
+        private bool _generateMapCsvFile;
         private int _parallelism;
         private InstructionSetSupport _instructionSetSupport;
         private ProfileDataManager _profileData;
@@ -126,6 +127,12 @@ namespace ILCompiler
         public ReadyToRunCodegenCompilationBuilder UseMapFile(bool generateMapFile)
         {
             _generateMapFile = generateMapFile;
+            return this;
+        }
+
+        public ReadyToRunCodegenCompilationBuilder UseMapCsvFile(bool generateMapCsvFile)
+        {
+            _generateMapCsvFile = generateMapCsvFile;
             return this;
         }
 
@@ -243,6 +250,7 @@ namespace ILCompiler
                 _instructionSetSupport,
                 _resilient,
                 _generateMapFile,
+                _generateMapCsvFile,
                 _parallelism,
                 _profileData,
                 _r2rMethodLayoutAlgorithm,

--- a/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
@@ -38,6 +38,7 @@ namespace ILCompiler
         public bool Partial { get; set; }
         public bool Resilient { get; set; }
         public bool Map { get; set; }
+        public bool MapCsv { get; set; }
         public int Parallelism { get; set; }
         public ReadyToRunMethodLayoutAlgorithm MethodLayout { get; set; }
         public ReadyToRunFileLayoutAlgorithm FileLayout { get; set; }
@@ -187,6 +188,10 @@ namespace ILCompiler
                     Argument = new Argument<int?>()
                 },
                 new Option(new[] { "--map" }, SR.MapFileOption)
+                {
+                    Argument = new Argument<bool>()
+                },
+                new Option(new[] { "--mapcsv" }, SR.MapCsvFileOption)
                 {
                     Argument = new Argument<bool>()
                 },

--- a/src/coreclr/src/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/Program.cs
@@ -553,6 +553,7 @@ namespace ILCompiler
                         .UseIbcTuning(_commandLineOptions.Tuning)
                         .UseResilience(_commandLineOptions.Resilient)
                         .UseMapFile(_commandLineOptions.Map)
+                        .UseMapCsvFile(_commandLineOptions.MapCsv)
                         .UseParallelism(_commandLineOptions.Parallelism)
                         .UseProfileData(profileDataManager)
                         .FileLayoutAlgorithms(_commandLineOptions.MethodLayout, _commandLineOptions.FileLayout)

--- a/src/coreclr/src/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/src/tools/aot/crossgen2/Properties/Resources.resx
@@ -285,4 +285,7 @@
   <data name="VerifyTypeAndFieldLayoutOption" xml:space="preserve">
     <value>Verify that struct type layout and field offsets match between compile time and runtime. Use only for diagnostic purposes.</value>
   </data>
+  <data name="MapCsvFileOption" xml:space="preserve">
+    <value>Generate a CSV formatted map file</value>
+  </data>
 </root>


### PR DESCRIPTION
Add `--csvmap` switch to Crossgen2 which causes it to generate node summary CSV files that are parsable by tests. The intent is to use this for size on disk perf tests so just the node type statistics and individual node map are implemented in CSV files.  We can add section and relocs easily if we think they'll be useful in future.