### PR TITLE
[interp] Fold "ldstr".Length to a constant

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1636,6 +1636,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 					g_assert(str && str->length >= 0);
 					interp_clear_ins(td->last_ins);
 					interp_get_ldc_i4_from_const(td, NULL, str->length);
+					SET_SIMPLE_TYPE(td->sp - 1, STACK_TYPE_I4);
 					td->ip += 5;
 					return TRUE;
 				}


### PR DESCRIPTION
A similar optimization for RyuJIT was quite profitable judging by the jit-diff: https://github.com/dotnet/runtime/pull/1378

Example:
```csharp
static int Test()
{
    return "hello".Length;
}
```
Current `MONO_VERBOSE_METHOD=Test` output:
```
IR_0000: ldstr      0
IR_0002: strlen
IR_0003: ret
```
New output:
```
IR_0000: ldc.i4.5
IR_0001: ret
```