### PR TITLE
Add feature switch for disabling startup hooks

### DIFF
--- a/docs/design/features/host-startup-hook.md
+++ b/docs/design/features/host-startup-hook.md
@@ -254,9 +254,9 @@ The type should be made `internal` to prevent exposing it as API
 surface to any managed code that happens to have access to the startup
 hook dll. However, the feature will also work if the type is `public`.
 
-### Linker unfriendly
+### Incompatible with trimming
 
 Startup hooks are disabled by default on trimmed apps. The usage of
 startup hooks on a trimmed app is potentially dangerous since these
 could make use of assemblies, types or members that were removed by
-the linker, causing the app to crash.
+trimming, causing the app to crash.

--- a/docs/design/features/host-startup-hook.md
+++ b/docs/design/features/host-startup-hook.md
@@ -256,4 +256,7 @@ hook dll. However, the feature will also work if the type is `public`.
 
 ### Linker unfriendly
 
-The usage of startup hooks on a trimmed app is potentially dangerous since these could make use of assemblies, types or members that were removed by the linker, causing the app to crash.
+Startup hooks are disabled by default on trimmed apps. The usage of
+startup hooks on a trimmed app is potentially dangerous since these
+could make use of assemblies, types or members that were removed by
+the linker, causing the app to crash.

--- a/docs/design/features/host-startup-hook.md
+++ b/docs/design/features/host-startup-hook.md
@@ -253,3 +253,7 @@ be defined either in the app or within the first hook that uses it:
 The type should be made `internal` to prevent exposing it as API
 surface to any managed code that happens to have access to the startup
 hook dll. However, the feature will also work if the type is `public`.
+
+### Linker unfriendly
+
+The usage of startup hooks on a trimmed app is potentially dangerous since these could make use of assemblies, types or members that were removed by the linker, causing the app to crash.

--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -15,6 +15,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | InvariantGlobalization | System.Globalization.Invariant | All globalization specific code and data is trimmed when set to true |
 | UseSystemResourceKeys | System.Resources.UseSystemResourceKeys |  Any localizable resources for system assemblies is trimmed when set to true |
 | HttpActivityPropagationSupport | System.Net.Http.EnableActivityPropagation | Any dependency related to diagnostics support for System.Net.Http is trimmed when set to false |
+| StartupHookSupport | System.StartupHookProvider.IsSupported | Any StartupHook related logic is trimmed when set to false |
 
 Any feature-switch which defines property can be set in csproj file or
 on the command line as any other MSBuild property. Those without predefined property name

--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -15,7 +15,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | InvariantGlobalization | System.Globalization.Invariant | All globalization specific code and data is trimmed when set to true |
 | UseSystemResourceKeys | System.Resources.UseSystemResourceKeys |  Any localizable resources for system assemblies is trimmed when set to true |
 | HttpActivityPropagationSupport | System.Net.Http.EnableActivityPropagation | Any dependency related to diagnostics support for System.Net.Http is trimmed when set to false |
-| StartupHookSupport | System.StartupHookProvider.IsSupported | Any StartupHook related logic is trimmed when set to false |
+| StartupHookSupport | System.StartupHookProvider.IsSupported | Startup hooks are disabled when set to false. Startup hook related functionality can be trimmed. |
 
 Any feature-switch which defines property can be set in csproj file or
 on the command line as any other MSBuild property. Those without predefined property name

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -15,10 +15,7 @@ namespace System
         private const string InitializeMethodName = "Initialize";
         private const string DisallowedSimpleAssemblyNameSuffix = ".dll";
 
