### PR TITLE
New event to track memory allocation for JIT code

### DIFF
--- a/src/coreclr/src/gc/env/etmdummy.h
+++ b/src/coreclr/src/gc/env/etmdummy.h
@@ -129,6 +129,7 @@
 #define FireEtwMethodJitInliningFailed(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, InlinerNamespace, InlinerName, InlinerNameSignature, InlineeNamespace, InlineeName, InlineeNameSignature, FailAlways, FailReason, ClrInstanceID) 0
 #define FireEtwMethodJitTailCallSucceeded(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, CallerNamespace, CallerName, CallerNameSignature, CalleeNamespace, CalleeName, CalleeNameSignature, TailPrefix, TailCallType, ClrInstanceID) 0
 #define FireEtwMethodJitTailCallFailed(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, CallerNamespace, CallerName, CallerNameSignature, CalleeNamespace, CalleeName, CalleeNameSignature, TailPrefix, FailReason, ClrInstanceID) 0
+#define FireEtwMethodJitMemoryAllocatedForCode(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, HotCodeSize, RODataSize, TotalRequestSize, CorJitAllocMemFlag, ClrInstanceID) 0
 #define FireEtwMethodILToNativeMap(MethodID, ReJITID, MethodExtent, CountOfMapEntries, ILOffsets, NativeOffsets, ClrInstanceID) 0
 #define FireEtwModuleDCStartV2(ModuleID, AssemblyID, ModuleFlags, Reserved1, ModuleILPath, ModuleNativePath) 0
 #define FireEtwModuleDCEndV2(ModuleID, AssemblyID, ModuleFlags, Reserved1, ModuleILPath, ModuleNativePath) 0

--- a/src/coreclr/src/gc/env/etmdummy.h
+++ b/src/coreclr/src/gc/env/etmdummy.h
@@ -129,7 +129,7 @@
 #define FireEtwMethodJitInliningFailed(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, InlinerNamespace, InlinerName, InlinerNameSignature, InlineeNamespace, InlineeName, InlineeNameSignature, FailAlways, FailReason, ClrInstanceID) 0
 #define FireEtwMethodJitTailCallSucceeded(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, CallerNamespace, CallerName, CallerNameSignature, CalleeNamespace, CalleeName, CalleeNameSignature, TailPrefix, TailCallType, ClrInstanceID) 0
 #define FireEtwMethodJitTailCallFailed(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, CallerNamespace, CallerName, CallerNameSignature, CalleeNamespace, CalleeName, CalleeNameSignature, TailPrefix, FailReason, ClrInstanceID) 0
-#define FireEtwMethodJitMemoryAllocatedForCode(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, JitHotCodeRequestSize, JitRODataRequestSize, AllocatedSizeForJitCode, JitAllocFlag, ClrInstanceID) 0
+#define FireEtwMethodJitMemoryAllocatedForCode(MethodID, ModuleID, JitHotCodeRequestSize, JitRODataRequestSize, AllocatedSizeForJitCode, JitAllocFlag, ClrInstanceID) 0
 #define FireEtwMethodILToNativeMap(MethodID, ReJITID, MethodExtent, CountOfMapEntries, ILOffsets, NativeOffsets, ClrInstanceID) 0
 #define FireEtwModuleDCStartV2(ModuleID, AssemblyID, ModuleFlags, Reserved1, ModuleILPath, ModuleNativePath) 0
 #define FireEtwModuleDCEndV2(ModuleID, AssemblyID, ModuleFlags, Reserved1, ModuleILPath, ModuleNativePath) 0

--- a/src/coreclr/src/gc/env/etmdummy.h
+++ b/src/coreclr/src/gc/env/etmdummy.h
@@ -129,7 +129,7 @@
 #define FireEtwMethodJitInliningFailed(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, InlinerNamespace, InlinerName, InlinerNameSignature, InlineeNamespace, InlineeName, InlineeNameSignature, FailAlways, FailReason, ClrInstanceID) 0
 #define FireEtwMethodJitTailCallSucceeded(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, CallerNamespace, CallerName, CallerNameSignature, CalleeNamespace, CalleeName, CalleeNameSignature, TailPrefix, TailCallType, ClrInstanceID) 0
 #define FireEtwMethodJitTailCallFailed(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, CallerNamespace, CallerName, CallerNameSignature, CalleeNamespace, CalleeName, CalleeNameSignature, TailPrefix, FailReason, ClrInstanceID) 0
