### PR TITLE
Add support for repeated XML elements without a name attribute

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/IXmlConfigurationValue.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/IXmlConfigurationValue.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Configuration.Xml
+{
+    /// <summary>
+    /// Represents a configuration value that was parsed from an XML source
+    /// </summary>
+    internal interface IXmlConfigurationValue
+    {
+        string Key { get; }
+        string Value { get; }
+        string LineInfo { get; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElement.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElement.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Extensions.Configuration.Xml
+{
+    internal class XmlConfigurationElement
+    {
+        public string ElementName { get; }
+
+        public string Name { get; }
+
+        public string LineInfo { get; }
+
+        public bool Multiple { get; set; }
+
+        public int Index { get; set; }
+
+        /// <summary>
+        /// The parent element, or null if this is the root element
+        /// </summary>
+        public XmlConfigurationElement Parent { get; }
+
+        public XmlConfigurationElement(XmlConfigurationElement parent, string elementName, string name, string lineInfo)
+        {
+            Parent = parent;
+            ElementName = elementName ?? throw new ArgumentNullException(nameof(elementName));
+            Name = name;
+            LineInfo = lineInfo;
+        }
+
+        public string Key
+        {
+            get
+            {
+                var tokens = new List<string>(3);
+
+                // the root element does not contribute to the prefix
+                if (Parent != null) tokens.Add(ElementName);
+
+                // the name attribute always contributes to the prefix
+                if (Name != null) tokens.Add(Name);
+
+                // the index only contributes to the prefix when there are multiple elements wih the same name
+                if (Multiple) tokens.Add(Index.ToString());
+
+                // the root element without a name attribute does not contribute to prefix at all
+                if (!tokens.Any()) return null;
+
+                return string.Join(ConfigurationPath.KeyDelimiter, tokens);
+            }
+        }
+
+        public bool IsSibling(XmlConfigurationElement xmlConfigurationElement)
+        {
+            return Parent != null
+                && xmlConfigurationElement.Parent == Parent
+                && string.Equals(ElementName, xmlConfigurationElement.ElementName)
+                && string.Equals(Name, xmlConfigurationElement.Name);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElement.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElement.cs
@@ -57,6 +57,11 @@ namespace Microsoft.Extensions.Configuration.Xml
 
         public bool IsSibling(XmlConfigurationElement xmlConfigurationElement)
         {
+            if (xmlConfigurationElement is null)
+            {
+                throw new ArgumentNullException(nameof(xmlConfigurationElement));
+            }
+
             return Parent != null
                 && xmlConfigurationElement.Parent == Parent
                 && string.Equals(ElementName, xmlConfigurationElement.ElementName)

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElementAttributeValue.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElementAttributeValue.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Extensions.Configuration.Xml
+{
+    internal class XmlConfigurationElementAttributeValue : IXmlConfigurationValue
+    {
+        private readonly XmlConfigurationElement[] _elementPath;
+        private readonly string _attribute;
+
+        public XmlConfigurationElementAttributeValue(Stack<XmlConfigurationElement> elementPath, string attribute, string value, string lineInfo)
+        {
+            _elementPath = elementPath?.Reverse()?.ToArray() ?? throw new ArgumentNullException(nameof(elementPath));
+            _attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+            LineInfo = lineInfo;
+        }
+
+        /// <summary>
+        /// Combines the path to this element with the attribute value to produce a key.
+        /// Note that this property cannot be computed during construction,
+        /// because the keys of the elements along the path may change when multiple elements with the same name are encountered
+        /// </summary>
+        public string Key => ConfigurationPath.Combine(_elementPath.Select(e => e.Key).Concat(new[] { _attribute }).Where(key => key != null));
+
+        public string Value { get; }
+
+        public string LineInfo { get; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElementContent.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationElementContent.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Extensions.Configuration.Xml
+{
+    internal class XmlConfigurationElementContent
+        : IXmlConfigurationValue
+    {
+        private readonly XmlConfigurationElement[] _elementPath;
+
+        public XmlConfigurationElementContent(Stack<XmlConfigurationElement> elementPath, string content, string lineInfo)
+        {
+            Value = content ?? throw new ArgumentNullException(nameof(content));
+            LineInfo = lineInfo ?? throw new ArgumentNullException(nameof(lineInfo));
+            _elementPath = elementPath?.Reverse().ToArray() ?? throw new ArgumentNullException(nameof(elementPath));
+        }
+
+        /// <summary>
+        /// Combines the path to this element to produce a key.
+        /// Note that this property cannot be computed during construction,
+        /// because the keys of the elements along the path may change when multiple elements with the same name are encountered
+        /// </summary>
+        public string Key => ConfigurationPath.Combine(_elementPath.Select(e => e.Key).Where(key => key != null));
+
+        public string Value { get; }
+
+        public string LineInfo { get; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
@@ -54,11 +54,12 @@ namespace Microsoft.Extensions.Configuration.Xml
                     switch (reader.NodeType)
                     {
                         case XmlNodeType.Element:
-                            var parent = currentPath.Any() ? currentPath.Peek() : null;
+                            XmlConfigurationElement parent = currentPath.Any() ? currentPath.Peek() : null;
+
                             var element = new XmlConfigurationElement(parent, reader.LocalName, GetName(reader), GetLineInfo(reader));
 
                             // check if this element has appeared before
-                            var sibling = allElements.Where(e => e.IsSibling(element)).OrderByDescending(e => e.Index).FirstOrDefault();
+                            XmlConfigurationElement sibling = allElements.Where(e => e.IsSibling(element)).OrderByDescending(e => e.Index).FirstOrDefault();
                             if (sibling != null)
                             {
                                 sibling.Multiple = element.Multiple = true;

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// <returns>The <see cref="IDictionary{String, String}"/> which was read from the stream.</returns>
         public static IDictionary<string, string> Read(Stream stream, XmlDocumentDecryptor decryptor)
         {
-            var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var configurationValues = new List<IXmlConfigurationValue>();
 
             var readerSettings = new XmlReaderSettings()
             {
@@ -42,13 +42,11 @@ namespace Microsoft.Extensions.Configuration.Xml
 
             using (XmlReader reader = decryptor.CreateDecryptingXmlReader(stream, readerSettings))
             {
-                var prefixStack = new Stack<string>();
+                // record all elements we encounter to check for repeated elements
+                var allElements = new List<XmlConfigurationElement>();
 
-                SkipUntilRootElement(reader);
-
-                // We process the root element individually since it doesn't contribute to prefix
-                ProcessAttributes(reader, prefixStack, data, AddNamePrefix);
-                ProcessAttributes(reader, prefixStack, data, AddAttributePair);
+                // keep track of the tree we followed to get where we are (breadcrumb style)
+                var currentPath = new Stack<XmlConfigurationElement>();
 
                 XmlNodeType preNodeType = reader.NodeType;
                 while (reader.Read())
@@ -56,43 +54,49 @@ namespace Microsoft.Extensions.Configuration.Xml
                     switch (reader.NodeType)
                     {
                         case XmlNodeType.Element:
-                            prefixStack.Push(reader.LocalName);
-                            ProcessAttributes(reader, prefixStack, data, AddNamePrefix);
-                            ProcessAttributes(reader, prefixStack, data, AddAttributePair);
+                            var parent = currentPath.Any() ? currentPath.Peek() : null;
+                            var element = new XmlConfigurationElement(parent, reader.LocalName, GetName(reader), GetLineInfo(reader));
+
+                            // check if this element has appeared before
+                            var sibling = allElements.Where(e => e.IsSibling(element)).OrderByDescending(e => e.Index).FirstOrDefault();
+                            if (sibling != null)
+                            {
+                                sibling.Multiple = element.Multiple = true;
+                                element.Index = sibling.Index + 1;
+                            }
+
+                            currentPath.Push(element);
+                            allElements.Add(element);
+
+                            ProcessAttributes(reader, currentPath, configurationValues);
 
                             // If current element is self-closing
                             if (reader.IsEmptyElement)
                             {
-                                prefixStack.Pop();
+                                currentPath.Pop();
                             }
                             break;
 
                         case XmlNodeType.EndElement:
-                            if (prefixStack.Any())
+                            if (currentPath.Any())
                             {
                                 // If this EndElement node comes right after an Element node,
                                 // it means there is no text/CDATA node in current element
                                 if (preNodeType == XmlNodeType.Element)
                                 {
-                                    string key = ConfigurationPath.Combine(prefixStack.Reverse());
-                                    data[key] = string.Empty;
+                                    var configurationValue = new XmlConfigurationElementContent(currentPath, string.Empty, GetLineInfo(reader));
+                                    configurationValues.Add(configurationValue);
                                 }
 
-                                prefixStack.Pop();
+                                currentPath.Pop();
                             }
                             break;
 
                         case XmlNodeType.CDATA:
                         case XmlNodeType.Text:
                             {
-                                string key = ConfigurationPath.Combine(prefixStack.Reverse());
-                                if (data.ContainsKey(key))
-                                {
-                                    throw new FormatException(SR.Format(SR.Error_KeyIsDuplicated, key,
-                                        GetLineInfo(reader)));
-                                }
-
-                                data[key] = reader.Value;
+                                var configurationValue = new XmlConfigurationElementContent(currentPath, reader.Value, GetLineInfo(reader));
+                                configurationValues.Add(configurationValue);
                                 break;
                             }
                         case XmlNodeType.XmlDeclaration:
@@ -107,6 +111,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                                 GetLineInfo(reader)));
                     }
                     preNodeType = reader.NodeType;
+
                     // If this element is a self-closing element,
                     // we pretend that we just processed an EndElement node
                     // because a self-closing element contains an end within itself
@@ -117,6 +122,19 @@ namespace Microsoft.Extensions.Configuration.Xml
                     }
                 }
             }
+
+            var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var configurationValue in configurationValues)
+            {
+                var key = configurationValue.Key;
+                if (data.ContainsKey(key))
+                {
+                    throw new FormatException(SR.Format(SR.Error_KeyIsDuplicated, key, configurationValue.LineInfo));
+                }
+                data[key] = configurationValue.Value;
+            }
+
             return data;
         }
 
@@ -129,18 +147,6 @@ namespace Microsoft.Extensions.Configuration.Xml
             Data = Read(stream, XmlDocumentDecryptor.Instance);
         }
 
-        private static void SkipUntilRootElement(XmlReader reader)
-        {
-            while (reader.Read())
-            {
-                if (reader.NodeType != XmlNodeType.XmlDeclaration &&
-                    reader.NodeType != XmlNodeType.ProcessingInstruction)
-                {
-                    break;
-                }
-            }
-        }
-
         private static string GetLineInfo(XmlReader reader)
         {
             var lineInfo = reader as IXmlLineInfo;
@@ -148,8 +154,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                 SR.Format(SR.Msg_LineInfo, lineInfo.LineNumber, lineInfo.LinePosition);
         }
 
-        private static void ProcessAttributes(XmlReader reader, Stack<string> prefixStack, IDictionary<string, string> data,
-            Action<XmlReader, Stack<string>, IDictionary<string, string>, XmlWriter> act, XmlWriter writer = null)
+        private static void ProcessAttributes(XmlReader reader, Stack<XmlConfigurationElement> elementPath, IList<IXmlConfigurationValue> data)
         {
             for (int i = 0; i < reader.AttributeCount; i++)
             {
@@ -161,7 +166,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                     throw new FormatException(SR.Format(SR.Error_NamespaceIsNotSupported, GetLineInfo(reader)));
                 }
 
-                act(reader, prefixStack, data, writer);
+                data.Add(new XmlConfigurationElementAttributeValue(elementPath, reader.LocalName, reader.Value, GetLineInfo(reader)));
             }
 
             // Go back to the element containing the attributes we just processed
@@ -169,41 +174,30 @@ namespace Microsoft.Extensions.Configuration.Xml
         }
 
         // The special attribute "Name" only contributes to prefix
-        // This method adds a prefix if current node in reader represents a "Name" attribute
-        private static void AddNamePrefix(XmlReader reader, Stack<string> prefixStack,
-            IDictionary<string, string> data, XmlWriter writer)
+        // This method retrieves the Name of the element, if the attribute is present
+        // Unfortunately XmlReader.GetAttribute cannot be used, as it does not support looking for attributes in a case insensitive manner
+        private static string GetName(XmlReader reader)
         {
-            if (!string.Equals(reader.LocalName, NameAttributeKey, StringComparison.OrdinalIgnoreCase))
+            string name = null;
+
+            while (reader.MoveToNextAttribute())
             {
-                return;
+                if (string.Equals(reader.LocalName, NameAttributeKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    // If there is a namespace attached to current attribute
+                    if (!string.IsNullOrEmpty(reader.NamespaceURI))
+                    {
+                        throw new FormatException(SR.Format(SR.Error_NamespaceIsNotSupported, GetLineInfo(reader)));
+                    }
+                    name = reader.Value;
+                    break;
+                }
             }
 
-            // If current element is not root element
-            if (prefixStack.Any())
-            {
-                string lastPrefix = prefixStack.Pop();
-                prefixStack.Push(ConfigurationPath.Combine(lastPrefix, reader.Value));
-            }
-            else
-            {
-                prefixStack.Push(reader.Value);
-            }
-        }
+            // Go back to the element containing the name we just processed
+            reader.MoveToElement();
 
-        // Common attributes contribute to key-value pairs
-        // This method adds a key-value pair if current node in reader represents a common attribute
-        private static void AddAttributePair(XmlReader reader, Stack<string> prefixStack,
-            IDictionary<string, string> data, XmlWriter writer)
-        {
-            prefixStack.Push(reader.LocalName);
-            string key = ConfigurationPath.Combine(prefixStack.Reverse());
-            if (data.ContainsKey(key))
-            {
-                throw new FormatException(SR.Format(SR.Error_KeyIsDuplicated, key, GetLineInfo(reader)));
-            }
-
-            data[key] = reader.Value;
-            prefixStack.Pop();
+            return name;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/ConfigurationProviderXmlTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/ConfigurationProviderXmlTest.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         public override void Has_debug_view()
-    {
-        var configRoot = BuildConfigRoot(LoadThroughProvider(TestSection.TestConfig));
-        var providerTag = configRoot.Providers.Single().ToString();
+        {
+            var configRoot = BuildConfigRoot(LoadThroughProvider(TestSection.TestConfig));
+            var providerTag = configRoot.Providers.Single().ToString();
 
-        var expected =
-            $@"Key1=Value1 ({providerTag})
+            var expected =
+                $@"Key1=Value1 ({providerTag})
 Section1:
   Key2=Value12 ({providerTag})
   Section2:
@@ -53,49 +53,49 @@ Section3:
     Key4=Value344 ({providerTag})
 ";
 
-        AssertDebugView(configRoot, expected);
-    }
+            AssertDebugView(configRoot, expected);
+        }
 
-    protected override (IConfigurationProvider Provider, Action Initializer) LoadThroughProvider(TestSection testConfig)
-    {
-        var xmlBuilder = new StringBuilder();
-        SectionToXml(xmlBuilder, "settings", testConfig);
-
-        var provider = new XmlConfigurationProvider(
-            new XmlConfigurationSource
-            {
-                Optional = true
-            });
-
-        var xml = xmlBuilder.ToString();
-        return (provider, () => provider.Load(TestStreamHelpers.StringToStream(xml)));
-    }
-
-    private void SectionToXml(StringBuilder xmlBuilder, string sectionName, TestSection section)
-    {
-        xmlBuilder.AppendLine($"<{sectionName}>");
-
-        foreach (var tuple in section.Values)
+        protected override (IConfigurationProvider Provider, Action Initializer) LoadThroughProvider(TestSection testConfig)
         {
-            if (tuple.Value.AsArray == null)
-            {
-                xmlBuilder.AppendLine($"<{tuple.Key}>{tuple.Value.AsString}</{tuple.Key}>");
-            }
-            else
-            {
-                for (var i = 0; i < tuple.Value.AsArray.Length; i++)
+            var xmlBuilder = new StringBuilder();
+            SectionToXml(xmlBuilder, "settings", testConfig);
+
+            var provider = new XmlConfigurationProvider(
+                new XmlConfigurationSource
                 {
-                    xmlBuilder.AppendLine($"<{tuple.Key} Name=\"{i}\">{tuple.Value.AsArray[i]}</{tuple.Key}>");
+                    Optional = true
+                });
+
+            var xml = xmlBuilder.ToString();
+            return (provider, () => provider.Load(TestStreamHelpers.StringToStream(xml)));
+        }
+
+        private void SectionToXml(StringBuilder xmlBuilder, string sectionName, TestSection section)
+        {
+            xmlBuilder.AppendLine($"<{sectionName}>");
+
+            foreach (var tuple in section.Values)
+            {
+                if (tuple.Value.AsArray == null)
+                {
+                    xmlBuilder.AppendLine($"<{tuple.Key}>{tuple.Value.AsString}</{tuple.Key}>");
+                }
+                else
+                {
+                    for (var i = 0; i < tuple.Value.AsArray.Length; i++)
+                    {
+                        xmlBuilder.AppendLine($"<{tuple.Key} Name=\"{i}\">{tuple.Value.AsArray[i]}</{tuple.Key}>");
+                    }
                 }
             }
-        }
 
-        foreach (var tuple in section.Sections)
-        {
-            SectionToXml(xmlBuilder, tuple.Key, tuple.Section);
-        }
+            foreach (var tuple in section.Sections)
+            {
+                SectionToXml(xmlBuilder, tuple.Key, tuple.Section);
+            }
 
-        xmlBuilder.AppendLine($"</{sectionName}>");
+            xmlBuilder.AppendLine($"</{sectionName}>");
+        }
     }
-}
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/ConfigurationProviderXmlTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/ConfigurationProviderXmlTest.cs
@@ -20,13 +20,23 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
             // Disabled test due to XML handling of empty section.
         }
 
-        public override void Has_debug_view()
+        public override void Load_from_single_provider_with_duplicates_throws()
         {
-            var configRoot = BuildConfigRoot(LoadThroughProvider(TestSection.TestConfig));
-            var providerTag = configRoot.Providers.Single().ToString();
+            // Disabled test due to duplicate keys being supported
+        }
 
-            var expected =
-                $@"Key1=Value1 ({providerTag})
+        public override void Load_from_single_provider_with_differing_case_duplicates_throws()
+        {
+            // Disabled test due to duplicate keys being supported
+        }
+
+        public override void Has_debug_view()
+    {
+        var configRoot = BuildConfigRoot(LoadThroughProvider(TestSection.TestConfig));
+        var providerTag = configRoot.Providers.Single().ToString();
+
+        var expected =
+            $@"Key1=Value1 ({providerTag})
 Section1:
   Key2=Value12 ({providerTag})
   Section2:
@@ -43,49 +53,49 @@ Section3:
     Key4=Value344 ({providerTag})
 ";
 
-            AssertDebugView(configRoot, expected);
-        }
-
-        protected override (IConfigurationProvider Provider, Action Initializer) LoadThroughProvider(TestSection testConfig)
-        {
-            var xmlBuilder = new StringBuilder();
-            SectionToXml(xmlBuilder, "settings", testConfig);
-
-            var provider = new XmlConfigurationProvider(
-                new XmlConfigurationSource
-                {
-                    Optional = true
-                });
-
-            var xml = xmlBuilder.ToString();
-            return (provider, () => provider.Load(TestStreamHelpers.StringToStream(xml)));
-        }
-
-        private void SectionToXml(StringBuilder xmlBuilder, string sectionName, TestSection section)
-        {
-            xmlBuilder.AppendLine($"<{sectionName}>");
-
-            foreach (var tuple in section.Values)
-            {
-                if (tuple.Value.AsArray == null)
-                {
-                    xmlBuilder.AppendLine($"<{tuple.Key}>{tuple.Value.AsString}</{tuple.Key}>");
-                }
-                else
-                {
-                    for (var i = 0; i < tuple.Value.AsArray.Length; i++)
-                    {
-                        xmlBuilder.AppendLine($"<{tuple.Key} Name=\"{i}\">{tuple.Value.AsArray[i]}</{tuple.Key}>");
-                    }
-                }
-            }
-
-            foreach (var tuple in section.Sections)
-            {
-                SectionToXml(xmlBuilder, tuple.Key, tuple.Section);
-            }
-
-            xmlBuilder.AppendLine($"</{sectionName}>");
-        }
+        AssertDebugView(configRoot, expected);
     }
+
+    protected override (IConfigurationProvider Provider, Action Initializer) LoadThroughProvider(TestSection testConfig)
+    {
+        var xmlBuilder = new StringBuilder();
+        SectionToXml(xmlBuilder, "settings", testConfig);
+
+        var provider = new XmlConfigurationProvider(
+            new XmlConfigurationSource
+            {
+                Optional = true
+            });
+
+        var xml = xmlBuilder.ToString();
+        return (provider, () => provider.Load(TestStreamHelpers.StringToStream(xml)));
+    }
+
+    private void SectionToXml(StringBuilder xmlBuilder, string sectionName, TestSection section)
+    {
+        xmlBuilder.AppendLine($"<{sectionName}>");
+
+        foreach (var tuple in section.Values)
+        {
+            if (tuple.Value.AsArray == null)
+            {
+                xmlBuilder.AppendLine($"<{tuple.Key}>{tuple.Value.AsString}</{tuple.Key}>");
+            }
+            else
+            {
+                for (var i = 0; i < tuple.Value.AsArray.Length; i++)
+                {
+                    xmlBuilder.AppendLine($"<{tuple.Key} Name=\"{i}\">{tuple.Value.AsArray[i]}</{tuple.Key}>");
+                }
+            }
+        }
+
+        foreach (var tuple in section.Sections)
+        {
+            SectionToXml(xmlBuilder, tuple.Key, tuple.Section);
+        }
+
+        xmlBuilder.AppendLine($"</{sectionName}>");
+    }
+}
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/ConfigurationProviderXmlTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/ConfigurationProviderXmlTest.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
 
         public override void Load_from_single_provider_with_duplicates_throws()
         {
-            // Disabled test due to duplicate keys being supported
+            AssertConfig(BuildConfigRoot(LoadThroughProvider(TestSection.DuplicatesTestConfig)));
         }
 
         public override void Load_from_single_provider_with_differing_case_duplicates_throws()
         {
-            // Disabled test due to duplicate keys being supported
+            AssertConfig(BuildConfigRoot(LoadThroughProvider(TestSection.DuplicatesTestConfig)));
         }
 
         public override void Has_debug_view()

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
@@ -169,6 +169,32 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         [Fact]
+        public void LowercaseNameAttributeContributesToPrefix()
+        {
+            var xml =
+                @"<settings>
+                    <Data name='DefaultConnection'>
+                        <ConnectionString>TestConnectionString</ConnectionString>
+                        <Provider>SqlClient</Provider>
+                    </Data>
+                    <Data name='Inventory'>
+                        <ConnectionString>AnotherTestConnectionString</ConnectionString>
+                        <Provider>MySql</Provider>
+                    </Data>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("DefaultConnection", xmlConfigSrc.Get("Data:DefaultConnection:Name"));
+            Assert.Equal("TestConnectionString", xmlConfigSrc.Get("Data:DefaultConnection:ConnectionString"));
+            Assert.Equal("SqlClient", xmlConfigSrc.Get("Data:DefaultConnection:Provider"));
+            Assert.Equal("Inventory", xmlConfigSrc.Get("Data:Inventory:Name"));
+            Assert.Equal("AnotherTestConnectionString", xmlConfigSrc.Get("Data:Inventory:ConnectionString"));
+            Assert.Equal("MySql", xmlConfigSrc.Get("Data:Inventory:Provider"));
+        }
+
+        [Fact]
         public void NameAttributeInRootElementContributesToPrefix()
         {
             var xml =
@@ -191,6 +217,125 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
             Assert.Equal("SqlClient", xmlConfigSrc.Get("Data:DefaultConnection:Provider"));
             Assert.Equal("AnotherTestConnectionString", xmlConfigSrc.Get("Data:Inventory:ConnectionString"));
             Assert.Equal("MySql", xmlConfigSrc.Get("Data:Inventory:Provider"));
+        }
+
+        [Fact]
+        public void RepeatedElementsContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:0:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("DefaultConnection:0:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:1:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("DefaultConnection:1:Provider"));
+        }
+
+        [Fact]
+        public void RepeatedElementsUnderNameContributeToPrefix()
+        {
+            var xml =
+              @"<settings Name='Data'>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("Data:DefaultConnection:0:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("Data:DefaultConnection:0:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("Data:DefaultConnection:1:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("Data:DefaultConnection:1:Provider"));
+        }
+
+        [Fact]
+        public void RepeatedElementsWithSameNameContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection Name='Data'>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection Name='Data'>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:Data:0:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("DefaultConnection:Data:0:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:Data:1:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("DefaultConnection:Data:1:Provider"));
+        }
+
+        [Fact]
+        public void RepeatedElementsWithDifferentNamesContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection Name='Data1'>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection Name='Data2'>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:Data1:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("DefaultConnection:Data1:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:Data2:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("DefaultConnection:Data2:Provider"));
+        }
+
+        [Fact]
+        public void NestedRepeatedElementsContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                  </DefaultConnection>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString3</ConnectionString>
+                      <ConnectionString>TestConnectionString4</ConnectionString>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:0:ConnectionString:0"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:0:ConnectionString:1"));
+            Assert.Equal("TestConnectionString3", xmlConfigSrc.Get("DefaultConnection:1:ConnectionString:0"));
+            Assert.Equal("TestConnectionString4", xmlConfigSrc.Get("DefaultConnection:1:ConnectionString:1"));
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationProviderTestBase.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationProviderTestBase.cs
@@ -95,20 +95,6 @@ Section3:
                     LoadThroughProvider(TestSection.TestConfig)));
         }
 
-        [Fact]
-        public virtual void Load_from_single_provider_with_duplicates_throws()
-        {
-            AssertFormatOrArgumentException(
-                () => BuildConfigRoot(LoadThroughProvider(TestSection.DuplicatesTestConfig)));
-        }
-
-        [Fact]
-        public virtual void Load_from_single_provider_with_differing_case_duplicates_throws()
-        {
-            AssertFormatOrArgumentException(
-                () => BuildConfigRoot(LoadThroughProvider(TestSection.DuplicatesDifferentCaseTestConfig)));
-        }
-
         private void AssertFormatOrArgumentException(Action test)
         {
             Exception caught = null;
@@ -570,100 +556,6 @@ Section3:
                                 ("SectioN4", new TestSection
                                 {
                                     Values = new[] {("KeY4", (TestKeyValue)"Value344")}
-                                })
-                            }
-                        })
-                    }
-                };
-
-            public static TestSection DuplicatesTestConfig { get; }
-                = new TestSection
-                {
-                    Values = new[]
-                    {
-                        ("Key1", (TestKeyValue)"Value1"),
-                        ("Key1", (TestKeyValue)"Value1")
-                    },
-                    Sections = new[]
-                    {
-                        ("Section1", new TestSection
-                        {
-                            Values = new[] {("Key2", (TestKeyValue)"Value12")},
-                            Sections = new[]
-                            {
-                                ("Section2", new TestSection
-                                {
-                                    Values = new[]
-                                    {
-                                        ("Key3", (TestKeyValue)"Value123"),
-                                        ("Key3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
-                                    },
-                                }),
-                                ("Section2", new TestSection
-                                {
-                                    Values = new[]
-                                    {
-                                        ("Key3", (TestKeyValue)"Value123"),
-                                        ("Key3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
-                                    },
-                                })
-
-                            }
-                        }),
-                        ("Section3", new TestSection
-                        {
-                            Sections = new[]
-                            {
-                                ("Section4", new TestSection
-                                {
-                                    Values = new[] {("Key4", (TestKeyValue)"Value344")}
-                                })
-                            }
-                        })
-                    }
-                };
-
-            public static TestSection DuplicatesDifferentCaseTestConfig { get; }
-                = new TestSection
-                {
-                    Values = new[]
-                    {
-                        ("Key1", (TestKeyValue)"Value1"),
-                        ("KeY1", (TestKeyValue)"Value1")
-                    },
-                    Sections = new[]
-                    {
-                        ("Section1", new TestSection
-                        {
-                            Values = new[] {("Key2", (TestKeyValue)"Value12")},
-                            Sections = new[]
-                            {
-                                ("Section2", new TestSection
-                                {
-                                    Values = new[]
-                                    {
-                                        ("Key3", (TestKeyValue)"Value123"),
-                                        ("Key3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
-                                    },
-                                }),
-                                ("SectioN2", new TestSection
-                                {
-                                    Values = new[]
-                                    {
-                                        ("KeY3", (TestKeyValue)"Value123"),
-                                        ("KeY3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
-                                    },
-                                })
-
-                            }
-                        }),
-                        ("Section3", new TestSection
-                        {
-                            Sections = new[]
-                            {
-                                ("Section4", new TestSection
-                                {
-                                    Values = new[] {("Key4", (TestKeyValue)"Value344")}
                                 })
                             }
                         })

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationProviderTestBase.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationProviderTestBase.cs
@@ -95,6 +95,20 @@ Section3:
                     LoadThroughProvider(TestSection.TestConfig)));
         }
 
+        [Fact]
+        public virtual void Load_from_single_provider_with_duplicates_throws()
+        {
+            AssertFormatOrArgumentException(
+                () => BuildConfigRoot(LoadThroughProvider(TestSection.DuplicatesTestConfig)));
+        }
+
+        [Fact]
+        public virtual void Load_from_single_provider_with_differing_case_duplicates_throws()
+        {
+            AssertFormatOrArgumentException(
+                () => BuildConfigRoot(LoadThroughProvider(TestSection.DuplicatesDifferentCaseTestConfig)));
+        }
+
         private void AssertFormatOrArgumentException(Action test)
         {
             Exception caught = null;
@@ -556,6 +570,100 @@ Section3:
                                 ("SectioN4", new TestSection
                                 {
                                     Values = new[] {("KeY4", (TestKeyValue)"Value344")}
+                                })
+                            }
+                        })
+                    }
+                };
+
+            public static TestSection DuplicatesTestConfig { get; }
+                = new TestSection
+                {
+                    Values = new[]
+                    {
+                        ("Key1", (TestKeyValue)"Value1"),
+                        ("Key1", (TestKeyValue)"Value1")
+                    },
+                    Sections = new[]
+                    {
+                        ("Section1", new TestSection
+                        {
+                            Values = new[] {("Key2", (TestKeyValue)"Value12")},
+                            Sections = new[]
+                            {
+                                ("Section2", new TestSection
+                                {
+                                    Values = new[]
+                                    {
+                                        ("Key3", (TestKeyValue)"Value123"),
+                                        ("Key3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
+                                    },
+                                }),
+                                ("Section2", new TestSection
+                                {
+                                    Values = new[]
+                                    {
+                                        ("Key3", (TestKeyValue)"Value123"),
+                                        ("Key3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
+                                    },
+                                })
+
+                            }
+                        }),
+                        ("Section3", new TestSection
+                        {
+                            Sections = new[]
+                            {
+                                ("Section4", new TestSection
+                                {
+                                    Values = new[] {("Key4", (TestKeyValue)"Value344")}
+                                })
+                            }
+                        })
+                    }
+                };
+
+            public static TestSection DuplicatesDifferentCaseTestConfig { get; }
+                = new TestSection
+                {
+                    Values = new[]
+                    {
+                        ("Key1", (TestKeyValue)"Value1"),
+                        ("KeY1", (TestKeyValue)"Value1")
+                    },
+                    Sections = new[]
+                    {
+                        ("Section1", new TestSection
+                        {
+                            Values = new[] {("Key2", (TestKeyValue)"Value12")},
+                            Sections = new[]
+                            {
+                                ("Section2", new TestSection
+                                {
+                                    Values = new[]
+                                    {
+                                        ("Key3", (TestKeyValue)"Value123"),
+                                        ("Key3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
+                                    },
+                                }),
+                                ("SectioN2", new TestSection
+                                {
+                                    Values = new[]
+                                    {
+                                        ("KeY3", (TestKeyValue)"Value123"),
+                                        ("KeY3a", (TestKeyValue)new[] {"ArrayValue0", "ArrayValue1", "ArrayValue2"})
+                                    },
+                                })
+
+                            }
+                        }),
+                        ("Section3", new TestSection
+                        {
+                            Sections = new[]
+                            {
+                                ("Section4", new TestSection
+                                {
+                                    Values = new[] {("Key4", (TestKeyValue)"Value344")}
                                 })
                             }
                         })


### PR DESCRIPTION
Fixes #36541
Fixes #36561 

This pull request adds support in Microsoft.Extensions.Configuration.Xml for repeated XML elements without requiring a Name attribute.
This solves a particularly subtle bug when configuring Serilog from an XML configuration source. For a full description, see https://github.com/dotnet/runtime/issues/36541

The original implementation of the XmlStreamConfigurationProvider has been modified to do the following:

- Maintain a stack of encountered XML elements while traversing the XML source. This is needed to detect siblings.
- When siblings are detected, automatically append an index to the generated configuration keys. This makes it work exactly the same as the JSON configuration provider with JSON arrays.

Tests are updated to reflect the new behavior:
- Tests that verified an exception occurs when entering duplicate keys have been removed. Duplicate keys are supported now.
- Add tests that verify duplicate keys result in the correct configuration keys, with all the lower/upper case variants and with support for the special "Name" attribute handling.

Thank you for your consideration.