### PR TITLE
Implement the reuse of duplicate constant values

### DIFF
--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -6827,7 +6827,7 @@ void CodeGen::genSSE2BitwiseOp(GenTree* treeNode)
     if (*maskFld == nullptr)
     {
         UINT64 maskPack[] = {mask, mask};
-        *maskFld          = GetEmitter()->emitAnyConst(&maskPack, 16, 16);
+        *maskFld          = GetEmitter()->emitBlkConst(&maskPack, 16, 16, treeNode->TypeGet());
     }
 
     GetEmitter()->emitIns_SIMD_R_R_C(ins, size, targetReg, operandReg, *maskFld, 0);

--- a/src/coreclr/src/jit/ee_il_dll.cpp
+++ b/src/coreclr/src/jit/ee_il_dll.cpp
@@ -1068,10 +1068,10 @@ bool Compiler::eeIsJitDataOffs(CORINFO_FIELD_HANDLE field)
     unsigned value = static_cast<unsigned>(reinterpret_cast<uintptr_t>(field));
     if (((CORINFO_FIELD_HANDLE)(size_t)value) != field)
     {
-        return false; // upper bits were set, not a jit data offset
+        return false; // some bits in the upper 32 bits were set, not a jit data offset
     }
 
-    // Data offsets are marked by the fact that the low two bits are 0b01 0x1
+    // Data offsets are marked by the fact that the low two bits are 0b01
     return (value & iaut_MASK) == iaut_DATA_OFFSET;
 }
 
@@ -1083,6 +1083,8 @@ int Compiler::eeGetJitDataOffs(CORINFO_FIELD_HANDLE field)
         unsigned dataOffs = static_cast<unsigned>(reinterpret_cast<uintptr_t>(field));
         assert(((CORINFO_FIELD_HANDLE)(size_t)dataOffs) == field);
         assert(dataOffs < 0x40000000);
