### PR TITLE
Add optimized String.Join for IList<string>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -632,7 +632,7 @@ namespace System
             }
             if (values is List<string?> valuesIList)
             {
-                return Join(separator, valuesIList, 0, valuesIList.Count);
+                return Join(separator, CollectionsMarshal.AsSpan(valuesIList), 0, valuesIList.Count);
             }
             if (values is string?[] valuesArray)
             {
@@ -684,13 +684,13 @@ namespace System
 
         // Joins an array of strings together as one string with a separator between each original string.
         //
-        private static unsafe string Join(string? separator, List<string?> value, int startIndex, int count)
+        private static unsafe string Join(string? separator, ReadOnlySpan<string?> value, int startIndex, int count)
         {
             separator ??= Empty;
             fixed (char* pSeparator = &separator._firstChar)
             {
                 // Defer argument validation to the internal function
-                return JoinCore(pSeparator, separator.Length, CollectionsMarshal.AsSpan(value), startIndex, count);
+                return JoinCore(pSeparator, separator.Length, value, startIndex, count);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -629,7 +629,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(values));
             }
-            if (values is IList<string?> valuesIList)
+            if (values is IReadOnlyList<string?> valuesIList)
             {
                 return Join(separator, valuesIList, 0, valuesIList.Count);
             }
@@ -679,7 +679,7 @@ namespace System
 
         // Joins an array of strings together as one string with a separator between each original string.
         //
-        private static unsafe string Join(string? separator, IList<string?> value, int startIndex, int count)
+        private static unsafe string Join(string? separator, IReadOnlyList<string?> value, int startIndex, int count)
         {
             separator ??= Empty;
             fixed (char* pSeparator = &separator._firstChar)
@@ -777,7 +777,7 @@ namespace System
             }
         }
 
-        private static unsafe string JoinCore(char* separator, int separatorLength, IList<string?> value, int startIndex, int count)
+        private static unsafe string JoinCore(char* separator, int separatorLength, IReadOnlyList<string?> value, int startIndex, int count)
         {
             // If the separator is null, it is converted to an empty string before entering this function.
             // Even for empty strings, fixed should never return null (it should return a pointer to a null char).

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -822,7 +822,7 @@ namespace System
             Debug.Assert(separator != null);
             Debug.Assert(separatorLength >= 0);
 
-            var count = value.Length;
+            int count = value.Length;
             if (count <= 1)
             {
                 return count == 0 ?

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -626,17 +626,19 @@ namespace System
 
         public static string Join(string? separator, IEnumerable<string?> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException(nameof(values));
-            }
             if (values is List<string?> valuesIList)
             {
-                return Join(separator, CollectionsMarshal.AsSpan(valuesIList), 0, valuesIList.Count);
+                return Join(separator, CollectionsMarshal.AsSpan(valuesIList));
             }
+
             if (values is string?[] valuesArray)
             {
                 return Join(separator, valuesArray, 0, valuesArray.Length);
+            }
+
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
             }
 
             using (IEnumerator<string?> en = values.GetEnumerator())
@@ -682,15 +684,15 @@ namespace System
             }
         }
 
-        // Joins an array of strings together as one string with a separator between each original string.
+        // Joins a span of strings together as one string with a separator between each original string.
         //
