### PR TITLE
FileStream: Restore Position to its original value when SetLength fails

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Windows.cs
@@ -389,6 +389,7 @@ namespace System.IO
                 SeekCore(_fileHandle, value, SeekOrigin.Begin);
             if (!Interop.Kernel32.SetEndOfFile(_fileHandle))
             {
+                SeekCore(_fileHandle, origPos, SeekOrigin.Begin);
                 int errorCode = Marshal.GetLastWin32Error();
                 if (errorCode == Interop.Errors.ERROR_INVALID_PARAMETER)
                     throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_FileLengthTooBig);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/8307

Set `Position` back to its original value when `SetEndOfFile` fails, this could be caused by not having enough space on disk for the new size of the file.

Note: In order to add a test that verifies this in CI frequently, I need to find a way to effectively test this without having to depend on disk space available.