-        private static bool IsSupported { get; } = StartupHookProviderIsSupported();
-
-        private static bool StartupHookProviderIsSupported() =>
-            AppContext.TryGetSwitch("System.StartupHookProvider.IsSupported", out bool isSupported) ? isSupported : true;
+        private static bool IsSupported => AppContext.TryGetSwitch("System.StartupHookProvider.IsSupported", out bool isSupported) ? isSupported : true;
 
         private struct StartupHookNameOrPath
         {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -103,8 +103,8 @@ namespace System
 
         // Load the specified assembly, and call the specified type's
         // "static void Initialize()" method.
-        [RequiresUnreferencedCode("Trimming may remove assemblies, types or members used by startup hooks. " +
-                                  "These can be disabled using the StartupHookSupport feature switch")]
+        [RequiresUnreferencedCode("The StartupHookSupport feature switch has been enabled for this app which is being trimmed. " +
+            "Startup hook code is not observable by the trimmer and so required assemblies, types and members may be removed")]
         private static void CallStartupHook(StartupHookNameOrPath startupHook)
         {
             Assembly assembly;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -102,6 +103,8 @@ namespace System
 
         // Load the specified assembly, and call the specified type's
         // "static void Initialize()" method.
+        [RequiresUnreferencedCode("Trimming may remove assemblies, types or members used by startup hooks. " +
+                                  "These can be disabled using the StartupHookSupport feature switch")]
         private static void CallStartupHook(StartupHookNameOrPath startupHook)
         {
             Assembly assembly;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -14,6 +15,11 @@ namespace System
         private const string InitializeMethodName = "Initialize";
         private const string DisallowedSimpleAssemblyNameSuffix = ".dll";
 
+        private static bool IsSupported { get; } = StartupHookProviderIsSupported();
+
+        private static bool StartupHookProviderIsSupported() =>
+            AppContext.TryGetSwitch("System.StartupHookProvider.IsSupported", out bool isSupported) ? isSupported : true;
+
         private struct StartupHookNameOrPath
         {
             public AssemblyName AssemblyName;
@@ -24,6 +30,9 @@ namespace System
         // containing a startup hook, and call each hook in turn.
         private static void ProcessStartupHooks()
         {
+            if (!IsSupported)
+                return;
+
             // Initialize tracing before any user code can be called.
             System.Diagnostics.Tracing.RuntimeEventSource.Initialize();
 

--- a/src/installer/tests/HostActivation.Tests/RuntimeConfig.cs
+++ b/src/installer/tests/HostActivation.Tests/RuntimeConfig.cs
@@ -276,7 +276,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 JObject configProperties = new JObject();
                 foreach (var property in _properties)
                 {
-                    configProperties.Add(property.Item1, property.Item2);
+                    var tokenValue = (property.Item2 == "false" || property.Item2 == "true") ?
+                        JToken.Parse(property.Item2) : property.Item2;
+                    configProperties.Add(property.Item1, tokenValue);
                 }
 
                 runtimeOptions.Add("configProperties", configProperties);

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
     {
         private SharedTestState sharedTestState;
         private string startupHookVarName = "DOTNET_STARTUP_HOOKS";
+        private string startupHookSupport = "System.StartupHookProvider.IsSupported";
 
         public StartupHooks(StartupHooks.SharedTestState fixture)
         {
@@ -637,6 +638,32 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
                 .And.ExitWith(2);
+        }
+
+        [Fact]
+        public void Muxer_activation_of_StartupHook_With_IsSupported_False()
+        {
+            var fixture = sharedTestState.PortableAppFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.StartupHookFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            RuntimeConfig.FromFile(fixture.TestProject.RuntimeConfigJson)
+                .WithProperty(startupHookSupport, "false")
+                .Save();
+
+            // Startup hooks are not executed when the StartupHookSupport
+            // feature switch is set to false.
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should().Pass()
+                .And.NotHaveStdOutContaining("Hello from startup hook!")
+                .And.HaveStdOutContaining("Hello World");
         }
 
         public class SharedTestState : IDisposable

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -18,5 +18,8 @@
     <type fullname="System.Threading.Tasks.Task" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false">
       <field name="s_asyncDebuggingEnabled" value="false" initialize="false" />
     </type>
+    <type fullname="System.StartupHookProvider" feature="System.StartupHookProvider.IsSupported" featurevalue="false">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
@@ -83,7 +83,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.StartupHookProvider.CallStartupHook(System.StartupHookProvider.StartupHookNameOrPath)</property>
+      <property name="Target">M:System.StartupHookProvider.ProcessStartupHooks()</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>


### PR DESCRIPTION
Fix #36526. This introduces a new feature switch which allows the `ILLinker` to trim the startup hooks logic.
