### PR TITLE
Fix loading component when application was started with `dotnet` instead of apphost

### DIFF
--- a/src/installer/corehost/cli/fxr/hostfxr.cpp
+++ b/src/installer/corehost/cli/fxr/hostfxr.cpp
@@ -35,8 +35,13 @@ SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_bundle_startupinfo(const int argc, 
         return bundleStatus;
     }
 
-    host_startup_info_t startup_info(host_path, dotnet_root, app_path);
+    if (host_path == nullptr || dotnet_root == nullptr || app_path == nullptr)
+    {
+        trace::error(_X("Invalid startup info: host_path, dotnet_root, and app_path should not be null."));
+        return StatusCode::InvalidArgFailure;
+    }
 
+    host_startup_info_t startup_info(host_path, dotnet_root, app_path);
     return fx_muxer_t::execute(pal::string_t(), argc, argv, startup_info, nullptr, 0, nullptr);
 }
 
@@ -45,8 +50,13 @@ SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_startupinfo(const int argc, const p
 {
     trace_hostfxr_entry_point(_X("hostfxr_main_startupinfo"));
 
-    host_startup_info_t startup_info(host_path, dotnet_root, app_path);
+    if (host_path == nullptr || dotnet_root == nullptr || app_path == nullptr)
+    {
+        trace::error(_X("Invalid startup info: host_path, dotnet_root, and app_path should not be null."));
+        return StatusCode::InvalidArgFailure;
+    }
 
+    host_startup_info_t startup_info(host_path, dotnet_root, app_path);
     return fx_muxer_t::execute(pal::string_t(), argc, argv, startup_info, nullptr, 0, nullptr);
 }
 

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -97,8 +97,10 @@ namespace
 
     int create_hostpolicy_context(
         hostpolicy_init_t &hostpolicy_init,
-        const arguments_t &args,
-        bool breadcrumbs_enabled)
+        const int argc,
+        const pal::char_t *argv[],
+        bool breadcrumbs_enabled,
+        /*out*/ arguments_t *out_args = nullptr)
     {
         {
             std::unique_lock<std::mutex> lock{ g_context_lock };
@@ -116,6 +118,14 @@ namespace
         }
 
         g_context_initializing_cv.notify_all();
+
+        arguments_t args;
+        if (!parse_arguments(hostpolicy_init, argc, argv, args))
+            return StatusCode::LibHostInvalidArgs;
+
+        args.trace();
+        if (out_args != nullptr)
+            *out_args = args;
 
         std::unique_ptr<hostpolicy_context_t> context_local(new hostpolicy_context_t());
         int rc = context_local->initialize(hostpolicy_init, args, breadcrumbs_enabled);
@@ -320,12 +330,11 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_load(host_interface_t* init)
     return StatusCode::Success;
 }
 
-int corehost_init(
+void trace_corehost_init(
     const hostpolicy_init_t &hostpolicy_init,
     const int argc,
     const pal::char_t* argv[],
-    const pal::string_t& location,
-    arguments_t& args)
+    const pal::string_t& location)
 {
     if (trace::is_enabled())
     {
@@ -337,28 +346,41 @@ int corehost_init(
         }
         trace::info(_X("}"));
 
+        const pal::char_t *host_mode_str;
+        switch (hostpolicy_init.host_mode)
+        {
+            case host_mode_t::muxer:
+                host_mode_str = _X("muxer");
+                break;
+            case host_mode_t::apphost:
+                host_mode_str = _X("apphost");
+                break;
+            case host_mode_t::split_fx:
+                host_mode_str = _X("split_fx");
+                break;
+            case host_mode_t::libhost:
+                host_mode_str = _X("libhost");
+                break;
+            case host_mode_t::invalid:
+            default:
+                host_mode_str = _X("invalid");
+                break;
+        }
+
+        trace::info(_X("Mode: %s"), host_mode_str);
         trace::info(_X("Deps file: %s"), hostpolicy_init.deps_file.c_str());
         for (const auto& probe : hostpolicy_init.probe_paths)
         {
             trace::info(_X("Additional probe dir: %s"), probe.c_str());
         }
     }
-
-    if (!parse_arguments(hostpolicy_init, argc, argv, args))
-    {
-        return StatusCode::LibHostInvalidArgs;
-    }
-
-    args.trace();
-    return StatusCode::Success;
 }
 
 int corehost_main_init(
     hostpolicy_init_t& hostpolicy_init,
     const int argc,
     const pal::char_t* argv[],
-    const pal::string_t& location,
-    arguments_t& args)
+    const pal::string_t& location)
 {
     // Take care of arguments
     if (!hostpolicy_init.host_info.is_valid(hostpolicy_init.host_mode))
@@ -386,18 +408,19 @@ int corehost_main_init(
         }
     }
 
