### PR TITLE
Enhance #43238 so that it covers DefineScope method group with the tests to reflect the behavior added in the PR.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Extensions.Logging
         /// <returns>A delegate which when invoked creates a log scope.</returns>
         public static Func<ILogger, T1, T2, T3, T4, IDisposable> DefineScope<T1, T2, T3, T4>(string formatString)
         {
-            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
 
             return (logger, arg1, arg2, arg3, arg4) => logger.BeginScope(new LogValues<T1, T2, T3, T4>(formatter, arg1, arg2, arg3, arg4));
         }
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.Logging
         /// <returns>A delegate which when invoked creates a log scope.</returns>
         public static Func<ILogger, T1, T2, T3, T4, T5, IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString)
         {
-            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
 
             return (logger, arg1, arg2, arg3, arg4, arg5) => logger.BeginScope(new LogValues<T1, T2, T3, T4, T5>(formatter, arg1, arg2, arg3, arg4, arg5));
         }
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Logging
         /// <returns>A delegate which when invoked creates a log scope.</returns>
         public static Func<ILogger, T1, T2, T3, T4, T5, T6, IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString)
         {
-            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);
 
             return (logger, arg1, arg2, arg3, arg4, arg5, arg6) => logger.BeginScope(new LogValues<T1, T2, T3, T4, T5, T6>(formatter, arg1, arg2, arg3, arg4, arg5, arg6));
         }


### PR DESCRIPTION
This PR covers all the changes discussed in the #43238 with @maryamariyan . 

 - Refactor the `LoggerMessage` class to use explicitly typed variable where the type of expression is not obvious instead of `var`
 - Add tests for `DefineScope` methods group to test that it throws `ArgumentNullException` when the `formatString` argument is `null`