### PR TITLE
Add test for exception propagation inside loader events

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -641,6 +641,48 @@ namespace System.Tests
             }).Dispose();
         }
 
+        class CorrectlyPropagatesException : Exception
+        {
+            public CorrectlyPropagatesException(string message) : base(message)
+            { }
+        }
+
+        [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/43909", TestRuntimes.Mono)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AssemblyResolve_ExceptionPropagatesCorrectly(bool throwOnError)
+        {
+            bool handlerExceptionThrown = false;
+
+            ResolveEventHandler handler = (sender, args) =>
+            {
+                if (args.Name.StartsWith("Some.Assembly"))
+                    throw new CorrectlyPropagatesException("Failure");
+                return null;
+            };
+
+            AppDomain.CurrentDomain.AssemblyResolve += handler;
+
+            try
+            {
+                Type.GetType("Some.Assembly.Type, Some.Assembly", throwOnError);
+            }
+            catch (FileLoadException e)
+            {
+                Assert.NotNull(e.InnerException);
+                Assert.IsAssignableFrom<CorrectlyPropagatesException>(e.InnerException);
+                Assert.Equal("Failure", e.InnerException.Message);
+                handlerExceptionThrown = true;
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.AssemblyResolve -= handler;
+            }
+
+            Assert.True(handlerExceptionThrown);
+        }
+
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TypeResolve()
         {


### PR DESCRIPTION
Currently broken on Mono, see https://github.com/dotnet/runtime/issues/43909