-    return corehost_init(hostpolicy_init, argc, argv, location, args);
+    trace_corehost_init(hostpolicy_init, argc, argv, location);
+    return StatusCode::Success;
 }
 
 SHARED_API int HOSTPOLICY_CALLTYPE corehost_main(const int argc, const pal::char_t* argv[])
 {
-    arguments_t args;
-    int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main"), args);
+    int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main"));
     if (rc != StatusCode::Success)
         return rc;
 
+    arguments_t args;
     assert(g_context == nullptr);
-    rc = create_hostpolicy_context(g_init, args, true /* breadcrumbs_enabled */);
+    rc = create_hostpolicy_context(g_init, argc, argv, true /* breadcrumbs_enabled */, &args);
     if (rc != StatusCode::Success)
         return rc;
 
@@ -410,13 +433,18 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_main(const int argc, const pal::char
 
 SHARED_API int HOSTPOLICY_CALLTYPE corehost_main_with_output_buffer(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
 {
-    arguments_t args;
-    int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main_with_output_buffer"), args);
+    int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main_with_output_buffer"));
     if (rc != StatusCode::Success)
         return rc;
 
     if (g_init.host_command == _X("get-native-search-directories"))
     {
+        arguments_t args;
+        if (!parse_arguments(g_init, argc, argv, args))
+            return StatusCode::LibHostInvalidArgs;
+
+        args.trace();
+
         pal::string_t output_string;
         rc = run_host_command(g_init, args, &output_string);
         if (rc != StatusCode::Success)
@@ -448,7 +476,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_main_with_output_buffer(const int ar
     return rc;
 }
 
-int corehost_libhost_init(const hostpolicy_init_t &hostpolicy_init, const pal::string_t& location, arguments_t& args)
+int corehost_libhost_init(const hostpolicy_init_t &hostpolicy_init, const pal::string_t& location)
 {
     // Host info should always be valid in the delegate scenario
     assert(hostpolicy_init.host_info.is_valid(host_mode_t::libhost));
@@ -456,7 +484,8 @@ int corehost_libhost_init(const hostpolicy_init_t &hostpolicy_init, const pal::s
     // Single-file bundle is only expected in apphost mode.
     assert(!bundle::info_t::is_single_file_bundle());
 
-    return corehost_init(hostpolicy_init, 0, nullptr, location, args);
+    trace_corehost_init(hostpolicy_init, 0, nullptr, location);
+    return StatusCode::Success;
 }
 
 namespace
@@ -708,7 +737,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
     // Trace entry point information and initialize args using previously set init information.
     // This function does not modify any global state.
     arguments_t args;
-    int rc = corehost_libhost_init(g_init, _X("corehost_initialize"), args);
+    int rc = corehost_libhost_init(g_init, _X("corehost_initialize"));
     if (rc != StatusCode::Success)
         return rc;
 
@@ -740,7 +769,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
     }
     else
     {
-        rc = create_hostpolicy_context(g_init, args, g_init.host_mode != host_mode_t::libhost);
+        rc = create_hostpolicy_context(g_init, 0 /*argc*/, nullptr /*argv*/, g_init.host_mode != host_mode_t::libhost);
         if (rc != StatusCode::Success && rc != StatusCode::Success_HostAlreadyInitialized)
             return rc;
     }

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -734,9 +734,8 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
         }
     }
 
-    // Trace entry point information and initialize args using previously set init information.
+    // Trace entry point information using previously set init information.
     // This function does not modify any global state.
-    arguments_t args;
     int rc = corehost_libhost_init(g_init, _X("corehost_initialize"));
     if (rc != StatusCode::Success)
         return rc;

--- a/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
@@ -692,6 +692,7 @@ bool host_context_test::non_context_mixed(
     const pal::char_t *config_path,
     int argc,
     const pal::char_t *argv[],
+    bool as_dotnet,
     pal::stringstream_t &test_output)
 {
     hostfxr_exports hostfxr { hostfxr_path };
@@ -706,13 +707,18 @@ bool host_context_test::non_context_mixed(
     block_mock_execute_assembly block_mock;
 
     std::vector<const pal::char_t*> argv_local;
+    if (as_dotnet)
+        argv_local.push_back(host_path.c_str());
+
     argv_local.push_back(app_path);
     for (int i = 0; i < argc; ++i)
         argv_local.push_back(argv[i]);
 
     pal::stringstream_t run_app_output;
     auto run_app = [&]{
-        int rc = hostfxr.main_startupinfo(argv_local.size(), argv_local.data(), host_path.c_str(), get_dotnet_root_from_fxr_path(hostfxr_path).c_str(), app_path);
+        // Imitate running as dotnet by passing empty as app_path to hostfxr_main_startupinfo
+        const pal::char_t *app_path_local = as_dotnet ? _X("") : app_path;
+        int rc = hostfxr.main_startupinfo(argv_local.size(), argv_local.data(), host_path.c_str(), get_dotnet_root_from_fxr_path(hostfxr_path).c_str(), app_path_local);
         if (rc != StatusCode::Success)
             run_app_output << _X("hostfxr_main_startupinfo failed: ") << std::hex << std::showbase << rc << std::endl;
     };

--- a/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
@@ -692,7 +692,7 @@ bool host_context_test::non_context_mixed(
     const pal::char_t *config_path,
     int argc,
     const pal::char_t *argv[],
-    bool as_dotnet,
+    bool launch_as_if_dotnet,
     pal::stringstream_t &test_output)
 {
     hostfxr_exports hostfxr { hostfxr_path };
@@ -707,7 +707,7 @@ bool host_context_test::non_context_mixed(
     block_mock_execute_assembly block_mock;
 
     std::vector<const pal::char_t*> argv_local;
-    if (as_dotnet)
+    if (launch_as_if_dotnet)
         argv_local.push_back(host_path.c_str());
 
     argv_local.push_back(app_path);
@@ -717,7 +717,7 @@ bool host_context_test::non_context_mixed(
     pal::stringstream_t run_app_output;
     auto run_app = [&]{
         // Imitate running as dotnet by passing empty as app_path to hostfxr_main_startupinfo
-        const pal::char_t *app_path_local = as_dotnet ? _X("") : app_path;
+        const pal::char_t *app_path_local = launch_as_if_dotnet ? _X("") : app_path;
         int rc = hostfxr.main_startupinfo(argv_local.size(), argv_local.data(), host_path.c_str(), get_dotnet_root_from_fxr_path(hostfxr_path).c_str(), app_path_local);
         if (rc != StatusCode::Success)
             run_app_output << _X("hostfxr_main_startupinfo failed: ") << std::hex << std::showbase << rc << std::endl;

--- a/src/installer/corehost/cli/test/nativehost/host_context_test.h
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.h
@@ -57,6 +57,7 @@ namespace host_context_test
         const pal::char_t *config_path,
         int argc,
         const pal::char_t *argv[],
+        bool as_dotnet,
         pal::stringstream_t &test_output);
     bool component_load_assembly_and_get_function_pointer(
         const pal::string_t &hostfxr_path,

--- a/src/installer/corehost/cli/test/nativehost/host_context_test.h
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.h
@@ -57,7 +57,7 @@ namespace host_context_test
         const pal::char_t *config_path,
         int argc,
         const pal::char_t *argv[],
-        bool as_dotnet,
+        bool launch_as_if_dotnet, // Imitate running the application as if it were launched with 'dotnet <appPath>'
         pal::stringstream_t &test_output);
     bool component_load_assembly_and_get_function_pointer(
         const pal::string_t &hostfxr_path,

--- a/src/installer/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/installer/corehost/cli/test/nativehost/nativehost.cpp
@@ -190,7 +190,8 @@ int main(const int argc, const pal::char_t *argv[])
 
             success = host_context_test::mixed(check_properties, hostfxr_path, app_or_config_path, config_path, remaining_argc, remaining_argv, test_output);
         }
-        else if (pal::strcmp(scenario, _X("non_context_mixed")) == 0)
+        else if (pal::strcmp(scenario, _X("non_context_mixed_apphost")) == 0
+            || pal::strcmp(scenario, _X("non_context_mixed_dotnet")) == 0)
         {
             // args: ... <scenario> <check_properties> <hostfxr_path> <app_path> <config_path>
             if (argc < min_argc + 1)
@@ -203,7 +204,8 @@ int main(const int argc, const pal::char_t *argv[])
             --remaining_argc;
             remaining_argv = remaining_argc > 0 ? &argv[min_argc + 1] : nullptr;
 
-            success = host_context_test::non_context_mixed(check_properties, hostfxr_path, app_or_config_path, config_path, remaining_argc, remaining_argv, test_output);
+            bool as_dotnet = pal::strcmp(scenario, _X("non_context_mixed_dotnet")) == 0;
+            success = host_context_test::non_context_mixed(check_properties, hostfxr_path, app_or_config_path, config_path, remaining_argc, remaining_argv, as_dotnet, test_output);
         }
         else
         {

--- a/src/installer/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/installer/corehost/cli/test/nativehost/nativehost.cpp
@@ -204,8 +204,8 @@ int main(const int argc, const pal::char_t *argv[])
             --remaining_argc;
             remaining_argv = remaining_argc > 0 ? &argv[min_argc + 1] : nullptr;
 
-            bool as_dotnet = pal::strcmp(scenario, _X("non_context_mixed_dotnet")) == 0;
-            success = host_context_test::non_context_mixed(check_properties, hostfxr_path, app_or_config_path, config_path, remaining_argc, remaining_argv, as_dotnet, test_output);
+            bool launch_as_if_dotnet = pal::strcmp(scenario, _X("non_context_mixed_dotnet")) == 0;
+            success = host_context_test::non_context_mixed(check_properties, hostfxr_path, app_or_config_path, config_path, remaining_argc, remaining_argv, launch_as_if_dotnet, test_output);
         }
         else
         {

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.FrameworkCompatibilityTestData.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.FrameworkCompatibilityTestData.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
+{
+    public partial class HostContext : IClassFixture<HostContext.SharedTestState>
+    {
+        public enum ExistingContextType
+        {
+            FrameworkDependent,
+            SelfContained_WithIncludedFrameworks,
+            SelfContained_NoIncludedFrameworks
+        }
+
+        public class FrameworkCompatibilityTestData : IXunitSerializable
+        {
+            // Requested
+            public string Name;
+            public string Version;
+            public string RollForward;
+
+            // Existing
+            public ExistingContextType ExistingContext;
+
+            // Expected
+            public bool? IsCompatible;
+
+            void IXunitSerializable.Deserialize(IXunitSerializationInfo info)
+            {
+                Name = info.GetValue<string>(nameof(Name));
+                Version = info.GetValue<string>(nameof(Version));
+                RollForward = info.GetValue<string>(nameof(RollForward));
+                ExistingContext = info.GetValue<ExistingContextType>(nameof(ExistingContext));
+                IsCompatible = info.GetValue<bool?>(nameof(IsCompatible));
+            }
+
+            void IXunitSerializable.Serialize(IXunitSerializationInfo info)
+            {
+                info.AddValue(nameof(Name), Name);
+                info.AddValue(nameof(Version), Version);
+                info.AddValue(nameof(RollForward), RollForward);
+                info.AddValue(nameof(ExistingContext), ExistingContext);
+                info.AddValue(nameof(IsCompatible), IsCompatible);
+            }
+
+            public override string ToString()
+            {
+                return $"{nameof(Name)}: {Name}, {nameof(Version)}: {Version}, {nameof(RollForward)}: {RollForward}, {nameof(ExistingContext)}: {ExistingContext}, {nameof(IsCompatible)}: {IsCompatible}";
+            }
+        }
+
+        public static System.Collections.Generic.IEnumerable<object[]> GetFrameworkCompatibilityTestData(string scenario)
+        {
+            var testData = new System.Collections.Generic.List<FrameworkCompatibilityTestData>();
+            switch (scenario)
+            {
+                case Scenario.ConfigMultiple:
+                    testData.AddRange(GetFrameworkCompatibilityTestData(ExistingContextType.FrameworkDependent));
+                    break;
+                case Scenario.Mixed:
+                case Scenario.NonContextMixedAppHost:
+                case Scenario.NonContextMixedDotnet:
+                    testData.AddRange(GetFrameworkCompatibilityTestData(ExistingContextType.FrameworkDependent));
+                    testData.AddRange(GetFrameworkCompatibilityTestData(ExistingContextType.SelfContained_WithIncludedFrameworks));
+                    testData.AddRange(GetFrameworkCompatibilityTestData(ExistingContextType.SelfContained_NoIncludedFrameworks));
+                    break;
+                default:
+                    throw new Exception($"Unexpected scenario: {scenario}");
+            }
+
+            foreach (var data in testData)
+            {
+                yield return new object[] { scenario, data };
+            }
+        }
+
+        private static System.Collections.Generic.IEnumerable<FrameworkCompatibilityTestData> GetFrameworkCompatibilityTestData(ExistingContextType existingContextType)
+        {
+            var exactVersion = Version.Parse(SharedTestState.NetCoreAppVersion);
+            Assert.True(exactVersion.Major >= 1 && exactVersion.Minor >= 1);
+
+            // Different versions of existing framework
+            var requestedVersionsToTest = new Version[]
+            {
+                // Lower major
+                new Version(exactVersion.Major - 1, exactVersion.Minor - 1, exactVersion.Build),
+                // Lower minor
+                new Version(exactVersion.Major, exactVersion.Minor - 1, exactVersion.Build),
+                // Exact
+                exactVersion,
+                // Higher
+                new Version(exactVersion.Major + 1, exactVersion.Minor - 1, exactVersion.Build),
+            };
+            foreach (Version requestedVersion in requestedVersionsToTest)
+            {
+                string[] rollForwardSettings;
+                if (requestedVersion == exactVersion)
+                {
+                    rollForwardSettings = new string[] { Constants.RollForwardSetting.Disable };
+                }
+                else if (requestedVersion > exactVersion)
+                {
+                    rollForwardSettings = new string[] { Constants.RollForwardSetting.LatestMinor };
+                }
+                else
+                {
+                    rollForwardSettings = new string[]
+                    {
+                        Constants.RollForwardSetting.LatestPatch,
+                        Constants.RollForwardSetting.Minor,
+                        Constants.RollForwardSetting.LatestMinor,
+                        Constants.RollForwardSetting.Major,
+                        Constants.RollForwardSetting.LatestMajor
+                    };
+                }
+
+                string requestedVersionString = requestedVersion.ToString();
+                foreach (string rollForward in rollForwardSettings)
+                {
+                    bool? isCompatibleVersion;
+                    if (existingContextType == ExistingContextType.SelfContained_NoIncludedFrameworks)
+                    {
+                        // Self-contained without included frameworks is always considered compatible
+                        isCompatibleVersion = true;
+                    }
+                    else
+                    {
+                        // Determine expected compatibility
+                        isCompatibleVersion = rollForward switch
+                        {
+                            Constants.RollForwardSetting.LatestPatch => requestedVersion.Major == exactVersion.Major && requestedVersion.Minor == exactVersion.Minor && requestedVersion.Build <= exactVersion.Build,
+                            Constants.RollForwardSetting.Minor
+                                or Constants.RollForwardSetting.LatestMinor => requestedVersion.Major == exactVersion.Major && requestedVersion.Minor <= exactVersion.Minor,
+                            Constants.RollForwardSetting.Major
+                                or Constants.RollForwardSetting.LatestMajor => requestedVersion.Major <= exactVersion.Major,
+                            Constants.RollForwardSetting.Disable => requestedVersion == exactVersion,
+                            _ => null
+                        };
+                    }
+
+                    yield return new FrameworkCompatibilityTestData()
+                    {
+                        Name = Constants.MicrosoftNETCoreApp,
+                        Version = requestedVersionString,
+                        RollForward = rollForward,
+                        ExistingContext = existingContextType,
+                        IsCompatible = isCompatibleVersion
+                    };
+                }
+            }
+
+            // Unknown framework
+            yield return new FrameworkCompatibilityTestData()
+            {
+                Name = "UnknownFramework",
+                Version = exactVersion.ToString(),
+                RollForward = null,
+                ExistingContext = existingContextType,
+                IsCompatible = existingContextType == ExistingContextType.SelfContained_NoIncludedFrameworks ? true : null
+            };
+        }
+    }
+}

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.PropertyCompatibilityTestData.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.PropertyCompatibilityTestData.cs
@@ -131,7 +131,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                         hasSecondProperty ? SharedTestState.ConfigMultiPropertyValue : null);
                     break;
                 case Scenario.Mixed:
-                case Scenario.NonContextMixed:
+                case Scenario.NonContextMixedAppHost:
+                case Scenario.NonContextMixedDotnet:
                     properties = GetPropertiesTestData(
                         SharedTestState.AppPropertyName,
                         SharedTestState.AppPropertyValue,

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -19,7 +19,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             public const string Config = "config";
             public const string ConfigMultiple = "config_multiple";
             public const string Mixed = "mixed";
-            public const string NonContextMixed = "non_context_mixed";
+            public const string NonContextMixedAppHost = "non_context_mixed_apphost";
+            public const string NonContextMixedDotnet = "non_context_mixed_dotnet";
         }
 
         public class CheckProperties
@@ -244,16 +245,23 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [InlineData(Scenario.Mixed, CheckProperties.GetAll)]
         [InlineData(Scenario.Mixed, CheckProperties.GetActive)]
         [InlineData(Scenario.Mixed, CheckProperties.GetAllActive)]
-        [InlineData(Scenario.NonContextMixed, CheckProperties.None)]
-        [InlineData(Scenario.NonContextMixed, CheckProperties.Get)]
-        [InlineData(Scenario.NonContextMixed, CheckProperties.Set)]
-        [InlineData(Scenario.NonContextMixed, CheckProperties.Remove)]
-        [InlineData(Scenario.NonContextMixed, CheckProperties.GetAll)]
-        [InlineData(Scenario.NonContextMixed, CheckProperties.GetActive)]
-        [InlineData(Scenario.NonContextMixed, CheckProperties.GetAllActive)]
+        [InlineData(Scenario.NonContextMixedAppHost, CheckProperties.None)]
+        [InlineData(Scenario.NonContextMixedAppHost, CheckProperties.Get)]
+        [InlineData(Scenario.NonContextMixedAppHost, CheckProperties.Set)]
+        [InlineData(Scenario.NonContextMixedAppHost, CheckProperties.Remove)]
+        [InlineData(Scenario.NonContextMixedAppHost, CheckProperties.GetAll)]
+        [InlineData(Scenario.NonContextMixedAppHost, CheckProperties.GetActive)]
+        [InlineData(Scenario.NonContextMixedAppHost, CheckProperties.GetAllActive)]
+        [InlineData(Scenario.NonContextMixedDotnet, CheckProperties.None)]
+        [InlineData(Scenario.NonContextMixedDotnet, CheckProperties.Get)]
+        [InlineData(Scenario.NonContextMixedDotnet, CheckProperties.Set)]
+        [InlineData(Scenario.NonContextMixedDotnet, CheckProperties.Remove)]
+        [InlineData(Scenario.NonContextMixedDotnet, CheckProperties.GetAll)]
+        [InlineData(Scenario.NonContextMixedDotnet, CheckProperties.GetActive)]
+        [InlineData(Scenario.NonContextMixedDotnet, CheckProperties.GetAllActive)]
         public void RunApp_GetDelegate(string scenario, string checkProperties)
         {
-            if (scenario != Scenario.Mixed && scenario != Scenario.NonContextMixed)
+            if (scenario != Scenario.Mixed && scenario != Scenario.NonContextMixedAppHost && scenario != Scenario.NonContextMixedDotnet)
                 throw new Exception($"Unexpected scenario: {scenario}");
 
             string[] args =
@@ -292,117 +300,49 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, false, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, false, "UnknownFramework", "2.2.0", null, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, true, true, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, false, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, false, "UnknownFramework", "2.2.0", null, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, true, true, "UnknownFramework", "2.2.0", null, null)]
-        public void CompatibilityCheck_Frameworks(string scenario, bool selfContained, bool useIncludedFrameworks, string frameworkName, string version, string rollForward, bool? isCompatibleVersion)
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.ConfigMultiple)]
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.Mixed)]
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.NonContextMixedAppHost)]
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.NonContextMixedDotnet)]
+        public void CompatibilityCheck_Frameworks(string scenario, FrameworkCompatibilityTestData testData)
         {
-            if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixed)
+            if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixedAppHost && scenario != Scenario.NonContextMixedDotnet)
                 throw new Exception($"Unexpected scenario: {scenario}");
 