+
+        // Shift away the low two bits
         return (static_cast<int>(reinterpret_cast<intptr_t>(field))) >> iaut_SHIFT;
     }
     else

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5709,13 +5709,12 @@ void emitter::emitDataGenEnd()
 
 UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, unsigned alignment, var_types dataType)
 {
-    UNATIVE_OFFSET cnum = INVALID_UNATIVE_OFFSET;
-
-    dataSection* secDesc = emitConsDsc.dsdList;
+    UNATIVE_OFFSET cnum    = INVALID_UNATIVE_OFFSET;
+    unsigned       curOffs = 0;
+    dataSection*   secDesc = emitConsDsc.dsdList;
     while (secDesc != nullptr)
     {
         // Search the existing secDesc entries
-        unsigned curOffs = 0;
 
         if ((secDesc->dsSize == cnsSize) && (secDesc->dsDataType == dataType) && ((curOffs % alignment) == 0))
         {

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5515,33 +5515,33 @@ UNATIVE_OFFSET emitter::emitFindOffset(insGroup* ig, unsigned insNum)
  *  block.
  */
 
-UNATIVE_OFFSET emitter::emitDataGenBeg(UNATIVE_OFFSET size, UNATIVE_OFFSET alignment)
+UNATIVE_OFFSET emitter::emitDataGenBeg(unsigned size, unsigned alignment, var_types dataType)
 {
     unsigned     secOffs;
     dataSection* secDesc;
 
     assert(emitDataSecCur == nullptr);
 
-    // The size must not be zero and must be a multiple of 4 bytes
-    // Additionally, 4 bytes is the minimum alignment that will
+    // The size must not be zero and must be a multiple of MIN_DATA_ALIGN
+    // Additionally, MIN_DATA_ALIGN is the minimum alignment that will
     // actually be used. That is, if the user requests an alignment
     // of 1 or 2, they will get  something that is at least 4-byte
     // aligned. We allow the others since 4 is at least 1/2 and its
     // simpler to allow it than to check and block.
-    assert((size != 0) && ((size % 4) == 0));
+    assert((size != 0) && ((size % dataSection::MIN_DATA_ALIGN) == 0));
 
     // This restricts the alignment to: 1, 2, 4, 8, 16, or 32 bytes
     // Alignments greater than 32 would require VM support in ICorJitInfo::allocMem
 
-    const size_t MaxAlignment = 32;
+    const size_t MaxAlignment = dataSection::MAX_DATA_ALIGN;
     assert(isPow2(alignment) && (alignment <= MaxAlignment));
 
     /* Get hold of the current offset */
     secOffs = emitConsDsc.dsdOffs;
 
-    if (((secOffs % alignment) != 0) && (alignment > 4))
+    if (((secOffs % alignment) != 0) && (alignment > dataSection::MIN_DATA_ALIGN))
     {
-        // As per the above comment, the minimum alignment is actually 4
+        // As per the above comment, the minimum alignment is actually 4 (MIN_DATA_ALIGN)
         // bytes so we don't need to make any adjustments if the requested
         // alignment is 1, 2, or 4.
         //
@@ -5550,12 +5550,13 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(UNATIVE_OFFSET size, UNATIVE_OFFSET align
         // alignment. So if the requested alignment is greater than 4, we need
         // to pad the space out so the offset is a multiple of the requested.
 
-        uint8_t zero[MaxAlignment] = {};
+        uint8_t zeros[MaxAlignment] = {};
 
-        UNATIVE_OFFSET zeroSize  = alignment - (secOffs % alignment);
-        UNATIVE_OFFSET zeroAlign = 4;
+        unsigned  zeroSize  = alignment - (secOffs % alignment);
+        unsigned  zeroAlign = dataSection::MIN_DATA_ALIGN;
+        var_types zeroType  = TYP_INT;
 
-        emitAnyConst(&zero, zeroSize, zeroAlign);
+        emitBlkConst(&zeros, zeroSize, zeroAlign, zeroType);
         secOffs = emitConsDsc.dsdOffs;
     }
 
@@ -5572,6 +5573,8 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(UNATIVE_OFFSET size, UNATIVE_OFFSET align
     secDesc->dsSize = size;
 
     secDesc->dsType = dataSection::data;
+
+    secDesc->dsDataType = dataType;
 
     secDesc->dsNext = nullptr;
 
@@ -5628,6 +5631,8 @@ UNATIVE_OFFSET emitter::emitBBTableDataGenBeg(unsigned numEntries, bool relative
     secDesc->dsSize = emittedSize;
 
     secDesc->dsType = relativeAddr ? dataSection::blockRelative32 : dataSection::blockAbsoluteAddr;
+
+    secDesc->dsDataType = TYP_UNKNOWN;
 
     secDesc->dsNext = nullptr;
 
@@ -5691,6 +5696,43 @@ void emitter::emitDataGenEnd()
 #endif
 }
 
+/*****************************************************************************
+ * Generates a data section constant
+ *
+ * Parameters:
+ *     cnsAddr  - memory location containing constant value
+ *     cnsSize  - size of constant in bytes
+ *     cnsAlign - alignment of constant in bytes
+ *
+ * Returns constant number as offset into data section.
+ */
+
+UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, unsigned alignment, var_types dataType)
+{
+    UNATIVE_OFFSET cnum = INVALID_UNATIVE_OFFSET;
+
+    dataSection* secDesc = emitConsDsc.dsdList;
+    while (secDesc != nullptr)
+    {
+        // Search the existing secDesc entries
+        unsigned curOffs = 0;
+
+        if ((secDesc->dsSize == cnsSize) && (secDesc->dsDataType == dataType) && ((curOffs % alignment) == 0))
+        {
+            if (memcmp(cnsAddr, secDesc->dsCont, cnsSize) == 0)
+            {
+                cnum = curOffs;
+                break;
+            }
+        }
+
+        curOffs += secDesc->dsSize;
+        secDesc = secDesc->dsNext;
+    }
+
+    return cnum;
+}
+
 /********************************************************************************
  * Generates a data section constant
  *
@@ -5701,17 +5743,21 @@ void emitter::emitDataGenEnd()
  *
  * Returns constant number as offset into data section.
  */
-UNATIVE_OFFSET emitter::emitDataConst(const void* cnsAddr, UNATIVE_OFFSET cnsSize, UNATIVE_OFFSET cnsAlign)
+UNATIVE_OFFSET emitter::emitDataConst(const void* cnsAddr, unsigned cnsSize, unsigned cnsAlign, var_types dataType)
 {
-    UNATIVE_OFFSET cnum = emitDataGenBeg(cnsSize, cnsAlign);
-    emitDataGenData(0, cnsAddr, cnsSize);
-    emitDataGenEnd();
+    UNATIVE_OFFSET cnum = emitDataGenFind(cnsAddr, cnsSize, cnsAlign, dataType);
 
+    if (cnum == INVALID_UNATIVE_OFFSET)
+    {
+        cnum = emitDataGenBeg(cnsSize, cnsAlign, dataType);
+        emitDataGenData(0, cnsAddr, cnsSize);
+        emitDataGenEnd();
+    }
     return cnum;
 }
 
 //------------------------------------------------------------------------
-// emitAnyConst: Create a data section constant of arbitrary size.
+// emitBlkConst: Create a data section constant of arbitrary size.
 //
 // Arguments:
 //    cnsAddr   - pointer to the data to be placed in the data section
@@ -5721,9 +5767,9 @@ UNATIVE_OFFSET emitter::emitDataConst(const void* cnsAddr, UNATIVE_OFFSET cnsSiz
 // Return Value:
 //    A field handle representing the data offset to access the constant.
 //
-CORINFO_FIELD_HANDLE emitter::emitAnyConst(const void* cnsAddr, UNATIVE_OFFSET cnsSize, UNATIVE_OFFSET cnsAlign)
+CORINFO_FIELD_HANDLE emitter::emitBlkConst(const void* cnsAddr, unsigned cnsSize, unsigned cnsAlign, var_types elemType)
 {
-    UNATIVE_OFFSET cnum = emitDataGenBeg(cnsSize, cnsAlign);
+    UNATIVE_OFFSET cnum = emitDataGenBeg(cnsSize, cnsAlign, elemType);
     emitDataGenData(0, cnsAddr, cnsSize);
     emitDataGenEnd();
 
@@ -5748,25 +5794,28 @@ CORINFO_FIELD_HANDLE emitter::emitFltOrDblConst(double constValue, emitAttr attr
 {
     assert((attr == EA_4BYTE) || (attr == EA_8BYTE));
 
-    void* cnsAddr;
-    float f;
+    void*     cnsAddr;
+    float     f;
+    var_types dataType;
 
     if (attr == EA_4BYTE)
     {
-        f       = forceCastToFloat(constValue);
-        cnsAddr = &f;
+        f        = forceCastToFloat(constValue);
+        cnsAddr  = &f;
+        dataType = TYP_FLOAT;
     }
     else
     {
-        cnsAddr = &constValue;
+        cnsAddr  = &constValue;
+        dataType = TYP_DOUBLE;
     }
 
     // Access to inline data is 'abstracted' by a special type of static member
     // (produced by eeFindJitDataOffs) which the emitter recognizes as being a reference
     // to constant data, not a real static field.
 
-    UNATIVE_OFFSET cnsSize  = (attr == EA_4BYTE) ? 4 : 8;
-    UNATIVE_OFFSET cnsAlign = cnsSize;
+    unsigned cnsSize  = (attr == EA_4BYTE) ? sizeof(float) : sizeof(double);
+    unsigned cnsAlign = (unsigned)cnsSize;
 
 #ifdef TARGET_XARCH
     if (emitComp->compCodeOpt() == Compiler::SMALL_CODE)
@@ -5774,11 +5823,11 @@ CORINFO_FIELD_HANDLE emitter::emitFltOrDblConst(double constValue, emitAttr attr
         // Some platforms don't require doubles to be aligned and so
         // we can use a smaller alignment to help with smaller code
 
-        cnsAlign = 1;
+        cnsAlign = dataSection::MIN_DATA_ALIGN;
     }
 #endif // TARGET_XARCH
 
-    UNATIVE_OFFSET cnum = emitDataConst(cnsAddr, cnsSize, cnsAlign);
+    UNATIVE_OFFSET cnum = emitDataConst(cnsAddr, cnsSize, cnsAlign, dataType);
     return emitComp->eeFindJitDataOffs(cnum);
 }
 
@@ -5810,6 +5859,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
     /* Walk and emit the contents of all the data blocks */
 
     dataSection* dsc;
+    size_t       curOffs = 0;
 
     for (dsc = sec->dsdList; dsc; dsc = dsc->dsNext)
     {
@@ -5870,8 +5920,6 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
         }
         else
         {
-            JITDUMP("  section %u, size %u, raw data\n", secNum++, dscSize);
-
             // Simple binary data: copy the bytes to the target
             assert(dsc->dsType == dataSection::data);
 
@@ -5880,19 +5928,33 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, BYTE* dst)
 #ifdef DEBUG
             if (EMITVERBOSE)
             {
-                printf("  ");
+                printf("  section %3u, size %2u, RWD%2u:\t", secNum++, dscSize, curOffs);
+
                 for (size_t i = 0; i < dscSize; i++)
                 {
                     printf("%02x ", dsc->dsCont[i]);
                     if ((((i + 1) % 16) == 0) && (i + 1 != dscSize))
                     {
-                        printf("\n  ");
+                        printf("\n\t\t\t\t\t");
                     }
+                }
+                switch (dsc->dsDataType)
+                {
+                    case TYP_FLOAT:
+                        printf(" ; float  %9.6g", (double)*reinterpret_cast<float*>(&dsc->dsCont));
+                        break;
+                    case TYP_DOUBLE:
+                        printf(" ; double %12.9g", *reinterpret_cast<double*>(&dsc->dsCont));
+                        break;
+                    default:
+                        break;
                 }
                 printf("\n");
             }
 #endif // DEBUG
         }
+
+        curOffs += dscSize;
         dst += dscSize;
     }
 }
@@ -5924,6 +5986,9 @@ void emitter::emitDispDataSec(dataSecDsc* section)
         printf(labelFormat, label);
         offset += data->dsSize;
 
+        // printf(" (DEBUG) data->dsType = %d,dsDataType = %d, data->dsSize = %d\n", data->dsType, data->dsDataType,
+        // data->dsSize);
+
         if ((data->dsType == dataSection::blockRelative32) || (data->dsType == dataSection::blockAbsoluteAddr))
         {
             insGroup* igFirst    = static_cast<insGroup*>(emitCodeGetCookie(emitComp->fgFirstBB));
@@ -5950,11 +6015,11 @@ void emitter::emitDispDataSec(dataSecDsc* section)
                 {
                     if (emitComp->opts.disDiffable)
                     {
-                        printf("dd\t%s - %s\n", blockLabel, firstLabel);
+                        printf("\tdd\t%s - %s\n", blockLabel, firstLabel);
                     }
                     else
                     {
-                        printf("dd\t%08Xh", ig->igOffs - igFirst->igOffs);
+                        printf("\tdd\t%08Xh", ig->igOffs - igFirst->igOffs);
                     }
                 }
                 else
@@ -5963,21 +6028,21 @@ void emitter::emitDispDataSec(dataSecDsc* section)
                     // We have a 32-BIT target
                     if (emitComp->opts.disDiffable)
                     {
-                        printf("dd\t%s\n", blockLabel);
+                        printf("\tdd\t%s\n", blockLabel);
                     }
                     else
                     {
-                        printf("dd\t%08Xh", (uint32_t)(size_t)emitOffsetToPtr(ig->igOffs));
+                        printf("\tdd\t%08Xh", (uint32_t)(size_t)emitOffsetToPtr(ig->igOffs));
                     }
 #else  // TARGET_64BIT
                     // We have a 64-BIT target
                     if (emitComp->opts.disDiffable)
                     {
-                        printf("dq\t%s\n", blockLabel);
+                        printf("\tdq\t%s\n", blockLabel);
                     }
                     else
                     {
-                        printf("dq\t%016llXh", reinterpret_cast<uint64_t>(emitOffsetToPtr(ig->igOffs)));
+                        printf("\tdq\t%016llXh", reinterpret_cast<uint64_t>(emitOffsetToPtr(ig->igOffs)));
                     }
 #endif // TARGET_64BIT
                 }
@@ -5991,24 +6056,106 @@ void emitter::emitDispDataSec(dataSecDsc* section)
         else
         {
             assert(data->dsType == dataSection::data);
-            switch (data->dsSize)
+            unsigned elemSize = genTypeSize(data->dsDataType);
+            if (elemSize == 0)
             {
-                case 2:
-                    printf("dw\t%04Xh\n", *reinterpret_cast<uint16_t*>(&data->dsCont));
-                    break;
-                case 4:
-                    printf("dd\t%08Xh\n", *reinterpret_cast<uint32_t*>(&data->dsCont));
-                    break;
-                case 8:
-                    printf("dq\t%016llXh\n", *reinterpret_cast<uint64_t*>(&data->dsCont));
-                    break;
-                default:
-                    printf("db\t");
-                    for (UNATIVE_OFFSET i = 0; i < data->dsSize; i++)
-                    {
-                        printf("%s0%02Xh", i > 0 ? ", " : "", data->dsCont[i]);
-                    }
-                    printf("\n");
+                if ((data->dsSize % 8) == 0)
+                {
+                    elemSize = 8;
+                }
+                else if ((data->dsSize % 4) == 0)
+                {
+                    elemSize = 4;
+                }
+                else if ((data->dsSize % 2) == 0)
+                {
+                    elemSize = 2;
+                }
+                else
+                {
+                    elemSize = 1;
+                }
+            }
+
+            unsigned i = 0;
+            unsigned j;
+            while (i < data->dsSize)
+            {
+                switch (data->dsDataType)
+                {
+                    case TYP_FLOAT:
+                        assert(data->dsSize >= 4);
+                        printf("\tdd\t%08llXh", *reinterpret_cast<uint32_t*>(&data->dsCont[i]));
+                        printf("\t\t; %9.6g", *reinterpret_cast<float*>(&data->dsCont[i]));
+                        i += 4;
+                        break;
+
+                    case TYP_DOUBLE:
+                        assert(data->dsSize >= 8);
+                        printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i]));
+                        printf("\t\t; %12.9g", *reinterpret_cast<double*>(&data->dsCont[i]));
+                        i += 8;
+                        break;
+
+                    default:
+                        switch (elemSize)
+                        {
+                            case 1:
+                                printf("\tdb\t%02Xh", *reinterpret_cast<uint16_t*>(&data->dsCont[i]));
+                                for (j = 1; j < 16; j++)
+                                {
+                                    if (i + j >= data->dsSize)
+                                        break;
+                                    printf(", %02Xh", *reinterpret_cast<uint16_t*>(&data->dsCont[i + j]));
+                                }
+                                i += j;
+                                break;
+
+                            case 2:
+                                assert((data->dsSize % 2) == 0);
+                                printf("\tdw\t%04Xh", *reinterpret_cast<uint16_t*>(&data->dsCont[i]));
+                                for (j = 2; j < 24; j += 2)
+                                {
+                                    if (i + j >= data->dsSize)
+                                        break;
+                                    printf(", %04Xh", *reinterpret_cast<uint16_t*>(&data->dsCont[i + j]));
+                                }
+                                i += j;
+                                break;
+
+                            case 12:
+                            case 4:
+                                assert((data->dsSize % 4) == 0);
+                                printf("\tdd\t%08Xh", *reinterpret_cast<uint32_t*>(&data->dsCont[i]));
+                                for (j = 4; j < 24; j += 4)
+                                {
+                                    if (i + j >= data->dsSize)
+                                        break;
+                                    printf(", %08Xh", *reinterpret_cast<uint32_t*>(&data->dsCont[i + j]));
+                                }
+                                i += j;
+                                break;
+
+                            case 32:
+                            case 16:
+                            case 8:
+                                assert((data->dsSize % 8) == 0);
+                                printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i]));
+                                for (j = 8; j < 32; j += 8)
+                                {
+                                    if (i + j >= data->dsSize)
+                                        break;
+                                    printf(", %016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i + j]));
+                                }
+                                i += j;
+                                break;
+
+                            default:
+                                assert(!"unexpected elemSize");
+                                break;
+                        }
+                }
+                printf("\n");
             }
         }
     }

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5723,7 +5723,7 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
         // We match the bit pattern, so the dataType can be different
         // Only match constants when the dsType is 'data'
         //
