### PR TITLE
Delete duplicate Buffer.Memmove implementations and avoid unnecessary pinning

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Text;
+using Internal.Runtime.CompilerServices;
 
 namespace System
 {
@@ -80,15 +81,12 @@ namespace System
         }
 
         // Copies the source String (byte buffer) to the destination IntPtr memory allocated with len bytes.
+        // Used by ilmarshalers.cpp
         internal static unsafe void InternalCopy(string src, IntPtr dest, int len)
         {
-            if (len == 0)
-                return;
-            fixed (char* charPtr = &src._firstChar)
+            if (len != 0)
             {
-                byte* srcPtr = (byte*)charPtr;
-                byte* dstPtr = (byte*)dest;
-                Buffer.Memcpy(dstPtr, srcPtr, len);
+                Buffer.Memmove(ref *(byte*)dest, ref Unsafe.As<char, byte>(ref src.GetRawStringData()), (nuint)len);
             }
         }
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -104,10 +104,7 @@ namespace System.StubHelpers
                     // + 1 for the null character from the user.  + 1 for the null character we put in.
                     pbNativeBuffer = (byte*)Marshal.AllocCoTaskMem(nb + 2);
 
-                    fixed (byte* pBytes = &bytes[0])
-                    {
-                        Buffer.Memcpy(pbNativeBuffer, pBytes, nb);
-                    }
+                    Buffer.Memmove(ref *pbNativeBuffer, ref MemoryMarshal.GetArrayDataReference(bytes), (nuint)nb);
                 }
             }
 
@@ -339,13 +336,7 @@ namespace System.StubHelpers
                 }
 
                 // copy characters from the managed string
-                fixed (char* ch = strManaged)
-                {
-                    Buffer.Memcpy(
-                        ptrToFirstChar,
-                        (byte*)ch,
-                        (strManaged.Length + 1) * 2);
-                }
+                Buffer.Memmove(ref *(char*)ptrToFirstChar, ref strManaged.GetRawStringData(), (nuint)strManaged.Length + 1);
 
                 // copy the trail byte if present
                 if (hasTrailByte)
@@ -438,11 +429,9 @@ namespace System.StubHelpers
             {
                 byte[] bytes = AnsiCharMarshaler.DoAnsiConversion(strManaged, fBestFit, fThrowOnUnmappableChar, out int nbytesused);
 
-                Debug.Assert(nbytesused < nbytes, "Insufficient buffer allocated in VBByValStrMarshaler.ConvertToNative");
-                fixed (byte* pBytes = &bytes[0])
-                {
-                    Buffer.Memcpy(pNative, pBytes, nbytesused);
-                }
+                Debug.Assert(nbytesused >= 0 && nbytesused < nbytes, "Insufficient buffer allocated in VBByValStrMarshaler.ConvertToNative");
+
+                Buffer.Memmove(ref *pNative, ref MemoryMarshal.GetArrayDataReference(bytes), (nuint)nbytesused);
 
                 pNative[nbytesused] = 0;
                 *pLength = nbytesused;
@@ -489,10 +478,11 @@ namespace System.StubHelpers
 
             uint length = (uint)nb;
             IntPtr bstr = Marshal.AllocBSTRByteLen(length);
-            fixed (byte* firstByte = bytes)
+            if (bytes != null)
             {
-                Buffer.Memmove((byte*)bstr, firstByte, length);
+                Buffer.Memmove(ref *(byte*)bstr, ref MemoryMarshal.GetArrayDataReference(bytes), length);
             }
+
             return bstr;
         }
 
@@ -845,11 +835,12 @@ namespace System.StubHelpers
             else
             {
                 // marshal the object as Unicode string (UnmanagedType.LPWStr)
-
                 int allocSize = (pManagedHome.Length + 1) * 2;
                 pNativeHome = Marshal.AllocCoTaskMem(allocSize);
-
-                string.InternalCopy(pManagedHome, pNativeHome, allocSize);
+                unsafe
+                {
+                    Buffer.Memmove(ref *(char*)pNativeHome, ref pManagedHome.GetRawStringData(), (nuint)pManagedHome.Length + 1);
+                }
             }
 
             return pNativeHome;
@@ -872,14 +863,23 @@ namespace System.StubHelpers
             // |                                    | |
             // +====================================+ / <-- native home
 
