### PR TITLE
Improve annotations for XLinq methods taking params object[]

### DIFF
--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -1389,7 +1389,7 @@ namespace System.Xml.Linq
             }
         }
 
-        private static void AddContentToList(List<object> list, object content)
+        private static void AddContentToList(List<object?> list, object? content)
         {
             IEnumerable? e = content is string ? null : content as IEnumerable;
             if (e == null)
@@ -1409,7 +1409,7 @@ namespace System.Xml.Linq
         internal static object? GetContentSnapshot(object? content)
         {
             if (content is string || !(content is IEnumerable)) return content;
-            List<object> list = new List<object>();
+            List<object?> list = new List<object?>();
             AddContentToList(list, content);
             return list;
         }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -165,16 +165,16 @@ namespace System.Xml.Linq
                 AddNode(new XElement(x));
                 return;
             }
-            object[]? o = content as object[];
+            object?[]? o = content as object?[];
             if (o != null)
             {
-                foreach (object obj in o) Add(obj);
+                foreach (object? obj in o) Add(obj);
                 return;
             }
             IEnumerable? e = content as IEnumerable;
             if (e != null)
             {
-                foreach (object obj in e) Add(obj);
+                foreach (object? obj in e) Add(obj);
                 return;
             }
             AddString(GetStringValue(content));
@@ -190,7 +190,7 @@ namespace System.Xml.Linq
         /// See XContainer.Add(object content) for details about the content that can be added
         /// using this method.
         /// </remarks>
-        public void Add(params object[] content)
+        public void Add(params object?[] content)
         {
             Add((object)content);
         }
@@ -229,7 +229,7 @@ namespace System.Xml.Linq
         /// <exception cref="InvalidOperationException">
         /// Thrown if the parent is null.
         /// </exception>
-        public void AddFirst(params object[] content)
+        public void AddFirst(params object?[] content)
         {
             AddFirst((object)content);
         }
@@ -452,7 +452,7 @@ namespace System.Xml.Linq
         /// See XContainer.Add(object content) for details about the content that can be added
         /// using this method.
         /// </remarks>
-        public void ReplaceNodes(params object[] content)
+        public void ReplaceNodes(params object?[] content)
         {
             ReplaceNodes((object)content);
         }
@@ -492,16 +492,16 @@ namespace System.Xml.Linq
                 AddNodeSkipNotify(new XElement(x));
                 return;
             }
-            object[]? o = content as object[];
+            object?[]? o = content as object?[];
             if (o != null)
             {
-                foreach (object obj in o) AddContentSkipNotify(obj);
+                foreach (object? obj in o) AddContentSkipNotify(obj);
                 return;
             }
             IEnumerable? e = content as IEnumerable;
             if (e != null)
             {
-                foreach (object obj in e) AddContentSkipNotify(obj);
+                foreach (object? obj in e) AddContentSkipNotify(obj);
                 return;
             }
             AddStringSkipNotify(GetStringValue(content));
