### PR TITLE
Set number handling for properties read after deserializing ctor params

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -56,6 +56,7 @@ namespace System.Text.Json.Serialization.Converters
 
                         state.Current.JsonPropertyName = propertyNameArray;
                         state.Current.JsonPropertyInfo = jsonPropertyInfo;
+                        state.Current.NumberHandling = jsonPropertyInfo.NumberHandling;
 
                         bool useExtensionProperty = dataExtKey != null;
 

--- a/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
@@ -7,9 +7,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json.Tests;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -1618,6 +1620,109 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Contains("handling", ex.ToString());
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => new JsonNumberHandlingAttribute((JsonNumberHandling)(8)));
+        }
+
+
+
+        [Theory]
+        [MemberData(nameof(NumberHandling_ForPropsReadAfter_DeserializingCtorParams_TestData))]
+        public static async Task NumberHandling_ForPropsReadAfter_DeserializingCtorParams(string json)
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                NumberHandling = JsonNumberHandling.AllowReadingFromString |JsonNumberHandling.WriteAsString,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            Result result = JsonSerializer.Deserialize<Result>(json, options);
+            JsonTestHelper.AssertJsonEqual(json, JsonSerializer.Serialize(result, options));
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            {
+                result = await JsonSerializer.DeserializeAsync<Result>(stream, options);
+                JsonTestHelper.AssertJsonEqual(json, JsonSerializer.Serialize(result, options));
+            }
+        }
+
+        private static IEnumerable<object[]> NumberHandling_ForPropsReadAfter_DeserializingCtorParams_TestData()
+        {
+            yield return new object[]
+            {
+                @"{
+                    ""album"": {
+                        ""userPlayCount"": ""123"",
+                        ""name"": ""the name of the album"",
+                        ""artist"": ""the name of the artist"",
+                        ""wiki"": {
+                            ""summary"": ""a summary of the album""
+                        }
+                    }
+                }"
+            };
+
+            yield return new object[]
+            {
+                @"{
+                    ""album"": {
+                        ""name"": ""the name of the album"",
+                        ""userPlayCount"": ""123"",
+                        ""artist"": ""the name of the artist"",
+                        ""wiki"": {
+                            ""summary"": ""a summary of the album""
+                        }
+                    }
+                }"
+            };
+
+            yield return new object[]
+            {
+                @"{
+                    ""album"": {
+                        ""name"": ""the name of the album"",
+                        ""artist"": ""the name of the artist"",
+                        ""userPlayCount"": ""123"",
+                        ""wiki"": {
+                            ""summary"": ""a summary of the album""
+                        }
+                    }
+                }"
+            };
+
+            yield return new object[]
+            {
+                @"{
+                    ""album"": {
+                        ""name"": ""the name of the album"",
+                        ""artist"": ""the name of the artist"",
+                        ""wiki"": {
+                            ""summary"": ""a summary of the album""
+                        },
+                        ""userPlayCount"": ""123""
+                    }
+                }"
+            };
+        }
+
+        public class Result
+        {
+            public Album Album { get; init; }
+        }
+
+        public class Album
+        {
+            public Album(string name, string artist)
+            {
+                Name = name;
+                Artist = artist;
+            }
+
+            public string Name { get; init; }
+            public string Artist { get; init; }
+
+            public long? userPlayCount { get; init; }
+
+            [JsonExtensionData]
+            public Dictionary<string, JsonElement> ExtensionData { get; set; }
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
@@ -1621,27 +1621,39 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => new JsonNumberHandlingAttribute((JsonNumberHandling)(8)));
         }
+    }
 
+    public class NumberHandlingTests_StreamOverload : NumberHandlingTests_OverloadSpecific
+    {
+        public NumberHandlingTests_StreamOverload() : base(DeserializationWrapper.StreamDeserializer) { }
+    }
 
+    public class NumberHandlingTests_SyncOverload : NumberHandlingTests_OverloadSpecific
+    {
+        public NumberHandlingTests_SyncOverload() : base(DeserializationWrapper.StringDeserializer) { }
+    }
+
+    public abstract class NumberHandlingTests_OverloadSpecific
+    {
+        private DeserializationWrapper Deserializer { get; }
+
+        public NumberHandlingTests_OverloadSpecific(DeserializationWrapper deserializer)
+        {
+            Deserializer = deserializer;
+        }
 
         [Theory]
         [MemberData(nameof(NumberHandling_ForPropsReadAfter_DeserializingCtorParams_TestData))]
-        public static async Task NumberHandling_ForPropsReadAfter_DeserializingCtorParams(string json)
+        public async Task NumberHandling_ForPropsReadAfter_DeserializingCtorParams(string json)
         {
             JsonSerializerOptions options = new JsonSerializerOptions
             {
-                NumberHandling = JsonNumberHandling.AllowReadingFromString |JsonNumberHandling.WriteAsString,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 
-            Result result = JsonSerializer.Deserialize<Result>(json, options);
+            Result result = await Deserializer.DeserializeWrapper<Result>(json, options);
             JsonTestHelper.AssertJsonEqual(json, JsonSerializer.Serialize(result, options));
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
-            {
-                result = await JsonSerializer.DeserializeAsync<Result>(stream, options);
-                JsonTestHelper.AssertJsonEqual(json, JsonSerializer.Serialize(result, options));
-            }
         }
 
         private static IEnumerable<object[]> NumberHandling_ForPropsReadAfter_DeserializingCtorParams_TestData()


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/43587.