### PR TITLE
Automatically trigger the ilasm round-trip test on PRs

### DIFF
--- a/eng/pipelines/coreclr/ilasm.yml
+++ b/eng/pipelines/coreclr/ilasm.yml
@@ -1,5 +1,14 @@
 trigger: none
 
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/coreclr/src/ilasm/*
+    - src/coreclr/src/ildasm/*
+
 schedules:
 - cron: "0 19 * * 6"
   displayName: Sat at 11:00 AM (UTC-8:00)


### PR DESCRIPTION
For changes to the ilasm or ildasm source code, trigger
the ilasm round-trip pipeline.

There could, of course, be other changes that could affect
ilasm/ildasm, but this at least catches the primary ones.