### PR TITLE
Fix test for 32-bit platforms

### DIFF
--- a/src/coreclr/src/vm/win32threadpool.cpp
+++ b/src/coreclr/src/vm/win32threadpool.cpp
@@ -739,14 +739,21 @@ BOOL ThreadpoolMgr::GetAvailableThreads(DWORD* AvailableWorkerThreads,
 
     EnsureInitialized();
 
-    ThreadCounter::Counts counts = WorkerCounter.GetCleanCounts();
-
-    if (UsePortableThreadPool() || MaxLimitTotalWorkerThreads < counts.NumActive)
+    if (UsePortableThreadPool())
+    {
         *AvailableWorkerThreads = 0;
+    }
     else
-        *AvailableWorkerThreads = MaxLimitTotalWorkerThreads - counts.NumWorking;
+    {
+        ThreadCounter::Counts counts = WorkerCounter.GetCleanCounts();
 
-    counts = CPThreadCounter.GetCleanCounts();
+        if (MaxLimitTotalWorkerThreads < counts.NumActive)
+            *AvailableWorkerThreads = 0;
+        else
+            *AvailableWorkerThreads = MaxLimitTotalWorkerThreads - counts.NumWorking;
+    }
+
+    ThreadCounter::Counts counts = CPThreadCounter.GetCleanCounts();
     if (MaxLimitTotalCPThreads < counts.NumActive)
         *AvailableIOCompletionThreads = counts.NumActive - counts.NumWorking;
     else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
@@ -15,10 +15,12 @@ namespace System.Threading
         private const int ThreadPoolThreadTimeoutMs = 20 * 1000; // If you change this make sure to change the timeout times in the tests.
         private const int SmallStackSizeBytes = 256 * 1024;
 
-#if TARGET_64BIT
         private const short MaxPossibleThreadCount = short.MaxValue;
+
+#if TARGET_64BIT
+        private const short DefaultMaxWorkerThreadCount = MaxPossibleThreadCount;
 #elif TARGET_32BIT
-        private const short MaxPossibleThreadCount = 1023;
+        private const short DefaultMaxWorkerThreadCount = 1023;
 #else
         #error Unknown platform
 #endif
@@ -77,8 +79,12 @@ namespace System.Threading
                 _minThreads = MaxPossibleThreadCount;
             }
 
-            _maxThreads = s_forcedMaxWorkerThreads > 0 ? s_forcedMaxWorkerThreads : MaxPossibleThreadCount;
-            if (_maxThreads < _minThreads)
+            _maxThreads = s_forcedMaxWorkerThreads > 0 ? s_forcedMaxWorkerThreads : DefaultMaxWorkerThreadCount;
+            if (_maxThreads > MaxPossibleThreadCount)
+            {
+                _maxThreads = MaxPossibleThreadCount;
+            }
+            else if (_maxThreads < _minThreads)
             {
                 _maxThreads = _minThreads;
             }

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -14,7 +14,8 @@ namespace System.Threading.ThreadPools.Tests
     {
         private const int UnexpectedTimeoutMilliseconds = ThreadTestHelpers.UnexpectedTimeoutMilliseconds;
         private const int ExpectedTimeoutMilliseconds = ThreadTestHelpers.ExpectedTimeoutMilliseconds;
-        private const int MaxPossibleThreadCount = 0x7fff;
+
+        private static readonly int MaxPossibleThreadCount = short.MaxValue;
 
         static ThreadPoolTests()
         {


### PR DESCRIPTION
- Fixed an assertion failure. `WorkerCounter` shouldn't be used in the native thread pool implementation when the portable thread pool is enabled (all the counts will be zero), fixed a missed case in `GetAvailableThreads`.
- The native implementation uses a smaller max default worker thread count by default on 32-bit platforms, allowing configured values to go beyond that. Fixed the portable thread pool implementation to do similar, instead of limiting the max including for configured values.