### PR TITLE
simplify SslStream_StreamToStream_Alpn_NonMatchingProtocols_Fail test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -132,64 +132,48 @@ namespace System.Net.Security.Tests
         [Fact]
         public async Task SslStream_StreamToStream_Alpn_NonMatchingProtocols_Fail()
         {
-            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
-            try
+            (SslStream clientStream, SslStream serverStream) = TestHelper.GetConnectedSslStreams();
+
+            using (serverStream)
+            using (clientStream)
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
             {
-                listener.Start();
-                using (TcpClient client = new TcpClient())
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
                 {
-                    Task<TcpClient> serverTask = listener.AcceptTcpClientAsync();
-                    await client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
+                    ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
+                    ServerCertificate = certificate,
+                };
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+                {
+                    ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 },
+                    RemoteCertificateValidationCallback = AllowAnyServerCertificate,
+                    TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false),
+                };
 
-                    using (TcpClient server = await serverTask)
-                    using (SslStream serverStream = new SslStream(server.GetStream(), leaveInnerStreamOpen: false))
-                    using (SslStream clientStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false))
-                    using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+                // Test ALPN failure only on platforms that supports ALPN.
+                if (BackendSupportsAlpn)
+                {
+                    Task t1 = Assert.ThrowsAsync<AuthenticationException>(() => clientStream.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions));
+
+                    try
                     {
-                        SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
-                        {
-                            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
-                            ServerCertificate = certificate,
-                        };
-                        SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
-                        {
-                            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http11 },
-                            RemoteCertificateValidationCallback = AllowAnyServerCertificate,
-                            TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false),
-                        };
-
-                        // Test alpn failure only on platforms that supports ALPN.
-                        if (BackendSupportsAlpn)
-                        {
-                            // schannel sends alert on ALPN failure, openssl does not.
-                            Task t1 = Assert.ThrowsAsync(TestConfiguration.SupportsAlpnAlerts ? typeof(AuthenticationException) : typeof(IOException), () =>
-                                clientStream.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions));
-
-                            try
-                            {
-                                await serverStream.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions);
-                                Assert.True(false, "AuthenticationException was not thrown.");
-                            }
-                            catch (AuthenticationException) { server.Dispose(); }
-
-                            await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1);
-                        }
-                        else
-                        {
-                            Task t1 = clientStream.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions);
-                            Task t2 = serverStream.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions);
-
-                            await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
-
-                            Assert.Equal(default(SslApplicationProtocol), clientStream.NegotiatedApplicationProtocol);
-                            Assert.Equal(default(SslApplicationProtocol), serverStream.NegotiatedApplicationProtocol);
-                        }
+                        await serverStream.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions);
+                        Assert.True(false, "AuthenticationException was not thrown.");
                     }
+                    catch (AuthenticationException) { serverStream.Dispose(); }
+
+                    await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1);
                 }
-            }
-            finally
-            {
-                listener.Stop();
+                else
+                {
+                    Task t1 = clientStream.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions);
+                    Task t2 = serverStream.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions);
+
+                    await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
+
+                    Assert.Equal(default(SslApplicationProtocol), clientStream.NegotiatedApplicationProtocol);
+                    Assert.Equal(default(SslApplicationProtocol), serverStream.NegotiatedApplicationProtocol);
+                }
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -155,14 +155,10 @@ namespace System.Net.Security.Tests
                 {
                     Task t1 = Assert.ThrowsAsync<AuthenticationException>(() => clientStream.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions));
 
-                    try
-                    {
-                        await serverStream.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions);
-                        Assert.True(false, "AuthenticationException was not thrown.");
-                    }
-                    catch (AuthenticationException) { serverStream.Dispose(); }
+                    await Assert.ThrowsAsync<AuthenticationException>(() => serverStream.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions));
+                    serverStream.Dispose();
 
-                    await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1);
+                    await t1.TimeoutAfter(TestConfiguration.PassingTestTimeoutMilliseconds);
                 }
                 else
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -29,8 +29,6 @@ namespace System.Net.Security.Tests
 
         public static bool SupportsHandshakeAlerts { get { return OperatingSystem.IsLinux() || OperatingSystem.IsWindows(); } }
 
-        public static bool SupportsAlpnAlerts { get { return OperatingSystem.IsWindows() || (OperatingSystem.IsLinux() && PlatformDetection.OpenSslVersion.CompareTo(new Version(1,0,2)) >= 0); } }
-
         public static Task WhenAllOrAnyFailedWithTimeout(params Task[] tasks)
             => tasks.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
 


### PR DESCRIPTION
- use TestHelper to get streams
- There is no need for SupportsAlpnAlerts: SslStream will inject Alert if underlying implementation does not