-#define FireEtwMethodJitMemoryAllocatedForCode(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, HotCodeSize, RODataSize, TotalRequestSize, CorJitAllocMemFlag, ClrInstanceID) 0
+#define FireEtwMethodJitMemoryAllocatedForCode(MethodBeingCompiledNamespace, MethodBeingCompiledName, MethodBeingCompiledNameSignature, JitHotCodeRequestSize, JitRODataRequestSize, AllocatedSizeForJitCode, JitAllocFlag, ClrInstanceID) 0
 #define FireEtwMethodILToNativeMap(MethodID, ReJITID, MethodExtent, CountOfMapEntries, ILOffsets, NativeOffsets, ClrInstanceID) 0
 #define FireEtwModuleDCStartV2(ModuleID, AssemblyID, ModuleFlags, Reserved1, ModuleILPath, ModuleNativePath) 0
 #define FireEtwModuleDCEndV2(ModuleID, AssemblyID, ModuleFlags, Reserved1, ModuleILPath, ModuleNativePath) 0

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -227,6 +227,7 @@
                             <opcode name="MethodDCStartVerbose" message="$(string.RuntimePublisher.MethodDCStartVerboseOpcodeMessage)" symbol="CLR_METHOD_METHODDCSTARTVERBOSE_OPCODE" value="39"> </opcode>
                             <opcode name="MethodDCEndVerbose" message="$(string.RuntimePublisher.MethodDCEndVerboseOpcodeMessage)" symbol="CLR_METHOD_METHODDCENDVERBOSE_OPCODE" value="40"> </opcode>
                             <opcode name="MethodJittingStarted" message="$(string.RuntimePublisher.MethodJittingStartedOpcodeMessage)" symbol="CLR_METHOD_METHODJITTINGSTARTED_OPCODE" value="42"> </opcode>
+                            <opcode name="MemoryAllocatedForJitCode" message="$(string.RuntimePublisher.MemoryAllocatedForJitCodeOpcodeMessage)" symbol="CLR_METHOD_MEMORY_ALLOCATED_FOR_JIT_CODE_OPCODE" value="103"> </opcode>
                             <opcode name="JitInliningSucceeded" message="$(string.RuntimePublisher.JitInliningSucceededOpcodeMessage)" symbol="CLR_JITINLININGSUCCEEDED_OPCODE" value="83"> </opcode>
                             <opcode name="JitInliningFailed" message="$(string.RuntimePublisher.JitInliningFailedOpcodeMessage)" symbol="CLR_JITINLININGFAILED_OPCODE" value="84"> </opcode>
                             <opcode name="JitTailCallSucceeded" message="$(string.RuntimePublisher.JitTailCallSucceededOpcodeMessage)" symbol="CLR_JITTAILCALLSUCCEEDED_OPCODE" value="85"> </opcode>
@@ -2356,6 +2357,30 @@
                         </UserData>
                     </template>
 
+                    <template tid="MethodJitMemoryAllocatedForCode">
+                        <data name="MethodBeingCompiledNamespace" inType="win:UnicodeString" />
+                        <data name="MethodBeingCompiledName" inType="win:UnicodeString" />
+                        <data name="MethodBeingCompiledNameSignature" inType="win:UnicodeString" />
+                        <data name="HotCodeSize" inType="win:UInt64" />
+                        <data name="RODataSize" inType="win:UInt64" />
+                        <data name="TotalRequestSize" inType="win:UInt64" />
+                        <data name="CorJitAllocMemFlag" inType="win:UInt32" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+
+                        <UserData>
+                            <MethodJitMemoryAllocatedForCode xmlns="myNs">
+                                <MethodBeingCompiledNamespace> %1 </MethodBeingCompiledNamespace>
+                                <MethodBeingCompiledName> %2 </MethodBeingCompiledName>
+                                <MethodBeingCompiledNameSignature> %3 </MethodBeingCompiledNameSignature>
+                                <HotCodeSize> %4 </HotCodeSize>
+                                <RODataSize> %5 </RODataSize>
+                                <TotalRequestSize> %6 </TotalRequestSize>
+                                <CorJitAllocMemFlag> %7 </CorJitAllocMemFlag>
+                                <ClrInstanceID> %8 </ClrInstanceID>
+                            </MethodJitMemoryAllocatedForCode>
+                        </UserData>
+                    </template>
+
                     <template tid="MethodILToNativeMap">
                       <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
                       <data name="ReJITID" inType="win:UInt64" outType="win:HexInt64" />
