### PR TITLE
Add alternative to reuse signing key in Android Sample App

### DIFF
--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -45,6 +45,8 @@ public class AndroidAppBuilderTask : Task
     /// </summary>
     public string? NativeMainSource { get; set; }
 
+    public string? KeyStorePath { get; set; }
+
     [Output]
     public string ApkBundlePath { get; set; } = ""!;
 
@@ -67,6 +69,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.BuildToolsVersion = BuildToolsVersion;
         apkBuilder.StripDebugSymbols = StripDebugSymbols;
         apkBuilder.NativeMainSource = NativeMainSource;
+        apkBuilder.KeyStorePath = KeyStorePath;
         (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, abi, MainLibraryFileName, MonoRuntimeHeaders);
 
         return true;

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -19,6 +19,7 @@ public class ApkBuilder
     public string? OutputDir { get; set; }
     public bool StripDebugSymbols { get; set; }
     public string? NativeMainSource { get; set; }
+    public string? KeyStorePath { get; set; }
 
     public (string apk, string packageId) BuildApk(
         string sourceDir,
@@ -244,11 +245,17 @@ public class ApkBuilder
         // 5. Generate key
 
         string signingKey = Path.Combine(OutputDir, "debug.keystore");
+        if (!string.IsNullOrEmpty(KeyStorePath))
+            signingKey = Path.Combine(KeyStorePath, "debug.keystore");
         if (!File.Exists(signingKey))
         {
             Utils.RunProcess(keytool, "-genkey -v -keystore debug.keystore -storepass android -alias " +
                 "androiddebugkey -keypass android -keyalg RSA -keysize 2048 -noprompt " +
                 "-dname \"CN=Android Debug,O=Android,C=US\"", workingDir: OutputDir, silent: true);
+        }
+        else
+        {
+            File.Copy(signingKey, Path.Combine(OutputDir, "debug.keystore"));
         }
 
         // 6. Sign APK


### PR DESCRIPTION
In the effort to port over the sample that builds an Android Application based on the Mono Runtime (https://github.com/dotnet/samples/pull/3944) to `dotnet/samples`, this PR allows users to reuse a key that signs the Android app. By doing so, the user will not be prompted to accept app permissions every time that the application is installed and ran.

The main workflow for the sample generates a new signing key every time. If an instance of the app is already installed, the signatures will not match, requiring the first instance to be uninstalled before installing the new instance. With every fresh installation of the application, the user is prompted with a dialogue to accept app permissions.
By reusing the signing key, the user will only have to accept permissions once until the app is uninstalled.

This PR is intended to be rebased and merged after https://github.com/dotnet/runtime/pull/44076 to resolve conflicts