### PR TITLE
add missing QUIC constructor overloads

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -15,6 +15,7 @@ namespace System.Net.Quic
     public sealed class QuicListener : IDisposable
     {
         public QuicListener(IPEndPoint listenEndPoint, System.Net.Security.SslServerAuthenticationOptions sslServerAuthenticationOptions) { throw null; }
+        public QuicListener(QuicListenerOptions options) { throw null; }
         public QuicListener(Implementations.QuicImplementationProvider implementationProvider, IPEndPoint listenEndPoint, System.Net.Security.SslServerAuthenticationOptions sslServerAuthenticationOptions) { throw null; }
         public QuicListener(Implementations.QuicImplementationProvider implementationProvider, QuicListenerOptions options) { throw null; }
         public IPEndPoint ListenEndPoint => throw null;
@@ -37,6 +38,7 @@ namespace System.Net.Quic
     public sealed class QuicConnection : IDisposable
     {
         public QuicConnection(System.Net.EndPoint remoteEndPoint, System.Net.Security.SslClientAuthenticationOptions? sslClientAuthenticationOptions, System.Net.IPEndPoint? localEndPoint = null) { throw null; }
+        public QuicConnection(QuicClientConnectionOptions options) { throw null; }
         public QuicConnection(Implementations.QuicImplementationProvider implementationProvider, System.Net.EndPoint remoteEndPoint, System.Net.Security.SslClientAuthenticationOptions? sslClientAuthenticationOptions, System.Net.IPEndPoint? localEndPoint = null) { throw null; }
         public QuicConnection(Implementations.QuicImplementationProvider implementationProvider, QuicClientConnectionOptions options) { throw null; }
         public bool Connected => throw null;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicClientConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicClientConnectionOptions.cs
@@ -43,7 +43,7 @@ namespace System.Net.Quic
         public long MaxUnidirectionalStreams { get; set; } = 100;
 
         /// <summary>
-        /// Idle timeout for connections, afterwhich the connection will be closed.
+        /// Idle timeout for connections, after which the connection will be closed.
         /// </summary>
         public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(2);
     }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -25,12 +25,22 @@ namespace System.Net.Quic
         {
         }
 
-        // !!! TEMPORARY: Remove "implementationProvider" before shipping
+        /// <summary>
+        /// Create an outbound QUIC connection.
+        /// </summary>
+        /// <param name="options">The connection options.</param>
+        public QuicConnection(QuicClientConnectionOptions options)
+            : this(QuicImplementationProviders.Default, options)
+        {
+        }
+
+        // !!! TEMPORARY: Remove or make internal before shipping
         public QuicConnection(QuicImplementationProvider implementationProvider, EndPoint remoteEndPoint, SslClientAuthenticationOptions? sslClientAuthenticationOptions, IPEndPoint? localEndPoint = null)
             : this(implementationProvider, new QuicClientConnectionOptions() { RemoteEndPoint = remoteEndPoint, ClientAuthenticationOptions = sslClientAuthenticationOptions, LocalEndPoint = localEndPoint })
         {
         }
 
+        // !!! TEMPORARY: Remove or make internal before shipping
         public QuicConnection(QuicImplementationProvider implementationProvider, QuicClientConnectionOptions options)
         {
             _provider = implementationProvider.CreateConnection(options);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -13,7 +13,7 @@ namespace System.Net.Quic
         private readonly QuicListenerProvider _provider;
 
         /// <summary>
-        /// Create a QUIC listener on the specified local endpoint and start listening.
+        /// Create a QUIC listener.
         /// </summary>
         /// <param name="listenEndPoint">The local endpoint to listen on.</param>
         /// <param name="sslServerAuthenticationOptions">TLS options for the listener.</param>
@@ -22,12 +22,22 @@ namespace System.Net.Quic
         {
         }
 
-        // !!! TEMPORARY: Remove "implementationProvider" before shipping
+        /// <summary>
+        /// Create a QUIC listener.
+        /// </summary>
+        /// <param name="options">The listener options.</param>
+        public QuicListener(QuicListenerOptions options)
+            : this(QuicImplementationProviders.Default, options)
+        {
+        }
+
+        // !!! TEMPORARY: Remove or make internal before shipping
         public QuicListener(QuicImplementationProvider implementationProvider, IPEndPoint listenEndPoint, SslServerAuthenticationOptions sslServerAuthenticationOptions)
             : this(implementationProvider,  new QuicListenerOptions() { ListenEndPoint = listenEndPoint, ServerAuthenticationOptions = sslServerAuthenticationOptions })
         {
         }
 
+        // !!! TEMPORARY: Remove or make internal before shipping
         public QuicListener(QuicImplementationProvider implementationProvider, QuicListenerOptions options)
         {
             _provider = implementationProvider.CreateListener(options);


### PR DESCRIPTION
Add overloads that don't require an implementation provider and just use the default provider.

@stephentoub @scalablecory @rzikm 

Edit: Note, System.Net.Quic has not gone through API review yet, so this does not require an approved API change.