### PR TITLE
Update Android instrumentation runner to be closer to upstream

### DIFF
--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -684,7 +684,7 @@ check_c_source_compiles(
     HAVE_MKSTEMP)
 
 if (NOT HAVE_MKSTEMPS AND NOT HAVE_MKSTEMP)
-    message(FATAL_ERROR "Cannot find mkstemp nor mkstemp on this platform.")
+    message(FATAL_ERROR "Cannot find mkstemps nor mkstemp on this platform.")
 endif()
 
 check_c_source_compiles(


### PR DESCRIPTION
The upstream instrumentation runners don't use runOnMainSync() in the onStart() method, update our runner to do the same and add a bit more logging.

Also fixed a small typo in configure.cmake that I happened to notice.