### PR TITLE
Socket.Tests: remove TestSettings.UDPRedundancy 

### DIFF
--- a/src/libraries/Common/tests/System/Net/Sockets/TestSettings.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/TestSettings.cs
@@ -11,14 +11,6 @@ namespace System.Net.Sockets.Tests
         public const int PassingTestTimeout = 10000;
         public const int FailingTestTimeout = 100;
 
-        // Number of redundant UDP packets to send to increase test reliability
-        // Update: was 10, changing to 1 to measure impact of random test failures occurring on *nix.
-        // Certain random failures appear to be caused by a UDP client sending in a loop (based on UDPRedundancy)
-        // to a server which was closed but another server created (on a different thread \ test) that happens to
-        // have the same port #.
-        // This occurs on *nix but not Windows because *nix uses random values (1024-65535) while Windows increments.
-        public const int UDPRedundancy = 1;
-
         public static Task WhenAllOrAnyFailedWithTimeout(params Task[] tasks) => tasks.WhenAllOrAnyFailed(PassingTestTimeout);
     }
 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/IPPacketInformationTest.cs
@@ -70,10 +70,7 @@ namespace System.Net.Sockets.Tests
                 Assert.True(receiver.ReceiveMessageFromAsync(receiveArgs), "receiver.ReceiveMessageFromAsync");
 
                 // Send a few packets, in case they aren't delivered reliably.
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, port));
-                }
+                sender.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, port));
 
                 Assert.True(waitHandle.WaitOne(ReceiveTimeout), "waitHandle.WaitOne");
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -29,10 +29,7 @@ namespace System.Net.Sockets.Tests
 
                     sender.ForceNonBlocking(forceNonBlocking);
 
-                    for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                    {
-                        sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.Loopback, port));
-                    }
+                    sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.Loopback, port));
 
                     IPPacketInformation packetInformation;
                     SocketFlags flags = SocketFlags.None;
@@ -69,10 +66,7 @@ namespace System.Net.Sockets.Tests
 
                     sender.ForceNonBlocking(forceNonBlocking);
 
-                    for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                    {
-                        sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.IPv6Loopback, port));
-                    }
+                    sender.SendTo(new byte[1024], new IPEndPoint(IPAddress.IPv6Loopback, port));
 
                     IPPacketInformation packetInformation;
                     SocketFlags flags = SocketFlags.None;
@@ -122,10 +116,7 @@ namespace System.Net.Sockets.Tests
                 receiver.SetSocketOption(level, SocketOptionName.PacketInformation, true);
                 sender.Bind(new IPEndPoint(loopback, 0));
 
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.SendTo(new byte[1024], new IPEndPoint(loopback, port));
-                }
+                sender.SendTo(new byte[1024], new IPEndPoint(loopback, port));
 
                 IPPacketInformation packetInformation;
                 SocketFlags flags = SocketFlags.None;
@@ -203,10 +194,7 @@ namespace System.Net.Sockets.Tests
                 saea.Completed += delegate { mres.Set(); };
 
                 bool pending = receiver.ReceiveMessageFromAsync(saea);
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.SendTo(new byte[1024], new IPEndPoint(loopback, port));
-                }
+                sender.SendTo(new byte[1024], new IPEndPoint(loopback, port));
                 if (pending) Assert.True(mres.Wait(30000), "Expected operation to complete within timeout");
 
                 Assert.Equal(1024, saea.BytesTransferred);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFromAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFromAsync.cs
