### PR TITLE
Fix IL interpreter build on GCC.

### DIFF
--- a/src/coreclr/src/vm/interpreter.cpp
+++ b/src/coreclr/src/vm/interpreter.cpp
@@ -3537,6 +3537,7 @@ bool Interpreter::MethodMayHaveLoop(BYTE* ilCode, unsigned codeSize)
             op = *(ilCode + 1) + 0x100;
             _ASSERTE(op < CEE_COUNT);  // Bounds check for below.
             // deliberate fall-through here.
+            __fallthrough;
         default:
             // For the rest of the 1-byte instructions, we'll use a table-driven approach.
             ilCode += opSizes1Byte[op];
@@ -4919,7 +4920,7 @@ void Interpreter::BinaryIntOpWork(T val1, T val2)
         {
             ThrowDivideByZero();
         }
-        else if (val2 == -1 && val1 == static_cast<T>(((UINT64)1) << (sizeof(T)*8 - 1))) // min int / -1 is not representable.
+        else if (val2 == static_cast<T>(-1) && val1 == static_cast<T>(((UINT64)1) << (sizeof(T)*8 - 1))) // min int / -1 is not representable.
         {
             ThrowSysArithException();
         }

--- a/src/coreclr/src/vm/interpreter.h
+++ b/src/coreclr/src/vm/interpreter.h
@@ -1038,7 +1038,7 @@ private:
     static MethodHandleToInterpMethInfoPtrMap* GetMethodHandleToInterpMethInfoPtrMap();
 
     static InterpreterMethodInfo* RecordInterpreterMethodInfoForMethodHandle(CORINFO_METHOD_HANDLE md, InterpreterMethodInfo* methInfo);
-    static InterpreterMethodInfo* Interpreter::MethodHandleToInterpreterMethInfoPtr(CORINFO_METHOD_HANDLE md);
+    static InterpreterMethodInfo* MethodHandleToInterpreterMethInfoPtr(CORINFO_METHOD_HANDLE md);
 
 public:
     static unsigned s_interpreterStubNum;


### PR DESCRIPTION
Build Command:
```
./build.sh clr -c debug -gcc -cmakeargs "-DFEATURE_INTERPRETER=1"
./build.sh clr -c release -gcc -cmakeargs "-DFEATURE_INTERPRETER=1"
```

Errors:
```
  /home/heiher/git/dotnet/runtime/src/coreclr/src/vm/interpreter.h:1041:35: error: extra qualification ‘Interpreter::’ on member ‘MethodHandleToInterpreterMethInfoPtr’ [-fpermissive]
   1041 |     static InterpreterMethodInfo* Interpreter::MethodHandleToInterpreterMethInfoPtr(CORINFO_METHOD_HANDLE md);

  /home/heiher/git/dotnet/runtime/src/coreclr/src/vm/interpreter.cpp:4922:23: error: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Werror=sign-compare]
   4922 |         else if (val2 == -1 && val1 == static_cast<T>(((UINT64)1) << (sizeof(T)*8 - 1))) // min int / -1 is not representable.
        |                  ~~~~~^~~~~

  /home/heiher/git/dotnet/runtime/src/coreclr/src/vm/interpreter.cpp: In static member function ‘static bool Interpreter::MethodMayHaveLoop(BYTE*, unsigned int)’:
  /home/heiher/git/dotnet/runtime/src/coreclr/src/inc/debugmacros.h:45:14: error: this statement may fall through [-Werror=implicit-fallthrough=]
     45 |              if (!(expr)) {                                                 \
        |              ^~
  /home/heiher/git/dotnet/runtime/src/coreclr/src/inc/debugmacros.h:54:26: note: in expansion of macro ‘_ASSERTE_MSG’
     54 |   #define _ASSERTE(expr) _ASSERTE_MSG(expr, #expr)
        |                          ^~~~~~~~~~~~
  /home/heiher/git/dotnet/runtime/src/coreclr/src/vm/interpreter.cpp:3538:13: note: in expansion of macro ‘_ASSERTE’
   3538 |             _ASSERTE(op < CEE_COUNT);  // Bounds check for below.
        |             ^~~~~~~~
  /home/heiher/git/dotnet/runtime/src/coreclr/src/vm/interpreter.cpp:3540:9: note: here
   3540 |         default:
        |         ^~~~~~~
```

@jkotas @am11 Request for review please.