### PR TITLE
Fix the signature of Interop.Sys.Log () to match the native signature.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Log.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Log.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Log")]
-        internal static extern unsafe bool Log(byte* buffer, int count);
+        internal static extern unsafe void Log(byte* buffer, int count);
     }
 }


### PR DESCRIPTION
Signature mismatches cause errors on some platforms like wasm.