### PR TITLE
Replace command-line parser for Crossgen2 

### DIFF
--- a/src/coreclr/src/tools/Common/CommandLine/Argument.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/Argument.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Internal.CommandLine
+{
+    public abstract class Argument
+    {
+        internal Argument(ArgumentCommand command, IEnumerable<string> names, bool isOption, bool isRequired)
+        {
+            var nameArray = names.ToArray();
+            Command = command;
+            Name = nameArray.First();
+            Names = new ReadOnlyCollection<string>(nameArray);
+            IsOption = isOption;
+            IsRequired = isRequired;
+        }
+
+        public ArgumentCommand Command { get; private set; }
+
+        public string Name { get; private set; }
+
+        public ReadOnlyCollection<string> Names { get; private set; }
+
+        public string Help { get; set; }
+
+        public bool IsOption { get; private set; }
+
+        public bool IsParameter
+        {
+            get { return !IsOption; }
+        }
+
+        public bool IsSpecified { get; private set; }
+
+        public bool IsHidden { get; set; }
+
+        public bool IsRequired { get; private set; }
+
+        public virtual bool IsList
+        {
+            get { return false; }
+        }
+
+        public object Value
+        {
+            get { return GetValue(); }
+        }
+
+        public object DefaultValue
+        {
+            get { return GetDefaultValue(); }
+        }
+
+        public bool IsActive
+        {
+            get { return Command == null || Command.IsActive; }
+        }
+
+        public abstract bool IsFlag { get; }
+
+        internal abstract object GetValue();
+
+        internal abstract object GetDefaultValue();
+
+        internal void MarkSpecified()
+        {
+            IsSpecified = true;
+        }
+
+        public string GetDisplayName()
+        {
+            return GetDisplayName(Name);
+        }
+
+        public IEnumerable<string> GetDisplayNames()
+        {
+            return Names.Select(GetDisplayName);
+        }
+
+        private string GetDisplayName(string name)
+        {
+            return IsOption ? GetOptionDisplayName(name) : GetParameterDisplayName(name);
+        }
+
+        private static string GetOptionDisplayName(string name)
+        {
+            var modifier = name.Length == 1 ? @"-" : @"--";
+            return modifier + name;
+        }
+
+        private static string GetParameterDisplayName(string name)
+        {
+            return @"<" + name + @">";
+        }
+
+        public virtual string GetDisplayValue()
+        {
+            return Value == null ? string.Empty : Value.ToString();
+        }
+
+        public override string ToString()
+        {
+            return GetDisplayName();
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentCommand.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentCommand.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Internal.CommandLine
+{
+    public abstract class ArgumentCommand
+    {
+        internal ArgumentCommand(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; private set; }
+
+        public string Help { get; set; }
+
+        public object Value
+        {
+            get { return GetValue(); }
+        }
+
+        public bool IsHidden { get; set; }
+
+        public bool IsActive { get; private set; }
+
+        internal abstract object GetValue();
+
+        internal void MarkActive()
+        {
+            IsActive = true;
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentCommand_1.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentCommand_1.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Internal.CommandLine
+{
+    public sealed class ArgumentCommand<T> : ArgumentCommand
+    {
+        internal ArgumentCommand(string name, T value)
+            : base(name)
+        {
+            Value = value;
+        }
+
+        public new T Value { get; private set; }
+
+        internal override object GetValue()
+        {
+            return Value;
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentLexer.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentLexer.cs
@@ -1,0 +1,196 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Internal.CommandLine
+{
+    internal static class ArgumentLexer
+    {
+        public static IReadOnlyList<ArgumentToken> Lex(IEnumerable<string> args, Func<string, IEnumerable<string>> responseFileReader = null)
+        {
+            var result = new List<ArgumentToken>();
+
+            // We'll split the arguments into tokens.
+            //
+            // A token combines the modifier (/, -, --), the option name, and the option
+            // value.
+            //
+            // Please note that this code doesn't combine arguments. It only provides
+            // some pre-processing over the arguments to split out the modifier,
+            // option, and value:
+            //
+            // { "--out", "out.exe" } ==> { new ArgumentToken("--", "out", null),
+            //                              new ArgumentToken(null, null, "out.exe") }
+            //
+            // {"--out:out.exe" }     ==> { new ArgumentToken("--", "out", "out.exe") }
+            //
+            // The reason it doesn't combine arguments is because it depends on the actual
+            // definition. For example, if --out is a flag (meaning it's of type bool) then
+            // out.exe in the first example wouldn't be considered its value.
+            //
+            // The code also handles the special -- token which indicates that the following
+            // arguments shouldn't be considered options.
+            //
+            // Finally, this code will also expand any reponse file entries, assuming the caller
+            // gave us a non-null reader.
+
+            var hasSeenDashDash = false;
+
+            foreach (var arg in ExpandResponseFiles(args, responseFileReader))
+            {
+                // If we've seen a -- already, then we'll treat one as a plain name, that is
+                // without a modifier or value.
+
+                if (!hasSeenDashDash && arg == @"--")
+                {
+                    hasSeenDashDash = true;
+                    continue;
+                }
+
+                string modifier;
+                string name;
+                string value;
+
+                if (hasSeenDashDash)
+                {
+                    modifier = null;
+                    name = arg;
+                    value = null;
+                }
+                else
+                {
+                    // If we haven't seen the -- separator, we're looking for options.
+                    // Options have leading modifiers, i.e. /, -, or --.
+                    //
+                    // Options can also have values, such as:
+                    //
+                    //      -f:false
+                    //      --name=hello
+
+
+                    if (!TryExtractOption(arg, out modifier, out string nameAndValue))
+                    {
+                        name = arg;
+                        value = null;
+                    }
+                    else if (!TrySplitNameValue(nameAndValue, out name, out value))
+                    {
+                        name = nameAndValue;
+                        value = null;
+                    }
+                }
+
+                var token = new ArgumentToken(modifier, name, value);
+                result.Add(token);
+            }
+
+            // Single letter options can be combined, for example the following two
+            // forms are considered equivalent:
+            //
+            //    (1)  -xdf
+            //    (2)  -x -d -f
+            //
+            // In order to free later phases from handling this case, we simply expand
+            // single letter options to the second form.
+
+            for (var i = result.Count - 1; i >= 0; i--)
+            {
+                if (IsOptionBundle(result[i]))
+                    ExpandOptionBundle(result, i);
+            }
+
+            return result.ToArray();
+        }
+
+        private static IEnumerable<string> ExpandResponseFiles(IEnumerable<string> args, Func<string, IEnumerable<string>> responseFileReader)
+        {
+            foreach (var arg in args)
+            {
+                if (responseFileReader == null || !arg.StartsWith(@"@"))
+                {
+                    yield return arg;
+                }
+                else
+                {
+                    var fileName = arg.Substring(1);
+
+                    var responseFileArguments = responseFileReader(fileName);
+
+                    // The reader can suppress expanding this response file by
+                    // returning null. In that case, we'll treat the response
+                    // file token as a regular argument.
+
+                    if (responseFileArguments == null)
+                    {
+                        yield return arg;
+                    }
+                    else
+                    {
+                        foreach (var responseFileArgument in responseFileArguments)
+                            yield return responseFileArgument.Trim();
+                    }
+                }
+            }
+        }
+
+        private static bool IsOptionBundle(ArgumentToken token)
+        {
+            return token.IsOption &&
+                   token.Modifier == @"-" &&
+                   token.Name.Length > 1;
+        }
+
+        private static void ExpandOptionBundle(IList<ArgumentToken> receiver, int index)
+        {
+            var options = receiver[index].Name;
+            receiver.RemoveAt(index);
+
+            foreach (var c in options)
+            {
+                var name = char.ToString(c);
+                var expandedToken = new ArgumentToken(@"-", name, null);
+                receiver.Insert(index, expandedToken);
+                index++;
+            }
+        }
+
+        private static bool TryExtractOption(string text, out string modifier, out string remainder)
+        {
+            return TryExtractOption(text, @"--", out modifier, out remainder) ||
+                   TryExtractOption(text, @"-", out modifier, out remainder);
+        }
+
+        private static bool TryExtractOption(string text, string prefix, out string modifier, out string remainder)
+        {
+            if (text.StartsWith(prefix))
+            {
+                remainder = text.Substring(prefix.Length);
+                modifier = prefix;
+                return true;
+            }
+
+            remainder = null;
+            modifier = null;
+            return false;
+        }
+
+        private static bool TrySplitNameValue(string text, out string name, out string value)
+        {
+            for (int idx = 0; idx < text.Length; idx++)
+            {
+                char ch = text[idx];
+                if (ch == ':' || ch == '=')
+                {
+                    name = text.Substring(0, idx);
+                    value = text.Substring(idx + 1);
+                    return true;
+                }
+            }
+            name = null;
+            value = null;
+            return false;
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentList_1.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentList_1.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Internal.CommandLine
+{
+    public sealed class ArgumentList<T> : Argument
+    {
+        internal ArgumentList(ArgumentCommand command, IEnumerable<string> names, IReadOnlyList<T> defaultValue, bool isRequired)
+            : base(command, names, true, isRequired)
+        {
+            Value = defaultValue;
+            DefaultValue = defaultValue;
+        }
+
+        internal ArgumentList(ArgumentCommand command, string name, IReadOnlyList<T> defaultValue)
+            : base(command, new[] { name }, false, true)
+        {
+            Value = defaultValue;
+            DefaultValue = defaultValue;
+        }
+
+        public override bool IsList
+        {
+            get { return true; }
+        }
+
+        public new IReadOnlyList<T> Value { get; private set; }
+
+        public new IReadOnlyList<T> DefaultValue { get; private set; }
+
+        public override bool IsFlag
+        {
+            get { return typeof(T) == typeof(bool); }
+        }
+
+        internal override object GetValue()
+        {
+            return Value;
+        }
+
+        internal override object GetDefaultValue()
+        {
+            return DefaultValue;
+        }
+
+        internal void SetValue(IReadOnlyList<T> value)
+        {
+            Value = value;
+            MarkSpecified();
+        }
+
+        public override string GetDisplayValue()
+        {
+            return string.Join(@", ", Value);
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentParser.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentParser.cs
@@ -1,0 +1,265 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Internal.CommandLine
+{
+    internal sealed class ArgumentParser
+    {
+        private readonly IReadOnlyList<ArgumentToken> _tokens;
+
+        public ArgumentParser(IEnumerable<string> arguments)
+            : this(arguments, null)
+        {
+        }
+
+        public ArgumentParser(IEnumerable<string> arguments, Func<string, IEnumerable<string>> responseFileReader)
+        {
+            if (arguments == null)
+                throw new ArgumentNullException("arguments");
+
+            _tokens = ArgumentLexer.Lex(arguments, responseFileReader);
+        }
+
+        public bool TryParseCommand(string name)
+        {
+            var token = _tokens.FirstOrDefault();
+
+            if (token == null || token.IsOption || token.IsSeparator)
+                return false;
+
+            if (!string.Equals(token.Name, name, StringComparison.Ordinal))
+                return false;
+
+            token.MarkMatched();
+            return true;
+        }
+
+        public bool TryParseOption<T>(string diagnosticName, IReadOnlyCollection<string> names, Func<string, T> valueConverter, bool isRequired, out T value, out bool specified)
+        {
+            if (!TryParseOptionList(diagnosticName, names, valueConverter, isRequired, out IReadOnlyList<T> values, out specified))
+            {
+                value = default;
+                return false;
+            }
+
+            // Please note that we don't verify that the option is only specified once.
+            // It's tradition on Unix to allow single options to occur more than once,
+            // with 'last one wins' semantics. This simplifies scripting because you
+            // can easily combine arguments.
+
+            value = values.Last();
+            return true;
+        }
+
+        public bool TryParseOptionList<T>(string diagnosticName, IReadOnlyCollection<string> names, Func<string, T> valueConverter, bool isRequired, out IReadOnlyList<T> values, out bool specified)
+        {
+            var result = new List<T>();
+            var tokenIndex = 0;
+            var isFlag = typeof(T) == typeof(bool);
+            specified = false;
+
+            while (tokenIndex < _tokens.Count)
+            {
+                if (TryParseOption(ref tokenIndex, names))
+                {
+                    specified = true;
+                    if (TryParseOptionArgument(ref tokenIndex, isFlag, out string valueText))
+                    {
+                        var value = ParseValue(diagnosticName, valueConverter, valueText);
+                        result.Add(value);
+                    }
+                    else if (isFlag)
+                    {
+                        var value = (T)(object)true;
+                        result.Add(value);
+                    }
+                    else if (isRequired)
+                    {
+                        var message = string.Format(Strings.OptionRequiresValueFmt, diagnosticName);
+                        throw new ArgumentSyntaxException(message);
+                    }
+                }
+
+                tokenIndex++;
+            }
+
+            if (!result.Any())
+            {
+                values = null;
+                return false;
+            }
+
+            values = result.ToArray();
+            return true;
+        }
+
+        public bool TryParseParameter<T>(string diagnosticName, Func<string, T> valueConverter, out T value)
+        {
+            foreach (var token in _tokens)
+            {
+                if (token.IsMatched || token.IsOption || token.IsSeparator)
+                    continue;
+
+                token.MarkMatched();
+
+                var valueText = token.Name;
+                value = ParseValue(diagnosticName, valueConverter, valueText);
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public bool TryParseParameterList<T>(string diagnosticName, Func<string, T> valueConverter, out IReadOnlyList<T> values)
+        {
+            var result = new List<T>();
+
+            while (TryParseParameter(diagnosticName, valueConverter, out T value))
+            {
+                result.Add(value);
+            }
+
+            if (!result.Any())
+            {
+                values = null;
+                return false;
+            }
+
+            values = result.ToArray();
+            return true;
+        }
+
+        private bool TryParseOption(ref int tokenIndex, IReadOnlyCollection<string> names)
+        {
+            while (tokenIndex < _tokens.Count)
+            {
+                var a = _tokens[tokenIndex];
+
+                if (a.IsOption)
+                {
+                    if (names.Any(n => string.Equals(a.Name, n, StringComparison.Ordinal)))
+                    {
+                        a.MarkMatched();
+                        return true;
+                    }
+                }
+
+                tokenIndex++;
+            }
+
+            return false;
+        }
+
+        private bool TryParseOptionArgument(ref int tokenIndex, bool isFlag, out string argument)
+        {
+            argument = null;
+
+            // Let's see whether the current token already has value, like "-o:value"
+
+            var a = _tokens[tokenIndex];
+            if (a.HasValue)
+            {
+                a.MarkMatched();
+                argument = a.Value;
+                return true;
+            }
+
+            // OK, we may need to have to advance one or two tokens. Since we don't know
+            // up front, we'll take a look ahead.
+
+
+            // So, do we have a token?
+
+            if (!TryGetNextToken(tokenIndex, out ArgumentToken lookahead))
+                return false;
+
+            // If it's an option, then it's not an argument and we're done.
+
+            if (lookahead.IsOption)
+                return false;
+
+            // OK, the lookahead is either a separator or it's an argument.
+
+            if (!lookahead.IsSeparator)
+            {
+                // If this is a flag, we need an explicit separator.
+                // Since there is none, we don't consume this token.
+
+                if (isFlag)
+                    return false;
+
+                lookahead.MarkMatched();
+                argument = lookahead.Name;
+                tokenIndex++;
+                return true;
+            }
+
+            // Skip separator
+
+            lookahead.MarkMatched();
+            tokenIndex++;
+
+            // See whether the next token is an argument.
+
+            if (!TryGetNextToken(tokenIndex, out lookahead))
+                return false;
+
+            if (lookahead.IsOption || lookahead.IsSeparator)
+                return false;
+
+            lookahead.MarkMatched();
+            argument = lookahead.Name;
+            tokenIndex++;
+            return true;
+        }
+
+        private bool TryGetNextToken(int tokenIndex, out ArgumentToken token)
+        {
+            if (++tokenIndex >= _tokens.Count)
+            {
+                token = null;
+                return false;
+            }
+
+            token = _tokens[tokenIndex];
+            return true;
+        }
+
+        private static T ParseValue<T>(string diagnosticName, Func<string, T> valueConverter, string valueText)
+        {
+            try
+            {
+                return valueConverter(valueText);
+            }
+            catch (FormatException ex)
+            {
+                var message = string.Format(Strings.CannotParseValueFmt, valueText, diagnosticName, ex.Message);
+                throw new ArgumentSyntaxException(message);
+            }
+        }
+
+        public string GetUnreadCommand()
+        {
+            return _tokens.Where(t => !t.IsOption && !t.IsSeparator).Select(t => t.Name).FirstOrDefault();
+        }
+
+        public IReadOnlyList<string> GetUnreadOptionNames()
+        {
+            return _tokens.Where(t => !t.IsMatched && t.IsOption).Select(t => t.Modifier + t.Name).ToArray();
+        }
+
+        public IReadOnlyList<string> GetUnreadParameters()
+        {
+            return _tokens.Where(t => !t.IsMatched && !t.IsOption).Select(t => t.ToString()).ToArray();
+        }
+
+        public IReadOnlyList<string> GetUnreadArguments()
+        {
+            return _tokens.Where(t => !t.IsMatched).Select(t => t.ToString()).ToArray();
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentSyntax.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentSyntax.cs
@@ -1,0 +1,441 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Internal.CommandLine
+{
+    public sealed partial class ArgumentSyntax
+    {
+        private readonly IEnumerable<string> _arguments;
+        private readonly List<ArgumentCommand> _commands = new List<ArgumentCommand>();
+        private readonly List<Argument> _options = new List<Argument>();
+        private readonly List<Argument> _parameters = new List<Argument>();
+
+        private ArgumentParser _parser;
+        private ArgumentCommand _definedCommand;
+        private ArgumentCommand _activeCommand;
+
+        internal ArgumentSyntax(IEnumerable<string> arguments)
+        {
+            _arguments = arguments;
+
+            ApplicationName = GetApplicationName();
+            HandleErrors = true;
+            HandleHelp = true;
+            HandleResponseFiles = true;
+            ErrorOnUnexpectedArguments = true;
+        }
+
+        public static ArgumentSyntax Parse(IEnumerable<string> arguments, Action<ArgumentSyntax> defineAction)
+        {
+            if (arguments == null)
+                throw new ArgumentNullException("arguments");
+
+            if (defineAction == null)
+                throw new ArgumentNullException("defineAction");
+
+            var syntax = new ArgumentSyntax(arguments);
+            defineAction(syntax);
+            syntax.Validate();
+            return syntax;
+        }
+
+        private void Validate()
+        {
+            // Check whether help is requested
+
+            if (HandleHelp && IsHelpRequested())
+            {
+                var helpText = GetHelpText();
+                Console.Error.Write(helpText);
+                Environment.Exit(0);
+            }
+
+            // Check for invalid or missing command
+
+            if (_activeCommand == null && _commands.Any())
+            {
+                var unreadCommand = Parser.GetUnreadCommand();
+                var message = unreadCommand == null
+                    ? Strings.MissingCommand
+                    : string.Format(Strings.UnknownCommandFmt, unreadCommand);
+                ReportError(message);
+            }
+
+            if (ErrorOnUnexpectedArguments)
+            {
+                // Check for invalid options and extra parameters
+
+                foreach (var option in Parser.GetUnreadOptionNames())
+                {
+                    var message = string.Format(Strings.InvalidOptionFmt, option);
+                    ReportError(message);
+                }
+
+                foreach (var parameter in Parser.GetUnreadParameters())
+                {
+                    var message = string.Format(Strings.ExtraParameterFmt, parameter);
+                    ReportError(message);
+                }
+            }
+        }
+
+        private bool IsHelpRequested()
+        {
+            return Parser.GetUnreadOptionNames()
+                         .Any(a => string.Equals(a, @"-?", StringComparison.Ordinal) ||
+                                   string.Equals(a, @"-h", StringComparison.Ordinal) ||
+                                   string.Equals(a, @"--help", StringComparison.Ordinal));
+        }
+
+        public void ReportError(string message)
+        {
+            if (HandleErrors)
+            {
+                Console.Error.WriteLine(Strings.ErrorWithMessageFmt, message);
+                Environment.Exit(1);
+            }
+
+            throw new ArgumentSyntaxException(message);
+        }
+
+        public ArgumentCommand<T> DefineCommand<T>(string name, T value)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException(Strings.NameMissing, "name");
+
+            if (!IsValidName(name))
+            {
+                var message = string.Format(Strings.CommandNameIsNotValidFmt, name);
+                throw new ArgumentException(message, "name");
+            }
+
+            if (_commands.Any(c => string.Equals(c.Name, name, StringComparison.Ordinal)))
+            {
+                var message = string.Format(Strings.CommandAlreadyDefinedFmt, name);
+                throw new InvalidOperationException(message);
+            }
+
+            if (_options.Concat(_parameters).Any(c => c.Command == null))
+                throw new InvalidOperationException(Strings.CannotDefineCommandsIfArgumentsExist);
+
+            var definedCommand = new ArgumentCommand<T>(name, value);
+            _commands.Add(definedCommand);
+            _definedCommand = definedCommand;
+
+            if (_activeCommand != null)
+                return definedCommand;
+
+            if (!Parser.TryParseCommand(name))
+                return definedCommand;
+
+            _activeCommand = _definedCommand;
+            _activeCommand.MarkActive();
+
+            return definedCommand;
+        }
+
+        public Argument<T> DefineOption<T>(string name, T defaultValue, Func<string, T> valueConverter, bool isRequired)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException(Strings.NameMissing, "name");
+
+            if (DefinedParameters.Any())
+                throw new InvalidOperationException(Strings.OptionsMustBeDefinedBeforeParameters);
+
+            var names = ParseOptionNameList(name);
+            var option = new Argument<T>(_definedCommand, names, defaultValue, isRequired);
+            _options.Add(option);
+
+            if (_activeCommand != _definedCommand)
+                return option;
+
+            try
+            {
+                if (Parser.TryParseOption(option.GetDisplayName(), option.Names, valueConverter, isRequired, out T value, out bool specified))
+                {
+                    option.SetValue(value);
+                }
+                else if (specified)
+                {
+                    // No value was provided, but the option was specified and a value wasn't required
+                    option.MarkSpecified();
+                }
+            }
+            catch (ArgumentSyntaxException ex)
+            {
+                ReportError(ex.Message);
+            }
+
+            return option;
+        }
+
+        public ArgumentList<T> DefineOptionList<T>(string name, IReadOnlyList<T> defaultValue, Func<string, T> valueConverter, bool isRequired)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException(Strings.NameMissing, "name");
+
+            if (DefinedParameters.Any())
+                throw new InvalidOperationException(Strings.OptionsMustBeDefinedBeforeParameters);
+
+            var names = ParseOptionNameList(name);
+            var optionList = new ArgumentList<T>(_definedCommand, names, defaultValue, isRequired);
+            _options.Add(optionList);
+
+            if (_activeCommand != _definedCommand)
+                return optionList;
+
+            try
+            {
+                if (Parser.TryParseOptionList(optionList.GetDisplayName(), optionList.Names, valueConverter, isRequired, out IReadOnlyList<T> value, out bool specified))
+                {
+                    optionList.SetValue(value);
+                }
+                else if (specified)
+                {
+                    // No value was provided, but the option was specified and a value wasn't required
+                    optionList.MarkSpecified();
+                }
+            }
+            catch (ArgumentSyntaxException ex)
+            {
+                ReportError(ex.Message);
+            }
+
+            return optionList;
+        }
+
+        public Argument<T> DefineParameter<T>(string name, T defaultValue, Func<string, T> valueConverter)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException(Strings.NameMissing, "name");
+
+            if (!IsValidName(name))
+            {
+                var message = string.Format(Strings.ParameterNameIsNotValidFmt, name);
+                throw new ArgumentException(message, "name");
+            }
+
+            if (DefinedParameters.Any(p => p.IsList))
+                throw new InvalidOperationException(Strings.ParametersCannotBeDefinedAfterLists);
+
+            if (DefinedParameters.Any(p => string.Equals(name, p.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                var message = string.Format(Strings.ParameterAlreadyDefinedFmt, name);
+                throw new InvalidOperationException(message);
+            }
+
+            var parameter = new Argument<T>(_definedCommand, name, defaultValue);
+            _parameters.Add(parameter);
+
+            if (_activeCommand != _definedCommand)
+                return parameter;
+
+            try
+            {
+                if (Parser.TryParseParameter(parameter.GetDisplayName(), valueConverter, out T value))
+                    parameter.SetValue(value);
+            }
+            catch (ArgumentSyntaxException ex)
+            {
+                ReportError(ex.Message);
+            }
+
+            return parameter;
+        }
+
+        public ArgumentList<T> DefineParameterList<T>(string name, IReadOnlyList<T> defaultValue, Func<string, T> valueConverter)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException(Strings.NameMissing, "name");
+
+            if (!IsValidName(name))
+            {
+                var message = string.Format(Strings.ParameterNameIsNotValidFmt, name);
+                throw new ArgumentException(message, "name");
+            }
+
+            if (DefinedParameters.Any(p => p.IsList))
+                throw new InvalidOperationException(Strings.CannotDefineMultipleParameterLists);
+
+            var parameterList = new ArgumentList<T>(_definedCommand, name, defaultValue);
+            _parameters.Add(parameterList);
+
+            if (_activeCommand != _definedCommand)
+                return parameterList;
+
+            try
+            {
+                if (Parser.TryParseParameterList(parameterList.GetDisplayName(), valueConverter, out IReadOnlyList<T> values))
+                    parameterList.SetValue(values);
+            }
+            catch (ArgumentSyntaxException ex)
+            {
+                ReportError(ex.Message);
+            }
+
+            return parameterList;
+        }
+
+        private static bool IsValidName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return false;
+
+            if (name[0] == '-')
+                return false;
+
+            return name.All(c => char.IsLetterOrDigit(c) ||
+                                 c == '-' ||
+                                 c == '_');
+        }
+
+        private IEnumerable<string> ParseOptionNameList(string name)
+        {
+            var names = name.Split('|').Select(n => n.Trim()).ToArray();
+
+            foreach (var alias in names)
+            {
+                if (!IsValidName(alias))
+                {
+                    var message = string.Format(Strings.OptionNameIsNotValidFmt, alias);
+                    throw new ArgumentException(message, "name");
+                }
+
+                foreach (var option in DefinedOptions)
+                {
+                    if (option.Names.Any(n => string.Equals(n, alias, StringComparison.Ordinal)))
+                    {
+                        var message = string.Format(Strings.OptionAlreadyDefinedFmt, alias);
+                        throw new InvalidOperationException(message);
+                    }
+                }
+            }
+
+            return names;
+        }
+
+        private IEnumerable<string> ParseResponseFile(string fileName)
+        {
+            if (!HandleResponseFiles)
+                return null;
+
+            if (!File.Exists(fileName))
+            {
+                var message = string.Format(Strings.ResponseFileDoesNotExistFmt, fileName);
+                ReportError(message);
+            }
+
+            return File.ReadLines(fileName);
+        }
+
+        private static string GetApplicationName()
+        {
+            var processPath = Environment.GetCommandLineArgs()[0];
+            var processName = Path.GetFileNameWithoutExtension(processPath);
+            return processName;
+        }
+
+        public string ApplicationName { get; set; }
+
+        public bool HandleErrors { get; set; }
+
+        public bool HandleHelp { get; set; }
+
+        public bool HandleResponseFiles { get; set; }
+
+        public bool ErrorOnUnexpectedArguments { get; set; }
+
+        public IEnumerable<string> RemainingArguments
+            => Parser.GetUnreadArguments();
+
+        private ArgumentParser Parser
+        {
+            get
+            {
+                if (_parser == null)
+                    _parser = new ArgumentParser(_arguments, ParseResponseFile);
+
+                return _parser;
+            }
+        }
+
+        private IEnumerable<Argument> DefinedOptions
+        {
+            get { return _options.Where(o => o.Command == null || o.Command == _definedCommand); }
+        }
+
+        private IEnumerable<Argument> DefinedParameters
+        {
+            get { return _parameters.Where(p => p.Command == null || p.Command == _definedCommand); }
+        }
+
+        public ArgumentCommand ActiveCommand
+        {
+            get { return _activeCommand; }
+        }
+
+        public IReadOnlyList<ArgumentCommand> Commands
+        {
+            get { return _commands; }
+        }
+
+        public IEnumerable<Argument> GetArguments()
+        {
+            return _options.Concat(_parameters);
+        }
+
+        public IEnumerable<Argument> GetArguments(ArgumentCommand command)
+        {
+            return GetArguments().Where(c => c.Command == null || c.Command == command);
+        }
+
+        public IEnumerable<Argument> GetOptions()
+        {
+            return _options;
+        }
+
+        public IEnumerable<Argument> GetOptions(ArgumentCommand command)
+        {
+            return _options.Where(c => c.Command == null || c.Command == command);
+        }
+
+        public IEnumerable<Argument> GetParameters()
+        {
+            return _parameters;
+        }
+
+        public IEnumerable<Argument> GetParameters(ArgumentCommand command)
+        {
+            return _parameters.Where(c => c.Command == null || c.Command == command);
+        }
+
+        public IEnumerable<Argument> GetActiveArguments()
+        {
+            return GetArguments(ActiveCommand);
+        }
+
+        public IEnumerable<Argument> GetActiveOptions()
+        {
+            return GetOptions(ActiveCommand);
+        }
+
+        public IEnumerable<Argument> GetActiveParameters()
+        {
+            return GetParameters(ActiveCommand);
+        }
+
+        public string GetHelpText()
+        {
+            return GetHelpText(Console.WindowWidth - 2);
+        }
+
+        public string GetHelpText(int maxWidth)
+        {
+            return HelpTextGenerator.Generate(this, maxWidth);
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentSyntaxException.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentSyntaxException.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Internal.CommandLine
+{
+    public sealed class ArgumentSyntaxException : Exception
+    {
+        public ArgumentSyntaxException()
+        {
+        }
+
+        public ArgumentSyntaxException(string message)
+            : base(message)
+        {
+        }
+
+        public ArgumentSyntaxException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentSyntax_Definers.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentSyntax_Definers.cs
@@ -1,0 +1,253 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Internal.CommandLine
+{
+    public partial class ArgumentSyntax
+    {
+        private static readonly Func<string, string> s_stringParser = v => v;
+        private static readonly Func<string, bool> s_booleanParser = v => bool.Parse(v);
+        private static readonly Func<string, int> s_int32Parser = v => int.Parse(v, CultureInfo.InvariantCulture);
+
+        // Commands
+
+        public ArgumentCommand<string> DefineCommand(string name)
+        {
+            return DefineCommand(name, name);
+        }
+
+        public ArgumentCommand<T> DefineCommand<T>(string name, ref T command, T value, string help)
+        {
+            var result = DefineCommand(name, value);
+            result.Help = help;
+
+            if (_activeCommand == result)
+                command = value;
+
+            return result;
+        }
+
+        public ArgumentCommand<string> DefineCommand(string name, ref string value, string help)
+        {
+            return DefineCommand(name, ref value, name, help);
+        }
+
+        // Options
+
+        public Argument<string> DefineOption(string name, string defaultValue)
+        {
+            return DefineOption(name, defaultValue, s_stringParser);
+        }
+
+        public Argument<bool> DefineOption(string name, bool defaultValue)
+        {
+            return DefineOption(name, defaultValue, s_booleanParser);
+        }
+
+        public Argument<int> DefineOption(string name, int defaultValue)
+        {
+            return DefineOption(name, defaultValue, s_int32Parser);
+        }
+
+        public Argument<string> DefineOption(string name, string defaultValue, bool requireValue)
+        {
+            return DefineOption(name, defaultValue, s_stringParser, requireValue);
+        }
+
+        public Argument<bool> DefineOption(string name, bool defaultValue, bool requireValue)
+        {
+            return DefineOption(name, defaultValue, s_booleanParser, requireValue);
+        }
+
+        public Argument<int> DefineOption(string name, int defaultValue, bool requireValue)
+        {
+            return DefineOption(name, defaultValue, s_int32Parser, requireValue);
+        }
+
+        public Argument<T> DefineOption<T>(string name, T defaultValue, Func<string, T> valueConverter)
+        {
+            return DefineOption(name, defaultValue, valueConverter, true);
+        }
+
+        public Argument<T> DefineOption<T>(string name, ref T value, Func<string, T> valueConverter, string help)
+        {
+            return DefineOption(name, ref value, valueConverter, true, help);
+        }
+
+        public Argument<T> DefineOption<T>(string name, ref T value, Func<string, T> valueConverter, bool requireValue, string help)
+        {
+            var option = DefineOption(name, value, valueConverter, requireValue);
+            option.Help = help;
+
+            value = option.Value;
+            return option;
+        }
+
+        public Argument<string> DefineOption(string name, ref string value, string help)
+        {
+            return DefineOption(name, ref value, s_stringParser, help);
+        }
+
+        public Argument<bool> DefineOption(string name, ref bool value, string help)
+        {
+            return DefineOption(name, ref value, s_booleanParser, help);
+        }
+
+        public Argument<int> DefineOption(string name, ref int value, string help)
+        {
+            return DefineOption(name, ref value, s_int32Parser, help);
+        }
+
+        public Argument<string> DefineOption(string name, ref string value, bool requireValue, string help)
+        {
+            return DefineOption(name, ref value, s_stringParser, requireValue, help);
+        }
+
+        public Argument<bool> DefineOption(string name, ref bool value, bool requireValue, string help)
+        {
+            return DefineOption(name, ref value, s_booleanParser, requireValue, help);
+        }
+
+        public Argument<int> DefineOption(string name, ref int value, bool requireValue, string help)
+        {
+            return DefineOption(name, ref value, s_int32Parser, requireValue, help);
+        }
+
+        // Option lists
+
+        public ArgumentList<string> DefineOptionList(string name, IReadOnlyList<string> defaultValue)
+        {
+            return DefineOptionList(name, defaultValue, s_stringParser);
+        }
+
+        public ArgumentList<int> DefineOptionList(string name, IReadOnlyList<int> defaultValue)
+        {
+            return DefineOptionList(name, defaultValue, s_int32Parser);
+        }
+
+        public ArgumentList<string> DefineOptionList(string name, IReadOnlyList<string> defaultValue, bool requireValue)
+        {
+            return DefineOptionList(name, defaultValue, s_stringParser, requireValue);
+        }
+
+        public ArgumentList<int> DefineOptionList(string name, IReadOnlyList<int> defaultValue, bool requireValue)
+        {
+            return DefineOptionList(name, defaultValue, s_int32Parser, requireValue);
+        }
+
+        public ArgumentList<T> DefineOptionList<T>(string name, IReadOnlyList<T> defaultValue, Func<string, T> valueConverter)
+        {
+            return DefineOptionList(name, defaultValue, valueConverter, true);
+        }
+
+        public ArgumentList<T> DefineOptionList<T>(string name, ref IReadOnlyList<T> value, Func<string, T> valueConverter, string help)
+        {
+            return DefineOptionList(name, ref value, valueConverter, true, help);
+        }
+
+        public ArgumentList<T> DefineOptionList<T>(string name, ref IReadOnlyList<T> value, Func<string, T> valueConverter, bool requireValue, string help)
+        {
+            var optionList = DefineOptionList(name, value, valueConverter, requireValue);
+            optionList.Help = help;
+
+            value = optionList.Value;
+            return optionList;
+        }
+
+        public ArgumentList<string> DefineOptionList(string name, ref IReadOnlyList<string> value, string help)
+        {
+            return DefineOptionList(name, ref value, s_stringParser, help);
+        }
+
+        public ArgumentList<int> DefineOptionList(string name, ref IReadOnlyList<int> value, string help)
+        {
+            return DefineOptionList(name, ref value, s_int32Parser, help);
+        }
+
+        public ArgumentList<string> DefineOptionList(string name, ref IReadOnlyList<string> value, bool requireValue, string help)
+        {
+            return DefineOptionList(name, ref value, s_stringParser, requireValue, help);
+        }
+
+        public ArgumentList<int> DefineOptionList(string name, ref IReadOnlyList<int> value, bool requireValue, string help)
+        {
+            return DefineOptionList(name, ref value, s_int32Parser, requireValue, help);
+        }
+
+        // Parameters
+
+        public Argument<string> DefineParameter(string name, string defaultValue)
+        {
+            return DefineParameter(name, defaultValue, s_stringParser);
+        }
+
+        public Argument<bool> DefineParameter(string name, bool defaultValue)
+        {
+            return DefineParameter(name, defaultValue, s_booleanParser);
+        }
+
+        public Argument<int> DefineParameter(string name, int defaultValue)
+        {
+            return DefineParameter(name, defaultValue, s_int32Parser);
+        }
+
+        public Argument<T> DefineParameter<T>(string name, ref T value, Func<string, T> valueConverter, string help)
+        {
+            var parameter = DefineParameter(name, value, valueConverter);
+            parameter.Help = help;
+
+            value = parameter.Value;
+            return parameter;
+        }
+
+        public Argument<string> DefineParameter(string name, ref string value, string help)
+        {
+            return DefineParameter(name, ref value, s_stringParser, help);
+        }
+
+        public Argument<bool> DefineParameter(string name, ref bool value, string help)
+        {
+            return DefineParameter(name, ref value, s_booleanParser, help);
+        }
+
+        public Argument<int> DefineParameter(string name, ref int value, string help)
+        {
+            return DefineParameter(name, ref value, s_int32Parser, help);
+        }
+
+        // Parameter list
+
+        public ArgumentList<string> DefineParameterList(string name, IReadOnlyList<string> defaultValue)
+        {
+            return DefineParameterList(name, defaultValue, s_stringParser);
+        }
+
+        public ArgumentList<int> DefineParameterList(string name, IReadOnlyList<int> defaultValue)
+        {
+            return DefineParameterList(name, defaultValue, s_int32Parser);
+        }
+
+        public ArgumentList<T> DefineParameterList<T>(string name, ref IReadOnlyList<T> value, Func<string, T> valueConverter, string help)
+        {
+            var parameterList = DefineParameterList(name, value, valueConverter);
+            parameterList.Help = help;
+
+            value = parameterList.Value;
+            return parameterList;
+        }
+
+        public ArgumentList<string> DefineParameterList(string name, ref IReadOnlyList<string> value, string help)
+        {
+            return DefineParameterList(name, ref value, s_stringParser, help);
+        }
+
+        public ArgumentList<int> DefineParameterList(string name, ref IReadOnlyList<int> value, string help)
+        {
+            return DefineParameterList(name, ref value, s_int32Parser, help);
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentToken.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentToken.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Internal.CommandLine
+{
+    internal sealed class ArgumentToken
+    {
+        internal ArgumentToken(string modifier, string name, string value)
+        {
+            Modifier = modifier;
+            Name = name;
+            Value = value;
+        }
+
+        public string Modifier { get; private set; }
+
+        public string Name { get; private set; }
+
+        public string Value { get; private set; }
+
+        public bool IsOption
+        {
+            get { return !string.IsNullOrEmpty(Modifier); }
+        }
+
+        public bool IsSeparator
+        {
+            get { return Name == @":" || Name == @"="; }
+        }
+
+        public bool HasValue
+        {
+            get { return !string.IsNullOrEmpty(Value); }
+        }
+
+        public bool IsMatched { get; private set; }
+
+        public void MarkMatched()
+        {
+            IsMatched = true;
+        }
+
+        private bool Equals(ArgumentToken other)
+        {
+            return string.Equals(Modifier, other.Modifier) &&
+                   string.Equals(Name, other.Name) &&
+                   string.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(obj, null))
+                return false;
+
+            if (ReferenceEquals(obj, this))
+                return true;
+
+            var other = obj as ArgumentToken;
+            return !ReferenceEquals(other, null) && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (Modifier != null ? Modifier.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Value != null ? Value.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return HasValue
+                ? string.Format(@"{0}{1}:{2}", Modifier, Name, Value)
+                : string.Format(@"{0}{1}", Modifier, Name);
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/Argument_1.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/Argument_1.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Internal.CommandLine
+{
+    public sealed class Argument<T> : Argument
+    {
+        internal Argument(ArgumentCommand command, IEnumerable<string> names, T defaultValue, bool isRequired)
+            : base(command, names, true, isRequired)
+        {
+            Value = defaultValue;
+            Value = DefaultValue = defaultValue;
+        }
+
+        internal Argument(ArgumentCommand command, string name, T defaultValue)
+            : base(command, new[] { name }, false, true)
+        {
+            Value = defaultValue;
+            DefaultValue = defaultValue;
+        }
+
+        public new T Value { get; private set; }
+
+        public new T DefaultValue { get; private set; }
+
+        public override bool IsFlag
+        {
+            get { return typeof(T) == typeof(bool); }
+        }
+
+        internal override object GetValue()
+        {
+            return Value;
+        }
+
+        internal override object GetDefaultValue()
+        {
+            return DefaultValue;
+        }
+
+        internal void SetValue(T value)
+        {
+            Value = value;
+            MarkSpecified();
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/Enumerable.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/Enumerable.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Linq = System.Linq;
+
+namespace Internal.CommandLine
+{
+    // Low-level replacement of LINQ Enumerable class. In particular, this implementation
+    // doesn't use generic virtual methods.
+    internal static class Enumerable
+    {
+        public static IEnumerable<T> Empty<T>()
+        {
+            return Linq.Enumerable.Empty<T>();
+        }
+
+        public static IEnumerable<U> Select<T, U>(this IEnumerable<T> values, Func<T, U> func)
+        {
+            Debug.Assert(values != null);
+
+            foreach (T value in values)
+            {
+                yield return func(value);
+            }
+        }
+
+        public static IEnumerable<T> Where<T>(this IEnumerable<T> values, Func<T, bool> func)
+        {
+            Debug.Assert(values != null);
+
+            foreach (T value in values)
+            {
+                if (func(value))
+                    yield return value;
+            }
+        }
+
+        public static IEnumerable<T> Concat<T>(this IEnumerable<T> first, IEnumerable<T> second)
+        {
+            return Linq.Enumerable.Concat(first, second);
+        }
+
+        public static bool All<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            return Linq.Enumerable.All(source, predicate);
+        }
+
+        public static bool Any<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            return Linq.Enumerable.Any(source, predicate);
+        }
+
+        public static bool Any<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.Any(source);
+        }
+
+        public static T[] ToArray<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.ToArray(source);
+        }
+
+        public static T Last<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.Last(source);
+        }
+
+        public static T FirstOrDefault<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.FirstOrDefault(source);
+        }
+
+        public static T First<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.First(source);
+        }
+
+        public static int Max(this IEnumerable<int> source)
+        {
+            return Linq.Enumerable.Max(source);
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/HelpTextGenerator.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/HelpTextGenerator.cs
@@ -1,0 +1,259 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace Internal.CommandLine
+{
+    internal static class HelpTextGenerator
+    {
+        public static string Generate(ArgumentSyntax argumentSyntax, int maxWidth)
+        {
+            var forCommandList = argumentSyntax.ActiveCommand == null &&
+                                 argumentSyntax.Commands.Any();
+
+            var page = forCommandList
+                ? GetCommandListHelp(argumentSyntax)
+                : GetCommandHelp(argumentSyntax, argumentSyntax.ActiveCommand);
+
+            var sb = new StringBuilder();
+            sb.WriteHelpPage(page, maxWidth);
+            return sb.ToString();
+        }
+
+        private struct HelpPage
+        {
+            public string ApplicationName;
+            public IEnumerable<string> SyntaxElements;
+            public IReadOnlyList<HelpRow> Rows;
+        }
+
+        private struct HelpRow
+        {
+            public string Header;
+            public string Text;
+        }
+
+        private static void WriteHelpPage(this StringBuilder sb, HelpPage page, int maxWidth)
+        {
+            sb.WriteUsage(page.ApplicationName, page.SyntaxElements, maxWidth);
+
+            if (!page.Rows.Any())
+                return;
+
+            sb.AppendLine();
+
+            sb.WriteRows(page.Rows, maxWidth);
+
+            sb.AppendLine();
+        }
+
+        private static void WriteUsage(this StringBuilder sb, string applicationName, IEnumerable<string> syntaxElements, int maxWidth)
+        {
+            var usageHeader = string.Format(Strings.HelpUsageOfApplicationFmt, applicationName);
+            sb.Append(usageHeader);
+
+            if (syntaxElements.Any())
+                sb.Append(@" ");
+
+            var syntaxIndent = usageHeader.Length + 1;
+            var syntaxMaxWidth = maxWidth - syntaxIndent;
+
+            sb.WriteWordWrapped(syntaxElements, syntaxIndent, syntaxMaxWidth);
+        }
+
+        private static void WriteRows(this StringBuilder sb, IReadOnlyList<HelpRow> rows, int maxWidth)
+        {
+            const int indent = 4;
+            var maxColumnWidth = rows.Select(r => r.Header.Length).Max();
+            var helpStartColumn = maxColumnWidth + 2 * indent;
+
+            var maxHelpWidth = maxWidth - helpStartColumn;
+            if (maxHelpWidth < 0)
+                maxHelpWidth = maxWidth;
+
+            foreach (var row in rows)
+            {
+                var headerStart = sb.Length;
+
+                sb.Append(' ', indent);
+                sb.Append(row.Header);
+
+                var headerLength = sb.Length - headerStart;
+                var requiredSpaces = helpStartColumn - headerLength;
+
+                sb.Append(' ', requiredSpaces);
+
+                var words = SplitWords(row.Text);
+                sb.WriteWordWrapped(words, helpStartColumn, maxHelpWidth);
+            }
+        }
+
+        private static void WriteWordWrapped(this StringBuilder sb, IEnumerable<string> words, int indent, int maxidth)
+        {
+            var helpLines = WordWrapLines(words, maxidth);
+            var isFirstHelpLine = true;
+
+            foreach (var helpLine in helpLines)
+            {
+                if (isFirstHelpLine)
+                    isFirstHelpLine = false;
+                else
+                    sb.Append(' ', indent);
+
+                sb.AppendLine(helpLine);
+            }
+
+            if (isFirstHelpLine)
+                sb.AppendLine();
+        }
+
+        private static HelpPage GetCommandListHelp(ArgumentSyntax argumentSyntax)
+        {
+            return new HelpPage
+            {
+                ApplicationName = argumentSyntax.ApplicationName,
+                SyntaxElements = GetGlobalSyntax(),
+                Rows = GetCommandRows(argumentSyntax).ToArray()
+            };
+        }
+
+        private static HelpPage GetCommandHelp(ArgumentSyntax argumentSyntax, ArgumentCommand command)
+        {
+            return new HelpPage
+            {
+                ApplicationName = argumentSyntax.ApplicationName,
+                SyntaxElements = GetCommandSyntax(argumentSyntax, command),
+                Rows = GetArgumentRows(argumentSyntax, command).ToArray()
+            };
+        }
+
+        private static IEnumerable<string> GetGlobalSyntax()
+        {
+            yield return @"<command>";
+            yield return @"[<args>]";
+        }
+
+        private static IEnumerable<string> GetCommandSyntax(ArgumentSyntax argumentSyntax, ArgumentCommand command)
+        {
+            if (command != null)
+                yield return command.Name;
+
+            foreach (var option in argumentSyntax.GetOptions(command).Where(o => !o.IsHidden))
+                yield return GetOptionSyntax(option);
+
+            if (argumentSyntax.GetParameters(command).All(p => p.IsHidden))
+                yield break;
+
+            if (argumentSyntax.GetOptions(command).Any(o => !o.IsHidden))
+                yield return @"[--]";
+
+            foreach (var parameter in argumentSyntax.GetParameters(command).Where(o => !o.IsHidden))
+                yield return GetParameterSyntax(parameter);
+        }
+
+        private static string GetOptionSyntax(Argument option)
+        {
+            var sb = new StringBuilder();
+
+            sb.Append(@"[");
+            sb.Append(option.GetDisplayName());
+
+            if (!option.IsFlag)
+                sb.Append(option.IsRequired ? @" <arg>" : @" [arg]");
+
+            if (option.IsList)
+                sb.Append(@"...");
+
+            sb.Append(@"]");
+
+            return sb.ToString();
+        }
+
+        private static string GetParameterSyntax(Argument parameter)
+        {
+            var sb = new StringBuilder();
+
+            sb.Append(parameter.GetDisplayName());
+            if (parameter.IsList)
+                sb.Append(@"...");
+
+            return sb.ToString();
+        }
+
+        private static IEnumerable<HelpRow> GetCommandRows(ArgumentSyntax argumentSyntax)
+        {
+            return argumentSyntax.Commands
+                              .Where(c => !c.IsHidden)
+                              .Select(c => new HelpRow { Header = c.Name, Text = c.Help });
+        }
+
+        private static IEnumerable<HelpRow> GetArgumentRows(ArgumentSyntax argumentSyntax, ArgumentCommand command)
+        {
+            return argumentSyntax.GetArguments(command)
+                              .Where(a => !a.IsHidden)
+                              .Select(a => new HelpRow { Header = GetArgumentRowHeader(a), Text = a.Help });
+        }
+
+        private static string GetArgumentRowHeader(Argument argument)
+        {
+            var sb = new StringBuilder();
+
+            foreach (var displayName in argument.GetDisplayNames())
+            {
+                if (sb.Length > 0)
+                    sb.Append(@", ");
+
+                sb.Append(displayName);
+            }
+
+            if (argument.IsOption && !argument.IsFlag)
+                sb.Append(argument.IsRequired ? @" <arg>" : @" [arg]");
+
+            if (argument.IsList)
+                sb.Append(@"...");
+
+            return sb.ToString();
+        }
+
+        private static IEnumerable<string> WordWrapLines(IEnumerable<string> tokens, int maxWidth)
+        {
+            var sb = new StringBuilder();
+
+            foreach (var token in tokens)
+            {
+                var newLength = sb.Length == 0
+                    ? token.Length
+                    : sb.Length + 1 + token.Length;
+
+                if (newLength > maxWidth)
+                {
+                    if (sb.Length == 0)
+                    {
+                        yield return token;
+                        continue;
+                    }
+
+                    yield return sb.ToString();
+                    sb.Clear();
+                }
+
+                if (sb.Length > 0)
+                    sb.Append(@" ");
+
+                sb.Append(token);
+            }
+
+            if (sb.Length > 0)
+                yield return sb.ToString();
+        }
+
+        private static IEnumerable<string> SplitWords(string text)
+        {
+            return string.IsNullOrEmpty(text)
+                ? Enumerable.Empty<string>()
+                : text.Split(' ');
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/CommandLine/Resources/Strings.resx
+++ b/src/coreclr/src/tools/Common/CommandLine/Resources/Strings.resx
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CannotDefineCommandsIfArgumentsExist" xml:space="preserve">
+    <value>Cannot define commands if global options or parameters exist.</value>
+  </data>
+  <data name="CannotParseValueFmt" xml:space="preserve">
+    <value>value '{0}' isn't valid for {1}: {2}</value>
+  </data>
+  <data name="CommandAlreadyDefinedFmt" xml:space="preserve">
+    <value>Command '{0}' is already defined.</value>
+  </data>
+  <data name="ErrorWithMessageFmt" xml:space="preserve">
+    <value>error: {0}</value>
+  </data>
+  <data name="ExtraParameterFmt" xml:space="preserve">
+    <value>extra parameter '{0}'</value>
+  </data>
+  <data name="HelpUsageOfApplicationFmt" xml:space="preserve">
+    <value>usage: {0}</value>
+  </data>
+  <data name="InvalidOptionFmt" xml:space="preserve">
+    <value>invalid option {0}</value>
+  </data>
+  <data name="MissingCommand" xml:space="preserve">
+    <value>missing command</value>
+  </data>
+  <data name="NameMissing" xml:space="preserve">
+    <value>You must specify a name.</value>
+  </data>
+  <data name="OptionAlreadyDefinedFmt" xml:space="preserve">
+    <value>Option '{0}' is already defined.</value>
+  </data>
+  <data name="OptionsMustBeDefinedBeforeParameters" xml:space="preserve">
+    <value>Options must be defined before any parameters.</value>
+  </data>
+  <data name="ResponseFileDoesNotExistFmt" xml:space="preserve">
+    <value>Response file '{0}' doesn't exist.</value>
+  </data>
+  <data name="UnknownCommandFmt" xml:space="preserve">
+    <value>unknown command '{0}'</value>
+  </data>
+  <data name="UnmatchedQuoteFmt" xml:space="preserve">
+    <value>Unmatched quote at position {0}.</value>
+  </data>
+  <data name="OptionRequiresValueFmt" xml:space="preserve">
+    <value>option {0} requires a value</value>
+  </data>
+  <data name="ParameterAlreadyDefinedFmt" xml:space="preserve">
+    <value>Parameter '{0}' is already defined.</value>
+  </data>
+  <data name="CannotDefineMultipleParameterLists" xml:space="preserve">
+    <value>Cannot define multiple parameter lists.</value>
+  </data>
+  <data name="ParametersCannotBeDefinedAfterLists" xml:space="preserve">
+    <value>Parameters cannot be defined after parameter lists.</value>
+  </data>
+  <data name="CommandNameIsNotValidFmt" xml:space="preserve">
+    <value>Name '{0}' cannot be used for a command.</value>
+  </data>
+  <data name="OptionNameIsNotValidFmt" xml:space="preserve">
+    <value>Name '{0}' cannot be used for an option.</value>
+  </data>
+  <data name="ParameterNameIsNotValidFmt" xml:space="preserve">
+    <value>Name '{0}' cannot be used for a parameter.</value>
+  </data>
+</root>

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -63,10 +63,10 @@ namespace ILCompiler.DependencyAnalysis
         private bool _generateMapCsvFile;
 
         /// <summary>
-        /// If non-null, the PE file will be laid out such that it can naturally be mapped with a higher alignment than 4KB
-        /// This is used to support loading via large pages on Linux
+        /// If non-zero, the PE file will be laid out such that it can naturally be mapped with a higher alignment than 4KB.
+        /// This is used to support loading via large pages on Linux.
         /// </summary>
-        private readonly int? _customPESectionAlignment;
+        private readonly int _customPESectionAlignment;
 
 
 #if DEBUG
@@ -87,7 +87,7 @@ namespace ILCompiler.DependencyAnalysis
         Dictionary<string, NodeInfo> _previouslyWrittenNodeNames = new Dictionary<string, NodeInfo>();
 #endif
 
-        public ReadyToRunObjectWriter(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, bool generateMapCsvFile, int? customPESectionAlignment)
+        public ReadyToRunObjectWriter(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, bool generateMapCsvFile, int customPESectionAlignment)
         {
             _objectFilePath = objectFilePath;
             _componentModule = componentModule;
@@ -322,7 +322,7 @@ namespace ILCompiler.DependencyAnalysis
             r2rPeBuilder.AddObjectData(data, section, name, mapFileBuilder);
         }
 
-        public static void EmitObject(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, bool generateMapCsvFile, int? customPESectionAlignment)
+        public static void EmitObject(string objectFilePath, EcmaModule componentModule, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile, bool generateMapCsvFile, int customPESectionAlignment)
         {
             Console.WriteLine($@"Emitting R2R PE file: {objectFilePath}");
             ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(objectFilePath, componentModule, nodes, factory, generateMapFile, generateMapCsvFile, customPESectionAlignment);

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -237,7 +237,7 @@ namespace ILCompiler
 
         public ReadyToRunSymbolNodeFactory SymbolNodeFactory { get; }
         public ReadyToRunCompilationModuleGroupBase CompilationModuleGroup { get; }
-        private readonly int? _customPESectionAlignment;
+        private readonly int _customPESectionAlignment;
         /// <summary>
         /// Determining whether a type's layout is fixed is a little expensive and the question can be asked many times
         /// for the same type during compilation so preserve the computed value.
@@ -261,7 +261,7 @@ namespace ILCompiler
             ProfileDataManager profileData,
             ReadyToRunMethodLayoutAlgorithm methodLayoutAlgorithm,
             ReadyToRunFileLayoutAlgorithm fileLayoutAlgorithm,
-            int? customPESectionAlignment,
+            int customPESectionAlignment,
             bool verifyTypeAndFieldLayout)
             : base(
                   dependencyGraph,
@@ -372,7 +372,7 @@ namespace ILCompiler
             }
             componentGraph.ComputeMarkedNodes();
             componentFactory.Header.Add(Internal.Runtime.ReadyToRunSectionType.OwnerCompositeExecutable, ownerExecutableNode, ownerExecutableNode);
-            ReadyToRunObjectWriter.EmitObject(outputFile, componentModule: inputModule, componentGraph.MarkedNodeList, componentFactory, generateMapFile: false, generateMapCsvFile: false, customPESectionAlignment: null);
+            ReadyToRunObjectWriter.EmitObject(outputFile, componentModule: inputModule, componentGraph.MarkedNodeList, componentFactory, generateMapFile: false, generateMapCsvFile: false, customPESectionAlignment: 0);
         }
 
         public override void WriteDependencyLog(string outputFileName)

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -29,7 +29,7 @@ namespace ILCompiler
         private ProfileDataManager _profileData;
         private ReadyToRunMethodLayoutAlgorithm _r2rMethodLayoutAlgorithm;
         private ReadyToRunFileLayoutAlgorithm _r2rFileLayoutAlgorithm;
-        private int? _customPESectionAlignment;
+        private int _customPESectionAlignment;
         private bool _verifyTypeAndFieldLayout;
 
         private string _jitPath;
@@ -93,9 +93,9 @@ namespace ILCompiler
             return _ilProvider;
         }
 
-        public ReadyToRunCodegenCompilationBuilder UseJitPath(FileInfo jitPath)
+        public ReadyToRunCodegenCompilationBuilder UseJitPath(string jitPath)
         {
-            _jitPath = jitPath == null ? null : jitPath.FullName;
+            _jitPath = jitPath;
             return this;
         }
 
@@ -154,7 +154,7 @@ namespace ILCompiler
             return this;
         }
 
-        public ReadyToRunCodegenCompilationBuilder UseCustomPESectionAlignment(int? customPESectionAlignment)
+        public ReadyToRunCodegenCompilationBuilder UseCustomPESectionAlignment(int customPESectionAlignment)
         {
             _customPESectionAlignment = customPESectionAlignment;
             return this;

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -159,7 +159,7 @@ namespace ILCompiler.PEWriter
         /// If non-null, the PE file will be laid out such that it can naturally be mapped with a higher alignment than 4KB
         /// This is used to support loading via large pages on Linux
         /// </summary>
-        private readonly int? _customPESectionAlignment;
+        private readonly int _customPESectionAlignment;
 
         /// <summary>
         /// Constructor initializes the various control structures and combines the section list.
@@ -173,7 +173,7 @@ namespace ILCompiler.PEWriter
             ISymbolNode r2rHeaderExportSymbol,
             string outputFileSimpleName,
             Func<RuntimeFunctionsTableNode> getRuntimeFunctionsTable,
-            int? customPESectionAlignment,
+            int customPESectionAlignment,
             Func<IEnumerable<Blob>, BlobContentId> deterministicIdProvider)
             : base(peHeaderBuilder, deterministicIdProvider: deterministicIdProvider)
         {
@@ -298,8 +298,8 @@ namespace ILCompiler.PEWriter
 
             UpdateSectionRVAs(outputStream);
 
-            if (_customPESectionAlignment.HasValue)
-                SetPEHeaderSectionAlignment(outputStream, _customPESectionAlignment.Value);
+            if (_customPESectionAlignment != 0)
+                SetPEHeaderSectionAlignment(outputStream, _customPESectionAlignment);
 
             ApplyMachineOSOverride(outputStream);
 
@@ -403,7 +403,7 @@ namespace ILCompiler.PEWriter
             int sectionCount = _sectionRVAs.Length;
             for (int sectionIndex = 0; sectionIndex < sectionCount; sectionIndex++)
             {
-                if (_customPESectionAlignment != null)
+                if (_customPESectionAlignment != 0)
                 {
                     // When _customPESectionAlignment is set, the physical and virtual sizes are the same
                     byte[] sizeBytes = BitConverter.GetBytes(_sectionRawSizes[sectionIndex]);
@@ -578,15 +578,15 @@ namespace ILCompiler.PEWriter
             }
 
             int injectedPadding = 0;
-            if (_customPESectionAlignment.HasValue && _customPESectionAlignment.Value != 0)
+            if (_customPESectionAlignment != 0)
             {
                 if (outputSectionIndex > 0)
                 {
                     sectionStartRva = Math.Max(sectionStartRva, _sectionRVAs[outputSectionIndex - 1] + _sectionRawSizes[outputSectionIndex - 1]);
                 }
 
-                int newSectionStartRva = AlignmentHelper.AlignUp(sectionStartRva, _customPESectionAlignment.Value);
-                int newSectionPointerToRawData = AlignmentHelper.AlignUp(location.PointerToRawData, _customPESectionAlignment.Value);
+                int newSectionStartRva = AlignmentHelper.AlignUp(sectionStartRva, _customPESectionAlignment);
+                int newSectionPointerToRawData = AlignmentHelper.AlignUp(location.PointerToRawData, _customPESectionAlignment);
                 if (newSectionPointerToRawData > location.PointerToRawData)
                 {
                     sectionDataBuilder = new BlobBuilder();
@@ -646,10 +646,10 @@ namespace ILCompiler.PEWriter
 
             int sectionRawSize = sectionDataBuilder.Count - injectedPadding;
 
-            if (_customPESectionAlignment.HasValue && _customPESectionAlignment.Value != 0)
+            if (_customPESectionAlignment != 0)
             {
                 // Align the end of the section to the padding offset
-                int count = AlignmentHelper.AlignUp(sectionRawSize, _customPESectionAlignment.Value);
+                int count = AlignmentHelper.AlignUp(sectionRawSize, _customPESectionAlignment);
                 sectionDataBuilder.WriteBytes(0, count - sectionRawSize);
                 sectionRawSize = count;
             }

--- a/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
@@ -2,212 +2,131 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.CommandLine;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+
+using Internal.CommandLine;
 
 namespace ILCompiler
 {
-    public class CommandLineOptions
+    internal class CommandLineOptions
     {
-        public FileInfo[] InputFilePaths { get; set; }
-        public FileInfo[] UnrootedInputFilePaths { get; set; }
-        public FileInfo[] Mibc { get; set; }
-        public string[] Reference { get; set; }
-        public string InstructionSet { get; set; }
-        public FileInfo OutputFilePath { get; set; }
+        public bool Help;
+        public string HelpText;
 
-        public DirectoryInfo CompositeRootPath { get; set; }
-        public bool Optimize { get; set; }
-        public bool OptimizeSpace { get; set; }
-        public bool OptimizeTime { get; set; }
-        public bool InputBubble { get; set; }
-        public bool CompileBubbleGenerics { get; set; }
-        public bool Verbose { get; set; }
-        public bool Composite { get; set; }
-        public bool CompileNoMethods { get; set; }
+        public IReadOnlyList<string> InputFilePaths;
+        public IReadOnlyList<string> UnrootedInputFilePaths;
+        public IReadOnlyList<string> ReferenceFilePaths;
+        public IReadOnlyList<string> MibcFilePaths;
+        public string InstructionSet;
+        public string OutputFilePath;
 
-        public FileInfo DgmlLogFileName { get; set; }
-        public bool GenerateFullDgmlLog { get; set; }
+        public string CompositeRootPath;
+        public bool Optimize;
+        public bool OptimizeSpace;
+        public bool OptimizeTime;
+        public bool InputBubble;
+        public bool CompileBubbleGenerics;
+        public bool Verbose;
+        public bool Composite;
+        public bool CompileNoMethods;
 
-        public string TargetArch { get; set; }
-        public string TargetOS { get; set; }
-        public FileInfo JitPath { get; set; }
-        public string SystemModule { get; set; }
-        public bool WaitForDebugger { get; set; }
-        public bool Tuning { get; set; }
-        public bool Partial { get; set; }
-        public bool Resilient { get; set; }
-        public bool Map { get; set; }
-        public bool MapCsv { get; set; }
-        public int Parallelism { get; set; }
-        public ReadyToRunMethodLayoutAlgorithm MethodLayout { get; set; }
-        public ReadyToRunFileLayoutAlgorithm FileLayout { get; set; }
-        public int? CustomPESectionAlignment { get; set; }
-        public bool VerifyTypeAndFieldLayout { get; set; }
+        public string DgmlLogFileName;
+        public bool GenerateFullDgmlLog;
 
-        public string SingleMethodTypeName { get; set; }
-        public string SingleMethodName { get; set; }
-        public string[] SingleMethodGenericArg { get; set; }
+        public string TargetArch;
+        public string TargetOS;
+        public string JitPath;
+        public string SystemModule;
+        public bool WaitForDebugger;
+        public bool Tuning;
+        public bool Partial;
+        public bool Resilient;
+        public bool Map;
+        public bool MapCsv;
+        public int Parallelism;
+        public int CustomPESectionAlignment;
+        public string MethodLayout;
+        public string FileLayout;
+        public bool VerifyTypeAndFieldLayout;
 
-        public string[] CodegenOptions { get; set; }
+        public string SingleMethodTypeName;
+        public string SingleMethodName;
+        public IReadOnlyList<string> SingleMethodGenericArg;
+
+        public IReadOnlyList<string> CodegenOptions;
 
         public bool CompositeOrInputBubble => Composite || InputBubble;
 
-        public static Command RootCommand()
+        public CommandLineOptions(string[] args)
         {
-            // For some reason, arity caps at 255 by default
-            ArgumentArity arbitraryArity = new ArgumentArity(0, 100000);
+            InputFilePaths = Array.Empty<string>();
+            UnrootedInputFilePaths = Array.Empty<string>();
+            ReferenceFilePaths = Array.Empty<string>();
+            MibcFilePaths = Array.Empty<string>();
+            CodegenOptions = Array.Empty<string>();
 
-            return new Command("Crossgen2Compilation")
+            Parallelism = Environment.ProcessorCount;
+            SingleMethodGenericArg = null;
+
+            ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, syntax =>
             {
-                new Argument<FileInfo[]>() 
-                { 
-                    Name = "input-file-paths", 
-                    Description = SR.InputFilesToCompile,
-                    Arity = arbitraryArity,
-                },
-                new Option(new[] { "--unrooted-input-file-paths", "-u" }, SR.UnrootedInputFilesToCompile)
-                {
-                    Argument = new Argument<FileInfo[]>()
-                    {
-                        Arity = arbitraryArity
-                    }
-                },
-                new Option(new[] { "--reference", "-r" }, SR.ReferenceFiles)
-                {
-                    Argument = new Argument<string[]>() 
-                    { 
-                        Arity = arbitraryArity
-                    } 
-                },
-                new Option(new[] { "--instruction-set" }, SR.InstructionSets)
-                {
-                    Argument = new Argument<string>() 
-                },
-                new Option(new[] { "--mibc", "-m" }, SR.MibcFiles)
-                {
-                    Argument = new Argument<string[]>()
-                    {
-                        Arity = arbitraryArity
-                    }
-                },
-                new Option(new[] { "--outputfilepath", "--out", "-o" }, SR.OutputFilePath)
-                {
-                    Argument = new Argument<FileInfo>()
-                },
-                new Option(new[] { "--compositerootpath", "--crp" }, SR.CompositeRootPath)
-                {
-                    Argument = new Argument<DirectoryInfo>()
-                },
-                new Option(new[] { "--optimize", "-O" }, SR.EnableOptimizationsOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--optimize-space", "--Os" }, SR.OptimizeSpaceOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--optimize-time", "--Ot" }, SR.OptimizeSpeedOption),
-                new Option(new[] { "--inputbubble" }, SR.InputBubbleOption),
-                new Option(new[] { "--composite" }, SR.CompositeBuildMode),
-                new Option(new[] { "--compile-no-methods" }, SR.CompileNoMethodsOption),
-                new Option(new[] { "--tuning" }, SR.TuningImageOption) 
-                {
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--partial" }, SR.PartialImageOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--compilebubblegenerics" }, SR.BubbleGenericsOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--dgml-log-file-name", "--dmgllog" }, SR.SaveDependencyLogOption) 
-                { 
-                    Argument = new Argument<FileInfo>() 
-                },
-                new Option(new[] { "--generate-full-dmgl-log", "--fulllog" }, SR.SaveDetailedLogOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--verbose" }, SR.VerboseLoggingOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--systemmodule" }, SR.SystemModuleOverrideOption) 
-                { 
-                    Argument = new Argument<string>() 
-                },
-                new Option(new[] { "--waitfordebugger" }, SR.WaitForDebuggerOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--codegen-options", "--codegenopt" }, SR.CodeGenOptions) 
-                { 
-                    Argument = new Argument<string[]>()
-                    {
-                        Arity = arbitraryArity
-                    }
-                },
-                new Option(new[] { "--resilient" }, SR.ResilientOption) 
-                { 
-                    Argument = new Argument<bool>() 
-                },
-                new Option(new[] { "--targetarch" }, SR.TargetArchOption) 
-                { 
-                    Argument = new Argument<string>() 
-                },
-                new Option(new[] { "--targetos" }, SR.TargetOSOption) 
-                { 
-                    Argument = new Argument<string>() 
-                },
-                new Option(new[] { "--jitpath" }, SR.JitPathOption) 
-                { 
-                    Argument =  new Argument<FileInfo>() 
-                },
-                new Option(new[] { "--singlemethodtypename" }, SR.SingleMethodTypeName) 
-                { 
-                    Argument = new Argument<string>() 
-                },
-                new Option(new[] { "--singlemethodname" }, SR.SingleMethodMethodName) 
-                { 
-                    Argument = new Argument<string>() 
-                },
-                new Option(new[] { "--singlemethodgenericarg" }, SR.SingleMethodGenericArgs) 
-                { 
-                    // We don't need to override arity here as 255 is the maximum number of generic arguments
-                    Argument = new Argument<string[]>()
-                },
-                new Option(new[] { "--parallelism" }, SR.ParalellismOption)
-                { 
-                    Argument = new Argument<int>(() => Environment.ProcessorCount)
-                },
-                new Option(new[] { "--custom-pe-section-alignment" }, SR.CustomPESectionAlignmentOption)
-                { 
-                    Argument = new Argument<int?>()
-                },
-                new Option(new[] { "--map" }, SR.MapFileOption)
-                {
-                    Argument = new Argument<bool>()
-                },
-                new Option(new[] { "--mapcsv" }, SR.MapCsvFileOption)
-                {
-                    Argument = new Argument<bool>()
-                },
-                new Option(new[] { "--method-layout" }, SR.MethodLayoutOption)
-                {
-                    Argument = new Argument<ReadyToRunMethodLayoutAlgorithm>()
-                },
-                new Option(new[] { "--file-layout" }, SR.FileLayoutOption)
-                {
-                    Argument = new Argument<ReadyToRunFileLayoutAlgorithm>()
-                },
-                new Option(new[] { "--verify-type-and-field-layout" }, SR.VerifyTypeAndFieldLayoutOption)
-                {
-                    Argument = new Argument<bool>()
-                }
-            };
+                syntax.ApplicationName = typeof(Program).Assembly.GetName().Name.ToString();
+
+                // HandleHelp writes to error, fails fast with crash dialog and lacks custom formatting.
+                syntax.HandleHelp = false;
+                syntax.HandleErrors = true;
+
+                syntax.DefineOptionList("u|unrooted-input-file-paths", ref UnrootedInputFilePaths, SR.UnrootedInputFilesToCompile);
+                syntax.DefineOptionList("r|reference", ref ReferenceFilePaths, SR.ReferenceFiles);
+                syntax.DefineOption("instruction-set", ref InstructionSet, SR.InstructionSets);
+                syntax.DefineOptionList("m|mibc", ref MibcFilePaths, SR.MibcFiles);
+                syntax.DefineOption("o|out|outputfilepath", ref OutputFilePath, SR.OutputFilePath);
+                syntax.DefineOption("crp|compositerootpath", ref CompositeRootPath, SR.CompositeRootPath);
+                syntax.DefineOption("O|optimize", ref Optimize, SR.EnableOptimizationsOption);
+                syntax.DefineOption("Os|optimize-space", ref OptimizeSpace, SR.OptimizeSpaceOption);
+                syntax.DefineOption("Ot|optimize-time", ref OptimizeTime, SR.OptimizeSpeedOption);
+                syntax.DefineOption("inputbubble", ref InputBubble, SR.InputBubbleOption);
+                syntax.DefineOption("composite", ref Composite, SR.CompositeBuildMode);
+                syntax.DefineOption("compile-no-methods", ref CompileNoMethods, SR.CompileNoMethodsOption);
+                syntax.DefineOption("tuning", ref Tuning, SR.TuningImageOption);
+                syntax.DefineOption("partial", ref Partial, SR.PartialImageOption);
+                syntax.DefineOption("compilebubblegenerics", ref CompileBubbleGenerics, SR.BubbleGenericsOption);
+                syntax.DefineOption("dgmllog|dgml-log-file-name", ref DgmlLogFileName, SR.SaveDependencyLogOption);
+                syntax.DefineOption("fulllog|generate-full-dmgl-log", ref GenerateFullDgmlLog, SR.SaveDetailedLogOption);
+                syntax.DefineOption("verbose", ref Verbose, SR.VerboseLoggingOption);
+                syntax.DefineOption("systemmodule", ref SystemModule, SR.SystemModuleOverrideOption);
+                syntax.DefineOption("waitfordebugger", ref WaitForDebugger, SR.WaitForDebuggerOption);
+                syntax.DefineOptionList("codegenopt|codegen-options", ref CodegenOptions, SR.CodeGenOptions);
+                syntax.DefineOption("resilient", ref Resilient, SR.ResilientOption);
+
+                syntax.DefineOption("targetarch", ref TargetArch, SR.TargetArchOption);
+                syntax.DefineOption("targetos", ref TargetOS, SR.TargetOSOption);
+                syntax.DefineOption("jitpath", ref JitPath, SR.JitPathOption);
+
+                syntax.DefineOption("singlemethodtypename", ref SingleMethodTypeName, SR.SingleMethodTypeName);
+                syntax.DefineOption("singlemethodname", ref SingleMethodName, SR.SingleMethodMethodName);
+                syntax.DefineOptionList("singlemethodgenericarg", ref SingleMethodGenericArg, SR.SingleMethodGenericArgs);
+
+                syntax.DefineOption("parallelism", ref Parallelism, SR.ParalellismOption);
+                syntax.DefineOption("custom-pe-section-alignment", ref CustomPESectionAlignment, SR.CustomPESectionAlignmentOption);
+                syntax.DefineOption("map", ref Map, SR.MapFileOption);
+                syntax.DefineOption("mapcsv", ref MapCsv, SR.MapCsvFileOption);
+
+                syntax.DefineOption("method-layout", ref MethodLayout, SR.MethodLayoutOption);
+                syntax.DefineOption("file-layout", ref FileLayout, SR.FileLayoutOption);
+                syntax.DefineOption("verify-type-and-field-layout", ref VerifyTypeAndFieldLayout, SR.VerifyTypeAndFieldLayoutOption);
+
+                syntax.DefineOption("h|help", ref Help, SR.HelpOption);
+
+                syntax.DefineParameterList("in", ref InputFilePaths, SR.InputFilesToCompile);
+            });
+
+            if (Help)
+            {
+                HelpText = argSyntax.GetHelpText();
+            }
         }
     }
 }

--- a/src/coreclr/src/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/Program.cs
@@ -3,21 +3,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.Reflection;
+using System.IO;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 
+using Internal.CommandLine;
 using Internal.IL;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
-
-using Internal.CommandLine;
-using System.Linq;
-using System.IO;
-using System.Reflection.Metadata;
 
 namespace ILCompiler
 {
@@ -33,10 +26,11 @@ namespace ILCompiler
         private Dictionary<string, string> _unrootedInputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private Dictionary<string, string> _referenceFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private CompilerTypeSystemContext _typeSystemContext;
+        private ReadyToRunMethodLayoutAlgorithm _methodLayout;
+        private ReadyToRunFileLayoutAlgorithm _fileLayout;
 
-        private Program(CommandLineOptions commandLineOptions)
+        private Program()
         {
-            _commandLineOptions = commandLineOptions;
         }
 
         private void InitializeDefaultOptions()
@@ -71,9 +65,16 @@ namespace ILCompiler
             }
         }
 
-        private void ProcessCommandLine()
+        private void ProcessCommandLine(string[] args)
         {
-            AssemblyName name = typeof(Program).GetTypeInfo().Assembly.GetName();
+            PerfEventSource.StartStopEvents.CommandLineProcessingStart();
+            _commandLineOptions = new CommandLineOptions(args);
+            PerfEventSource.StartStopEvents.CommandLineProcessingStop();
+
+            if (_commandLineOptions.Help)
+            {
+                return;
+            }
 
             if (_commandLineOptions.WaitForDebugger)
             {
@@ -102,14 +103,46 @@ namespace ILCompiler
             else if (_commandLineOptions.Optimize)
                 _optimizationMode = OptimizationMode.Blended;
 
-            foreach (var input in _commandLineOptions.InputFilePaths ?? Enumerable.Empty<FileInfo>())
-                Helpers.AppendExpandedPaths(_inputFilePaths, input.FullName, true);
+            foreach (var input in _commandLineOptions.InputFilePaths)
+                Helpers.AppendExpandedPaths(_inputFilePaths, input, true);
 
-            foreach (var input in _commandLineOptions.UnrootedInputFilePaths ?? Enumerable.Empty<FileInfo>())
-                Helpers.AppendExpandedPaths(_unrootedInputFilePaths, input.FullName, true);
+            foreach (var input in _commandLineOptions.UnrootedInputFilePaths)
+                Helpers.AppendExpandedPaths(_unrootedInputFilePaths, input, true);
 
-            foreach (var reference in _commandLineOptions.Reference ?? Enumerable.Empty<string>())
+            foreach (var reference in _commandLineOptions.ReferenceFilePaths)
                 Helpers.AppendExpandedPaths(_referenceFilePaths, reference, false);
+
+
+            int alignment = _commandLineOptions.CustomPESectionAlignment;
+            if (alignment != 0)
+            {
+                // Must be a power of two and >= 4096
+                if (alignment < 4096 || (alignment & (alignment - 1)) != 0)
+                    throw new CommandLineException(SR.InvalidCustomPESectionAlignment);
+            }
+
+            if (_commandLineOptions.MethodLayout != null)
+            {
+                _methodLayout = _commandLineOptions.MethodLayout.ToLowerInvariant() switch
+                {
+                    "defaultsort" => ReadyToRunMethodLayoutAlgorithm.DefaultSort,
+                    "exclusiveweight" => ReadyToRunMethodLayoutAlgorithm.ExclusiveWeight,
+                    "hotcold" => ReadyToRunMethodLayoutAlgorithm.HotCold,
+                    "hotwarmcold" => ReadyToRunMethodLayoutAlgorithm.HotWarmCold,
+                    _ => throw new CommandLineException(SR.InvalidMethodLayout)
+                };
+            }
+
+            if (_commandLineOptions.FileLayout != null)
+            {
+                _fileLayout = _commandLineOptions.FileLayout.ToLowerInvariant() switch
+                {
+                    "defaultsort" => ReadyToRunFileLayoutAlgorithm.DefaultSort,
+                    "methodorder" => ReadyToRunFileLayoutAlgorithm.MethodOrder,
+                    _ => throw new CommandLineException(SR.InvalidFileLayout)
+                };
+            }
+
         }
 
         private void ConfigureTarget()
@@ -223,7 +256,7 @@ namespace ILCompiler
                 // support AVX instructions. As the jit generates logic that depends on these features it will call
                 // notifyInstructionSetUsage, which will result in generation of a fixup to verify the behavior of
                 // code.
-                // 
+                //
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sse");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sse2");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sse4.1");
@@ -234,7 +267,7 @@ namespace ILCompiler
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("lzcnt");
             }
 
-            optimisticInstructionSetSupportBuilder.ComputeInstructionSetFlags(out var optimisticInstructionSet, out _, 
+            optimisticInstructionSetSupportBuilder.ComputeInstructionSetFlags(out var optimisticInstructionSet, out _,
                 (string specifiedInstructionSet, string impliedInstructionSet) => throw new NotSupportedException());
             optimisticInstructionSet.Remove(unsupportedInstructionSet);
             optimisticInstructionSet.Add(supportedInstructionSet);
@@ -246,27 +279,7 @@ namespace ILCompiler
                                                                   _targetArchitecture);
         }
 
-        private void CheckCustomPESectionAlignment()
-        {
-            if (_commandLineOptions.CustomPESectionAlignment != null)
-            {
-                int alignment = _commandLineOptions.CustomPESectionAlignment.Value;
-                bool invalidArgument = false;
-                if (alignment < 4096)
-                {
-                    invalidArgument = true;
-                }
-                if ((alignment & (alignment - 1)) != 0)
-                {
-                    invalidArgument = true; // Alignment not power of two
-                }
-
-                if (invalidArgument)
-                    throw new CommandLineException(SR.InvalidCustomPESectionAlignment);
-            }
-        }
-
-        private int Run()
+        private int Run(string[] args)
         {
             using (PerfEventSource.StartStopEvents.CompilationEvents())
             {
@@ -275,12 +288,17 @@ namespace ILCompiler
                 {
                     InitializeDefaultOptions();
 
-                    ProcessCommandLine();
+                    ProcessCommandLine(args);
+
+                    if (_commandLineOptions.Help)
+                    {
+                        Console.WriteLine(_commandLineOptions.HelpText);
+                        return 1;
+                    }
 
                     if (_commandLineOptions.OutputFilePath == null)
                         throw new CommandLineException(SR.MissingOutputFile);
 
-                    CheckCustomPESectionAlignment();
                     ConfigureTarget();
                     InstructionSetSupport instructionSetSupport = ConfigureInstructionSetSupport();
 
@@ -322,7 +340,7 @@ namespace ILCompiler
 
                     _typeSystemContext = new ReadyToRunCompilerContext(targetDetails, genericsMode, versionBubbleIncludesCoreLib);
 
-                    string compositeRootPath = _commandLineOptions.CompositeRootPath?.FullName;
+                    string compositeRootPath = _commandLineOptions.CompositeRootPath;
 
                     //
                     // TODO: To support our pre-compiled test tree, allow input files that aren't managed assemblies since
@@ -412,7 +430,7 @@ namespace ILCompiler
 
                     if (_typeSystemContext.InputFilePaths.Count == 0)
                     {
-                        if (_commandLineOptions.InputFilePaths.Count() > 0)
+                        if (_commandLineOptions.InputFilePaths.Count > 0)
                         {
                             Console.WriteLine(SR.InputWasNotLoadable);
                             return 2;
@@ -430,12 +448,9 @@ namespace ILCompiler
                     var logger = new Logger(Console.Out, _commandLineOptions.Verbose);
 
                     List<string> mibcFiles = new List<string>();
-                    if (_commandLineOptions.Mibc != null)
+                    foreach (var file in _commandLineOptions.MibcFilePaths)
                     {
-                        foreach (var file in _commandLineOptions.Mibc)
-                        {
-                            mibcFiles.Add(file.FullName);
-                        }
+                        mibcFiles.Add(file);
                     }
 
                     foreach (var referenceFile in _referenceFilePaths.Values)
@@ -556,12 +571,12 @@ namespace ILCompiler
                         .UseMapCsvFile(_commandLineOptions.MapCsv)
                         .UseParallelism(_commandLineOptions.Parallelism)
                         .UseProfileData(profileDataManager)
-                        .FileLayoutAlgorithms(_commandLineOptions.MethodLayout, _commandLineOptions.FileLayout)
+                        .FileLayoutAlgorithms(_methodLayout, _fileLayout)
                         .UseJitPath(_commandLineOptions.JitPath)
                         .UseInstructionSetSupport(instructionSetSupport)
                         .UseCustomPESectionAlignment(_commandLineOptions.CustomPESectionAlignment)
                         .UseVerifyTypeAndFieldLayout(_commandLineOptions.VerifyTypeAndFieldLayout)
-                        .GenerateOutputFile(_commandLineOptions.OutputFilePath.FullName)
+                        .GenerateOutputFile(_commandLineOptions.OutputFilePath)
                         .UseILProvider(ilProvider)
                         .UseBackendOptions(_commandLineOptions.CodegenOptions)
                         .UseLogger(logger)
@@ -572,10 +587,10 @@ namespace ILCompiler
                     compilation = builder.ToCompilation();
 
                 }
-                compilation.Compile(_commandLineOptions.OutputFilePath.FullName);
+                compilation.Compile(_commandLineOptions.OutputFilePath);
 
                 if (_commandLineOptions.DgmlLogFileName != null)
-                    compilation.WriteDependencyLog(_commandLineOptions.DgmlLogFileName.FullName);
+                    compilation.WriteDependencyLog(_commandLineOptions.DgmlLogFileName);
             }
 
             return 0;
@@ -624,7 +639,7 @@ namespace ILCompiler
                 throw new CommandLineException(string.Format(SR.MethodNotFoundOnType, _commandLineOptions.SingleMethodName, _commandLineOptions.SingleMethodTypeName));
 
             if (method.HasInstantiation != (_commandLineOptions.SingleMethodGenericArg != null) ||
-                (method.HasInstantiation && (method.Instantiation.Length != _commandLineOptions.SingleMethodGenericArg.Length)))
+                (method.HasInstantiation && (method.Instantiation.Length != _commandLineOptions.SingleMethodGenericArg.Count)))
             {
                 throw new CommandLineException(
                     string.Format(SR.GenericArgCountMismatch, method.Instantiation.Length, _commandLineOptions.SingleMethodName, _commandLineOptions.SingleMethodTypeName));
@@ -659,21 +674,12 @@ namespace ILCompiler
             return false;
         }
 
-        public static async Task<int> Main(string[] args)
+        private static int Main(string[] args)
         {
-            PerfEventSource.StartStopEvents.CommandLineProcessingStart();
-            var command = CommandLineOptions.RootCommand();
-            command.Handler = CommandHandler.Create<CommandLineOptions>((CommandLineOptions options) => InnerMain(options));
-            return await command.InvokeAsync(args);
-        }
-
-        private static int InnerMain(CommandLineOptions buildOptions)
-        {
-            PerfEventSource.StartStopEvents.CommandLineProcessingStop();
 #if DEBUG
             try
             {
-                return new Program(buildOptions).Run();
+                return new Program().Run(args);
             }
             catch (CodeGenerationFailedException ex) when (DumpReproArguments(ex))
             {
@@ -682,7 +688,7 @@ namespace ILCompiler
 #else
             try
             {
-                return new Program(buildOptions).Run();
+                return new Program().Run(args);
             }
             catch (Exception e)
             {

--- a/src/coreclr/src/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/src/tools/aot/crossgen2/Properties/Resources.resx
@@ -135,8 +135,17 @@
   <data name="GenericArgCountMismatch" xml:space="preserve">
     <value>Expected {0} generic arguments for method '{1}' on type '{2}'</value>
   </data>
+  <data name="HelpOption" xml:space="preserve">
+    <value>Display this usage message</value>
+  </data>
   <data name="InputBubbleOption" xml:space="preserve">
     <value>True when the entire input forms a version bubble (default = per-assembly bubble)</value>
+  </data>
+  <data name="InvalidFileLayout" xml:space="preserve">
+    <value>Method layout must be either DefaultSort or MethodOrder.</value>
+  </data>
+  <data name="InvalidMethodLayout" xml:space="preserve">
+    <value>Method layout must be either DefaultSort, ExclusiveWeight, HotCold, or HotWarmCold.</value>
   </data>
   <data name="CompileNoMethodsOption" xml:space="preserve">
     <value>True to skip compiling methods into the R2R image (default = false)</value>
@@ -160,7 +169,7 @@
     <value>Instruction set '{0}' implies support for instruction set '{1}'</value>
   </data>
   <data name="UnrootedInputFilesToCompile" xml:space="preserve">
-    <value>"Input files without automatic rooting of all methods</value>
+    <value>Input files without automatic rooting of all methods</value>
   </data>
   <data name="JitPathOption" xml:space="preserve">
     <value>Path to JIT compiler library</value>
@@ -175,7 +184,7 @@
     <value>Mibc file(s) for profile guided optimization</value>
   </data>
   <data name="MissingOutputFile" xml:space="preserve">
-    <value>Output filename must be specified (/out &lt;file&gt;)</value>
+    <value>Output filename must be specified (--out &lt;file&gt;)</value>
   </data>
   <data name="InputWasNotLoadable" xml:space="preserve">
     <value>No input files are loadable</value>
@@ -265,16 +274,16 @@
     <value>Use custom alignment for PE sections in generated PE file</value>
   </data>
   <data name="InvalidCustomPESectionAlignment" xml:space="preserve">
-    <value>Custom PE Section Alignment must be a power of two greater than 4096.</value>
+    <value>Custom PE Section Alignment must be a power of two greater or equal to 4096.</value>
   </data>
   <data name="ErrorMultipleInputFilesCompositeModeOnly" xml:space="preserve">
     <value>Error: multiple input files are only supported in composite build mode: {0}</value>
   </data>
   <data name="MethodLayoutOption" xml:space="preserve">
-    <value>Layout methods in file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled</value>
+    <value>Layout algorithm used by profile-driven optimization for arranging methods in a file: DefaultSort, ExclusiveWeight, HotCold, or HotWarmCold). The default value is DefaultSort, which indicates that complex layout is disabled.</value>
   </data>
   <data name="FileLayoutOption" xml:space="preserve">
-    <value>Layout non-method contents of file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled</value>
+    <value>Layout algorithm used by profile-driven optimization for arranging non-method contents in a file: DefaultSort or MethodOrder. The default value is DefaultSort, which indicates that complex layout is disabled.</value>
   </data>
   <data name="CompositeRootPath" xml:space="preserve">
     <value>Logical root folder for composite builds; defaults to directory of 1st input file.</value>

--- a/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
@@ -21,6 +21,11 @@
       <GenerateSource>true</GenerateSource>
       <ClassName>System.SR</ClassName>
     </EmbeddedResource>
+
+    <EmbeddedResource Include="..\..\Common\CommandLine\Resources\Strings.resx">
+      <GenerateSource>true</GenerateSource>
+      <ClassName>Internal.CommandLine.Strings</ClassName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>
@@ -30,14 +35,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Common\CommandLine\Argument.cs" />
+    <Compile Include="..\..\Common\CommandLine\Argument_1.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentCommand.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentCommand_1.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentLexer.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentList_1.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentParser.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentSyntax.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentSyntax_Definers.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentSyntaxException.cs" />
+    <Compile Include="..\..\Common\CommandLine\ArgumentToken.cs" />
     <Compile Include="..\..\Common\CommandLine\CommandLineException.cs" />
     <Compile Include="..\..\Common\CommandLine\CommandLineHelpers.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.CommandLine">
-      <Version>$(SystemCommandLineVersion)</Version>
-    </PackageReference>
+    <Compile Include="..\..\Common\CommandLine\Enumerable.cs" />
+    <Compile Include="..\..\Common\CommandLine\HelpTextGenerator.cs" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -52,7 +52,6 @@
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)ILCompiler*.dll" />
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)Microsoft.DiaSymReader.dll" />
-      <Crossgen2File Include="$(CoreCLRCrossgen2Dir)System.CommandLine.dll" />
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)jitinterface_$(TargetArchitecture)$(LibraryFileExtension)" />
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_win_x86_$(TargetArchitecture)$(LibraryFileExtension)" />
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_win_arm_$(TargetArchitecture)$(LibraryFileExtension)" />


### PR DESCRIPTION
Switch back to the old command-line parser for Crossgen2 to improve performance of parsing arguments.  The source code for the old command-line parser was taken from https://github.com/dotnet/runtimelab/tree/feature/NativeAOT/src/coreclr/src/tools/System.CommandLine.  I updated copyright comments and replaced the `System.CommandLine` namespace with `Internal.CommandLine`.

This change removes the dependency on the System.CommandLine package and reduces the unpacked size of the Crossgen2 win-x64 package by 133 KiB.  To estimate performance impact on parsing arguments, I ran Crossgen2 processes in a loop with a typical command line used by the SDK, exiting the process immediately after the arguments are parsed.  The response file contained 171 lines and had size about 25 KiB.  For that setup, the time spent parsing the arguments decreased from 153 ms to 28 ms.

Known behavior differences: the old parser displays the help text differently, it treats `-abc` as `-a -b -c`, and it does not recognize `/?`.  That may be addressed separately.