### PR TITLE
Disable 2 failing coreclr tests until they are fixed.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -126,6 +126,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294/*">
             <Issue>https://github.com/dotnet/runtime/issues/44341</Issue>
+        </ExcludeList>   
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NativeClients/Dispatch/*">
+            <Issue>https://github.com/dotnet/runtime/issues/44186</Issue>
         </ExcludeList>        
     </ItemGroup>
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -124,6 +124,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/crossgen2/crossgen2smoke_donotalwaysusecrossgen2/*">
             <Issue>https://github.com/dotnet/runtime/issues/44234</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294/*">
+            <Issue>https://github.com/dotnet/runtime/issues/44341</Issue>
+        </ExcludeList>        
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->


### PR DESCRIPTION
The PR disables 2 failing tests. Enable them when they are fixed  https://github.com/dotnet/runtime/issues/44341,  #44186
