### PR TITLE
Turn off performance PR runs

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -19,7 +19,7 @@ trigger:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
   
-pr: none
+#pr: none
 
 jobs:
 #


### PR DESCRIPTION
I accidently left pr runs on for the performance jobs. This turns them off.