### PR TITLE
Add assert to SharedPerformanceCounter to debug test failures in CI

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
@@ -697,6 +697,7 @@ namespace System.Diagnostics
                             }
                             else
                             {
+                                Debug.Assert(counterNamesObject is string[], $"Expected string[], got '{counterNamesObject}' with kind '{categoryKey.GetValueKind("Counter Names")}'for category '{_categoryName}'");
                                 string[] counterNames = (string[])counterNamesObject;
                                 for (int i = 0; i < counterNames.Length; i++)
                                     counterNames[i] = counterNames[i].ToLowerInvariant();


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/44208
cc: @danmosemsft, @Anipik 