@@ -3504,6 +3529,11 @@
                            keywords ="JitKeyword" opcode="MethodJittingStarted"
                            task="CLRMethod"
                            symbol="MethodJittingStarted_V1" message="$(string.RuntimePublisher.MethodJittingStarted_V1EventMessage)"/>
+
+                    <event value="146" version="0" level="win:Verbose"  template="MethodJitMemoryAllocatedForCode"
+                           keywords ="JitKeyword" opcode="MemoryAllocatedForJitCode"
+                           task="CLRMethod"
+                           symbol="MethodJitMemoryAllocatedForCode" message="$(string.RuntimePublisher.MethodJitMemoryAllocatedForCodeEventMessage)"/>
 
                     <event value="185" version="0" level="win:Verbose"  template="MethodJitInliningSucceeded"
                            keywords ="JitTracingKeyword" opcode="JitInliningSucceeded"
@@ -7071,6 +7101,7 @@
                 <string id="RuntimePublisher.MethodJitInliningSucceededEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nInlinerNamespace=%4;%nInlinerName=%5;%nInlinerNameSignature=%6;%nInlineeNamespace=%7;%nInlineeName=%8;%nInlineeNameSignature=%9;%nClrInstanceID=%10" />
                 <string id="RuntimePublisher.MethodJitTailCallFailedEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nCallerNamespace=%4;%nCallerName=%5;%nCallerNameSignature=%6;%nCalleeNamespace=%7;%nCalleeName=%8;%nCalleeNameSignature=%9;%nTailPrefix=%10;%nFailReason=%11;%nClrInstanceID=%12" />
                 <string id="RuntimePublisher.MethodJitTailCallSucceededEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nCallerNamespace=%4;%nCallerName=%5;%nCallerNameSignature=%6;%nCalleeNamespace=%7;%nCalleeName=%8;%nCalleeNameSignature=%9;%nTailPrefix=%10;%nTailCallType=%11;%nClrInstanceID=%12" />
+                <string id="RuntimePublisher.MethodJitMemoryAllocatedForCodeEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nHotCodeSize=%4;%nRODataSize=%5;%nTotalRequestSize=%6;%nCorJitAllocMemFlag=%7;%nClrInstanceID=%8" />
                 <string id="RuntimePublisher.SetGCHandleEventMessage" value="HandleID=%1;%nObjectID=%2;%nKind=%3;%nGeneration=%4;%nAppDomainID=%5;%nClrInstanceID=%6" />
                 <string id="RuntimePublisher.DestroyGCHandleEventMessage" value="HandleID=%1;%nClrInstanceID=%2" />
                 <string id="RuntimePublisher.CodeSymbolsEventMessage" value="%nClrInstanceId=%1;%nModuleId=%2;%nTotalChunks=%3;%nChunkNumber=%4;%nChunkLength=%5;%nChunk=%6" />
@@ -7654,6 +7685,7 @@
                 <string id="RuntimePublisher.JitInliningFailedOpcodeMessage" value="InliningFailed" />
                 <string id="RuntimePublisher.JitTailCallSucceededOpcodeMessage" value="TailCallSucceeded" />
                 <string id="RuntimePublisher.JitTailCallFailedOpcodeMessage" value="TailCallFailed" />
+                <string id="RuntimePublisher.MemoryAllocatedForJitCodeOpcodeMessage" value="MemoryAllocatedForJitCode" />
                 <string id="RuntimePublisher.MethodILToNativeMapOpcodeMessage" value="MethodILToNativeMap" />
                 <string id="RuntimePublisher.DomainModuleLoadOpcodeMessage" value="DomainModuleLoad" />
                 <string id="RuntimePublisher.ModuleLoadOpcodeMessage" value="ModuleLoad" />

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -2358,9 +2358,8 @@
                     </template>
 
                     <template tid="MethodJitMemoryAllocatedForCode">
