### PR TITLE
Improve nullable annotation on Volatile.Read

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -337,7 +337,7 @@ namespace System.Threading
         public static long VolatileRead(ref long address) => Volatile.Read(ref address);
         public static IntPtr VolatileRead(ref IntPtr address) => Volatile.Read(ref address);
         [return: NotNullIfNotNull("address")]
-        public static object? VolatileRead(ref object? address) => Volatile.Read(ref address);
+        public static object? VolatileRead([NotNullIfNotNull("address")] ref object? address) => Volatile.Read(ref address);
         [CLSCompliant(false)]
         public static sbyte VolatileRead(ref sbyte address) => Volatile.Read(ref address);
         public static float VolatileRead(ref float address) => Volatile.Read(ref address);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -219,7 +219,7 @@ namespace System.Threading
         [Intrinsic]
         [NonVersionable]
         [return: NotNullIfNotNull("location")]
-        public static T Read<T>(ref T location) where T : class? =>
+        public static T Read<T>([NotNullIfNotNull("location")] ref T location) where T : class? =>
             Unsafe.As<T>(Unsafe.As<T, VolatileObject>(ref location).Value);
 
         [Intrinsic]

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -103,7 +103,7 @@ namespace System.Threading
         public static long VolatileRead(ref long address) { throw null; }
         public static System.IntPtr VolatileRead(ref System.IntPtr address) { throw null; }
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("address")]
-        public static object? VolatileRead(ref object? address) { throw null; }
+        public static object? VolatileRead([System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("address")] ref object? address) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static sbyte VolatileRead(ref sbyte address) { throw null; }
         public static float VolatileRead(ref float address) { throw null; }

--- a/src/libraries/System.Threading/ref/System.Threading.cs
+++ b/src/libraries/System.Threading/ref/System.Threading.cs
@@ -478,7 +478,7 @@ namespace System.Threading
         [System.CLSCompliantAttribute(false)]
         public static System.UIntPtr Read(ref System.UIntPtr location) { throw null; }
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("location")]
-        public static T Read<T>(ref T location) where T : class? { throw null; }
+        public static T Read<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("location")] ref T location) where T : class? { throw null; }
         public static void Write(ref bool location, bool value) { }
         public static void Write(ref byte location, byte value) { }
         public static void Write(ref double location, double value) { }


### PR DESCRIPTION
Make it clear to the compiler that Volatile.Read doesn't write to the ref argument, such that if the input was non-null before the call, it'll still be non-null after the call.

cc: @buyaa-n, @krwq 