+            // Cache StringBuilder capacity and length to ensure we don't allocate a certain amount of
+            // native memory and then walk beyond its end if the StringBuilder concurrently grows erroneously.
+            int pManagedHomeCapacity = pManagedHome.Capacity;
+            int pManagedHomeLength = pManagedHome.Length;
+            if (pManagedHomeLength > pManagedHomeCapacity)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+
             // Note that StringBuilder.Capacity is the number of characters NOT including any terminators.
 
             if (IsAnsi(dwFlags))
             {
-                StubHelpers.CheckStringLength(pManagedHome.Capacity);
+                StubHelpers.CheckStringLength(pManagedHomeCapacity);
 
                 // marshal the object as Ansi string (UnmanagedType.LPStr)
-                int allocSize = checked((pManagedHome.Capacity * Marshal.SystemMaxDBCSCharSize) + 4);
+                int allocSize = checked((pManagedHomeCapacity * Marshal.SystemMaxDBCSCharSize) + 4);
                 pNativeHome = Marshal.AllocCoTaskMem(allocSize);
 
                 byte* ptr = (byte*)pNativeHome;
@@ -903,7 +903,7 @@ namespace System.StubHelpers
             else
             {
                 // marshal the object as Unicode string (UnmanagedType.LPWStr)
-                int allocSize = checked((pManagedHome.Capacity * 2) + 4);
+                int allocSize = checked((pManagedHomeCapacity * 2) + 4);
                 pNativeHome = Marshal.AllocCoTaskMem(allocSize);
 
                 byte* ptr = (byte*)pNativeHome;
@@ -912,10 +912,10 @@ namespace System.StubHelpers
 
                 if (IsIn(dwFlags))
                 {
-                    int length = pManagedHome.Length * 2;
-                    pManagedHome.InternalCopy(pNativeHome, length);
+                    pManagedHome.InternalCopy(pNativeHome, pManagedHomeLength);
 
                     // null-terminate the native string
+                    int length = pManagedHomeLength * 2;
                     *(ptr + length + 0) = 0;
                     *(ptr + length + 1) = 0;
                 }

--- a/src/coreclr/src/vm/ilmarshalers.cpp
+++ b/src/coreclr/src/vm/ilmarshalers.cpp
@@ -756,7 +756,7 @@ void ILWSTRBufferMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEm
 {
     STANDARD_VM_CONTRACT;
 
-    DWORD dwTempNumBytesLocal = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
+    DWORD dwTempNumCharsLocal = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
 
     ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
 
@@ -778,19 +778,14 @@ void ILWSTRBufferMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEm
 
     // stack: StringBuilder length
 
-    pslILEmit->EmitDUP();
-    pslILEmit->EmitADD();
-
-    // stack: StringBuilder cb
-
-    pslILEmit->EmitSTLOC(dwTempNumBytesLocal);
+    pslILEmit->EmitSTLOC(dwTempNumCharsLocal);
 
     // stack: StringBuilder
 
     EmitLoadNativeValue(pslILEmit);
-    pslILEmit->EmitLDLOC(dwTempNumBytesLocal);
+    pslILEmit->EmitLDLOC(dwTempNumCharsLocal);
 
-    // stack: stringbuilder native_buffer cb
+    // stack: StringBuilder native_buffer length
 
     // void System.Text.StringBuilder.InternalCopy(IntPtr dest,int len)
     pslILEmit->EmitCALL(METHOD__STRING_BUILDER__INTERNAL_COPY, 3, 0);
@@ -799,8 +794,10 @@ void ILWSTRBufferMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEm
     // null-terminate the native string
     //
     EmitLoadNativeValue(pslILEmit);
-    pslILEmit->EmitLDLOC(dwTempNumBytesLocal);
-    pslILEmit->EmitADD();
+    pslILEmit->EmitLDLOC(dwTempNumCharsLocal);
+    pslILEmit->EmitDUP();
+    pslILEmit->EmitADD(); // dwTempNumCharsLocal + dwTempNumCharsLocal
+    pslILEmit->EmitADD(); // + native_buffer
     pslILEmit->EmitLDC(0);
     pslILEmit->EmitSTIND_I2();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -90,7 +90,9 @@ namespace System
         {
             // array argument validation done via ByteLength
             if ((uint)index >= (uint)ByteLength(array))
-                throw new ArgumentOutOfRangeException(nameof(index));
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
+            }
 
             return Unsafe.Add<byte>(ref array.GetRawArrayData(), index);
         }
@@ -99,7 +101,9 @@ namespace System
         {
             // array argument validation done via ByteLength
             if ((uint)index >= (uint)ByteLength(array))
-                throw new ArgumentOutOfRangeException(nameof(index));
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
+            }
 
             Unsafe.Add<byte>(ref array.GetRawArrayData(), index) = value;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -104,7 +104,6 @@ namespace System
             Unsafe.Add<byte>(ref array.GetRawArrayData(), index) = value;
         }
 
-        // This method has different signature for x64 and other platforms and is done for performance reasons.
         internal static unsafe void ZeroMemory(byte* dest, nuint len)
         {
             SpanHelpers.ClearWithoutReferences(ref *dest, len);
@@ -120,7 +119,8 @@ namespace System
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.sourceBytesToCopy);
             }
-            Memmove((byte*)destination, (byte*)source, checked((nuint)sourceBytesToCopy));
+
+            Memmove(ref *(byte*)destination, ref *(byte*)source, checked((nuint)sourceBytesToCopy));
         }
 
         // The attributes on this method are chosen for best JIT performance.
@@ -133,179 +133,11 @@ namespace System
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.sourceBytesToCopy);
             }
-            Memmove((byte*)destination, (byte*)source, checked((nuint)sourceBytesToCopy));
+
+            Memmove(ref *(byte*)destination, ref *(byte*)source, checked((nuint)sourceBytesToCopy));
         }
 
