### PR TITLE
Increase Hosting tests timeout

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -197,8 +197,8 @@ namespace Microsoft.Extensions.Hosting.Tests
             {
                 configReloadedCancelTokenSource.Cancel();
             }, null);
-            // Wait for up to 10 seconds, if config reloads at any time, cancel the wait.
-            await Task.WhenAny(Task.Delay(10000, configReloadedCancelToken)); // Task.WhenAny ignores the task throwing on cancellation.
+            // Wait for up to 1 minute, if config reloads at any time, cancel the wait.
+            await Task.WhenAny(Task.Delay(TimeSpan.FromMinutes(1), configReloadedCancelToken)); // Task.WhenAny ignores the task throwing on cancellation.
             Assert.NotEqual(dynamicConfigMessage1, dynamicConfigMessage2); // Messages are different.
             Assert.Equal(dynamicConfigMessage2, config["Hello"]); // Config DID reload from disk
         }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading;
@@ -1239,7 +1240,8 @@ namespace Microsoft.Extensions.Hosting.Internal
                 .Start();
 
             // give the background service 1 minute to log the failure
-            Task timeout = Task.Delay(TimeSpan.FromMinutes(1));
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            Stopwatch sw = Stopwatch.StartNew();
 
             while (true)
             {
@@ -1251,14 +1253,8 @@ namespace Microsoft.Extensions.Hosting.Internal
                     break;
                 }
 
-                if (timeout.IsCompleted)
-                {
-                    Assert.True(false, "'BackgroundService failed' did not get logged");
-                }
-                else
-                {
-                    await Task.Delay(TimeSpan.FromMilliseconds(30));
-                }
+                Assert.InRange(sw.Elapsed, TimeSpan.Zero, timeout);
+                await Task.Delay(TimeSpan.FromMilliseconds(30));
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -1223,7 +1223,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         /// (after an await), the exception gets logged correctly.
         /// </summary>
         [Fact]
-        public void BackgroundServiceAsyncExceptionGetsLogged()
+        public async Task BackgroundServiceAsyncExceptionGetsLogged()
         {
             using TestEventListener listener = new TestEventListener();
 
@@ -1238,8 +1238,8 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Start();
 
-            // give the background service 5 seconds to log the failure
-            Task timeout = Task.Delay(new TimeSpan(0, 0, 5));
+            // give the background service 1 minute to log the failure
+            Task timeout = Task.Delay(TimeSpan.FromMinutes(1));
 
             while (true)
             {
@@ -1254,6 +1254,10 @@ namespace Microsoft.Extensions.Hosting.Internal
                 if (timeout.IsCompleted)
                 {
                     Assert.True(false, "'BackgroundService failed' did not get logged");
+                }
+                else
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(30));
                 }
             }
         }


### PR DESCRIPTION
There are some environments (checked CoreCLR, no tiered compilation) where the current timeout is insufficient. Increasing the timeout so the tests don't fail in these environments.

Fix #43389