### PR TITLE
Omit ErrorInformation from ManagementException binary serialization

### DIFF
--- a/src/libraries/System.Management/src/System/Management/ManagementException.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementException.cs
@@ -674,7 +674,6 @@ namespace System.Management
         protected ManagementException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             errorCode = (ManagementStatus)info.GetValue("errorCode", typeof(ManagementStatus));
-            errorObject = info.GetValue("errorObject", typeof(ManagementBaseObject)) as ManagementBaseObject;
         }
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.Management.ManagementException'/> class</para>
@@ -721,7 +720,6 @@ namespace System.Management
         {
             base.GetObjectData(info, context);
             info.AddValue("errorCode", errorCode);
-            info.AddValue("errorObject", errorObject);
         }
 
         private static string GetMessage(Exception e)

--- a/src/libraries/System.Management/src/System/Management/ManagementException.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementException.cs
@@ -720,6 +720,9 @@ namespace System.Management
         {
             base.GetObjectData(info, context);
             info.AddValue("errorCode", errorCode);
+
+            // For .NET Framework compat we need to set `errorObject` as null
+            info.AddValue("errorObject", null);
         }
 
         private static string GetMessage(Exception e)

--- a/src/libraries/System.Management/tests/System/Management/ManagementObjectTests.cs
+++ b/src/libraries/System.Management/tests/System/Management/ManagementObjectTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using Xunit;
 
 namespace System.Management.Tests
@@ -83,6 +85,36 @@ namespace System.Management.Tests
                 Assert.Equal(0u, resultCode);
 
                 Assert.True(targetProcess.HasExited);
+            }
+        }
+
+        [ConditionalFact(typeof(WmiTestHelper), nameof(WmiTestHelper.IsWmiSupported))]
+        [OuterLoop]
+        public void Serialize_ManagementException()
+        {
+            try
+            {
+                new ManagementObject("Win32_LogicalDisk.DeviceID=\"InvalidDeviceId\"").Get();
+            }
+            catch (ManagementException e)
+            {
+                using var ms = new MemoryStream();
+                var formatter = new BinaryFormatter();
+                formatter.Serialize(ms, e);
+                ms.Position = 0;
+
+                var exception = (ManagementException)formatter.Deserialize(ms);
+
+                Assert.Equal(e.ErrorCode, exception.ErrorCode);
+
+                // On .NET Framework the `ErrorInformation` underlying field is serialized
+                if (PlatformDetection.IsNetFramework)
+                {
+                    Assert.Equal(e.ErrorInformation, exception.ErrorInformation);
+                    return;
+                }
+
+                Assert.Null(exception.ErrorInformation);
             }
         }
     }


### PR DESCRIPTION
Fixes #2116

Using the `NonSerialized` attribute wouldn't make sense since the `ManagementException` class is overriding the `GetObjectData` method.