### PR TITLE
Use the new async Run method from xharness and implement a test

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20530.4",
+      "version": "1.0.0-prerelease.20555.2",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -190,13 +190,13 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>57974c1f5790e6fb33f5fce161707be5cd86c4d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20530.4">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20555.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>bdad61dfc3d09ae826ba940d92e43a7441ec83b0</Sha>
+      <Sha>ab2eee629494e7a17592feda257b4ede4ff2fc82</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20530.4">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20555.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>bdad61dfc3d09ae826ba940d92e43a7441ec83b0</Sha>
+      <Sha>ab2eee629494e7a17592feda257b4ede4ff2fc82</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -137,8 +137,8 @@
     <RefOnlyNugetPackagingVersion>4.9.4</RefOnlyNugetPackagingVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.8.0-release-20201022-02</MicrosoftNETTestSdkVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20530.4</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20530.4</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20555.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20555.2</MicrosoftDotNetXHarnessCLIVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>

--- a/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.cs
+++ b/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
 public class SimpleWasmTestRunner : WasmApplicationEntryPoint
 {
-    public static int Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
         var testAssembly = args[0];
         var excludedTraits = new List<string>();
@@ -57,6 +58,6 @@ public class SimpleWasmTestRunner : WasmApplicationEntryPoint
             IncludedMethods = includedMethods
         };
 
-        return runner.Run();
+        return await runner.Run();
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/Http/HttpRequestMessageTest.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/Http/HttpRequestMessageTest.cs
@@ -383,6 +383,32 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
                 "}", rm.ToString());
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowserDomSupported))]
+        public async Task BlobUri_Marshal_CorrectValues_Browser()
+        {
+            Runtime.InvokeJS(@"
+                function typedArrayToURL(typedArray, mimeType) {
+                    return URL.createObjectURL(new Blob([typedArray.buffer], {type: mimeType}))
+                }
+                const bytes = new Uint8Array(59);
+                for(let i = 0; i < 59; i++) {
+                    bytes[i] = 32 + i;
+                }
+                const url = typedArrayToURL(bytes, 'text/plain');
+                // Calls method with string that will be marshaled as valid URI
+                App.call_test_method  (""InvokeString"", [ url ]);
+            ");
+
+            var client = new HttpClient ();
+            Assert.StartsWith ("blob:", HelperMarshal._stringResource);
+
+            HttpRequestMessage rm = new HttpRequestMessage(HttpMethod.Get, new Uri (HelperMarshal._stringResource));
+            HttpResponseMessage resp = await client.SendAsync (rm);
+            Assert.NotNull (resp.Content);
+            string content = await resp.Content.ReadAsStringAsync();
+            Assert.Equal (59, content.Length);
+        }
+
         [Fact]
         public void BlobStringUri_Marshal_CorrectValues()
         {

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -395,7 +395,6 @@ extern void mono_set_timeout (int t, int d);
 extern void mono_wasm_queue_tp_cb (void);
 G_END_DECLS
 
-extern void mono_wasm_pump_threadpool (void);
 void mono_background_exec (void);
 
 #endif // HOST_WASM
@@ -624,20 +623,11 @@ mono_wasm_queue_tp_cb (void)
 }
 
 void
-mono_wasm_pump_threadpool (void)
-{
-#ifdef HOST_WASM
-	mono_background_exec ();
-#endif
-}
-
-void
 mono_arch_register_icall (void)
 {
 #ifdef ENABLE_NETCORE
 	mono_add_internal_call_internal ("System.Threading.TimerQueue::SetTimeout", mono_wasm_set_timeout);
 	mono_add_internal_call_internal ("System.Threading.ThreadPool::QueueCallback", mono_wasm_queue_tp_cb);
-	mono_add_internal_call_internal ("System.Threading.ThreadPool::PumpThreadPool", mono_wasm_pump_threadpool);
 #else
 	mono_add_internal_call_internal ("System.Threading.WasmRuntime::SetTimeout", mono_wasm_set_timeout);
 #endif

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
@@ -104,12 +104,8 @@ namespace System.Threading
         }
 
         [DynamicDependency("Callback")]
-        [DynamicDependency("PumpThreadPool")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void QueueCallback();
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void PumpThreadPool(); // NOTE: this method is called via reflection by test code
 
         private static void Callback()
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.Mono.cs
@@ -58,7 +58,7 @@ namespace System.Threading
             return true;
         }
 
-        private static int PumpTimerQueue() // NOTE: this method is called via reflection by test code
+        private static int PumpTimerQueue()
         {
             if (s_scheduledTimersToFire == null)
             {


### PR DESCRIPTION
Update browser tests to use https://github.com/dotnet/xharness/pull/345 and be able to run promise related tests. Depends on https://github.com/dotnet/runtime/pull/44045

The build will fail until the xharness change makes it in.