+            string frameworkName = testData.Name;
+            string version = testData.Version;
             string frameworkCompatConfig = Path.Combine(sharedState.BaseDirectory, "frameworkCompat.runtimeconfig.json");
             RuntimeConfig.FromFile(frameworkCompatConfig)
                 .WithFramework(new RuntimeConfig.Framework(frameworkName, version))
-                .WithRollForward(rollForward)
+                .WithRollForward(testData.RollForward)
                 .Save();
 
-            string appOrConfigPath = scenario == Scenario.ConfigMultiple ? sharedState.RuntimeConfigPath : 
-                (selfContained ? (useIncludedFrameworks ? sharedState.SelfContainedWithIncludedFrameworksAppPath : sharedState.SelfContainedAppPath) : sharedState.AppPath);
+            string appOrConfigPath = scenario == Scenario.ConfigMultiple
+                ? sharedState.RuntimeConfigPath
+                : testData.ExistingContext switch
+                    {
+                        ExistingContextType.FrameworkDependent => sharedState.AppPath,
+                        ExistingContextType.SelfContained_NoIncludedFrameworks => sharedState.SelfContainedAppPath,
+                        ExistingContextType.SelfContained_WithIncludedFrameworks => sharedState.SelfContainedWithIncludedFrameworksAppPath,
+                        _ => throw new Exception($"Unexpected test data {nameof(testData.ExistingContext)}: {testData.ExistingContext}")
+                    };
+
+            string hostfxrPath = scenario == Scenario.NonContextMixedDotnet
+                ? sharedState.HostFxrPath // Imitating dotnet - always use the non-self-contained hostfxr
+                : testData.ExistingContext switch
+                    {
+                        ExistingContextType.FrameworkDependent => sharedState.HostFxrPath,
+                        ExistingContextType.SelfContained_NoIncludedFrameworks => sharedState.SelfContainedHostFxrPath,
+                        ExistingContextType.SelfContained_WithIncludedFrameworks => sharedState.SelfContainedWithIncludedFrameworksHostFxrPath,
+                        _ => throw new Exception($"Unexpected test data {nameof(testData.ExistingContext)}: {testData.ExistingContext}")
+                    };
 
             string[] args =
             {
                 HostContextArg,
                 scenario,
                 CheckProperties.None,
-                selfContained ? (useIncludedFrameworks ? sharedState.SelfContainedWithIncludedFrameworksHostFxrPath : sharedState.SelfContainedHostFxrPath) : sharedState.HostFxrPath,
+                hostfxrPath,
                 appOrConfigPath,
                 frameworkCompatConfig
             };