@@ -1398,7 +1398,7 @@ namespace System.Xml.Linq
             }
             else
             {
-                foreach (object obj in e)
+                foreach (object? obj in e)
                 {
                     if (obj != null) AddContentToList(list, obj);
                 }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -59,7 +59,7 @@ namespace System.Xml.Linq
         /// See <see cref="XContainer.Add(object)"/> for details about the content that can be added
         /// using this method.
         /// </remarks>
-        public XDocument(params object[] content)
+        public XDocument(params object?[] content)
             : this()
         {
             AddContentSkipNotify(content);
@@ -87,7 +87,7 @@ namespace System.Xml.Linq
         /// See <see cref="XContainer.Add(object)"/> for details about the content that can be added
         /// using this method.
         /// </remarks>
-        public XDocument(XDeclaration? declaration, params object[] content)
+        public XDocument(XDeclaration? declaration, params object?[] content)
             : this(content)
         {
             _declaration = declaration;

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -92,7 +92,7 @@ namespace System.Xml.Linq
         /// See XContainer.Add(object content) for details about the content that can be added
         /// using this method.
         /// </remarks>
-        public XElement(XName name, params object[] content) : this(name, (object)content) { }
+        public XElement(XName name, params object?[] content) : this(name, (object)content) { }
 
         /// <summary>
         /// Initializes a new instance of the XElement class from another XElement object.
@@ -983,7 +983,7 @@ namespace System.Xml.Linq
         /// See XContainer.Add(object content) for details about the content that can be added
         /// using this method.
         /// </remarks>
-        public void ReplaceAll(params object[] content)
+        public void ReplaceAll(params object?[] content)
         {
             ReplaceAll((object)content);
         }
@@ -1020,7 +1020,7 @@ namespace System.Xml.Linq
         /// See XContainer.Add(object content) for details about the content that can be added
         /// using this method.
         /// </remarks>
-        public void ReplaceAttributes(params object[] content)
+        public void ReplaceAttributes(params object?[] content)
         {
             ReplaceAttributes((object)content);
         }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XLinq.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XLinq.cs
@@ -95,16 +95,16 @@ namespace System.Xml.Linq
                 AddNode(new XElement(x));
                 return;
             }
-            object[]? o = content as object[];
+            object?[]? o = content as object?[];
             if (o != null)
             {
-                foreach (object obj in o) AddContent(obj);
+                foreach (object? obj in o) AddContent(obj);
                 return;
             }
             IEnumerable? e = content as IEnumerable;
             if (e != null)
             {
-                foreach (object obj in e) AddContent(obj);
+                foreach (object? obj in e) AddContent(obj);
                 return;
             }
             if (content is XAttribute) throw new ArgumentException(SR.Argument_AddAttribute);

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNode.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNode.cs
@@ -138,7 +138,7 @@ namespace System.Xml.Linq
         /// <exception cref="InvalidOperationException">
         /// Thrown if the parent is null.
         /// </exception>
-        public void AddAfterSelf(params object[] content)
+        public void AddAfterSelf(params object?[] content)
         {
             AddAfterSelf((object)content);
         }
@@ -185,7 +185,7 @@ namespace System.Xml.Linq
         /// <exception cref="InvalidOperationException">
         /// Thrown if the parent is null.
         /// </exception>
-        public void AddBeforeSelf(params object[] content)
+        public void AddBeforeSelf(params object?[] content)
         {
             AddBeforeSelf((object)content);
         }
@@ -567,7 +567,7 @@ namespace System.Xml.Linq
         /// Replaces this node with the specified content.
         /// </summary>
         /// <param name="content">Content that replaces this node.</param>
-        public void ReplaceWith(params object[] content)
+        public void ReplaceWith(params object?[] content)
         {
             ReplaceWith((object)content);
         }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XStreamingElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XStreamingElement.cs
@@ -43,7 +43,7 @@ namespace System.Xml.Linq
         /// </summary>
         /// <param name="name">The name to assign to the new <see cref="XStreamingElement"/> node</param>
         /// <param name="content">An array containing content to assign to the new <see cref="XStreamingElement"/> node</param>
-        public XStreamingElement(XName name, params object[] content)
+        public XStreamingElement(XName name, params object?[] content)
             : this(name)
         {
             this.content = content;
@@ -88,7 +88,7 @@ namespace System.Xml.Linq
         /// Add content to an <see cref="XStreamingElement"/>
         /// </summary>
         /// <param name="content">array of objects containing content to add</param>
-        public void Add(params object[] content)
+        public void Add(params object?[] content)
         {
             Add((object)content);
         }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XStreamingElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XStreamingElement.cs
@@ -32,10 +32,10 @@ namespace System.Xml.Linq
         /// </summary>
         /// <param name="name">The name to assign to the new <see cref="XStreamingElement"/> node</param>
         /// <param name="content">The content to assign to the new <see cref="XStreamingElement"/> node</param>
-        public XStreamingElement(XName name, object content)
+        public XStreamingElement(XName name, object? content)
             : this(name)
         {
-            this.content = content is List<object> ? new object[] { content } : content;
+            this.content = content is List<object?> ? new object?[] { content } : content;
         }
 
         /// <summary>

--- a/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
+++ b/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
@@ -150,9 +150,9 @@ namespace System.Xml.Linq
         public System.Xml.Linq.XNode? FirstNode { get { throw null; } }
         public System.Xml.Linq.XNode? LastNode { get { throw null; } }
         public void Add(object? content) { }
-        public void Add(params object[] content) { }
+        public void Add(params object?[] content) { }
         public void AddFirst(object? content) { }
-        public void AddFirst(params object[] content) { }
+        public void AddFirst(params object?[] content) { }
         public System.Xml.XmlWriter CreateWriter() { throw null; }
         public System.Collections.Generic.IEnumerable<System.Xml.Linq.XNode> DescendantNodes() { throw null; }
         public System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> Descendants() { throw null; }
@@ -163,7 +163,7 @@ namespace System.Xml.Linq
         public System.Collections.Generic.IEnumerable<System.Xml.Linq.XNode> Nodes() { throw null; }
         public void RemoveNodes() { }
         public void ReplaceNodes(object? content) { }
-        public void ReplaceNodes(params object[] content) { }
+        public void ReplaceNodes(params object?[] content) { }
     }
     public partial class XDeclaration
     {
@@ -177,8 +177,8 @@ namespace System.Xml.Linq
     public partial class XDocument : System.Xml.Linq.XContainer
     {
         public XDocument() { }
-        public XDocument(params object[] content) { }
-        public XDocument(System.Xml.Linq.XDeclaration? declaration, params object[] content) { }
+        public XDocument(params object?[] content) { }
+        public XDocument(System.Xml.Linq.XDeclaration? declaration, params object?[] content) { }
         public XDocument(System.Xml.Linq.XDocument other) { }
         public System.Xml.Linq.XDeclaration? Declaration { get { throw null; } set { } }
         public System.Xml.Linq.XDocumentType? DocumentType { get { throw null; } }
@@ -229,7 +229,7 @@ namespace System.Xml.Linq
         public XElement(System.Xml.Linq.XElement other) { }
         public XElement(System.Xml.Linq.XName name) { }
         public XElement(System.Xml.Linq.XName name, object? content) { }
-        public XElement(System.Xml.Linq.XName name, params object[] content) { }
+        public XElement(System.Xml.Linq.XName name, params object?[] content) { }
         public XElement(System.Xml.Linq.XStreamingElement other) { }
         public static System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> EmptySequence { get { throw null; } }
         public System.Xml.Linq.XAttribute? FirstAttribute { get { throw null; } }
@@ -330,9 +330,9 @@ namespace System.Xml.Linq
         public void RemoveAll() { }
         public void RemoveAttributes() { }
         public void ReplaceAll(object? content) { }
-        public void ReplaceAll(params object[] content) { }
+        public void ReplaceAll(params object?[] content) { }
         public void ReplaceAttributes(object? content) { }
-        public void ReplaceAttributes(params object[] content) { }
+        public void ReplaceAttributes(params object?[] content) { }
         public void Save(System.IO.Stream stream) { }
         public void Save(System.IO.Stream stream, System.Xml.Linq.SaveOptions options) { }
         public void Save(System.IO.TextWriter textWriter) { }
@@ -398,9 +398,9 @@ namespace System.Xml.Linq
         public System.Xml.Linq.XNode? NextNode { get { throw null; } }
         public System.Xml.Linq.XNode? PreviousNode { get { throw null; } }
         public void AddAfterSelf(object? content) { }
-        public void AddAfterSelf(params object[] content) { }
+        public void AddAfterSelf(params object?[] content) { }
         public void AddBeforeSelf(object? content) { }
-        public void AddBeforeSelf(params object[] content) { }
+        public void AddBeforeSelf(params object?[] content) { }
         public System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> Ancestors() { throw null; }
         public System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> Ancestors(System.Xml.Linq.XName? name) { throw null; }
         public static int CompareDocumentOrder(System.Xml.Linq.XNode? n1, System.Xml.Linq.XNode? n2) { throw null; }
@@ -419,7 +419,7 @@ namespace System.Xml.Linq
         public static System.Threading.Tasks.Task<System.Xml.Linq.XNode> ReadFromAsync(System.Xml.XmlReader reader, System.Threading.CancellationToken cancellationToken) { throw null; }
         public void Remove() { }
         public void ReplaceWith(object? content) { }
-        public void ReplaceWith(params object[] content) { }
+        public void ReplaceWith(params object?[] content) { }
         public override string ToString() { throw null; }
         public string ToString(System.Xml.Linq.SaveOptions options) { throw null; }
         public abstract void WriteTo(System.Xml.XmlWriter writer);
@@ -489,10 +489,10 @@ namespace System.Xml.Linq
     {
         public XStreamingElement(System.Xml.Linq.XName name) { }
         public XStreamingElement(System.Xml.Linq.XName name, object content) { }
-        public XStreamingElement(System.Xml.Linq.XName name, params object[] content) { }
+        public XStreamingElement(System.Xml.Linq.XName name, params object?[] content) { }
         public System.Xml.Linq.XName Name { get { throw null; } set { } }
         public void Add(object? content) { }
-        public void Add(params object[] content) { }
+        public void Add(params object?[] content) { }
         public void Save(System.IO.Stream stream) { }
         public void Save(System.IO.Stream stream, System.Xml.Linq.SaveOptions options) { }
         public void Save(System.IO.TextWriter textWriter) { }

--- a/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
+++ b/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
@@ -488,7 +488,7 @@ namespace System.Xml.Linq
     public partial class XStreamingElement
     {
         public XStreamingElement(System.Xml.Linq.XName name) { }
-        public XStreamingElement(System.Xml.Linq.XName name, object content) { }
+        public XStreamingElement(System.Xml.Linq.XName name, object? content) { }
         public XStreamingElement(System.Xml.Linq.XName name, params object?[] content) { }
         public System.Xml.Linq.XName Name { get { throw null; } set { } }
         public void Add(object? content) { }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/43416

plus similar APIs across XLinq

cc: @jeffhandley for bar-check