### PR TITLE
Http version test cleanup

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/DribbleStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/DribbleStream.cs
@@ -10,42 +10,28 @@ namespace System.Net.Http.Functional.Tests
     public sealed class DribbleStream : Stream
     {
         private readonly Stream _wrapped;
-        private readonly bool _clientDisconnectAllowed;
 
-        public DribbleStream(Stream wrapped, bool clientDisconnectAllowed = false)
+        public DribbleStream(Stream wrapped)
         {
             _wrapped = wrapped;
-            _clientDisconnectAllowed = clientDisconnectAllowed;
         }
 
         public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            try
+            for (int i = 0; i < count; i++)
             {
-                for (int i = 0; i < count; i++)
-                {
-                    await _wrapped.WriteAsync(buffer, offset + i, 1);
-                    await _wrapped.FlushAsync();
-                    await Task.Yield(); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
-                }
-            }
-            catch (IOException) when (_clientDisconnectAllowed)
-            {
+                await _wrapped.WriteAsync(buffer, offset + i, 1);
+                await _wrapped.FlushAsync();
+                await Task.Yield(); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
             }
         }
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            try
+            for (int i = 0; i < count; i++)
             {
-                for (int i = 0; i < count; i++)
-                {
-                    _wrapped.Write(buffer, offset + i, 1);
-                    _wrapped.Flush();
-                }
-            }
-            catch (IOException) when (_clientDisconnectAllowed)
-            {
+                _wrapped.Write(buffer, offset + i, 1);
+                _wrapped.Flush();
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -493,6 +493,5 @@ namespace System.Net.Http.Functional.Tests
         public HttpProtocolTests_Dribble(ITestOutputHelper output) : base(output) { }
 
         protected override Stream GetStream(Stream s) => new DribbleStream(s);
-        protected override Stream GetStream_ClientDisconnectOk(Stream s) => new DribbleStream(s, true);
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -207,7 +207,7 @@ namespace System.Net.Http.Functional.Tests
                         server.AcceptConnectionSendCustomResponseAndCloseAsync(
                             $"HTTP/{responseMajorVersion}.{responseMinorVersion} 200 OK\r\nConnection: close\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
 
-                    await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
+                    await Assert.ThrowsAsync<HttpRequestException>(() => getResponseTask);
                 }
             }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -186,29 +186,9 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(9)]
-        public async Task GetAsync_ResponseVersion0X_ThrowsOr10(int responseMinorVersion)
-        {
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
-            {
-                using (HttpClient client = CreateHttpClient())
-                {
-                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
-                    request.Version = HttpVersion.Version11;
-
-                    Task<HttpResponseMessage> getResponseTask = client.SendAsync(TestAsync, request);
-                    Task<List<string>> serverTask =
-                        server.AcceptConnectionSendCustomResponseAndCloseAsync(
-                            $"HTTP/0.{responseMinorVersion} 200 OK\r\nConnection: close\r\nDate: {DateTimeOffset.UtcNow:R}\r\nContent-Length: 0\r\n\r\n");
-
-                    await Assert.ThrowsAsync<HttpRequestException>(async () => await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask));
-                }
-            }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
-        }
-
-        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 1)]
+        [InlineData(0, 9)]
         [InlineData(2, 0)]
         [InlineData(2, 1)]
         [InlineData(3, 0)]

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -118,7 +118,7 @@ namespace System.Net.Http.Functional.Tests
                     var requestLines = await serverTask;
                     Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
                 }
-            }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
+            });
         }
 
         [Theory]

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -15,7 +15,6 @@ namespace System.Net.Http.Functional.Tests
     public abstract class HttpProtocolTests : HttpClientHandlerTestBase
     {
         protected virtual Stream GetStream(Stream s) => s;
-        protected virtual Stream GetStream_ClientDisconnectOk(Stream s) => s;
 
         public HttpProtocolTests(ITestOutputHelper output) : base(output) { }
 
@@ -209,7 +208,7 @@ namespace System.Net.Http.Functional.Tests
 
                     await Assert.ThrowsAsync<HttpRequestException>(() => getResponseTask);
                 }
-            }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         [Theory]

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -118,7 +118,7 @@ namespace System.Net.Http.Functional.Tests
                     var requestLines = await serverTask;
                     Assert.Equal($"GET {url.PathAndQuery} HTTP/1.1", requestLines[0]);
                 }
-            });
+            }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
         [Theory]


### PR DESCRIPTION
Remove some dead code (likely left over from CurlHandler removal)
Minor test cleanup/consolidation
Remove "clientDisconnectAllowed" logic from DribbleStream 