### PR TITLE
LongProcessNamesAreSupported: make test work on distros where sleep is a symlink/script

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -162,9 +162,7 @@ namespace System.Diagnostics.Tests
             string scriptName = GetTestFileName();
             string filename = Path.Combine(TestDirectory, scriptName);
             File.WriteAllText(filename, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
-            // set x-bit
-            int mode = Convert.ToInt32("744", 8);
-            Assert.Equal(0, chmod(filename, mode));
+            ChMod(filename, "744"); // set x-bit
 
             using (var process = Process.Start(new ProcessStartInfo { FileName = filename }))
             {
@@ -198,8 +196,7 @@ namespace System.Diagnostics.Tests
             // Create a file that has the x-bit set, but which isn't a valid script.
             string filename = WriteScriptFile(TestDirectory, GetTestFileName(), returnValue: 0);
             File.WriteAllText(filename, $"not a script");
-            int mode = Convert.ToInt32("744", 8);
-            Assert.Equal(0, chmod(filename, mode));
+            ChMod(filename, "744"); // set x-bit
 
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["PATH"] = path;
@@ -482,9 +479,7 @@ namespace System.Diagnostics.Tests
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
-            int mode = Convert.ToInt32("644", 8);
-
-            Assert.Equal(0, chmod(path, mode));
+            ChMod(path, "644");
 
             Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
             Assert.NotEqual(0, e.NativeErrorCode);
@@ -495,9 +490,7 @@ namespace System.Diagnostics.Tests
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
-            int mode = Convert.ToInt32("744", 8);
-
-            Assert.Equal(0, chmod(path, mode)); // execute permissions
+            ChMod(path, "744"); // set x-bit
 
             Win32Exception e = Assert.Throws<Win32Exception>(() => Process.Start(path));
             Assert.NotEqual(0, e.NativeErrorCode);
@@ -899,6 +892,11 @@ namespace System.Diagnostics.Tests
         [DllImport("libc")]
         private static extern int chmod(string path, int mode);
 
+        private static void ChMod(string filename, string mode)
+        {
+            Assert.Equal(0, chmod(filename, Convert.ToInt32(mode, 8)));
+        }
+
         [DllImport("libc")]
         private static extern uint geteuid();
         [DllImport("libc")]
@@ -946,9 +944,7 @@ namespace System.Diagnostics.Tests
         {
             string filename = Path.Combine(directory, name);
             File.WriteAllText(filename, $"#!/bin/sh\nexit {returnValue}\n");
-            // set x-bit
-            int mode = Convert.ToInt32("744", 8);
-            Assert.Equal(0, chmod(filename, mode));
+            ChMod(filename, "744"); // set x-bit
             return filename;
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 
 namespace System.Diagnostics.Tests
@@ -14,5 +15,8 @@ namespace System.Diagnostics.Tests
             File.WriteAllText(filename, $"exit {returnValue}");
             return filename;
         }
+
+        private static void ChMod(string filename, string mode)
+            => throw new PlatformNotSupportedException();
     }
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1969,8 +1969,7 @@ namespace System.Diagnostics.Tests
             {
                 // On some distros sleep is implemented using a script/symlink, which causes this test to fail.
                 // Instead of using sleep directly, we wrap it with a script.
-                string scriptName = GetTestFileName();
-                sleepPath = Path.Combine(TestDirectory, scriptName);
+                string sleepPath = GetTestFilePath();
                 File.WriteAllText(sleepPath, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
                 ChMod(sleepPath, "744");
             }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1969,7 +1969,7 @@ namespace System.Diagnostics.Tests
             {
                 // On some distros sleep is implemented using a script/symlink, which causes this test to fail.
                 // Instead of using sleep directly, we wrap it with a script.
-                string sleepPath = GetTestFilePath();
+                sleepPath = GetTestFilePath();
                 File.WriteAllText(sleepPath, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
                 ChMod(sleepPath, "744");
             }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1964,23 +1964,28 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void LongProcessNamesAreSupported()
         {
-            // Alpine implements sleep as a symlink to the busybox executable.
-            // If we rename it, the program will no longer sleep.
-            if (PlatformDetection.IsAlpine)
+            string sleepPath;
+            if (OperatingSystem.IsLinux())
             {
-                return;
+                // On some distros sleep is implemented using a script/symlink, which causes this test to fail.
+                // Instead of using sleep directly, we wrap it with a script.
+                string scriptName = GetTestFileName();
+                sleepPath = Path.Combine(TestDirectory, scriptName);
+                File.WriteAllText(sleepPath, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
+                ChMod(sleepPath, "744");
             }
-
-            string programPath = GetProgramPath("sleep");
-
-            if (programPath == null)
+            else
             {
-                return;
+                sleepPath = GetProgramPath("sleep");
+                if (sleepPath == null)
+                {
+                    return;
+                }
             }
 
             const string LongProcessName = "123456789012345678901234567890";
             string sleepCommandPathFileName = Path.Combine(TestDirectory, LongProcessName);
-            File.Copy(programPath, sleepCommandPathFileName);
+            File.Copy(sleepPath, sleepCommandPathFileName);
 
             using (Process px = Process.Start(sleepCommandPathFileName, "600"))
             {


### PR DESCRIPTION
cc @wfurt 