### PR TITLE
Add static libraries for System.Native back to mobile runtime packs

### DIFF
--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -102,7 +102,7 @@
       <LibrariesRuntimeFiles Condition="'%(IsNative)' != 'true'" TargetPath="runtimes/$(PackageRID)/lib/$(NetCoreAppCurrent)" />
       <LibrariesRuntimeFiles Condition="'%(IsNative)' == 'true'" TargetPath="$([System.String]::new('runtimes/$(PackageRID)/native/%(LibrariesRuntimeFiles.NativeSubDirectory)%(RecursiveDir)').TrimEnd('/'))" />
       <ReferenceCopyLocalPaths Include="@(LibrariesRuntimeFiles)" 
-          Condition="'%(LibrariesRuntimeFiles.Extension)' != '.a'"/>
+          Condition="'%(LibrariesRuntimeFiles.Extension)' != '.a' or '$(TargetsMobile)' == 'true'"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We need them for various scenarios there. It was removed in https://github.com/dotnet/runtime/pull/41966.

Fixes https://github.com/dotnet/runtime/issues/43949