### PR TITLE
[release/5.0] Add backward compatibility file to timezone data compilation

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -155,7 +155,7 @@
              AssemblyFile="$(CreateCreateWasmBundlesAssemblyPath)" />
   <Target Condition="'$(TargetOS)' == 'Browser'" Name="LoadTimeZone" >
     <PropertyGroup>
-      <TimeZoneDataVersion>2020a</TimeZoneDataVersion>
+      <TimeZoneDataVersion>2020d</TimeZoneDataVersion>
     </PropertyGroup>
     <DownloadTimeZoneData
       InputDirectory="$(BundleDir)obj/data/input"

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2287,6 +2287,50 @@ namespace System.Tests
 
         }
 
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Browser)]
+        [InlineData("America/Buenos_Aires", "America/Argentina/Buenos_Aires")]
+        [InlineData("America/Catamarca", "America/Argentina/Catamarca")]
+        [InlineData("America/Cordoba", "America/Argentina/Cordoba")]
+        [InlineData("America/Jujuy", "America/Argentina/Jujuy")]
+        [InlineData("America/Mendoza", "America/Argentina/Mendoza")]
+        [InlineData("America/Indianapolis", "America/Indiana/Indianapolis")]
+        public static void TestTimeZoneIdBackwardCompatibility(string oldId, string currentId)
+        {
+            TimeZoneInfo oldtz = TimeZoneInfo.FindSystemTimeZoneById(oldId);
+            TimeZoneInfo currenttz = TimeZoneInfo.FindSystemTimeZoneById(currentId);
+
+            Assert.Equal(oldtz.StandardName, currenttz.StandardName);
+            Assert.Equal(oldtz.DisplayName, currenttz.DisplayName);
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Browser)]
+        [InlineData("America/Buenos_Aires")]
+        [InlineData("America/Catamarca")]
+        [InlineData("America/Cordoba")]
+        [InlineData("America/Jujuy")]
+        [InlineData("America/Mendoza")]
+        [InlineData("America/Indianapolis")]
+        public static void ChangeLocalTimeZone(string id) 
+        {
+            string originalTZ = Environment.GetEnvironmentVariable("TZ");
+            try {
+                TimeZoneInfo.ClearCachedData();
+                Environment.SetEnvironmentVariable("TZ", id);
+
+                TimeZoneInfo localtz = TimeZoneInfo.Local;
+                TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById(id);
+
+                Assert.Equal(tz.StandardName, localtz.StandardName);
+                Assert.Equal(tz.DisplayName, localtz.DisplayName); 
+            }
+            finally {
+                TimeZoneInfo.ClearCachedData();
+                Environment.SetEnvironmentVariable("TZ", originalTZ);
+            }
+        }
+
         private static bool IsEnglishUILanguageAndRemoteExecutorSupported => (CultureInfo.CurrentUICulture.Name == "en" || CultureInfo.CurrentUICulture.Name.StartsWith("en-", StringComparison.Ordinal)) && RemoteExecutor.IsSupported;
 
         private static void VerifyConvertException<TException>(DateTimeOffset inputTime, string destinationTimeZoneId) where TException : Exception

--- a/src/mono/wasm/wasm.targets
+++ b/src/mono/wasm/wasm.targets
@@ -40,7 +40,7 @@
     <DownloadTimeZoneData
       InputDirectory="$(ArtifactsObjDir)wasm/data/input"
       OutputDirectory="$(ArtifactsObjDir)wasm/data/output"
-      Version="2020a" />
+      Version="2020d" />
   </Target>
 
   <UsingTask TaskName="CreateWasmBundle" AssemblyFile="$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'CreateWasmBundle', 'Debug', '$(NetCoreAppCurrent)', 'publish', 'CreateWasmBundle.dll'))"/>

--- a/tools-local/tasks/mobile.tasks/CreateWasmBundle/DownloadTimeZoneData.cs
+++ b/tools-local/tasks/mobile.tasks/CreateWasmBundle/DownloadTimeZoneData.cs
@@ -25,7 +25,7 @@ public class DownloadTimeZoneData : Task
 
     private void DownloadTimeZoneDataSource() 
     {
-        List<string> files = new List<string>() {"africa", "antarctica", "asia", "australasia", "etcetera", "europe", "northamerica", "southamerica", "zone1970.tab"};
+        List<string> files = new List<string>() {"africa", "antarctica", "asia", "australasia", "etcetera", "europe", "northamerica", "southamerica", "zone1970.tab", "backward"};
         using (var client = new WebClient())
         {
             Console.WriteLine("Downloading TimeZone data files");


### PR DESCRIPTION
backport of #43786 to release/5.0

/cc @tqiu8 

## Customer Impact
In some cases the browser ends up using older names for timezones.  This adds back backward compatibility to timezone data, allowing the browser to find local timezones even with outdated ids. Applicable to all Argentina timezones. Fixes #43518.

## Testing
Missing test cases were added into TimeZoneInfoTests. 2 tests were added to address this issue.

## Risk
Low, fix is very small and easy to understand.
