### PR TITLE
[mono] Use lax Roslyn and analyzers settings for samples

### DIFF
--- a/src/mono/netcore/sample/Directory.Build.props
+++ b/src/mono/netcore/sample/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <RunAnalyzers>false</RunAnalyzers>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <Import Project="..\..\Directory.Build.props"/>
+</Project>

--- a/src/mono/netcore/sample/HelloWorld/Makefile
+++ b/src/mono/netcore/sample/HelloWorld/Makefile
@@ -2,7 +2,7 @@ TOP=../../../../../
 DOTNET:=$(TOP)./dotnet.sh
 DOTNET_Q_ARGS=--nologo -v:q -consoleloggerparameters:NoSummary
 
-MONO_CONFIG=Release
+MONO_CONFIG ?=Release
 MONO_ARCH=x64
 
 OS := $(shell uname -s)
@@ -12,12 +12,14 @@ else
 	TARGET_OS=linux
 endif
 
+MONO_ENV_OPTIONS ?=--llvm
+
 publish:
 	$(DOTNET) publish -c $(MONO_CONFIG) -r $(TARGET_OS)-$(MONO_ARCH)
 
 run: publish
 	COMPlus_DebugWriteToStdErr=1 \
-	MONO_ENV_OPTIONS="--llvm" \
+	MONO_ENV_OPTIONS="$(MONO_ENV_OPTIONS)" \
 	$(TOP)artifacts/bin/HelloWorld/$(MONO_ARCH)/$(MONO_CONFIG)/$(TARGET_OS)-$(MONO_ARCH)/publish/HelloWorld
 
 clean:


### PR DESCRIPTION
The samples are often used for debugging runtime problems by modifying the code
to reproduce issues.  The code analyzers add a papercut before a modified
sample can run.