### PR TITLE
Extend allowed Task.Delay/CTS TimeSpan values to match Timer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3359,7 +3359,7 @@
     <value>The specified TaskContinuationOptions excluded all continuation kinds.</value>
   </data>
   <data name="Task_Delay_InvalidDelay" xml:space="preserve">
-    <value>The value needs to translate in milliseconds to -1 (signifying an infinite timeout), 0 or a positive integer less than or equal to Int32.MaxValue.</value>
+    <value>The value needs to translate in milliseconds to -1 (signifying an infinite timeout), 0 or a positive integer less than or equal to the maximum allowed timer duration.</value>
   </data>
   <data name="Task_Delay_InvalidMillisecondsDelay" xml:space="preserve">
     <value>The value needs to be either -1 (signifying an infinite timeout), 0 or a positive integer.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -151,7 +151,7 @@ namespace System.Threading
         /// </summary>
         /// <param name="delay">The time span to wait before canceling this <see cref="CancellationTokenSource"/></param>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// The exception that is thrown when <paramref name="delay"/> is less than -1 or greater than int.MaxValue.
+        /// The <paramref name="delay"/> is less than -1 or greater than the maximum allowed timer duration.
         /// </exception>
         /// <remarks>
         /// <para>
@@ -168,12 +168,12 @@ namespace System.Threading
         public CancellationTokenSource(TimeSpan delay)
         {
             long totalMilliseconds = (long)delay.TotalMilliseconds;
-            if (totalMilliseconds < -1 || totalMilliseconds > int.MaxValue)
+            if (totalMilliseconds < -1 || totalMilliseconds > Timer.MaxSupportedTimeout)
             {
                 throw new ArgumentOutOfRangeException(nameof(delay));
             }
 
-            InitializeWithTimer((int)totalMilliseconds);
+            InitializeWithTimer((uint)totalMilliseconds);
         }
 
         /// <summary>
@@ -202,14 +202,14 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException(nameof(millisecondsDelay));
             }
 
-            InitializeWithTimer(millisecondsDelay);
+            InitializeWithTimer((uint)millisecondsDelay);
         }
 
         /// <summary>
         /// Common initialization logic when constructing a CTS with a delay parameter.
         /// A zero delay will result in immediate cancellation.
         /// </summary>
