### PR TITLE
ServiceProcess Controller Refactor

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/src/Microsoft/Win32/SafeHandles/SafeServiceHandle.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/Microsoft/Win32/SafeHandles/SafeServiceHandle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Security;
-using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -243,8 +243,10 @@ namespace System.ServiceProcess
             {
                 if (_eventLog == null)
                 {
-                    _eventLog = new EventLog("Application");
-                    _eventLog.Source = ServiceName;
+                    _eventLog = new EventLog("Application")
+                    {
+                        Source = ServiceName
+                    };
                 }
 
                 return _eventLog;
@@ -295,7 +297,7 @@ namespace System.ServiceProcess
             // no slashes or backslash allowed
             foreach (char c in serviceName)
             {
-                if ((c == '\\') || (c == '/'))
+                if (c == '\\' || c == '/')
                     return false;
             }
 
@@ -628,7 +630,7 @@ namespace System.ServiceProcess
                     }
                 }
 
-                string errorMessage = "";
+                string errorMessage = string.Empty;
 
                 if (!res)
                 {
@@ -701,8 +703,8 @@ namespace System.ServiceProcess
                 _status.checkPoint = 0;
                 _status.waitHint = 0;
 
-                _mainCallback = new ServiceMainCallback(this.ServiceMainCallback);
-                _commandCallbackEx = new ServiceControlCallbackEx(this.ServiceCommandCallbackEx);
+                _mainCallback = this.ServiceMainCallback;
+                _commandCallbackEx = this.ServiceCommandCallbackEx;
 
                 _initialized = true;
             }

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceProcessDescriptionAttribute.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceProcessDescriptionAttribute.cs
@@ -13,7 +13,7 @@ namespace System.ServiceProcess
     [AttributeUsage(AttributeTargets.All)]
     public class ServiceProcessDescriptionAttribute : DescriptionAttribute
     {
-        private bool replaced;
+        private bool _replaced;
 
         /// <summary>
         /// Constructs a new sys description
@@ -29,9 +29,9 @@ namespace System.ServiceProcess
         {
             get
             {
-                if (!replaced)
+                if (!_replaced)
                 {
-                    replaced = true;
+                    _replaced = true;
                     DescriptionValue = base.Description;
                 }
                 return base.Description;

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/SessionChangeDescription.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/SessionChangeDescription.cs
@@ -14,32 +14,18 @@ namespace System.ServiceProcess
             _id = id;
         }
 
-        public SessionChangeReason Reason
-        {
-            get
-            {
-                return _reason;
-            }
-        }
+        public SessionChangeReason Reason => _reason;
 
-        public int SessionId
-        {
-            get
-            {
-                return _id;
-            }
-        }
+        public int SessionId => _id;
 
         public override bool Equals(object? obj)
         {
-            if (obj == null || !(obj is SessionChangeDescription))
+            if (!(obj is SessionChangeDescription))
             {
                 return false;
             }
-            else
-            {
-                return Equals((SessionChangeDescription)obj);
-            }
+
+            return Equals((SessionChangeDescription)obj);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
1. Simplified if checks.
2. Use expression property syntax.
3. Used using-declaration.
4. Inline `out` declaration.
5. Removed unwanted unsafe modifier.
6. Removed redundant casting. 