### PR TITLE
Armel support in crossgen2

### DIFF
--- a/src/coreclr/inc/corjitflags.h
+++ b/src/coreclr/inc/corjitflags.h
@@ -97,7 +97,12 @@ public:
 
         CORJIT_FLAG_NO_INLINING             = 42, // JIT should not inline any called method into this method
 
+#if defined(TARGET_ARM)
+        CORJIT_FLAG_SOFTFP_ABI              = 43, // JIT should generate PC-relative address computations instead of EE relocation records
+#else // !defined(TARGET_ARM)
         CORJIT_FLAG_UNUSED16                = 43,
+#endif // !defined(TARGET_ARM)
+
         CORJIT_FLAG_UNUSED17                = 44,
         CORJIT_FLAG_UNUSED18                = 45,
         CORJIT_FLAG_UNUSED19                = 46,

--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -150,7 +150,7 @@
 // do not work reliably with conservative GC.
 #define FEATURE_CONSERVATIVE_GC 1
 
-#if (defined(TARGET_ARM) && !defined(ARM_SOFTFP)) || defined(TARGET_ARM64)
+#if (defined(TARGET_ARM) && (!defined(ARM_SOFTFP) || defined(CONFIGURABLE_ARM_ABI))) || defined(TARGET_ARM64)
 #define FEATURE_HFA
 #endif
 

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -490,6 +490,7 @@ if (CLR_CMAKE_BUILD_SUBSET_ALLJITS AND NOT CLR_CROSS_COMPONENTS_BUILD)
 
   create_standalone_jit(TARGET clrjit_unix_armel_${ARCH_HOST_NAME} OS unix ARCH armel)
   create_standalone_jit(TARGET clrjit_unix_arm_${ARCH_HOST_NAME} OS unix ARCH arm)
+  target_compile_definitions(clrjit_unix_arm_${ARCH_HOST_NAME} PRIVATE ARM_SOFTFP CONFIGURABLE_ARM_ABI)
   create_standalone_jit(TARGET clrjit_win_arm_${ARCH_HOST_NAME} OS win ARCH arm)
   create_standalone_jit(TARGET clrjit_win_x86_${ARCH_HOST_NAME} OS win ARCH x86)
 else()

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3244,6 +3244,8 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #elif defined(ARM_SOFTFP)
     // Armel is unconditionally enabled in the JIT. Verify that the VM side agrees.
     assert(jitFlags->IsSet(JitFlags::JIT_FLAG_SOFTFP_ABI));
+#elif TARGET_ARM
+    assert(!jitFlags->IsSet(JitFlags::JIT_FLAG_SOFTFP_ABI));
 #endif // CONFIGURABLE_ARM_ABI
 
     opts.compScopeInfo = opts.compDbgInfo;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3244,9 +3244,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #elif defined(ARM_SOFTFP)
     // Armel is unconditionally enabled in the JIT. Verify that the VM side agrees.
     assert(jitFlags->IsSet(JitFlags::JIT_FLAG_SOFTFP_ABI));
-#else
-    // Not ARM, or normal armhf abi compilation
-    assert(!jitFlags->IsSet(JitFlags::JIT_FLAG_SOFTFP_ABI));
 #endif // CONFIGURABLE_ARM_ABI
 
     opts.compScopeInfo = opts.compDbgInfo;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -54,6 +54,12 @@ bool       Compiler::s_pJitFunctionFileInitialized = false;
 MethodSet* Compiler::s_pJitMethodSet               = nullptr;
 #endif // DEBUG
 
