### PR TITLE
Resolve warnings for assignment or explicit cast of possibly null type parameter value

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -536,7 +536,7 @@ namespace System.Collections.Concurrent
         /// <remarks>A call to <see cref="Take()"/> may block until an item is available to be removed.</remarks>
         public T Take()
         {
-            T item;
+            T? item;
 
             if (!TryTake(out item, Timeout.Infinite, CancellationToken.None))
             {
@@ -560,7 +560,7 @@ namespace System.Collections.Concurrent
         /// <remarks>A call to <see cref="Take(CancellationToken)"/> may block until an item is available to be removed.</remarks>
         public T Take(CancellationToken cancellationToken)
         {
-            T item;
+            T? item;
 
             if (!TryTake(out item, Timeout.Infinite, cancellationToken))
             {
@@ -1658,7 +1658,7 @@ namespace System.Collections.Concurrent
                 linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _consumersCancellationTokenSource.Token);
                 while (!IsCompleted)
                 {
-                    T item;
+                    T? item;
                     if (TryTakeWithNoTimeValidation(out item, Timeout.Infinite, cancellationToken, linkedTokenSource))
                     {
                         yield return item;

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -448,7 +448,7 @@ namespace System.Collections.Concurrent
                 FreezeBag(ref lockTaken);
                 for (WorkStealingQueue? queue = _workStealingQueues; queue != null; queue = queue._nextQueue)
                 {
-                    T ignored;
+                    T? ignored;
                     while (queue.TrySteal(out ignored, take: true));
                 }
             }

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1022,7 +1022,7 @@ namespace System.Collections.Concurrent
         {
             get
             {
-                if (!TryGetValue(key, out TValue value))
+                if (!TryGetValue(key, out TValue? value))
                 {
                     ThrowKeyNotFoundException(key);
                 }
@@ -1132,7 +1132,7 @@ namespace System.Collections.Concurrent
             IEqualityComparer<TKey>? comparer = _comparer;
             int hashcode = comparer is null ? key.GetHashCode() : comparer.GetHashCode(key);
 
-            if (!TryGetValueInternal(key, hashcode, out TValue resultingValue))
+            if (!TryGetValueInternal(key, hashcode, out TValue? resultingValue))
             {
                 TryAddInternal(key, hashcode, valueFactory(key), updateIfExists: false, acquireLock: true, out resultingValue);
             }
@@ -1171,7 +1171,7 @@ namespace System.Collections.Concurrent
             IEqualityComparer<TKey>? comparer = _comparer;
             int hashcode = comparer is null ? key.GetHashCode() : comparer.GetHashCode(key);
 
-            if (!TryGetValueInternal(key, hashcode, out TValue resultingValue))
+            if (!TryGetValueInternal(key, hashcode, out TValue? resultingValue))
             {
                 TryAddInternal(key, hashcode, valueFactory(key, factoryArgument), updateIfExists: false, acquireLock: true, out resultingValue);
             }
@@ -1201,7 +1201,7 @@ namespace System.Collections.Concurrent
             IEqualityComparer<TKey>? comparer = _comparer;
             int hashcode = comparer is null ? key.GetHashCode() : comparer.GetHashCode(key);
 
-            if (!TryGetValueInternal(key, hashcode, out TValue resultingValue))
+            if (!TryGetValueInternal(key, hashcode, out TValue? resultingValue))
             {
                 TryAddInternal(key, hashcode, value, updateIfExists: false, acquireLock: true, out resultingValue);
             }
@@ -1252,7 +1252,7 @@ namespace System.Collections.Concurrent
 
             while (true)
             {
-                if (TryGetValueInternal(key, hashcode, out TValue oldValue))
+                if (TryGetValueInternal(key, hashcode, out TValue? oldValue))
                 {
                     // key exists, try to update
                     TValue newValue = updateValueFactory(key, oldValue, factoryArgument);
@@ -1313,7 +1313,7 @@ namespace System.Collections.Concurrent
 
             while (true)
             {
-                if (TryGetValueInternal(key, hashcode, out TValue oldValue))
+                if (TryGetValueInternal(key, hashcode, out TValue? oldValue))
                 {
                     // key exists, try to update
                     TValue newValue = updateValueFactory(key, oldValue);
@@ -1367,7 +1367,7 @@ namespace System.Collections.Concurrent
 
             while (true)
             {
-                if (TryGetValueInternal(key, hashcode, out TValue oldValue))
+                if (TryGetValueInternal(key, hashcode, out TValue? oldValue))
                 {
                     // key exists, try to update
                     TValue newValue = updateValueFactory(key, oldValue);
@@ -1538,7 +1538,7 @@ namespace System.Collections.Concurrent
         /// cref="ICollection{T}"/>; otherwise, false.</returns>
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            if (!TryGetValue(keyValuePair.Key, out TValue value))
+            if (!TryGetValue(keyValuePair.Key, out TValue? value))
             {
                 return false;
             }
@@ -1730,7 +1730,7 @@ namespace System.Collections.Concurrent
                     ThrowHelper.ThrowKeyNullException();
                 }
 
-                if (key is TKey tkey && TryGetValue(tkey, out TValue value))
+                if (key is TKey tkey && TryGetValue(tkey, out TValue? value))
                 {
                     return value;
                 }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -196,7 +196,7 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNullAllowStructs(key, nameof(key));
 
-                TValue value;
+                TValue? value;
                 if (this.TryGetValue(key, out value))
                 {
                     return value;

--- a/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException(nameof(dictionary));
             }
 
-            TValue value;
+            TValue? value;
             return dictionary.TryGetValue(key, out value) ? value : defaultValue;
         }
 

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -326,7 +326,7 @@ namespace System.Collections.Generic
             {
                 if (IsCompatibleKey(key))
                 {
-                    TValue value;
+                    TValue? value;
                     if (TryGetValue((TKey)key, out value))
                     {
                         return value;

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -146,8 +146,8 @@ namespace System.Collections.Generic
 
         private void RemoveAllElements(IEnumerable<T> collection)
         {
-            T min = Min;
-            T max = Max;
+            T? min = Min;
+            T? max = Max;
             foreach (T item in collection)
             {
                 if (!(comparer.Compare(item, min) < 0 || comparer.Compare(item, max) > 0) && Contains(item))
@@ -1031,7 +1031,7 @@ namespace System.Collections.Generic
                 Enumerator mine = this.GetEnumerator();
                 Enumerator theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext(), theirsEnded = !theirs.MoveNext();
-                T max = Max;
+                T? max = Max;
 
                 while (!mineEnded && !theirsEnded && Comparer.Compare(theirs.Current, max) <= 0)
                 {
@@ -1109,8 +1109,8 @@ namespace System.Collections.Generic
                 // Outside range, no point in doing anything
                 if (comparer.Compare(asSorted.Max, Min) >= 0 && comparer.Compare(asSorted.Min, Max) <= 0)
                 {
-                    T min = Min;
-                    T max = Max;
+                    T? min = Min;
+                    T? max = Max;
                     foreach (T item in other)
                     {
                         if (comparer.Compare(item, min) < 0)

--- a/src/libraries/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
+++ b/src/libraries/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
@@ -277,8 +277,8 @@ namespace System.ComponentModel.Composition.Hosting
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void SetValue(object key, object? value) { }
-        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out T value) { throw null; }
-        public bool TryGetValue<T>(object key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out T value) { throw null; }
+        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T value) { throw null; }
+        public bool TryGetValue<T>(object key, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T value) { throw null; }
     }
     public partial class CatalogExportProvider : System.ComponentModel.Composition.Hosting.ExportProvider, System.IDisposable
     {

--- a/src/libraries/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
+++ b/src/libraries/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.cs
@@ -277,8 +277,8 @@ namespace System.ComponentModel.Composition.Hosting
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public void SetValue(object key, object? value) { }
-        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T value) { throw null; }
-        public bool TryGetValue<T>(object key, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T value) { throw null; }
+        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out T value) { throw null; }
+        public bool TryGetValue<T>(object key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out T value) { throw null; }
     }
     public partial class CatalogExportProvider : System.ComponentModel.Composition.Hosting.ExportProvider, System.IDisposable
     {

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
@@ -70,12 +70,12 @@ namespace System.ComponentModel.Composition.Hosting
             SetValueInternal(key, value);
         }
 
-        public bool TryGetValue<T>(object key, [NotNullWhen(true)] out T? value)
+        public bool TryGetValue<T>(object key, [MaybeNullWhen(false)] out T value)
         {
             return TryGetValue(key, false, out value);
         }
 
-        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [NotNullWhen(true)] out T? value)
+        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [MaybeNullWhen(false)] out T value)
         {
             ThrowIfDisposed();
             ThrowIfCompleted();
@@ -277,7 +277,7 @@ namespace System.ComponentModel.Composition.Hosting
             }
         }
 
-        private bool TryGetValueInternal<T>(object key, bool localAtomicCompositionOnly, [NotNullWhen(true)] out T? value)
+        private bool TryGetValueInternal<T>(object key, bool localAtomicCompositionOnly, [MaybeNullWhen(false)] out T value)
         {
             for (var index = 0; index < _valueCount; index++)
             {

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
@@ -70,12 +70,12 @@ namespace System.ComponentModel.Composition.Hosting
             SetValueInternal(key, value);
         }
 
-        public bool TryGetValue<T>(object key, [MaybeNullWhen(false)] out T value)
+        public bool TryGetValue<T>(object key, [NotNullWhen(true)] out T? value)
         {
             return TryGetValue(key, false, out value);
         }
 
-        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [MaybeNullWhen(false)] out T value)
+        public bool TryGetValue<T>(object key, bool localAtomicCompositionOnly, [NotNullWhen(true)] out T? value)
         {
             ThrowIfDisposed();
             ThrowIfCompleted();
@@ -277,7 +277,7 @@ namespace System.ComponentModel.Composition.Hosting
             }
         }
 
-        private bool TryGetValueInternal<T>(object key, bool localAtomicCompositionOnly, [MaybeNullWhen(false)] out T value)
+        private bool TryGetValueInternal<T>(object key, bool localAtomicCompositionOnly, [NotNullWhen(true)] out T? value)
         {
             for (var index = 0; index < _valueCount; index++)
             {

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicCompositionExtensions.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicCompositionExtensions.cs
@@ -18,7 +18,7 @@ namespace System.ComponentModel.Composition.Hosting
 
         internal static T GetValueAllowNull<T>(this AtomicComposition? atomicComposition, object key, T defaultResult)
         {
-            T result;
+            T? result;
             if (atomicComposition != null && atomicComposition.TryGetValue(key, out result))
             {
                 return result;

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicCompositionExtensions.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicCompositionExtensions.cs
@@ -19,7 +19,7 @@ namespace System.ComponentModel.Composition.Hosting
         internal static T GetValueAllowNull<T>(this AtomicComposition? atomicComposition, object key, T defaultResult)
         {
             T? result;
-            if (atomicComposition != null && atomicComposition.TryGetValue(key, out result))
+            if (atomicComposition != null && atomicComposition.TryGetValue<T>(key, out result))
             {
                 return result;
             }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Utilities.cs
@@ -271,7 +271,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 Debug.Assert(key != null);
 
-                TValue res;
+                TValue? res;
                 if (TryGetValue(key, out res))
                 {
                     return res;

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
@@ -104,7 +104,7 @@ namespace System.Linq.Parallel
         // anyway, so having the repartitioning operator do so isn't complicating matters much at all.
         //
 
-        internal override bool MoveNext(ref Pair<TInputOutput, THashKey> currentElement, ref TOrderKey currentKey)
+        internal override bool MoveNext(ref Pair<TInputOutput, THashKey> currentElement, [AllowNull] ref TOrderKey currentKey)
         {
             if (_partitionCount == 1)
             {

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ExceptQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ExceptQueryOperator.cs
@@ -257,7 +257,7 @@ namespace System.Linq.Parallel
             // Walks the two data sources, left and then right, to produce the distinct set
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, ref TLeftKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, [AllowNull] ref TLeftKey currentKey)
             {
                 Debug.Assert(_leftSource != null);
                 Debug.Assert(_rightSource != null);

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/HashJoinQueryOperatorEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/HashJoinQueryOperatorEnumerator.cs
@@ -90,7 +90,7 @@ namespace System.Linq.Parallel
         // as we do for inner joins.
         //
 
-        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TOutput currentElement, ref TOutputKey currentKey)
+        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TOutput currentElement, [AllowNull] ref TOutputKey currentKey)
         {
             Debug.Assert(_resultSelector != null, "expected a compiled result selector");
             Debug.Assert(_leftSource != null);

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/IntersectQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/IntersectQueryOperator.cs
@@ -258,7 +258,7 @@ namespace System.Linq.Parallel
             // Walks the two data sources, left and then right, to produce the intersection.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, ref TLeftKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, [AllowNull] ref TLeftKey currentKey)
             {
                 Debug.Assert(_leftSource != null);
                 Debug.Assert(_rightSource != null);

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/LongCountAggregationOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/LongCountAggregationOperator.cs
@@ -95,8 +95,8 @@ namespace System.Linq.Parallel
 
             protected override bool MoveNextCore(ref long currentElement)
             {
-                TSource elementUnused = default(TSource)!;
-                TKey keyUnused = default(TKey)!;
+                TSource? elementUnused = default(TSource);
+                TKey? keyUnused = default(TKey);
 
                 QueryOperatorEnumerator<TSource, TKey> source = _source;
                 if (source.MoveNext(ref elementUnused, ref keyUnused))

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/QueryOperatorEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/QueryOperatorEnumerator.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Parallel
     {
         // Moves the position of the enumerator forward by one, and simultaneously returns
         // the (new) current element and key. If empty, false is returned.
-        internal abstract bool MoveNext([MaybeNullWhen(false), AllowNull] ref TElement currentElement, ref TKey currentKey);
+        internal abstract bool MoveNext([MaybeNullWhen(false), AllowNull] ref TElement currentElement, [AllowNull] ref TKey currentKey);
 
         // Standard implementation of the disposable pattern.
         public void Dispose()

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DefaultIfEmptyQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DefaultIfEmptyQueryOperator.cs
@@ -139,7 +139,7 @@ namespace System.Linq.Parallel
             // Straightforward IEnumerator<T> methods.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TSource currentElement, ref TKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TSource currentElement, [AllowNull] ref TKey currentKey)
             {
                 Debug.Assert(_source != null);
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DistinctQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DistinctQueryOperator.cs
@@ -220,7 +220,7 @@ namespace System.Linq.Parallel
             // Walks the single data source, skipping elements it has already seen.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, ref TKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, [AllowNull] ref TKey currentKey)
             {
                 Debug.Assert(_source != null);
                 Debug.Assert(_hashLookup != null);

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ForAllOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ForAllOperator.cs
@@ -155,8 +155,8 @@ namespace System.Linq.Parallel
 
                 // Cancellation testing must be performed here as full enumeration occurs within this method.
                 // We only need to throw a simple exception here.. marshalling logic handled via QueryTaskGroupState.QueryEnd (called by ForAllSpoolingTask)
-                TInput element = default(TInput)!;
-                TKey keyUnused = default(TKey)!;
+                TInput? element = default(TInput);
+                TKey? keyUnused = default(TKey);
                 int i = 0;
                 while (_source.MoveNext(ref element, ref keyUnused))
                 {

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/GroupByQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/GroupByQueryOperator.cs
@@ -253,7 +253,7 @@ namespace System.Linq.Parallel
         // just enumerate the key-set from the hash-table, retrieving groupings of key-elements.
         //
 
-        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref IGrouping<TGroupKey, TElement> currentElement, ref TOrderKey currentKey)
+        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref IGrouping<TGroupKey, TElement> currentElement, [AllowNull] ref TOrderKey currentKey)
         {
             Debug.Assert(_source != null);
 
@@ -459,7 +459,7 @@ namespace System.Linq.Parallel
         // just enumerate the key-set from the hash-table, retrieving groupings of key-elements.
         //
 
-        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref IGrouping<TGroupKey, TElement> currentElement, ref TOrderKey currentKey)
+        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref IGrouping<TGroupKey, TElement> currentElement, [AllowNull] ref TOrderKey currentKey)
         {
             Debug.Assert(_source != null);
             Debug.Assert(_keySelector != null);

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ReverseQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ReverseQueryOperator.cs
@@ -124,7 +124,7 @@ namespace System.Linq.Parallel
             // Straightforward IEnumerator<T> methods.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TSource currentElement, ref TKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TSource currentElement, [AllowNull] ref TKey currentKey)
             {
                 // If the buffer has not been created, we will generate it lazily on demand.
                 if (_buffer == null)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectQueryOperator.cs
@@ -111,7 +111,7 @@ namespace System.Linq.Parallel
             // Straightforward IEnumerator<T> methods.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TOutput currentElement, ref TKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TOutput currentElement, [AllowNull] ref TKey currentKey)
             {
                 // So long as the source has a next element, we have an element.
                 TInput element = default(TInput)!;

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SortQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SortQueryOperator.cs
@@ -198,7 +198,7 @@ namespace System.Linq.Parallel
         // in memory, and the data sorted.
         //
 
-        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, ref TSortKey currentKey)
+        internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, [AllowNull] ref TSortKey currentKey)
         {
             Debug.Assert(_source != null);
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
@@ -187,7 +187,7 @@ namespace System.Linq.Parallel
             // Straightforward IEnumerator<T> methods.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TResult currentElement, ref TKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TResult currentElement, [AllowNull] ref TKey currentKey)
             {
                 Debug.Assert(_sharedIndices != null);
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
@@ -247,7 +247,7 @@ namespace System.Linq.Parallel
             // Straightforward IEnumerator<T> methods.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TResult currentElement, ref TKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TResult currentElement, [AllowNull] ref TKey currentKey)
             {
                 // If the buffer has not been created, we will generate it lazily on demand.
                 if (_buffer == null)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/WhereQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/WhereQueryOperator.cs
@@ -125,7 +125,7 @@ namespace System.Linq.Parallel
             // Moves to the next matching element in the underlying data stream.
             //
 
-            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, ref TKey currentKey)
+            internal override bool MoveNext([MaybeNullWhen(false), AllowNull] ref TInputOutput currentElement, [AllowNull] ref TKey currentKey)
             {
                 Debug.Assert(_predicate != null, "expected a compiled operator");
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
@@ -42,7 +42,7 @@ namespace System.Linq.Parallel
         // If value is not in set, add it and return true; otherwise return false
         internal bool Add(TKey key, TValue value)
         {
-            return !Find(key, true, false, ref value);
+            return !Find(key, true, false, ref value!);
         }
 
         // Check whether value is in set
@@ -55,7 +55,7 @@ namespace System.Linq.Parallel
         {
             set
             {
-                TValue v = value;
+                TValue? v = value;
                 Find(key, false, true, ref v);
             }
         }

--- a/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
@@ -17,7 +17,7 @@ namespace System.Linq
 
             if (source is IPartition<TSource> partition)
             {
-                TSource element = partition.TryGetElementAt(index, out bool found);
+                TSource? element = partition.TryGetElementAt(index, out bool found);
                 if (found)
                 {
                     return element!;

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static TSource First<TSource>(this IEnumerable<TSource> source)
         {
-            TSource first = source.TryGetFirst(out bool found);
+            TSource? first = source.TryGetFirst(out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoElementsException();
@@ -21,7 +21,7 @@ namespace System.Linq
 
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            TSource first = source.TryGetFirst(predicate, out bool found);
+            TSource? first = source.TryGetFirst(predicate, out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoMatchException();

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static TSource Last<TSource>(this IEnumerable<TSource> source)
         {
-            TSource last = source.TryGetLast(out bool found);
+            TSource? last = source.TryGetLast(out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoElementsException();
@@ -21,7 +21,7 @@ namespace System.Linq
 
         public static TSource Last<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            TSource last = source.TryGetLast(predicate, out bool found);
+            TSource? last = source.TryGetLast(predicate, out bool found);
             if (!found)
             {
                 ThrowHelper.ThrowNoMatchException();

--- a/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -560,7 +560,7 @@ namespace System.Linq
             public TResult? TryGetElementAt(int index, out bool found)
             {
                 bool sourceFound;
-                TSource input = _source.TryGetElementAt(index, out sourceFound);
+                TSource? input = _source.TryGetElementAt(index, out sourceFound);
                 found = sourceFound;
                 return sourceFound ? _selector(input!) : default!;
             }
@@ -568,7 +568,7 @@ namespace System.Linq
             public TResult? TryGetFirst(out bool found)
             {
                 bool sourceFound;
-                TSource input = _source.TryGetFirst(out sourceFound);
+                TSource? input = _source.TryGetFirst(out sourceFound);
                 found = sourceFound;
                 return sourceFound ? _selector(input!) : default!;
             }
@@ -576,7 +576,7 @@ namespace System.Linq
             public TResult? TryGetLast(out bool found)
             {
                 bool sourceFound;
-                TSource input = _source.TryGetLast(out sourceFound);
+                TSource? input = _source.TryGetLast(out sourceFound);
                 found = sourceFound;
                 return sourceFound ? _selector(input!) : default!;
             }

--- a/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -161,7 +161,7 @@ namespace System.Collections.ObjectModel
                     return null;
                 }
 
-                if (m_dictionary.TryGetValue((TKey)key, out TValue value))
+                if (m_dictionary.TryGetValue((TKey)key, out TValue? value))
                 {
                     return value;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -187,7 +187,7 @@ namespace System.Runtime.CompilerServices
                 throw new ArgumentNullException(nameof(createValueCallback));
             }
 
-            return TryGetValue(key, out TValue existingValue) ?
+            return TryGetValue(key, out TValue? existingValue) ?
                 existingValue :
                 GetValueLocked(key, createValueCallback);
         }
@@ -201,7 +201,7 @@ namespace System.Runtime.CompilerServices
             lock (_lock)
             {
                 // Now that we've taken the lock, must recheck in case we lost a race to add the key.
-                if (_container.TryGetValueWorker(key, out TValue existingValue))
+                if (_container.TryGetValueWorker(key, out TValue? existingValue))
                 {
                     return existingValue;
                 }
@@ -336,7 +336,7 @@ namespace System.Runtime.CompilerServices
                             while (_currentIndex < _maxIndexInclusive)
                             {
                                 _currentIndex++;
-                                if (c.TryGetEntry(_currentIndex, out TKey? key, out TValue value))
+                                if (c.TryGetEntry(_currentIndex, out TKey? key, out TValue? value))
                                 {
                                     _current = new KeyValuePair<TKey, TValue>(key, value);
                                     return true;

--- a/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
@@ -54,7 +54,7 @@ namespace System
         public bool TryGetTarget([MaybeNullWhen(false), NotNullWhen(true)] out T target)
         {
             // Call the worker method that has more performant but less user friendly signature.
-            T o = this.Target;
+            T? o = this.Target;
             target = o!;
             return o != null;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathParser.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathParser.cs
@@ -27,7 +27,7 @@ namespace System.Xml.Xsl.XPath
             Debug.Assert(_scanner == null && _builder == null);
             Debug.Assert(scanner != null && builder != null);
 
-            Node result = default(Node);
+            Node? result = default(Node);
             _scanner = scanner;
             _builder = builder;
             _posInfo.Clear();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -88,7 +88,7 @@ namespace System.Text.Json.Serialization.Converters
 
                         // Read the value and add.
                         reader.ReadWithVerify();
-                        TValue element = valueConverter.Read(ref reader, ElementType, options);
+                        TValue? element = valueConverter.Read(ref reader, ElementType, options);
                         Add(key, element!, options, ref state);
                     }
                 }
@@ -113,7 +113,7 @@ namespace System.Text.Json.Serialization.Converters
                         reader.ReadWithVerify();
 
                         // Get the value from the converter and add it.
-                        valueConverter.TryRead(ref reader, ElementType, options, ref state, out TValue element);
+                        valueConverter.TryRead(ref reader, ElementType, options, ref state, out TValue? element);
                         Add(key, element!, options, ref state);
                     }
                 }
@@ -214,7 +214,7 @@ namespace System.Text.Json.Serialization.Converters
                     if (state.Current.PropertyState < StackFramePropertyState.TryRead)
                     {
                         // Get the value from the converter and add it.
-                        bool success = elementConverter.TryRead(ref reader, typeof(TValue), options, ref state, out TValue element);
+                        bool success = elementConverter.TryRead(ref reader, typeof(TValue), options, ref state, out TValue? element);
                         if (!success)
                         {
                             value = default;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization.Converters
                         }
 
                         // Obtain the CLR value from the JSON and apply to the object.
-                        TElement element = elementConverter.Read(ref reader, elementConverter.TypeToConvert, options);
+                        TElement? element = elementConverter.Read(ref reader, elementConverter.TypeToConvert, options);
                         Add(element!, ref state);
                     }
                 }
@@ -81,7 +81,7 @@ namespace System.Text.Json.Serialization.Converters
                         }
 
                         // Get the value from the converter and add it.
-                        elementConverter.TryRead(ref reader, typeof(TElement), options, ref state, out TElement element);
+                        elementConverter.TryRead(ref reader, typeof(TElement), options, ref state, out TElement? element);
                         Add(element!, ref state);
                     }
                 }
@@ -169,7 +169,7 @@ namespace System.Text.Json.Serialization.Converters
                         if (state.Current.PropertyState < StackFramePropertyState.TryRead)
                         {
                             // Get the value from the converter and add it.
-                            if (!elementConverter.TryRead(ref reader, typeof(TElement), options, ref state, out TElement element))
+                            if (!elementConverter.TryRead(ref reader, typeof(TElement), options, ref state, out TElement? element))
                             {
                                 value = default;
                                 return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -63,10 +63,10 @@ namespace System.Text.Json.Serialization.Converters
             var info = (JsonParameterInfo<TArg>)jsonParameterInfo;
             var converter = (JsonConverter<TArg>)jsonParameterInfo.ConverterBase;
 
-            bool success = converter.TryRead(ref reader, info.RuntimePropertyType, info.Options!, ref state, out TArg value);
+            bool success = converter.TryRead(ref reader, info.RuntimePropertyType, info.Options!, ref state, out TArg? value);
 
             arg = value == null && jsonParameterInfo.IgnoreDefaultValuesOnRead
-                ? (TArg)info.DefaultValue! // Use default value specified on parameter, if any.
+                ? (TArg?)info.DefaultValue! // Use default value specified on parameter, if any.
                 : value!;
 
             return success;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.ReadCore.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.ReadCore.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization
                 }
 
                 JsonPropertyInfo jsonPropertyInfo = state.Current.JsonClassInfo.PropertyInfoForClassInfo;
-                bool success = TryRead(ref reader, jsonPropertyInfo.RuntimePropertyType!, options, ref state, out T value);
+                bool success = TryRead(ref reader, jsonPropertyInfo.RuntimePropertyType!, options, ref state, out T? value);
                 if (success)
                 {
                     // Read any trailing whitespace. This will throw if JsonCommentHandling=Disallow.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -204,7 +204,7 @@ namespace System.Text.Json.Serialization
 
                     if (JsonSerializer.TryGetReferenceFromJsonElement(ref state, element, out object? referenceValue))
                     {
-                        value = (T)referenceValue;
+                        value = (T?)referenceValue;
                     }
                 }
 
@@ -289,7 +289,7 @@ namespace System.Text.Json.Serialization
 
         internal override sealed bool TryReadAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, ref ReadStack state, out object? value)
         {
-            bool success = TryRead(ref reader, TypeToConvert, options, ref state, out T typedValue);
+            bool success = TryRead(ref reader, TypeToConvert, options, ref state, out T? typedValue);
             value = typedValue;
             return success;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -243,7 +243,7 @@ namespace System.Text.Json
 
                 if (!IgnoreDefaultValuesOnRead)
                 {
-                    T value = default;
+                    T? value = default;
                     Set!(obj, value!);
                 }
 
@@ -257,7 +257,7 @@ namespace System.Text.Json
                 if (!isNullToken || !IgnoreDefaultValuesOnRead || !PropertyTypeCanBeNull)
                 {
                     // Optimize for internal converters by avoiding the extra call to TryRead.
-                    T fastValue = Converter.Read(ref reader, RuntimePropertyType!, Options);
+                    T? fastValue = Converter.Read(ref reader, RuntimePropertyType!, Options);
                     Set!(obj, fastValue!);
                 }
 
@@ -268,7 +268,7 @@ namespace System.Text.Json
                 success = true;
                 if (!isNullToken || !IgnoreDefaultValuesOnRead || !PropertyTypeCanBeNull || state.IsContinuation)
                 {
-                    success = Converter.TryRead(ref reader, RuntimePropertyType!, Options, ref state, out T value);
+                    success = Converter.TryRead(ref reader, RuntimePropertyType!, Options, ref state, out T? value);
                     if (success)
                     {
 #if !DEBUG
@@ -324,7 +324,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    success = Converter.TryRead(ref reader, RuntimePropertyType!, Options, ref state, out T typedValue);
+                    success = Converter.TryRead(ref reader, RuntimePropertyType!, Options, ref state, out T? typedValue);
                     value = typedValue;
                 }
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization
 
             ReadStack state = default;
             state.Initialize(typeToConvert, options, supportContinuation: false);
-            TryRead(ref reader, typeToConvert, options, ref state, out T value);
+            TryRead(ref reader, typeToConvert, options, ref state, out T? value);
             return value;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -233,7 +233,7 @@ namespace System.Text.Json
             state.ReadAhead = !isFinalBlock;
             state.BytesConsumed = 0;
 
-            TValue value = ReadCore<TValue>(converterBase, ref reader, options, ref state);
+            TValue? value = ReadCore<TValue>(converterBase, ref reader, options, ref state);
 
             readerState = reader.CurrentState;
             return value!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -191,7 +191,7 @@ namespace System.Text.Json
                 var readerState = new JsonReaderState(options.GetReaderOptions());
                 var reader = new Utf8JsonReader(utf8, isFinalBlock: true, readerState);
 
-                TValue value = ReadCore<TValue>(ref reader, returnType, options);
+                TValue? value = ReadCore<TValue>(ref reader, returnType, options);
 
                 // The reader should have thrown if we have remaining bytes.
                 Debug.Assert(reader.BytesConsumed == actualByteCount);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -316,7 +316,7 @@ namespace System.Text.Json
                 var newReader = new Utf8JsonReader(rentedSpan, originalReaderOptions);
 
                 JsonConverter jsonConverter = state.Current.JsonPropertyInfo!.ConverterBase;
-                TValue value = ReadCore<TValue>(jsonConverter, ref newReader, options, ref state);
+                TValue? value = ReadCore<TValue>(jsonConverter, ref newReader, options, ref state);
 
                 // The reader should have thrown if we have remaining bytes.
                 Debug.Assert(newReader.BytesConsumed == length);

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -139,7 +139,7 @@ namespace System.Threading.Channels
             }
 
             ExceptionDispatchInfo? error = _error;
-            TResult result = _result;
+            TResult? result = _result;
             _currentId++;
 
             if (_pooled)

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
@@ -50,7 +50,7 @@ namespace System.Threading.Channels
 
             try
             {
-                if (TryRead(out T fastItem))
+                if (TryRead(out T? fastItem))
                 {
                     return new ValueTask<T>(fastItem);
                 }
@@ -71,7 +71,7 @@ namespace System.Threading.Channels
                         throw new ChannelClosedException();
                     }
 
-                    if (TryRead(out T item))
+                    if (TryRead(out T? item))
                     {
                         return item;
                     }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.netstandard21.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.netstandard21.cs
@@ -19,7 +19,7 @@ namespace System.Threading.Channels
         {
             while (await WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                while (TryRead(out T item))
+                while (TryRead(out T? item))
                 {
                     yield return item;
                 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
@@ -72,7 +72,7 @@ namespace System.Threading.Channels
                     return new ValueTask<T>(Task.FromCanceled<T>(cancellationToken));
                 }
 
-                if (TryRead(out T item))
+                if (TryRead(out T? item))
                 {
                     return new ValueTask<T>(item);
                 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
@@ -67,7 +67,7 @@ namespace System.Threading.Channels
 
                 // Dequeue an item if we can.
                 UnboundedChannel<T> parent = _parent;
-                if (parent._items.TryDequeue(out T item))
+                if (parent._items.TryDequeue(out T? item))
                 {
                     CompleteIfDone(parent);
                     return new ValueTask<T>(item);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Interlocked.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Interlocked.Mono.cs
@@ -104,9 +104,7 @@ namespace System.Threading
             //
             // This is not entirely convincing due to lack of volatile.
             //
-#pragma warning disable 8654 // null problems; is there another way?
-            T result = null;
-#pragma warning restore 8654
+            T? result = null;
             // T : class so call the object overload.
             CompareExchange(ref Unsafe.As<T, object?>(ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref comparand), ref Unsafe.As<T, object?>(ref result!));
             return result;
@@ -137,9 +135,7 @@ namespace System.Threading
             //
             // This is not entirely convincing due to lack of volatile.
             //
-#pragma warning disable 8654 // null problems; is there another way?
-            T result = null;
-#pragma warning restore 8654
+            T? result = null;
             // T : class so call the object overload.
             Exchange(ref Unsafe.As<T, object?>(ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref result!));
             return result;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/WeakReference.T.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/WeakReference.T.Mono.cs
@@ -16,7 +16,7 @@ namespace System
             get
             {
                 GCHandle h = handle;
-                return h.IsAllocated ? (T)h.Target : null;
+                return h.IsAllocated ? (T?)h.Target : null;
             }
         }
 


### PR DESCRIPTION
Resolve warnings for assignment or explicit cast of possibly null type parameter value.

```C#
T t = default; // warning: may be null

object? o = ...;
t = (T)o; // warning: may be null
```

See https://github.com/dotnet/roslyn/pull/48803.