-        // This method has different signature for x64 and other platforms and is done for performance reasons.
-        internal static unsafe void Memmove(byte* dest, byte* src, nuint len)
-        {
-            // P/Invoke into the native version when the buffers are overlapping.
-            if (((nuint)dest - (nuint)src < len) || ((nuint)src - (nuint)dest < len))
-            {
-                goto PInvoke;
-            }
-
-            byte* srcEnd = src + len;
-            byte* destEnd = dest + len;
-
-            if (len <= 16) goto MCPY02;
-            if (len > 64) goto MCPY05;
-
-        MCPY00:
-            // Copy bytes which are multiples of 16 and leave the remainder for MCPY01 to handle.
-            Debug.Assert(len > 16 && len <= 64);
-#if HAS_CUSTOM_BLOCKS
-            *(Block16*)dest = *(Block16*)src;                   // [0,16]
-#elif TARGET_64BIT
-            *(long*)dest = *(long*)src;
-            *(long*)(dest + 8) = *(long*)(src + 8);             // [0,16]
-#else
-            *(int*)dest = *(int*)src;
-            *(int*)(dest + 4) = *(int*)(src + 4);
-            *(int*)(dest + 8) = *(int*)(src + 8);
-            *(int*)(dest + 12) = *(int*)(src + 12);             // [0,16]
-#endif
-            if (len <= 32) goto MCPY01;
-#if HAS_CUSTOM_BLOCKS
-            *(Block16*)(dest + 16) = *(Block16*)(src + 16);     // [0,32]
-#elif TARGET_64BIT
-            *(long*)(dest + 16) = *(long*)(src + 16);
-            *(long*)(dest + 24) = *(long*)(src + 24);           // [0,32]
-#else
-            *(int*)(dest + 16) = *(int*)(src + 16);
-            *(int*)(dest + 20) = *(int*)(src + 20);
-            *(int*)(dest + 24) = *(int*)(src + 24);
-            *(int*)(dest + 28) = *(int*)(src + 28);             // [0,32]
-#endif
-            if (len <= 48) goto MCPY01;
-#if HAS_CUSTOM_BLOCKS
-            *(Block16*)(dest + 32) = *(Block16*)(src + 32);     // [0,48]
-#elif TARGET_64BIT
-            *(long*)(dest + 32) = *(long*)(src + 32);
-            *(long*)(dest + 40) = *(long*)(src + 40);           // [0,48]
-#else
-            *(int*)(dest + 32) = *(int*)(src + 32);
-            *(int*)(dest + 36) = *(int*)(src + 36);
-            *(int*)(dest + 40) = *(int*)(src + 40);
-            *(int*)(dest + 44) = *(int*)(src + 44);             // [0,48]
-#endif
-
-        MCPY01:
-            // Unconditionally copy the last 16 bytes using destEnd and srcEnd and return.
-            Debug.Assert(len > 16 && len <= 64);
-#if HAS_CUSTOM_BLOCKS
-            *(Block16*)(destEnd - 16) = *(Block16*)(srcEnd - 16);
-#elif TARGET_64BIT
-            *(long*)(destEnd - 16) = *(long*)(srcEnd - 16);
-            *(long*)(destEnd - 8) = *(long*)(srcEnd - 8);
-#else
-            *(int*)(destEnd - 16) = *(int*)(srcEnd - 16);
-            *(int*)(destEnd - 12) = *(int*)(srcEnd - 12);
-            *(int*)(destEnd - 8) = *(int*)(srcEnd - 8);
-            *(int*)(destEnd - 4) = *(int*)(srcEnd - 4);
-#endif
-            return;
-
-        MCPY02:
-            // Copy the first 8 bytes and then unconditionally copy the last 8 bytes and return.
-            if ((len & 24) == 0) goto MCPY03;
-            Debug.Assert(len >= 8 && len <= 16);
-#if TARGET_64BIT
-            *(long*)dest = *(long*)src;
-            *(long*)(destEnd - 8) = *(long*)(srcEnd - 8);
-#else
-            *(int*)dest = *(int*)src;
-            *(int*)(dest + 4) = *(int*)(src + 4);
-            *(int*)(destEnd - 8) = *(int*)(srcEnd - 8);
-            *(int*)(destEnd - 4) = *(int*)(srcEnd - 4);
-#endif
-            return;
-
-        MCPY03:
-            // Copy the first 4 bytes and then unconditionally copy the last 4 bytes and return.
-            if ((len & 4) == 0) goto MCPY04;
-            Debug.Assert(len >= 4 && len < 8);
-            *(int*)dest = *(int*)src;
-            *(int*)(destEnd - 4) = *(int*)(srcEnd - 4);
-            return;
-
-            MCPY04:
-            // Copy the first byte. For pending bytes, do an unconditionally copy of the last 2 bytes and return.
-            Debug.Assert(len < 4);
-            if (len == 0) return;
-            *dest = *src;
-            if ((len & 2) == 0) return;
-            *(short*)(destEnd - 2) = *(short*)(srcEnd - 2);
-            return;
-
-            MCPY05:
-            // PInvoke to the native version when the copy length exceeds the threshold.
-            if (len > MemmoveNativeThreshold)
-            {
-                goto PInvoke;
-            }
-
-            // Copy 64-bytes at a time until the remainder is less than 64.
-            // If remainder is greater than 16 bytes, then jump to MCPY00. Otherwise, unconditionally copy the last 16 bytes and return.
-            Debug.Assert(len > 64 && len <= MemmoveNativeThreshold);
-            nuint n = len >> 6;
-
-        MCPY06:
-#if HAS_CUSTOM_BLOCKS
-            *(Block64*)dest = *(Block64*)src;
-#elif TARGET_64BIT
-            *(long*)dest = *(long*)src;
-            *(long*)(dest + 8) = *(long*)(src + 8);
-            *(long*)(dest + 16) = *(long*)(src + 16);
-            *(long*)(dest + 24) = *(long*)(src + 24);
-            *(long*)(dest + 32) = *(long*)(src + 32);
-            *(long*)(dest + 40) = *(long*)(src + 40);
-            *(long*)(dest + 48) = *(long*)(src + 48);
-            *(long*)(dest + 56) = *(long*)(src + 56);
-#else
-            *(int*)dest = *(int*)src;
-            *(int*)(dest + 4) = *(int*)(src + 4);
-            *(int*)(dest + 8) = *(int*)(src + 8);
-            *(int*)(dest + 12) = *(int*)(src + 12);
-            *(int*)(dest + 16) = *(int*)(src + 16);
-            *(int*)(dest + 20) = *(int*)(src + 20);
-            *(int*)(dest + 24) = *(int*)(src + 24);
-            *(int*)(dest + 28) = *(int*)(src + 28);
-            *(int*)(dest + 32) = *(int*)(src + 32);
-            *(int*)(dest + 36) = *(int*)(src + 36);
-            *(int*)(dest + 40) = *(int*)(src + 40);
-            *(int*)(dest + 44) = *(int*)(src + 44);
-            *(int*)(dest + 48) = *(int*)(src + 48);
-            *(int*)(dest + 52) = *(int*)(src + 52);
-            *(int*)(dest + 56) = *(int*)(src + 56);
-            *(int*)(dest + 60) = *(int*)(src + 60);
-#endif
-            dest += 64;
-            src += 64;
-            n--;
-            if (n != 0) goto MCPY06;
-
-            len %= 64;
-            if (len > 16) goto MCPY00;
-#if HAS_CUSTOM_BLOCKS
-            *(Block16*)(destEnd - 16) = *(Block16*)(srcEnd - 16);
-#elif TARGET_64BIT
-            *(long*)(destEnd - 16) = *(long*)(srcEnd - 16);
-            *(long*)(destEnd - 8) = *(long*)(srcEnd - 8);
-#else
-            *(int*)(destEnd - 16) = *(int*)(srcEnd - 16);
-            *(int*)(destEnd - 12) = *(int*)(srcEnd - 12);
-            *(int*)(destEnd - 8) = *(int*)(srcEnd - 8);
-            *(int*)(destEnd - 4) = *(int*)(srcEnd - 4);
-#endif
-            return;
-
-        PInvoke:
-            _Memmove(dest, src, len);
-        }
-
-        // This method has different signature for x64 and other platforms and is done for performance reasons.
-        private static void Memmove(ref byte dest, ref byte src, nuint len)
+        internal static void Memmove(ref byte dest, ref byte src, nuint len)
         {
             // P/Invoke into the native version when the buffers are overlapping.
             if (((nuint)(nint)Unsafe.ByteOffset(ref src, ref dest) < len) || ((nuint)(nint)Unsafe.ByteOffset(ref dest, ref src) < len))
@@ -489,14 +321,6 @@ namespace System
 
         PInvoke:
             _Memmove(ref dest, ref src, len);
-        }
-
-        // Non-inlinable wrapper around the QCall that avoids polluting the fast path
-        // with P/Invoke prolog/epilog.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static unsafe void _Memmove(byte* dest, byte* src, nuint len)
-        {
-            __Memmove(dest, src, len);
         }
 
         // Non-inlinable wrapper around the QCall that avoids polluting the fast path

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -170,7 +170,7 @@ namespace System
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             if (s.Length != 1)
@@ -334,7 +334,10 @@ namespace System
         public static char ToUpper(char c, CultureInfo culture)
         {
             if (culture == null)
-                throw new ArgumentNullException(nameof(culture));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
+            }
+
             return culture.TextInfo.ToUpper(c);
         }
 
@@ -361,7 +364,10 @@ namespace System
         public static char ToLower(char c, CultureInfo culture)
         {
             if (culture == null)
-                throw new ArgumentNullException(nameof(culture));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
+            }
+
             return culture.TextInfo.ToLower(c);
         }
 