@@ -433,12 +373,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                         .InitializeContextForApp(appOrConfigPath)
                         .And.ExecuteAssemblyMock(appOrConfigPath, new string[0]);
                     break;
-                case Scenario.NonContextMixed:
+                case Scenario.NonContextMixedAppHost:
+                case Scenario.NonContextMixedDotnet:
                     result.Should()
-                        .ExecuteAssemblyMock(appOrConfigPath, new string[0]);
+                        .ExecuteAssemblyMock(appOrConfigPath, new string[0])
+                        .And.HaveStdErrContaining($"Mode: {(scenario == Scenario.NonContextMixedAppHost ? "apphost" : "muxer")}");
                     break;
             }
 
+            bool? isCompatibleVersion = testData.IsCompatible;
             if (isCompatibleVersion.HasValue)
             {
                 if (isCompatibleVersion.Value)
@@ -467,11 +410,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.ConfigMultiple, true })]
         [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.Mixed, false })]
         [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.Mixed, true })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixed, false })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixed, true })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedAppHost, false })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedAppHost, true })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedDotnet, false })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedDotnet, true })]
         public void CompatibilityCheck_Properties(string scenario, bool hasMultipleProperties, PropertyTestData[] properties)
         {
-            if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixed)
+            if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixedAppHost && scenario != Scenario.NonContextMixedDotnet)
                 throw new Exception($"Unexpected scenario: {scenario}");
 
             string propertyCompatConfig = Path.Combine(sharedState.BaseDirectory, "propertyCompat.runtimeconfig.json");
