### PR TITLE
Trim quoted file names passed to Crossgen2

### DIFF
--- a/src/coreclr/src/tools/Common/CommandLine/ArgumentLexer.cs
+++ b/src/coreclr/src/tools/Common/CommandLine/ArgumentLexer.cs
@@ -80,6 +80,10 @@ namespace Internal.CommandLine
                         name = nameAndValue;
                         value = null;
                     }
+                    else
+                    {
+                        value = value.Trim('"');
+                    }
                 }
 
                 var token = new ArgumentToken(modifier, name, value);


### PR DESCRIPTION
Trim quoted file names in Crossgen2 command-line options like `--jitpath` and `--out`.  The code does not follow the standard parsing rules regarding quotes and slashes and worth reworking.  This quick fix is intended to unblock integration to SDK and implements the same behavior as the parser we used before: https://github.com/dotnet/command-line-api/blob/34a2df49f1dcf3fdc46d0c4a3daedf84b3057e05/src/System.CommandLine/Parsing/StringExtensions.cs#L133-L134.