### PR TITLE
Add R2RDump support for lazy GC info

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -116,10 +116,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             get
             {
-                if (_size < 0)
-                {
-                    _size = GetSize();
-                }
+                EnsureInitialized();
                 return _size;
             }
         }
@@ -200,6 +197,14 @@ namespace ILCompiler.Reflection.ReadyToRun
             UnwindInfo = unwindInfo;
             CodeOffset = codeOffset;
             method.GetGcInfo = gcInfo;
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_size < 0)
+            {
+                _size = GetSize();
+            }
         }
 
         private int GetSize()
@@ -301,10 +306,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             get
             {
-                if (_gcInfo == null && GetGcInfo != null)
-                {
-                    _gcInfo = GetGcInfo();
-                }
+                EnsureInitialized();
                 return _gcInfo;
             }
         }
@@ -439,6 +441,14 @@ namespace ILCompiler.Reflection.ReadyToRun
             sb.Append(")");
 
             SignatureString = sb.ToString();
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_gcInfo == null && GetGcInfo != null)
+            {
+                _gcInfo = GetGcInfo();
+            }
         }
 
         private void EnsureFixupCells()

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -116,15 +116,15 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             get
             {
-                if (_sizeCache < 0)
+                if (_size < 0)
                 {
-                    _sizeCache = GetSize();
+                    _size = GetSize();
                 }
-                return _sizeCache;
+                return _size;
             }
         }
 
-        private int _sizeCache;
+        private int _size = -1;
 
         /// <summary>
         /// The relative virtual address to the unwind info
@@ -301,15 +301,15 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             get
             {
-                if (_gcInfoCache == null && GetGcInfo != null)
+                if (_gcInfo == null && GetGcInfo != null)
                 {
-                    _gcInfoCache = GetGcInfo();
+                    _gcInfo = GetGcInfo();
                 }
-                return _gcInfoCache;
+                return _gcInfo;
             }
         }
 
-        private BaseGcInfo _gcInfoCache;
+        private BaseGcInfo _gcInfo;
 
 
         private ReadyToRunReader _readyToRunReader;

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -199,7 +199,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             Method = method;
             UnwindInfo = unwindInfo;
             CodeOffset = codeOffset;
-            method.GcInfo = gcInfo;
+            method.GetGcInfo = gcInfo;
         }
 
         private int GetSize()
@@ -222,7 +222,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
             else if (Method.GcInfo != null)
             {
-                return Method.GcInfo().CodeLength; 
+                return Method.GcInfo.CodeLength; 
             }
             else
             {
@@ -295,7 +295,22 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public int EntryPointRuntimeFunctionId { get; set; }
 
-        public Func<BaseGcInfo> GcInfo { get; set; }
+        public Func<BaseGcInfo> GetGcInfo { get; set; }
+
+        public BaseGcInfo GcInfo
+        {
+            get
+            {
+                if (_gcInfoCache == null && GetGcInfo != null)
+                {
+                    _gcInfoCache = GetGcInfo();
+                }
+                return _gcInfoCache;
+            }
+        }
+
+        private BaseGcInfo _gcInfoCache;
+
 
         private ReadyToRunReader _readyToRunReader;
         private List<FixupCell> _fixupCells;

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -101,13 +101,30 @@ namespace ILCompiler.Reflection.ReadyToRun
         public int StartAddress { get; }
 
         /// <summary>
+        /// The relative virtual address to the end of the code block
+        /// </summary>
+        public int EndAddress { get;  }
+
+        /// <summary>
         /// The size of the code block in bytes
         /// </summary>
         /// /// <remarks>
         /// The EndAddress field in the runtime functions section is conditional on machine type
         /// Size is -1 for images without the EndAddress field
         /// </remarks>
-        public int Size { get; }
+        public int Size
+        {
+            get
+            {
+                if (_sizeCache < 0)
+                {
+                    _sizeCache = GetSize();
+                }
+                return _sizeCache;
+            }
+        }
+
+        private int _sizeCache;
 
         /// <summary>
         /// The relative virtual address to the unwind info
@@ -171,41 +188,46 @@ namespace ILCompiler.Reflection.ReadyToRun
             int codeOffset,
             ReadyToRunMethod method,
             BaseUnwindInfo unwindInfo,
-            BaseGcInfo gcInfo)
+            Func<BaseGcInfo> gcInfo)
         {
             _readyToRunReader = readyToRunReader;
+
             Id = id;
             StartAddress = startRva;
+            EndAddress = endRva;
             UnwindRVA = unwindRva;
             Method = method;
             UnwindInfo = unwindInfo;
+            CodeOffset = codeOffset;
+            method.GcInfo = gcInfo;
+        }
 
