### PR TITLE
Extend SendAsync/ReceiveAsync cancellation tests

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1696,20 +1696,21 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [OuterLoop]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task SendAsync_CanceledDuringOperation_Throws(bool ipv6)
         {
             const int CancelAfter = 200; // ms
-            const int NumOfSends = 1000;
+            const int NumOfSends = 100;
+            const int SendBufferSize = 1024;
 
             (Socket client, Socket server) = SocketTestExtensions.CreateConnectedSocketPair(ipv6);
             byte[] buffer = new byte[1024 * 64];
             using (client)
             using (server)
             {
+                client.SendBufferSize = SendBufferSize;
                 CancellationTokenSource cts = new CancellationTokenSource();
 
                 List<Task> tasks = new List<Task>();

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1696,6 +1696,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [OuterLoop]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -1705,14 +1706,16 @@ namespace System.Net.Sockets.Tests
             const int NumOfSends = 1000;
 
             (Socket client, Socket server) = SocketTestExtensions.CreateConnectedSocketPair(ipv6);
-            byte[] buffer = new byte[8192 * 8];
+            byte[] buffer = new byte[1024 * 64];
             using (client)
             using (server)
             {
                 CancellationTokenSource cts = new CancellationTokenSource();
 
-                List<Task<int>> tasks = new List<Task<int>>();
+                List<Task> tasks = new List<Task>();
 
+                // After flooding the socket with a high number of send tasks,
+                // we assume some of them won't complete before the "CancelAfter" period expires.
                 for (int i=0; i < NumOfSends; i++)
                 {
                     var task = client.SendAsync(buffer, SocketFlags.None, cts.Token).AsTask();


### PR DESCRIPTION
- Rename `CanceledDuringOperation_Throws` to `ReceiveAsync_CanceledDuringOperation_Throws` and extend it to IPv6 sockets
- Introduce cancellation test for `Socket.SendAsync`. Unless I'm missing something, this method was missing functional coverage.

@geoffkizer @stephentoub @tmds PTAL. I want to find the best practices for testing cancellation for stuff in #43935.