### PR TITLE
Change Task.FromResult to use same task cache as async methods

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
@@ -77,16 +77,16 @@ namespace System.Collections.Generic.Tests
             // The explicit implementation of IComparer.Compare(object, object) should
             // throw if both inputs are non-null and one of them is not of type T
             IComparer comparer = Comparer<T>.Default;
-            Task<T> notOfTypeT = Task.FromResult(default(T));
+            StrongBox<T> notOfTypeT = new StrongBox<T>(default(T));
             if (default(T) != null) // if default(T) is null these asserts will fail as IComparer.Compare returns early if either side is null
             {
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Compare(notOfTypeT, default(T))); // lhs is the problem
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Compare(default(T), notOfTypeT)); // rhs is the problem
             }
-            if (!(notOfTypeT is T)) // catch cases where Task<T> actually is a T, like object or non-generic Task
+            if (!(notOfTypeT is T)) // catch cases where StrongBox<T> actually is a T, such as T == object
             {
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Compare(notOfTypeT, notOfTypeT)); // The implementation should not attempt to short-circuit if both sides have reference equality
-                AssertExtensions.Throws<ArgumentException>(null, () => comparer.Compare(notOfTypeT, Task.FromResult(default(T)))); // And it should also work when they don't
+                AssertExtensions.Throws<ArgumentException>(null, () => comparer.Compare(notOfTypeT, new StrongBox<T>(default(T)))); // And it should also work when they don't
             }
         }
 

--- a/src/libraries/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -74,7 +75,7 @@ namespace System.Collections.Generic.Tests
             // throw if the inputs are not reference-equal, both non-null and either of them
             // is not of type T.
             IEqualityComparer comparer = EqualityComparer<T>.Default;
-            Task<T> notOfTypeT = Task.FromResult(default(T));
+            StrongBox<T> notOfTypeT = new StrongBox<T>(default(T));
 
             Assert.True(comparer.Equals(default(T), default(T))); // This should not throw since both inputs will either be null or Ts.
             Assert.True(comparer.Equals(notOfTypeT, notOfTypeT)); // This should not throw since the inputs are reference-equal.
@@ -90,9 +91,9 @@ namespace System.Collections.Generic.Tests
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Equals(default(T), notOfTypeT)); // rhs is the problem
             }
 