@@ -473,10 +479,12 @@ namespace System
         public static bool IsControl(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
             // Control chars are always in the BMP, so don't need to worry about surrogate handling.
@@ -486,60 +494,76 @@ namespace System
         public static bool IsDigit(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
                 return IsInRange(c, '0', '9');
             }
+
             return CharUnicodeInfo.GetUnicodeCategoryInternal(s, index) == UnicodeCategory.DecimalDigitNumber;
         }
 
         public static bool IsLetter(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsAscii(c))
             {
                 // The ASCII range doesn't include letters in categories other than "upper" and "lower"
                 return (Latin1CharInfo[c] & (IsUpperCaseLetterFlag | IsLowerCaseLetterFlag)) != 0;
             }
+
             return CheckLetter(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         public static bool IsLetterOrDigit(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
                 return CheckLetterOrDigit(GetLatin1UnicodeCategory(c));
             }
+
             return CheckLetterOrDigit(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         public static bool IsLower(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
+
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
@@ -574,11 +598,14 @@ namespace System
         public static bool IsNumber(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
@@ -586,8 +613,10 @@ namespace System
                 {
                     return IsInRange(c, '0', '9');
                 }
+
                 return CheckNumber(GetLatin1UnicodeCategory(c));
             }
+
             return CheckNumber(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
@@ -602,16 +631,20 @@ namespace System
         public static bool IsPunctuation(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
                 return CheckPunctuation(GetLatin1UnicodeCategory(c));
             }
+
             return CheckPunctuation(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
@@ -643,16 +676,20 @@ namespace System
         public static bool IsSeparator(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
                 return IsSeparatorLatin1(c);
             }
+
             return CheckSeparator(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
@@ -665,12 +702,13 @@ namespace System
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             return IsSurrogate(s[index]);
         }
 
@@ -695,27 +733,34 @@ namespace System
         public static bool IsSymbol(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
                 return CheckSymbol(GetLatin1UnicodeCategory(c));
             }
+
             return CheckSymbol(CharUnicodeInfo.GetUnicodeCategoryInternal(s, index));
         }
 
         public static bool IsUpper(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             char c = s[index];
             if (IsLatin1(c))
             {
@@ -728,10 +773,12 @@ namespace System
         public static bool IsWhiteSpace(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
             // All white space code points are within the BMP,
@@ -752,15 +799,19 @@ namespace System
         public static UnicodeCategory GetUnicodeCategory(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             if (IsLatin1(s[index]))
             {
                 return GetLatin1UnicodeCategory(s[index]);
             }
+
             return CharUnicodeInfo.GetUnicodeCategoryInternal(s, index);
         }
 
@@ -772,11 +823,14 @@ namespace System
         public static double GetNumericValue(string s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             return CharUnicodeInfo.GetNumericValueInternal(s, index);
         }
 
@@ -792,12 +846,13 @@ namespace System
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
-            if (index < 0 || index >= s.Length)
+            if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             return IsHighSurrogate(s[index]);
         }
 
@@ -813,12 +868,13 @@ namespace System
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
-            if (index < 0 || index >= s.Length)
+            if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             return IsLowSurrogate(s[index]);
         }
 
@@ -829,16 +885,18 @@ namespace System
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
-            if (index < 0 || index >= s.Length)
+            if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
+
             if (index + 1 < s.Length)
             {
                 return IsSurrogatePair(s[index], s[index + 1]);
             }
+
             return false;
         }
 
@@ -933,7 +991,7 @@ namespace System
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             if (index < 0 || index >= s.Length)

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2561,7 +2561,9 @@ namespace System
             // "s" is an unfortunate parameter name, but we need to keep it for backward compat.
 
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
 
             unsafe
             {
@@ -2576,7 +2578,7 @@ namespace System
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             return TryFromBase64Chars(s.AsSpan(), bytes, out bytesWritten);
@@ -2849,7 +2851,9 @@ namespace System
         public static byte[] FromHexString(string s)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
 
             return FromHexString(s.AsSpan());
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -15,7 +15,12 @@ namespace System.IO
 
         public StringReader(string s)
         {
-            _s = s ?? throw new ArgumentNullException(nameof(s));
+            if (s is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
+
+            _s = s;
             _length = s.Length;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
@@ -767,7 +767,7 @@ namespace System
 
                 // Zero out result internal blocks.
                 result._length = maxResultLength;
-                Buffer.ZeroMemory((byte*)result.GetBlocksPointer(), (uint)maxResultLength * sizeof(uint));
+                result.Clear((uint)maxResultLength);
 
                 int smallIndex = 0;
                 int resultStartIndex = 0;
@@ -813,7 +813,7 @@ namespace System
                 Debug.Assert(unchecked((uint)result._length) <= MaxBlockCount);
                 if (blocksToShift > 0)
                 {
-                    Buffer.ZeroMemory((byte*)result.GetBlocksPointer(), blocksToShift * sizeof(uint));
+                    result.Clear(blocksToShift);
                 }
                 result._blocks[blocksToShift] = 1U << (int)(remainingBitsToShift);
             }
@@ -1113,7 +1113,7 @@ namespace System
             {
                 int rhsLength = value._length;
                 result._length = rhsLength;
-                Buffer.Memcpy((byte*)result.GetBlocksPointer(), (byte*)value.GetBlocksPointer(), rhsLength * sizeof(uint));
+                Buffer.Memmove(ref result._blocks[0], ref value._blocks[0], (nuint)rhsLength);
             }
 
             public static void SetZero(out BigInteger result)
@@ -1152,7 +1152,7 @@ namespace System
                     _length += (int)(blocksToShift);
 
                     // Zero the remaining low blocks
-                    Buffer.ZeroMemory((byte*)GetBlocksPointer(), blocksToShift * sizeof(uint));
+                    Clear(blocksToShift);
                 }
                 else
                 {
@@ -1185,7 +1185,7 @@ namespace System
                     _blocks[writeIndex - 1] = block << (int)(remainingBitsToShift);
 
                     // Zero the remaining low blocks
-                    Buffer.ZeroMemory((byte*)GetBlocksPointer(), blocksToShift * sizeof(uint));
+                    Clear(blocksToShift);
 
                     // Check if the terminating block has no set bits
                     if (_blocks[_length - 1] == 0)
@@ -1220,11 +1220,10 @@ namespace System
                 return 0;
             }
 
-            private uint* GetBlocksPointer()
-            {
-                // This is safe to do since we are a ref struct
-                return (uint*)(Unsafe.AsPointer(ref _blocks[0]));
-            }
+            private void Clear(uint length) =>
+                Buffer.ZeroMemory(
+                    (byte*)Unsafe.AsPointer(ref _blocks[0]), // This is safe to do since we are a ref struct
+                    length * sizeof(uint));
 
             private static uint DivRem32(uint value, out uint remainder)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Unix.cs
@@ -150,6 +150,7 @@ namespace System.Runtime.InteropServices
 
             IntPtr s = p + sizeof(IntPtr);
             *(((uint*)s) - 1) = (uint)(length * sizeof(char));
+            ((char*)s)[length] = '\0';
 
             return s;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -677,10 +677,10 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentOutOfRangeException(nameof(s));
             }
 
-            IntPtr hglobal = AllocHGlobal((IntPtr)nb);
+            IntPtr ptr = AllocHGlobal((IntPtr)nb);
 
-            StringToAnsiString(s, (byte*)hglobal, nb);
-            return hglobal;
+            StringToAnsiString(s, (byte*)ptr, nb);
+            return ptr;
         }
 
         public static unsafe IntPtr StringToHGlobalUni(string? s)
@@ -695,16 +695,15 @@ namespace System.Runtime.InteropServices
             // Overflow checking
             if (nb < s.Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(s));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.s);
             }
 
-            IntPtr hglobal = AllocHGlobal((IntPtr)nb);
+            IntPtr ptr = AllocHGlobal((IntPtr)nb);
 
-            fixed (char* firstChar = s)
-            {
-                string.wstrcpy((char*)hglobal, firstChar, s.Length + 1);
-            }
-            return hglobal;
+            s.AsSpan().CopyTo(new Span<char>((char*)ptr, s.Length));
+            ((char*)ptr)[s.Length] = '\0';
+
+            return ptr;
         }
 
         private static unsafe IntPtr StringToHGlobalUTF8(string? s)
