### PR TITLE
Consolidate RID and native file naming in MSBuild scripts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,7 +57,7 @@
     <WasmAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'WasmAppBuilder', 'Debug', '$(NetCoreAppCurrent)', 'publish'))</WasmAppBuilderDir>
     <WasmBuildTasksDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'WasmBuildTasks', 'Debug', '$(NetCoreAppCurrent)', 'publish'))</WasmBuildTasksDir>
     <MonoAOTCompilerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'MonoAOTCompiler', 'Debug', '$(NetCoreAppCurrent)'))</MonoAOTCompilerDir>
-  
+
     <AppleAppBuilderTasksAssemblyPath>$([MSBuild]::NormalizePath('$(AppleAppBuilderDir)', 'AppleAppBuilder.dll'))</AppleAppBuilderTasksAssemblyPath>
     <AndroidAppBuilderTasksAssemblyPath>$([MSBuild]::NormalizePath('$(AndroidAppBuilderDir)', 'AndroidAppBuilder.dll'))</AndroidAppBuilderTasksAssemblyPath>
     <WasmAppBuilderTasksAssemblyPath>$([MSBuild]::NormalizePath('$(WasmAppBuilderDir)', 'WasmAppBuilder.dll'))</WasmAppBuilderTasksAssemblyPath>
@@ -105,8 +105,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Default to portable build if not explicitly set -->
-    <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>
     <!-- Default to discarding symbols if not explicitly set -->
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == ''">false</KeepNativeSymbols>
     <!-- Used for launchSettings.json and runtime config files. -->

--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -100,7 +100,6 @@
     <_portableOS Condition="'$(_runtimeOS)' == 'android'">android</_portableOS>
 
     <_runtimeOS Condition="$(_runtimeOS.StartsWith('tizen'))">linux</_runtimeOS>
-    <NonPortableRuntimeOS Condition="'$(PortableBuild)' == 'true'">$(_runtimeOS)</NonPortableRuntimeOS>
     <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
 
     <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->

--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -5,6 +5,11 @@
   -->
 
   <PropertyGroup>
+    <!-- Default to portable build if not explicitly set -->
+    <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LibrariesProjectRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'libraries'))</LibrariesProjectRoot>
     <CoreClrProjectRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'coreclr'))</CoreClrProjectRoot>
     <MonoProjectRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'mono'))</MonoProjectRoot>
@@ -49,9 +54,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <HostRuntimeIdentifier Condition="'$(HostRuntimeIdentifier)' == '' and '$(MSBuildRuntimeType)' == 'core'">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</HostRuntimeIdentifier>
-    <HostRuntimeIdentifier Condition="'$(HostRuntimeIdentifier)' == '' and '$(MSBuildRuntimeType)' != 'core'">win-$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</HostRuntimeIdentifier>
-
     <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('OSX'))">OSX</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('NETBSD'))">NetBSD</TargetOS>
@@ -68,6 +70,109 @@
     <TargetsMobile Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'Browser'">true</TargetsMobile>
   </PropertyGroup>
 