+#ifdef CONFIGURABLE_ARM_ABI
+// static
+bool GlobalJitOptions::compFeatureHfa          = false;
+LONG GlobalJitOptions::compUseSoftFPConfigured = 0;
+#endif // CONFIGURABLE_ARM_ABI
+
 /*****************************************************************************
  *
  *  Little helpers to grab the current cycle counter value; this is done
@@ -468,49 +474,6 @@ var_types Compiler::getJitGCType(BYTE gcType)
     return result;
 }
 
-#ifdef ARM_SOFTFP
-//---------------------------------------------------------------------------
-// IsSingleFloat32Struct:
-//    Check if the given struct type contains only one float32 value type
-//
-// Arguments:
-//    clsHnd     - the handle for the struct type
-//
-// Return Value:
-//    true if the given struct type contains only one float32 value type,
-//    false otherwise.
-//
-
-bool Compiler::isSingleFloat32Struct(CORINFO_CLASS_HANDLE clsHnd)
-{
-    for (;;)
-    {
-        // all of class chain must be of value type and must have only one field
-        if (!info.compCompHnd->isValueClass(clsHnd) || info.compCompHnd->getClassNumInstanceFields(clsHnd) != 1)
-        {
-            return false;
-        }
-
-        CORINFO_CLASS_HANDLE* pClsHnd   = &clsHnd;
-        CORINFO_FIELD_HANDLE  fldHnd    = info.compCompHnd->getFieldInClass(clsHnd, 0);
-        CorInfoType           fieldType = info.compCompHnd->getFieldType(fldHnd, pClsHnd);
-
-        switch (fieldType)
-        {
-            case CORINFO_TYPE_VALUECLASS:
-                clsHnd = *pClsHnd;
-                break;
-
-            case CORINFO_TYPE_FLOAT:
-                return true;
-
-            default:
-                return false;
-        }
-    }
-}
-#endif // ARM_SOFTFP
-
 #ifdef TARGET_X86
 //---------------------------------------------------------------------------
 // isTrivialPointerSizedStruct:
@@ -623,53 +586,44 @@ var_types Compiler::getPrimitiveTypeForStruct(unsigned structSize, CORINFO_CLASS
 
     var_types useType = TYP_UNKNOWN;
 
-// Start by determining if we have an HFA/HVA with a single element.
-#ifdef FEATURE_HFA
-#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
-    // Arm64 Windows VarArg methods arguments will not classify HFA types, they will need to be treated
-    // as if they are not HFA types.
-    if (!isVarArg)
-#endif // defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
+    // Start by determining if we have an HFA/HVA with a single element.
+    if (GlobalJitOptions::compFeatureHfa)
     {
-        switch (structSize)
+#if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
+        // Arm64 Windows VarArg methods arguments will not classify HFA types, they will need to be treated
+        // as if they are not HFA types.
+        if (!isVarArg)
+#endif // defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
         {
-            case 4:
-            case 8:
-#ifdef TARGET_ARM64
-            case 16:
-#endif // TARGET_ARM64
+            switch (structSize)
             {
-                var_types hfaType;
-#ifdef ARM_SOFTFP
-                // For ARM_SOFTFP, HFA is unsupported so we need to check in another way.
-                // This matters only for size-4 struct because bigger structs would be processed with RetBuf.
-                if (isSingleFloat32Struct(clsHnd))
+                case 4:
+                case 8:
+#ifdef TARGET_ARM64
+                case 16:
+#endif // TARGET_ARM64
                 {
-                    hfaType = TYP_FLOAT;
-                }
-#else  // !ARM_SOFTFP
-                hfaType = GetHfaType(clsHnd);
-#endif // ARM_SOFTFP
-                // We're only interested in the case where the struct size is equal to the size of the hfaType.
-                if (varTypeIsValidHfaType(hfaType))
-                {
-                    if (genTypeSize(hfaType) == structSize)
+                    var_types hfaType = GetHfaType(clsHnd);
+                    // We're only interested in the case where the struct size is equal to the size of the hfaType.
+                    if (varTypeIsValidHfaType(hfaType))
                     {
-                        useType = hfaType;
-                    }
-                    else
-                    {
-                        return TYP_UNKNOWN;
+                        if (genTypeSize(hfaType) == structSize)
+                        {
+                            useType = hfaType;
+                        }
+                        else
+                        {
+                            return TYP_UNKNOWN;
+                        }
                     }
                 }
             }
-        }
-        if (useType != TYP_UNKNOWN)
-        {
-            return useType;
+            if (useType != TYP_UNKNOWN)
+            {
+                return useType;
+            }
         }
     }
-#endif // FEATURE_HFA
 
     // Now deal with non-HFA/HVA structs.
     switch (structSize)
@@ -3272,6 +3226,28 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         opts.compFastTailCalls = false;
     }
 #endif // FEATURE_FASTTAILCALL
+
+#ifdef CONFIGURABLE_ARM_ABI
+    opts.compUseSoftFP        = jitFlags->IsSet(JitFlags::JIT_FLAG_SOFTFP_ABI);
+    unsigned int softFPConfig = opts.compUseSoftFP ? 2 : 1;
+    unsigned int oldSoftFPConfig =
+        InterlockedCompareExchange(&GlobalJitOptions::compUseSoftFPConfigured, softFPConfig, 0);
+    if (oldSoftFPConfig != softFPConfig && oldSoftFPConfig != 0)
+    {
+        // There are no current scenarios where the abi can change during the lifetime of a process
+        // that uses the JIT. If such a change occurs, either compFeatureHfa will need to change to a TLS static
+        // or we will need to have some means to reset the flag safely.
+        NO_WAY("SoftFP ABI setting changed during lifetime of process");
+    }
+
+    GlobalJitOptions::compFeatureHfa = !opts.compUseSoftFP;
+#elif defined(ARM_SOFTFP)
+    // Armel is unconditionally enabled in the JIT. Verify that the VM side agrees.
+    assert(jitFlags->IsSet(JitFlags::JIT_FLAG_SOFTFP_ABI));
+#else
+    // Not ARM, or normal armhf abi compilation
+    assert(!jitFlags->IsSet(JitFlags::JIT_FLAG_SOFTFP_ABI));
+#endif // CONFIGURABLE_ARM_ABI
 
     opts.compScopeInfo = opts.compDbgInfo;
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -139,7 +139,6 @@ const int BAD_STK_OFFS = 0xBAADF00D; // for LclVarDsc::lvStkOffs
 //------------------------------------------------------------------------
 // HFA info shared by LclVarDsc and fgArgTabEntry
 //------------------------------------------------------------------------
-#ifdef FEATURE_HFA
 inline bool IsHfa(CorInfoHFAElemType kind)
 {
     return kind != CORINFO_HFA_ELEM_NONE;
@@ -186,7 +185,6 @@ inline CorInfoHFAElemType HfaElemKindFromType(var_types type)
             return CORINFO_HFA_ELEM_NONE;
     }
 }
-#endif // FEATURE_HFA
 
 // The following holds the Local var info (scope information)
 typedef const char* VarName; // Actual ASCII string
@@ -489,9 +487,9 @@ public:
     unsigned char lvIsMultiRegArg : 1; // true if this is a multireg LclVar struct used in an argument context
     unsigned char lvIsMultiRegRet : 1; // true if this is a multireg LclVar struct assigned from a multireg call
 
-#ifdef FEATURE_HFA
+#ifdef FEATURE_HFA_FIELDS_PRESENT
     CorInfoHFAElemType _lvHfaElemKind : 3; // What kind of an HFA this is (CORINFO_HFA_ELEM_NONE if it is not an HFA).
-#endif                                     // FEATURE_HFA
+#endif                                     // FEATURE_HFA_FIELDS_PRESENT
 
 #ifdef DEBUG
     // TODO-Cleanup: See the note on lvSize() - this flag is only in use by asserts that are checking for struct
@@ -561,22 +559,47 @@ public:
     }
 #endif // FEATURE_MULTIREG_ARGS
 
+    CorInfoHFAElemType GetLvHfaElemKind() const
+    {
+#ifdef FEATURE_HFA_FIELDS_PRESENT
+        return _lvHfaElemKind;
+#else
+        NOWAY_MSG("GetLvHfaElemKind");
+        return CORINFO_HFA_ELEM_NONE;
+#endif // FEATURE_HFA_FIELDS_PRESENT
+    }
+
+    void SetLvHfaElemKind(CorInfoHFAElemType elemKind)
+    {
+#ifdef FEATURE_HFA_FIELDS_PRESENT
+        _lvHfaElemKind = elemKind;
+#else
+        NOWAY_MSG("SetLvHfaElemKind");
+#endif // FEATURE_HFA_FIELDS_PRESENT
+    }
+
     bool lvIsHfa() const
     {
-#ifdef FEATURE_HFA
-        return IsHfa(_lvHfaElemKind);
-#else
-        return false;
-#endif
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            return IsHfa(GetLvHfaElemKind());
+        }
+        else
+        {
+            return false;
+        }
     }
 
     bool lvIsHfaRegArg() const
     {
-#ifdef FEATURE_HFA
-        return lvIsRegArg && lvIsHfa();
-#else
-        return false;
-#endif
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            return lvIsRegArg && lvIsHfa();
+        }
+        else
+        {
+            return false;
+        }
     }
 
     //------------------------------------------------------------------------------
@@ -595,7 +618,7 @@ public:
         slots = lvExactSize / sizeof(float);
         assert(slots <= 8);
 #elif defined(TARGET_ARM64)
-        switch (_lvHfaElemKind)
+        switch (GetLvHfaElemKind())
         {
             case CORINFO_HFA_ELEM_NONE:
                 assert(!"lvHfaSlots called for non-HFA");
@@ -921,22 +944,26 @@ public:
 
     var_types GetHfaType() const
     {
-#ifdef FEATURE_HFA
-        assert(lvIsHfa());
-        return HfaTypeFromElemKind(_lvHfaElemKind);
-#else
-        return TYP_UNDEF;
-#endif // FEATURE_HFA
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            assert(lvIsHfa());
+            return HfaTypeFromElemKind(GetLvHfaElemKind());
+        }
+        else
+        {
+            return TYP_UNDEF;
+        }
     }
 
     void SetHfaType(var_types type)
     {
-#ifdef FEATURE_HFA
-        CorInfoHFAElemType elemKind = HfaElemKindFromType(type);
-        _lvHfaElemKind              = elemKind;
-        // Ensure we've allocated enough bits.
-        assert(_lvHfaElemKind == elemKind);
-#endif // FEATURE_HFA
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            CorInfoHFAElemType elemKind = HfaElemKindFromType(type);
+            SetLvHfaElemKind(elemKind);
+            // Ensure we've allocated enough bits.
+            assert(GetLvHfaElemKind() == elemKind);
+        }
     }
 
     var_types lvaArgType();
@@ -1481,9 +1508,27 @@ public:
 #ifdef FEATURE_ARG_SPLIT
     bool _isSplit : 1; // True when this argument is split between the registers and OutArg area
 #endif                 // FEATURE_ARG_SPLIT
-#ifdef FEATURE_HFA
+#ifdef FEATURE_HFA_FIELDS_PRESENT
     CorInfoHFAElemType _hfaElemKind : 3; // What kind of an HFA this is (CORINFO_HFA_ELEM_NONE if it is not an HFA).
 #endif
+    CorInfoHFAElemType GetHfaElemKind() const
+    {
+#ifdef FEATURE_HFA_FIELDS_PRESENT
+        return _hfaElemKind;
+#else
+        NOWAY_MSG("GetHfaElemKind");
+        return CORINFO_HFA_ELEM_NONE;
+#endif
+    }
+
+    void SetHfaElemKind(CorInfoHFAElemType elemKind)
+    {
+#ifdef FEATURE_HFA_FIELDS_PRESENT
+        _hfaElemKind = elemKind;
+#else
+        NOWAY_MSG("SetHfaElemKind");
+#endif
+    }
 
     bool isLateArg() const
     {
@@ -1557,20 +1602,26 @@ public:
 
     bool IsHfaArg() const
     {
-#ifdef FEATURE_HFA
-        return IsHfa(_hfaElemKind);
-#else
-        return false;
-#endif
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            return IsHfa(GetHfaElemKind());
+        }
+        else
+        {
+            return false;
+        }
     }
 
     bool IsHfaRegArg() const
     {
-#ifdef FEATURE_HFA
-        return IsHfa(_hfaElemKind) && isPassedInRegisters();
-#else
-        return false;
-#endif
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            return IsHfa(GetHfaElemKind()) && isPassedInRegisters();
+        }
+        else
+        {
+            return false;
+        }
     }
 
     unsigned intRegCount() const
@@ -1626,57 +1677,61 @@ public:
 
     var_types GetHfaType() const
     {
-#ifdef FEATURE_HFA
-        return HfaTypeFromElemKind(_hfaElemKind);
-#else
-        return TYP_UNDEF;
-#endif // FEATURE_HFA
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            return HfaTypeFromElemKind(GetHfaElemKind());
+        }
+        else
+        {
+            return TYP_UNDEF;
+        }
     }
 
     void SetHfaType(var_types type, unsigned hfaSlots)
     {
-#ifdef FEATURE_HFA
-        if (type != TYP_UNDEF)
+        if (GlobalJitOptions::compFeatureHfa)
         {
-            // We must already have set the passing mode.
-            assert(numRegs != 0 || GetStackByteSize() != 0);
-            // We originally set numRegs according to the size of the struct, but if the size of the
-            // hfaType is not the same as the pointer size, we need to correct it.
-            // Note that hfaSlots is the number of registers we will use. For ARM, that is twice
-            // the number of "double registers".
-            unsigned numHfaRegs = hfaSlots;
-#ifdef TARGET_ARM
-            if (type == TYP_DOUBLE)
+            if (type != TYP_UNDEF)
             {
-                // Must be an even number of registers.
-                assert((numRegs & 1) == 0);
-                numHfaRegs = hfaSlots / 2;
-            }
+                // We must already have set the passing mode.
+                assert(numRegs != 0 || GetStackByteSize() != 0);
+                // We originally set numRegs according to the size of the struct, but if the size of the
+                // hfaType is not the same as the pointer size, we need to correct it.
+                // Note that hfaSlots is the number of registers we will use. For ARM, that is twice
+                // the number of "double registers".
+                unsigned numHfaRegs = hfaSlots;
+#ifdef TARGET_ARM
+                if (type == TYP_DOUBLE)
+                {
+                    // Must be an even number of registers.
+                    assert((numRegs & 1) == 0);
+                    numHfaRegs = hfaSlots / 2;
+                }
 #endif // TARGET_ARM
 
-            if (!IsHfaArg())
-            {
-                // We haven't previously set this; do so now.
-                CorInfoHFAElemType elemKind = HfaElemKindFromType(type);
-                _hfaElemKind                = elemKind;
-                // Ensure we've allocated enough bits.
-                assert(_hfaElemKind == elemKind);
-                if (isPassedInRegisters())
+                if (!IsHfaArg())
                 {
-                    numRegs = numHfaRegs;
+                    // We haven't previously set this; do so now.
+                    CorInfoHFAElemType elemKind = HfaElemKindFromType(type);
+                    SetHfaElemKind(elemKind);
+                    // Ensure we've allocated enough bits.
+                    assert(GetHfaElemKind() == elemKind);
+                    if (isPassedInRegisters())
+                    {
+                        numRegs = numHfaRegs;
+                    }
                 }
-            }
-            else
-            {
-                // We've already set this; ensure that it's consistent.
-                if (isPassedInRegisters())
+                else
                 {
-                    assert(numRegs == numHfaRegs);
+                    // We've already set this; ensure that it's consistent.
+                    if (isPassedInRegisters())
+                    {
+                        assert(numRegs == numHfaRegs);
+                    }
+                    assert(type == HfaTypeFromElemKind(GetHfaElemKind()));
                 }
-                assert(type == HfaTypeFromElemKind(_hfaElemKind));
             }
         }
-#endif // FEATURE_HFA
     }
 
 #ifdef TARGET_ARM
@@ -1749,33 +1804,34 @@ public:
     unsigned getSize() const
     {
         unsigned size = getSlotCount();
-#ifdef FEATURE_HFA
-        if (IsHfaRegArg())
+        if (GlobalJitOptions::compFeatureHfa)
         {
+            if (IsHfaRegArg())
+            {
 #ifdef TARGET_ARM
-            // We counted the number of regs, but if they are DOUBLE hfa regs we have to double the size.
-            if (GetHfaType() == TYP_DOUBLE)
-            {
-                assert(!IsSplit());
-                size <<= 1;
-            }
+                // We counted the number of regs, but if they are DOUBLE hfa regs we have to double the size.
+                if (GetHfaType() == TYP_DOUBLE)
+                {
+                    assert(!IsSplit());
+                    size <<= 1;
+                }
 #elif defined(TARGET_ARM64)
-            // We counted the number of regs, but if they are FLOAT hfa regs we have to halve the size,
-            // or if they are SIMD16 vector hfa regs we have to double the size.
-            if (GetHfaType() == TYP_FLOAT)
-            {
-                // Round up in case of odd HFA count.
-                size = (size + 1) >> 1;
-            }
+                // We counted the number of regs, but if they are FLOAT hfa regs we have to halve the size,
+                // or if they are SIMD16 vector hfa regs we have to double the size.
+                if (GetHfaType() == TYP_FLOAT)
+                {
+                    // Round up in case of odd HFA count.
+                    size = (size + 1) >> 1;
+                }
 #ifdef FEATURE_SIMD
-            else if (GetHfaType() == TYP_SIMD16)
-            {
-                size <<= 1;
-            }
+                else if (GetHfaType() == TYP_SIMD16)
+                {
+                    size <<= 1;
+                }
 #endif // FEATURE_SIMD
 #endif // TARGET_ARM64
+            }
         }
-#endif // FEATURE_HFA
         return size;
     }
 
@@ -2272,10 +2328,6 @@ public:
 #endif // FEATURE_MULTIREG_RET
 
     GenTree* impAssignSmallStructTypeToVar(GenTree* op, CORINFO_CLASS_HANDLE hClass);
-
-#ifdef ARM_SOFTFP
-    bool isSingleFloat32Struct(CORINFO_CLASS_HANDLE hClass);
-#endif // ARM_SOFTFP
 
 #ifdef TARGET_X86
     bool isTrivialPointerSizedStruct(CORINFO_CLASS_HANDLE clsHnd) const;
@@ -9169,11 +9221,15 @@ public:
         int compJitSaveFpLrWithCalleeSavedRegisters;
 #endif // defined(TARGET_ARM64)
 
+#ifdef CONFIGURABLE_ARM_ABI
+        bool compUseSoftFP = false;
+#else
 #ifdef ARM_SOFTFP
         static const bool compUseSoftFP = true;
-#else // !ARM_SOFTFP
+#else  // !ARM_SOFTFP
         static const bool compUseSoftFP = false;
-#endif
+#endif // ARM_SOFTFP
+#endif // CONFIGURABLE_ARM_ABI
     } opts;
 
     static bool                s_pAltJitExcludeAssembliesListInitialized;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -230,14 +230,19 @@ void GenTree::InitNodeSize()
     // Now set all of the appropriate entries to 'large'
     CLANG_FORMAT_COMMENT_ANCHOR;
 
-// clang-format off
-#if defined(FEATURE_HFA) || defined(UNIX_AMD64_ABI)
-    // On ARM32, ARM64 and System V for struct returning
-    // there is code that does GT_ASG-tree.CopyObj call.
-    // CopyObj is a large node and the GT_ASG is small, which triggers an exception.
-    GenTree::s_gtNodeSizes[GT_ASG]              = TREE_NODE_SZ_LARGE;
-    GenTree::s_gtNodeSizes[GT_RETURN]           = TREE_NODE_SZ_LARGE;
-#endif // defined(FEATURE_HFA) || defined(UNIX_AMD64_ABI)
+    // clang-format off
+    if (GlobalJitOptions::compFeatureHfa
+#if defined(UNIX_AMD64_ABI)
+        || true
+#endif // defined(UNIX_AMD64_ABI)
+        )
+    {
+        // On ARM32, ARM64 and System V for struct returning
+        // there is code that does GT_ASG-tree.CopyObj call.
+        // CopyObj is a large node and the GT_ASG is small, which triggers an exception.
+        GenTree::s_gtNodeSizes[GT_ASG]              = TREE_NODE_SZ_LARGE;
+        GenTree::s_gtNodeSizes[GT_RETURN]           = TREE_NODE_SZ_LARGE;
+    }
 
     GenTree::s_gtNodeSizes[GT_CALL]             = TREE_NODE_SZ_LARGE;
     GenTree::s_gtNodeSizes[GT_CAST]             = TREE_NODE_SZ_LARGE;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9719,7 +9719,7 @@ GenTree* Compiler::impFixupStructReturnType(GenTree*                 op,
         return impAssignMultiRegTypeToVar(op, retClsHnd DEBUGARG(unmgdCallConv));
     }
 
-#endif //  FEATURE_MULTIREG_RET && FEATURE_HFA
+#endif //  FEATURE_MULTIREG_RET && TARGET_ARM64
 
     if (!compDoOldStructRetyping() && (!op->IsCall() || !op->AsCall()->TreatAsHasRetBufArg(this)))
     {

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -386,6 +386,27 @@ typedef ptrdiff_t ssize_t;
 #define FLD_GLOBAL_DS ((CORINFO_FIELD_HANDLE)-4)
 #define FLD_GLOBAL_FS ((CORINFO_FIELD_HANDLE)-8)
 
+class GlobalJitOptions
+{
+public:
+#ifdef FEATURE_HFA
+#define FEATURE_HFA_FIELDS_PRESENT
+#ifdef CONFIGURABLE_ARM_ABI
+    // These are safe to have globals as they cannot change once initialized within the process.
+    static LONG compUseSoftFPConfigured;
+    static bool compFeatureHfa;
+#else  // !CONFIGURABLE_ARM_ABI
+    static const bool compFeatureHfa = true;
+#endif // CONFIGURABLE_ARM_ABI
+#else  // !FEATURE_HFA
+    static const bool compFeatureHfa = false;
+#endif // FEATURE_HFA
+
+#ifdef FEATURE_HFA
+#undef FEATURE_HFA
+#endif
+};
+
 /*****************************************************************************/
 
 #include "vartype.h"
