### PR TITLE
Setting value of enums didn't properly widen the value when setting

### DIFF
--- a/src/coreclr/src/vm/reflectioninvocation.cpp
+++ b/src/coreclr/src/vm/reflectioninvocation.cpp
@@ -332,7 +332,7 @@ FCIMPL7(void, RuntimeFieldHandle::SetValue, ReflectFieldObject *pFieldUNSAFE, Ob
 
     HELPER_METHOD_FRAME_BEGIN_PROTECT(gc);
 
-    InvokeUtil::SetValidField(fieldType.GetSignatureCorElementType(), fieldType, pFieldDesc, &gc.target, &gc.value, declaringType, pDomainInitialized);
+    InvokeUtil::SetValidField(fieldType.GetVerifierCorElementType(), fieldType, pFieldDesc, &gc.target, &gc.value, declaringType, pDomainInitialized);
 
     HELPER_METHOD_FRAME_END();
 }

--- a/src/libraries/System.Reflection/tests/FieldInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/FieldInfoTests.cs
@@ -91,6 +91,9 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.intField), new FieldInfoTests(), 1000 };
             yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.s_stringField), new FieldInfoTests(), "new" };
             yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.stringField), new FieldInfoTests(), "new" };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.shortEnumField), new FieldInfoTests(), (byte)1 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.intEnumField), new FieldInfoTests(), (short)2 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.longEnumField), new FieldInfoTests(), (int)3 };
         }
 
         [Theory]
@@ -452,6 +455,13 @@ namespace System.Reflection.Tests
 
         public int intField = 101;
         public string stringField = "non static";
+
+        public enum ShortEnum : short {}
+        public enum IntEnum {}
+        public enum LongEnum : long {}
+        public ShortEnum shortEnumField;
+        public IntEnum intEnumField;
+        public LongEnum longEnumField;
 
         private int privateIntField = 1;
         private string privateStringField = "privateStringField";

--- a/src/libraries/System.Reflection/tests/FieldInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/FieldInfoTests.cs
@@ -86,26 +86,26 @@ namespace System.Reflection.Tests
 
         public static IEnumerable<object[]> SetValue_TestData()
         {
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.s_intField), new FieldInfoTests(), 1000 };
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.s_intField), null, 1000 };
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.intField), new FieldInfoTests(), 1000 };
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.s_stringField), new FieldInfoTests(), "new" };
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.stringField), new FieldInfoTests(), "new" };
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.shortEnumField), new FieldInfoTests(), (byte)1 };
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.intEnumField), new FieldInfoTests(), (short)2 };
-            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.longEnumField), new FieldInfoTests(), (int)3 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.s_intField), new FieldInfoTests(), 1000, 1000 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.s_intField), null, 1000, 1000 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.intField), new FieldInfoTests(), 1000, 1000 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.s_stringField), new FieldInfoTests(), "new", "new" };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.stringField), new FieldInfoTests(), "new", "new" };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.shortEnumField), new FieldInfoTests(), (byte)1, (ShortEnum)1 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.intEnumField), new FieldInfoTests(), (short)2, (IntEnum)2 };
+            yield return new object[] { typeof(FieldInfoTests), nameof(FieldInfoTests.longEnumField), new FieldInfoTests(), (int)3, (LongEnum)3 };
         }
 
         [Theory]
         [MemberData(nameof(SetValue_TestData))]
-        public void SetValue(Type type, string name, object obj, object value)
+        public void SetValue(Type type, string name, object obj, object value, object expected)
         {
             FieldInfo fieldInfo = GetField(type, name);
             object original = fieldInfo.GetValue(obj);
             try
             {
                 fieldInfo.SetValue(obj, value);
-                Assert.Equal(value, fieldInfo.GetValue(obj));
+                Assert.Equal(expected, fieldInfo.GetValue(obj));
             }
             finally
             {

--- a/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
@@ -96,9 +96,9 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(BaseClass), nameof(BaseClass.Name), new BaseClass(), "hello", null, "hello" };
             yield return new object[] { typeof(AdvancedIndexerClass), "Item", new AdvancedIndexerClass(), "hello", new object[] { 99, 2, new string[] { "hello" }, "f" }, "992f1" };
             yield return new object[] { typeof(AdvancedIndexerClass), "Item", new AdvancedIndexerClass(), "pw", new object[] { 99, 2, new string[] { "hello" }, "SOME string" }, "992SOME string1" };
-            yield return new object[] { typeof(BaseClass), nameof(BaseClass.ShortEnumProperty), typeof(BaseClass), (byte)1, null, (short)1 };
-            yield return new object[] { typeof(BaseClass), nameof(BaseClass.IntEnumProperty), typeof(BaseClass), (short)2, null, (int)2 };
-            yield return new object[] { typeof(BaseClass), nameof(BaseClass.ShortEnumProperty), typeof(BaseClass), (int)3, null, (long)3 };
+            yield return new object[] { typeof(BaseClass), nameof(BaseClass.ShortEnumProperty), new BaseClass(), (byte)1, null, (BaseClass.ShortEnum)1 };
+            yield return new object[] { typeof(BaseClass), nameof(BaseClass.IntEnumProperty), new BaseClass(), (short)2, null, (BaseClass.IntEnum)2 };
+            yield return new object[] { typeof(BaseClass), nameof(BaseClass.LongEnumProperty), new BaseClass(), (int)3, null, (BaseClass.LongEnum)3 };
         }
 
         [Theory]

--- a/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
@@ -96,6 +96,9 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(BaseClass), nameof(BaseClass.Name), new BaseClass(), "hello", null, "hello" };
             yield return new object[] { typeof(AdvancedIndexerClass), "Item", new AdvancedIndexerClass(), "hello", new object[] { 99, 2, new string[] { "hello" }, "f" }, "992f1" };
             yield return new object[] { typeof(AdvancedIndexerClass), "Item", new AdvancedIndexerClass(), "pw", new object[] { 99, 2, new string[] { "hello" }, "SOME string" }, "992SOME string1" };
+            yield return new object[] { typeof(BaseClass), nameof(BaseClass.ShortEnumProperty), typeof(BaseClass), (byte)1, null, (short)1 };
+            yield return new object[] { typeof(BaseClass), nameof(BaseClass.IntEnumProperty), typeof(BaseClass), (short)2, null, (int)2 };
+            yield return new object[] { typeof(BaseClass), nameof(BaseClass.ShortEnumProperty), typeof(BaseClass), (int)3, null, (long)3 };
         }
 
         [Theory]
@@ -357,6 +360,13 @@ namespace System.Reflection.Tests
                 get { return _staticObjectArrayProperty; }
                 set { _staticObjectArrayProperty = value; }
             }
+
+            public enum ShortEnum : short {}
+            public enum IntEnum {}
+            public enum LongEnum : long {}
+            public ShortEnum ShortEnumProperty { get; set; }
+            public IntEnum IntEnumProperty { get; set; }
+            public LongEnum LongEnumProperty { get; set; }
 
             public object[] _objectArray;
             public object[] ObjectArrayProperty


### PR DESCRIPTION
Use VerifierCorElementType instead of SignatureCorElementType to specify the element type of the target field
- This will send the runtime down the path which can perform primitive widening