### PR TITLE
Fix regex-redux tests to consistently remove newlines

### DIFF
--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-1.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-1.cs
@@ -64,7 +64,7 @@ namespace BenchmarksGame
             int initialLength = sequence.Length;
 
             // remove FASTA sequence descriptions and new-lines
-            Regex r = new Regex(">.*\n|\n", RegexOptions.Compiled);
+            Regex r = new Regex(">.*\n|\n|\r\n", RegexOptions.Compiled);
             sequence = r.Replace(sequence, "");
             int codeLength = sequence.Length;
 

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-5.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-5.cs
@@ -75,7 +75,7 @@ namespace BenchmarksGame
         {
             var sequences = inputReader.ReadToEnd();
             var initialLength = sequences.Length;
-            sequences = Regex.Replace(sequences, ">.*\n|\n", "");
+            sequences = Regex.Replace(sequences, ">.*\n|\n|\r\n", "");
 
             var magicTask = Task.Run(() =>
             {


### PR DESCRIPTION
Need to check for \r\n as well as \n.