### PR TITLE
Remove LazyInitializer usage from corelib

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -14,13 +15,18 @@ namespace System.IO
     {
         public static readonly Stream Null = new NullStream();
 
-        /// <summary>To implement Async IO operations on streams that don't support async IO</summary>
-        private SemaphoreSlim? _asyncActiveSemaphore;
+        /// <summary>To serialize async operations on streams that don't implement their own.</summary>
+        private protected SemaphoreSlim? _asyncActiveSemaphore;
 
-        internal SemaphoreSlim EnsureAsyncActiveSemaphoreInitialized() =>
+        [MemberNotNull(nameof(_asyncActiveSemaphore))]
+        private protected SemaphoreSlim EnsureAsyncActiveSemaphoreInitialized() =>
             // Lazily-initialize _asyncActiveSemaphore.  As we're never accessing the SemaphoreSlim's
             // WaitHandle, we don't need to worry about Disposing it in the case of a race condition.
-            LazyInitializer.EnsureInitialized(ref _asyncActiveSemaphore, () => new SemaphoreSlim(1, 1));
+#pragma warning disable CS8774 // We lack a NullIffNull annotation for Volatile.Read
+            Volatile.Read(ref _asyncActiveSemaphore) ??
+#pragma warning restore CS8774
+            Interlocked.CompareExchange(ref _asyncActiveSemaphore, new SemaphoreSlim(1, 1), null) ??
+            _asyncActiveSemaphore;
 
         public abstract bool CanRead { get; }
         public abstract bool CanWrite { get; }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1822,18 +1822,12 @@ namespace System
 
         #endregion
 
-        private TypeCache cache;
+        private TypeCache? cache;
 
-        internal TypeCache Cache
-        {
-            get
-            {
-                if (cache == null)
-                    LazyInitializer.EnsureInitialized(ref cache, () => new TypeCache());
-
-                return cache;
-            }
-        }
+        internal TypeCache Cache =>
+            Volatile.Read(ref cache) ??
+            Interlocked.CompareExchange(ref cache, new TypeCache(), null) ??
+            cache;
 
         internal sealed class TypeCache
         {


### PR DESCRIPTION
It's fine for higher layers, but in corelib we don't want to forcibly prevent LazyInitializer from being trimmed nor pay the overheads of additional cached delegates.

cc: @jkotas