### PR TITLE
Fix incremental build of tasks.proj for mobile

### DIFF
--- a/tools-local/tasks/tasks.proj
+++ b/tools-local/tasks/tasks.proj
@@ -47,6 +47,16 @@
 
     <ItemGroup>
       <TasksSrc Include="$(MSBuildThisFileDirectory)**\*.cs*;$(MSBuildThisFileDirectory)**\*.*proj" />
+      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\AndroidAppBuilder\AndroidAppBuilder.csproj"
+                        Condition="'$(TargetOS)' != 'Android'" />
+      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\AppleAppBuilder\AppleAppBuilder.csproj"
+                        Condition="'$(TargetOS)' != 'iOS' and '$(TargetOS)' != 'tvOS'" />
+      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj"
+                        Condition="'$(TargetOS)' != 'Browser'" />
+      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\WasmBuildTasks\WasmBuildTasks.csproj"
+                        Condition="'$(TargetOS)' != 'Browser'" />
+      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\AotCompilerTask\MonoAOTCompiler.csproj"
+                        Condition="'$(TargetsMobile)' != 'true'" />
     </ItemGroup>
   </Target>
 </Project>

--- a/tools-local/tasks/tasks.proj
+++ b/tools-local/tasks/tasks.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)**\*.csproj" Exclude="$(MSBuildProjectFullPath)" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)**\*.csproj" />
     <ProjectReference Remove="$(MSBuildThisFileDirectory)mobile.tasks\AndroidAppBuilder\AndroidAppBuilder.csproj"
                       Condition="'$(TargetOS)' != 'Android'" />
     <ProjectReference Remove="$(MSBuildThisFileDirectory)mobile.tasks\AppleAppBuilder\AppleAppBuilder.csproj"
@@ -40,13 +40,16 @@
                       Overwrite="true" />
   </Target>
 
-  <Target Name="GetTasksSrc">
+  <Target Name="GetTasksSrc"
+          DependsOnTargets="PrepareProjectReferences">
     <PropertyGroup>
       <TasksIntermediateFile>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore.txt'))</TasksIntermediateFile>
     </PropertyGroup>
 
+    <!-- Include both the project file and its sources as an input. -->
     <ItemGroup>
-      <TasksSrc Include="@(ProjectReference)" />
+      <TasksSrc Include="%(ProjectReferenceWithConfiguration.Identity)" />
+      <TasksSrc Include="%(ProjectReferenceWithConfiguration.RelativeDir)%(ProjectReferenceWithConfiguration.RecursiveDir)**\*.cs" />
     </ItemGroup>
   </Target>
 </Project>

--- a/tools-local/tasks/tasks.proj
+++ b/tools-local/tasks/tasks.proj
@@ -46,17 +46,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <TasksSrc Include="$(MSBuildThisFileDirectory)**\*.cs*;$(MSBuildThisFileDirectory)**\*.*proj" />
-      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\AndroidAppBuilder\AndroidAppBuilder.csproj"
-                        Condition="'$(TargetOS)' != 'Android'" />
-      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\AppleAppBuilder\AppleAppBuilder.csproj"
-                        Condition="'$(TargetOS)' != 'iOS' and '$(TargetOS)' != 'tvOS'" />
-      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj"
-                        Condition="'$(TargetOS)' != 'Browser'" />
-      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\WasmBuildTasks\WasmBuildTasks.csproj"
-                        Condition="'$(TargetOS)' != 'Browser'" />
-      <TasksSrc Remove="$(MSBuildThisFileDirectory)mobile.tasks\AotCompilerTask\MonoAOTCompiler.csproj"
-                        Condition="'$(TargetsMobile)' != 'true'" />
+      <TasksSrc Include="@(ProjectReference)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
The semaphore file that is used as the input for deciding whether to rebuild tasks.proj wasn't properly taking the mobile task projects into account.
This resulted in e.g. WasmAppBuilder not being built if you built for desktop before, resulting in a build error.

We now use the same conditions for the semaphore file as we do for the project references.