### PR TITLE
Simple GT_NEG optimization for #13837

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13361,8 +13361,8 @@ DONE_MORPHING_CHILDREN:
                     // op2: NEG
                     // op2Child: b
 
-                    GenTree* op1Child = op1->AsOp()->gtOp1; // a
-                    GenTree* op2Child = op2->AsOp()->gtOp1; // b
+                    GenTree* op1Child   = op1->AsOp()->gtOp1; // a
+                    GenTree* op2Child   = op2->AsOp()->gtOp1; // b
                     tree->AsOp()->gtOp1 = op2Child;
                     tree->AsOp()->gtOp2 = op1Child;
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13324,6 +13324,61 @@ DONE_MORPHING_CHILDREN:
 
                 /* No match - exit */
             }
+
+            if (opts.OptimizationEnabled() &&
+                (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
+            {
+                bool op1OperIsGT_NEG = op1->OperIs(GT_NEG);
+                bool op2OperIsGT_NEG = op2->OperIs(GT_NEG);
+
+                // a - -b = > a + b
+                // SUB(a, (NEG(b)) => ADD(a, b)
+
+                if (!op1OperIsGT_NEG && op2OperIsGT_NEG)
+                {
+                    // tree: SUB
+                    // op1: a
+                    // op2: NEG
+                    // op2Child: b
+
+                    GenTree* op2Child = op2->AsOp()->gtOp1; // b
+                    oper              = GT_ADD;
+                    tree->SetOper(oper);
+                    tree->AsOp()->gtOp1 = op1; // no change
+                    tree->AsOp()->gtOp2 = op2Child;
+
+                    DEBUG_DESTROY_NODE(op2);
+
+                    // op1 = op1;   // no change
+                    op2 = op2Child;
+                }
+
+                // -a - -b = > b - a
+                // SUB(NEG(a), (NEG(b)) => SUB(b, a)
+
+                if (op1OperIsGT_NEG && op2OperIsGT_NEG)
+                {
+                    // tree: SUB
+                    // op1: NEG
+                    // op1Child: a
+                    // op2: NEG
+                    // op2Child: b
+
+                    GenTree* op1Child = op1->AsOp()->gtOp1; // a
+                    GenTree* op2Child = op2->AsOp()->gtOp1; // b
+                    oper              = GT_SUB;             // no change
+                    tree->SetOper(oper);                    // no change
+                    tree->AsOp()->gtOp1 = op2Child;
+                    tree->AsOp()->gtOp2 = op1Child;
+
+                    DEBUG_DESTROY_NODE(op1);
+                    DEBUG_DESTROY_NODE(op2);
+
+                    op1 = op2Child;
+                    op2 = op1Child;
+                }
+            }
+
             break;
 
 #ifdef TARGET_ARM64
@@ -13531,6 +13586,57 @@ DONE_MORPHING_CHILDREN:
 
                             return op1;
                         }
+                    }
+                }
+
+                if (opts.OptimizationEnabled() &&
+                    (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
+                {
+                    bool op1OperIsGT_NEG = op1->OperIs(GT_NEG);
+                    bool op2OperIsGT_NEG = op2->OperIs(GT_NEG);
+
+                    // - a + b = > b - a
+                    // ADD((NEG(a), b) => SUB(b, a)
+
+                    if (op1OperIsGT_NEG && !op2OperIsGT_NEG)
+                    {
+                        // tree: ADD
+                        // op1: NEG
+                        // op2: b
+                        // op1Child: a
+
+                        GenTree* op1Child = op1->AsOp()->gtOp1; // a
+                        oper              = GT_SUB;
+                        tree->SetOper(oper);
+                        tree->AsOp()->gtOp1 = op2;
+                        tree->AsOp()->gtOp2 = op1Child;
+
+                        DEBUG_DESTROY_NODE(op1);
+
+                        op1 = op2;
+                        op2 = op1Child;
+                    }
+
+                    // a + -b = > a - b
+                    // ADD(a, (NEG(b)) => SUB(a, b)
+
+                    if (!op1OperIsGT_NEG && op2OperIsGT_NEG)
+                    {
+                        // tree: ADD
+                        // op1: a
+                        // op2: NEG
+                        // op2Child: b
+
+                        GenTree* op2Child = op2->AsOp()->gtOp1; // a
+                        oper              = GT_SUB;
+                        tree->SetOper(oper);
+                        // tree->AsOp()->gtOp1 = op1;   // no change
+                        tree->AsOp()->gtOp2 = op2Child;
+
+                        DEBUG_DESTROY_NODE(op2);
+
+                        // op1 = op2;
+                        op2 = op2Child;
                     }
                 }
             }
@@ -14957,23 +15063,22 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
     //                    / \      / \.
     //                   x  AND   x  AND
     //                      / \      / \.
-    //                     y  31   ADD  31
+    //                     y  31   SUB  31
     //                             / \.
-    //                            NEG 32
-    //                             |
-    //                             y
+    //                            32  y
+
     // The patterns recognized:
-    // (x << (y & M)) op (x >>> ((-y + N) & M))
-    // (x >>> ((-y + N) & M)) op (x << (y & M))
+    // (x << (y & M)) op (x >>> ((N - y) & M))
+    // (x >>> ((N - y) & M)) op (x << (y & M))
     //
-    // (x << y) op (x >>> (-y + N))
-    // (x >> > (-y + N)) op (x << y)
+    // (x << y) op (x >>> (N - y))
+    // (x >> > (N - y)) op (x << y)
     //
-    // (x >>> (y & M)) op (x << ((-y + N) & M))
-    // (x << ((-y + N) & M)) op (x >>> (y & M))
+    // (x >>> (y & M)) op (x << ((N - y) & M))
+    // (x << ((N - y) & M)) op (x >>> (y & M))
     //
-    // (x >>> y) op (x << (-y + N))
-    // (x << (-y + N)) op (x >>> y)
+    // (x >>> y) op (x << (N - y))
+    // (x << (N - y)) op (x >>> y)
     //
     // (x << c1) op (x >>> c2)
     // (x >>> c1) op (x << c2)
@@ -15072,55 +15177,52 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
             return tree;
         }
 
