### PR TITLE
Fix inconsistency of the 'CanRead' property after disposing an HTTP content stream

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -254,6 +254,29 @@ namespace System.Net.Http.Functional.Tests
                 await ReadAsStreamHelper(uri);
             });
         }
+
+        [Theory]
+        [InlineData(TransferType.None, TransferError.None)]
+        [InlineData(TransferType.ContentLength, TransferError.None)]
+        [InlineData(TransferType.Chunked, TransferError.None)]
+        public async Task ReadAsStreamAsync_StreamCanReadIsFalseAfterDispose(
+            TransferType transferType,
+            TransferError transferError)
+        {
+            await StartTransferTypeAndErrorServer(transferType, transferError, async uri =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                using (HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead))
+                {
+                    Stream stream = await response.Content.ReadAsStreamAsync();
+                    Assert.True(stream.CanRead);
+
+                    stream.Dispose();
+
+                    Assert.False(stream.CanRead);
+                }
+            });
+        }
 #endif
 
         public enum TransferType

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1415,7 +1415,7 @@ namespace System.Net.Http
                     base.Dispose(disposing);
                 }
 
-                public override bool CanRead => true;
+                public override bool CanRead => _http2Stream != null;
                 public override bool CanWrite => false;
 
                 public override int Read(Span<byte> destination)
@@ -1488,7 +1488,7 @@ namespace System.Net.Http
                 }
 
                 public override bool CanRead => false;
-                public override bool CanWrite => true;
+                public override bool CanWrite => _http2Stream != null;
 
                 public override int Read(Span<byte> buffer) => throw new NotSupportedException();
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1171,7 +1171,7 @@ namespace System.Net.Http
             private Http3RequestStream? _stream;
             private HttpResponseMessage? _response;
 
-            public override bool CanRead => true;
+            public override bool CanRead => _stream != null;
 
             public override bool CanWrite => false;
 
@@ -1256,7 +1256,7 @@ namespace System.Net.Http
 
             public override bool CanRead => false;
 
-            public override bool CanWrite => true;
+            public override bool CanWrite => _stream != null;
 
             public Http3WriteStream(Http3RequestStream stream)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -17,7 +17,7 @@ namespace System.Net.Http
             {
             }
 
-            public sealed override bool CanRead => true;
+            public sealed override bool CanRead => _disposed == 0;
             public sealed override bool CanWrite => false;
 
             public sealed override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.net_http_content_readonly_stream);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
                 Debug.Assert(connection != null);
 
             public sealed override bool CanRead => false;
-            public sealed override bool CanWrite => true;
+            public sealed override bool CanWrite => _connection != null;
 
             public sealed override void Flush() =>
                 _connection?.Flush();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -17,8 +17,8 @@ namespace System.Net.Http
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             }
 
-            public sealed override bool CanRead => true;
-            public sealed override bool CanWrite => true;
+            public sealed override bool CanRead => _connection != null;
+            public sealed override bool CanWrite => _connection != null;
 
             public override int Read(Span<byte> buffer)
             {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/RawConnectionStreamTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/RawConnectionStreamTest.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Net.Test.Common;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class RawConnectionStreamTest 
+    {
+        [Fact]
+        public async Task RawConnectionStream_Dispose()
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
+            {
+                using (HttpClient client = new HttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    Assert.True(responseStream.CanRead);
+                    Assert.True(responseStream.CanWrite);
+
+                    responseStream.Dispose();
+
+                    Assert.False(responseStream.CanRead);
+                    Assert.False(responseStream.CanWrite);
+                }
+            },
+            async server =>
+            {
+                // --> used to return System.Net.Http.HttpConnection+RawConnectionStream
+                await server.HandleRequestAsync(HttpStatusCode.SwitchingProtocols); 
+            });
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/RawConnectionStreamTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/RawConnectionStreamTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Net.Test.Common;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -155,6 +155,7 @@
     <Compile Include="TelemetryTest.cs" />
     <Compile Include="StreamContentTest.cs" />
     <Compile Include="StringContentTest.cs" />
+    <Compile Include="RawConnectionStreamTest.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\SyncBlockingContent.cs"
              Link="Common\System\Net\Http\SyncBlockingContent.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\DefaultCredentialsTest.cs"


### PR DESCRIPTION
Just pushing the rebased commits from https://github.com/dotnet/runtime/pull/38528, which was good to go but I somehow invalidated the branch when rebasing it.
cc: @angelobreuer 