@@ -716,10 +715,10 @@ namespace System.Runtime.InteropServices
 
             int nb = Encoding.UTF8.GetMaxByteCount(s.Length);
 
-            IntPtr pMem = AllocHGlobal(nb + 1);
+            IntPtr ptr = AllocHGlobal(nb + 1);
 
             int nbWritten;
-            byte* pbMem = (byte*)pMem;
+            byte* pbMem = (byte*)ptr;
 
             fixed (char* firstChar = s)
             {
@@ -728,7 +727,7 @@ namespace System.Runtime.InteropServices
 
             pbMem[nbWritten] = 0;
 
-            return pMem;
+            return ptr;
         }
 
         public static unsafe IntPtr StringToCoTaskMemUni(string? s)
@@ -743,16 +742,15 @@ namespace System.Runtime.InteropServices
             // Overflow checking
             if (nb < s.Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(s));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.s);
             }
 
-            IntPtr hglobal = AllocCoTaskMem(nb);
+            IntPtr ptr = AllocCoTaskMem(nb);
 
-            fixed (char* firstChar = s)
-            {
-                string.wstrcpy((char*)hglobal, firstChar, s.Length + 1);
-            }
-            return hglobal;
+            s.AsSpan().CopyTo(new Span<char>((char*)ptr, s.Length));
+            ((char*)ptr)[s.Length] = '\0';
+
+            return ptr;
         }
 
         public static unsafe IntPtr StringToCoTaskMemUTF8(string? s)
@@ -764,10 +762,10 @@ namespace System.Runtime.InteropServices
 
             int nb = Encoding.UTF8.GetMaxByteCount(s.Length);
 
-            IntPtr pMem = AllocCoTaskMem(nb + 1);
+            IntPtr ptr = AllocCoTaskMem(nb + 1);
 
             int nbWritten;
-            byte* pbMem = (byte*)pMem;
+            byte* pbMem = (byte*)ptr;
 
             fixed (char* firstChar = s)
             {
@@ -776,7 +774,7 @@ namespace System.Runtime.InteropServices
 
             pbMem[nbWritten] = 0;
 
-            return pMem;
+            return ptr;
         }
 
         public static unsafe IntPtr StringToCoTaskMemAnsi(string? s)
@@ -795,10 +793,10 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentOutOfRangeException(nameof(s));
             }
 
-            IntPtr hglobal = AllocCoTaskMem(nb);
+            IntPtr ptr = AllocCoTaskMem(nb);
 
-            StringToAnsiString(s, (byte*)hglobal, nb);
-            return hglobal;
+            StringToAnsiString(s, (byte*)ptr, nb);
+            return ptr;
         }
 
         /// <summary>
@@ -976,10 +974,8 @@ namespace System.Runtime.InteropServices
 
             IntPtr bstr = AllocBSTR(s.Length);
 
