### PR TITLE
disable DefaultConnect_EndToEnd_Ok on Windows7

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -70,7 +70,7 @@ namespace System.Net.Security.Tests
             return EndToEndHelper(host);
         }
 
-        [ConditionalTheory(nameof(IsNotWindows7))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls12))]
         [OuterLoop("Uses external servers")]
         [InlineData("api.nuget.org")]
         [InlineData("")]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -70,7 +70,7 @@ namespace System.Net.Security.Tests
             return EndToEndHelper(host);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls12))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls12))]
         [OuterLoop("Uses external servers")]
         [InlineData("api.nuget.org")]
         [InlineData("")]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -70,7 +70,7 @@ namespace System.Net.Security.Tests
             return EndToEndHelper(host);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(nameof(IsNotWindows7))]
         [OuterLoop("Uses external servers")]
         [InlineData("api.nuget.org")]
         [InlineData("")]


### PR DESCRIPTION
Both sites require TLS1.2+ and strong ciphers. That is not available on Windows7 by default and all the reported failures are on Win7. 

fixes #43575