### PR TITLE
File.Exists() is not null when true

### DIFF
--- a/src/libraries/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -23,7 +23,7 @@ namespace System.IO
         public static System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern) { throw null; }
         public static System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, System.IO.EnumerationOptions enumerationOptions) { throw null; }
         public static System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, System.IO.SearchOption searchOption) { throw null; }
-        public static bool Exists(string? path) { throw null; }
+        public static bool Exists([NotNullWhen(true)] string? path) { throw null; }
         public static System.DateTime GetCreationTime(string path) { throw null; }
         public static System.DateTime GetCreationTimeUtc(string path) { throw null; }
         public static string GetCurrentDirectory() { throw null; }

--- a/src/libraries/System.IO.FileSystem/ref/System.IO.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/ref/System.IO.FileSystem.cs
@@ -23,7 +23,7 @@ namespace System.IO
         public static System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern) { throw null; }
         public static System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, System.IO.EnumerationOptions enumerationOptions) { throw null; }
         public static System.Collections.Generic.IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, System.IO.SearchOption searchOption) { throw null; }
-        public static bool Exists([NotNullWhen(true)] string? path) { throw null; }
+        public static bool Exists([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? path) { throw null; }
         public static System.DateTime GetCreationTime(string path) { throw null; }
         public static System.DateTime GetCreationTimeUtc(string path) { throw null; }
         public static string GetCurrentDirectory() { throw null; }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Runtime.Versioning;

--- a/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
@@ -114,7 +114,7 @@ namespace System.IO
         // given by the specified path exists; otherwise, the result is
         // false.  Note that if path describes a directory,
         // Exists will return true.
-        public static bool Exists(string? path)
+        public static bool Exists([NotNullWhen(true)] string? path)
         {
             try
             {

--- a/src/libraries/System.Private.CoreLib/src/Internal/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/IO/File.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Security;
 using System.IO;
 

--- a/src/libraries/System.Private.CoreLib/src/Internal/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/IO/File.cs
@@ -18,7 +18,7 @@ namespace Internal.IO
         // given by the specified path exists; otherwise, the result is
         // false.  Note that if path describes a directory,
         // Exists will return true.
-        public static bool Exists(string? path)
+        public static bool Exists([NotNullWhen(true)] string? path)
         {
             try
             {


### PR DESCRIPTION
Addresses a scenario like:
```c#
    class Program
    {
        static async Task Main(string[] args)
        {
            if (args.Length != 1)
            {
                Console.WriteLine("...");
                return;
            }

            var inputPath = args[0]; // inputPath is defined as 'string?' and could be null.

            if (!File.Exists(inputPath))
            {
                Console.WriteLine("...");
                return;
            }

            // Since the file exists the inputPath is not null and no compiler warnings should be issued.
            using var inputFile = new StreamReader(inputPath);

            ...
        }
    }
```