### PR TITLE
Add tests for assembly name stringification inside Type.GetType

### DIFF
--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <!-- LoadFrom_SameIdentityAsAssemblyWithDifferentPath_ReturnsEqualAssemblies test relies on no deps.json -->
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
This test uses the AssemblyResolve handler, but it's arguably a reflection test at the core, so I've put it here. Happy to move it elsewhere as appropriate. Similarly, if I'm missing useful cases here I'm happy to add them.

It currently passes on Mono due to https://github.com/dotnet/runtime/pull/43910 but should not, so I've disabled it for now. Once that issue is resolved, I'll push a fix for Mono and re-enable the test. The underlying issue is tracked at https://github.com/mono/mono/issues/19803