### PR TITLE
Add issues.targets CG2 entries for issue #44054

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -890,6 +890,12 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
             <Issue>https://github.com/dotnet/runtime/issues/38291</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/threadpool/unregister/unregister01/*">
+            <Issue>https://github.com/dotnet/runtime/issues/44054</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/threadpool/unregister/unregister03/*">
+            <Issue>https://github.com/dotnet/runtime/issues/44054</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/IJW/NativeVarargs/NativeVarargsTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/38096</Issue>
         </ExcludeList>


### PR DESCRIPTION
After David's yesterday fix for various signature issues in CG2 these are the only two tests that still fail in outerloop runs. Hopefully with this change we may be able to see some green CG2 outerloop legs for the first time ever.

/cc @dotnet/crossgen-contrib