### PR TITLE
Fix perf issue in System.Diagnostics.Activity

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -609,7 +609,7 @@ namespace System.Diagnostics
         /// <seealso cref="SetEndTime(DateTime)"/>
         public void Stop()
         {
-            if (Id == null)
+            if (_id == null && _spanId == null)
             {
                 NotifyError(new InvalidOperationException(SR.ActivityNotStarted));
                 return;


### PR DESCRIPTION
Fixes #43704 

Fixed Activity automatically allocating Id when Stop is called while using W3C format.

Benchmark:
```csharp
        [Benchmark]
        public void ActivityAllocations()
        {
            Activity activity = new Activity("TestActivity");
            activity.SetIdFormat(ActivityIdFormat.W3C);
            activity.Start();
            activity.Stop();
        }
```

Results:
|              Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
| ActivityAllocationsBefore | 618.8 ns | 12.37 ns | 12.15 ns | 618.5 ns | 601.5 ns | 644.4 ns | 0.0733 |     - |     - |     632 B |
| ActivityAllocationsAfter | 545.1 ns | 22.54 ns | 25.96 ns | 541.5 ns | 513.7 ns | 605.3 ns | 0.0454 |     - |     - |     392 B |

/cc @tarekgh 