### PR TITLE
Fix covariant return type validation for canon parents

### DIFF
--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1171,9 +1171,12 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
             if (!pMD->RequiresCovariantReturnTypeChecking() && !pParentMD->RequiresCovariantReturnTypeChecking())
                 continue;
 
-            // The context used to load the return type of the parent method has to use the generic method arguments
-            // of the overriding method, otherwise the type comparison below will not work correctly
-            SigTypeContext context1(pParentMD->GetClassInstantiation(), pMD->GetMethodInstantiation());
+            Instantiation classInst = pParentMD->GetClassInstantiation();
+            if (ClassLoader::IsTypicalSharedInstantiation(classInst))
+            {
+                classInst = pParentMT->GetInstantiation();
+            }
+            SigTypeContext context1(classInst, pMD->GetMethodInstantiation());
             MetaSig methodSig1(pParentMD);
             TypeHandle hType1 = methodSig1.GetReturnProps().GetTypeHandleThrowing(pParentMD->GetModule(), &context1, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
 

--- a/src/tests/Regressions/coreclr/GitHub_43763/test43763.cs
+++ b/src/tests/Regressions/coreclr/GitHub_43763/test43763.cs
@@ -1,0 +1,48 @@
+﻿class Program
+{
+    static int Main(string[] args)
+    {
+        System.Console.WriteLine(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+        CallC();
+        CallB();
+        CallC2();
+        CallB2();
+
+        return 100;
+    }
+
+    static void CallB() => new B();
+    static void CallC() => new C();
+    static void CallB2() => new B2();
+    static void CallC2() => new C2();
+}
+
+abstract class A<T>
+{
+    public abstract A<T> M();
+}
+
+abstract class A2<T>
+{
+    public abstract A2<T> M<U>();
+}
+
+class B : A<string>
+{
+    public override B M() => new B();
+}
+
+class B2 : A2<string>
+{
+    public override B2 M<U>() => new B2();
+}
+
+class C : A<int>
+{
+    public override C M() => new C();
+}
+
+class C2 : A2<int>
+{
+    public override C2 M<U>() => new C2();
+}

--- a/src/tests/Regressions/coreclr/GitHub_43763/test43763.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_43763/test43763.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test43763.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The return type validation was rejecting cases when the method being
overriden had canon type in its generic arguments.
This change fixes the problem by using parent method type instantiation
for constructing the SigTypeContext in such case.
It also adds a regression test.

Close #43763