### PR TITLE
Forbid `- byref cnst` -> `+ (byref -cnst)` transformation.

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13354,7 +13354,7 @@ DONE_MORPHING_CHILDREN:
                 /* Check for "op1 - cns2" , we change it to "op1 + (-cns2)" */
 
                 noway_assert(op2);
-                if (op2->IsCnsIntOrI() && varTypeIsIntOrI(op2))
+                if (op2->IsCnsIntOrI() && !op2->IsIConHandle())
                 {
                     // Negate the constant and change the node to be "+",
                     // except when `op2` is a const byref.

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13354,7 +13354,7 @@ DONE_MORPHING_CHILDREN:
                 /* Check for "op1 - cns2" , we change it to "op1 + (-cns2)" */
 
                 noway_assert(op2);
-                if (op2->IsCnsIntOrI() && !op2->IsIConHandle())
+                if (op2->IsCnsIntOrI() && !op2->IsIconHandle())
                 {
                     // Negate the constant and change the node to be "+",
                     // except when `op2` is a const byref.

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13354,9 +13354,10 @@ DONE_MORPHING_CHILDREN:
                 /* Check for "op1 - cns2" , we change it to "op1 + (-cns2)" */
 
                 noway_assert(op2);
-                if (op2->IsCnsIntOrI())
+                if (op2->IsCnsIntOrI() && varTypeIsIntOrI(op2))
                 {
-                    /* Negate the constant and change the node to be "+" */
+                    // Negate the constant and change the node to be "+",
+                    // except when `op2` is a const byref.
 
                     op2->AsIntConCommon()->SetIconValue(-op2->AsIntConCommon()->IconValue());
                     op2->AsIntConRef().gtFieldSeq = FieldSeqStore::NotAField();

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.il
@@ -37,8 +37,14 @@
     call native int a::byrefsubbyref(class ctest&, class ctest&)
     stloc V_3
     ldloc V_3
-    call       void [System.Console]System.Console::WriteLine(int32)
+    call       void a::KeepA(native int)
     ldc.i4.s   100    
+    ret
+  }
+  
+  .method public hidebysig static void  KeepA(native int a) cil managed noinlining
+  {
+    .maxstack  8
     ret
   }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.il
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This test shows an inlining of `byref LCL_VAR_ADDR - byref CNST_INT` method that returns a native int.
+// However, Jit could try to optimize `-` as `+ -CNST_INT` that could lead to an incorrect `long + (-byref)`.
+
+.assembly extern System.Console {}
+.assembly extern legacy library mscorlib {}
+.assembly byrefsubbyref1 { }
+.class a extends [mscorlib]System.Object
+{
+  .field static class ctest S_1
+  .method public static native int byrefsubbyref(class ctest& V_1, class ctest& V_2) aggressiveinlining
+  {
+    ldarg 0
+    ldarg 1
+    sub
+    ret
+  }
+
+  .method public static int32 main() cil managed
+  {
+    .entrypoint
+    .maxstack  2
+    .locals init (class ctest V_1,
+             class ctest V_2,
+             native int V_3)
+    newobj     instance void ctest::.ctor()
+    stloc.0
+    newobj     instance void ctest::.ctor()
+    dup
+    stsfld class ctest a::S_1
+    stloc.1
+
+    ldloca V_1
+    ldsflda class ctest a::S_1
+    call native int a::byrefsubbyref(class ctest&, class ctest&)
+    stloc V_3
+    ldloc V_3
+    ret
+  }
+}
+
+.class private auto ansi ctest
+       extends [mscorlib]System.Object
+{
+  .method public specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    .maxstack  1
+    ldarg.0
+    call       instance void [mscorlib]System.Object::.ctor()
+    ret
+  } 
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.il
@@ -37,6 +37,8 @@
     call native int a::byrefsubbyref(class ctest&, class ctest&)
     stloc V_3
     ldloc V_3
+    call       void [System.Console]System.Console::WriteLine(int32)
+    ldc.i4.s   100    
     ret
   }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44266/Runtime_44266.ilproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
+    <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This came up during #43386 work, 
if we declare a method that subs 2 addresses and returns native int:
```
  .method public static native int byrefsubbyref(class ctest& V_1, class ctest& V_2) aggressiveinlining
  {
    ldarg 0
    ldarg 1
    sub
    ret
  }
```
and pass to it  a local var addr (will be represented as long on x64) and a const byref:
```
               [000040] ------------              *  SUB       long  
               [000037] ------------              +--*  ADDR      long  // not sure why this is not a byref...
               [000038] -------N----              |  \--*  LCL_VAR   ref    V00 loc0         
               [000039] H-----------              \--*  CNS_INT(h) byref  0x1f6a1802cb8 static Fseq[S_1]
```
and if morph transforms `SUB` to `ADD` with `-` on  `[000039]` we will get:
```
N004 (  6, 14) [000040] ------------              \--*  ADD       long   $300
N002 (  3,  3) [000037] ------------                 +--*  ADDR      long   $2c0
N001 (  3,  2) [000038] ----G--N----                 |  \--*  LCL_VAR   ref   (AX) V00 loc0          $280
N003 (  2, 10) [000039] H-----------                 \--*  CNS_INT(h) byref  -0x1f6a1802cb8 static $142
```
then this tree will trigger an assert `Make sure a GC address doesn't end up in 'rv2'` when we try to create an addr mode from it.

The PR fixes it by forbidding `SUB(A, CNST)` -> `ADD(A, -CNST)` transformation for byrefs.

[oldJit.NewTest.BeforeTheFix.txt](https://github.com/dotnet/runtime/files/5491239/oldJit.NewTest.BeforeTheFix.txt)
[oldJit.NewTest.AfterTheFix.txt](https://github.com/dotnet/runtime/files/5491240/oldJit.NewTest.AfterTheFix.txt)