@@ -527,7 +472,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                         .InitializeContextForApp(appOrConfigPath)
                         .And.ExecuteAssemblyMock(appOrConfigPath, new string[0]);
                     break;
-                case Scenario.NonContextMixed:
+                case Scenario.NonContextMixedAppHost:
+                case Scenario.NonContextMixedDotnet:
                     result.Should()
                         .ExecuteAssemblyMock(appOrConfigPath, new string[0]);
                     break;


### PR DESCRIPTION
`hostpolicy` maintains global initialization info - including the mode (e.g. `muxer`, `apphost`, `libhost`) - based on the way it was first initialized through `corehost_load`. This information is used in `corehost_initialize` to create a context (`hostpolicy_context_t`) for starting the runtime.

When running an application using `dotnet` and then loading a component, as part of loading the component, we would parse arguments for creating the context in `muxer` mode (since the application was started with `dotnet`), but using arguments that would be expected in `libhost`. The argument parsing is only needed for actually creating a `hostpolicy_context`. There can only be one context, so the argument parsing is just extra work and not necessary if a context already exists.

- Don't try to parse arguments needed for creating a context until we actually need to create the context
- Explicitly error on invalid startup info in `hostfxr_main_startupinfo` and `hostfxr_main_bundle_startupinfo`
  - We were always failing in this case with an AV in `host_startup_info_t` constructor. This makes it log and return invalid arg instead.
- Update tests for native hosting to imitate running in `muxer` mode
  - Moved the inline data for tests cases for `HostContext.CompatibilityCheck_Frameworks` to a member function. They were getting a bit long / hard to read in my opinion.

Fixes #42745

cc @AaronRobinsonMSFT @jkoritzinsky This should allow us to run our integration tests for the P/Invoke source generator through `dotnet test` on non-Windows.