### PR TITLE
Fix C++ build for mono/metadata/threads.c

### DIFF
--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -1326,13 +1326,13 @@ throw_thread_start_exception (guint32 error_code, MonoError *error)
 {
 	ERROR_DECL (method_error);
 
-	MONO_STATIC_POINTER_INIT (MonoMethod, throw)
+	MONO_STATIC_POINTER_INIT (MonoMethod, throw_method)
 
-	throw = mono_class_get_method_from_name_checked (mono_defaults.thread_class, "ThrowThreadStartException", 1, 0, method_error);
+	throw_method = mono_class_get_method_from_name_checked (mono_defaults.thread_class, "ThrowThreadStartException", 1, 0, method_error);
 	mono_error_assert_ok (method_error);
 
-	MONO_STATIC_POINTER_INIT_END (MonoMethod, throw)
-	g_assert (throw);
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, throw_method)
+	g_assert (throw_method);
 
 	char *msg = g_strdup_printf ("0x%x", error_code);
 	MonoException *ex = mono_get_exception_execution_engine (msg);
@@ -1341,7 +1341,7 @@ throw_thread_start_exception (guint32 error_code, MonoError *error)
 	gpointer args [1];
 	args [0] = ex;
 
-	mono_runtime_invoke_checked (throw, NULL, args, error);
+	mono_runtime_invoke_checked (throw_method, NULL, args, error);
 }
 
 /*


### PR DESCRIPTION
`throw` is a reserved keyword in C++.