@@ -508,7 +529,7 @@ typedef ptrdiff_t ssize_t;
 
 #if DUMP_GC_TABLES
 #pragma message("NOTE: this non-debug build has GC ptr table dumping always enabled!")
-const bool dspGCtbls = true;
+const bool            dspGCtbls      = true;
 #endif
 
 /*****************************************************************************/

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -306,6 +306,10 @@ CONFIG_INTEGER(EnableArm64Sm4,          W("EnableArm64Sm4"), 1)
 CONFIG_INTEGER(EnableArm64Sve,          W("EnableArm64Sve"), 1)
 #endif // defined(TARGET_ARM64)
 
+#if defined(CONFIGURABLE_ARM_ABI)
+CONFIG_INTEGER(JitSoftFP, W("JitSoftFP"), 0)
+#endif // defined(CONFIGURABLE_ARM_ABI)
+
 // clang-format on
 
 #ifdef FEATURE_SIMD

--- a/src/coreclr/jit/jitee.h
+++ b/src/coreclr/jit/jitee.h
@@ -81,7 +81,12 @@ public:
 
         JIT_FLAG_NO_INLINING             = 42, // JIT should not inline any called method into this method
 
+#if defined(TARGET_ARM)
+        JIT_FLAG_SOFTFP_ABI              = 43, // On ARM should enable armel calling convention
+#else // !defined(TARGET_ARM)
         JIT_FLAG_UNUSED16                = 43,
