### PR TITLE
[jit] Fix gsharedvt constrained calls to Object.GetType () under netcore.

### DIFF
--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1420,6 +1420,21 @@ mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *kl
 	gpointer this_arg;
 	gpointer new_args [16];
 
+#ifdef ENABLE_NETCORE
+	if (!mono_class_is_ginst (cmethod->klass) && !cmethod->is_inflated) {
+		MonoVTable *vt;
+
+		/* Object.GetType () is an intrinsic under netcore */
+		g_assert (!strcmp (cmethod->name, "GetType"));
+		vt = mono_class_vtable_checked (mono_domain_get (), klass, error);
+		if (!is_ok (error)) {
+			mono_error_set_pending_exception (error);
+			return NULL;
+		}
+		return vt->type;
+	}
+#endif
+
 	m = constrained_gsharedvt_call_setup (mp, cmethod, klass, &this_arg, error);
 	if (!is_ok (error)) {
 		mono_error_set_pending_exception (error);

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1425,7 +1425,7 @@ mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *kl
 		MonoVTable *vt;
 
 		/* Object.GetType () is an intrinsic under netcore */
-		g_assert (!strcmp (cmethod->name, "GetType"));
+		g_assertf (!strcmp (cmethod->name, "GetType"), "%s.%s", m_class_get_name (cmethod->klass), cmethod->name);
 		vt = mono_class_vtable_checked (mono_domain_get (), klass, error);
 		if (!is_ok (error)) {
 			mono_error_set_pending_exception (error);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/35674.