### PR TITLE
Check catch and throw non-Exception derived types

### DIFF
--- a/src/coreclr/src/tools/ILVerification/Strings.resx
+++ b/src/coreclr/src/tools/ILVerification/Strings.resx
@@ -171,6 +171,9 @@
   <data name="CatchByRef" xml:space="preserve">
     <value>ByRef not allowed as catch type.</value>
   </data>
+  <data name="ThrowOrCatchOnlyExceptionType" xml:space="preserve">
+    <value>The type caught or thrown must be derived from System.Exception.</value>
+  </data>
   <data name="CodeSizeZero" xml:space="preserve">
     <value>Code size is zero.</value>
   </data>

--- a/src/coreclr/src/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/src/tools/ILVerification/Verifier.cs
@@ -179,7 +179,10 @@ namespace ILVerify
 
             try
             {
-                var importer = new ILImporter(method, methodIL);
+                var importer = new ILImporter(method, methodIL)
+                {
+                    SanityChecks = _verifierOptions.SanityChecks
+                };
 
                 importer.ReportVerificationError = (args, code) =>
                 {
@@ -321,5 +324,6 @@ namespace ILVerify
     public class VerifierOptions
     {
         public bool IncludeMetadataTokensInErrorMessages { get; set; }
+        public bool SanityChecks { get; set; }
     }
 }

--- a/src/coreclr/src/tools/ILVerification/VerifierError.cs
+++ b/src/coreclr/src/tools/ILVerification/VerifierError.cs
@@ -145,6 +145,7 @@ namespace ILVerify
         DelegateCtorSigO,               // Unrecognized delegate .ctor signature; expected Object.
         //E_RA_PTR_TO_STACK             "Mkrefany on TypedReference, ArgHandle, or ArgIterator."
         CatchByRef,                     // ByRef not allowed as catch type.
+        ThrowOrCatchOnlyExceptionType,  // The type caught or thrown must be derived from System.Exception.
         LdvirtftnOnStatic,              // ldvirtftn on static.
         CallVirtOnStatic,               // callvirt on static.
         InitLocals,                     // initlocals must be set for verifiable methods with one or more local variables.
@@ -189,6 +190,6 @@ namespace ILVerify
         //IDS_E_GLOBAL         "<GlobalFunction>"
         //IDS_E_MDTOKEN        "[mdToken=0x%x]"
         InterfaceImplHasDuplicate,            // InterfaceImpl has a duplicate
-        InterfaceMethodNotImplemented         // Class implements interface but not method 
+        InterfaceMethodNotImplemented         // Class implements interface but not method
     }
 }

--- a/src/tests/ilverify/ILMethodTester.cs
+++ b/src/tests/ilverify/ILMethodTester.cs
@@ -28,7 +28,7 @@ namespace ILVerification.Tests
         void TestMethodsWithInvalidIL(InvalidILTestCase invalidIL)
         {
             IEnumerable<VerificationResult> results = null;
-            
+
             try
             {
                 results = Verify(invalidIL);
@@ -58,7 +58,12 @@ namespace ILVerification.Tests
             EcmaModule module = TestDataLoader.GetModuleForTestAssembly(testCase.ModuleName);
             var methodHandle = (MethodDefinitionHandle) MetadataTokens.EntityHandle(testCase.MetadataToken);
             var method = (EcmaMethod)module.GetMethod(methodHandle);
-            var verifier = new Verifier((ILVerifyTypeSystemContext)method.Context, new VerifierOptions() { IncludeMetadataTokensInErrorMessages = true });
+            var verifier = new Verifier((ILVerifyTypeSystemContext)method.Context, new VerifierOptions
+            {
+                IncludeMetadataTokensInErrorMessages = true,
+                SanityChecks = true
+            });
+
             return verifier.Verify(module.PEReader, methodHandle);
         }
     }

--- a/src/tests/ilverify/ILTests/ExceptionRegionTests.il
+++ b/src/tests/ilverify/ILTests/ExceptionRegionTests.il
@@ -12,6 +12,15 @@
 .class public sequential ansi sealed beforefieldinit ExceptionRegionTests
        extends [System.Runtime]System.Object
 {
+    .method public hidebysig specialname rtspecialname instance void .ctor () cil managed
+    {
+        .maxstack 1
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+        IL_0006: ret
+    }
+
     .method public instance void ExceptionRegion.NestedTryFinally_Valid() cil managed
     {
         .try
@@ -732,5 +741,27 @@
     MethodEnd:
         ret
     }
-}
 
+    .method public hidebysig instance void Catch.NonExceptionDerivedType_Invalid_ThrowOrCatchOnlyExceptionType() cil managed
+    {
+        .maxstack 1
+
+        .try {}
+        catch ExceptionRegionTests
+        {
+            leave.s MethodEnd
+        }
+
+        MethodEnd:
+            ret
+    }
+
+    .method public hidebysig instance void Throw.NonExceptionDerivedType_Invalid_ThrowOrCatchOnlyExceptionType() cil managed
+    {
+        .maxstack 1
+
+        newobj instance void ExceptionRegionTests::.ctor()
+        throw
+        ret
+    }
+}

--- a/src/tests/ilverify/ILTests/ThisStateTests.il
+++ b/src/tests/ilverify/ILTests/ThisStateTests.il
@@ -83,7 +83,7 @@
 .class public auto ansi beforefieldinit ThisStateTestsType
         extends [System.Runtime]System.Object
 {
-    .method public hidebysig instance void 'special.ThrowThisUninit..ctor_Invalid_UninitStack'() cil managed { ret }
+    .method public hidebysig instance void 'special.ThrowThisUninit..ctor_Invalid_UninitStack.ThrowOrCatchOnlyExceptionType'() cil managed { ret }
     .method public hidebysig specialname rtspecialname instance void .ctor() cil managed 
     {
         ldarg.0

--- a/src/tests/ilverify/ILTypeVerificationTester.cs
+++ b/src/tests/ilverify/ILTypeVerificationTester.cs
@@ -58,7 +58,11 @@ namespace ILVerification.Tests
             EcmaModule module = TestDataLoader.GetModuleForTestAssembly(testCase.ModuleName);
             var typeHandle = (TypeDefinitionHandle)MetadataTokens.EntityHandle(testCase.MetadataToken);
             var type = (EcmaType)module.GetType(typeHandle);
-            var verifier = new Verifier((ILVerifyTypeSystemContext)type.Context, new VerifierOptions() { IncludeMetadataTokensInErrorMessages = true });
+            var verifier = new Verifier((ILVerifyTypeSystemContext)type.Context, new VerifierOptions
+            {
+                IncludeMetadataTokensInErrorMessages = true,
+                SanityChecks = true
+            });
             return verifier.Verify(module.PEReader, typeHandle);
         }
 


### PR DESCRIPTION
Verifies:

* `X` is derived from `Exception` in `throw X`.
* `throw null` is valid.
* `X` is derived from `Exception` in `catch(X)`.