### PR TITLE
Set the MSVC RuntimeLibrary properties for ASM_MASM when we use MASM.

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -627,6 +627,10 @@ if (CLR_CMAKE_HOST_WIN32)
       set(CMAKE_ASM_COMPILE_OBJECT "<CMAKE_ASM_COMPILER> -g <INCLUDES> <FLAGS> -o <OBJECT> <SOURCE>")
     else()
       enable_language(ASM_MASM)
+      set(CMAKE_ASM_MASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreaded         "")
+      set(CMAKE_ASM_MASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL      "")
+      set(CMAKE_ASM_MASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDebug    "")
+      set(CMAKE_ASM_MASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDebugDLL "")
     endif()
 
     # Ensure that MC is present


### PR DESCRIPTION
Set the MSVC RuntimeLibrary properties for ASM_MASM since they aren't populated until CMake 3.16.4 due to a bug in CMake.

This is currently blocking local builds for anyone using a CMake version prior to 3.16.4.