### PR TITLE
Initial changes to support Mac Catalyst

### DIFF
--- a/src/mono/mono/utils/mono-log-darwin.c
+++ b/src/mono/mono/utils/mono-log-darwin.c
@@ -5,7 +5,7 @@
  */
 #include <config.h>
 
-#if defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)
+#if (defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)) || defined(HOST_MACCAT)
 /* emitted by clang:
  *   > /Users/lewurm/work/mono-watch4/mono/utils/mono-log-darwin.c:35:2: error: 'asl_log' is \
  *   > deprecated: first deprecated in watchOS 3.0 - os_log(3) has replaced \


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20537,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This patch introduces new Mac Catalyst support for mono!

**Background** Mac Catalyst allows a developer to use the traditionally iOS APIs - like UIKit - on macOS. It retains the same ABI as macOS x86_64, however, is compiled with a new `-target` flag that is required in all static and dynamic libraries.

This patch is my first build so I appreciate any code reviews. :-)

I started with a clean build target so as not to break current iOS and Mac support. There is the potential to merge this with the existing iOS support, but I think this method of a specific `maccat.mk` file is a cleaner separation.

I discussed this publicly on the Merge Conflict podcast: https://www.mergeconflict.fm/225

I also show off the work on my Twitch stream: https://twitch.tv/FrankKrueger

