### PR TITLE
[wasm][debugger] Fix check for already loaded assemblies

### DIFF
--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -213,7 +213,8 @@ mono_wasm_assembly_already_added (const char *assembly_name)
 
 	WasmAssembly *entry = assemblies;
 	while (entry != NULL) {
-		if (strlen(entry->assembly.name - 4) == strlen(assembly_name) && strncmp (entry->assembly.name, assembly_name, strlen(entry->assembly.name - 4)) == 0)
+		int entry_name_minus_extn_len = strlen(entry->assembly.name) - 4;
+		if (entry_name_minus_extn_len == strlen(assembly_name) && strncmp (entry->assembly.name, assembly_name, entry_name_minus_extn_len) == 0)
 			return 1;
 		entry = entry->next;
 	}

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -2363,9 +2363,6 @@ var MonoSupportLib = {
 		if (MONO.mono_wasm_runtime_is_ready !== true)
 			return;
 
-		if (!this.mono_wasm_assembly_already_added)
-			this.mono_wasm_assembly_already_added = Module.cwrap ("mono_wasm_assembly_already_added", 'number', ['string']);
-
 		const assembly_name_str = assembly_name !== 0 ? Module.UTF8ToString(assembly_name).concat('.dll') : '';
 
 		const assembly_data = new Uint8Array(Module.HEAPU8.buffer, assembly_ptr, assembly_len);


### PR DESCRIPTION
We send assembly loaded events to the proxy based off events from the
debugger engine. And we check that it isn't an assembly that was already
loaded. This check has a bug in computing the assembly name, from the
filename, which caused these events to be sent even for already loaded
assemblies.