### PR TITLE
improve link detection for WIFI on macOS

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -27,6 +27,9 @@
 #include <linux/sockios.h>
 #include <arpa/inet.h>
 #endif
+#if HAVE_NET_IFMEDIA_H
+#include <net/if_media.h>
+#endif
 
 #if defined(AF_PACKET)
 #include <sys/ioctl.h>
@@ -199,6 +202,26 @@ int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onIpv4Found,
                 lla.NumAddressBytes = sadl->sdl_alen;
                 lla.HardwareType = MapHardwareType(sadl->sdl_type);
 
+#if HAVE_NET_IFMEDIA_H
+                if (lla.HardwareType == NetworkInterfaceType_Ethernet)
+                {
+                    // WI-FI and Ethernet have same address type so we can try to distinguish more
+                    int fd =  socket(AF_INET, SOCK_DGRAM, 0);
+                    if (fd >= 0)
+                    {
+                        struct ifmediareq ifmr;
+                        memset(&ifmr, 0, sizeof(ifmr));
+                        strncpy(ifmr.ifm_name, actualName, sizeof(ifmr.ifm_name));
+
+                        if ((ioctl(fd, SIOCGIFMEDIA, (caddr_t)&ifmr) == 0) && (IFM_TYPE(ifmr.ifm_current) == IFM_IEEE80211))
+                        {
+                            lla.HardwareType = NetworkInterfaceType_Wireless80211;
+                        }
+
+                        close(fd);
+                    }
+                }
+#endif
                 memcpy_s(&lla.AddressBytes, sizeof_member(LinkLayerAddressInfo, AddressBytes), (uint8_t*)LLADDR(sadl), sadl->sdl_alen);
                 onLinkLayerFound(current->ifa_name, &lla);
             }

--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -206,7 +206,7 @@ int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onIpv4Found,
                 if (lla.HardwareType == NetworkInterfaceType_Ethernet)
                 {
                     // WI-FI and Ethernet have same address type so we can try to distinguish more
-                    int fd =  socket(AF_INET, SOCK_DGRAM, 0);
+                    int fd = socket(AF_INET, SOCK_DGRAM, 0);
                     if (fd >= 0)
                     {
                         struct ifmediareq ifmr;

--- a/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
@@ -613,7 +613,7 @@ int32_t SystemNative_GetNativeIPInterfaceStatistics(char* interfaceName, NativeI
                     {
                         // WI-FI on macOS sometimes does not report link when interface is disabled. (still has _UP flag)
                         // For other interface types, report Unknown status.
-                        if (IFM_TYPE(ifmr.ifm_current) == IFM_IEEE80211)
+                        if (IFM_TYPE(ifmr.ifm_current) != IFM_IEEE80211)
                         {
                             retStats->Flags |= InterfaceError;
                         }

--- a/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
@@ -611,7 +611,12 @@ int32_t SystemNative_GetNativeIPInterfaceStatistics(char* interfaceName, NativeI
                     }
                     else if ((ifmr.ifm_status & IFM_AVALID) == 0)
                     {
-                        retStats->Flags |= InterfaceError;
+                        // WI-FI on macOS sometimes does not report link when interface is disabled. (still has _UP flag)
+                        // For other interface types, report Unknown status.
+                        if (IFM_TYPE(ifmr.ifm_current) == IFM_IEEE80211)
+                        {
+                            retStats->Flags |= InterfaceError;
+                        }
                     }
                     else
                     {

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdNetworkInterface.cs
@@ -43,7 +43,7 @@ namespace System.Net.NetworkInformation
             for (int attempt = 0; attempt < MaxTries; attempt++)
             {
                 // Because these callbacks are executed in a reverse-PInvoke, we do not want any exceptions
-                // to propogate out, because they will not be catchable. Instead, we track all the exceptions
+                // to propagate out, because they will not be catchable. Instead, we track all the exceptions
                 // that are thrown in these callbacks, and aggregate them at the end.
                 int result = Interop.Sys.EnumerateInterfaceAddresses(
                     (name, ipAddr) =>

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -94,7 +94,6 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1332")]
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX|TestPlatforms.FreeBSD)]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Bsd()


### PR DESCRIPTION
I was finally able to look this on CI machine. It seems like some hardware warrants do not report link if the interface is disabled on boot. Interestingly, when I run it on & off again, it would return link down as expected. 

So I updated the UP/DOWN calculation accordingly. 

While in this section of code and testing on different machines, I noticed that the failing "en1" was reported as Ethernet. (since is has Ethernet like MAC) I added little bit of code to detect WIFI and now they are reported as Wireless80211.


fixes #1332