+  <PropertyGroup Label="CalculateOS">
+    <_runtimeOS>$(RuntimeOS)</_runtimeOS>
+
+    <_parseDistroRid>$(__DistroRid)</_parseDistroRid>
+    <_parseDistroRid Condition="'$(_parseDistroRid)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</_parseDistroRid>
+    <_distroRidIndex>$(_parseDistroRid.LastIndexOfAny("-"))</_distroRidIndex>
+
+    <_runtimeOS Condition="'$(_runtimeOS)' == ''">$(_parseDistroRid.SubString(0, $(_distroRidIndex)))</_runtimeOS>
+
+    <!-- _runtimeOS is calculated based on the build system OS, however if building for Browser/iOS/Android we need to let
+         the build system to use browser/ios/android as the _runtimeOS for produced package RIDs. -->
+    <_runtimeOS Condition="'$(TargetsMobile)' == 'true'">$(TargetOS.ToLowerInvariant())</_runtimeOS>
+
+    <_runtimeOSVersionIndex>$(_runtimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
+    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(_runtimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
+
+    <_buildingInOSX>$([MSBuild]::IsOSPlatform('OSX'))</_buildingInOSX>
+    <_portableOS>linux</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'linux-musl'">linux-musl</_portableOS>
+    <_portableOS Condition="$(_buildingInOSX)">osx</_portableOS>
+    <_portableOS Condition="'$(_runtimeOSFamily)' == 'win' or '$(TargetOS)' == 'windows'">win</_portableOS>
+    <_portableOS Condition="'$(_runtimeOSFamily)' == 'FreeBSD'">freebsd</_portableOS>
+    <_portableOS Condition="'$(_runtimeOSFamily)' == 'illumos'">illumos</_portableOS>
+    <_portableOS Condition="'$(_runtimeOSFamily)' == 'Solaris'">solaris</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'Browser'">browser</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'ios'">ios</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'tvos'">tvos</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'android'">android</_portableOS>
+
+    <_runtimeOS Condition="$(_runtimeOS.StartsWith('tizen'))">linux</_runtimeOS>
+    <NonPortableRuntimeOS Condition="'$(PortableBuild)' == 'true'">$(_runtimeOS)</NonPortableRuntimeOS>
+    <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
+
+    <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->
+    <_portableOS Condition="'$(TargetOS)' == 'Unix' and '$(_runtimeOSFamily)' != 'osx' and '$(_runtimeOSFamily)' != 'FreeBSD' and '$(_runtimeOS)' != 'linux-musl' and '$(_runtimeOSFamily)' != 'illumos' and '$(_runtimeOSFamily)' != 'Solaris'">linux</_portableOS>
+  </PropertyGroup>
+
+  <PropertyGroup Label="CalculateArch">
+    <_hostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</_hostArch>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'arm'">arm</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'arm64'">arm64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(TargetOS)' == 'Browser'">wasm</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(TargetsMobile)' == 'true'">x64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+  </PropertyGroup>
+
+  <PropertyGroup Label="CalculateRID">
+    <_toolRuntimeRID Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(_runtimeOS)-x64</_toolRuntimeRID>
+    <_toolRuntimeRID Condition="'$(_toolRuntimeRID)' == ''">$(_runtimeOS)-$(_hostArch)</_toolRuntimeRID>
+    <!-- We build linux-musl-arm on a ubuntu container, so we can't use the toolset build for alpine runtime. We need to use portable linux RID for our toolset in order to be able to use it. -->
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'linux-musl' and $(TargetArchitecture.StartsWith('arm')) and !$(_hostArch.StartsWith('arm'))">linux-x64</_toolRuntimeRID>
+
+    <!-- There are no WebAssembly tools, so use the default ones -->
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'browser' and '$(TargetOS)' == 'windows'">win-x64</_toolRuntimeRID>
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'browser' and '$(TargetOS)' != 'windows' and $(_buildingInOSX)">osx-x64</_toolRuntimeRID>
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'browser' and '$(TargetOS)' != 'windows' and !$(_buildingInOSX)">linux-x64</_toolRuntimeRID>
+
+    <!-- There are no Android tools, so use the default ones -->
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'android' and '$(TargetOS)' == 'windows'">win-x64</_toolRuntimeRID>
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'android' and '$(TargetOS)' != 'windows' and $(_buildingInOSX)">osx-x64</_toolRuntimeRID>
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'android' and '$(TargetOS)' != 'windows' and !$(_buildingInOSX)">linux-x64</_toolRuntimeRID>
+
+    <!-- There are no iOS or tvOS tools and it can be built on OSX only, so use that -->
+    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'ios' or '$(_runtimeOS)' == 'tvos'">osx-x64</_toolRuntimeRID>
+    <MicrosoftNetCoreIlasmPackageRuntimeId>$(_toolRuntimeRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
+
+    <_packageRID Condition="'$(PortableBuild)' == 'true'">$(_portableOS)-$(TargetArchitecture)</_packageRID>
+    <PackageRID Condition="'$(PackageRID)' == ''">$(_packageRID)</PackageRID>
+    <PackageRID Condition="'$(PackageRID)' == ''">$(_runtimeOS)-$(TargetArchitecture)</PackageRID>
+
+    <_outputRID Condition="'$(TargetOS)' == 'windows'">win-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'NetBSD'">netbsd-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'illumos'">illumos-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'Solaris'">solaris-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'iOS'">ios-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'tvOS'">tvos-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</_outputRID>
+    <_outputRID Condition="'$(TargetOS)' == 'Browser'">browser-$(TargetArchitecture)</_outputRID>
+
+    <OutputRid Condition="'$(OutputRid)' == ''">$(PackageRID)</OutputRid>
+    <OutputRid Condition="'$(PortableBuild)' == 'true'">$(_outputRID)</OutputRid>
+  </PropertyGroup>
+
+  <PropertyGroup Label="CalculateTargetOSName" Condition="'$(SkipInferTargetOSName)' != 'true'">
+    <TargetsFreeBSD Condition="'$(TargetOS)' == 'FreeBSD'">true</TargetsFreeBSD>
+    <Targetsillumos Condition="'$(TargetOS)' == 'illumos'">true</Targetsillumos>
+    <TargetsSolaris Condition="'$(TargetOS)' == 'Solaris'">true</TargetsSolaris>
+    <TargetsLinux Condition="'$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'Android'">true</TargetsLinux>
+    <TargetsNetBSD Condition="'$(TargetOS)' == 'NetBSD'">true</TargetsNetBSD>
+    <TargetsOSX Condition="'$(TargetOS)' == 'OSX'">true</TargetsOSX>
+    <TargetsiOS Condition="'$(TargetOS)' == 'iOS'">true</TargetsiOS>
+    <TargetstvOS Condition="'$(TargetOS)' == 'tvOS'">true</TargetstvOS>
+    <TargetsiOSSimulator Condition="'$(TargetsiOS)' == 'true' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86')">true</TargetsiOSSimulator>
+    <TargetstvOSSimulator Condition="'$(TargetstvOS)' == 'true' and '$(TargetArchitecture)' == 'x64'">true</TargetstvOSSimulator>
+    <TargetsAndroid Condition="'$(TargetOS)' == 'Android'">true</TargetsAndroid>
+    <TargetsBrowser Condition="'$(TargetOS)' == 'Browser'">true</TargetsBrowser>
+    <TargetsWindows Condition="'$(TargetOS)' == 'windows'">true</TargetsWindows>
+    <TargetsUnix Condition="'$(TargetsFreeBSD)' == 'true' or '$(Targetsillumos)' == 'true' or '$(TargetsSolaris)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsNetBSD)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetsAndroid)' == 'true'">true</TargetsUnix>
+  </PropertyGroup>
+
   <!--Feature switches -->
   <PropertyGroup>
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and '$(Configuration)' == 'Release'">true</EnableNgenOptimization>
@@ -76,4 +181,6 @@
     <!-- Turn off end of life target framework checks as we intentionally build older .NETCoreApp configurations. -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)native\naming.props" />
 </Project>

--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -119,7 +119,6 @@ initNonPortableDistroRid()
 #
 #   __DistroRid
 #   __PortableBuild
-#   __RuntimeId
 #
 initDistroRidGlobal()
 {
@@ -194,13 +193,8 @@ initDistroRidGlobal()
 
     if [ -z "$__DistroRid" ]; then
         echo "DistroRid is not set. This is almost certainly an error"
-
         exit 1
-    else
-        echo "__DistroRid: ${__DistroRid}"
-        echo "__RuntimeId: ${__DistroRid}"
-
-        __RuntimeId="${__DistroRid}"
-        export __RuntimeId
     fi
+
+    echo "__DistroRid: ${__DistroRid}"
 }

--- a/eng/native/naming.props
+++ b/eng/native/naming.props
@@ -1,45 +1,54 @@
 <Project>
+  <PropertyGroup>
+    <StaticLibPrefix>lib</StaticLibPrefix>
+  </PropertyGroup>
+
   <!-- Add path globs specific to native binaries to exclude unnecessary files from packages. -->
   <Choose>
-    <When Condition=" '$(_runtimeOSFamily)' == 'win' OR $(RuntimeIdentifier.StartsWith('win')) ">
+    <When Condition="$(PackageRID.StartsWith('win'))">
       <PropertyGroup>
-        <ApplicationFileExtension>.exe</ApplicationFileExtension>
-        <LibraryFilePrefix></LibraryFilePrefix>
-        <LibraryFileExtension>.dll</LibraryFileExtension>
-        <StaticLibraryFileExtension>.lib</StaticLibraryFileExtension>
-        <SymbolFileExtension>.pdb</SymbolFileExtension>
+        <ExeSuffix>.exe</ExeSuffix>
+        <LibSuffix>.dll</LibSuffix>
+        <StaticLibSuffix>.lib</StaticLibSuffix>
+        <SymbolsSuffix>.pdb</SymbolsSuffix>
       </PropertyGroup>
     </When>
-    <When Condition=" '$(_runtimeOSFamily)' == 'osx' or $(RuntimeIdentifier.StartsWith('osx')) or '$(_runtimeOSFamily)' == 'ios' or $(RuntimeIdentifier.StartsWith('ios'))">
+    <When Condition="$(PackageRID.StartsWith('osx'))">
       <PropertyGroup>
-        <LibraryFilePrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibraryFilePrefix>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <StaticLibraryFileExtension>.a</StaticLibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
+        <LibPrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibPrefix>
+        <LibSuffix>.dylib</LibSuffix>
+        <StaticLibSuffix>.a</StaticLibSuffix>
+        <SymbolsSuffix>.dwarf</SymbolsSuffix>
       </PropertyGroup>
     </When>
-    <When Condition=" '$(_runtimeOSFamily)' == 'android' ">
+    <When Condition="$(PackageRID.StartsWith('android'))">
       <PropertyGroup>
-        <LibraryFilePrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibraryFilePrefix>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <StaticLibraryFileExtension>.a</StaticLibraryFileExtension>
+        <LibPrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibPrefix>
+        <LibSuffix>.so</LibSuffix>
+        <StaticLibSuffix>.a</StaticLibSuffix>
         <!--symbols included in .so, like Linux, but can be generated externally and if so, uses .debug ext-->
-        <SymbolFileExtension>.debug</SymbolFileExtension>
+        <SymbolsSuffix>.debug</SymbolsSuffix>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <LibraryFilePrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibraryFilePrefix>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <StaticLibraryFileExtension>.a</StaticLibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
+        <LibPrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibPrefix>
+        <LibSuffix>.so</LibSuffix>
+        <StaticLibSuffix>.a</StaticLibSuffix>
+        <SymbolsSuffix>.dbg</SymbolsSuffix>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
   <ItemGroup>
-    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
-    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
+    <AdditionalLibPackageExcludes Condition="'$(SymbolsSuffix)' != ''" Include="%2A%2A\%2A$(SymbolsSuffix)" />
+    <AdditionalSymbolPackageExcludes Condition="'$(LibSuffix)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibSuffix)" />
   </ItemGroup>
+
+  <!-- arcade is using long name for this property; 'SymbolFileExtension'.
+       remove this property group when arcade is updated with short name (SymbolsSuffix). -->
+  <PropertyGroup>
+    <SymbolFileExtension>$(SymbolsSuffix)</SymbolFileExtension>
+  </PropertyGroup>
 
 </Project>

--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -50,22 +50,6 @@
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
   </PropertyGroup>
 
-  <!-- Set up common target properties that we use to conditionally include sources -->
-  <PropertyGroup>
-    <TargetsFreeBSD Condition="'$(TargetOS)' == 'FreeBSD'">true</TargetsFreeBSD>
-    <TargetsLinux Condition="'$(TargetOS)' == 'Linux'">true</TargetsLinux>
-    <TargetsNetBSD Condition="'$(TargetOS)' == 'NetBSD'">true</TargetsNetBSD>
-    <Targetsillumos Condition="'$(TargetOS)' == 'illumos'">true</Targetsillumos>
-    <TargetsSolaris Condition="'$(TargetOS)' == 'Solaris'">true</TargetsSolaris>
-    <TargetsOSX Condition="'$(TargetOS)' == 'OSX'">true</TargetsOSX>
-    <TargetsWindows Condition="'$(TargetOS)' == 'windows'">true</TargetsWindows>
-
-    <TargetsUnix Condition="'$(TargetsFreeBSD)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsNetBSD)' == 'true' or '$(TargetsOSX)' == 'true' or '$(Targetsillumos)' == 'true' or '$(TargetsSolaris)' == 'true'">true</TargetsUnix>
-
-    <!-- We are only tracking Linux Distributions for Nuget RID mapping -->
-    <DistroRid Condition="'$(TargetsLinux)' == 'true'">$(__DistroRid)</DistroRid>
-  </PropertyGroup>
-
   <!-- Set the kind of PDB to Portable -->
   <PropertyGroup>
     <DebugType Condition="'$(DebugType)' == ''">Portable</DebugType>

--- a/src/coreclr/src/.nuget/Directory.Build.props
+++ b/src/coreclr/src/.nuget/Directory.Build.props
@@ -20,36 +20,14 @@
     <!-- indicates that lib prefix is not added to library names for Unix-like operating systems -->
     <SkipLibraryPrefixFromUnix>true</SkipLibraryPrefixFromUnix>
 
-    <!-- Distro rid is passed as runtimeos-arch-->
-    <_parseDistroRid>$(__DistroRid)</_parseDistroRid>
-    <_parseDistroRid Condition="'$(_parseDistroRid)' == '' and '$(TargetOS)' == 'OSX'">osx.10.12-x64</_parseDistroRid>
-    <_distroRidIndex>$(_parseDistroRid.LastIndexOfAny("-"))</_distroRidIndex>
-    <_archRidIndex>$([MSBuild]::Add($(_distroRidIndex), 1))</_archRidIndex>
-    <OSRid Condition="'$(OSRid)' == '' and '$(_distroRidIndex)' != '-1'">$(_parseDistroRid.SubString(0, $(_distroRidIndex)))</OSRid>
-    <OSRid Condition="'$(OSRid)' == ''">win10</OSRid>
-
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_archRidIndex)' != '0'">$(_parseDistroRid.SubString($(_archRidIndex)))</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(Platform)' != ''">$(Platform)</TargetArchitecture>
-
-    <RuntimeOS Condition="'$(RuntimeOS)' == ''">$(OSRid)</RuntimeOS>
-
     <SupportedPackageOSGroups Condition="'$(SupportedPackageOSGroups)' == ''">windows;OSX;Android;Linux;FreeBSD;NetBSD;illumos;Solaris</SupportedPackageOSGroups>
     <SupportedPackageOSGroups>;$(SupportedPackageOSGroups);</SupportedPackageOSGroups>
 
-    <!-- Identify OS family based upon the RuntimeOS, which could be distro specific (e.g. osx.10.12) or
-         portable (e.g. osx).
-    -->
-    <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
-    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
-    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' == '-1'">$(RuntimeOS)</_runtimeOSFamily>
     <_isSupportedOSGroup>true</_isSupportedOSGroup>
   </PropertyGroup>
 
   <!-- derive an OS Group based on the OS Family -->
   <PropertyGroup>
-    <_derivedPackageTargetOSGroup Condition="'$(_derivedPackageTargetOSGroup)' == '' and '$(_runtimeOSFamily)' == 'osx'">OSX</_derivedPackageTargetOSGroup>
-    <_derivedPackageTargetOSGroup Condition="'$(_derivedPackageTargetOSGroup)' == '' and '$(_runtimeOSFamily)' == 'android'">Android</_derivedPackageTargetOSGroup>
-    <_derivedPackageTargetOSGroup Condition="'$(_derivedPackageTargetOSGroup)' == '' and '$(_runtimeOSFamily)' == 'win'">windows</_derivedPackageTargetOSGroup>
     <_derivedPackageTargetOSGroup Condition="'$(_derivedPackageTargetOSGroup)' == '' and '$(TargetOS)' != ''">$(TargetOS)</_derivedPackageTargetOSGroup>
     <_derivedPackageTargetOSGroup Condition="'$(_derivedPackageTargetOSGroup)' == ''">Linux</_derivedPackageTargetOSGroup>
 
@@ -72,92 +50,6 @@
     <SkipValidatePackage>true</SkipValidatePackage>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
   </PropertyGroup>
-
-  <Choose>
-    <When Condition="'$(PackageRID)' != ''" />
-    <When Condition="'$(OutputRID)' != ''">
-      <PropertyGroup>
-        <!-- If OutputRID is explicitly set use that as the PackageRID -->
-        <PackageRID>$(OutputRID)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'win'">
-      <PropertyGroup>
-        <!-- Note: Windows builds are always portable (-PortableBuild=false is ignored) -->
-        <PackageRID>win-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'osx'">
-      <PropertyGroup>
-        <PackageRID>osx.10.12-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">osx-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'freebsd'">
-      <PropertyGroup>
-        <PackageRID>freebsd.11-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">freebsd-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'netbsd'">
-      <PropertyGroup>
-        <PackageRID>netbsd-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">netbsd-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'illumos'">
-      <PropertyGroup>
-        <PackageRID>illumos-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">illumos-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'solaris'">
-      <PropertyGroup>
-        <PackageRID>solaris-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">solaris-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'android'">
-      <PropertyGroup>
-        <PackageRID>android.21-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == '1'">android-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'rhel'">
-      <PropertyGroup>
-        <PackageRID>$(OSRid)-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">linux-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'alpine'">
-      <PropertyGroup>
-        <PackageRID>$(OSRid)-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">linux-musl-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(RuntimeOS)' == 'linux-musl'">
-      <PropertyGroup>
-        <PackageRID>$(RuntimeOS)-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <PackageRID>$(RuntimeOS)-$(TargetArchitecture)</PackageRID>
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == 'true'">linux-$(TargetArchitecture)</PackageRID>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
-  <Import Project="$(RepoRoot)eng\native\naming.props" />
 
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Linux;'))">
     <OfficialBuildRID Include="linux-x64" />

--- a/src/coreclr/src/.nuget/Directory.Build.targets
+++ b/src/coreclr/src/.nuget/Directory.Build.targets
@@ -9,8 +9,8 @@
     Finds symbol files and injects them into the package build.
   -->
   <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
-    <ItemGroup Condition="'$(SymbolFileExtension)' != ''">
-      <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolFileExtension)"/>
+    <ItemGroup Condition="'$(SymbolsSuffix)' != ''">
+      <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolsSuffix)"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -42,7 +42,7 @@
       <NonWindowsNativeFile Include="@(NativeWithSymbolFile)"
                             Exclude="@(WindowsNativeFile)" />
 
