### PR TITLE
Workaround xunit bug for disabling FileStreamStandaloneConformanceTests

### DIFF
--- a/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 namespace System.IO.Tests
 {
     /// <summary>Base class providing tests for any Stream-derived type.</summary>
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))] // lots of operations aren't supported on browser
+    [PlatformSpecific(~TestPlatforms.Browser)] // lots of operations aren't supported on browser
     public abstract class StreamConformanceTests : FileCleanupTestBase
     {
         /// <summary>Gets the name of the byte[] argument to Read/Write methods.</summary>

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.cs
@@ -44,6 +44,7 @@ namespace System.IO.Tests
     }
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34583", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+    [PlatformSpecific(~TestPlatforms.Browser)] // copied from base class due to https://github.com/xunit/xunit/issues/2186
     public class UnbufferedAsyncFileStreamStandaloneConformanceTests : FileStreamStandaloneConformanceTests
     {
         protected override FileOptions Options => FileOptions.Asynchronous;
@@ -51,6 +52,7 @@ namespace System.IO.Tests
     }
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34583", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+    [PlatformSpecific(~TestPlatforms.Browser)] // copied from base class due to https://github.com/xunit/xunit/issues/2186
     public class BufferedAsyncFileStreamStandaloneConformanceTests : FileStreamStandaloneConformanceTests
     {
         protected override FileOptions Options => FileOptions.Asynchronous;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44214, working around https://github.com/xunit/xunit/issues/2186