### PR TITLE
Add code for linker to generate xml warning suppressions when builds fail

### DIFF
--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -28,7 +28,7 @@
       <LinkerNoWarn Condition="'$(TargetOS)' != 'windows'">$(LinkerNoWarn);IL2008</LinkerNoWarn>
       <LinkerNoWarn Condition="'$(Platform)' != 'x64' AND '$(Platform)' != 'arm64'">$(LinkerNoWarn);IL2012</LinkerNoWarn>
       <ILLinkArgs>$(ILLinkArgs) --nowarn $(LinkerNoWarn)</ILLinkArgs>
-      <ILLinkArgs>$(ILLinkArgs) --generate-warning-suppressions xml</ILLinkArgs>
+      <ILLinkArgs Condition="'$(GenerateLinkerWarningSuppressions)' == 'true'">$(ILLinkArgs) --generate-warning-suppressions xml</ILLinkArgs>
     </PropertyGroup>
 
      <!-- Retrieve CoreLib's targetpath via GetTargetPath as it isn't binplaced yet. -->

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -28,6 +28,7 @@
       <LinkerNoWarn Condition="'$(TargetOS)' != 'windows'">$(LinkerNoWarn);IL2008</LinkerNoWarn>
       <LinkerNoWarn Condition="'$(Platform)' != 'x64' AND '$(Platform)' != 'arm64'">$(LinkerNoWarn);IL2012</LinkerNoWarn>
       <ILLinkArgs>$(ILLinkArgs) --nowarn $(LinkerNoWarn)</ILLinkArgs>
+      <ILLinkArgs>$(ILLinkArgs) --generate-warning-suppressions xml</ILLinkArgs>
     </PropertyGroup>
 
      <!-- Retrieve CoreLib's targetpath via GetTargetPath as it isn't binplaced yet. -->


### PR DESCRIPTION
Makes it a bit easier to suppress linker warnings in PRs such as https://github.com/dotnet/runtime/pull/43965/checks?check_run_id=1355002347. With this change the following steps can be taken:

1. Build locally using the command failing in CI, adding `/p:GenerateLinkerWarningSuppressions=true`,
    - e.g. `build.cmd -subset libs -configuration Debug -ci -allConfigurations /p:GenerateLinkerWarningSuppressions=true` from [this failure log](https://dev.azure.com/dnceng/public/_build/results?buildId=875800&view=logs&j=81a0f8c2-d4db-561f-9b8e-3f045280d7fe&t=1cf839b6-61a9-50ad-05e8-14db2dbd38ba&l=11).
2. Find suppression XML file(s) generated to the local/config-dependent equivalent of this location: `runtime\artifacts\bin\ILLinkTrimAssembly\net6.0-windows-Release-x64\trimmed-runtimepack`
3. Move the contents of the generated XML files to the corresponding XML linker suppression file location for the erring assembly (or create one if necessary). e.g, suppression data for warnings in `System.Net.Security` would go to a file named `runtime\src\libraries\System.Net.Security\src\ILLink\ILLink.Suppressions.xml`.
    - Note that there might need to be a build-configuration specific file, e.g. `ILLink.Suppressions.Windows_NT.xml`. See [this code](https://github.com/dotnet/runtime/blob/c4feddbc1d7031a083523d158fe61cb42f6af6fc/eng/illink.targets#L49-L51) for some existing conventions. A new convention might need to be added, depending on the failing scenario. Also see https://github.com/dotnet/runtime/pull/40691 which added several XML suppression files to address https://github.com/dotnet/runtime/issues/38033.

TODO:

- [ ] Document these steps somewhere appropriate
- [ ] Investigate a way to automatically make such changes (e.g. an MSBuild target). We should be sure not to lower the bar for adding new linker-unfriendly code as a result.