+#endif // !defined(TARGET_ARM)
+
         JIT_FLAG_UNUSED17                = 44,
         JIT_FLAG_UNUSED18                = 45,
         JIT_FLAG_UNUSED19                = 46,
@@ -215,6 +220,13 @@ public:
 #endif // TARGET_ARM
 
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_NO_INLINING, JIT_FLAG_NO_INLINING);
+
+#if defined(TARGET_ARM)
+
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SOFTFP_ABI, JIT_FLAG_SOFTFP_ABI);
+
+#endif // TARGET_ARM
+
 #undef FLAGS_EQUAL
     }
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1400,11 +1400,12 @@ void Compiler::lvaInitVarDsc(LclVarDsc*              varDsc,
     varDsc->lvIsImplicitByRef = 0;
 #endif // defined(TARGET_AMD64) || defined(TARGET_ARM64)
 
-// Set the lvType (before this point it is TYP_UNDEF).
+    // Set the lvType (before this point it is TYP_UNDEF).
 
-#ifdef FEATURE_HFA
-    varDsc->SetHfaType(TYP_UNDEF);
-#endif
+    if (GlobalJitOptions::compFeatureHfa)
+    {
+        varDsc->SetHfaType(TYP_UNDEF);
+    }
     if ((varTypeIsStruct(type)))
     {
         lvaSetStruct(varNum, typeHnd, typeHnd != nullptr, !tiVerificationNeeded);
@@ -2804,25 +2805,26 @@ void Compiler::lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool 
                 varDsc->lvBaseType = simdBaseType;
             }
 #endif // FEATURE_SIMD
-#ifdef FEATURE_HFA
-            // For structs that are small enough, we check and set HFA element type
-            if (varDsc->lvExactSize <= MAX_PASS_MULTIREG_BYTES)
+            if (GlobalJitOptions::compFeatureHfa)
             {
-                // hfaType is set to float, double or SIMD type if it is an HFA, otherwise TYP_UNDEF
-                var_types hfaType = GetHfaType(typeHnd);
-                if (varTypeIsValidHfaType(hfaType))
+                // For structs that are small enough, we check and set HFA element type
+                if (varDsc->lvExactSize <= MAX_PASS_MULTIREG_BYTES)
                 {
-                    varDsc->SetHfaType(hfaType);
+                    // hfaType is set to float, double or SIMD type if it is an HFA, otherwise TYP_UNDEF
+                    var_types hfaType = GetHfaType(typeHnd);
+                    if (varTypeIsValidHfaType(hfaType))
+                    {
+                        varDsc->SetHfaType(hfaType);
 
-                    // hfa variables can never contain GC pointers
-                    assert(!layout->HasGCPtr());
-                    // The size of this struct should be evenly divisible by 4 or 8
-                    assert((varDsc->lvExactSize % genTypeSize(hfaType)) == 0);
-                    // The number of elements in the HFA should fit into our MAX_ARG_REG_COUNT limit
-                    assert((varDsc->lvExactSize / genTypeSize(hfaType)) <= MAX_ARG_REG_COUNT);
+                        // hfa variables can never contain GC pointers
+                        assert(!layout->HasGCPtr());
+                        // The size of this struct should be evenly divisible by 4 or 8
+                        assert((varDsc->lvExactSize % genTypeSize(hfaType)) == 0);
+                        // The number of elements in the HFA should fit into our MAX_ARG_REG_COUNT limit
+                        assert((varDsc->lvExactSize / genTypeSize(hfaType)) <= MAX_ARG_REG_COUNT);
+                    }
                 }
             }
-#endif // FEATURE_HFA
         }
     }
     else
