### PR TITLE
[Portable thread pool] Don't spin-wait on semaphore when hill climbing stops a thread from processing work

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
@@ -36,11 +36,11 @@ namespace System.Threading
             Create(maximumSignalCount);
         }
 
-        public bool Wait(int timeoutMs)
+        public bool Wait(int timeoutMs, bool spinWait)
         {
             Debug.Assert(timeoutMs >= -1);
 
-            int spinCount = _spinCount;
+            int spinCount = spinWait ? _spinCount : 0;
 
             // Try to acquire the semaphore or
             // a) register as a spinner if spinCount > 0 and timeoutMs > 0
@@ -118,7 +118,7 @@ namespace System.Threading
                 }
             }
 
-            // Unregister as spinner and acquire the semaphore or register as a waiter
+            // Unregister as spinner, and acquire the semaphore or register as a waiter
             counts = _separated._counts;
             while (true)
             {
@@ -142,7 +142,6 @@ namespace System.Threading
                 counts = countsBeforeUpdate;
             }
         }
-
 
         public void Release(int releaseCount)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -213,7 +213,7 @@ namespace System.Threading
         private void ResetThreadPoolThreadSlow()
         {
             Debug.Assert(this == CurrentThread);
-            Debug.Assert(IsThreadPoolThread);
+            Debug.Assert(!IsThreadStartSupported || IsThreadPoolThread); // there are no dedicated threadpool threads on runtimes where we can't start threads
             Debug.Assert(_mayNeedResetForThreadPool);
 
             _mayNeedResetForThreadPool = false;


### PR DESCRIPTION
Similarly to the native implementation of the thread pool where it makes these threads "retired", and they wait on a different semaphore without spin-waiting. Also a miscellaneous assertion fix.