### PR TITLE
Try a different attribute for disabling stream conformance tests on browser

### DIFF
--- a/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 namespace System.IO.Tests
 {
     /// <summary>Base class providing tests for any Stream-derived type.</summary>
-    [PlatformSpecific(~TestPlatforms.Browser)] // lots of operations aren't supported on browser
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))] // lots of operations aren't supported on browser
     public abstract class StreamConformanceTests : FileCleanupTestBase
     {
         /// <summary>Gets the name of the byte[] argument to Read/Write methods.</summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44214 hopefully?