### PR TITLE
Fix ildasm of certain floating-point numbers

### DIFF
--- a/src/coreclr/src/ildasm/dis.cpp
+++ b/src/coreclr/src/ildasm/dis.cpp
@@ -1574,7 +1574,7 @@ BOOL Disassemble(IMDInternalImport *pImport, BYTE *ILHeader, void *GUICookie, md
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), "%-10s %s", pszInstrName, szf);
                 else
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), "%-10s (%2.2X %2.2X %2.2X %2.2X)",
-                        pszInstrName, pCode[PC+3], pCode[PC+2], pCode[PC+1], pCode[PC]);
+                        pszInstrName, pCode[PC], pCode[PC+1], pCode[PC+2], pCode[PC+3]);
                 PC += 4;
                 break;
             }
@@ -1615,8 +1615,8 @@ BOOL Disassemble(IMDInternalImport *pImport, BYTE *ILHeader, void *GUICookie, md
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr),
                         "%-10s (%2.2X %2.2X %2.2X %2.2X %2.2X %2.2X %2.2X %2.2X)",
                         pszInstrName, 
-                        pCode[PC+7], pCode[PC+6], pCode[PC+5], pCode[PC+4],
-                        pCode[PC+3], pCode[PC+2], pCode[PC+1], pCode[PC]);
+                        pCode[PC], pCode[PC+1], pCode[PC+2], pCode[PC+3],
+                        pCode[PC+4], pCode[PC+5], pCode[PC+6], pCode[PC+7]);
                 PC += 8;
                 break;
             }


### PR DESCRIPTION
Change #42848 altered comments to print numbers in comments in
little-endian format, but went too far and changed two places
that print out numbers outside of comments that are later parsed
by ilasm in round-trip testing.

Fixes #43672