### PR TITLE
Improve performance of Enum's generic IsDefined / GetName / GetValues / GetNames

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -258,11 +258,26 @@ namespace System
             return result;
         }
 
+        private static ulong ToUInt64<TEnum>(TEnum value) where TEnum : struct, Enum =>
+            Type.GetTypeCode(typeof(TEnum)) switch
+            {
+                TypeCode.SByte => (ulong)Unsafe.As<TEnum, sbyte>(ref value),
+                TypeCode.Byte => Unsafe.As<TEnum, byte>(ref value),
+                TypeCode.Boolean => Convert.ToByte(Unsafe.As<TEnum, bool>(ref value)),
+                TypeCode.Int16 => (ulong)Unsafe.As<TEnum, short>(ref value),
+                TypeCode.UInt16 => Unsafe.As<TEnum, ushort>(ref value),
+                TypeCode.Char => Unsafe.As<TEnum, char>(ref value),
+                TypeCode.UInt32 => Unsafe.As<TEnum, uint>(ref value),
+                TypeCode.Int32 => (ulong)Unsafe.As<TEnum, int>(ref value),
+                TypeCode.UInt64 => Unsafe.As<TEnum, ulong>(ref value),
+                TypeCode.Int64 => (ulong)Unsafe.As<TEnum, long>(ref value),
+                _ => throw new InvalidOperationException(SR.InvalidOperation_UnknownEnumType),
+            };
         #endregion
 
         #region Public Static Methods
         public static string? GetName<TEnum>(TEnum value) where TEnum : struct, Enum
-            => GetName(typeof(TEnum), value);
+            => GetEnumName((RuntimeType)typeof(TEnum), ToUInt64(value));
 
         public static string? GetName(Type enumType, object value)
         {
@@ -273,7 +288,7 @@ namespace System
         }
 
         public static string[] GetNames<TEnum>() where TEnum : struct, Enum
-            => GetNames(typeof(TEnum));
+            => new ReadOnlySpan<string>(InternalGetNames((RuntimeType)typeof(TEnum))).ToArray();
 
         public static string[] GetNames(Type enumType)
         {


### PR DESCRIPTION
Eliminates the boxing in IsDefined/GetName/GetValues, in GetValues avoids going through the non-generic Array.SetValue for each value, and in GetNames avoids having to go through RuntimeType's GetEnumNames override.

|    Method |           Toolchain |      Mean | Ratio | Allocated |
|---------- |-------------------- |----------:|------:|----------:|
| IsDefined | \master\corerun.exe |  34.39 ns |  1.00 |      24 B |
| IsDefined |     \pr\corerun.exe |  24.37 ns |  0.70 |         - |
|           |                     |           |       |           |
|   GetName | \master\corerun.exe |  52.31 ns |  1.00 |      24 B |
|   GetName |     \pr\corerun.exe |  25.16 ns |  0.48 |         - |
|           |                     |           |       |           |
|  GetNames | \master\corerun.exe |  37.25 ns |  1.00 |      80 B |
|  GetNames |     \pr\corerun.exe |  22.80 ns |  0.61 |      80 B |
|           |                     |           |       |           |
| GetValues | \master\corerun.exe | 573.06 ns |  1.00 |     224 B |
| GetValues |     \pr\corerun.exe |  19.05 ns |  0.03 |      56 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private DayOfWeek _value = DayOfWeek.Friday;

    [Benchmark]
    public bool IsDefined() => Enum.IsDefined(_value);

    [Benchmark]
    public string GetName() => Enum.GetName(_value);

    [Benchmark]
    public string[] GetNames() => Enum.GetNames<DayOfWeek>();

    [Benchmark]
    public DayOfWeek[] GetValues() => Enum.GetValues<DayOfWeek>();
}
```