### PR TITLE
[interp] return false for IsLittleEndian on BE

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5236,14 +5236,14 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			MonoType *ftype = mono_field_get_type_internal (field);
 			mt = mint_type (ftype);
 			klass = mono_class_from_mono_type_internal (ftype);
-			gboolean in_corlib = m_class_get_image(field->parent) == mono_defaults.corlib;
+			gboolean in_corlib = m_class_get_image (field->parent) == mono_defaults.corlib;
 
-			if (in_corlib && !strcmp(field->name, "IsLittleEndian") &&
-				!strcmp(field->parent->name, "BitConverter") &&
-				!strcmp(field->parent->name_space, "System"))
+			if (in_corlib && !strcmp (field->name, "IsLittleEndian") &&
+				!strcmp (field->parent->name, "BitConverter") &&
+				!strcmp (field->parent->name_space, "System"))
 			{
-				interp_add_ins(td, (TARGET_BYTE_ORDER == G_LITTLE_ENDIAN) ? MINT_LDC_I4_1 : MINT_LDC_I4_0);
-				push_simple_type(td, STACK_TYPE_I4);
+				interp_add_ins (td, (TARGET_BYTE_ORDER == G_LITTLE_ENDIAN) ? MINT_LDC_I4_1 : MINT_LDC_I4_0);
+				push_simple_type (td, STACK_TYPE_I4);
 				td->ip += 5;
 				break;
 			}

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5236,6 +5236,17 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			MonoType *ftype = mono_field_get_type_internal (field);
 			mt = mint_type (ftype);
 			klass = mono_class_from_mono_type_internal (ftype);
+			gboolean in_corlib = m_class_get_image(field->parent) == mono_defaults.corlib;
+
+			if (in_corlib && !strcmp(field->name, "IsLittleEndian") &&
+				!strcmp(field->parent->name, "BitConverter") &&
+				!strcmp(field->parent->name_space, "System"))
+			{
+				interp_add_ins(td, (TARGET_BYTE_ORDER == G_LITTLE_ENDIAN) ? MINT_LDC_I4_1 : MINT_LDC_I4_0);
+				push_simple_type(td, STACK_TYPE_I4);
+				td->ip += 5;
+				break;
+			}
 
 			interp_emit_sfld_access (td, field, klass, mt, TRUE, error);
 			goto_if_nok (error, exit);


### PR DESCRIPTION
To help those who maintain Mono for BE.
Also, it allows interpreter to fold branches since now IsLittleEndian is converted into `LDC.I4.1` always on LE.

Example:
```csharp
static void Validate()
{
    if (!BitConverter.IsLittleEndian)
        throw new PlatformNotSupportedException();
}
```
Current output for `MONO_VERBOSE_METHOD=Validate` on both LE/BE:
```
IR_0000: ldsfld.u1  0
IR_0003: brtrue.i4.s IR_000b
IR_0005: newobj_fast 3
IR_000a: throw
IR_000b: ret.void
```

New output on LE:
```
IR_0000: ret.void
```