-        private void InitializeWithTimer(int millisecondsDelay)
+        private void InitializeWithTimer(uint millisecondsDelay)
         {
             if (millisecondsDelay == 0)
             {
@@ -218,7 +218,7 @@ namespace System.Threading
             else
             {
                 _state = NotCanceledState;
-                _timer = new TimerQueueTimer(s_timerCallback, this, (uint)millisecondsDelay, Timeout.UnsignedInfinite, flowExecutionContext: false);
+                _timer = new TimerQueueTimer(s_timerCallback, this, millisecondsDelay, Timeout.UnsignedInfinite, flowExecutionContext: false);
 
                 // The timer roots this CTS instance while it's scheduled.  That is by design, so
                 // that code like:
@@ -286,8 +286,7 @@ namespace System.Threading
         /// cref="CancellationTokenSource"/> has been disposed.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// The exception thrown when <paramref name="delay"/> is less than -1 or
-        /// greater than int.MaxValue.
+        /// The <paramref name="delay"/> is less than -1 or greater than maximum allowed timer duration.
         /// </exception>
         /// <remarks>
         /// <para>
@@ -303,12 +302,12 @@ namespace System.Threading
         public void CancelAfter(TimeSpan delay)
         {
             long totalMilliseconds = (long)delay.TotalMilliseconds;
-            if (totalMilliseconds < -1 || totalMilliseconds > int.MaxValue)
+            if (totalMilliseconds < -1 || totalMilliseconds > Timer.MaxSupportedTimeout)
             {
-                throw new ArgumentOutOfRangeException(nameof(delay));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.delay);
             }
 
-            CancelAfter((int)totalMilliseconds);
+            CancelAfter((uint)totalMilliseconds);
         }
 
         /// <summary>
@@ -337,12 +336,17 @@ namespace System.Threading
         /// </remarks>
         public void CancelAfter(int millisecondsDelay)
         {
-            ThrowIfDisposed();
-
             if (millisecondsDelay < -1)
             {
-                throw new ArgumentOutOfRangeException(nameof(millisecondsDelay));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.millisecondsDelay);
             }
+
+            CancelAfter((uint)millisecondsDelay);
+        }
+
+        private void CancelAfter(uint millisecondsDelay)
+        {
+            ThrowIfDisposed();
 
             if (IsCancellationRequested)
             {
@@ -379,7 +383,7 @@ namespace System.Threading
             // the following in a try/catch block.
             try
             {
-                timer.Change((uint)millisecondsDelay, Timeout.UnsignedInfinite);
+                timer.Change(millisecondsDelay, Timeout.UnsignedInfinite);
             }
             catch (ObjectDisposedException)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -693,7 +693,7 @@ namespace System.Threading
 
     public sealed class Timer : MarshalByRefObject, IDisposable, IAsyncDisposable
     {
-        private const uint MAX_SUPPORTED_TIMEOUT = (uint)0xfffffffe;
+        internal const uint MaxSupportedTimeout = 0xfffffffe;
 
         private TimerHolder _timer;
 
@@ -727,13 +727,13 @@ namespace System.Threading
             long dueTm = (long)dueTime.TotalMilliseconds;
             if (dueTm < -1)
                 throw new ArgumentOutOfRangeException(nameof(dueTime), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
-            if (dueTm > MAX_SUPPORTED_TIMEOUT)
+            if (dueTm > MaxSupportedTimeout)
                 throw new ArgumentOutOfRangeException(nameof(dueTime), SR.ArgumentOutOfRange_TimeoutTooLarge);
 
             long periodTm = (long)period.TotalMilliseconds;
             if (periodTm < -1)
                 throw new ArgumentOutOfRangeException(nameof(period), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
-            if (periodTm > MAX_SUPPORTED_TIMEOUT)
+            if (periodTm > MaxSupportedTimeout)
                 throw new ArgumentOutOfRangeException(nameof(period), SR.ArgumentOutOfRange_PeriodTooLarge);
 
             TimerSetup(callback, state, (uint)dueTm, (uint)periodTm);
@@ -757,9 +757,9 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException(nameof(dueTime), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
             if (period < -1)
                 throw new ArgumentOutOfRangeException(nameof(period), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
-            if (dueTime > MAX_SUPPORTED_TIMEOUT)
+            if (dueTime > MaxSupportedTimeout)
                 throw new ArgumentOutOfRangeException(nameof(dueTime), SR.ArgumentOutOfRange_TimeoutTooLarge);
-            if (period > MAX_SUPPORTED_TIMEOUT)
+            if (period > MaxSupportedTimeout)
                 throw new ArgumentOutOfRangeException(nameof(period), SR.ArgumentOutOfRange_PeriodTooLarge);
             TimerSetup(callback, state, (uint)dueTime, (uint)period);
         }
@@ -814,9 +814,9 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException(nameof(dueTime), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
             if (period < -1)
                 throw new ArgumentOutOfRangeException(nameof(period), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
-            if (dueTime > MAX_SUPPORTED_TIMEOUT)
+            if (dueTime > MaxSupportedTimeout)
                 throw new ArgumentOutOfRangeException(nameof(dueTime), SR.ArgumentOutOfRange_TimeoutTooLarge);
-            if (period > MAX_SUPPORTED_TIMEOUT)
+            if (period > MaxSupportedTimeout)
                 throw new ArgumentOutOfRangeException(nameof(period), SR.ArgumentOutOfRange_PeriodTooLarge);
 
             return _timer._timer.Change((uint)dueTime, (uint)period);

--- a/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
@@ -1052,27 +1052,28 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void CancellationTokenSourceWithTimer_Negative()
         {
-            TimeSpan bigTimeSpan = new TimeSpan(2000, 0, 0, 0, 0);
+            TimeSpan bigTimeSpan = TimeSpan.FromMilliseconds(uint.MaxValue);
             TimeSpan reasonableTimeSpan = new TimeSpan(0, 0, 1);
-            //
-            // Test exception logic
-            //
-            Assert.Throws<ArgumentOutOfRangeException>(
-               () => { new CancellationTokenSource(-2); });
-            Assert.Throws<ArgumentOutOfRangeException>(
-               () => { new CancellationTokenSource(bigTimeSpan); });
 
-            CancellationTokenSource cts = new CancellationTokenSource();
-            Assert.Throws<ArgumentOutOfRangeException>(
-               () => { cts.CancelAfter(-2); });
-            Assert.Throws<ArgumentOutOfRangeException>(
-               () => { cts.CancelAfter(bigTimeSpan); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new CancellationTokenSource(-2); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { new CancellationTokenSource(bigTimeSpan); });
+
+            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(uint.MaxValue - 1));
+            Assert.False(cts.IsCancellationRequested);
+            cts.Dispose();
+
+            cts = new CancellationTokenSource();
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cts.CancelAfter(-2); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cts.CancelAfter(bigTimeSpan); });
+
+            cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromMilliseconds(uint.MaxValue - 1));
+            Assert.False(cts.IsCancellationRequested);
+            cts.Dispose();
 
             cts.Dispose();
-            Assert.Throws<ObjectDisposedException>(
-               () => { cts.CancelAfter(1); });
-            Assert.Throws<ObjectDisposedException>(
-               () => { cts.CancelAfter(reasonableTimeSpan); });
+            Assert.Throws<ObjectDisposedException>(() => { cts.CancelAfter(1); });
+            Assert.Throws<ObjectDisposedException>(() => { cts.CancelAfter(reasonableTimeSpan); });
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -495,6 +495,29 @@ namespace System.Threading.Tasks.Tests
             Assert.True((bool)isHandledField.GetValue(holderObject), "Expected FromException task to be observed after accessing Exception");
         }
 
+        [Theory]
+        [InlineData(-2L)]
+        [InlineData((long)int.MinValue)]
+        [InlineData((long)uint.MaxValue)]
+        public static void TaskDelay_OutOfBounds_ThrowsException(long delay)
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("delay", () => { Task.Delay(TimeSpan.FromMilliseconds(delay)); });
+            if (delay >= int.MinValue && delay <= int.MaxValue)
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsDelay", () => { Task.Delay((int)delay); });
+            }
+        }
+
+        [Fact]
+        public static void TaskDelay_MaxSupported_Success()
+        {
+            var cts = new CancellationTokenSource();
+            Task t = Task.Delay(TimeSpan.FromMilliseconds(uint.MaxValue - 2), cts.Token);
+            Assert.False(t.IsCompleted);
+            cts.Cancel();
+            Assert.True(t.IsCanceled);
+        }
+
         [Fact]
         public static void RunDelayTests()
         {


### PR DESCRIPTION
For some reason, Task.Delay(TimeSpan, ...) and CancellationTokenSource.CancelAfter(TimeSpan) cut off the max allowed timeout at int.MaxValue milliseconds, whereas Timer's TimeSpan support (which is used under the covers) goes all the way to UInt32.MaxValue - 1.  This changes Task/CancellationTokenSource to match, effectively doubling the allowed length of the timeouts.

Fixes https://github.com/dotnet/runtime/issues/41238. While we don't support the full range of TimeSpan,  this change makes the example in that repro work (a month).