-      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
+      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolsSuffix)')" />
 
       <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />
       <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)') AND '$(SkipPackagingXplatSymbols)'!='true'" />

--- a/src/coreclr/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/coreclr/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(RuntimeBinDir)ilasm$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(RuntimeBinDir)ilasm$(ExeSuffix)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/coreclr/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/coreclr/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(RuntimeBinDir)ildasm$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(RuntimeBinDir)ildasm$(ExeSuffix)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/coreclr/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/coreclr/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(RuntimeBinDir)corerun$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(RuntimeBinDir)corerun$(ExeSuffix)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
@@ -63,13 +63,7 @@
     <TargetSpec>$(TargetOSComponent)_$(TargetArchitecture)_$(TargetArchitecture)</TargetSpec>
     <CrossTargetSpec>$(TargetOSComponent)_$(TargetArchitecture)_$(CrossHostArch)</CrossTargetSpec>
 
-    <LibraryNamePrefix>lib</LibraryNamePrefix>
-    <LibraryNamePrefix Condition="$([MSBuild]::IsOsPlatform('WINDOWS'))"></LibraryNamePrefix>
-    <LibraryNameExtension Condition="$([MSBuild]::IsOsPlatform('WINDOWS'))">.dll</LibraryNameExtension>
-    <LibraryNameExtension Condition="$([MSBuild]::IsOsPlatform('LINUX'))">.so</LibraryNameExtension>
-    <LibraryNameExtension Condition="$([MSBuild]::IsOsPlatform('OSX'))">.dylib</LibraryNameExtension>
-
-    <JitInterfaceLibraryName>$(LibraryNamePrefix)jitinterface_$(TargetArchitecture)$(LibraryNameExtension)</JitInterfaceLibraryName>
+    <JitInterfaceLibraryName>$(LibPrefix)jitinterface_$(TargetArchitecture)$(LibSuffix)</JitInterfaceLibraryName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -79,7 +73,7 @@
       Link="%(FileName)%(Extension)"
      />
 
-    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibraryNamePrefix)clrjit_*_$(TargetArchitecture)$(LibraryNameExtension)"
+    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibPrefix)clrjit_*_$(TargetArchitecture)$(LibSuffix)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="%(FileName)%(Extension)"
@@ -89,10 +83,10 @@
   <!-- On windows we can re-use the clrjit.dll produced in the build for aot compilation. On Linux
        this works at runtime, but makes it difficult to debug the jit.-->
   <ItemGroup Condition="'$(TargetOS)' == 'windows'">
-    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibraryNamePrefix)clrjit$(LibraryNameExtension)"
+    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibPrefix)clrjit$(LibSuffix)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
-      Link="$(LibraryNamePrefix)clrjit_$(TargetSpec)$(LibraryNameExtension)"
+      Link="$(LibPrefix)clrjit_$(TargetSpec)$(LibSuffix)"
      />
   </ItemGroup>
 
@@ -104,8 +98,8 @@
 
     <ItemGroup>
       <PackageFile Include="$(RuntimeBinDir)\crossgen2\*"
-        Exclude="$(RuntimeBinDir)\crossgen2\$(JitInterfaceLibraryName);$(RuntimeBinDir)\crossgen2\$(LibraryNamePrefix)clrjit_*$(LibraryNameExtension)" />
-      <PackageFile Include="$(RuntimeBinDir)\$(CrossHostArch)\$(LibraryNamePrefix)jitinterface_$(CrossHostArch)$(LibraryNameExtension)" />
+        Exclude="$(RuntimeBinDir)\crossgen2\$(JitInterfaceLibraryName);$(RuntimeBinDir)\crossgen2\$(LibPrefix)clrjit_*$(LibSuffix)" />
+      <PackageFile Include="$(RuntimeBinDir)\$(CrossHostArch)\$(LibPrefix)jitinterface_$(CrossHostArch)$(LibSuffix)" />
     </ItemGroup>
 
     <MakeDir Directories="$(CrossPackageFolder)" />
@@ -117,14 +111,14 @@
 
     <Copy
       Condition="'$(TargetOS)' != 'windows'"
-      SourceFiles="$(RuntimeBinDir)$(CrossHostArch)\$(LibraryNamePrefix)clrjit_$(CrossTargetSpec)$(LibraryNameExtension)"
+      SourceFiles="$(RuntimeBinDir)$(CrossHostArch)\$(LibPrefix)clrjit_$(CrossTargetSpec)$(LibSuffix)"
       DestinationFolder="$(CrossPackageFolder)"
       UseHardLinksIfPossible="true"
       />
     <Copy
       Condition="'$(TargetOS)' == 'windows'"
-      SourceFiles="$(RuntimeBinDir)$(CrossHostArch)\$(LibraryNamePrefix)clrjit$(LibraryNameExtension)"
-      DestinationFiles="$(CrossPackageFolder)\$(LibraryNamePrefix)clrjit_$(CrossTargetSpec)$(LibraryNameExtension)"
+      SourceFiles="$(RuntimeBinDir)$(CrossHostArch)\$(LibPrefix)clrjit$(LibSuffix)"
+      DestinationFiles="$(CrossPackageFolder)\$(LibPrefix)clrjit_$(CrossTargetSpec)$(LibSuffix)"
       UseHardLinksIfPossible="true"
       />
 

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -112,27 +112,6 @@
     <SharedHostInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(SharedHostInstallerStart)$(InstallerStartSuffix)-</SharedHostInstallerStart>
     <HostFxrInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(HostFxrInstallerStart)$(InstallerStartSuffix)-</HostFxrInstallerStart>
     <SharedFrameworkInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
-
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
-    <HostMachineRidTargetsDebianPackages Condition="
-      $(NonPortableRuntimeOS.StartsWith('debian')) or
-      $(NonPortableRuntimeOS.StartsWith('ubuntu')) or
-      $(NonPortableRuntimeOS.StartsWith('linuxmint'))">true</HostMachineRidTargetsDebianPackages>
-    <!-- If the build machine isn't known to be Debian-based, try to build RPM packages. -->
-    <HostMachineRidTargetsRpmPackages Condition="'$(HostMachineRidTargetsDebianPackages)' != 'true'">true</HostMachineRidTargetsRpmPackages>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <CompressedFileExtension Condition="'$(TargetOS)' == 'windows'">.zip</CompressedFileExtension>
-    <CompressedFileExtension Condition="'$(TargetOS)' != 'windows'">.tar.gz</CompressedFileExtension>
-    <InstallerExtension Condition="'$(TargetOS)' == 'windows'">.msi</InstallerExtension>
-    <InstallerExtension Condition="'$(TargetOS)' == 'OSX'">.pkg</InstallerExtension>
-    <InstallerExtension Condition="$(OutputRid.StartsWith('debian')) or $(OutputRid.StartsWith('ubuntu')) or $(OutputRid.StartsWith('linuxmint')) or '$(HostMachineRidTargetsDebianPackages)' == 'true'">.deb</InstallerExtension>
-    <InstallerExtension Condition="$(OutputRid.StartsWith('rhel')) or $(OutputRid.StartsWith('centos')) or $(OutputRid.StartsWith('opensuse')) or $(OutputRid.StartsWith('fedora')) or $(OutputRid.StartsWith('oracle')) or $(OutputRid.StartsWith('sles')) or '$(HostMachineRidTargetsRpmPackages)' == 'true'">.rpm</InstallerExtension>
-    <CombinedInstallerExtension Condition="'$(TargetOS)' == 'windows'">.exe</CombinedInstallerExtension>
-    <CombinedInstallerExtension Condition="'$(TargetOS)' != 'windows'">$(InstallerExtension)</CombinedInstallerExtension>
   </PropertyGroup>
 
   <!-- Use actual publishable (non-dummy) package name produced by the build system for this RID -->

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -57,29 +57,6 @@
     <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <ExeSuffix Condition="'$(TargetOS)' == 'windows'">.exe</ExeSuffix>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OutputRid)' == '' and '$(HostRuntimeIdentifier)' != ''">