-            fixed (char* firstChar = s)
-            {
-                string.wstrcpy((char*)bstr, firstChar, s.Length + 1);
-            }
+            s.AsSpan().CopyTo(new Span<char>((char*)bstr, s.Length)); // AllocBSTR already included the null terminator
+
             return bstr;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -615,7 +615,7 @@ namespace System.Runtime.InteropServices
         {
             if (s is null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             return s.MarshalToBSTR();
@@ -625,7 +625,7 @@ namespace System.Runtime.InteropServices
         {
             if (s is null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             return s.MarshalToString(globalAlloc: false, unicode: false);
@@ -635,7 +635,7 @@ namespace System.Runtime.InteropServices
         {
             if (s is null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             return s.MarshalToString(globalAlloc: false, unicode: true);
@@ -645,7 +645,7 @@ namespace System.Runtime.InteropServices
         {
             if (s is null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             return s.MarshalToString(globalAlloc: true, unicode: false);
@@ -655,7 +655,7 @@ namespace System.Runtime.InteropServices
         {
             if (s is null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
 
             return s.MarshalToString(globalAlloc: true, unicode: true);
@@ -674,7 +674,7 @@ namespace System.Runtime.InteropServices
             // Overflow checking
             if (nb != lnb)
             {
-                throw new ArgumentOutOfRangeException(nameof(s));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.s);
             }
 
             IntPtr ptr = AllocHGlobal((IntPtr)nb);
@@ -790,7 +790,7 @@ namespace System.Runtime.InteropServices
             // Overflow checking
             if (nb != lnb)
             {
-                throw new ArgumentOutOfRangeException(nameof(s));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.s);
             }
 
             IntPtr ptr = AllocCoTaskMem(nb);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -193,8 +193,7 @@ namespace System.Runtime.InteropServices
             {
                 DangerousAddRef(ref mustCallRelease);
 
-                fixed (byte* pStructure = &Unsafe.As<T, byte>(ref value))
-                    Buffer.Memmove(pStructure, ptr, sizeofT);
+                Buffer.Memmove(ref Unsafe.As<T, byte>(ref value), ref *ptr, sizeofT);
             }
             finally
             {
@@ -227,7 +226,6 @@ namespace System.Runtime.InteropServices
             if (_numBytes == Uninitialized)
                 throw NotInitialized();
 
-            uint sizeofT = SizeOf<T>();
             uint alignedSizeofT = AlignedSizeOf<T>();
             byte* ptr = (byte*)handle + byteOffset;
             SpaceCheck(ptr, checked((nuint)(alignedSizeofT * buffer.Length)));
@@ -237,11 +235,9 @@ namespace System.Runtime.InteropServices
             {
                 DangerousAddRef(ref mustCallRelease);
 
-                fixed (byte* pStructure = &Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(buffer)))
-                {
-                    for (int i = 0; i < buffer.Length; i++)
-                        Buffer.Memmove(pStructure + sizeofT * i, ptr + alignedSizeofT * i, sizeofT);
-                }
+                ref T structure = ref MemoryMarshal.GetReference(buffer);
+                for (int i = 0; i < buffer.Length; i++)
+                    Buffer.Memmove(ref Unsafe.Add(ref structure, i), ref Unsafe.AsRef<T>(ptr + alignedSizeofT * i), 1);
             }
             finally
             {
@@ -274,8 +270,7 @@ namespace System.Runtime.InteropServices
             {
                 DangerousAddRef(ref mustCallRelease);
 
-                fixed (byte* pStructure = &Unsafe.As<T, byte>(ref value))
-                    Buffer.Memmove(ptr, pStructure, sizeofT);
+                Buffer.Memmove(ref *ptr, ref Unsafe.As<T, byte>(ref value), sizeofT);
             }
             finally
             {
@@ -307,7 +302,6 @@ namespace System.Runtime.InteropServices
             if (_numBytes == Uninitialized)
                 throw NotInitialized();
 
-            uint sizeofT = SizeOf<T>();
             uint alignedSizeofT = AlignedSizeOf<T>();
             byte* ptr = (byte*)handle + byteOffset;
             SpaceCheck(ptr, checked((nuint)(alignedSizeofT * data.Length)));
@@ -317,11 +311,9 @@ namespace System.Runtime.InteropServices
             {
                 DangerousAddRef(ref mustCallRelease);
 
-                fixed (byte* pStructure = &Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(data)))
-                {
-                    for (int i = 0; i < data.Length; i++)
-                        Buffer.Memmove(ptr + alignedSizeofT * i, pStructure + sizeofT * i, sizeofT);
-                }
+                ref T structure = ref MemoryMarshal.GetReference(data);
+                for (int i = 0; i < data.Length; i++)
+                    Buffer.Memmove(ref Unsafe.AsRef<T>(ptr + alignedSizeofT * i), ref Unsafe.Add(ref structure, i), 1);
             }
             finally
             {

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -341,7 +341,7 @@ namespace System
             }
 
             string result = FastAllocateString(length);
-            Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
+            Span<char> resultSpan = new Span<char>(ref result._firstChar, result.Length);
 
             str0.CopyTo(resultSpan);
             str1.CopyTo(resultSpan.Slice(str0.Length));
@@ -358,7 +358,7 @@ namespace System
             }
 
             string result = FastAllocateString(length);
-            Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
+            Span<char> resultSpan = new Span<char>(ref result._firstChar, result.Length);
 
             str0.CopyTo(resultSpan);
             resultSpan = resultSpan.Slice(str0.Length);
@@ -380,7 +380,7 @@ namespace System
             }
 
             string result = FastAllocateString(length);
-            Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
+            Span<char> resultSpan = new Span<char>(ref result._firstChar, result.Length);
 
             str0.CopyTo(resultSpan);
             resultSpan = resultSpan.Slice(str0.Length);
@@ -533,7 +533,7 @@ namespace System
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-            if (startIndex < 0 || startIndex > this.Length)
+            if ((uint)startIndex > Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
 
             int oldLength = Length;
@@ -547,21 +547,11 @@ namespace System
             // In case this computation overflows, newLength will be negative and FastAllocateString throws OutOfMemoryException
             int newLength = oldLength + insertLength;
             string result = FastAllocateString(newLength);
-            unsafe
-            {
-                fixed (char* srcThis = &_firstChar)
-                {
-                    fixed (char* srcInsert = &value._firstChar)
-                    {
-                        fixed (char* dst = &result._firstChar)
-                        {
-                            wstrcpy(dst, srcThis, startIndex);
-                            wstrcpy(dst + startIndex, srcInsert, insertLength);
-                            wstrcpy(dst + startIndex + insertLength, srcThis + startIndex, oldLength - startIndex);
-                        }
-                    }
-                }
-            }
+
+            Buffer.Memmove(ref result._firstChar, ref _firstChar, (nuint)startIndex);
+            Buffer.Memmove(ref Unsafe.Add(ref result._firstChar, startIndex), ref value._firstChar, (nuint)insertLength);
+            Buffer.Memmove(ref Unsafe.Add(ref result._firstChar, startIndex + insertLength), ref Unsafe.Add(ref _firstChar, startIndex), (nuint)(oldLength - startIndex));
+
             return result;
         }
 
@@ -856,19 +846,12 @@ namespace System
             int count = totalWidth - oldLength;
             if (count <= 0)
                 return this;
+
             string result = FastAllocateString(totalWidth);
-            unsafe
-            {
-                fixed (char* dst = &result._firstChar)
-                {
-                    for (int i = 0; i < count; i++)
-                        dst[i] = paddingChar;
-                    fixed (char* src = &_firstChar)
-                    {
-                        wstrcpy(dst + count, src, oldLength);
-                    }
-                }
-            }
+
+            new Span<char>(ref result._firstChar, count).Fill(paddingChar);
+            Buffer.Memmove(ref Unsafe.Add(ref result._firstChar, count), ref _firstChar, (nuint)oldLength);
+
             return result;
         }
 
@@ -882,19 +865,12 @@ namespace System
             int count = totalWidth - oldLength;
             if (count <= 0)
                 return this;
+
             string result = FastAllocateString(totalWidth);
-            unsafe
-            {
-                fixed (char* dst = &result._firstChar)
-                {
-                    fixed (char* src = &_firstChar)
-                    {
-                        wstrcpy(dst, src, oldLength);
-                    }
-                    for (int i = 0; i < count; i++)
-                        dst[oldLength + i] = paddingChar;
-                }
-            }
+
+            Buffer.Memmove(ref result._firstChar, ref _firstChar, (nuint)oldLength);
+            new Span<char>(ref Unsafe.Add(ref result._firstChar, oldLength), count).Fill(paddingChar);
+
             return result;
         }
 
@@ -912,20 +888,13 @@ namespace System
                 return this;
             int newLength = oldLength - count;
             if (newLength == 0)
-                return string.Empty;
+                return Empty;
 
             string result = FastAllocateString(newLength);
-            unsafe
-            {
-                fixed (char* src = &_firstChar)
-                {
-                    fixed (char* dst = &result._firstChar)
-                    {
-                        wstrcpy(dst, src, startIndex);
-                        wstrcpy(dst + startIndex, src + startIndex + count, newLength - startIndex);
-                    }
-                }
-            }
+
+            Buffer.Memmove(ref result._firstChar, ref _firstChar, (nuint)startIndex);
+            Buffer.Memmove(ref Unsafe.Add(ref result._firstChar, startIndex), ref Unsafe.Add(ref _firstChar, startIndex + count), (nuint)(newLength - startIndex));
+
             return result;
         }
 
@@ -1181,7 +1150,7 @@ namespace System
                 throw new OutOfMemoryException();
             string dst = FastAllocateString((int)dstLength);
 
-            Span<char> dstSpan = new Span<char>(ref dst.GetRawStringData(), dst.Length);
+            Span<char> dstSpan = new Span<char>(ref dst._firstChar, dst.Length);
 
             int thisIdx = 0;
             int dstIdx = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -563,12 +563,6 @@ namespace System
             return result;
         }
 
-        internal static unsafe void wstrcpy(char* dmem, char* smem, int charCount)
-        {
-            Buffer.Memmove((byte*)dmem, (byte*)smem, ((uint)charCount) * 2);
-        }
-
-
         // Returns this string.
         public override string ToString()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -553,7 +553,9 @@ namespace System.Text
         public virtual int GetByteCount(string s)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
 
             char[] chars = s.ToCharArray();
             return GetByteCount(chars, 0, chars.Length);
@@ -708,10 +710,13 @@ namespace System.Text
         }
 
         public virtual int GetBytes(string s, int charIndex, int charCount,
-                                       byte[] bytes, int byteIndex)
+                                    byte[] bytes, int byteIndex)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
+
             return GetBytes(s.ToCharArray(), charIndex, charCount, bytes, byteIndex);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.Collections.Generic;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Text
 {
@@ -146,13 +147,7 @@ namespace System.Text
             m_ChunkChars = GC.AllocateUninitializedArray<char>(capacity);
             m_ChunkLength = length;
 
-            unsafe
-            {
-                fixed (char* sourcePtr = value)
-                {
-                    ThreadSafeCopy(sourcePtr + startIndex, m_ChunkChars, 0, length);
-                }
-            }
+            value.AsSpan(startIndex, length).CopyTo(m_ChunkChars);
         }
 
         /// <summary>
@@ -357,37 +352,31 @@ namespace System.Text
 
             string result = string.FastAllocateString(Length);
             StringBuilder? chunk = this;
-            unsafe
+            do
             {
-                fixed (char* destinationPtr = result)
+                if (chunk.m_ChunkLength > 0)
                 {
-                    do
+                    // Copy these into local variables so that they are stable even in the presence of race conditions
+                    char[] sourceArray = chunk.m_ChunkChars;
+                    int chunkOffset = chunk.m_ChunkOffset;
+                    int chunkLength = chunk.m_ChunkLength;
+
+                    // Check that we will not overrun our boundaries.
+                    if ((uint)(chunkLength + chunkOffset) > (uint)result.Length || (uint)chunkLength > (uint)sourceArray.Length)
                     {
-                        if (chunk.m_ChunkLength > 0)
-                        {
-                            // Copy these into local variables so that they are stable even in the presence of race conditions
-                            char[] sourceArray = chunk.m_ChunkChars;
-                            int chunkOffset = chunk.m_ChunkOffset;
-                            int chunkLength = chunk.m_ChunkLength;
-
-                            // Check that we will not overrun our boundaries.
-                            if ((uint)(chunkLength + chunkOffset) <= (uint)result.Length && (uint)chunkLength <= (uint)sourceArray.Length)
-                            {
-                                fixed (char* sourcePtr = &sourceArray[0])
-                                    string.wstrcpy(destinationPtr + chunkOffset, sourcePtr, chunkLength);
-                            }
-                            else
-                            {
-                                throw new ArgumentOutOfRangeException(nameof(chunkLength), SR.ArgumentOutOfRange_Index);
-                            }
-                        }
-                        chunk = chunk.m_ChunkPrevious;
+                        throw new ArgumentOutOfRangeException(nameof(chunkLength), SR.ArgumentOutOfRange_Index);
                     }
-                    while (chunk != null);
 
-                    return result;
+                    Buffer.Memmove(
+                        ref Unsafe.Add(ref result.GetRawStringData(), chunkOffset),
+                        ref MemoryMarshal.GetArrayDataReference(sourceArray),
+                        (nuint)chunkLength);
                 }
+                chunk = chunk.m_ChunkPrevious;
             }
+            while (chunk != null);
+
+            return result;
         }
 
         /// <summary>
