### PR TITLE
Add threshold on number of files / partition in SPMI collection

### DIFF
--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -105,7 +105,7 @@ jobs:
     - template: /eng/pipelines/coreclr/templates/superpmi-send-to-helix.yml
       parameters:
         HelixSource: '$(HelixSourcePrefix)/$(Build.Repository.Name)/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
-        HelixType: 'test/superpmi/$(Kind)/$(_Framework)/$(Architecture)'
+        HelixType: 'test/superpmi/$(CollectionName)/$(_Framework)/$(Architecture)'
         HelixAccessToken: $(HelixApiAccessToken)
         HelixTargetQueues: $(Queue)
         HelixPreCommands: $(HelixPreCommand)

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -89,7 +89,7 @@ native_binaries_to_ignore = [
     "superpmi-shim-counter.dll",
     "superpmi-shim-simple.dll",
 ]
-
+MAX_FILES_COUNT = 2500
 
 def setup_args(args):
     """ Setup the args for SuperPMI to use.
@@ -206,7 +206,7 @@ def first_fit(sorted_by_size, max_size):
         if file_size < max_size:
             for p_index in partitions:
                 total_in_curr_par = sum(n for _, n in partitions[p_index])
-                if (total_in_curr_par + file_size) < max_size:
+                if (((total_in_curr_par + file_size) < max_size) and (len(partitions[p_index]) < MAX_FILES_COUNT)):
                     partitions[p_index].append(curr_file)
                     found_bucket = True
                     break
@@ -217,7 +217,7 @@ def first_fit(sorted_by_size, max_size):
     total_size = 0
     for p_index in partitions:
         partition_size = sum(n for _, n in partitions[p_index])
-        print("Partition {0}: {1} bytes.".format(p_index, partition_size))
+        print("Partition {0}: {1} files with {2} bytes.".format(p_index, len(partitions[p_index]), partition_size))
         total_size += partition_size
     print("Total {0} partitions with {1} bytes.".format(str(len(partitions)), total_size))
 

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -89,7 +89,7 @@ native_binaries_to_ignore = [
     "superpmi-shim-counter.dll",
     "superpmi-shim-simple.dll",
 ]
-MAX_FILES_COUNT = 2500
+MAX_FILES_COUNT = 1500
 
 def setup_args(args):
     """ Setup the args for SuperPMI to use.

--- a/src/coreclr/scripts/superpmi.proj
+++ b/src/coreclr/scripts/superpmi.proj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
 
-  <PropertyGroup Condition="'$(AGENT_OS)' == 'windows'">
+  <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
     <FileSeparatorChar>\</FileSeparatorChar>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(AGENT_OS)' != 'windows'">
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <FileSeparatorChar>/</FileSeparatorChar>
   </PropertyGroup>
 
@@ -16,7 +16,7 @@
          PmiAssembliesPayload - Path that will be sent to helix machine to run collection on
          PmiAssembliesDirectory - Path on helix machine itself where superpmi.py will discover the sent assemblies.
     -->
-  <PropertyGroup Condition="'$(AGENT_OS)' == 'windows'">
+  <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
     <Python>%HELIX_PYTHONPATH%</Python>
     <PmiAssembliesPayload>$(WorkItemDirectory)\pmiAssembliesDirectory</PmiAssembliesPayload>
     <PmiAssembliesDirectory>%HELIX_WORKITEM_PAYLOAD%\binaries</PmiAssembliesDirectory>
@@ -26,7 +26,7 @@
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
     <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect --pmi -pmi_location $(SuperPMIDirectory)\pmi.dll </WorkItemCommand>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(AGENT_OS)' != 'windows'">
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <Python>$HELIX_PYTHONPATH</Python>
     <PmiAssembliesPayload>$(WorkItemDirectory)/pmiAssembliesDirectory</PmiAssembliesPayload>
     <PmiAssembliesDirectory>$HELIX_WORKITEM_PAYLOAD/binaries</PmiAssembliesDirectory>


### PR DESCRIPTION
- We have seen in past runs that if files count is large, we don't finish the SPMI collection in given time. So restrict the no. of files we include in partition. 
- Also, revert a regression introduced in https://github.com/dotnet/runtime/pull/43651 that was checking `$(Agent_OS)` to `"windows"` instead of `"Windows_NT"`.
- Update `superpmi.py` script to not upload anything to azure if the `*.mch` file is empty. Without this, a failed run would override the valid .mch files on Azure storage with empty ones.