-    <OutputRid>$(HostRuntimeIdentifier.Remove($(HostRuntimeIdentifier.LastIndexOf('-'))))-$(TargetArchitecture)</OutputRid>
-  </PropertyGroup>
-
-  <!-- Portable -->
-  <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
-    <OutputRid Condition="'$(TargetOS)' == 'windows'">win-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'NetBSD'">netbsd-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'illumos'">illumos-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'Solaris'">solaris-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'iOS'">ios-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'tvOS'">tvos-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'Browser'">browser-$(TargetArchitecture)</OutputRid>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == '' and '$(EnsureRuntimeIdentifierSet)' == 'true'">
     <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
   </PropertyGroup>
@@ -138,175 +115,22 @@
 
   </PropertyGroup>
 
-  <PropertyGroup>
-    <TargetsWindows>false</TargetsWindows>
-    <TargetsOSX>false</TargetsOSX>
-    <TargetsiOS>false</TargetsiOS>
-    <TargetstvOS>false</TargetstvOS>
-    <TargetsAndroid>false</TargetsAndroid>
-    <TargetsLinux>false</TargetsLinux>
-    <TargetsUnix>false</TargetsUnix>
-    <TargetsUbuntu>false</TargetsUbuntu>
-    <TargetsLinuxMint>false</TargetsLinuxMint>
-    <TargetsDebian>false</TargetsDebian>
-    <TargetsRhel>false</TargetsRhel>
-    <TargetsOpensuse>false</TargetsOpensuse>
-    <TargetsFedora>false</TargetsFedora>
-    <TargetsCentos>false</TargetsCentos>
-    <TargetsOracle>false</TargetsOracle>
-    <TargetsSles>false</TargetsSles>
-    <TargetsBrowser>false</TargetsBrowser>
+  <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
+    <HostMachineRidTargetsDebianPackages Condition="
+      $(NonPortableRuntimeOS.StartsWith('debian')) or
+      $(NonPortableRuntimeOS.StartsWith('ubuntu')) or
+      $(NonPortableRuntimeOS.StartsWith('linuxmint'))">true</HostMachineRidTargetsDebianPackages>
+    <!-- If the build machine isn't known to be Debian-based, try to build RPM packages. -->
+    <HostMachineRidTargetsRpmPackages Condition="'$(HostMachineRidTargetsDebianPackages)' != 'true'">true</HostMachineRidTargetsRpmPackages>
   </PropertyGroup>
-  <Choose>
-    <When Condition="$(OutputRid.StartsWith('win'))">
-      <PropertyGroup>
-        <TargetsWindows>true</TargetsWindows>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('osx'))">
-      <PropertyGroup>
-        <TargetsOSX>true</TargetsOSX>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('ios'))">
-      <PropertyGroup>
-        <TargetsiOS>true</TargetsiOS>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsMobile>true</TargetsMobile>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('tvos'))">
-      <PropertyGroup>
-        <TargetstvOS>true</TargetstvOS>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsMobile>true</TargetsMobile>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('android'))">
-      <PropertyGroup>
-        <TargetsAndroid>true</TargetsAndroid>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsMobile>true</TargetsMobile>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('browser'))">
-      <PropertyGroup>
-        <TargetsBrowser>true</TargetsBrowser>
-        <TargetsMobile>true</TargetsMobile>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('debian'))">
-      <PropertyGroup>
-        <TargetsDebian>true</TargetsDebian>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('ubuntu'))">
-      <PropertyGroup>
-        <TargetsUbuntu>true</TargetsUbuntu>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('linuxmint'))">
-      <PropertyGroup>
-        <TargetsLinuxMint>true</TargetsLinuxMint>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('rhel'))">
-      <PropertyGroup>
-        <TargetsRhel>true</TargetsRhel>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('centos'))">
-      <PropertyGroup>
-        <TargetsCentos>true</TargetsCentos>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('opensuse'))">
-      <PropertyGroup>
-        <TargetsOpensuse>true</TargetsOpensuse>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('fedora'))">
-      <PropertyGroup>
-        <TargetsFedora>true</TargetsFedora>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('oracle'))">
-      <PropertyGroup>
-        <TargetsOracle>true</TargetsOracle>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('sles'))">
-      <PropertyGroup>
-        <TargetsSles>true</TargetsSles>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('freebsd'))">
-      <PropertyGroup>
-        <TargetsFreeBSD>true</TargetsFreeBSD>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('netbsd'))">
-      <PropertyGroup>
-        <TargetsNetBSD>true</TargetsNetBSD>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('illumos'))">
-      <PropertyGroup>
-        <Targetsillumos>true</Targetsillumos>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(OutputRid.StartsWith('solaris'))">
-      <PropertyGroup>
-        <TargetsSolaris>true</TargetsSolaris>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <TargetsLinux>true</TargetsLinux>
-        <TargetsUnix>true</TargetsUnix>
-      </PropertyGroup>
-      <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
-        <HostMachineRidTargetsDebianPackages Condition="
-          $(HostRuntimeIdentifier.StartsWith('debian')) or
-          $(HostRuntimeIdentifier.StartsWith('ubuntu')) or
-          $(HostRuntimeIdentifier.StartsWith('linuxmint'))">true</HostMachineRidTargetsDebianPackages>
-        <!-- If the build machine isn't known to be Debian-based, try to build RPM packages. -->
-        <HostMachineRidTargetsRpmPackages Condition="'$(HostMachineRidTargetsDebianPackages)' != 'true'">true</HostMachineRidTargetsRpmPackages>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
 
   <PropertyGroup>
     <CompressedFileExtension Condition="'$(TargetOS)' == 'windows'">.zip</CompressedFileExtension>
     <CompressedFileExtension Condition="'$(TargetOS)' != 'windows'">.tar.gz</CompressedFileExtension>
     <InstallerExtension Condition="'$(TargetOS)' == 'windows'">.msi</InstallerExtension>
     <InstallerExtension Condition="'$(TargetOS)' == 'OSX'">.pkg</InstallerExtension>
-    <InstallerExtension Condition="'$(TargetsDebian)' == 'true' or '$(TargetsUbuntu)' == 'true' or '$(TargetsLinuxMint)' == 'true' or '$(HostMachineRidTargetsDebianPackages)' == 'true'">.deb</InstallerExtension>
-    <InstallerExtension Condition="'$(TargetsRhel)' == 'true' or '$(TargetsCentos)' == 'true' or '$(TargetsOpensuse)' == 'true' or '$(TargetsFedora)' == 'true' or '$(TargetsOracle)' == 'true' or '$(TargetsSles)' == 'true' or '$(HostMachineRidTargetsRpmPackages)' == 'true'">.rpm</InstallerExtension>
+    <InstallerExtension Condition="$(OutputRid.StartsWith('debian')) or $(OutputRid.StartsWith('ubuntu')) or $(OutputRid.StartsWith('linuxmint')) or '$(HostMachineRidTargetsDebianPackages)' == 'true'">.deb</InstallerExtension>
+    <InstallerExtension Condition="$(OutputRid.StartsWith('rhel')) or $(OutputRid.StartsWith('centos')) or $(OutputRid.StartsWith('opensuse')) or $(OutputRid.StartsWith('fedora')) or $(OutputRid.StartsWith('oracle')) or $(OutputRid.StartsWith('sles')) or '$(HostMachineRidTargetsRpmPackages)' == 'true'">.rpm</InstallerExtension>
     <CombinedInstallerExtension Condition="'$(TargetOS)' == 'windows'">.exe</CombinedInstallerExtension>
     <CombinedInstallerExtension Condition="'$(TargetOS)' != 'windows'">$(InstallerExtension)</CombinedInstallerExtension>
   </PropertyGroup>
@@ -324,16 +148,6 @@
          want to ensure we use the correct packages.
     -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LibPrefix Condition="'$(TargetOS)' != 'windows'">lib</LibPrefix>
-    <LibSuffix>.so</LibSuffix>
-    <LibSuffix Condition="'$(TargetOS)' == 'windows'">.dll</LibSuffix>
-    <LibSuffix Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">.dylib</LibSuffix>
-    <StaticLibPrefix>lib</StaticLibPrefix>
-    <StaticLibSuffix>.a</StaticLibSuffix>
-    <StaticLibSuffix Condition="'$(TargetOS)' == 'windows'">.lib</StaticLibSuffix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -114,13 +114,6 @@
     <SharedFrameworkInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
   </PropertyGroup>
 
-  <!-- Use actual publishable (non-dummy) package name produced by the build system for this RID -->
-  <PropertyGroup Condition="'$(OutputRid)' != ''">
-    <PackageTargetRid>$(OutputRid)</PackageTargetRid>
-    <PackageTargetRid Condition="'$(OutputRid)' == 'osx.10.11-x64'">osx.10.10-x64</PackageTargetRid>
-    <PackageTargetRid Condition="$(OutputRid.StartsWith('rhel.7.')) and $(OutputRid.EndsWith('-x64'))">rhel.7-x64</PackageTargetRid>
-  </PropertyGroup>
-
   <PropertyGroup>
     <!-- Never use the NuGet fallback folder that comes with the SDK we use to build.
          The NuGet fallback folder can/will contain packages we are building in this repo, and we
@@ -128,12 +121,4 @@
     -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <CrossGenSymbolExtension>.map</CrossGenSymbolExtension>
-    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'windows'">.ni.pdb</CrossGenSymbolExtension>
-    <!-- OSX doesn't have crossgen symbols, yet -->
-    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'FreeBSD'"></CrossGenSymbolExtension>
-  </PropertyGroup>
-
 </Project>

