### PR TITLE
Clarify string.IndexOf rules in code comments

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -225,16 +225,22 @@ namespace System
         * ========================================================
         *
         * Given a search string 'searchString', a target string 'value' to locate within the search string, and a comparer
-        * 'comparer', the comparer will return a set S of tuples '(startPos, endPos)' for which the below expression
+        * 'comparer', we ask the comparer to generate a set S of tuples '(startPos, endPos)' for which the below expression
         * returns true:
         *
         * >> bool result = searchString.Substring(startPos, endPos - startPos).Equals(value, comparer);
         *
-        * If the set S is empty (i.e., there is no combination of values 'startPos' and 'endPos' which makes the
+        * If the generated set S is empty (i.e., there is no combination of values 'startPos' and 'endPos' which makes the
         * above expression evaluate to true), then we say "'searchString' does not contain 'value'", and the expression
         * "searchString.Contains(value, comparer)" should evaluate to false. If the set S is non-empty, then we say
         * "'searchString' contains 'value'", and the expression "searchString.Contains(value, comparer)" should
         * evaluate to true.
+        *
+        * n.b. There may be other tuples '(startPos, endPos)' *not* present in the generated set S for which the above
+        * expression evaluates to true. We discount the existence of these values. Allowing any such values to factor
+        * into the logic below could result in splitting the search string in a manner inappropriate for the culture
+        * rules of the specified comparer. For the remainder of this discussion, when we refer to 'startPos' and
+        * 'endPos', we consider only tuples '(startPos, endPos)' as they may be present in the generated set S.
         *
         * Given a 'searchString', 'value', and 'comparer', the behavior of the IndexOf method is that it finds the
         * smallest possible 'endPos' for which there exists any corresponding 'startPos' which makes the above


### PR DESCRIPTION
There are __no code changes__ as part of this PR. It's simply clarifying a code comment.

The code comment block directly above `string.IndexOf` attempts to mathematically formalize the relationship between `IndexOf`, `LastIndexOf`, `StartsWith`, and `EndsWith`. However, in the formalization there's an ambiguity which allows the search string to be split in a non-linguistic manner in order to locate the target value.

I've updated the code comments to clarify that the comparer is the final arbiter of what splits are or are not appropriate when performing a linguistic search.

tl;dr: `"endz".Contains("z", "hu-HU")` should return "not found!" even though the expression `"endz".Substring(3, 4 - 3).Equals("z", "hu-HU")` evaluates to _true_. The new paragraph in the doc clarifies that even though _(startPos = 3, endPos = 4)_ makes the expression evaluate to true, we shouldn't assume that such values are legal unless the comparer explicitly tells us that they are.