### PR TITLE
change `using`  in ConnectCallback_UseUnixDomainSocket_Success

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2476,22 +2476,26 @@ namespace System.Net.Http.Functional.Tests
                 return new NetworkStream(clientSocket, ownsSocket: true);
             };
 
-            using HttpClient client = CreateHttpClient(handler);
-            client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+            using (HttpClient client = CreateHttpClient(handler))
+            {
+                client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
 
-            Task<string> clientTask = client.GetStringAsync($"{(options.UseSsl ? "https" : "http")}://{guid}/foo");
+                Task<string> clientTask = client.GetStringAsync($"{(options.UseSsl ? "https" : "http")}://{guid}/foo");
 
-            Socket serverSocket = await listenSocket.AcceptAsync();
-            using GenericLoopbackConnection loopbackConnection = await LoopbackServerFactory.CreateConnectionAsync(socket: null, new NetworkStream(serverSocket, ownsSocket: true), options);
-            await loopbackConnection.InitializeConnectionAsync();
+                Socket serverSocket = await listenSocket.AcceptAsync();
+                using (GenericLoopbackConnection loopbackConnection = await LoopbackServerFactory.CreateConnectionAsync(socket: null, new NetworkStream(serverSocket, ownsSocket: true), options))
+                {
+                    await loopbackConnection.InitializeConnectionAsync();
 
-            HttpRequestData requestData = await loopbackConnection.ReadRequestDataAsync();
-            Assert.Equal("/foo", requestData.Path);
+                    HttpRequestData requestData = await loopbackConnection.ReadRequestDataAsync();
+                    Assert.Equal("/foo", requestData.Path);
 
-            await loopbackConnection.SendResponseAsync(content: "foo");
+                    await loopbackConnection.SendResponseAsync(content: "foo");
 
-            string response = await clientTask;
-            Assert.Equal("foo", response);
+                    string response = await clientTask;
+                    Assert.Equal("foo", response);
+                }
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Http2.ConnectCallback_UseUnixDomainSocket_Success was failing often for me and there are some CI failures as well. 
We speculated with @geoffkizer about the root cause maybe being Windows implementation since it fails only on Windows. 

I was experimenting with the test to gain more insight to what is going on. Surprisingly changing the test like this PR made failures to vanish. I did ~800 runs since and I did not see a single failure so far. Aside from chain timing I don't really have explanation. I tried to call Dispose explicitly in different order but that did not impact the test.

So I'm putt8ing it up for review as speculative change. If approved I'll watch failures to confirm if this has impact on CI runs as well. 

contributes to #44183