-        GenTree*   shiftIndexWithAdd    = nullptr;
-        GenTree*   shiftIndexWithoutAdd = nullptr;
+        GenTree*   shiftIndexWithSUB    = nullptr;
+        GenTree*   shiftIndexWithoutSUB = nullptr;
         genTreeOps rotateOp             = GT_NONE;
         GenTree*   rotateIndex          = nullptr;
 
-        if (leftShiftIndex->OperGet() == GT_ADD)
+        if (leftShiftIndex->OperGet() == GT_SUB)
         {
-            shiftIndexWithAdd    = leftShiftIndex;
-            shiftIndexWithoutAdd = rightShiftIndex;
+            shiftIndexWithSUB    = leftShiftIndex;
+            shiftIndexWithoutSUB = rightShiftIndex;
             rotateOp             = GT_ROR;
         }
-        else if (rightShiftIndex->OperGet() == GT_ADD)
+        else if (rightShiftIndex->OperGet() == GT_SUB)
         {
-            shiftIndexWithAdd    = rightShiftIndex;
-            shiftIndexWithoutAdd = leftShiftIndex;
+            shiftIndexWithSUB    = rightShiftIndex;
+            shiftIndexWithoutSUB = leftShiftIndex;
             rotateOp             = GT_ROL;
         }
 
