### PR TITLE
[w32socket] Turn WireGuard ENOKEY errno to WASANETUNREACH

### DIFF
--- a/src/mono/mono/metadata/w32socket-unix.c
+++ b/src/mono/mono/metadata/w32socket-unix.c
@@ -1549,6 +1549,9 @@ mono_w32socket_convert_error (gint error)
 #ifdef ENONET
 	case ENONET: return WSAENETUNREACH;
 #endif
+#ifdef ENOKEY
+	case ENOKEY: return WSAENETUNREACH;
+#endif
 	default:
 		g_error ("%s: no translation into winsock error for (%d) \"%s\"", __func__, error, g_strerror (error));
 	}


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20508,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When the destination IP on the packet doesn't match any WireGuard peer (such as
if the peer is disconnected while the app is running), the sender may get an ENOKEY errno.

This is mentioned in Section 3 "Send/Receive" of
https://www.wireguard.com/papers/wireguard.pdf

Fixes https://github.com/mono/mono/issues/20503