-                        <data name="MethodBeingCompiledNamespace" inType="win:UnicodeString" />
-                        <data name="MethodBeingCompiledName" inType="win:UnicodeString" />
-                        <data name="MethodBeingCompiledNameSignature" inType="win:UnicodeString" />
+                        <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
                         <data name="JitHotCodeRequestSize" inType="win:UInt64" />
                         <data name="JitRODataRequestSize" inType="win:UInt64" />
                         <data name="AllocatedSizeForJitCode" inType="win:UInt64" />
@@ -2369,14 +2368,13 @@
 
                         <UserData>
                             <MethodJitMemoryAllocatedForCode xmlns="myNs">
-                                <MethodBeingCompiledNamespace> %1 </MethodBeingCompiledNamespace>
-                                <MethodBeingCompiledName> %2 </MethodBeingCompiledName>
-                                <MethodBeingCompiledNameSignature> %3 </MethodBeingCompiledNameSignature>
-                                <JitHotCodeRequestSize> %4 </JitHotCodeRequestSize>
-                                <JitRODataRequestSize> %5 </JitRODataRequestSize>
-                                <AllocatedSizeForJitCode> %6 </AllocatedSizeForJitCode>
-                                <JitAllocFlag> %7 </JitAllocFlag>
-                                <ClrInstanceID> %8 </ClrInstanceID>
+                                <MethodID> %1 </MethodID>
+                                <ModuleID> %2 </ModuleID>
+                                <JitHotCodeRequestSize> %3 </JitHotCodeRequestSize>
+                                <JitRODataRequestSize> %4 </JitRODataRequestSize>
+                                <AllocatedSizeForJitCode> %5 </AllocatedSizeForJitCode>
+                                <JitAllocFlag> %6 </JitAllocFlag>
+                                <ClrInstanceID> %7 </ClrInstanceID>
                             </MethodJitMemoryAllocatedForCode>
                         </UserData>
                     </template>
@@ -7101,7 +7099,7 @@
                 <string id="RuntimePublisher.MethodJitInliningSucceededEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nInlinerNamespace=%4;%nInlinerName=%5;%nInlinerNameSignature=%6;%nInlineeNamespace=%7;%nInlineeName=%8;%nInlineeNameSignature=%9;%nClrInstanceID=%10" />
                 <string id="RuntimePublisher.MethodJitTailCallFailedEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nCallerNamespace=%4;%nCallerName=%5;%nCallerNameSignature=%6;%nCalleeNamespace=%7;%nCalleeName=%8;%nCalleeNameSignature=%9;%nTailPrefix=%10;%nFailReason=%11;%nClrInstanceID=%12" />
                 <string id="RuntimePublisher.MethodJitTailCallSucceededEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nCallerNamespace=%4;%nCallerName=%5;%nCallerNameSignature=%6;%nCalleeNamespace=%7;%nCalleeName=%8;%nCalleeNameSignature=%9;%nTailPrefix=%10;%nTailCallType=%11;%nClrInstanceID=%12" />
-                <string id="RuntimePublisher.MethodJitMemoryAllocatedForCodeEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nJitHotCodeRequestSize=%4;%nJitRODataRequestSize=%5;%nAllocatedSizeForJitCode=%6;%nJitAllocFlag=%7;%nClrInstanceID=%8" />
+                <string id="RuntimePublisher.MethodJitMemoryAllocatedForCodeEventMessage" value="MethodID=%1;%nModuleID=%2;%nJitHotCodeRequestSize=%3;%nJitRODataRequestSize=%4;%nAllocatedSizeForJitCode=%5;%nJitAllocFlag=%6;%nClrInstanceID=%7" />
                 <string id="RuntimePublisher.SetGCHandleEventMessage" value="HandleID=%1;%nObjectID=%2;%nKind=%3;%nGeneration=%4;%nAppDomainID=%5;%nClrInstanceID=%6" />
                 <string id="RuntimePublisher.DestroyGCHandleEventMessage" value="HandleID=%1;%nClrInstanceID=%2" />
                 <string id="RuntimePublisher.CodeSymbolsEventMessage" value="%nClrInstanceId=%1;%nModuleId=%2;%nTotalChunks=%3;%nChunkNumber=%4;%nChunkLength=%5;%nChunk=%6" />

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -2361,10 +2361,10 @@
                         <data name="MethodBeingCompiledNamespace" inType="win:UnicodeString" />
                         <data name="MethodBeingCompiledName" inType="win:UnicodeString" />
                         <data name="MethodBeingCompiledNameSignature" inType="win:UnicodeString" />
