### PR TITLE
Allow dynamic code sample to compile on v3.0-5.0

### DIFF
--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.cs
@@ -491,7 +491,13 @@ namespace System.Text.Json.Serialization.Samples
                     case JsonTokenType.True:
                         return new JsonDynamicBoolean(true, options);
                     case JsonTokenType.Number:
-                        JsonElement jsonElement = JsonElement.ParseValue(ref reader);
+                        JsonElement jsonElement;
+                        using (JsonDocument document = JsonDocument.ParseValue(ref reader))
+                        {
+                            jsonElement = document.RootElement.Clone();
+                        }
+                        // In 6.0, this can be used instead for increased performance:
+                        //JsonElement jsonElement = JsonElement.ParseValue(ref reader);
                         return new JsonDynamicNumber(jsonElement, options);
                     case JsonTokenType.Null:
                         return null;


### PR DESCRIPTION
As an update to https://github.com/dotnet/runtime/pull/42097, remove a call to a newly added 6.0 API so the code sample can compile on v3.0-5.0.