### PR TITLE
Ctor_SafeHandle_BasicPropertiesPropagate_Success: improve raw packet case.

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
@@ -269,6 +269,15 @@ namespace System.Net.Sockets.Tests
         [InlineData(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified)]
         public void Ctor_SafeHandle_BasicPropertiesPropagate_Success(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
+            bool isRawPacket = (addressFamily == AddressFamily.Packet) &&
+                               (socketType == SocketType.Raw);
+            if (isRawPacket)
+            {
+                // protocol is the IEEE 802.3 protocol number in network byte order.
+                const short ETH_P_ARP = 0x0806;
+                protocolType = (ProtocolType)IPAddress.HostToNetworkOrder(ETH_P_ARP);
+            }
+
             Socket tmpOrig;
             try
             {
@@ -332,7 +341,13 @@ namespace System.Net.Sockets.Tests
 
             Assert.Equal(addressFamily, copy.AddressFamily);
             Assert.Equal(socketType, copy.SocketType);
-            Assert.Equal(protocolType, copy.ProtocolType);
+            ProtocolType expectedProtocolType = protocolType;
+            if (isRawPacket)
+            {
+                // raw packet doesn't support getting the protocol using getsockopt SO_PROTOCOL.
+                expectedProtocolType = ProtocolType.Unspecified;
+            }
+            Assert.Equal(expectedProtocolType, copy.ProtocolType);
 
             Assert.True(orig.Blocking);
             Assert.True(copy.Blocking);


### PR DESCRIPTION
Fix expected value for ProtocolType when a new Socket is created from
an existing raw packet socket Handle. This assert isn't checked unless
the test runs as root.

And use a proper value for the ProtocolType when the Socket is created.

cc @wfurt @antonfirsov 