### PR TITLE
Fix asserts that were always true due to a missed neg.

### DIFF
--- a/src/coreclr/src/gc/gchandletable.cpp
+++ b/src/coreclr/src/gc/gchandletable.cpp
@@ -99,7 +99,7 @@ IGCHandleStore* GCHandleManager::CreateHandleStore()
 
     return store;
 #else
-    assert("CreateHandleStore is not implemented when FEATURE_REDHAWK is defined!");
+    assert(!"CreateHandleStore is not implemented when FEATURE_REDHAWK is defined!");
     return nullptr;
 #endif
 }

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -5464,6 +5464,26 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                             break;
                         }
 
+                        case NI_SSE2_ShiftLeftLogical128BitLane:
+                        case NI_SSE2_ShiftRightLogical128BitLane:
+                        case NI_AVX2_ShiftLeftLogical128BitLane:
+                        case NI_AVX2_ShiftRightLogical128BitLane:
+                        {
+#if DEBUG
+                            // These intrinsics should have been marked contained by the general-purpose handling earlier in the method.
+
+                            GenTree* lastOp = HWIntrinsicInfo::lookupLastOp(node);
+                            assert(lastOp != nullptr);
+
+                            if (HWIntrinsicInfo::isImmOp(intrinsicId, lastOp) && lastOp->IsCnsIntOrI())
+                            {
+                                assert(lastOp->isContained());
+                            }
+#endif
+
+                            break;
+                        }
+
                         default:
                         {
                             assert(!"Unhandled containment for binary hardware intrinsic with immediate operand");

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -5466,7 +5466,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
 
                         default:
                         {
-                            assert("Unhandled containment for binary hardware intrinsic with immediate operand");
+                            assert(!"Unhandled containment for binary hardware intrinsic with immediate operand");
                             break;
                         }
                     }
@@ -5643,7 +5643,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
 
                         default:
                         {
-                            assert("Unhandled containment for ternary hardware intrinsic with immediate operand");
+                            assert(!"Unhandled containment for ternary hardware intrinsic with immediate operand");
                             break;
                         }
                     }


### PR DESCRIPTION
It took me a while to understand how in https://github.com/dotnet/runtime/pull/43397#discussion_r504809585 we did not fail on `assert("Unhandled containment for ternary hardware intrinsic with immediate operand");` 

cc @janvorli 