### PR TITLE
Disable failing crossgen2smoke_donotalwaysusecrossgen2.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -121,6 +121,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/r2rdump/R2RDumpTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/10888 https://github.com/dotnet/runtime/issues/11823 </Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/readytorun/crossgen2/crossgen2smoke_donotalwaysusecrossgen2/*">
+            <Issue>https://github.com/dotnet/runtime/issues/44234</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->


### PR DESCRIPTION
Revert when https://github.com/dotnet/runtime/issues/44234 is fixed.

Unblocks outerloop.