-        if ((secDesc->dsType = dataSection::data) && (secDesc->dsSize >= cnsSize) && ((curOffs % alignment) == 0))
+        if ((secDesc->dsType == dataSection::data) && (secDesc->dsSize >= cnsSize) && ((curOffs % alignment) == 0))
         {
             if (memcmp(cnsAddr, secDesc->dsCont, cnsSize) == 0)
             {

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -5552,7 +5552,7 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(unsigned size, unsigned alignment, var_ty
         // alignment.  So if the requested alignment is greater than MIN_DATA_ALIGN,
         // we need to pad the space out so the offset is a multiple of the requested.
         //
-        uint8_t zeros[dataSection::MAX_DATA_ALIGN] = {};  // auto initialize to all zeros
+        uint8_t zeros[dataSection::MAX_DATA_ALIGN] = {}; // auto initialize to all zeros
 
         unsigned  zeroSize  = alignment - (secOffs % alignment);
         unsigned  zeroAlign = dataSection::MIN_DATA_ALIGN;
@@ -5734,7 +5734,7 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
                 if ((secDesc->dsDataType != dataType) && (secDesc->dsSize == cnsSize))
                 {
                     // If the subsequent dataType is floating point then change the original dsDataType
-                    // 
+                    //
                     if (varTypeIsFloating(dataType))
                     {
                         secDesc->dsDataType = dataType;

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -2167,6 +2167,9 @@ public:
 
     struct dataSection
     {
+        // Note to use alignments greater than 32 requires modification in the VM
+        // to support larger alignments (see ICorJitInfo::allocMem)
+        //
         const static unsigned MIN_DATA_ALIGN = 4;
         const static unsigned MAX_DATA_ALIGN = 32;
 

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -1694,7 +1694,7 @@ public:
     void emitSetMediumJump(instrDescJmp* id);
 
 public:
-    CORINFO_FIELD_HANDLE emitAnyConst(const void* cnsAddr, UNATIVE_OFFSET cnsSize, UNATIVE_OFFSET cnsAlign);
+    CORINFO_FIELD_HANDLE emitBlkConst(const void* cnsAddr, unsigned cnsSize, unsigned cnsAlign, var_types elemType);
 
 private:
     CORINFO_FIELD_HANDLE emitFltOrDblConst(double constValue, emitAttr attr);
@@ -2167,6 +2167,9 @@ public:
 
     struct dataSection
     {
+        const static unsigned MIN_DATA_ALIGN = 4;
+        const static unsigned MAX_DATA_ALIGN = 32;
+
         enum sectionType
         {
             data,
@@ -2177,6 +2180,8 @@ public:
         dataSection*   dsNext;
         UNATIVE_OFFSET dsSize;
         sectionType    dsType;
+        var_types      dsDataType;
+
         // variable-sized array used to store the constant data
         // or BasicBlock* array in the block cases.
         BYTE dsCont[0];

--- a/src/coreclr/src/jit/emitpub.h
+++ b/src/coreclr/src/jit/emitpub.h
@@ -82,7 +82,7 @@ void emitIns_J(instruction ins, BasicBlock* dst, int instrCount = 0);
 /*                   Emit initialized data sections                     */
 /************************************************************************/
 
-UNATIVE_OFFSET emitDataGenBeg(UNATIVE_OFFSET size, UNATIVE_OFFSET alignment);
+UNATIVE_OFFSET emitDataGenBeg(unsigned size, unsigned alignment, var_types dataType);
 
 UNATIVE_OFFSET emitBBTableDataGenBeg(unsigned numEntries, bool relativeAddr);
 
@@ -92,7 +92,11 @@ void emitDataGenData(unsigned offs, BasicBlock* label);
 
 void emitDataGenEnd();
 
-UNATIVE_OFFSET emitDataConst(const void* cnsAddr, UNATIVE_OFFSET cnsSize, UNATIVE_OFFSET cnsAlign);
+static const UNATIVE_OFFSET INVALID_UNATIVE_OFFSET = (UNATIVE_OFFSET)-1;
+
+UNATIVE_OFFSET emitDataGenFind(const void* cnsAddr, unsigned size, unsigned alignment, var_types dataType);
+
+UNATIVE_OFFSET emitDataConst(const void* cnsAddr, unsigned cnsSize, unsigned cnsAlign, var_types dataType);
 
 UNATIVE_OFFSET emitDataSize();
 

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -992,11 +992,13 @@ void Lowering::LowerHWIntrinsicCreate(GenTreeHWIntrinsic* node)
             }
         }
 
-        UNATIVE_OFFSET cnsSize  = (simdSize == 12) ? 16 : simdSize;
-        UNATIVE_OFFSET cnsAlign = cnsSize;
+        unsigned  cnsSize  = (simdSize == 12) ? 16 : simdSize;
+        unsigned  cnsAlign = cnsSize;
+        var_types dataType = Compiler::getSIMDTypeForSize(simdSize);
 
-        CORINFO_FIELD_HANDLE hnd = comp->GetEmitter()->emitAnyConst(&vecCns, cnsSize, cnsAlign);
-        GenTree* clsVarAddr      = new (comp, GT_CLS_VAR_ADDR) GenTreeClsVar(GT_CLS_VAR_ADDR, TYP_I_IMPL, hnd, nullptr);
+        UNATIVE_OFFSET       cnum = comp->GetEmitter()->emitDataConst(&vecCns, cnsSize, cnsAlign, dataType);
+        CORINFO_FIELD_HANDLE hnd  = comp->eeFindJitDataOffs(cnum);
+        GenTree* clsVarAddr = new (comp, GT_CLS_VAR_ADDR) GenTreeClsVar(GT_CLS_VAR_ADDR, TYP_I_IMPL, hnd, nullptr);
         BlockRange().InsertBefore(node, clsVarAddr);
 
         node->ChangeOper(GT_IND);


### PR DESCRIPTION
- Duplicate values will now be reused in the constants area
- Added MIN_DATA_ALIGN and MAX_DATA_ALIGN constants
- Added dsDataType to record the type of the constant
- Print the floating point values in the constants area
- Changed 'alignment' and 'cnsSize' parameters to be unsigned instead of UNATIVE_OFFSET
- Added method emitDataGenFind to search and return a duplicate constant value