### PR TITLE
Disable / fix failing test in runincontext testing

### DIFF
--- a/src/tests/profiler/elt/slowpatheltenter.csproj
+++ b/src/tests/profiler/elt/slowpatheltenter.csproj
@@ -6,6 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/elt/slowpatheltleave.csproj
+++ b/src/tests/profiler/elt/slowpatheltleave.csproj
@@ -6,6 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/eventpipe/eventpipe.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe.csproj
@@ -8,6 +8,11 @@
     <Optimize>true</Optimize>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
@@ -8,6 +8,11 @@
     <Optimize>true</Optimize>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/gc/gc.csproj
+++ b/src/tests/profiler/gc/gc.csproj
@@ -8,6 +8,11 @@
     <Optimize>true</Optimize>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/gc/gcbasic.csproj
+++ b/src/tests/profiler/gc/gcbasic.csproj
@@ -8,6 +8,11 @@
     <Optimize>true</Optimize>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/rejit/rejit.csproj
+++ b/src/tests/profiler/rejit/rejit.csproj
@@ -9,6 +9,11 @@
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
+++ b/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
@@ -8,6 +8,11 @@
     <Optimize>true</Optimize>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/unittest/metadatagetdispenser.csproj
+++ b/src/tests/profiler/unittest/metadatagetdispenser.csproj
@@ -8,6 +8,11 @@
     <Optimize>true</Optimize>
     <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/unittest/releaseondetach.csproj
+++ b/src/tests/profiler/unittest/releaseondetach.csproj
@@ -5,6 +5,11 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/readytorun/multifolder/multifolder.csproj
+++ b/src/tests/readytorun/multifolder/multifolder.csproj
@@ -59,7 +59,7 @@ $(CLRTestBatchPreCommands)
     dir %scriptPath%
     dir %scriptPath%\multifolder
 
-    set ExePath=%scriptPath%\multifolder\multifolder.dll
+    set ExePath=multifolder\multifolder.dll
     set COMPlus_NativeImageSearchPaths=%scriptPath%
 
 ]]></CLRTestBatchPreCommands>
@@ -97,7 +97,7 @@ $(BashCLRTestPreCommands)
     echo Running crossgen2: $__Command
     $__Command
 
-    ExePath=$__OutputDir/multifolder/multifolder.dll
+    ExePath=multifolder/multifolder.dll
     export COMPlus_NativeImageSearchPaths=$__OutputDir
 
 ]]></BashCLRTestPreCommands>

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -6,6 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since 
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
* Disable all profiler tests since they launch a secondary process
  and process launch creates an infinite event loop in the
  SocketAsyncEngine on Linux. Since runincontext loads even
  framework assemblies into the unloadable context, locals in this
  loop prevent unloading.
  The tests were working before Process.Start moved to using sockets.
* Fix the multifoldertest to work under runincontext - the shell
  script generated from the .csproj was passing an absolute path
  for the multifolder.dll to the runincontext.sh/cmd instead of
  a relative path that is used in all other tests and that the
  runincontext expects.