-            if (endRva != -1)
+        private int GetSize()
+        {
+            if (EndAddress != -1)
             {
-                Size = endRva - startRva;
+                return EndAddress - StartAddress;
             }
-            else if (unwindInfo is x86.UnwindInfo)
+            else if (UnwindInfo is x86.UnwindInfo)
             {
-                Size = (int)((x86.UnwindInfo)unwindInfo).FunctionLength;
+                return (int)((x86.UnwindInfo)UnwindInfo).FunctionLength;
             }
-            else if (unwindInfo is Arm.UnwindInfo)
+            else if (UnwindInfo is Arm.UnwindInfo)
             {
-                Size = (int)((Arm.UnwindInfo)unwindInfo).FunctionLength;
+                return (int)((Arm.UnwindInfo)UnwindInfo).FunctionLength;
             }
-            else if (unwindInfo is Arm64.UnwindInfo)
+            else if (UnwindInfo is Arm64.UnwindInfo)
             {
-                Size = (int)((Arm64.UnwindInfo)unwindInfo).FunctionLength;
+                return (int)((Arm64.UnwindInfo)UnwindInfo).FunctionLength;
             }
-            else if (gcInfo != null)
+            else if (Method.GcInfo != null)
             {
-                Size = gcInfo.CodeLength;
+                return Method.GcInfo().CodeLength; 
             }
             else
             {
-                Size = -1;
+                return -1;
             }
-            CodeOffset = codeOffset;
-            method.GcInfo = gcInfo;
         }
     }
 
@@ -273,7 +295,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public int EntryPointRuntimeFunctionId { get; set; }
 
-        public BaseGcInfo GcInfo { get; set; }
+        public Func<BaseGcInfo> GcInfo { get; set; }
 
         private ReadyToRunReader _readyToRunReader;
         private List<FixupCell> _fixupCells;
@@ -460,7 +482,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             int runtimeFunctionSize = _readyToRunReader.CalculateRuntimeFunctionSize();
             int runtimeFunctionOffset = _readyToRunReader.CompositeReader.GetOffset(_readyToRunReader.ReadyToRunHeader.Sections[ReadyToRunSectionType.RuntimeFunctions].RelativeVirtualAddress);
             int curOffset = runtimeFunctionOffset + runtimeFunctionId * runtimeFunctionSize;
-            BaseGcInfo gcInfo = null;
+            Func<BaseGcInfo> gcInfo = default(Func<BaseGcInfo>);
             int codeOffset = 0;
             for (int i = 0; i < RuntimeFunctionCount; i++)
             {
@@ -485,7 +507,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     unwindInfo = new Amd64.UnwindInfo(_readyToRunReader.Image, unwindOffset);
                     if (i == 0)
                     {
-                        gcInfo = new Amd64.GcInfo(_readyToRunReader.Image, unwindOffset + unwindInfo.Size, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion);
+                        gcInfo = new Func<BaseGcInfo>(() => new Amd64.GcInfo(_readyToRunReader.Image, unwindOffset + unwindInfo.Size, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion));
                     }
                 }
                 else if (_readyToRunReader.Machine == Machine.I386)
@@ -493,7 +515,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     unwindInfo = new x86.UnwindInfo(_readyToRunReader.Image, unwindOffset);
                     if (i == 0)
                     {
-                        gcInfo = new x86.GcInfo(_readyToRunReader.Image, unwindOffset, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion);
+                        gcInfo = new Func<BaseGcInfo>(() => new x86.GcInfo(_readyToRunReader.Image, unwindOffset, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion));
                     }
                 }
                 else if (_readyToRunReader.Machine == Machine.ArmThumb2)