@@ -35,10 +35,7 @@ namespace System.Net.Sockets.Tests
 
                 for (int iters = 0; iters < 5; iters++)
                 {
-                    for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                    {
-                        sender.SendTo(new byte[DataLength], new IPEndPoint(loopback, port));
-                    }
+                    sender.SendTo(new byte[DataLength], new IPEndPoint(loopback, port));
 
                     if (changeReceiveBufferEachCall)
                     {
@@ -78,10 +75,7 @@ namespace System.Net.Sockets.Tests
 
                 for (int iters = 0; iters < 5; iters++)
                 {
-                    for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                    {
-                        sender.SendTo(new byte[DataLength], new IPEndPoint(loopback, port));
-                    }
+                    sender.SendTo(new byte[DataLength], new IPEndPoint(loopback, port));
 
                     SocketReceiveMessageFromResult result = await receiver.ReceiveMessageFromAsync(
                         new ArraySegment<byte>(new byte[DataLength], 0, DataLength), SocketFlags.None,

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SelectAndPollTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SelectAndPollTests.cs
@@ -36,10 +36,7 @@ namespace System.Net.Sockets.Tests
                 int receiverPort = receiver.BindToAnonymousPort(IPAddress.Loopback);
                 var receiverEndpoint = new IPEndPoint(IPAddress.Loopback, receiverPort);
 
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
-                }
+                sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
 
                 var list = new List<Socket> { receiver };
                 Socket.Select(list, null, null, SelectSuccessTimeoutMicroseconds);
@@ -76,11 +73,8 @@ namespace System.Net.Sockets.Tests
                 int secondReceiverPort = secondReceiver.BindToAnonymousPort(IPAddress.Loopback);
                 var secondReceiverEndpoint = new IPEndPoint(IPAddress.Loopback, secondReceiverPort);
 
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.SendTo(new byte[1], SocketFlags.None, firstReceiverEndpoint);
-                    sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
-                }
+                sender.SendTo(new byte[1], SocketFlags.None, firstReceiverEndpoint);
+                sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
 
                 var sw = Stopwatch.StartNew();
                 Assert.True(SpinWait.SpinUntil(() =>
@@ -127,10 +121,7 @@ namespace System.Net.Sockets.Tests
                 int secondReceiverPort = secondReceiver.BindToAnonymousPort(IPAddress.Loopback);
                 var secondReceiverEndpoint = new IPEndPoint(IPAddress.Loopback, secondReceiverPort);
 
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
-                }
+                sender.SendTo(new byte[1], SocketFlags.None, secondReceiverEndpoint);
 
                 var list = new List<Socket> { firstReceiver, secondReceiver };
                 Socket.Select(list, null, null, SelectSuccessTimeoutMicroseconds);
@@ -276,10 +267,7 @@ namespace System.Net.Sockets.Tests
                 int receiverPort = receiver.BindToAnonymousPort(IPAddress.Loopback);
                 var receiverEndpoint = new IPEndPoint(IPAddress.Loopback, receiverPort);
 
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
-                }
+                sender.SendTo(new byte[1], SocketFlags.None, receiverEndpoint);
 
                 Assert.True(receiver.Poll(SelectSuccessTimeoutMicroseconds, SelectMode.SelectRead));
             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -100,10 +100,7 @@ namespace System.Net.Sockets.Tests
                 var receiveBuffer = new byte[1024];
                 var receiveTask = receiveSocket.ReceiveAsync(new ArraySegment<byte>(receiveBuffer), SocketFlags.None);
 
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sendSocket.SendTo(Encoding.UTF8.GetBytes(message), new IPEndPoint(multicastAddress, port));
-                }
+                sendSocket.SendTo(Encoding.UTF8.GetBytes(message), new IPEndPoint(multicastAddress, port));
 
                 var cts = new CancellationTokenSource();
                 Assert.True(await Task.WhenAny(receiveTask, Task.Delay(30_000, cts.Token)) == receiveTask, "Waiting for received data timed out");
@@ -213,10 +210,7 @@ namespace System.Net.Sockets.Tests
                 var receiveBuffer = new byte[1024];
                 var receiveTask = receiveSocket.ReceiveAsync(new ArraySegment<byte>(receiveBuffer), SocketFlags.None);
 
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sendSocket.SendTo(Encoding.UTF8.GetBytes(message), new IPEndPoint(multicastAddress, port));
-                }
+                sendSocket.SendTo(Encoding.UTF8.GetBytes(message), new IPEndPoint(multicastAddress, port));
 
                 var cts = new CancellationTokenSource();
                 Assert.True(await Task.WhenAny(receiveTask, Task.Delay(30_000, cts.Token)) == receiveTask, "Waiting for received data timed out");

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -505,10 +505,7 @@ namespace System.Net.Sockets.Tests
             using (var receiver = new UdpClient(new IPEndPoint(address, 0)))
             using (var sender = new UdpClient(new IPEndPoint(address, 0)))
             {
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.Send(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
-                }
+                sender.Send(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
 
                 IPEndPoint remoteEP = null;
                 byte[] data = receiver.Receive(ref remoteEP);
@@ -525,10 +522,7 @@ namespace System.Net.Sockets.Tests
             using (var receiver = new UdpClient("localhost", 0))
             using (var sender = new UdpClient("localhost", ((IPEndPoint)receiver.Client.LocalEndPoint).Port))
             {
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.Send(new byte[1], 1);
-                }
+                sender.Send(new byte[1], 1);
 
                 IPEndPoint remoteEP = null;
                 byte[] data = receiver.Receive(ref remoteEP);
@@ -548,10 +542,7 @@ namespace System.Net.Sockets.Tests
             using (var receiver = new UdpClient(new IPEndPoint(address, 0)))
             using (var sender = new UdpClient(new IPEndPoint(address, 0)))
             {
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.Send(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
-                }
+                sender.Send(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
 
                 Assert.True(SpinWait.SpinUntil(() => receiver.Available > 0, 30000), "Expected data to be available for receive within time limit");
             }
@@ -568,10 +559,7 @@ namespace System.Net.Sockets.Tests
             using (var receiver = new UdpClient(new IPEndPoint(address, 0)))
             using (var sender = new UdpClient(new IPEndPoint(address, 0)))
             {
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.EndSend(sender.BeginSend(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port), null, null));
-                }
+                sender.EndSend(sender.BeginSend(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port), null, null));
 
                 IPEndPoint remoteEP = null;
                 byte[] data = receiver.EndReceive(receiver.BeginReceive(null, null), ref remoteEP);
@@ -588,10 +576,7 @@ namespace System.Net.Sockets.Tests
             using (var receiver = new UdpClient("localhost", 0))
             using (var sender = new UdpClient("localhost", ((IPEndPoint)receiver.Client.LocalEndPoint).Port))
             {
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    sender.EndSend(sender.BeginSend(new byte[1], 1, null, null));
-                }
+                sender.EndSend(sender.BeginSend(new byte[1], 1, null, null));
 
                 IPEndPoint remoteEP = null;
                 byte[] data = receiver.EndReceive(receiver.BeginReceive(null, null), ref remoteEP);
@@ -611,10 +596,7 @@ namespace System.Net.Sockets.Tests
             using (var receiver = new UdpClient(new IPEndPoint(address, 0)))
             using (var sender = new UdpClient(new IPEndPoint(address, 0)))
             {
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    await sender.SendAsync(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
-                }
+                await sender.SendAsync(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
 
                 UdpReceiveResult result = await receiver.ReceiveAsync();
                 Assert.NotNull(result.RemoteEndPoint);
@@ -631,10 +613,7 @@ namespace System.Net.Sockets.Tests
             using (var receiver = new UdpClient("localhost", 0))
             using (var sender = new UdpClient("localhost", ((IPEndPoint)receiver.Client.LocalEndPoint).Port))
             {
-                for (int i = 0; i < TestSettings.UDPRedundancy; i++)
-                {
-                    await sender.SendAsync(new byte[1], 1);
-                }
+                await sender.SendAsync(new byte[1], 1);
 
                 UdpReceiveResult result = await receiver.ReceiveAsync();
                 Assert.NotNull(result.RemoteEndPoint);


### PR DESCRIPTION
dotnet/corefx#15697 changed this value to 1, and no-one touched it since then.

As the comment in that PR points out, the root cause of the UDP test failures wasn't packet loss, but IPv4 / IPv6 port collision on Unix in dual-mode cases.

The value and the for loops are complicating Socket test code unnecessarily, simplification seems reasonable.

/cc @geoffkizer @stephentoub 