### PR TITLE
[iOS] Fix build for Xcode 12.1

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -221,7 +221,7 @@
     </ItemGroup>
     <!-- iOS simulator specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' == 'true'">
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,gac"/>
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,gac,eventpipe"/>
     </ItemGroup>
     <!-- iOS device specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true'">
@@ -251,7 +251,7 @@
       <_MonoCMakeArgs Condition="'$(Platform)' == 'arm'" Include="-DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a" />
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x86'" Include="-DCMAKE_ANDROID_ARCH_ABI=x86" />
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x64'" Include="-DCMAKE_ANDROID_ARCH_ABI=x86_64" />
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,portability,attach,verifier,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac,cfgdir_config" />
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,portability,attach,verifier,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac,cfgdir_config,eventpipe" />
       <_MonoCMakeArgs Include="-DENABLE_SIGALTSTACK=1"/>
       <_MonoCMakeArgs Include="-DDISABLE_CRASH_REPORTING=1"/>
       <_MonoCMakeArgs Include="-DENABLE_PERFTRACING=0"/>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -251,7 +251,7 @@
       <_MonoCMakeArgs Condition="'$(Platform)' == 'arm'" Include="-DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a" />
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x86'" Include="-DCMAKE_ANDROID_ARCH_ABI=x86" />
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x64'" Include="-DCMAKE_ANDROID_ARCH_ABI=x86_64" />
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,portability,attach,verifier,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac,cfgdir_config,eventpipe" />
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,portability,attach,verifier,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac,cfgdir_config" />
       <_MonoCMakeArgs Include="-DENABLE_SIGALTSTACK=1"/>
       <_MonoCMakeArgs Include="-DDISABLE_CRASH_REPORTING=1"/>
       <_MonoCMakeArgs Include="-DENABLE_PERFTRACING=0"/>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -221,7 +221,7 @@
     </ItemGroup>
     <!-- iOS simulator specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' == 'true'">
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,gac,eventpipe"/>
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,gac"/>
     </ItemGroup>
     <!-- iOS device specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true'">

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -15,7 +15,7 @@ runtimepack:
 
 run: clean appbuilder
 	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH) \
-	/p:UseLLVM=$(USE_LLVM) /p:UseAotForSimulator=true
+	/p:UseLLVM=$(USE_LLVM) /p:UseAotForSimulator=false
 
 clean:
 	rm -rf bin

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/Xcode.cs
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/Xcode.cs
@@ -100,9 +100,7 @@ internal class Xcode
             .Append(" -B").Append(projectName)
             .Append(" -GXcode")
             .Append(" -DCMAKE_SYSTEM_NAME=iOS")
-            .Append(" \"-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64\"")
-            .Append(" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.1")
-            .Append(" -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO");
+            .Append(" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.1");
 
         File.WriteAllText(Path.Combine(binDir, "runtime.h"),
             Utils.GetEmbeddedResource("runtime.h"));
@@ -134,7 +132,7 @@ internal class Xcode
     {
         string sdk = "";
         var args = new StringBuilder();
-        args.Append("ONLY_ACTIVE_ARCH=NO");
+        args.Append("ONLY_ACTIVE_ARCH=YES");
         if (architecture == "arm64")
         {
             sdk = "iphoneos";


### PR DESCRIPTION
1) Disable eventpipe for mobiles for now (it used to be disabled on our previous build system)
2) XCode 12 prefers arm64 even for simulators now (see https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios)
3) Disable AOT for sim by default