### PR TITLE
[mono][jit] Emit profiler enter after jit attach; leave before detach

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10594,7 +10594,7 @@ field_access_end:
 				MONO_START_BB (cfg, next_bb);
 			} else {
 				if (token == MONO_JIT_ICALL_mono_threads_detach_coop) {
-					/* can't emit profilng code after a detach, so emit it now */
+					/* can't emit profiling code after a detach, so emit it now */
 					mini_profiler_emit_leave (cfg, NULL);
 					detached_before_ret = TRUE;
 				}
@@ -11597,6 +11597,7 @@ mono_ldptr:
 	/* emit profiler enter code after a jit attach if there is one */
 	cfg->cbb = init_localsbb2;
 	mini_profiler_emit_enter (cfg);
+	cfg->cbb = init_localsbb;
 
 	if (seq_points) {
 		MonoBasicBlock *bb;


### PR DESCRIPTION
profiler enter code (such as mono_trace_enter_method) must not be called before a thread attaches to the runtime - otherwise calls like `mono_domain_get()` will return NULL unexpectedly and then crash.
When detaching, we should call the profiler leave code before the detach, and suppress it on return.

Simple repro (that relies on pal_signal.c SignalHandlerLoop - which is a background thread from System.Native that calls back into managed when there's a SIGCHLD): compile and run this program with `MONO_ENV_OPTIONS=--trace`

```csharp
using System;
using System.Diagnostics;

namespace Repro
{
    internal class Program
    {
        private static void Main(string[] args)
        {
            using (Process myProcess = new Process())
            {
                    myProcess.StartInfo.UseShellExecute = true;
                    myProcess.StartInfo.FileName = "echo";
                    myProcess.StartInfo.Arguments = "hello from shell";
                    myProcess.StartInfo.CreateNoWindow = true;
                    myProcess.Start();
                    myProcess.WaitForExit();
            }
            Console.ReadKey ();
        }
    }
}
```