### PR TITLE
enable BasicTest_AccessInstanceProperties_NoExceptions_Bsd as OuterLoop test

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -84,7 +84,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1332")]
+        [OuterLoop("ttps://github.com/dotnet/runtime/issues/1332")]
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX|TestPlatforms.FreeBSD)]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Bsd()

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -84,7 +84,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [OuterLoop("ttps://github.com/dotnet/runtime/issues/1332")]
+        [OuterLoop("https://github.com/dotnet/runtime/issues/1332")]
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX|TestPlatforms.FreeBSD)]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Bsd()


### PR DESCRIPTION
BasicTest_AccessInstanceProperties_NoExceptions_Bsd started failing at some point on macOS. That can be caused by changes in CI hardwire or some other environmental conditions.

I was not able to reproduce the failure locally.
We could simply remove the check for valid status (e.g. UP OR DOWN) but it feels like that can mask some real bugs. 
So instead this PR brings the test back as OuterLoop (to limit negative impact) so we can collect more data. 
I'll try to work with DDIT and get access to machines where the test is failing. 

contributes to #1332