@@ -823,14 +812,10 @@ namespace System.Text
                     }
                     else
                     {
-                        unsafe
-                        {
-                            fixed (char* valuePtr = value)
-                            fixed (char* destPtr = &chunkChars[chunkLength])
-                            {
-                                string.wstrcpy(destPtr, valuePtr, valueLen);
-                            }
-                        }
+                        Buffer.Memmove(
+                            ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(chunkChars), chunkLength),
+                            ref value.GetRawStringData(),
+                            (nuint)valueLen);
                     }
 
                     m_ChunkLength = chunkLength + valueLen;
@@ -1046,9 +1031,7 @@ namespace System.Text
                     curDestIndex -= chunkCount;
                     count -= chunkCount;
 
-                    // We ensure that chunkStartIndex + chunkCount are within range of m_chunkChars as well as
-                    // ensuring that curDestIndex + chunkCount are within range of destination
-                    ThreadSafeCopy(chunk.m_ChunkChars, chunkStartIndex, destination, curDestIndex, chunkCount);
+                    new ReadOnlySpan<char>(chunk.m_ChunkChars, chunkStartIndex, chunkCount).CopyTo(destination.Slice(curDestIndex));
                 }
                 chunk = chunk.m_ChunkPrevious;
             }
@@ -2093,7 +2076,7 @@ namespace System.Text
             int newIndex = valueCount + m_ChunkLength;
             if (newIndex <= m_ChunkChars.Length)
             {
-                ThreadSafeCopy(value, m_ChunkChars, m_ChunkLength, valueCount);
+                new ReadOnlySpan<char>(value, valueCount).CopyTo(m_ChunkChars.AsSpan(m_ChunkLength));
                 m_ChunkLength = newIndex;
             }
             else