-                        <data name="HotCodeSize" inType="win:UInt64" />
-                        <data name="RODataSize" inType="win:UInt64" />
-                        <data name="TotalRequestSize" inType="win:UInt64" />
-                        <data name="CorJitAllocMemFlag" inType="win:UInt32" />
+                        <data name="JitHotCodeRequestSize" inType="win:UInt64" />
+                        <data name="JitRODataRequestSize" inType="win:UInt64" />
+                        <data name="AllocatedSizeForJitCode" inType="win:UInt64" />
+                        <data name="JitAllocFlag" inType="win:UInt32" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
 
                         <UserData>
@@ -2372,10 +2372,10 @@
                                 <MethodBeingCompiledNamespace> %1 </MethodBeingCompiledNamespace>
                                 <MethodBeingCompiledName> %2 </MethodBeingCompiledName>
                                 <MethodBeingCompiledNameSignature> %3 </MethodBeingCompiledNameSignature>
-                                <HotCodeSize> %4 </HotCodeSize>
-                                <RODataSize> %5 </RODataSize>
-                                <TotalRequestSize> %6 </TotalRequestSize>
-                                <CorJitAllocMemFlag> %7 </CorJitAllocMemFlag>
+                                <JitHotCodeRequestSize> %4 </JitHotCodeRequestSize>
+                                <JitRODataRequestSize> %5 </JitRODataRequestSize>
+                                <AllocatedSizeForJitCode> %6 </AllocatedSizeForJitCode>
+                                <JitAllocFlag> %7 </JitAllocFlag>
                                 <ClrInstanceID> %8 </ClrInstanceID>
                             </MethodJitMemoryAllocatedForCode>
                         </UserData>
@@ -7101,7 +7101,7 @@
                 <string id="RuntimePublisher.MethodJitInliningSucceededEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nInlinerNamespace=%4;%nInlinerName=%5;%nInlinerNameSignature=%6;%nInlineeNamespace=%7;%nInlineeName=%8;%nInlineeNameSignature=%9;%nClrInstanceID=%10" />
                 <string id="RuntimePublisher.MethodJitTailCallFailedEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nCallerNamespace=%4;%nCallerName=%5;%nCallerNameSignature=%6;%nCalleeNamespace=%7;%nCalleeName=%8;%nCalleeNameSignature=%9;%nTailPrefix=%10;%nFailReason=%11;%nClrInstanceID=%12" />
                 <string id="RuntimePublisher.MethodJitTailCallSucceededEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nCallerNamespace=%4;%nCallerName=%5;%nCallerNameSignature=%6;%nCalleeNamespace=%7;%nCalleeName=%8;%nCalleeNameSignature=%9;%nTailPrefix=%10;%nTailCallType=%11;%nClrInstanceID=%12" />
-                <string id="RuntimePublisher.MethodJitMemoryAllocatedForCodeEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nHotCodeSize=%4;%nRODataSize=%5;%nTotalRequestSize=%6;%nCorJitAllocMemFlag=%7;%nClrInstanceID=%8" />
+                <string id="RuntimePublisher.MethodJitMemoryAllocatedForCodeEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nJitHotCodeRequestSize=%4;%nJitRODataRequestSize=%5;%nAllocatedSizeForJitCode=%6;%nJitAllocFlag=%7;%nClrInstanceID=%8" />
                 <string id="RuntimePublisher.SetGCHandleEventMessage" value="HandleID=%1;%nObjectID=%2;%nKind=%3;%nGeneration=%4;%nAppDomainID=%5;%nClrInstanceID=%6" />
                 <string id="RuntimePublisher.DestroyGCHandleEventMessage" value="HandleID=%1;%nClrInstanceID=%2" />
                 <string id="RuntimePublisher.CodeSymbolsEventMessage" value="%nClrInstanceId=%1;%nModuleId=%2;%nTotalChunks=%3;%nChunkNumber=%4;%nChunkLength=%5;%nChunk=%6" />

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12009,6 +12009,27 @@ void CEEJitInfo::allocMem (
         COMPlusThrowHR(CORJIT_OUTOFMEM);
     }
 
