### PR TITLE
(MQ cleanup) Remove unused ifdef logic in ODBC

### DIFF
--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcStatementHandle.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcStatementHandle.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Data.Odbc
 {
-    internal struct SQLLEN
+    internal readonly struct SQLLEN
     {
         private readonly IntPtr _value;
 
@@ -17,11 +17,7 @@ namespace System.Data.Odbc
 
         internal SQLLEN(long value)
         {
-#if WIN32
-            _value = new IntPtr(checked((int)value));
-#else
             _value = new IntPtr(value);
-#endif
         }
 
         internal SQLLEN(IntPtr value)
@@ -30,7 +26,7 @@ namespace System.Data.Odbc
         }
 
         public static implicit operator SQLLEN(int value)
-        { //
+        {
             return new SQLLEN(value);
         }
 
@@ -39,22 +35,17 @@ namespace System.Data.Odbc
             return new SQLLEN(value);
         }
 
-        public static unsafe implicit operator int(SQLLEN value)
+        public static implicit operator int(SQLLEN value)
         {
-#if WIN32
-            return (int)value._value.ToInt32();
-#else
-            long l = (long)value._value.ToInt64();
-            return checked((int)l);
-#endif
+            return value._value.ToInt32();
         }
 
-        public static unsafe explicit operator long(SQLLEN value)
+        public static explicit operator long(SQLLEN value)
         {
             return value._value.ToInt64();
         }
 
-        public unsafe long ToInt64()
+        public long ToInt64()
         {
             return _value.ToInt64();
         }


### PR DESCRIPTION
The internal struct `SQLLEN` has some \#ifdef logic around 32-bit vs. 64-bit runtimes. Since these defines are no longer enabled, this logic was always falling back to the "assume 64-bit and let IntPtr sort it out" code paths. I've removed the unused code paths.