@@ -501,7 +523,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     unwindInfo = new Arm.UnwindInfo(_readyToRunReader.Image, unwindOffset);
                     if (i == 0)
                     {
-                        gcInfo = new Amd64.GcInfo(_readyToRunReader.Image, unwindOffset + unwindInfo.Size, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion); // Arm and Arm64 use the same GcInfo format as x64
+                        gcInfo = new Func<BaseGcInfo>(() => new Amd64.GcInfo(_readyToRunReader.Image, unwindOffset + unwindInfo.Size, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion)); // Arm and Arm64 use the same GcInfo format as x6
                     }
                 }
                 else if (_readyToRunReader.Machine == Machine.Arm64)
@@ -509,7 +531,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     unwindInfo = new Arm64.UnwindInfo(_readyToRunReader.Image, unwindOffset);
                     if (i == 0)
                     {
-                        gcInfo = new Amd64.GcInfo(_readyToRunReader.Image, unwindOffset + unwindInfo.Size, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion);
+                        gcInfo = new Func<BaseGcInfo>(() => new Amd64.GcInfo(_readyToRunReader.Image, unwindOffset + unwindInfo.Size, _readyToRunReader.Machine, _readyToRunReader.ReadyToRunHeader.MajorVersion));
                     }
                 }
 

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -155,7 +155,7 @@ namespace R2RDump
 
             if (_options.GC && method.GcInfo != null)
             {
-                BaseGcInfo gcInfo = method.GcInfo();
+                BaseGcInfo gcInfo = method.GcInfo;
                 _writer.WriteLine("GC info:");
                 _writer.Write(gcInfo);
 
@@ -227,7 +227,7 @@ namespace R2RDump
                     _writer.WriteLine();
                 }
 
-                BaseGcInfo gcInfo = (_options.HideTransitions ? null : rtf.Method?.GcInfo());
+                BaseGcInfo gcInfo = (_options.HideTransitions ? null : rtf.Method?.GcInfo);
                 if (gcInfo != null && gcInfo.Transitions.TryGetValue(codeOffset, out List<BaseGcTransition> transitionsForOffset))
                 {
                     string[] formattedTransitions = new string[transitionsForOffset.Count];

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -155,12 +155,13 @@ namespace R2RDump
 
             if (_options.GC && method.GcInfo != null)
             {
+                BaseGcInfo gcInfo = method.GcInfo();
                 _writer.WriteLine("GC info:");
-                _writer.Write(method.GcInfo);
+                _writer.Write(gcInfo);
 
                 if (_options.Raw)
                 {
-                    DumpBytes(method.GcInfo.Offset, (uint)method.GcInfo.Size, "", false);
+                    DumpBytes(gcInfo.Offset, (uint)gcInfo.Size, "", false);
                 }
             }
             SkipLine();
@@ -226,7 +227,8 @@ namespace R2RDump
                     _writer.WriteLine();
                 }
 
-                if (!_options.HideTransitions && rtf.Method.GcInfo?.Transitions != null && rtf.Method.GcInfo.Transitions.TryGetValue(codeOffset, out List<BaseGcTransition> transitionsForOffset))
+                BaseGcInfo gcInfo = (_options.HideTransitions ? null : rtf.Method?.GcInfo());
+                if (gcInfo != null && gcInfo.Transitions.TryGetValue(codeOffset, out List<BaseGcTransition> transitionsForOffset))
                 {
                     string[] formattedTransitions = new string[transitionsForOffset.Count];
                     for (int transitionIndex = 0; transitionIndex < formattedTransitions.Length; transitionIndex++)


### PR DESCRIPTION
This change makes it such that GC info is not automatically parsed
for each method, we only store a delegate performing the parsing
that gets called on demand. In practice this also helps us with
working around a bug in GC info previously crashing R2RDump when
emitting PDB in ARM release build mode.

Thanks

Tomas