### PR TITLE
Make StringValues.ToArray return a copy of internal array

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -286,8 +286,7 @@ namespace Microsoft.Extensions.Primitives
             object value = _values;
             if (value is string[] values)
             {
-                var valuesCopy = (string[])values.Clone();
-                return valuesCopy;
+                return (string[])values.Clone();
             }
             else if (value != null)
             {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -286,7 +286,9 @@ namespace Microsoft.Extensions.Primitives
             object value = _values;
             if (value is string[] values)
             {
-                return values;
+                var valuesCopy = new string[values.Length];
+                values.CopyTo(valuesCopy, 0);
+                return valuesCopy;
             }
             else if (value != null)
             {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -286,8 +286,7 @@ namespace Microsoft.Extensions.Primitives
             object value = _values;
             if (value is string[] values)
             {
-                var valuesCopy = new string[values.Length];
-                values.CopyTo(valuesCopy, 0);
+                var valuesCopy = (string[])values.Clone();
                 return valuesCopy;
             }
             else if (value != null)

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringValuesTests.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringValuesTests.cs
@@ -610,5 +610,15 @@ namespace Microsoft.Extensions.Primitives
             Assert.True(StringValues.Equals(stringValues, new StringValues(expected)));
             Assert.Equal(stringValues.GetHashCode(), new StringValues(expected).GetHashCode());
         }
+
+        [Theory]
+        [MemberData(nameof(FilledStringValues))]
+        public void ToArray_CopiesValues(StringValues stringValues)
+        {
+            var array = stringValues.ToArray();
+            array[0] = "bcd";
+
+            Assert.Equal("abc", stringValues[0]);
+        }
     }
 }


### PR DESCRIPTION
Fixes #36131