--- a/src/installer/Directory.Build.targets
+++ b/src/installer/Directory.Build.targets
@@ -142,60 +142,6 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="GetInstallerLocations"
-          DependsOnTargets="GetProductVersions">
-    <PropertyGroup>
-      <CombinedInstallerFile>$(CombinedInstallerStart)$(ProductMoniker)$(CombinedInstallerExtension)</CombinedInstallerFile>
-      <CombinedInstallerEngine>$(CombinedInstallerStart)$(ProductMoniker)-engine.exe</CombinedInstallerEngine>
-
-      <SharedHostInstallerFile>$(SharedHostInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedHostInstallerFile>
-      <HostFxrInstallerFile>$(HostFxrInstallerStart)$(HostResolverVersionMoniker)$(InstallerExtension)</HostFxrInstallerFile>
-      <SharedFrameworkInstallerFile>$(SharedFrameworkInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedFrameworkInstallerFile>
-      <DotnetRuntimeDependenciesPackageInstallerFile>$(DotnetRuntimeDependenciesPackageInstallerStart)$(ProductMoniker)$(InstallerExtension)</DotnetRuntimeDependenciesPackageInstallerFile>
-
-      <CombinedCompressedFile>dotnet-runtime-$(ProductMoniker)$(CompressedFileExtension)</CombinedCompressedFile>
-      <HostFxrCompressedFile>dotnet-hostfxr-internal-$(PackageTargetRid).$(HostResolverVersion)$(CompressedFileExtension)</HostFxrCompressedFile>
-      <NetHostCompressedFile>dotnet-nethost-$(AppHostVersion)-$(PackageTargetRid)$(CompressedFileExtension)</NetHostCompressedFile>
-      <Crossgen2CompressedFile>dotnet-crossgen2-$(ProductMoniker)$(CompressedFileExtension)</Crossgen2CompressedFile>
-      <SharedFrameworkCompressedFile>dotnet-runtime-internal-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkCompressedFile>
-      <SharedFrameworkSymbolsCompressedFile>dotnet-runtime-symbols-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkSymbolsCompressedFile>
-
-      <HostFxrDebPkgName>$(DotnetHostFxrString)$(ProductBandVersion)</HostFxrDebPkgName>
-      <HostFxrDebPkgName>$(HostFxrDebPkgName.ToLower())</HostFxrDebPkgName>
-      <SharedFxDebPkgName>$(DotnetRuntimeString)$(ProductBandVersion)</SharedFxDebPkgName>
-      <SharedFxDebPkgName>$(SharedFxDebPkgName.ToLower())</SharedFxDebPkgName>
-      <RuntimeDependenciesDebPkgName>$(DotnetRuntimeDependenciesPackageString)$(ProductBandVersion)</RuntimeDependenciesDebPkgName>
-      <RuntimeDependenciesDebPkgName>$(RuntimeDependenciesDebPkgName.ToLower())</RuntimeDependenciesDebPkgName>
-
-      <HostFxrRpmPkgName>dotnet-hostfxr-$(ProductBandVersion)</HostFxrRpmPkgName>
-      <HostFxrRpmPkgName>$(HostFxrRpmPkgName.ToLower())</HostFxrRpmPkgName>
-      <SharedFxRpmPkgName>dotnet-runtime-$(ProductBandVersion)</SharedFxRpmPkgName>
-      <SharedFxRpmPkgName>$(SharedFxRpmPkgName.ToLower())</SharedFxRpmPkgName>
-      <RuntimeDependenciesRpmPkgName>$(DotnetRuntimeDependenciesPackageString)$(ProductBandVersion)</RuntimeDependenciesRpmPkgName>
-      <RuntimeDependenciesRpmPkgName>$(RuntimeDependenciesRpmPkgName.ToLower())</RuntimeDependenciesRpmPkgName>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <TargetingPackInstallerFile>$(AssetOutputPath)dotnet-targeting-pack-$(ProductMoniker)$(InstallerExtension)</TargetingPackInstallerFile>
-      <AppHostPackInstallerFile>$(AssetOutputPath)dotnet-apphost-pack-$(ProductMoniker)$(InstallerExtension)</AppHostPackInstallerFile>
-      <NetStandardProductBandVersion>2.1</NetStandardProductBandVersion>
-      <NetStandardProductMoniker>$(NetStandardProductBandVersion).$(PatchVersion)$(ProductVersionSuffix)-$(PackageTargetRid)</NetStandardProductMoniker>
-      <NetStandardTargetingPackInstallerFile>$(AssetOutputPath)netstandard-targeting-pack-$(NetStandardProductMoniker)$(InstallerExtension)</NetStandardTargetingPackInstallerFile>
-    </PropertyGroup>
-
-    <!-- Runtime Deb and Rpm packages are distro version agnostic -->
-    <PropertyGroup Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm'">
-      <SharedHostInstallerFile>$(SharedHostInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedHostInstallerFile>
-      <HostFxrInstallerFile>$(HostFxrInstallerStart)$(HostResolverVersion)-$(TargetArchitecture)$(InstallerExtension)</HostFxrInstallerFile>
-      <SharedFrameworkInstallerFile>$(SharedFrameworkInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedFrameworkInstallerFile>
-    </PropertyGroup>
-
-    <!-- Runtime-deps Deb package is distro version agnostic. -->
-    <PropertyGroup Condition="'$(InstallerExtension)' == '.deb'">
-      <DotnetRuntimeDependenciesPackageInstallerFile>$(DotnetRuntimeDependenciesPackageInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</DotnetRuntimeDependenciesPackageInstallerFile>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="GetLatestCommitHash"
           Condition="'$(LatestCommit)' == ''">
     <!-- Get the latest commit hash -->

--- a/src/installer/Directory.Build.targets
+++ b/src/installer/Directory.Build.targets
@@ -89,11 +89,6 @@
       <InstallersRelativePath>Runtime/$(SharedFrameworkNugetVersion)/</InstallersRelativePath>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(OutputRid)' != ''">
-      <ProductMoniker>$(SharedFrameworkNugetVersion)-$(PackageTargetRid)</ProductMoniker>
-      <HostResolverVersionMoniker>$(HostResolverVersion)-$(PackageTargetRid)</HostResolverVersionMoniker>
-    </PropertyGroup>
-
     <PropertyGroup>
       <HostPackageVersion>$(HostVersion)</HostPackageVersion>
       <HostPackageRelease>1</HostPackageRelease>

--- a/src/installer/pkg/projects/Directory.Build.props
+++ b/src/installer/pkg/projects/Directory.Build.props
@@ -157,6 +157,4 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
-
-  <Import Project="$(RepoRoot)eng\native\naming.props" />
 </Project>

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -133,8 +133,8 @@
     Finds symbol files and injects them into the package build.
   -->
   <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
-    <ItemGroup Condition="'$(SymbolFileExtension)' != ''">
-      <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolFileExtension)"/>
+    <ItemGroup Condition="'$(SymbolsSuffix)' != ''">
+      <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolsSuffix)"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -162,7 +162,7 @@
       <NonWindowsNativeFile Include="@(NativeWithSymbolFile)"
                             Exclude="@(WindowsNativeFile)" />
 
-      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
+      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolsSuffix)')" />
 
       <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />
       <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)') AND '$(SkipPackagingXplatSymbols)'!='true'" />

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -4,10 +4,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(DotNetHostBinDir)/apphost$(ApplicationFileExtension)" />
-    <NativeBinary Include="$(DotNetHostBinDir)/singlefilehost$(ApplicationFileExtension)" />
-    <NativeBinary Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)nethost$(LibraryFileExtension)" />
-    <NativeBinary Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)nethost$(StaticLibraryFileExtension)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/apphost$(ExeSuffix)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/singlefilehost$(ExeSuffix)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)nethost$(LibSuffix)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)nethost$(StaticLibSuffix)" />
     <NativeBinary Include="$(DotNetHostBinDir)/coreclr_delegates.h" />
     <NativeBinary Include="$(DotNetHostBinDir)/hostfxr.h" />
     <NativeBinary Include="$(DotNetHostBinDir)/nethost.h" />

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
-    <NativeBinary Include="$(DotNetHostBinDir)/dotnet$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/dotnet$(ExeSuffix)" />
     <File Include="@(NativeBinary)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsNative>true</IsNative>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
-    <NativeBinary Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostpolicy$(LibraryFileExtension)"/>
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)hostpolicy$(LibSuffix)"/>
     <File Include="@(NativeBinary)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsNative>true</IsNative>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
-    <NativeBinary Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostfxr$(LibraryFileExtension)"/>
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(LibSuffix)"/>
     <File Include="@(NativeBinary)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsNative>true</IsNative>

--- a/src/installer/pkg/sfx/Directory.Build.props
+++ b/src/installer/pkg/sfx/Directory.Build.props
@@ -20,6 +20,4 @@
     <GenerateInstallers>true</GenerateInstallers>
     <GenerateVSInsertionPackages>true</GenerateVSInsertionPackages>
   </PropertyGroup>
-
-  <Import Project="$(RepositoryEngineeringDir)native\naming.props" />
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -21,7 +21,7 @@
     <HostJsonTargetPath>tools/</HostJsonTargetPath>
     <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <TargetOSComponent>unix</TargetOSComponent>
     <TargetOSComponent Condition="'$(TargetOS)' == 'windows'">win</TargetOSComponent>
@@ -33,17 +33,17 @@
     <Reference Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
     <Reference Include="$(CoreCLRCrossgen2Dir)ILCompiler*.dll" />
     <Reference Include="$(CoreCLRCrossgen2Dir)Microsoft.DiaSymReader.dll" />