@@ -2936,14 +2938,15 @@ void Compiler::makeExtraStructQueries(CORINFO_CLASS_HANDLE structHandle, int lev
 
 void Compiler::lvaSetStructUsedAsVarArg(unsigned varNum)
 {
-#ifdef FEATURE_HFA
+    if (GlobalJitOptions::compFeatureHfa)
+    {
 #if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
-    LclVarDsc* varDsc = &lvaTable[varNum];
-    // For varargs methods incoming and outgoing arguments should not be treated
-    // as HFA.
-    varDsc->SetHfaType(TYP_UNDEF);
+        LclVarDsc* varDsc = &lvaTable[varNum];
+        // For varargs methods incoming and outgoing arguments should not be treated
+        // as HFA.
+        varDsc->SetHfaType(TYP_UNDEF);
 #endif // defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
-#endif // FEATURE_HFA
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3243,38 +3243,41 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
 //
 void Lowering::LowerRetStruct(GenTreeUnOp* ret)
 {
-#if defined(FEATURE_HFA) && defined(TARGET_ARM64)
-    if (varTypeIsSIMD(ret))
+#ifdef TARGET_ARM64
+    if (GlobalJitOptions::compFeatureHfa)
     {
-        if (comp->info.compRetNativeType == TYP_STRUCT)
+        if (varTypeIsSIMD(ret))
         {
-            assert(varTypeIsSIMD(ret->gtGetOp1()));
-            assert(comp->compMethodReturnsMultiRegRegTypeAlternate());
-            if (!comp->compDoOldStructRetyping())
+            if (comp->info.compRetNativeType == TYP_STRUCT)
             {
-                ret->ChangeType(comp->info.compRetNativeType);
+                assert(varTypeIsSIMD(ret->gtGetOp1()));
+                assert(comp->compMethodReturnsMultiRegRegTypeAlternate());
+                if (!comp->compDoOldStructRetyping())
+                {
+                    ret->ChangeType(comp->info.compRetNativeType);
+                }
+                else
+                {
+                    // With old struct retyping a value that is returned as HFA
+                    // could have both SIMD* or STRUCT types, keep it as it.
+                    return;
+                }
             }
             else
             {
-                // With old struct retyping a value that is returned as HFA
-                // could have both SIMD* or STRUCT types, keep it as it.
+                assert(comp->info.compRetNativeType == ret->TypeGet());
+                GenTree* retVal = ret->gtGetOp1();
+                if (retVal->TypeGet() != ret->TypeGet())
+                {
+                    assert(retVal->OperIs(GT_LCL_VAR));
+                    assert(!comp->compDoOldStructRetyping());
+                    LowerRetSingleRegStructLclVar(ret);
+                }
                 return;
             }
         }
-        else
-        {
-            assert(comp->info.compRetNativeType == ret->TypeGet());
-            GenTree* retVal = ret->gtGetOp1();
-            if (retVal->TypeGet() != ret->TypeGet())
-            {
-                assert(retVal->OperIs(GT_LCL_VAR));
-                assert(!comp->compDoOldStructRetyping());
-                LowerRetSingleRegStructLclVar(ret);
-            }
-            return;
-        }
     }
-#endif
+#endif // TARGET_ARM64
 
     if (comp->compMethodReturnsMultiRegRegTypeAlternate())
     {
@@ -3461,25 +3464,26 @@ void Lowering::LowerCallStruct(GenTreeCall* call)
         return;
     }
 
-#if defined(FEATURE_HFA)
-    if (comp->IsHfa(call))
+    if (GlobalJitOptions::compFeatureHfa)
     {
-#if defined(TARGET_ARM64)
-        assert(comp->GetHfaCount(call) == 1);
-#elif defined(TARGET_ARM)
-        // ARM returns double in 2 float registers, but
-        // `call->HasMultiRegRetVal()` count double registers.
-        assert(comp->GetHfaCount(call) <= 2);
-#elif  // !TARGET_ARM64 && !TARGET_ARM
-        unreached();
-#endif // !TARGET_ARM64 && !TARGET_ARM
-        var_types hfaType = comp->GetHfaType(call);
-        if (call->TypeIs(hfaType))
+        if (comp->IsHfa(call))
         {
-            return;
+#if defined(TARGET_ARM64)
+            assert(comp->GetHfaCount(call) == 1);
+#elif defined(TARGET_ARM)
+            // ARM returns double in 2 float registers, but
+            // `call->HasMultiRegRetVal()` count double registers.
+            assert(comp->GetHfaCount(call) <= 2);
+#else  // !TARGET_ARM64 && !TARGET_ARM
+            NYI("Unknown architecture");
+#endif // !TARGET_ARM64 && !TARGET_ARM
+            var_types hfaType = comp->GetHfaType(call);
+            if (call->TypeIs(hfaType))
+            {
+                return;
+            }
         }
     }
-#endif // FEATURE_HFA
 
     assert(!comp->compDoOldStructRetyping());
     CORINFO_CLASS_HANDLE        retClsHnd = call->gtRetClsHnd;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1056,9 +1056,10 @@ fgArgTabEntry* fgArgInfo::AddRegArg(unsigned          argNum,
     curArgTabEntry->needTmp   = false;
     curArgTabEntry->needPlace = false;
     curArgTabEntry->processed = false;
-#ifdef FEATURE_HFA
-    curArgTabEntry->_hfaElemKind = CORINFO_HFA_ELEM_NONE;
-#endif
+    if (GlobalJitOptions::compFeatureHfa)
+    {
+        curArgTabEntry->SetHfaElemKind(CORINFO_HFA_ELEM_NONE);
+    }
     curArgTabEntry->isBackFilled  = false;
     curArgTabEntry->isNonStandard = false;
     curArgTabEntry->isStruct      = isStruct;
@@ -1153,9 +1154,10 @@ fgArgTabEntry* fgArgInfo::AddStkArg(unsigned          argNum,
     curArgTabEntry->needTmp   = false;
     curArgTabEntry->needPlace = false;
     curArgTabEntry->processed = false;
-#ifdef FEATURE_HFA
-    curArgTabEntry->_hfaElemKind = CORINFO_HFA_ELEM_NONE;
-#endif
+    if (GlobalJitOptions::compFeatureHfa)
+    {
+        curArgTabEntry->SetHfaElemKind(CORINFO_HFA_ELEM_NONE);
+    }
     curArgTabEntry->isBackFilled  = false;
     curArgTabEntry->isNonStandard = false;
     curArgTabEntry->isStruct      = isStruct;
@@ -3015,28 +3017,29 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         bool                 isNonStandard = false;
         regNumber            nonStdRegNum  = REG_NA;
 
-#ifdef FEATURE_HFA
-        hfaType  = GetHfaType(argx);
-        isHfaArg = varTypeIsValidHfaType(hfaType);
+        if (GlobalJitOptions::compFeatureHfa)
+        {
+            hfaType  = GetHfaType(argx);
+            isHfaArg = varTypeIsValidHfaType(hfaType);
 
 #if defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
-        // Make sure for vararg methods isHfaArg is not true.
-        isHfaArg = callIsVararg ? false : isHfaArg;
+            // Make sure for vararg methods isHfaArg is not true.
+            isHfaArg = callIsVararg ? false : isHfaArg;
 #endif // defined(TARGET_WINDOWS) && defined(TARGET_ARM64)
 
-        if (isHfaArg)
-        {
-            isHfaArg = true;
-            hfaSlots = GetHfaCount(argx);
+            if (isHfaArg)
+            {
+                isHfaArg = true;
+                hfaSlots = GetHfaCount(argx);
 
-            // If we have a HFA struct it's possible we transition from a method that originally
-            // only had integer types to now start having FP types.  We have to communicate this
-            // through this flag since LSRA later on will use this flag to determine whether
-            // or not to track the FP register set.
-            //
-            compFloatingPointUsed = true;
+                // If we have a HFA struct it's possible we transition from a method that originally
+                // only had integer types to now start having FP types.  We have to communicate this
+                // through this flag since LSRA later on will use this flag to determine whether
+                // or not to track the FP register set.
+                //
+                compFloatingPointUsed = true;
+            }
         }
-#endif // FEATURE_HFA
 
         const bool isFloatHfa = (hfaType == TYP_FLOAT);
 
@@ -3586,12 +3589,14 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 #endif
         }
 
-#ifdef FEATURE_HFA
-        if (isHfaArg)
+        if (GlobalJitOptions::compFeatureHfa)
         {
-            newArgEntry->SetHfaType(hfaType, hfaSlots);
+            if (isHfaArg)
+            {
+                newArgEntry->SetHfaType(hfaType, hfaSlots);
+            }
         }
-#endif // FEATURE_HFA
+
         newArgEntry->SetMultiRegNums();
 
         noway_assert(newArgEntry != nullptr);

--- a/src/coreclr/jit/vartype.h
+++ b/src/coreclr/jit/vartype.h
@@ -335,20 +335,23 @@ inline bool varTypeUsesFloatArgReg(T vt)
 template <class T>
 inline bool varTypeIsValidHfaType(T vt)
 {
-#ifdef FEATURE_HFA
-    bool isValid = (TypeGet(vt) != TYP_UNDEF);
-    if (isValid)
+    if (GlobalJitOptions::compFeatureHfa)
     {
+        bool isValid = (TypeGet(vt) != TYP_UNDEF);
+        if (isValid)
+        {
 #ifdef TARGET_ARM64
-        assert(varTypeUsesFloatReg(vt));
+            assert(varTypeUsesFloatReg(vt));
 #else  // !TARGET_ARM64
-        assert(varTypeIsFloating(vt));
+            assert(varTypeIsFloating(vt));
 #endif // !TARGET_ARM64
+        }
+        return isValid;
     }
-    return isValid;
-#else  // !FEATURE_HFA
-    return false;
-#endif // !FEATURE_HFA
+    else
+    {
+        return false;
+    }
 }
 
 /*****************************************************************************/

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3318,7 +3318,14 @@ namespace Internal.JitInterface
             }
 
             if (this.MethodBeingCompiled.IsNoOptimization)
+            {
                 flags.Set(CorJitFlag.CORJIT_FLAG_MIN_OPT);
+            }
+
+            if (this.MethodBeingCompiled.Context.Target.Abi == TargetAbi.CoreRTArmel)
+            {
+                flags.Set(CorJitFlag.CORJIT_FLAG_SOFTFP_ABI);
+            }
 
             return (uint)sizeof(CORJIT_FLAGS);
         }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1334,6 +1334,7 @@ namespace Internal.JitInterface
         CORJIT_FLAG_TIER1 = 40, // This is the final tier (for now) for tiered compilation which should generate high quality code
         CORJIT_FLAG_RELATIVE_CODE_RELOCS = 41, // JIT should generate PC-relative address computations instead of EE relocation records
         CORJIT_FLAG_NO_INLINING = 42, // JIT should not inline any called method into this method
+        CORJIT_FLAG_SOFTFP_ABI = 43, // On ARM should enable armel calling convention
     }
 
     public struct CORJIT_FLAGS

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -915,6 +915,9 @@ namespace Internal.TypeSystem
             if ((targetArch != TargetArchitecture.ARM) && (targetArch != TargetArchitecture.ARM64))
                 return NotHA;
 
+            if (type.Context.Target.Abi == TargetAbi.CoreRTArmel)
+                return NotHA;
+
             MetadataType metadataType = (MetadataType)type;
 
             // No HAs with explicit layout. There may be cases where explicit layout may be still

--- a/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
@@ -29,6 +29,10 @@ namespace Internal.TypeSystem
         /// </summary>
         CoreRT,
         /// <summary>
+        /// model for armel execution model
+        /// </summary>
+        CoreRTArmel,
+        /// <summary>
         /// Jit runtime ABI
         /// </summary>
         Jit,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -1085,7 +1085,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                         // Ignore floating point argument placement in registers if we're dealing with a vararg function (the ABI
                         // specifies this so that vararg processing on the callee side is simplified).
-                        if (fFloatingPoint && !IsVarArg)
+                        if (fFloatingPoint && _transitionBlock.IsArmhfABI && !IsVarArg)
                         {
                             // Handle floating point (primitive) arguments.
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -29,7 +29,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         X64UnixTransitionBlock.Instance;
 
                 case TargetArchitecture.ARM:
-                    return Arm32TransitionBlock.Instance;
+                    if (target.Abi == TargetAbi.CoreRTArmel)
+                    {
+                        return Arm32TransitionBlock.Instance;
+                    }
+                    else
+                    {
+                        return Arm32ElTransitionBlock.Instance;
+                    }
 
                 case TargetArchitecture.ARM64:
                     return Arm64TransitionBlock.Instance;
@@ -56,6 +63,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         /// This property is only overridden in AMD64 Unix variant of the transition block.
         /// </summary>
         public virtual bool IsX64UnixABI => false;
+
+        public virtual bool IsArmelABI => false;
+        public virtual bool IsArmhfABI => false;
 
         public abstract int PointerSize { get; }
 
@@ -301,11 +311,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     throw new NotSupportedException();
 
                 case CorElementType.ELEMENT_TYPE_R4:
-                    fpReturnSize = sizeof(float);
+                    if (!IsArmelABI)
+                    {
+                        fpReturnSize = sizeof(float);
+                    }
                     break;
 
                 case CorElementType.ELEMENT_TYPE_R8:
-                    fpReturnSize = sizeof(double);
+                    if (!IsArmelABI)
+                    {
+                        fpReturnSize = sizeof(double);
+                    }
                     break;
 
                 case CorElementType.ELEMENT_TYPE_VALUETYPE:
@@ -499,27 +515,37 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override bool IsArgPassedByRef(TypeHandle th) => false;
         }
 
-        private sealed class Arm32TransitionBlock : TransitionBlock
+        private class Arm32TransitionBlock : TransitionBlock
         {
             public static TransitionBlock Instance = new Arm32TransitionBlock();
 
-            public override TargetArchitecture Architecture => TargetArchitecture.ARM;
-            public override int PointerSize => 4;
+            public sealed override TargetArchitecture Architecture => TargetArchitecture.ARM;
+            public sealed override int PointerSize => 4;
             // R0, R1, R2, R3
-            public override int NumArgumentRegisters => 4;
+            public sealed override int NumArgumentRegisters => 4;
             // R4, R5, R6, R7, R8, R9, R10, R11, R14
-            public override int NumCalleeSavedRegisters => 9;
+            public sealed override int NumCalleeSavedRegisters => 9;
             // Callee-saves, argument registers
-            public override int SizeOfTransitionBlock => SizeOfCalleeSavedRegisters + SizeOfArgumentRegisters;
-            public override int OffsetOfArgumentRegisters => SizeOfCalleeSavedRegisters;
+            public sealed override int SizeOfTransitionBlock => SizeOfCalleeSavedRegisters + SizeOfArgumentRegisters;
+            public sealed override int OffsetOfArgumentRegisters => SizeOfCalleeSavedRegisters;
             // D0..D7
-            public override int OffsetOfFloatArgumentRegisters => 8 * sizeof(double) + PointerSize;
-            public override int EnregisteredParamTypeMaxSize => 0;
-            public override int EnregisteredReturnTypeIntegerMaxSize => 4;
+            public sealed override int OffsetOfFloatArgumentRegisters => 8 * sizeof(double) + PointerSize;
+            public sealed override int EnregisteredParamTypeMaxSize => 0;
+            public sealed override int EnregisteredReturnTypeIntegerMaxSize => 4;
 
-            public override bool IsArgPassedByRef(TypeHandle th) => false;
+            public override bool IsArmhfABI => true;
 
-            public override int GetRetBuffArgOffset(bool hasThis) => OffsetOfArgumentRegisters + (hasThis ? PointerSize : 0);
+            public sealed override bool IsArgPassedByRef(TypeHandle th) => false;
+
+            public sealed override int GetRetBuffArgOffset(bool hasThis) => OffsetOfArgumentRegisters + (hasThis ? PointerSize : 0);
+        }
+
+        private class Arm32ElTransitionBlock : Arm32TransitionBlock
+        {
+            public new static TransitionBlock Instance = new Arm32ElTransitionBlock();
+
+            public override bool IsArmhfABI => false;
+            public override bool IsArmelABI => true;
         }
 
         private sealed class Arm64TransitionBlock : TransitionBlock

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -31,11 +31,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 case TargetArchitecture.ARM:
                     if (target.Abi == TargetAbi.CoreRTArmel)
                     {
-                        return Arm32TransitionBlock.Instance;
+                        return Arm32ElTransitionBlock.Instance;
                     }
                     else
                     {
-                        return Arm32ElTransitionBlock.Instance;
+                        return Arm32TransitionBlock.Instance;
                     }
 
                 case TargetArchitecture.ARM64:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -82,6 +82,11 @@ namespace ILCompiler
                 builder.Add(new KeyValuePair<string, string>(name, value));
             }
 
+            if (_context.Target.Abi == TargetAbi.CoreRTArmel)
+            {
+                builder.Add(new KeyValuePair<string, string>("JitSoftFP", "1"));
+            }
+
             _ryujitOptions = builder.ToArray();
 
             return this;

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -23,6 +23,7 @@ namespace ILCompiler
         private CommandLineOptions _commandLineOptions;
         public TargetOS _targetOS;
         public TargetArchitecture _targetArchitecture;
+        private bool _armelAbi = false;
         public OptimizationMode _optimizationMode;
         private Dictionary<string, string> _inputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private Dictionary<string, string> _unrootedInputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -167,7 +168,10 @@ namespace ILCompiler
                 else if (_commandLineOptions.TargetArch.Equals("arm", StringComparison.OrdinalIgnoreCase))
                     _targetArchitecture = TargetArchitecture.ARM;
                 else if (_commandLineOptions.TargetArch.Equals("armel", StringComparison.OrdinalIgnoreCase))
+                {
                     _targetArchitecture = TargetArchitecture.ARM;
+                    _armelAbi = true;
+                }
                 else if (_commandLineOptions.TargetArch.Equals("arm64", StringComparison.OrdinalIgnoreCase))
                     _targetArchitecture = TargetArchitecture.ARM64;
                 else
@@ -316,7 +320,7 @@ namespace ILCompiler
 
                     SharedGenericsMode genericsMode = SharedGenericsMode.CanonicalReferenceTypes;
 
-                    var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT, instructionSetSupport.GetVectorTSimdVector());
+                    var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, _armelAbi ? TargetAbi.CoreRTArmel : TargetAbi.CoreRT, instructionSetSupport.GetVectorTSimdVector());
 
                     bool versionBubbleIncludesCoreLib = false;
                     if (_commandLineOptions.InputBubble)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12910,6 +12910,10 @@ CORJIT_FLAGS GetCompileFlags(MethodDesc * ftn, CORJIT_FLAGS flags, CORINFO_METHO
         flags.Clear(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_INFO);
     }
 
