### PR TITLE
add support for less standard serial port speeds on macOS

### DIFF
--- a/src/libraries/Native/Unix/Common/pal_config.h.in
+++ b/src/libraries/Native/Unix/Common/pal_config.h.in
@@ -112,6 +112,7 @@
 #cmakedefine01 HAVE_CFMAKERAW
 #cmakedefine01 HAVE_GETGROUPLIST
 #cmakedefine01 HAVE_SYS_PROCINFO_H
+#cmakedefine01 HAVE_IOSS_H
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/libraries/Native/Unix/System.IO.Ports.Native/pal_termios.c
+++ b/src/libraries/Native/Unix/System.IO.Ports.Native/pal_termios.c
@@ -11,6 +11,9 @@
 #if HAVE_SYS_FILIO_H
 #include <sys/filio.h>
 #endif
+#ifdef HAVE_IOSS_H
+#include <IOKit/serial/ioss.h>
+#endif
 
 /* This is dup of System/IO/Ports/NativeMethods.cs */
 enum
@@ -352,6 +355,14 @@ int32_t SystemIoPortsNative_TermiosSetSpeed(intptr_t handle, int32_t speed)
 
     if (brate == B0)
     {
+#if HAVE_IOSS_H
+        // Looks like custom speed out of POSIX. Let see if we can set it via specialized call.
+        brate = speed;
+        if (ioctl(fd, IOSSIOSPEED, &brate) != -1)
+        {
+            return speed;
+        }
+#endif
         errno = EINVAL;
         return -1;
     }
@@ -418,6 +429,7 @@ int32_t SystemIoPortsNative_TermiosReset(intptr_t handle, int32_t speed, int32_t
 {
     int fd = ToFileDescriptor(handle);
     struct termios term;
+    speed_t brate;
     int ret = 0;
 
     if (tcgetattr(fd, &term) < 0)
@@ -503,24 +515,41 @@ int32_t SystemIoPortsNative_TermiosReset(intptr_t handle, int32_t speed, int32_t
 
     if (speed)
     {
-        speed_t brate = SystemIoPortsNative_TermiosSpeed2Rate(speed);
+        brate = SystemIoPortsNative_TermiosSpeed2Rate(speed);
         if (brate == B0)
         {
+#if !HAVE_IOSS_H
+            // We can try to set non-standard speed after tcsetattr().
             errno = EINVAL;
             return -1;
-        }
-
-#if HAVE_CFSETSPEED
-        ret = cfsetspeed(&term, brate);
-#else
-        ret = cfsetispeed(&term, brate) & cfsetospeed(&term, brate);
 #endif
+        }
+        else
+        {
+#if HAVE_CFSETSPEED
+            ret = cfsetspeed(&term, brate);
+#else
+            ret = cfsetispeed(&term, brate) & cfsetospeed(&term, brate);
+#endif
+        }
     }
 
     if ((ret != 0) || (tcsetattr(fd, TCSANOW, &term) < 0))
     {
         return -1;
     }
+
+#if HAVE_IOSS_H
+    if (speed && brate == B0)
+    {
+        // we have deferred non-standard speed.
+        brate = speed;
+        if (ioctl(fd, IOSSIOSPEED, &brate) == -1)
+        {
+           return  -1;
+        }
+    }
+#endif
 
     return 0;
 }

--- a/src/libraries/Native/Unix/System.IO.Ports.Native/pal_termios.c
+++ b/src/libraries/Native/Unix/System.IO.Ports.Native/pal_termios.c
@@ -11,7 +11,7 @@
 #if HAVE_SYS_FILIO_H
 #include <sys/filio.h>
 #endif
-#ifdef HAVE_IOSS_H
+#if HAVE_IOSS_H
 #include <IOKit/serial/ioss.h>
 #endif
 

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -831,6 +831,10 @@ check_include_files(
     linux/can.h
     HAVE_LINUX_CAN_H)
 
+check_include_files(
+    IOKit/serial/ioss.h
+    HAVE_IOSS_H)
+
 check_symbol_exists(
     getpeereid
     unistd.h


### PR DESCRIPTION
It seems like macOS terms end with B230400 (probably limit of legacy serial) but many USB serial devices can do more. 
When .NET tries to use higher speed it always fails as we fail to lookup platform speed mapping. macOS has call to set specific speed so this PR use that as fallback if speed lookup fails. That leaves the decision to driver and OS e.g. it will either succeed or fail and we report that accordingly. 

I don't have enough gear to but I was able to verify that serial port can be opened with speed beyond B230400.

 fixes #43719