### PR TITLE
Provide logic verifying access to function pointer

### DIFF
--- a/src/coreclr/src/tools/ILVerification/AccessVerificationHelpers.cs
+++ b/src/coreclr/src/tools/ILVerification/AccessVerificationHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -21,6 +22,14 @@ namespace ILVerify
 
             if (targetClass.IsParameterizedType)
                 return currentClass.CanAccess(((ParameterizedType)targetClass).ParameterType);
+
+            if (targetClass.IsFunctionPointer)
+            {
+                var signatureBeingPointed = ((FunctionPointerType)targetClass).Signature;
+
+                return currentClass.CanAccess(signatureBeingPointed.ReturnType) &&
+                    signatureBeingPointed._parameters.All(p => currentClass.CanAccess(p));
+            };
 
 #if false
             // perform transparency check on the type, if the caller is transparent


### PR DESCRIPTION
Extend AccessVerificationHelpers.CanAccess method so that it is
able to handle FunctionPointerType by making sure that a current class
can access all the types returned or accepted by the method pointed
by the given function pointer.

Fix #43502