### PR TITLE
Move serializable types for xml serialization generator tests to separate assembly

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/Microsoft.XmlSerializer.Generator.sln
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/Microsoft.XmlSerializer.Generator.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{71CDAEB3-0F69-4DCD-A720-92270C4C44C8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerializableAssembly", "tests\SerializableAssembly.csproj", "{81BE9FCA-42C2-4EFE-913C-36C291A6DD76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{71CDAEB3-0F69-4DCD-A720-92270C4C44C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{71CDAEB3-0F69-4DCD-A720-92270C4C44C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{71CDAEB3-0F69-4DCD-A720-92270C4C44C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81BE9FCA-42C2-4EFE-913C-36C291A6DD76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81BE9FCA-42C2-4EFE-913C-36C291A6DD76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81BE9FCA-42C2-4EFE-913C-36C291A6DD76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81BE9FCA-42C2-4EFE-913C-36C291A6DD76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -15,7 +15,6 @@
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true'">
     <Compile Include="SGenTests.cs" />
     <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
-    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Private.Xml\tests\XmlSerializer\XmlSerializerTests.cs" />
   </ItemGroup>
 
@@ -28,18 +27,19 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true'">
     <ProjectReference Include="..\src\Microsoft.XmlSerializer.Generator.csproj" />
+    <ProjectReference Include="SerializableAssembly.csproj" />
   </ItemGroup>
 
   <!-- This target runs before binplacing as it needs to provide a test assembly to binplace, and depends on CopyFilesToOutputDirectory
        so that the Generator app dll and runtimeconfig will be copied to the OutputPath -->
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <PropertyGroup>
-      <SerializerName>$(AssemblyName).XmlSerializers</SerializerName>
+      <SerializerName>SerializableAssembly.XmlSerializers</SerializerName>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll --force --quiet" />
+    <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)SerializableAssembly.dll --force --quiet" />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs" />
     <Copy SourceFiles="$(OutputPath)$(SerializerName).cs" DestinationFiles="$(OutputPath)LKG.$(SerializerName).cs" />
     <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true'" OutputAssembly="$(OutputPath)$(SerializerName).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" DebugType="$(DebugType)" Sources="$(OutputPath)$(SerializerName).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(NoWarn), 219" UseSharedCompilation="true" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.XmlSerializer.Generator.Tests
         [Fact]
         public static void SgenCommandTest()
         {
-            const string CodeFile = "Microsoft.XmlSerializer.Generator.Tests.XmlSerializers.cs";
+            const string CodeFile = "SerializableAssembly.XmlSerializers.cs";
             const string LKGCodeFile = "LKG." + CodeFile;
 
             var type = Type.GetType("Microsoft.XmlSerializer.Generator.Sgen, dotnet-Microsoft.XmlSerializer.Generator");
             MethodInfo md = type.GetMethod("Main", BindingFlags.Static | BindingFlags.Public);
-            string[] args = new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "--force", "--quiet" };
+            string[] args = new string[] { "SerializableAssembly.dll", "--force", "--quiet" };
             int n = (int)md.Invoke(null, new object[] { args });
 
             Assert.Equal(0, n);

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/SerializableAssembly.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/SerializableAssembly.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/SerializableAssembly.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/SerializableAssembly.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- We need a separate assembly in order to run SGen during the test build because if we just run
+    SGen on the test assembly itself, everytime we move the shared framework assemblies to VNext.0.0
+    or to target a new TFM, since we use the SDK to invoke SGen and there is no recent SDK with
+    VNext.0.0 then SGen fails when it tries to load the types to serialize. -->
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/43137

cc: @GrabYourPitchforks 