### PR TITLE
Fix genEventing.py to generate correct EventEnabled functions

### DIFF
--- a/src/coreclr/src/scripts/genEventing.py
+++ b/src/coreclr/src/scripts/genEventing.py
@@ -274,9 +274,9 @@ def generateClrallEvents(eventNodes,allTemplates):
         clrallEvents.append("EventPipeEventEnabled" + eventName + "()")
 
         if os.name == 'posix':
-            clrallEvents.append("|| (XplatEventLogger::IsEventLoggingEnabled() && EventXplatEnabled" + eventName + "());}\n\n")
+            clrallEvents.append(" || (XplatEventLogger::IsEventLoggingEnabled() && EventXplatEnabled" + eventName + "());}\n\n")
         else:
-            clrallEvents.append(";}\n\n")
+            clrallEvents.append(" || EventXplatEnabled" + eventName + "();}\n\n")
         #generate FireEtw functions
         fnptype     = []
         fnbody      = []


### PR DESCRIPTION
Fix #44383. 

Output (clretwallmain.h) before the change:
```cpp
inline BOOL EventEnabledGCStart_V1() {return EventPipeEventEnabledGCStart_V1();}

inline BOOL EventEnabledGCStart_V2() {return EventPipeEventEnabledGCStart_V2();}

inline BOOL EventEnabledGCEnd() {return EventPipeEventEnabledGCEnd();}
```

Output (clretwallmain.h) after the change:
```cpp
inline BOOL EventEnabledGCStart_V1() {return EventPipeEventEnabledGCStart_V1()|| EventXplatEnabledGCStart_V1();}

inline BOOL EventEnabledGCStart_V2() {return EventPipeEventEnabledGCStart_V2()|| EventXplatEnabledGCStart_V2();}

inline BOOL EventEnabledGCEnd() {return EventPipeEventEnabledGCEnd()|| EventXplatEnabledGCEnd();}
```