-        private static unsafe string Join(string? separator, ReadOnlySpan<string?> value, int startIndex, int count)
+        private static unsafe string Join(string? separator, ReadOnlySpan<string?> value)
         {
             separator ??= Empty;
             fixed (char* pSeparator = &separator._firstChar)
             {
                 // Defer argument validation to the internal function
-                return JoinCore(pSeparator, separator.Length, value, startIndex, count);
+                return JoinCore(pSeparator, separator.Length, value, 0, value.Length);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -667,7 +667,19 @@ namespace System
 
         // Joins an array of strings together as one string with a separator between each original string.
         //
-        public static unsafe string Join(string? separator, IList<string?> value, int startIndex, int count)
+        public static unsafe string Join(string? separator, string?[] value, int startIndex, int count)
+        {
+            separator ??= Empty;
+            fixed (char* pSeparator = &separator._firstChar)
+            {
+                // Defer argument validation to the internal function
+                return JoinCore(pSeparator, separator.Length, value, startIndex, count);
+            }
+        }
+
+        // Joins an array of strings together as one string with a separator between each original string.
+        //
+        private static unsafe string Join(string? separator, IList<string?> value, int startIndex, int count)
         {
             separator ??= Empty;
             fixed (char* pSeparator = &separator._firstChar)

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -629,6 +629,10 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(values));
             }
+            if (values is IList<string?> valuesIList)
+            {
+                return Join(separator, valuesIList, 0, valuesIList.Count);
+            }
 
             using (IEnumerator<string?> en = values.GetEnumerator())
             {
@@ -663,7 +667,7 @@ namespace System
 
         // Joins an array of strings together as one string with a separator between each original string.
         //
-        public static unsafe string Join(string? separator, string?[] value, int startIndex, int count)
+        public static unsafe string Join(string? separator, IList<string?> value, int startIndex, int count)
         {
             separator ??= Empty;
             fixed (char* pSeparator = &separator._firstChar)
@@ -761,7 +765,7 @@ namespace System
             }
         }
 
-        private static unsafe string JoinCore(char* separator, int separatorLength, string?[] value, int startIndex, int count)
+        private static unsafe string JoinCore(char* separator, int separatorLength, IList<string?> value, int startIndex, int count)
         {
             // If the separator is null, it is converted to an empty string before entering this function.
             // Even for empty strings, fixed should never return null (it should return a pointer to a null char).
@@ -780,7 +784,7 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NegativeCount);
             }
-            if (startIndex > value.Length - count)
+            if (startIndex > value.Count - count)
             {
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_IndexCountBuffer);
             }
@@ -867,7 +871,7 @@ namespace System
             // fall back should be extremely rare.
             return copiedLength == totalLength ?
                 result :
-                JoinCore(separator, separatorLength, (string?[])value.Clone(), startIndex, count);
+                JoinCore(separator, separatorLength, new List<string?>(value), startIndex, count);
         }
 
         public string PadLeft(int totalWidth) => PadLeft(totalWidth, ' ');

--- a/src/libraries/System.Runtime/tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/StringTests.cs
@@ -546,6 +546,7 @@ namespace System.Tests
             {
                 Assert.Equal(expected, string.Join(separator, values));
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<string>)values));
+                // We are using concat to force the value to be an IEnumerable and execise non-IReadOnlyList<T> paths
                 Assert.Equal(expected, string.Join(separator, values.Concat(new string[0])));
                 Assert.Equal(expected, string.Join(separator, (object[])values));
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));

--- a/src/libraries/System.Runtime/tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/StringTests.cs
@@ -546,6 +546,7 @@ namespace System.Tests
             {
                 Assert.Equal(expected, string.Join(separator, values));
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<string>)values));
+                Assert.Equal(expected, string.Join(separator, values.Concat(new string[0])));
                 Assert.Equal(expected, string.Join(separator, (object[])values));
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
             }

--- a/src/libraries/System.Runtime/tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/StringTests.cs
@@ -546,7 +546,7 @@ namespace System.Tests
             {
                 Assert.Equal(expected, string.Join(separator, values));
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<string>)values));
-                // We are using concat to force the value to be an IEnumerable and execise non-IReadOnlyList<T> paths
+                // We are using concat to force the value to be an IEnumerable and avoid the optimizations for List<T> and T[]
                 Assert.Equal(expected, string.Join(separator, values.Concat(new string[0])));
                 Assert.Equal(expected, string.Join(separator, (object[])values));
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));

--- a/src/libraries/System.Runtime/tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/StringTests.cs
@@ -548,6 +548,8 @@ namespace System.Tests
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<string>)values));
                 // We are using concat to force the value to be an IEnumerable and avoid the optimizations for List<T> and T[]
                 Assert.Equal(expected, string.Join(separator, values.Concat(new string[0])));
+                // Validate the optimization for List<T>
+                Assert.Equal(expected, string.Join(separator, new List<string>(values)));
                 Assert.Equal(expected, string.Join(separator, (object[])values));
                 Assert.Equal(expected, string.Join(separator, (IEnumerable<object>)values));
             }


### PR DESCRIPTION
When joining IEnumerable<string> check whether it is a IList<string> and if so go through the path used for string[].
Fixes #44027 