-    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)jitinterface_$(TargetArchitecture)$(LibraryFileExtension)" TargetPath="tools/" />
-    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_win_x86_$(TargetArchitecture)$(LibraryFileExtension)" TargetPath="tools/"  />
-    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_win_arm_$(TargetArchitecture)$(LibraryFileExtension)" TargetPath="tools/"  />
-    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_unix_arm_$(TargetArchitecture)$(LibraryFileExtension)" TargetPath="tools/"  />
-    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_win_x64_$(TargetArchitecture)$(LibraryFileExtension)"  TargetPath="tools/" />
-    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_win_arm64_$(TargetArchitecture)$(LibraryFileExtension)" TargetPath="tools/"  />
-    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_unix_x64_$(TargetArchitecture)$(LibraryFileExtension)" TargetPath="tools/" />
-    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit_unix_arm64_$(TargetArchitecture)$(LibraryFileExtension)" TargetPath="tools/"  />
+    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)jitinterface_$(TargetArchitecture)$(LibSuffix)" TargetPath="tools/" />
+    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)clrjit_win_x86_$(TargetArchitecture)$(LibSuffix)" TargetPath="tools/"  />
+    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)clrjit_win_arm_$(TargetArchitecture)$(LibSuffix)" TargetPath="tools/"  />
+    <NativeRuntimeAsset Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)clrjit_unix_arm_$(TargetArchitecture)$(LibSuffix)" TargetPath="tools/"  />
+    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)clrjit_win_x64_$(TargetArchitecture)$(LibSuffix)"  TargetPath="tools/" />
+    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)clrjit_win_arm64_$(TargetArchitecture)$(LibSuffix)" TargetPath="tools/"  />
+    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)clrjit_unix_x64_$(TargetArchitecture)$(LibSuffix)" TargetPath="tools/" />
+    <NativeRuntimeAsset Condition="'$(TargetArchitecture)' == 'arm64' or  '$(TargetArchitecture)' == 'x64'" Include="$(CoreCLRCrossgen2Dir)$(LibPrefix)clrjit_unix_arm64_$(TargetArchitecture)$(LibSuffix)" TargetPath="tools/"  />
     <!-- Include the native hosting layer  -->
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostfxr$(LibraryFileExtension)" TargetPath="tools/" />
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostpolicy$(LibraryFileExtension)" TargetPath="tools/" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(LibSuffix)" TargetPath="tools/" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostpolicy$(LibSuffix)" TargetPath="tools/" />
   </ItemGroup>
 
   <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
@@ -75,10 +75,10 @@
 
   <Target Name="ResolveReadyToRunCompilers" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
     <ItemGroup Condition="'$(RuntimeFlavor)' != 'Mono'">
-      <_crossTargetJit Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == '$(LibraryFilePrefix)clrjit' and '%(Extension)' == '$(LibraryFileExtension)'" />
-      <_clrjit Include="@(RuntimeFiles)" Condition="'%(FileName)' == '$(LibraryFilePrefix)clrjit' and '%(Extension)' == '$(LibraryFileExtension)'" />
-      <_crossTargetCrossgen Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ApplicationFileExtension)'" />
-      <_crossgen Include="@(RuntimeFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ApplicationFileExtension)'" />
+      <_crossTargetJit Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == '$(LibPrefix)clrjit' and '%(Extension)' == '$(LibSuffix)'" />
+      <_clrjit Include="@(RuntimeFiles)" Condition="'%(FileName)' == '$(LibPrefix)clrjit' and '%(Extension)' == '$(LibSuffix)'" />
+      <_crossTargetCrossgen Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ExeSuffix)'" />
+      <_crossgen Include="@(RuntimeFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ExeSuffix)'" />
     </ItemGroup>
     <ItemGroup Condition="'@(_crossTargetJit)' != '' and '@(_crossTargetCrossgen)' != ''">
       <CrossgenTool Include="@(_crossTargetCrossgen->ClearMetadata())"

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/apphost$(ApplicationFileExtension)" />
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/singlefilehost$(ApplicationFileExtension)" />
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)nethost$(LibraryFileExtension)" />
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)nethost$(StaticLibraryFileExtension)" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/apphost$(ExeSuffix)" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/singlefilehost$(ExeSuffix)" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)nethost$(LibSuffix)" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)nethost$(StaticLibSuffix)" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/nethost.h" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/hostfxr.h" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/coreclr_delegates.h" />
@@ -40,7 +40,7 @@
                     IsSymbolFile="true"
                     IsNative="true" />
     <_SymbolFiles Condition="'$(TargetOS)' != 'windows'"
-                    Include="@(NativeRuntimeAsset->'%(RootDir)%(Directory)PDB/%(Filename)%(Extension)%(SymbolFileExtension)')"
+                    Include="@(NativeRuntimeAsset->'%(RootDir)%(Directory)PDB/%(Filename)%(Extension)%(SymbolsSuffix)')"
                     IsSymbolFile="true"
                     IsNative="true" />
   </ItemGroup>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
@@ -44,8 +44,8 @@
 
   <!-- Mobile uses a different hosting model, so we don't include the .NET host components. -->
   <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostpolicy$(LibraryFileExtension)" />
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostfxr$(LibraryFileExtension)" PackOnly="true" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostpolicy$(LibSuffix)" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(LibSuffix)" PackOnly="true" />
   </ItemGroup>
 
   <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
@@ -108,10 +108,10 @@
 
   <Target Name="ResolveReadyToRunCompilers" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
     <ItemGroup Condition="'$(RuntimeFlavor)' != 'Mono'">
-      <_crossTargetJit Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == '$(LibraryFilePrefix)clrjit' and '%(Extension)' == '$(LibraryFileExtension)'" />
-      <_clrjit Include="@(RuntimeFiles)" Condition="'%(FileName)' == '$(LibraryFilePrefix)clrjit' and '%(Extension)' == '$(LibraryFileExtension)'" />
-      <_crossTargetCrossgen Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ApplicationFileExtension)'" />
-      <_crossgen Include="@(RuntimeFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ApplicationFileExtension)'" />
+      <_crossTargetJit Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == '$(LibPrefix)clrjit' and '%(Extension)' == '$(LibSuffix)'" />
+      <_clrjit Include="@(RuntimeFiles)" Condition="'%(FileName)' == '$(LibPrefix)clrjit' and '%(Extension)' == '$(LibSuffix)'" />
+      <_crossTargetCrossgen Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ExeSuffix)'" />
+      <_crossgen Include="@(RuntimeFiles)" Condition="'%(FileName)' == 'crossgen' and '%(Extension)' == '$(ExeSuffix)'" />
     </ItemGroup>
     <ItemGroup Condition="'@(_crossTargetJit)' != '' and '@(_crossTargetCrossgen)' != ''">
       <CrossgenTool Include="@(_crossTargetCrossgen->ClearMetadata())"

--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -33,8 +33,8 @@
     <Error Condition="'$(OutputPath)' == ''" Text="Publishing to disk requires the OutputPath to be set to the root of the path to write to." />
 
     <ItemGroup>
-      <FilesToPublish Include="$(DotNetHostBinDir)\dotnet$(ApplicationFileExtension)"
-            Destination="$(OutputPath)dotnet$(ApplicationFileExtension)" />
+      <FilesToPublish Include="$(DotNetHostBinDir)\dotnet$(ExeSuffix)"
+            Destination="$(OutputPath)dotnet$(ExeSuffix)" />
       <FilesToPublish Include="$(InstallerProjectRoot)pkg\THIRD-PARTY-NOTICES.TXT"
             Destination="$(OutputPath)ThirdPartyNotices.txt" />
       <FilesToPublish Include="$(RepoRoot)LICENSE.TXT"

--- a/src/installer/pkg/sfx/installers/dotnet-hostfxr.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-hostfxr.proj
@@ -29,7 +29,7 @@
   <Target Name="PublishToDisk">
     <Error Condition="'$(OutputPath)' == ''" Text="Publishing to disk requires the OutputPath to be set to the root of the path to write to." />
 
-    <Copy SourceFiles="$(DotNetHostBinDir)\$(LibraryFilePrefix)hostfxr$(LibraryFileExtension)"
+    <Copy SourceFiles="$(DotNetHostBinDir)\$(LibPrefix)hostfxr$(LibSuffix)"
           DestinationFolder="$(OutputPath)/host/fxr/$(Version)" />
   </Target>
 

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -106,7 +106,7 @@
 
   <Target Name="DetermineTestOutputDirectory">
     <PropertyGroup>
-      <TestTargetRid Condition="'$(TestTargetRid)' == ''">$(HostRuntimeIdentifier)</TestTargetRid>
+      <TestTargetRid Condition="'$(TestTargetRid)' == ''">$(PackageRID)</TestTargetRid>
       <TestsOutputName Condition="'$(TestsOutputName)' == ''">$(MSBuildProjectName)</TestsOutputName>
 
       <TestsOutputRootDir Condition="'$(TestsOutputRootDir)' == ''">$(ArtifactsDir)tests/$(Configuration)/</TestsOutputRootDir>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project TreatAsLocalProperty="TargetOS">
   <PropertyGroup>
     <SkipImportArcadeSdkFromRoot>true</SkipImportArcadeSdkFromRoot>
+    <SkipInferTargetOSName>true</SkipInferTargetOSName>
   </PropertyGroup>
   <Import Project="..\..\Directory.Build.props" />
   <Import Project="NetCoreAppLibrary.props" />
@@ -19,24 +20,9 @@
     <GeneratePlatformNotSupportedAssemblyHeaderFile>$(RepositoryEngineeringDir)LicenseHeader.txt</GeneratePlatformNotSupportedAssemblyHeaderFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <RuntimeOS Condition="'$(RuntimeOS)' == '' and '$(HostRuntimeIdentifier)' != ''">$(HostRuntimeIdentifier.Remove($(HostRuntimeIdentifier.LastIndexOf('-'))))</RuntimeOS>
-  </PropertyGroup>
-
   <Import Sdk="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