-        if (shiftIndexWithAdd != nullptr)
+        if (shiftIndexWithSUB != nullptr)
         {
-            if (shiftIndexWithAdd->gtGetOp2()->IsCnsIntOrI())
+            if (shiftIndexWithSUB->gtGetOp1()->IsCnsIntOrI())
             {
-                if (shiftIndexWithAdd->gtGetOp2()->AsIntCon()->gtIconVal == rotatedValueBitSize)
+                if (shiftIndexWithSUB->gtGetOp1()->AsIntCon()->gtIconVal == rotatedValueBitSize)
                 {
-                    if (shiftIndexWithAdd->gtGetOp1()->OperGet() == GT_NEG)
+                    if (GenTree::Compare(shiftIndexWithSUB->gtGetOp2(), shiftIndexWithoutSUB))
                     {
-                        if (GenTree::Compare(shiftIndexWithAdd->gtGetOp1()->gtGetOp1(), shiftIndexWithoutAdd))
-                        {
-                            // We found one of these patterns:
-                            // (x << (y & M)) | (x >>> ((-y + N) & M))
-                            // (x << y) | (x >>> (-y + N))
-                            // (x >>> (y & M)) | (x << ((-y + N) & M))
-                            // (x >>> y) | (x << (-y + N))
-                            // where N == bitsize(x), M is const, and
-                            // M & (N - 1) == N - 1
-                            CLANG_FORMAT_COMMENT_ANCHOR;
+                        // We found one of these patterns:
+                        // (x << (y & M)) | (x >>> ((N - y) & M))
+                        // (x << y) | (x >>> (N - y))
+                        // (x >>> (y & M)) | (x << ((N - y) & M))
+                        // (x >>> y) | (x << (N - y))
+                        // where N == bitsize(x), M is const, and
+                        // M & (N - 1) == N - 1
+                        CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifndef TARGET_64BIT
-                            if (!shiftIndexWithoutAdd->IsCnsIntOrI() && (rotatedValueBitSize == 64))
-                            {
-                                // TODO-X86-CQ: we need to handle variable-sized long shifts specially on x86.
-                                // GT_LSH, GT_RSH, and GT_RSZ have helpers for this case. We may need
-                                // to add helpers for GT_ROL and GT_ROR.
-                                return tree;
-                            }
+                        if (!shiftIndexWithoutSUB->IsCnsIntOrI() && (rotatedValueBitSize == 64))
+                        {
+                            // TODO-X86-CQ: we need to handle variable-sized long shifts specially on x86.
+                            // GT_LSH, GT_RSH, and GT_RSZ have helpers for this case. We may need
+                            // to add helpers for GT_ROL and GT_ROR.
+                            return tree;
+                        }
 #endif
 
-                            rotateIndex = shiftIndexWithoutAdd;
-                        }
+                        rotateIndex = shiftIndexWithoutSUB;
                     }
                 }
             }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13327,7 +13327,7 @@ DONE_MORPHING_CHILDREN:
 
             // Skip optimization if non-NEG operand is constant.
             // Both op1 and op2 are not constant because it was already checked above.
-            if (opts.OptimizationEnabled() &&
+            if (opts.OptimizationEnabled() && fgGlobalMorph &&
                 (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
             {
                 // a - -b = > a + b
@@ -13342,7 +13342,7 @@ DONE_MORPHING_CHILDREN:
 
                     GenTree* op2Child = op2->AsOp()->gtOp1; // b
                     oper              = GT_ADD;
-                    tree->SetOper(oper);
+                    tree->SetOper(oper, GenTree::PRESERVE_VN);
                     tree->AsOp()->gtOp1 = op1; // no change
                     tree->AsOp()->gtOp2 = op2Child;
 
@@ -13365,8 +13365,8 @@ DONE_MORPHING_CHILDREN:
 
                     GenTree* op1Child = op1->AsOp()->gtOp1; // a
                     GenTree* op2Child = op2->AsOp()->gtOp1; // b
-                    oper              = GT_SUB;             // no change
-                    tree->SetOper(oper);                    // no change
+                    // oper              = GT_SUB;                // no change
+                    // tree->SetOper(oper, GenTree::PRESERVE_VN); // no change
                     tree->AsOp()->gtOp1 = op2Child;
                     tree->AsOp()->gtOp2 = op1Child;
 
@@ -13588,7 +13588,7 @@ DONE_MORPHING_CHILDREN:
                     }
                 }
 
-                if (opts.OptimizationEnabled() &&
+                if (opts.OptimizationEnabled() && fgGlobalMorph &&
                     (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
                 {
                     // - a + b = > b - a
@@ -13605,7 +13605,7 @@ DONE_MORPHING_CHILDREN:
 
                         GenTree* op1Child = op1->AsOp()->gtOp1; // a
                         oper              = GT_SUB;
-                        tree->SetOper(oper);
+                        tree->SetOper(oper, GenTree::PRESERVE_VN);
                         tree->AsOp()->gtOp1 = op2;
                         tree->AsOp()->gtOp2 = op1Child;
 
@@ -13630,7 +13630,7 @@ DONE_MORPHING_CHILDREN:
 
                         GenTree* op2Child = op2->AsOp()->gtOp1; // a
                         oper              = GT_SUB;
-                        tree->SetOper(oper);
+                        tree->SetOper(oper, GenTree::PRESERVE_VN);
                         // tree->AsOp()->gtOp1 = op1;   // no change
                         tree->AsOp()->gtOp2 = op2Child;
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13325,16 +13325,15 @@ DONE_MORPHING_CHILDREN:
                 /* No match - exit */
             }
 
+            // Skip optimization if non-NEG operand is constant.
+            // Both op1 and op2 are not constant because it was already checked above.
             if (opts.OptimizationEnabled() &&
                 (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
             {
-                bool op1OperIsGT_NEG = op1->OperIs(GT_NEG);
-                bool op2OperIsGT_NEG = op2->OperIs(GT_NEG);
-
                 // a - -b = > a + b
                 // SUB(a, (NEG(b)) => ADD(a, b)
 
-                if (!op1OperIsGT_NEG && op2OperIsGT_NEG)
+                if (!op1->OperIs(GT_NEG) && op2->OperIs(GT_NEG))
                 {
                     // tree: SUB
                     // op1: a
@@ -13356,7 +13355,7 @@ DONE_MORPHING_CHILDREN:
                 // -a - -b = > b - a
                 // SUB(NEG(a), (NEG(b)) => SUB(b, a)
 
-                if (op1OperIsGT_NEG && op2OperIsGT_NEG)
+                if (op1->OperIs(GT_NEG) && op2->OperIs(GT_NEG))
                 {
                     // tree: SUB
                     // op1: NEG
@@ -13592,13 +13591,12 @@ DONE_MORPHING_CHILDREN:
                 if (opts.OptimizationEnabled() &&
                     (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
                 {
-                    bool op1OperIsGT_NEG = op1->OperIs(GT_NEG);
-                    bool op2OperIsGT_NEG = op2->OperIs(GT_NEG);
-
                     // - a + b = > b - a
                     // ADD((NEG(a), b) => SUB(b, a)
 
-                    if (op1OperIsGT_NEG && !op2OperIsGT_NEG)
+                    // Skip optimization if non-NEG operand is constant.
+                    if (op1->OperIs(GT_NEG) && !op2->OperIs(GT_NEG) &&
+                        !(op2->IsCnsIntOrI() && varTypeIsIntegralOrI(typ)))
                     {
                         // tree: ADD
                         // op1: NEG
@@ -13620,8 +13618,11 @@ DONE_MORPHING_CHILDREN:
                     // a + -b = > a - b
                     // ADD(a, (NEG(b)) => SUB(a, b)
 
-                    if (!op1OperIsGT_NEG && op2OperIsGT_NEG)
+                    if (!op1->OperIs(GT_NEG) && op2->OperIs(GT_NEG))
                     {
+                        // a is non cosntant because it was already canonicalized to have
+                        // variable on the left and constant on the right.
+
                         // tree: ADD
                         // op1: a
                         // op2: NEG
@@ -15063,22 +15064,23 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
     //                    / \      / \.
     //                   x  AND   x  AND
     //                      / \      / \.
-    //                     y  31   SUB  31
+    //                     y  31   ADD  31
     //                             / \.
-    //                            32  y
-
+    //                            NEG 32
+    //                             |
+    //                             y
     // The patterns recognized:
-    // (x << (y & M)) op (x >>> ((N - y) & M))
-    // (x >>> ((N - y) & M)) op (x << (y & M))
+    // (x << (y & M)) op (x >>> ((-y + N) & M))
+    // (x >>> ((-y + N) & M)) op (x << (y & M))
     //
-    // (x << y) op (x >>> (N - y))
-    // (x >> > (N - y)) op (x << y)
+    // (x << y) op (x >>> (-y + N))
+    // (x >> > (-y + N)) op (x << y)
     //
-    // (x >>> (y & M)) op (x << ((N - y) & M))
-    // (x << ((N - y) & M)) op (x >>> (y & M))
+    // (x >>> (y & M)) op (x << ((-y + N) & M))
+    // (x << ((-y + N) & M)) op (x >>> (y & M))
     //
-    // (x >>> y) op (x << (N - y))
-    // (x << (N - y)) op (x >>> y)
+    // (x >>> y) op (x << (-y + N))
+    // (x << (-y + N)) op (x >>> y)
     //
     // (x << c1) op (x >>> c2)
     // (x >>> c1) op (x << c2)
@@ -15177,52 +15179,55 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
             return tree;
         }
 
-        GenTree*   shiftIndexWithSUB    = nullptr;
-        GenTree*   shiftIndexWithoutSUB = nullptr;
+        GenTree*   shiftIndexWithAdd    = nullptr;
+        GenTree*   shiftIndexWithoutAdd = nullptr;
         genTreeOps rotateOp             = GT_NONE;
         GenTree*   rotateIndex          = nullptr;
 
-        if (leftShiftIndex->OperGet() == GT_SUB)
+        if (leftShiftIndex->OperGet() == GT_ADD)
         {
-            shiftIndexWithSUB    = leftShiftIndex;
-            shiftIndexWithoutSUB = rightShiftIndex;
+            shiftIndexWithAdd    = leftShiftIndex;
+            shiftIndexWithoutAdd = rightShiftIndex;
             rotateOp             = GT_ROR;
         }
-        else if (rightShiftIndex->OperGet() == GT_SUB)
+        else if (rightShiftIndex->OperGet() == GT_ADD)
         {
-            shiftIndexWithSUB    = rightShiftIndex;
-            shiftIndexWithoutSUB = leftShiftIndex;
+            shiftIndexWithAdd    = rightShiftIndex;
+            shiftIndexWithoutAdd = leftShiftIndex;
             rotateOp             = GT_ROL;
         }
 
-        if (shiftIndexWithSUB != nullptr)
+        if (shiftIndexWithAdd != nullptr)
         {
-            if (shiftIndexWithSUB->gtGetOp1()->IsCnsIntOrI())
+            if (shiftIndexWithAdd->gtGetOp2()->IsCnsIntOrI())
             {
-                if (shiftIndexWithSUB->gtGetOp1()->AsIntCon()->gtIconVal == rotatedValueBitSize)
+                if (shiftIndexWithAdd->gtGetOp2()->AsIntCon()->gtIconVal == rotatedValueBitSize)
                 {
-                    if (GenTree::Compare(shiftIndexWithSUB->gtGetOp2(), shiftIndexWithoutSUB))
+                    if (shiftIndexWithAdd->gtGetOp1()->OperGet() == GT_NEG)
                     {
-                        // We found one of these patterns:
-                        // (x << (y & M)) | (x >>> ((N - y) & M))
-                        // (x << y) | (x >>> (N - y))
-                        // (x >>> (y & M)) | (x << ((N - y) & M))
-                        // (x >>> y) | (x << (N - y))
-                        // where N == bitsize(x), M is const, and
-                        // M & (N - 1) == N - 1
-                        CLANG_FORMAT_COMMENT_ANCHOR;
+                        if (GenTree::Compare(shiftIndexWithAdd->gtGetOp1()->gtGetOp1(), shiftIndexWithoutAdd))
+                        {
+                            // We found one of these patterns:
+                            // (x << (y & M)) | (x >>> ((-y + N) & M))
+                            // (x << y) | (x >>> (-y + N))
+                            // (x >>> (y & M)) | (x << ((-y + N) & M))
+                            // (x >>> y) | (x << (-y + N))
+                            // where N == bitsize(x), M is const, and
+                            // M & (N - 1) == N - 1
+                            CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifndef TARGET_64BIT
-                        if (!shiftIndexWithoutSUB->IsCnsIntOrI() && (rotatedValueBitSize == 64))
-                        {
-                            // TODO-X86-CQ: we need to handle variable-sized long shifts specially on x86.
-                            // GT_LSH, GT_RSH, and GT_RSZ have helpers for this case. We may need
-                            // to add helpers for GT_ROL and GT_ROR.
-                            return tree;
-                        }
+                            if (!shiftIndexWithoutAdd->IsCnsIntOrI() && (rotatedValueBitSize == 64))
+                            {
+                                // TODO-X86-CQ: we need to handle variable-sized long shifts specially on x86.
+                                // GT_LSH, GT_RSH, and GT_RSZ have helpers for this case. We may need
+                                // to add helpers for GT_ROL and GT_ROR.
+                                return tree;
+                            }
 #endif
 
-                        rotateIndex = shiftIndexWithoutSUB;
+                            rotateIndex = shiftIndexWithoutAdd;
+                        }
                     }
                 }
             }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13343,12 +13343,10 @@ DONE_MORPHING_CHILDREN:
                     GenTree* op2Child = op2->AsOp()->gtOp1; // b
                     oper              = GT_ADD;
                     tree->SetOper(oper, GenTree::PRESERVE_VN);
-                    tree->AsOp()->gtOp1 = op1; // no change
                     tree->AsOp()->gtOp2 = op2Child;
 
                     DEBUG_DESTROY_NODE(op2);
 
-                    // op1 = op1;   // no change
                     op2 = op2Child;
                 }
 
@@ -13365,8 +13363,6 @@ DONE_MORPHING_CHILDREN:
 
                     GenTree* op1Child = op1->AsOp()->gtOp1; // a
                     GenTree* op2Child = op2->AsOp()->gtOp1; // b
-                    // oper              = GT_SUB;                // no change
-                    // tree->SetOper(oper, GenTree::PRESERVE_VN); // no change
                     tree->AsOp()->gtOp1 = op2Child;
                     tree->AsOp()->gtOp2 = op1Child;
 
@@ -13631,12 +13627,10 @@ DONE_MORPHING_CHILDREN:
                         GenTree* op2Child = op2->AsOp()->gtOp1; // a
                         oper              = GT_SUB;
                         tree->SetOper(oper, GenTree::PRESERVE_VN);
-                        // tree->AsOp()->gtOp1 = op1;   // no change
                         tree->AsOp()->gtOp2 = op2Child;
 
                         DEBUG_DESTROY_NODE(op2);
 
-                        // op1 = op2;
                         op2 = op2Child;
                     }
                 }


### PR DESCRIPTION
Fixes #13837 

replaces #43148 (use rebase to fix merge related issues).
```
Total bytes of diff: -42 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
         -13 : System.Private.CoreLib.dasm (-0.00% of base)
          -8 : Microsoft.VisualBasic.Core.dasm (-0.00% of base)
          -8 : System.Private.Xml.dasm (-0.00% of base)
          -8 : System.Runtime.Numerics.dasm (-0.01% of base)
          -4 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
          -1 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
6 total files with Code Size differences (6 improved, 0 regressed), 262 unchanged.
Top method improvements (bytes):
          -8 (-1.44% of base) : Microsoft.VisualBasic.Core.dasm - Financial:NPer(double,double,double,double,int):double
          -8 (-5.41% of base) : System.Runtime.Numerics.dasm - Complex:op_Division(Complex,Complex):Complex
          -6 (-1.46% of base) : System.Private.Xml.dasm - XmlSqlBinaryReader:FillAllowEOF():bool:this
          -5 (-0.70% of base) : System.Private.CoreLib.dasm - Number:NumberToFloatingPointBitsSlow(byref,byref,int,int,int):long
          -4 (-1.02% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceConstructorSymbol:CalculateLocalSyntaxOffset(int,SyntaxTree):int:this
          -4 (-1.94% of base) : System.Private.CoreLib.dasm - ScopeTree:AddScopeInfo(byte,int):this
          -2 (-1.55% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunCounted(byref,int,Span`1,byref,byref):bool
          -2 (-1.05% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunShortest(byref,byref,byref,Span`1,byref,byref):bool
          -2 (-0.19% of base) : System.Private.Xml.dasm - FloatingDecimal:AdjustDbl(double):double:this
          -1 (-0.20% of base) : Microsoft.CodeAnalysis.dasm - CustomDebugInfoWriter:SerializeReferenceToIteratorClass(String,ArrayBuilder`1)
Top method improvements (percentages):
          -8 (-5.41% of base) : System.Runtime.Numerics.dasm - Complex:op_Division(Complex,Complex):Complex
          -4 (-1.94% of base) : System.Private.CoreLib.dasm - ScopeTree:AddScopeInfo(byte,int):this
          -2 (-1.55% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunCounted(byref,int,Span`1,byref,byref):bool
          -6 (-1.46% of base) : System.Private.Xml.dasm - XmlSqlBinaryReader:FillAllowEOF():bool:this
          -8 (-1.44% of base) : Microsoft.VisualBasic.Core.dasm - Financial:NPer(double,double,double,double,int):double
          -2 (-1.05% of base) : System.Private.CoreLib.dasm - Grisu3:TryRunShortest(byref,byref,byref,Span`1,byref,byref):bool
          -4 (-1.02% of base) : Microsoft.CodeAnalysis.CSharp.dasm - SourceConstructorSymbol:CalculateLocalSyntaxOffset(int,SyntaxTree):int:this
          -5 (-0.70% of base) : System.Private.CoreLib.dasm - Number:NumberToFloatingPointBitsSlow(byref,byref,int,int,int):long
          -1 (-0.20% of base) : Microsoft.CodeAnalysis.dasm - CustomDebugInfoWriter:SerializeReferenceToIteratorClass(String,ArrayBuilder`1)
          -2 (-0.19% of base) : System.Private.Xml.dasm - FloatingDecimal:AdjustDbl(double):double:this
10 total methods with Code Size differences (10 improved, 0 regressed), 258863 unchanged.
```