+#ifdef ARM_SOFTFP
+    flags.Set(CORJIT_FLAGS::CORJIT_FLAG_SOFTFP_ABI);
+#endif // ARM_SOFTFP
+
 #ifdef FEATURE_PGO
 
     // Instrument, if

--- a/src/coreclr/zap/zapinfo.cpp
+++ b/src/coreclr/zap/zapinfo.cpp
@@ -205,6 +205,10 @@ CORJIT_FLAGS ZapInfo::ComputeJitFlags(CORINFO_METHOD_HANDLE handle)
     }
 #endif  // FEATURE_READYTORUN_COMPILER
 
+#ifdef ARM_SOFTFP
+    jitFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_SOFTFP_ABI);
+#endif
+
     return jitFlags;
 }
 


### PR DESCRIPTION
This change adds support for armel target compilation in crossgen2

To use the feature compile an application using the --targetos Linux and --targetarch armel flags.

Summary of changes
- To avoid bloating the compilation matrix, the #ifdefs used in the JIT that were conditional on ARM_SOFTFP behavior have been changed in to variable checks. To avoid perf penalties, this dynamic behavior is only enabled for the jit intended for compiling using crossgen2.
- Armel abi processing was integrated into the various parts of the managed crossgen2 codebase that correspond to components with special handling in the coreclr codebase
  - HFA support is disabled for Armel targets
  - Floating point registers are not used when passing arguments

With this change it becomes possible to run crossgen2 on a Windows or Linux machine and target a Linux Armel target. 