+    if (EventEnabledMethodJitMemoryAllocatedForCode())
+    {
+        SString methodBeingCompiledNames[3];
+        MethodDesc* methodBeingCompiled = m_pMethodBeingCompiled;
+        if (methodBeingCompiled)
+        {
+            (methodBeingCompiled)->GetMethodInfo((methodBeingCompiledNames)[0], (methodBeingCompiledNames)[1], (methodBeingCompiledNames)[2]);
+        }
+        else
+        {
+            (methodBeingCompiledNames)[0].Set(W("<null>"));
+            (methodBeingCompiledNames)[1].Set(W("<null>"));
+            (methodBeingCompiledNames)[2].Set(W("<null>"));
+        }
+
+        FireEtwMethodJitMemoryAllocatedForCode(methodBeingCompiledNames[0].GetUnicode(),
+            methodBeingCompiledNames[1].GetUnicode(),
+            methodBeingCompiledNames[2].GetUnicode(),
+            hotCodeSize, roDataSize, totalSize.Value(), flag, GetClrInstanceId());
+    }
+
     m_CodeHeader = m_jitManager->allocCode(m_pMethodBeingCompiled, totalSize.Value(), GetReserveForJumpStubs(), flag
 #ifdef FEATURE_EH_FUNCLETS
                                            , m_totalUnwindInfos

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12011,22 +12011,17 @@ void CEEJitInfo::allocMem (
 
     if (EventEnabledMethodJitMemoryAllocatedForCode())
     {
-        SString methodBeingCompiledNames[3];
-        MethodDesc* methodBeingCompiled = m_pMethodBeingCompiled;
-        if (methodBeingCompiled)
+        ULONGLONG ullMethodIdentifier = 0;
+        ULONGLONG ullModuleID = 0;
+
+        if (m_pMethodBeingCompiled)
         {
-            (methodBeingCompiled)->GetMethodInfo((methodBeingCompiledNames)[0], (methodBeingCompiledNames)[1], (methodBeingCompiledNames)[2]);
-        }
-        else
-        {
-            (methodBeingCompiledNames)[0].Set(W("<null>"));
-            (methodBeingCompiledNames)[1].Set(W("<null>"));
-            (methodBeingCompiledNames)[2].Set(W("<null>"));
+            Module* pModule = m_pMethodBeingCompiled->GetModule_NoLogging();
+            ullModuleID = (ULONGLONG)(TADDR)pModule;
+            ullMethodIdentifier = (ULONGLONG)m_pMethodBeingCompiled;
         }
 
-        FireEtwMethodJitMemoryAllocatedForCode(methodBeingCompiledNames[0].GetUnicode(),
-            methodBeingCompiledNames[1].GetUnicode(),
-            methodBeingCompiledNames[2].GetUnicode(),
+        FireEtwMethodJitMemoryAllocatedForCode(ullMethodIdentifier, ullModuleID,
             hotCodeSize + coldCodeSize, roDataSize, totalSize.Value(), flag, GetClrInstanceId());
     }
 

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12009,7 +12009,7 @@ void CEEJitInfo::allocMem (
         COMPlusThrowHR(CORJIT_OUTOFMEM);
     }
 
-    if (EventEnabledMethodJitMemoryAllocatedForCode())
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, MethodJitMemoryAllocatedForCode))
     {
         ULONGLONG ullMethodIdentifier = 0;
         ULONGLONG ullModuleID = 0;

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12027,7 +12027,7 @@ void CEEJitInfo::allocMem (
         FireEtwMethodJitMemoryAllocatedForCode(methodBeingCompiledNames[0].GetUnicode(),
             methodBeingCompiledNames[1].GetUnicode(),
             methodBeingCompiledNames[2].GetUnicode(),
-            hotCodeSize, roDataSize, totalSize.Value(), flag, GetClrInstanceId());
+            hotCodeSize + coldCodeSize, roDataSize, totalSize.Value(), flag, GetClrInstanceId());
     }
 
     m_CodeHeader = m_jitManager->allocCode(m_pMethodBeingCompiled, totalSize.Value(), GetReserveForJumpStubs(), flag


### PR DESCRIPTION
Add new event `MethodJitMemoryAllocatedForCode` that is fired to track the memory allocation size requested by JIT from VM.

Corresponding changes to display the values in PerfView is in https://github.com/microsoft/perfview/pull/1289

This is needed to measure the impact of code alignment that will be done as part of https://github.com/dotnet/runtime/issues/43227