-    <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</HostArch>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(HostArch)' == 'arm'">arm</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(HostArch)' == 'arm64'">arm64</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(TargetOS)' == 'Browser'">wasm</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(TargetsMobile)' == 'true'">x64</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
-
-    <!-- RuntimeOS is calculated based on the build system OS, however if building for Browser/iOS/Android we need to let
-         the build system to use browser/ios/android as the RuntimeOS for produced package RIDs. -->
-    <RuntimeOS Condition="'$(TargetsMobile)' == 'true'">$(TargetOS.ToLowerInvariant())</RuntimeOS>
-
     <!-- Initialize BuildSettings from the individual properties. -->
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <BuildTargetFramework Condition="'$(BuildTargetFramework)' == '' and '$(TargetFramework)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '(-[^;]+)', ''))</BuildTargetFramework>
@@ -92,57 +78,6 @@
     <!-- Projects which are manually built. -->
     <ProjectExclusions Include="$(CommonTestPath)System\Net\Prerequisites\**\*.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
-    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
-    <_portableOS>linux</_portableOS>
-    <_portableOS Condition="'$(RuntimeOS)' == 'linux-musl'">linux-musl</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'win' or '$(TargetOS)' == 'windows'">win</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'osx'">osx</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'FreeBSD'">freebsd</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'illumos'">illumos</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'Solaris'">solaris</_portableOS>
-    <_portableOS Condition="'$(RuntimeOS)' == 'Browser'">browser</_portableOS>
-    <_portableOS Condition="'$(RuntimeOS)' == 'ios'">ios</_portableOS>
-    <_portableOS Condition="'$(RuntimeOS)' == 'tvos'">tvos</_portableOS>
-    <_portableOS Condition="'$(RuntimeOS)' == 'android'">android</_portableOS>
-
-    <_runtimeOS>$(RuntimeOS)</_runtimeOS>
-    <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.4.0.0'">linux</_runtimeOS>
-    <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.5.0.0'">linux</_runtimeOS>
-    <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
-    <ToolRuntimeRID Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(_runtimeOS)-x64</ToolRuntimeRID>
-    <ToolRuntimeRID Condition="'$(ToolRuntimeRID)' == ''">$(_runtimeOS)-$(HostArch)</ToolRuntimeRID>
-    <!-- We build linux-musl-arm on a ubuntu container, so we can't use the toolset build for alpine runtime. We need to use portable linux RID for our toolset in order to be able to use it. -->
-    <ToolRuntimeRID Condition="'$(_runtimeOS)' == 'linux-musl' and $(TargetArchitecture.StartsWith('arm')) and !$(HostArch.StartsWith('arm'))">linux-x64</ToolRuntimeRID>
-
-    <!-- There are no WebAssembly tools, so use the default ones -->
-    <_buildingInOSX>$([MSBuild]::IsOSPlatform('OSX'))</_buildingInOSX>
-    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'browser' and '$(TargetOS)' == 'windows'">win-x64</ToolRuntimeRID>
-    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'browser' and '$(TargetOS)' != 'windows' and $(_buildingInOSX)">osx-x64</ToolRuntimeRID>
-    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'browser' and '$(TargetOS)' != 'windows' and !$(_buildingInOSX)">linux-x64</ToolRuntimeRID>
-
-    <!-- There are no Android tools, so use the default ones -->
-    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'android' and '$(TargetOS)' == 'windows'">win-x64</ToolRuntimeRID>
-    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'android' and '$(TargetOS)' != 'windows' and $(_buildingInOSX)">osx-x64</ToolRuntimeRID>
-    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'android' and '$(TargetOS)' != 'windows' and !$(_buildingInOSX)">linux-x64</ToolRuntimeRID>
-
-    <!-- There are no iOS or tvOS tools and it can be built on OSX only, so use that -->
-    <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'ios' or '$(RuntimeOS)' == 'tvos'">osx-x64</ToolRuntimeRID>
-    <MicrosoftNetCoreIlasmPackageRuntimeId>$(ToolRuntimeRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
-
-    <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->
-    <_portableOS Condition="'$(TargetOS)' == 'Unix' and '$(_runtimeOSFamily)' != 'osx' and '$(_runtimeOSFamily)' != 'FreeBSD' and '$(_runtimeOS)' != 'linux-musl' and '$(_runtimeOSFamily)' != 'illumos' and '$(_runtimeOSFamily)' != 'Solaris'">linux</_portableOS>
-
-    <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->
-    <_portableOS Condition="'$(TargetOS)' == 'Unix' and '$(_runtimeOSFamily)' != 'osx' and '$(_runtimeOSFamily)' != 'FreeBSD' and '$(_runtimeOS)' != 'linux-musl' and '$(_runtimeOSFamily)' != 'illumos' and '$(_runtimeOSFamily)' != 'Solaris'">linux</_portableOS>
-
-    <_packageRID />
-    <_packageRID Condition="'$(PortableBuild)' == 'true'">$(_portableOS)-$(TargetArchitecture)</_packageRID>
-    <PackageRID Condition="'$(PackageRID)' == ''">$(_packageRID)</PackageRID>
-    <PackageRID Condition="'$(PackageRID)' == ''">$(RuntimeOS)-$(TargetArchitecture)</PackageRID>
-  </PropertyGroup>
 
   <PropertyGroup>
     <BuildingNETCoreAppVertical Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -30,7 +30,7 @@
     <PropertyGroup>
       <UseHardlink>true</UseHardlink>
       <!-- workaround core-setup problem for hardlinking dotnet executable to testhost: core-setup #4742 -->
-      <UseHardlink Condition="'$(_runtimeOSFamily)' == 'FreeBSD'">false</UseHardlink>
+      <UseHardlink Condition="$(PackageRID.StartsWith('freebsd'))">false</UseHardlink>
     </PropertyGroup>
 
     <!-- We do not need apphost.exe.

--- a/src/libraries/pkg/Directory.Build.props
+++ b/src/libraries/pkg/Directory.Build.props
@@ -44,6 +44,4 @@
     <SuppressFinalPackageVersion Condition="'$(SuppressFinalPackageVersion)' == '' and $(MSBuildProjectName.Contains('Private'))">true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
-  <Import Project="$(RepoRoot)eng\native\naming.props" />
-
 </Project>

--- a/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
+++ b/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
@@ -5,7 +5,7 @@
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   <ItemGroup Condition="'$(PackageTargetRuntime)' == 'linux-arm' or '$(PackageTargetRuntime)' == 'linux-arm64' or '$(PackageTargetRuntime)' == 'linux-x64' or '$(PackageTargetRuntime)' == 'osx-x64' or '$(PackageTargetRuntime)' == 'freebsd-x64'">
-    <File Include="$(NativeBinDir)$(LibraryFilePrefix)System.IO.Ports.Native$(LibraryFileExtension)" >
+    <File Include="$(NativeBinDir)$(LibPrefix)System.IO.Ports.Native$(LibSuffix)" >
       <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
     </File>
   </ItemGroup>

--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -31,24 +31,6 @@
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
   </PropertyGroup>
 
-  <!-- Set up common target properties that we use to conditionally include sources -->
-  <PropertyGroup>
-    <TargetsFreeBSD Condition="'$(TargetOS)' == 'FreeBSD'">true</TargetsFreeBSD>
-    <Targetsillumos Condition="'$(TargetOS)' == 'illumos'">true</Targetsillumos>
-    <TargetsSolaris Condition="'$(TargetOS)' == 'Solaris'">true</TargetsSolaris>
-    <TargetsLinux Condition="'$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'Android'">true</TargetsLinux>
-    <TargetsNetBSD Condition="'$(TargetOS)' == 'NetBSD'">true</TargetsNetBSD>
-    <TargetsOSX Condition="'$(TargetOS)' == 'OSX'">true</TargetsOSX>
-    <TargetsiOS Condition="'$(TargetOS)' == 'iOS'">true</TargetsiOS>
-    <TargetstvOS Condition="'$(TargetOS)' == 'tvOS'">true</TargetstvOS>
-    <TargetsiOSSimulator Condition="'$(TargetsiOS)' == 'true' and ('$(Platform)' == 'x64' or '$(Platform)' == 'x86')">true</TargetsiOSSimulator>
-    <TargetstvOSSimulator Condition="'$(TargetstvOS)' == 'true' and '$(Platform)' == 'x64'">true</TargetstvOSSimulator>
-    <TargetsAndroid Condition="'$(TargetOS)' == 'Android'">true</TargetsAndroid>
-    <TargetsBrowser Condition="'$(TargetOS)' == 'Browser'">true</TargetsBrowser>
-    <TargetsWindows Condition="'$(TargetOS)' == 'windows'">true</TargetsWindows>
-    <TargetsUnix Condition="'$(TargetsFreeBSD)' == 'true' or '$(Targetsillumos)' == 'true' or '$(TargetsSolaris)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsNetBSD)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetsAndroid)' == 'true'">true</TargetsUnix>
-  </PropertyGroup>
-
   <PropertyGroup>
     <!-- Minimum target OS version, keep in sync with src/libraries/Native/build-native.sh -->
     <iOSVersionMin>8.0</iOSVersionMin>

--- a/src/tests/Common/ilasm/ilasm.ilproj
+++ b/src/tests/Common/ilasm/ilasm.ilproj
@@ -4,6 +4,6 @@
        needed by the IL SDK. -->
 
   <PropertyGroup>
-    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/src/tests/Common/publishdependency.targets
+++ b/src/tests/Common/publishdependency.targets
@@ -28,7 +28,7 @@
   <Target Name="CopyDependencyToCoreRoot">
     <MSBuild Projects="@(CoreRootProjectFiles)"
              Targets="CopyDependencyToCoreRoot"
-             Properties="Language=C#;RuntimeIdentifier=$(TargetRid)" />
+             Properties="Language=C#;RuntimeIdentifier=$(PackageRID)" />
 
   </Target>
 </Project>

--- a/src/tests/Common/test_dependencies/test_dependencies.csproj
+++ b/src/tests/Common/test_dependencies/test_dependencies.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <DisableRarCache>true</DisableRarCache>
     <DisablePackageAssetsCache>true</DisablePackageAssetsCache>
-    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(PackageRID)</RuntimeIdentifiers>
     <IncludeOOBLibraries>true</IncludeOOBLibraries>
     <LibrariesConfiguration>Release</LibrariesConfiguration>
   </PropertyGroup>

--- a/src/tests/Common/test_dependencies_fs/test_dependencies.fsproj
+++ b/src/tests/Common/test_dependencies_fs/test_dependencies.fsproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <DisableRarCache>true</DisableRarCache>
     <DisablePackageAssetsCache>true</DisablePackageAssetsCache>
-    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(PackageRID)</RuntimeIdentifiers>
     <IncludeOOBLibraries>true</IncludeOOBLibraries>
     <LibrariesConfiguration>Release</LibrariesConfiguration>
   </PropertyGroup>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -106,85 +106,11 @@
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
-  <!-- Setup properties per TargetOS -->
-  <Choose>
-    <When Condition="'$(TargetOS)'=='AnyOS'">
-      <PropertyGroup>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetOS)'=='windows'">
-      <PropertyGroup>
-        <!-- Since cross compilation of test builds on Windows is possible, the
-             TargetsWindows property may already be set. Only set the property if
-             it is not already defined -->
-        <TargetsWindows Condition="'$(TargetsWindows)' == ''" >true</TargetsWindows>
-        <TestNugetRuntimeId>win-$(TargetArchitecture)</TestNugetRuntimeId>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetOS)'=='Linux'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsLinux>true</TargetsLinux>
-        <TestNugetRuntimeId>ubuntu.14.04-$(TargetArchitecture)</TestNugetRuntimeId>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetOS)'=='OSX'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsOSX>true</TargetsOSX>
-        <TestNugetRuntimeId>osx.10.12-$(TargetArchitecture)</TestNugetRuntimeId>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetOS)'=='FreeBSD'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsFreeBSD>true</TargetsFreeBSD>
-        <TestNugetRuntimeId>ubuntu.14.04-$(TargetArchitecture)</TestNugetRuntimeId>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetOS)'=='NetBSD'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsNetBSD>true</TargetsNetBSD>
-        <TestNugetRuntimeId>ubuntu.14.04-$(TargetArchitecture)</TestNugetRuntimeId>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetOS)'=='illumos'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <Targetsillumos>true</Targetsillumos>
-        <TestNugetRuntimeId>ubuntu.14.04-$(TargetArchitecture)</TestNugetRuntimeId>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetOS)'=='Solaris'">
-      <PropertyGroup>
-        <TargetsUnix>true</TargetsUnix>
-        <TargetsSolaris>true</TargetsSolaris>
-        <TestNugetRuntimeId>ubuntu.14.04-$(TargetArchitecture)</TestNugetRuntimeId>
-      </PropertyGroup>
-    </When>
-  </Choose>
-
   <!-- Set arch specific properties -->
   <PropertyGroup>
     <TargetBits>32</TargetBits>
     <TargetBits Condition="'$(TargetArchitecture)'=='x64'">64</TargetBits>
     <TargetBits Condition="'$(TargetArchitecture)'=='arm64'">64</TargetBits>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TargetRid>$(__RuntimeId)</TargetRid>
