### PR TITLE
Fix List Separator on Windows

### DIFF
--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -126,6 +126,14 @@ namespace System.Globalization.Tests
             Assert.NotEqual(string.Empty, new CultureInfo("en-US").TextInfo.ListSeparator);
         }
 
+        // On Linux when using ICU, we fallback to use Thousands Separator which can return empty string for cultures like fr-FR
+        // We should return more better values on Windows even if we are using ICU as we fallback to NLS for the list separator.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        public void ListSeparator_FrFr()
+        {
+            Assert.NotEqual(string.Empty, new CultureInfo("fr-FR").TextInfo.ListSeparator);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData(" ")]

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2286,7 +2286,8 @@ namespace System.Globalization
             if (GlobalizationMode.Invariant)
                 return null!;
 
-            return ShouldUseUserOverrideNlsData ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
+            // For ListSeparator on Windows, we don't call ICU as we fallback there to the thousands separator and getting the value from NLS would better here.
+            return ShouldUseUserOverrideNlsData || (type == LocaleStringData.ListSeparator && IsWin32Installed) ? NlsGetLocaleInfo(type) : IcuGetLocaleInfo(type);
         }
 
         private string GetLocaleInfoCore(LocaleStringData type)


### PR DESCRIPTION
When using ICU and requesting `TextInfo.ListSeparator`, we don't have exact equivalent property in ICU that match the list separator and we fallback to decimal separator. The issue for some cultures, it returns empty string. We'll look more into enhancing this experience. The change here is to fix that when running on Windows by falling back to NLS.