-            if (!(notOfTypeT is T)) // catch cases where Task<T> actually is a T, like object or non-generic Task
+            if (!(notOfTypeT is T)) // catch cases where StrongBox<T> actually is a T, such as T == object
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => comparer.Equals(notOfTypeT, Task.FromResult(default(T))));
+                AssertExtensions.Throws<ArgumentException>(null, () => comparer.Equals(notOfTypeT, new StrongBox<T>(default(T))));
             }
         }
 

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -13,7 +13,6 @@ namespace System.IO.Pipes
     public abstract partial class PipeStream : Stream
     {
         internal const string AnonymousPipeName = "anonymous";
-        private static readonly Task<int> s_zeroTask = Task.FromResult(0);
 
         private SafePipeHandle? _handle;
         private bool _canRead;
@@ -164,7 +163,7 @@ namespace System.IO.Pipes
             if (count == 0)
             {
                 UpdateMessageCompletion(false);
-                return s_zeroTask;
+                return Task.FromResult(0);
             }
 
             return ReadAsyncCore(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -620,7 +620,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilderAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncStateMachineAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncTaskMethodBuilderT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />
@@ -980,6 +979,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\Sources\ManualResetValueTaskSourceCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\Task.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskAsyncEnumerableExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskCanceledException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskCompletionSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskCompletionSource_T.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -848,8 +848,6 @@ namespace System.IO
 
         private sealed class NullStream : Stream
         {
-            private static readonly Task<int> s_zeroTask = Task.FromResult(0);
-
             internal NullStream() { }
 
             public override bool CanRead => true;
@@ -942,7 +940,7 @@ namespace System.IO
 
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
-                return s_zeroTask;
+                return Task.FromResult(0);
             }
 
             public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -20,9 +20,6 @@ namespace System.Runtime.CompilerServices
     /// </remarks>
     public struct AsyncTaskMethodBuilder<TResult>
     {
-        /// <summary>A cached task for default(TResult).</summary>
-        internal static readonly Task<TResult> s_defaultResultTask = AsyncTaskCache.CreateCacheableTask<TResult>(default);
-
         /// <summary>The lazily-initialized built task.</summary>
         private Task<TResult>? m_task; // Debugger depends on the exact name of this field.
 
@@ -420,8 +417,7 @@ namespace System.Runtime.CompilerServices
             // If there isn't one, get a task and store it.
             if (m_task is null)
             {
-                m_task = GetTaskForResult(result);
-                Debug.Assert(m_task != null, $"{nameof(GetTaskForResult)} should never return null");
+                m_task = Threading.Tasks.Task.FromResult(result);
             }
             else
             {
@@ -523,91 +519,5 @@ namespace System.Runtime.CompilerServices
         /// when no other threads are in the middle of accessing this or other members that lazily initialize the task.
         /// </remarks>
         internal object ObjectIdForDebugger => m_task ??= CreateWeaklyTypedStateMachineBox();
-
-        /// <summary>
-        /// Gets a task for the specified result.  This will either
-        /// be a cached or new task, never null.
-        /// </summary>
-        /// <param name="result">The result for which we need a task.</param>
-        /// <returns>The completed task containing the result.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] // method looks long, but for a given TResult it results in a relatively small amount of asm
-        internal static Task<TResult> GetTaskForResult(TResult result)
-        {
-            // The goal of this function is to be give back a cached task if possible,
-            // or to otherwise give back a new task.  To give back a cached task,
-            // we need to be able to evaluate the incoming result value, and we need
-            // to avoid as much overhead as possible when doing so, as this function
-            // is invoked as part of the return path from every async method.
-            // Most tasks won't be cached, and thus we need the checks for those that are
-            // to be as close to free as possible. This requires some trickiness given the
-            // lack of generic specialization in .NET.
-            //
-            // Be very careful when modifying this code.  It has been tuned
-            // to comply with patterns recognized by both 32-bit and 64-bit JITs.
-            // If changes are made here, be sure to look at the generated assembly, as
-            // small tweaks can have big consequences for what does and doesn't get optimized away.
-            //
-            // Note that this code only ever accesses a static field when it knows it'll
-            // find a cached value, since static fields (even if readonly and integral types)
-            // require special access helpers in this NGEN'd and domain-neutral.
-
-            if (null != (object?)default(TResult)) // help the JIT avoid the value type branches for ref types
-            {
-                // Special case simple value types:
-                // - Boolean
-                // - Byte, SByte
-                // - Char
-                // - Int32, UInt32
-                // - Int64, UInt64
-                // - Int16, UInt16
-                // - IntPtr, UIntPtr
-                // As of .NET 4.5, the (Type)(object)result pattern used below
-                // is recognized and optimized by both 32-bit and 64-bit JITs.
-
-                // For Boolean, we cache all possible values.
-                if (typeof(TResult) == typeof(bool)) // only the relevant branches are kept for each value-type generic instantiation
-                {
-                    bool value = (bool)(object)result!;
-                    Task<bool> task = value ? AsyncTaskCache.s_trueTask : AsyncTaskCache.s_falseTask;
-                    return Unsafe.As<Task<TResult>>(task); // UnsafeCast avoids type check we know will succeed
-                }
-                // For Int32, we cache a range of common values, e.g. [-1,9).
-                else if (typeof(TResult) == typeof(int))
-                {
-                    // Compare to constants to avoid static field access if outside of cached range.
-                    // We compare to the upper bound first, as we're more likely to cache miss on the upper side than on the
-                    // lower side, due to positive values being more common than negative as return values.
-                    int value = (int)(object)result!;
-                    if (value < AsyncTaskCache.ExclusiveInt32Max &&
-                        value >= AsyncTaskCache.InclusiveInt32Min)
-                    {
-                        Task<int> task = AsyncTaskCache.s_int32Tasks[value - AsyncTaskCache.InclusiveInt32Min];
-                        return Unsafe.As<Task<TResult>>(task); // UnsafeCast avoids a type check we know will succeed
-                    }
-                }
-                // For other known value types, we only special-case 0 / default(TResult).
-                else if (
-                    (typeof(TResult) == typeof(uint) && default == (uint)(object)result!) ||
-                    (typeof(TResult) == typeof(byte) && default(byte) == (byte)(object)result!) ||
-                    (typeof(TResult) == typeof(sbyte) && default(sbyte) == (sbyte)(object)result!) ||
-                    (typeof(TResult) == typeof(char) && default(char) == (char)(object)result!) ||
-                    (typeof(TResult) == typeof(long) && default == (long)(object)result!) ||
-                    (typeof(TResult) == typeof(ulong) && default == (ulong)(object)result!) ||
-                    (typeof(TResult) == typeof(short) && default(short) == (short)(object)result!) ||
-                    (typeof(TResult) == typeof(ushort) && default(ushort) == (ushort)(object)result!) ||
-                    (typeof(TResult) == typeof(IntPtr) && default == (IntPtr)(object)result!) ||
-                    (typeof(TResult) == typeof(UIntPtr) && default == (UIntPtr)(object)result!))
-                {
-                    return s_defaultResultTask;
-                }
-            }
-            else if (result == null) // optimized away for value types
-            {
-                return s_defaultResultTask;
-            }
-
-            // No cached task is available.  Manufacture a new one for this result.
-            return new Task<TResult>(result);
-        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
@@ -22,7 +22,7 @@ namespace System.Runtime.CompilerServices
         /// is valid for the mode in which we're operating.  As such, it's cached on the generic builder per TResult
         /// rather than having one sentinel instance for all types.
         /// </remarks>
-        internal static readonly object s_syncSuccessSentinel = AsyncTaskCache.s_valueTaskPoolingEnabled ? (object)
+        internal static readonly object s_syncSuccessSentinel = AsyncValueTaskMethodBuilder.s_valueTaskPoolingEnabled ? (object)
             new SyncSuccessSentinelStateMachineBox() :
             new Task<TResult>(default(TResult)!);
 
@@ -56,7 +56,7 @@ namespace System.Runtime.CompilerServices
                 _result = result;
                 m_task = s_syncSuccessSentinel;
             }
-            else if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            else if (AsyncValueTaskMethodBuilder.s_valueTaskPoolingEnabled)
             {
                 Unsafe.As<StateMachineBox>(m_task).SetResult(result);
             }
@@ -70,7 +70,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="exception">The exception to bind to the value task.</param>
         public void SetException(Exception exception)
         {
-            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            if (AsyncValueTaskMethodBuilder.s_valueTaskPoolingEnabled)
             {
                 SetException(exception, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
             }
@@ -108,7 +108,7 @@ namespace System.Runtime.CompilerServices
                 // "work" but in a degraded mode, as we don't know the TStateMachine type here, and thus we use a box around
                 // the interface instead.
 
-                if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+                if (AsyncValueTaskMethodBuilder.s_valueTaskPoolingEnabled)
                 {
                     var box = Unsafe.As<StateMachineBox?>(m_task);
                     if (box is null)
@@ -138,7 +138,7 @@ namespace System.Runtime.CompilerServices
             where TAwaiter : INotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            if (AsyncValueTaskMethodBuilder.s_valueTaskPoolingEnabled)
             {
                 AwaitOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
             }
@@ -173,7 +173,7 @@ namespace System.Runtime.CompilerServices
             where TAwaiter : ICriticalNotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            if (AsyncValueTaskMethodBuilder.s_valueTaskPoolingEnabled)
             {
                 AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
             }
@@ -286,7 +286,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (m_task is null)
                 {
-                    m_task = AsyncTaskCache.s_valueTaskPoolingEnabled ? (object)
+                    m_task = AsyncValueTaskMethodBuilder.s_valueTaskPoolingEnabled ? (object)
                         CreateWeaklyTypedStateMachineBox() :
                         AsyncTaskMethodBuilder<TResult>.CreateWeaklyTypedStateMachineBox();
                 }
@@ -428,13 +428,13 @@ namespace System.Runtime.CompilerServices
                 // Try to acquire the cache lock.  If there's any contention, or if the cache is full, we just throw away the object.
                 if (Interlocked.CompareExchange(ref s_cacheLock, 1, 0) == 0)
                 {
-                    if (s_cacheSize < AsyncTaskCache.s_valueTaskPoolingCacheSize)
+                    if (s_cacheSize < AsyncValueTaskMethodBuilder.s_valueTaskPoolingCacheSize)
                     {
                         // Push the box onto the cache stack for subsequent reuse.
                         _next = s_cache;
                         s_cache = this;
                         s_cacheSize++;
-                        Debug.Assert(s_cacheSize > 0 && s_cacheSize <= AsyncTaskCache.s_valueTaskPoolingCacheSize, "Expected cache size to be within bounds.");
+                        Debug.Assert(s_cacheSize > 0 && s_cacheSize <= AsyncValueTaskMethodBuilder.s_valueTaskPoolingCacheSize, "Expected cache size to be within bounds.");
                     }
 
                     // Release the lock.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -61,13 +61,6 @@ namespace System.Threading
         // Tail of list representing asynchronous waits on the semaphore.
         private TaskNode? m_asyncTail;
 
-        // A pre-completed task with Result==true
-        private static readonly Task<bool> s_trueTask =
-            new Task<bool>(false, true, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default);
-        // A pre-completed task with Result==false
-        private static readonly Task<bool> s_falseTask =
-            new Task<bool>(false, false, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default);
-
         // No maximum constant
         private const int NO_MAXIMUM = int.MaxValue;
 
@@ -625,12 +618,12 @@ namespace System.Threading
                 {
                     --m_currentCount;
                     if (m_waitHandle != null && m_currentCount == 0) m_waitHandle.Reset();
-                    return s_trueTask;
+                    return Task.FromResult(true);
                 }
                 else if (millisecondsTimeout == 0)
                 {
                     // No counts, if timeout is zero fail fast
-                    return s_falseTask;
+                    return Task.FromResult(false);
                 }
                 // If there aren't, create and return a task to the caller.
                 // The task will be completed either when they've successfully acquired

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -58,10 +58,13 @@ namespace System.Threading.Tasks
     [DebuggerDisplay("Id = {Id}, Status = {Status}, Method = {DebuggerDisplayMethodDescription}, Result = {DebuggerDisplayResultDescription}")]
     public class Task<TResult> : Task
     {
-        // The value itself, if set.
-        internal TResult? m_result;
+        /// <summary>A cached task for default(TResult).</summary>
+        internal static readonly Task<TResult> s_defaultResultTask = TaskCache.CreateCacheableTask<TResult>(default);
 
         private static readonly TaskFactory<TResult> s_Factory = new TaskFactory<TResult>();
+
+        // The value itself, if set.
+        internal TResult? m_result;
 
         // Extract rarely used helper for a static method in a separate type so that the Func<Task<Task>, Task<TResult>>
         // generic instantiations don't contribute to all Task instantiations, but only those where WhenAny is used.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5025,12 +5025,62 @@ namespace System.Threading.Tasks
 
         #region FromResult / FromException / FromCanceled
 
-        /// <summary>Creates a <see cref="Task{TResult}"/> that's completed successfully with the specified result.</summary>
+        /// <summary>Gets a <see cref="Task{TResult}"/> that's completed successfully with the specified result.</summary>
         /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
         /// <param name="result">The result to store into the completed task.</param>
         /// <returns>The successfully completed task.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // method looks long, but for a given TResult it results in a relatively small amount of asm
         public static Task<TResult> FromResult<TResult>(TResult result)
         {
+            // The goal of this function is to be give back a cached task if possible, or to otherwise give back a new task.
+            // To give back a cached task, we need to be able to evaluate the incoming result value, and we need to avoid as
+            // much overhead as possible when doing so, as this function is invoked as part of the return path from every async
+            // method and Task.FromResult. Most tasks won't be cached, and thus we need the checks for those that are to be as
+            // close to free as possible. This requires some trickiness given the lack of generic specialization in .NET.
+
+            if (null != (object?)default(TResult)) // help the JIT avoid the value type branches for ref types
+            {
+                // For Boolean, we cache all possible values.
+                if (typeof(TResult) == typeof(bool)) // only the relevant branches are kept for each value-type generic instantiation
+                {
+                    bool value = (bool)(object)result!;
+                    Task<bool> task = value ? TaskCache.s_trueTask : TaskCache.s_falseTask;
+                    return Unsafe.As<Task<TResult>>(task); // UnsafeCast avoids type check we know will succeed
+                }
+                // For Int32, we cache a range of common values, [-1,9).
+                else if (typeof(TResult) == typeof(int))
+                {
+                    // Compare to constants to avoid static field access if outside of cached range.
+                    int value = (int)(object)result!;
+                    if ((uint)(value - TaskCache.InclusiveInt32Min) < (TaskCache.ExclusiveInt32Max - TaskCache.InclusiveInt32Min))
+                    {
+                        Task<int> task = TaskCache.s_int32Tasks[value - TaskCache.InclusiveInt32Min];
+                        return Unsafe.As<Task<TResult>>(task); // Unsafe.As avoids a type check we know will succeed
+                    }
+                }
+                // For other known value types, we only special-case 0 / default(TResult).  We don't include
+                // floating point types as == may return true for different bit representations of the same value.
+                else if (
+                    (typeof(TResult) == typeof(uint) && default == (uint)(object)result!) ||
+                    (typeof(TResult) == typeof(byte) && default(byte) == (byte)(object)result!) ||
+                    (typeof(TResult) == typeof(sbyte) && default(sbyte) == (sbyte)(object)result!) ||
+                    (typeof(TResult) == typeof(char) && default(char) == (char)(object)result!) ||
+                    (typeof(TResult) == typeof(long) && default == (long)(object)result!) ||
+                    (typeof(TResult) == typeof(ulong) && default == (ulong)(object)result!) ||
+                    (typeof(TResult) == typeof(short) && default(short) == (short)(object)result!) ||
+                    (typeof(TResult) == typeof(ushort) && default(ushort) == (ushort)(object)result!) ||
+                    (typeof(TResult) == typeof(IntPtr) && default == (IntPtr)(object)result!) ||
+                    (typeof(TResult) == typeof(UIntPtr) && default == (UIntPtr)(object)result!))
+                {
+                    return TaskCache<TResult>.s_defaultResultTask;
+                }
+            }
+            else if (result is null) // optimized away for value types
+            {
+                return TaskCache<TResult>.s_defaultResultTask;
+            }
+
+            // No cached task is available.  Manufacture a new one for this result.
             return new Task<TResult>(result);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
@@ -3,12 +3,11 @@
 
 using System.Diagnostics;
 using System.Threading.Tasks;
-using System.Diagnostics.CodeAnalysis;
 
-namespace System.Runtime.CompilerServices
+namespace System.Threading.Tasks
 {
-    /// <summary>Provides a cache of closed generic tasks for async methods.</summary>
-    internal static class AsyncTaskCache
+    /// <summary>Provides a cache of tasks for async methods.</summary>
+    internal static class TaskCache
     {
         /// <summary>A cached Task{Boolean}.Result == true.</summary>
         internal static readonly Task<bool> s_trueTask = CreateCacheableTask(result: true);
@@ -20,26 +19,6 @@ namespace System.Runtime.CompilerServices
         internal const int InclusiveInt32Min = -1;
         /// <summary>The maximum value, exclusive, for which we want a cached task.</summary>
         internal const int ExclusiveInt32Max = 9;
-
-        /// <summary>true if we should use reusable boxes for async completions of ValueTask methods; false if we should use tasks.</summary>
-        /// <remarks>
-        /// We rely on tiered compilation turning this into a const and doing dead code elimination to make checks on this efficient.
-        /// It's also required for safety that this value never changes once observed, as Unsafe.As casts are employed based on its value.
-        /// </remarks>
-        internal static readonly bool s_valueTaskPoolingEnabled = GetPoolAsyncValueTasksSwitch();
-        /// <summary>Maximum number of boxes that are allowed to be cached per state machine type.</summary>
-        internal static readonly int s_valueTaskPoolingCacheSize = GetPoolAsyncValueTasksLimitValue();
-
-        private static bool GetPoolAsyncValueTasksSwitch()
-        {
-            string? value = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_THREADING_POOLASYNCVALUETASKS");
-            return value != null && (bool.IsTrueStringIgnoreCase(value) || value.Equals("1"));
-        }
-
-        private static int GetPoolAsyncValueTasksLimitValue() =>
-            int.TryParse(Environment.GetEnvironmentVariable("DOTNET_SYSTEM_THREADING_POOLASYNCVALUETASKSLIMIT"), out int result) && result > 0 ?
-                result :
-                Environment.ProcessorCount * 4; // arbitrary default value
 
         /// <summary>Creates a non-disposable task.</summary>
         /// <typeparam name="TResult">Specifies the result type.</typeparam>
@@ -61,5 +40,12 @@ namespace System.Runtime.CompilerServices
 
             return tasks;
         }
+    }
+
+    /// <summary>Provides a cache of tasks for async methods.</summary>
+    internal static class TaskCache<TResult>
+    {
+        /// <summary>A cached task for default(TResult).</summary>
+        internal static readonly Task<TResult> s_defaultResultTask = TaskCache.CreateCacheableTask<TResult>(default);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
@@ -41,11 +41,4 @@ namespace System.Threading.Tasks
             return tasks;
         }
     }
-
-    /// <summary>Provides a cache of tasks for async methods.</summary>
-    internal static class TaskCache<TResult>
-    {
-        /// <summary>A cached task for default(TResult).</summary>
-        internal static readonly Task<TResult> s_defaultResultTask = TaskCache.CreateCacheableTask<TResult>(default);
-    }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -556,7 +556,7 @@ namespace System.Threading.Tasks
 
             if (obj == null)
             {
-                return AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result!);
+                return Task.FromResult(_result!);
             }
 
             if (obj is Task<TResult> t)
@@ -584,7 +584,7 @@ namespace System.Threading.Tasks
                 {
                     // Get the result of the operation and return a task for it.
                     // If any exception occurred, propagate it
-                    return AsyncTaskMethodBuilder<TResult>.GetTaskForResult(t.GetResult(_token));
+                    return Task.FromResult(t.GetResult(_token));
 
                     // If status is Faulted or Canceled, GetResult should throw.  But
                     // we can't guarantee every implementation will do the "right thing".

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -482,40 +482,40 @@ namespace System.Threading.Tasks.Tests
                 Assert.Equal(i, Task.FromResult(i).Result);
             }
 
-            Assert.Equal(Task.FromResult('\0'), Task.FromResult('\0'));
+            Assert.Same(Task.FromResult('\0'), Task.FromResult('\0'));
             Assert.Equal('\0', Task.FromResult('\0').Result);
 
-            Assert.Equal(Task.FromResult((byte)0), Task.FromResult((byte)0));
+            Assert.Same(Task.FromResult((byte)0), Task.FromResult((byte)0));
             Assert.Equal(0, Task.FromResult((byte)0).Result);
 
-            Assert.Equal(Task.FromResult((ushort)0), Task.FromResult((ushort)0));
+            Assert.Same(Task.FromResult((ushort)0), Task.FromResult((ushort)0));
             Assert.Equal(0, Task.FromResult((ushort)0).Result);
 
-            Assert.Equal(Task.FromResult((uint)0), Task.FromResult((uint)0));
+            Assert.Same(Task.FromResult((uint)0), Task.FromResult((uint)0));
             Assert.Equal(0u, Task.FromResult((uint)0).Result);
 
-            Assert.Equal(Task.FromResult((ulong)0), Task.FromResult((ulong)0));
+            Assert.Same(Task.FromResult((ulong)0), Task.FromResult((ulong)0));
             Assert.Equal(0ul, Task.FromResult((ulong)0).Result);
 
-            Assert.Equal(Task.FromResult((sbyte)0), Task.FromResult((sbyte)0));
+            Assert.Same(Task.FromResult((sbyte)0), Task.FromResult((sbyte)0));
             Assert.Equal(0, Task.FromResult((sbyte)0).Result);
 
-            Assert.Equal(Task.FromResult((short)0), Task.FromResult((short)0));
+            Assert.Same(Task.FromResult((short)0), Task.FromResult((short)0));
             Assert.Equal(0, Task.FromResult((short)0).Result);
 
-            Assert.Equal(Task.FromResult((long)0), Task.FromResult((long)0));
+            Assert.Same(Task.FromResult((long)0), Task.FromResult((long)0));
             Assert.Equal(0, Task.FromResult((long)0).Result);
 
-            Assert.Equal(Task.FromResult(IntPtr.Zero), Task.FromResult(IntPtr.Zero));
+            Assert.Same(Task.FromResult(IntPtr.Zero), Task.FromResult(IntPtr.Zero));
             Assert.Equal(IntPtr.Zero, Task.FromResult(IntPtr.Zero).Result);
 
-            Assert.Equal(Task.FromResult(UIntPtr.Zero), Task.FromResult(UIntPtr.Zero));
+            Assert.Same(Task.FromResult(UIntPtr.Zero), Task.FromResult(UIntPtr.Zero));
             Assert.Equal(UIntPtr.Zero, Task.FromResult(UIntPtr.Zero).Result);
 
-            Assert.Equal(Task.FromResult((object)null), Task.FromResult((object)null));
+            Assert.Same(Task.FromResult((object)null), Task.FromResult((object)null));
             Assert.Null(Task.FromResult((object)null).Result);
 
-            Assert.Equal(Task.FromResult((string)null), Task.FromResult((string)null));
+            Assert.Same(Task.FromResult((string)null), Task.FromResult((string)null));
             Assert.Null(Task.FromResult((string)null).Result);
 
             // Not cached

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -367,7 +367,7 @@ namespace System.Threading.Tasks.Tests
         {
             // Test FromResult with value type
             {
-                var results = new[] { -1, 0, 1, 1, 42, int.MaxValue, int.MinValue, 42, -42 }; // includes duplicate values to ensure that tasks from these aren't the same object
+                var results = new[] { -1, 0, 1, 42, int.MaxValue, int.MinValue, 42, -42 }; // includes duplicate values to ensure that tasks from these aren't the same object
                 Task<int>[] tasks = new Task<int>[results.Length];
                 for (int i = 0; i < results.Length; i++)
                     tasks[i] = Task.FromResult(results[i]);
@@ -396,7 +396,7 @@ namespace System.Threading.Tasks.Tests
 
             // Test FromResult with reference type
             {
-                var results = new[] { new object(), null, new object(), null, new object() }; // includes duplicate values to ensure that tasks from these aren't the same object
+                var results = new[] { new object(), new object(), null, new object() };
                 Task<object>[] tasks = new Task<object>[results.Length];
                 for (int i = 0; i < results.Length; i++)
                     tasks[i] = Task.FromResult(results[i]);
@@ -459,6 +459,77 @@ namespace System.Threading.Tasks.Tests
                 // Make sure we throw from waiting on a faulted task
                 Assert.Throws<AggregateException>(() => { var result = Task.FromException<object>(new InvalidOperationException()).Result; });
             }
+        }
+
+        [Fact]
+        public static void FromResult_KnownResults_Cached()
+        {
+            // Task.FromResult caches some known values, as an implementation detail.
+            // What's cached could change over time, in which case this test will also
+            // need to be updated.
+
+            // Cached
+
+            foreach (bool result in new[] { false, true })
+            {
+                Assert.Same(Task.FromResult(result), Task.FromResult(result));
+                Assert.Equal(result, Task.FromResult(result).Result);
+            }
+
+            for (int i = -1; i <= 8; i++)
+            {
+                Assert.Same(Task.FromResult(i), Task.FromResult(i));
+                Assert.Equal(i, Task.FromResult(i).Result);
+            }
+
+            Assert.Equal(Task.FromResult('\0'), Task.FromResult('\0'));
+            Assert.Equal('\0', Task.FromResult('\0').Result);
+
+            Assert.Equal(Task.FromResult((byte)0), Task.FromResult((byte)0));
+            Assert.Equal(0, Task.FromResult((byte)0).Result);
+
+            Assert.Equal(Task.FromResult((ushort)0), Task.FromResult((ushort)0));
+            Assert.Equal(0, Task.FromResult((ushort)0).Result);
+
+            Assert.Equal(Task.FromResult((uint)0), Task.FromResult((uint)0));
+            Assert.Equal(0u, Task.FromResult((uint)0).Result);
+
+            Assert.Equal(Task.FromResult((ulong)0), Task.FromResult((ulong)0));
+            Assert.Equal(0ul, Task.FromResult((ulong)0).Result);
+
+            Assert.Equal(Task.FromResult((sbyte)0), Task.FromResult((sbyte)0));
+            Assert.Equal(0, Task.FromResult((sbyte)0).Result);
+
+            Assert.Equal(Task.FromResult((short)0), Task.FromResult((short)0));
+            Assert.Equal(0, Task.FromResult((short)0).Result);
+
+            Assert.Equal(Task.FromResult((long)0), Task.FromResult((long)0));
+            Assert.Equal(0, Task.FromResult((long)0).Result);
+
+            Assert.Equal(Task.FromResult(IntPtr.Zero), Task.FromResult(IntPtr.Zero));
+            Assert.Equal(IntPtr.Zero, Task.FromResult(IntPtr.Zero).Result);
+
+            Assert.Equal(Task.FromResult(UIntPtr.Zero), Task.FromResult(UIntPtr.Zero));
+            Assert.Equal(UIntPtr.Zero, Task.FromResult(UIntPtr.Zero).Result);
+
+            Assert.Equal(Task.FromResult((object)null), Task.FromResult((object)null));
+            Assert.Null(Task.FromResult((object)null).Result);
+
+            Assert.Equal(Task.FromResult((string)null), Task.FromResult((string)null));
+            Assert.Null(Task.FromResult((string)null).Result);
+
+            // Not cached
+
+            foreach (int i in new[] { -2, 9, int.MinValue, int.MaxValue })
+            {
+                Assert.NotSame(Task.FromResult(i), Task.FromResult(i));
+                Assert.Equal(i, Task.FromResult(i).Result);
+            }
+
+            Assert.NotSame(Task.FromResult((double)0), Task.FromResult((double)0));
+            Assert.NotSame(Task.FromResult((float)0), Task.FromResult((float)0));
+            Assert.NotSame(Task.FromResult((decimal)0), Task.FromResult((decimal)0));
+            Assert.NotSame(Task.FromResult((Half)0), Task.FromResult((Half)0));
         }
 
         [Fact]


### PR DESCRIPTION
Task.FromResult today always creates a new task.  This leads developers that are aware of this to then create their own caches for common values, typically 0, true, and false, to avoid task allocations for those common values.  But we already have such values cached internally, used for async method return values.  We can just use the same cache for Task.FromResult.

Fixes https://github.com/dotnet/runtime/issues/22627