### PR TITLE
Add NativeMainSource alternative to Android Sample App

### DIFF
--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -66,7 +66,8 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.BuildApiLevel = BuildApiLevel;
         apkBuilder.BuildToolsVersion = BuildToolsVersion;
         apkBuilder.StripDebugSymbols = StripDebugSymbols;
-        (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, abi, MainLibraryFileName, MonoRuntimeHeaders, NativeMainSource);
+        apkBuilder.NativeMainSource = NativeMainSource;
+        (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, abi, MainLibraryFileName, MonoRuntimeHeaders);
 
         return true;
     }

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -39,6 +39,12 @@ public class AndroidAppBuilderTask : Task
 
     public bool StripDebugSymbols { get; set; }
 
+    /// <summary>
+    /// Path to a custom MainActivity.java with custom UI
+    /// A default one is used if it's not set
+    /// </summary>
+    public string? NativeMainSource { get; set; }
+
     [Output]
     public string ApkBundlePath { get; set; } = ""!;
 
@@ -60,7 +66,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.BuildApiLevel = BuildApiLevel;
         apkBuilder.BuildToolsVersion = BuildToolsVersion;
         apkBuilder.StripDebugSymbols = StripDebugSymbols;
-        (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, abi, MainLibraryFileName, MonoRuntimeHeaders);
+        (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, abi, MainLibraryFileName, MonoRuntimeHeaders, NativeMainSource);
 
         return true;
     }

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -20,7 +20,11 @@ public class ApkBuilder
     public bool StripDebugSymbols { get; set; }
 
     public (string apk, string packageId) BuildApk(
-        string sourceDir, string abi, string entryPointLib, string monoRuntimeHeaders)
+        string sourceDir,
+        string abi,
+        string entryPointLib,
+        string monoRuntimeHeaders,
+        string? nativeMainSource = null)
     {
         if (!Directory.Exists(sourceDir))
             throw new ArgumentException($"sourceDir='{sourceDir}' is empty or doesn't exist");
@@ -177,15 +181,20 @@ public class ApkBuilder
         string javaSrcFolder = Path.Combine(OutputDir, "src", "net", "dot");
         Directory.CreateDirectory(javaSrcFolder);
 
+        string javaActivityPath = Path.Combine(javaSrcFolder, "MainActivity.java");
+        string monoRunnerPath = Path.Combine(javaSrcFolder, "MonoRunner.java");
+
         string packageId = $"net.dot.{ProjectName}";
 
-        File.WriteAllText(Path.Combine(javaSrcFolder, "MainActivity.java"),
+        File.WriteAllText(javaActivityPath,
             Utils.GetEmbeddedResource("MainActivity.java")
                 .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib)));
+        if (!string.IsNullOrEmpty(nativeMainSource))
+            File.Copy(nativeMainSource, javaActivityPath, true);
 
         string monoRunner = Utils.GetEmbeddedResource("MonoRunner.java")
             .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib));
-        File.WriteAllText(Path.Combine(javaSrcFolder, "MonoRunner.java"), monoRunner);
+        File.WriteAllText(monoRunnerPath, monoRunner);
 
         File.WriteAllText(Path.Combine(OutputDir, "AndroidManifest.xml"),
             Utils.GetEmbeddedResource("AndroidManifest.xml")
@@ -193,8 +202,8 @@ public class ApkBuilder
                 .Replace("%MinSdkLevel%", MinApiLevel));
 
         string javaCompilerArgs = $"-d obj -classpath src -bootclasspath {androidJar} -source 1.8 -target 1.8 ";
-        Utils.RunProcess(javac, javaCompilerArgs + Path.Combine(javaSrcFolder, "MainActivity.java"), workingDir: OutputDir);
-        Utils.RunProcess(javac, javaCompilerArgs + Path.Combine(javaSrcFolder, "MonoRunner.java"), workingDir: OutputDir);
+        Utils.RunProcess(javac, javaCompilerArgs + javaActivityPath, workingDir: OutputDir);
+        Utils.RunProcess(javac, javaCompilerArgs + monoRunnerPath, workingDir: OutputDir);
         Utils.RunProcess(dx, "--dex --output=classes.dex obj", workingDir: OutputDir);
 
         // 3. Generate APK

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -18,13 +18,13 @@ public class ApkBuilder
     public string? BuildToolsVersion { get; set; }
     public string? OutputDir { get; set; }
     public bool StripDebugSymbols { get; set; }
+    public string? NativeMainSource { get; set; }
 
     public (string apk, string packageId) BuildApk(
         string sourceDir,
         string abi,
         string entryPointLib,
-        string monoRuntimeHeaders,
-        string? nativeMainSource = null)
+        string monoRuntimeHeaders)
     {
         if (!Directory.Exists(sourceDir))
             throw new ArgumentException($"sourceDir='{sourceDir}' is empty or doesn't exist");
@@ -189,8 +189,8 @@ public class ApkBuilder
         File.WriteAllText(javaActivityPath,
             Utils.GetEmbeddedResource("MainActivity.java")
                 .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib)));
-        if (!string.IsNullOrEmpty(nativeMainSource))
-            File.Copy(nativeMainSource, javaActivityPath, true);
+        if (!string.IsNullOrEmpty(NativeMainSource))
+            File.Copy(NativeMainSource, javaActivityPath, true);
 
         string monoRunner = Utils.GetEmbeddedResource("MonoRunner.java")
             .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib));

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -173,9 +173,7 @@ public class AppleAppBuilderTask : Task
                 }
                 else
                 {
-                    AppBundlePath = Xcode.BuildAppBundle(
-                        Path.Combine(binDir, ProjectName, ProjectName + ".xcodeproj"),
-                        Arch, Optimized, DevTeamProvisioning);
+                    AppBundlePath = Xcode.BuildAppBundle(XcodeProjectPath, Arch, Optimized, DevTeamProvisioning);
                 }
             }
         }


### PR DESCRIPTION
In the effort to port over the sample that builds an Android Application based on the Mono Runtime (https://github.com/dotnet/samples/pull/3944) to `dotnet/samples`, this PR allows users to utilize their own Activity file to modify the Android Application's UI. By doing so, the user gains the freedom to easily alter the sample and better understand how the mono runtime allows the managed and unmanaged side to call each other when they see their own changes reflected in the application.