### PR TITLE
improve accuracy of Expect100Continue_WaitsExpectedPeriodOfTimeBeforeSendingContent test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -63,7 +63,7 @@ namespace System.Net.Http.Functional.Tests
                     long start = Environment.TickCount64;
                     (await invoker.SendAsync(TestAsync, request, default)).Dispose();
                     long elapsed = content.Ticks - start;
-                    Assert.True(elapsed > delay.Milliseconds);
+                    Assert.True(elapsed >= delay.TotalMilliseconds);
                 }
             }, async server =>
             {
@@ -88,8 +88,8 @@ namespace System.Net.Http.Functional.Tests
 
             protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
-                _tcs.SetResult(true);
                 Ticks = Environment.TickCount64;
+                _tcs.SetResult(true);
                 return base.SerializeToStreamAsync(stream, context);
             }
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -60,11 +60,10 @@ namespace System.Net.Http.Functional.Tests
                     var request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = content, Version = UseVersion };
                     request.Headers.ExpectContinue = true;
 
-                    var sw = Stopwatch.StartNew();
+                    long start = Environment.TickCount64;
                     (await invoker.SendAsync(TestAsync, request, default)).Dispose();
-                    sw.Stop();
-
-                    Assert.InRange(sw.Elapsed, delay - TimeSpan.FromSeconds(.5), delay * 20); // arbitrary wiggle room
+                    long elapsed = content.Ticks - start;
+                    Assert.True(elapsed > delay.Milliseconds);
                 }
             }, async server =>
             {
@@ -80,6 +79,7 @@ namespace System.Net.Http.Functional.Tests
         private sealed class SetTcsContent : StreamContent
         {
             private readonly TaskCompletionSource<bool> _tcs;
+            public long Ticks;
 
             public SetTcsContent(Stream stream, TaskCompletionSource<bool> tcs) : base(stream) => _tcs = tcs;
 
@@ -89,6 +89,7 @@ namespace System.Net.Http.Functional.Tests
             protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
                 _tcs.SetResult(true);
+                Ticks = Environment.TickCount64;
                 return base.SerializeToStreamAsync(stream, context);
             }
         }


### PR DESCRIPTION
From the name of the test, I assume we are trying to verify that provided `Expect100ContinueTimeout` is respected e.g. we wait longer than default 1s. 

Right now the test does it be measuring whole request/response and verifying duration within arbitrary time range. 
With delay of 3s and fudge of 20 we expect everything to finish within 1 minute. From test failures are are sometimes over that - with max duration ~ 1:30 -1:40.

This PR is changing the test logic. Instead of measuring the whole duration, I measure delay between start and sending content e.g. call to SerializeToStreamAsync(). It should be at least expected delay - and could be more depending on system load and other environmental conditions. With default 1s, that should be sufficient verification that the delay actually works. 

I originally used Stopwatch and I saw occasion failures when elapsed time would be slightly shorter e.g. 2995-2999.
I solved by using Environment.TickCount64 instead as it seems to use semi coarse base as Timer class. 

fixes #41530
fixes #41953
