### PR TITLE
Fill out hardware intrinsics linker substitutions for unsupported platforms

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoArmIntrinsics.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoArmIntrinsics.xml
@@ -9,6 +9,9 @@
     <type fullname="System.Runtime.Intrinsics.Arm.Aes">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
     </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Aes/Arm64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
+    </type>
     <type fullname="System.Runtime.Intrinsics.Arm.ArmBase">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
     </type>
@@ -21,10 +24,28 @@
     <type fullname="System.Runtime.Intrinsics.Arm.Crc32/Arm64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
     </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Dp">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Dp/Arm64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Rdm">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Rdm/Arm64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
+    </type>
     <type fullname="System.Runtime.Intrinsics.Arm.Sha1">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
     </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Sha1/Arm64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
+    </type>
     <type fullname="System.Runtime.Intrinsics.Arm.Sha256">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Sha256/Arm64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" /> 
     </type>
   </assembly>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoX86Intrinsics.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoX86Intrinsics.xml
@@ -3,10 +3,19 @@
     <type fullname="System.Runtime.Intrinsics.X86.Aes">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Aes/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
     <type fullname="System.Runtime.Intrinsics.X86.Avx">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
     <type fullname="System.Runtime.Intrinsics.X86.Avx2">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx2/X64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.X86.Bmi1">
@@ -24,6 +33,9 @@
     <type fullname="System.Runtime.Intrinsics.X86.Fma">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Fma/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
     <type fullname="System.Runtime.Intrinsics.X86.Lzcnt">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
@@ -31,6 +43,9 @@
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.X86.Pclmulqdq">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Pclmulqdq/X64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.X86.Popcnt">
@@ -54,6 +69,9 @@
     <type fullname="System.Runtime.Intrinsics.X86.Sse3">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Sse3/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
     <type fullname="System.Runtime.Intrinsics.X86.Sse41">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
@@ -67,6 +85,9 @@
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.X86.Ssse3">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Ssse3/X64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.X86.X86Base">


### PR DESCRIPTION
Added the recently added arm intrinsics classes: `Dp` and `Rdm` to the linker subsitutions.

I also ensured all the 64-bit nested classes are substituted as well, even if they don't have any methods.

Fix #44146