-    <TargetRid Condition="'$(TargetRid)' == ''">$(TestNugetRuntimeId)</TargetRid>
-  </PropertyGroup>
-
-  <!-- The IL SDK adds a packagereference to the native ilasm package,
-       but does not detect musl or rhel, so we set the RID
-       ourselves. If we passed in a proper host RID from the build
-       scripts, we could also use that instead of relying on the IL
-       SDK RID detection. -->
-  <PropertyGroup>
-    <MicrosoftNetCoreIlasmPackageRuntimeId Condition=" '$(TargetRid)' == 'linux-musl-x64' ">$(TargetRid)</MicrosoftNetCoreIlasmPackageRuntimeId>
-    <MicrosoftNetCoreIlasmPackageRuntimeId Condition=" '$(TargetRid)' == 'rhel.6-x64' ">$(TargetRid)</MicrosoftNetCoreIlasmPackageRuntimeId>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -52,7 +52,6 @@ set __SkipManaged=
 set __SkipTestWrappers=
 set __BuildTestWrappersOnly=
 set __SkipNative=
-set __RuntimeId=
 set __TargetsWindows=1
 set __DoCrossgen=
 set __DoCrossgen2=
@@ -109,7 +108,6 @@ if /i "%1" == "buildagainstpackages"  (echo error: Remove /BuildAgainstPackages 
 if /i "%1" == "crossgen"              (set __DoCrossgen=1&set __TestBuildMode=crossgen&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen2"             (set __DoCrossgen2=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "composite"             (set __CompositeBuildMode=1&set __DoCrossgen2=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "-priority"             (set __Priority=%2&shift&set processedArgs=!processedArgs! %1=%2&shift&goto Arg_Loop)
@@ -426,11 +424,6 @@ REM ============================================================================
 
 echo %__MsgPrefix%Creating test overlay
 
-set RuntimeIdArg=
-if defined __RuntimeId (
-    set RuntimeIdArg=/p:RuntimeId="%__RuntimeId%"
-)
-
 set __BuildLogRootName=Tests_Overlay_Managed
 set __BuildLog=%__LogsDir%\%__BuildLogRootName%_%__TargetOS%__%__BuildArch%__%__BuildType%.log
 set __BuildWrn=%__LogsDir%\%__BuildLogRootName%_%__TargetOS%__%__BuildArch%__%__BuildType%.wrn
@@ -445,7 +438,7 @@ powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   %__SkipFXRestoreArg%^
-  !__Logging! %__CommonMSBuildArgs% %RuntimeIdArg% %__PriorityArg% %__BuildNeedTargetArg% %__UnprocessedBuildArgs%
+  !__Logging! %__CommonMSBuildArgs% %__PriorityArg% %__BuildNeedTargetArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo %__ErrMsgPrefix%%__MsgPrefix%Error: Create Test Overlay failed. Refer to the build log files for details:
     echo     %__BuildLog%
@@ -560,7 +553,6 @@ echo Build type: one of Debug, Checked, Release ^(default: Debug^).
 echo skipmanaged: skip the managed tests build
 echo skipnative: skip the native tests build
 echo skiprestorepackages: skip package restore
-echo runtimeid ^<ID^>: Builds a test overlay for the specified OS ^(Only supported when building against packages^). Supported IDs are:
 echo     alpine.3.4.3-x64: Builds overlay for Alpine 3.4.3
 echo     debian.8-x64: Builds overlay for Debian 8
 echo     fedora.24-x64: Builds overlay for Fedora 24

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -553,19 +553,6 @@ echo Build type: one of Debug, Checked, Release ^(default: Debug^).
 echo skipmanaged: skip the managed tests build
 echo skipnative: skip the native tests build
 echo skiprestorepackages: skip package restore
-echo     alpine.3.4.3-x64: Builds overlay for Alpine 3.4.3
-echo     debian.8-x64: Builds overlay for Debian 8
-echo     fedora.24-x64: Builds overlay for Fedora 24
-echo     linux-x64: Builds overlay for portable linux
-echo     opensuse.42.1-x64: Builds overlay for OpenSUSE 42.1
-echo     osx.10.12-x64: Builds overlay for OSX 10.12
-echo     osx-x64: Builds overlay for portable OSX
-echo     rhel.7-x64: Builds overlay for RHEL 7 or CentOS
-echo     ubuntu.14.04-x64: Builds overlay for Ubuntu 14.04
-echo     ubuntu.16.04-x64: Builds overlay for Ubuntu 16.04
-echo     ubuntu.16.10-x64: Builds overlay for Ubuntu 16.10
-echo     win-x64: Builds overlay for portable Windows
-echo     win7-x64: Builds overlay for Windows 7
 echo crossgen: Precompiles the framework managed assemblies
 echo copynativeonly: Only copy the native test binaries to the managed output. Do not build the native or managed tests.
 echo skipgeneratelayout: Do not generate the Core_Root layout

--- a/src/tests/run.proj
+++ b/src/tests/run.proj
@@ -445,22 +445,22 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
       <RuntimePackNativeLibs Include="$(MicrosoftNetCoreAppRuntimePackDir)/**/*.dll;$(MicrosoftNetCoreAppRuntimePackDir)native/**/*.a;$(MicrosoftNetCoreAppRuntimePackDir)native/**/*.so" />
     </ItemGroup>
 
-    <Copy 
+    <Copy
         SourceFiles="@(TestAssemblies)"
         DestinationFolder="$(BuildDir)" />
 
-    <Copy 
+    <Copy
         SourceFiles="@(AssembliesInTestDirs)"
         DestinationFolder="$(BuildDir)" />
 
-    <Copy 
+    <Copy
         SourceFiles="@(RuntimePackNativeLibs)"
         DestinationFolder="$(BuildDir)" />
 
-    <Copy 
+    <Copy
         SourceFiles="@(RuntimePackLibs)"
         DestinationFolder="$(BuildDir)" />
-    
+
     <!-- TEMP: consume OpenSSL binaries from external sources via env. variables.-->
     <Copy Condition="'$(ANDROID_OPENSSL_AAR)' != ''"
           SourceFiles="$(ANDROID_OPENSSL_AAR)\prefab\modules\crypto\libs\android.$(AndroidAbi)\libcrypto.so"
@@ -505,7 +505,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
   <Target Name="CreateTestOverlay">
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CopyDependencyToCoreRoot"
-             Properties="Language=C#;TargetRid=$(TargetRid);RuntimeIdentifier=$(TargetRid)" />
+             Properties="Language=C#;PackageRID=$(PackageRID);RuntimeIdentifier=$(PackageRID)" />
   </Target>
 
   <Target Name="Build">


### PR DESCRIPTION
* Use short variable names for native files naming convention, that are
  used by `framework.sharedfx.targets` in arcade, and cleanup
  redefinitions from crossgen2 and installer. e.g. `ExeSuffix` instead
  of `ApplicationFileExtension`, `LibSuffix` instead of
  `LibraryFileExtension` and so on.
* Calculate `TargetArchitecture`, `NonPortableRuntimeOS` (for
  `PortableBuild`) and `PackageRID` values once for the entire
  livebuild, inside `eng/Configurations.props`. This implementation is
  a union of three varied implementations that are being deleted.
* Import `names.props` once in `eng/Configurations.props` based on
  calculated `PackageRID` and cleanup imports of this file from various
  places.
* Combine OS targets definition in MSBuild scripts.