### PR TITLE
Add stream conformance tests for TranscodingStream

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
@@ -459,6 +459,11 @@ namespace System.Text
         {
             EnsurePreWriteConditions();
 
+            if (buffer.IsEmpty)
+            {
+                return;
+            }
+
             int rentalLength = Math.Clamp(buffer.Length, MinWriteRentedArraySize, MaxWriteRentedArraySize);
 
             char[] scratchChars = ArrayPool<char>.Shared.Rent(rentalLength);
@@ -525,6 +530,11 @@ namespace System.Text
             if (cancellationToken.IsCancellationRequested)
             {
                 return ValueTask.FromCanceled(cancellationToken);
+            }
+
+            if (buffer.IsEmpty)
+            {
+                return ValueTask.CompletedTask;
             }
 
             return WriteAsyncCore(buffer, cancellationToken);

--- a/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -79,6 +79,12 @@
     <Compile Include="UnicodeEncoding\UnicodeEncoding.cs" />
     <Compile Include="Decoder\Decoder.cs" />
     <Compile Include="Encoder\Encoder.cs" />
+    <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
+    <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
+    <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="runtimeconfig.template.json" />


### PR DESCRIPTION
And fix 0-length input handling of Encoder/Decoder.Convert (fixes https://github.com/dotnet/runtime/issues/44247)

cc: @GrabYourPitchforks, @tarekgh 