@@ -2102,7 +2085,7 @@ namespace System.Text
                 int firstLength = m_ChunkChars.Length - m_ChunkLength;
                 if (firstLength > 0)
                 {
-                    ThreadSafeCopy(value, m_ChunkChars, m_ChunkLength, firstLength);
+                    new ReadOnlySpan<char>(value, firstLength).CopyTo(m_ChunkChars.AsSpan(m_ChunkLength));
                     m_ChunkLength = m_ChunkChars.Length;
                 }
 
@@ -2112,7 +2095,7 @@ namespace System.Text
                 Debug.Assert(m_ChunkLength == 0, "A new block was not created.");
 
                 // Copy the second chunk
-                ThreadSafeCopy(value + firstLength, m_ChunkChars, 0, restLength);
+                new ReadOnlySpan<char>(value + firstLength, restLength).CopyTo(m_ChunkChars);
                 m_ChunkLength = restLength;
             }
             AssertInvariants();
@@ -2281,7 +2264,7 @@ namespace System.Text
                     Debug.Assert(lengthInChunk >= 0, "Index isn't in the chunk.");
 
                     int lengthToCopy = Math.Min(lengthInChunk, count);
-                    ThreadSafeCopy(value, chunk.m_ChunkChars, indexInChunk, lengthToCopy);
+                    new ReadOnlySpan<char>(value, lengthToCopy).CopyTo(chunk.m_ChunkChars.AsSpan(indexInChunk));
 
                     // Advance the index.
                     indexInChunk += lengthToCopy;
@@ -2297,46 +2280,6 @@ namespace System.Text
                     }
                     value += lengthToCopy;
                 }
-            }
-        }
-
-        /// <remarks>
-        /// This method prevents out-of-bounds writes in the case a different thread updates a field in the builder just before a copy begins.
-        /// All interesting variables are copied out of the heap into the parameters of this method, and then bounds checks are run.
-        /// </remarks>
-        private static unsafe void ThreadSafeCopy(char* sourcePtr, char[] destination, int destinationIndex, int count)
-        {
-            if (count > 0)
-            {
-                if ((uint)destinationIndex <= (uint)destination.Length && (destinationIndex + count) <= destination.Length)
-                {
-                    fixed (char* destinationPtr = &destination[destinationIndex])
-                        string.wstrcpy(destinationPtr, sourcePtr, count);
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException(nameof(destinationIndex), SR.ArgumentOutOfRange_Index);
-                }
-            }
-        }
-
-        private static unsafe void ThreadSafeCopy(char[] source, int sourceIndex, Span<char> destination, int destinationIndex, int count)
-        {
-            if (count > 0)
-            {
-                if ((uint)sourceIndex > (uint)source.Length || count > source.Length - sourceIndex)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(sourceIndex), SR.ArgumentOutOfRange_Index);
-                }
-
-                if ((uint)destinationIndex > (uint)destination.Length || count > destination.Length - destinationIndex)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(destinationIndex), SR.ArgumentOutOfRange_Index);
-                }
-
-                fixed (char* sourcePtr = &source[sourceIndex])
-                fixed (char* destinationPtr = &MemoryMarshal.GetReference(destination))
-                    string.wstrcpy(destinationPtr + destinationIndex, sourcePtr, count);
             }
         }
 
@@ -2521,20 +2464,14 @@ namespace System.Text
             int copyCount1 = Math.Min(count, indexInChunk);
             if (copyCount1 > 0)
             {
-                unsafe
-                {
-                    fixed (char* chunkCharsPtr = &chunk.m_ChunkChars[0])
-                    {
-                        ThreadSafeCopy(chunkCharsPtr, newChunk.m_ChunkChars, 0, copyCount1);
+                new ReadOnlySpan<char>(chunk.m_ChunkChars, 0, copyCount1).CopyTo(newChunk.m_ChunkChars);
 
-                        // Slide characters over in the current buffer to make room.
-                        int copyCount2 = indexInChunk - copyCount1;
-                        if (copyCount2 >= 0)
-                        {
-                            ThreadSafeCopy(chunkCharsPtr + copyCount1, chunk.m_ChunkChars, 0, copyCount2);
-                            indexInChunk = copyCount2;
-                        }
-                    }
+                // Slide characters over in the current buffer to make room.
+                int copyCount2 = indexInChunk - copyCount1;
+                if (copyCount2 >= 0)
+                {
+                    new ReadOnlySpan<char>(chunk.m_ChunkChars, copyCount1, copyCount2).CopyTo(chunk.m_ChunkChars);
+                    indexInChunk = copyCount2;
                 }
             }
 
@@ -2644,7 +2581,7 @@ namespace System.Text
             // Remove any characters in the end chunk, by sliding the characters down.
             if (copyTargetIndexInChunk != endIndexInChunk) // Sometimes no move is necessary
             {
-                ThreadSafeCopy(endChunk.m_ChunkChars, endIndexInChunk, endChunk.m_ChunkChars, copyTargetIndexInChunk, copyCount);
+                new ReadOnlySpan<char>(endChunk.m_ChunkChars, endIndexInChunk, copyCount).CopyTo(endChunk.m_ChunkChars.AsSpan(copyTargetIndexInChunk));
             }
 
             Debug.Assert(chunk != null, "We fell off the beginning of the string!");

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
@@ -119,7 +119,9 @@ namespace System.Text
         {
             // Validate input
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
 
             fixed (char* pChars = s)
                 return GetByteCount(pChars, s.Length, null);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
@@ -163,7 +163,9 @@ namespace System.Text
         {
             // Validate input
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
 
             fixed (char* pChars = s)
                 return GetByteCount(pChars, s.Length, null);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
@@ -112,7 +112,9 @@ namespace System.Text
         {
             // Validate input
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            }
 
             fixed (char* pChars = s)
                 return GetByteCount(pChars, s.Length, null);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Buffer.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Buffer.Mono.cs
@@ -8,8 +8,6 @@ namespace System
 {
     public partial class Buffer
     {
-        internal static unsafe void Memcpy(byte* dest, byte* src, int len) => Memmove(dest, src, (nuint)len);
-
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern unsafe void __Memmove(byte* dest, byte* src, nuint len);
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/String.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/String.Mono.cs
@@ -109,7 +109,7 @@ namespace System
 
         private static unsafe void memcpy(byte* dest, byte* src, int size)
         {
-            Buffer.Memcpy(dest, src, size);
+            Buffer.Memmove(ref *dest, ref *src, (nuint)size);
         }
 
         /* Used by the runtime */


### PR DESCRIPTION
We have several versions of Buffer.Memmove, including one implemented around `byte*` and one implemented around `ref byte`.  We can delete the former and just use the latter everywhere.  In doing so, we can also remove a few wrapper helpers, and reduce pinning in places where those wrappers were pinning to get pointers only to eventually end up in the ref-based implementation, anyway.

cc: @jkotas, @GrabYourPitchforks 