### PR TITLE
Support System.Type.Missing arguments for late bound calls to IDynamicObject methods with 8 or more arguments

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/ILLink/ILLink.Suppressions.xml
@@ -113,6 +113,12 @@
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.VisualBasic.CompilerServices.IDOUtils.CreateInvoker(System.Int32)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2075</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:Microsoft.VisualBasic.CompilerServices.LateBinding.InternalLateSet(System.Object,System.Type@,System.String,System.Object[],System.String[],System.Boolean,Microsoft.VisualBasic.CallType)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
@@ -30,6 +30,7 @@
     <Compile Include="Microsoft\VisualBasic\ComClassAttribute.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\BooleanType.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\ByteType.vb" />
+    <Compile Include="Microsoft\VisualBasic\CompilerServices\CacheDict.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\CharType.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\CharArrayType.vb" />
     <Compile Include="Microsoft\VisualBasic\CompilerServices\ConversionResolution.vb" />
@@ -112,6 +113,9 @@
     <Reference Include="System.Linq.Expressions" />
     <Reference Include="System.ObjectModel" />
     <Reference Include="System.Reflection" />
+    <Reference Include="System.Reflection.Emit" />
+    <Reference Include="System.Reflection.Emit.ILGeneration" />
+    <Reference Include="System.Reflection.Emit.Lightweight" />
     <Reference Include="System.Reflection.Extensions" />
     <Reference Include="System.Reflection.Primitives" />
     <Reference Include="System.Reflection.TypeExtensions" />

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/CacheDict.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/CacheDict.vb
@@ -1,0 +1,69 @@
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Imports System.Collections.Generic
+Imports System.Runtime.InteropServices
+
+Namespace Microsoft.VisualBasic.CompilerServices
+
+    ' Implements a MRU collection for caching dynamic methods used in IDO late binding.
+    Friend Class CacheDict(Of TKey, TValue)
+        ' The Dictionary to quickly access cached data
+        Private ReadOnly _dict As Dictionary(Of TKey, KeyInfo)
+        ' MRU sorted linked list
+        Private ReadOnly _list As LinkedList(Of TKey)
+        ' Maximum size
+        Private ReadOnly _maxSize As Integer
+
+        Friend Sub New(ByVal maxSize As Integer)
+            _dict = New Dictionary(Of TKey, KeyInfo)
+            _list = New LinkedList(Of TKey)
+            _maxSize = maxSize
+        End Sub
+
+        Friend Sub Add(ByVal key As TKey, ByVal value As TValue)
+            Dim info As New KeyInfo
+            If _dict.TryGetValue(key, info) Then
+                ' If the key is already in the collection, remove it
+                _list.Remove(info.List)
+            ElseIf (_list.Count = _maxSize) Then
+                ' Age out the last element if we hit the max size
+                Dim last As LinkedListNode(Of TKey) = _list.Last
+                _list.RemoveLast()
+                _dict.Remove(last.Value)
+            End If
+
+            ' Add the new element
+            Dim node As New LinkedListNode(Of TKey)(key)
+            _list.AddFirst(node)
+            _dict.Item(key) = New KeyInfo(value, node)
+        End Sub
+
+        Friend Function TryGetValue(ByVal key As TKey, <Out()> ByRef value As TValue) As Boolean
+            Dim info As New KeyInfo
+            If _dict.TryGetValue(key, info) Then
+                Dim list As LinkedListNode(Of TKey) = info.List
+                If (list.Previous IsNot Nothing) Then
+                    _list.Remove(list)
+                    _list.AddFirst(list)
+                End If
+                value = info.Value
+                Return True
+            End If
+            value = Nothing
+            Return False
+        End Function
+
+        ' KeyInfo to store in the dictionary
+        Private Structure KeyInfo
+            Friend ReadOnly Value As TValue
+            Friend ReadOnly List As LinkedListNode(Of TKey)
+
+            Friend Sub New(ByVal v As TValue, ByVal l As LinkedListNode(Of TKey))
+                Value = v
+                List = l
+            End Sub
+        End Structure
+    End Class
+
+End Namespace

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Microsoft\VisualBasic\MyGroupCollectionAttributeTests.cs" />
     <Compile Include="Microsoft\VisualBasic\VBFixedArrayAttributeTests.cs" />
     <Compile Include="Microsoft\VisualBasic\VBFixedStringAttributeTests.cs" />
+    <Compile Include="NewLateBindingTests.cs" />
     <Compile Include="ObjectTypeTests.cs" />
     <Compile Include="OperatorsTests.cs" />
     <Compile Include="OperatorsTests.Comparison.cs" />

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/NewLateBindingTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/NewLateBindingTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using Xunit;
+
+namespace Microsoft.VisualBasic.CompilerServices.Tests
+{
+    public class NewLateBindingTests
+    {
+        private sealed class OptionalValuesType : DynamicObject
+        {
+            public object F1<T>(T p1 = default)
+            {
+                return $"{typeof(T)}, {ToString(p1)}";
+            }
+            public object F2<T>(T p1 = default, int? p2 = 2)
+            {
+                return $"{typeof(T)}, {ToString(p1)}, {ToString(p2)}";
+            }
+            public object F3<T>(object p1, T p2 = default, int? p3 = 3)
+            {
+                return $"{typeof(T)}, {ToString(p2)}, {ToString(p3)}";
+            }
+            public object F4<T>(object p1, object p2, T p3 = default, int? p4 = 4)
+            {
+                return $"{typeof(T)}, {ToString(p3)}, {ToString(p4)}";
+            }
+            public object F5<T>(object p1, object p2, object p3, T p4 = default, int? p5 = 5)
+            {
+                return $"{typeof(T)}, {ToString(p4)}, {ToString(p5)}";
+            }
+            public object F6<T>(object p1, object p2, object p3, object p4, T p5 = default, int? p6 = 6)
+            {
+                return $"{typeof(T)}, {ToString(p5)}, {ToString(p6)}";
+            }
+            public object F7<T>(object p1, object p2, object p3, object p4, object p5, T p6 = default, int? p7 = 7)
+            {
+                return $"{typeof(T)}, {ToString(p6)}, {ToString(p7)}";
+            }
+            public object F8<T>(object p1, object p2, object p3, object p4, object p5, object p6, T p7 = default, int? p8 = 8)
+            {
+                return $"{typeof(T)}, {ToString(p7)}, {ToString(p8)}";
+            }
+            private static string ToString(object obj) => obj?.ToString() ?? "null";
+        }
+
+        public static IEnumerable<object[]> LateCall_OptionalValues_Data()
+        {
+            // If System.Type.Missing is used for a parameter with type parameter type,
+            // System.Reflection.Missing is used in type inference. This matches .NET Framework behavior.
+
+            yield return CreateData("F1", new object[] { -1 }, null, "System.Int32, -1");
+            yield return CreateData("F1", new object[] { Type.Missing }, null, "System.Reflection.Missing, null");
+            yield return CreateData("F1", new object[] { Type.Missing }, new[] { typeof(int) }, "System.Int32, 0");
+
+            yield return CreateData("F2", new object[] { 1, -1 }, null, "System.Int32, 1, -1");
+            yield return CreateData("F2", new object[] { 1, Type.Missing }, null, "System.Int32, 1, 2");
+            yield return CreateData("F2", new object[] { Type.Missing, Type.Missing }, null, "System.Reflection.Missing, null, 2");
+            yield return CreateData("F2", new object[] { Type.Missing, Type.Missing }, new[] { typeof(int) }, "System.Int32, 0, 2");
+
+            yield return CreateData("F3", new object[] { 1, 2, -1 }, null, "System.Int32, 2, -1");
+            yield return CreateData("F3", new object[] { 1, 2, Type.Missing }, null, "System.Int32, 2, 3");
+            yield return CreateData("F3", new object[] { 1, Type.Missing, Type.Missing }, null, "System.Reflection.Missing, null, 3");
+            yield return CreateData("F3", new object[] { 1, Type.Missing, Type.Missing }, new[] { typeof(int) }, "System.Int32, 0, 3");
+
+            yield return CreateData("F4", new object[] { 1, 2, 3, -1 }, null, "System.Int32, 3, -1");
+            yield return CreateData("F4", new object[] { 1, 2, 3, Type.Missing }, null, "System.Int32, 3, 4");
+            yield return CreateData("F4", new object[] { 1, 2, Type.Missing, Type.Missing }, null, "System.Reflection.Missing, null, 4");
+            yield return CreateData("F4", new object[] { 1, 2, Type.Missing, Type.Missing }, new[] { typeof(int) }, "System.Int32, 0, 4");
+
+            yield return CreateData("F5", new object[] { 1, 2, 3, 4, -1 }, null, "System.Int32, 4, -1");
+            yield return CreateData("F5", new object[] { 1, 2, 3, 4, Type.Missing }, null, "System.Int32, 4, 5");
+            yield return CreateData("F5", new object[] { 1, 2, 3, Type.Missing, Type.Missing }, null, "System.Reflection.Missing, null, 5");
+            yield return CreateData("F5", new object[] { 1, 2, 3, Type.Missing, Type.Missing }, new[] { typeof(int) }, "System.Int32, 0, 5");
+
+            yield return CreateData("F6", new object[] { 1, 2, 3, 4, 5, -1 }, null, "System.Int32, 5, -1");
+            yield return CreateData("F6", new object[] { 1, 2, 3, 4, 5, Type.Missing }, null, "System.Int32, 5, 6");
+            yield return CreateData("F6", new object[] { 1, 2, 3, 4, Type.Missing, Type.Missing }, null, "System.Reflection.Missing, null, 6");
+            yield return CreateData("F6", new object[] { 1, 2, 3, 4, Type.Missing, Type.Missing }, new[] { typeof(int) }, "System.Int32, 0, 6");
+
+            yield return CreateData("F7", new object[] { 1, 2, 3, 4, 5, 6, -1 }, null, "System.Int32, 6, -1");
+            yield return CreateData("F7", new object[] { 1, 2, 3, 4, 5, 6, Type.Missing }, null, "System.Int32, 6, 7");
+            yield return CreateData("F7", new object[] { 1, 2, 3, 4, 5, Type.Missing, Type.Missing }, null, "System.Reflection.Missing, null, 7");
+            yield return CreateData("F7", new object[] { 1, 2, 3, 4, 5, Type.Missing, Type.Missing }, new[] { typeof(int) }, "System.Int32, 0, 7");
+
+            yield return CreateData("F8", new object[] { 1, 2, 3, 4, 5, 6, 7, -1 }, null, "System.Int32, 7, -1");
+            yield return CreateData("F8", new object[] { 1, 2, 3, 4, 5, 6, 7, Type.Missing }, null, "System.Int32, 7, 8");
+            yield return CreateData("F8", new object[] { 1, 2, 3, 4, 5, 6, Type.Missing, Type.Missing }, null, "System.Reflection.Missing, null, 8");
+            yield return CreateData("F8", new object[] { 1, 2, 3, 4, 5, 6, Type.Missing, Type.Missing }, new[] { typeof(int) }, "System.Int32, 0, 8");
+
+            static object[] CreateData(string memberName, object[] arguments, Type[] typeArguments, string expectedValue) => new object[] { memberName, arguments, typeArguments, expectedValue };
+        }
+
+        [Theory]
+        [MemberData(nameof(LateCall_OptionalValues_Data))]
+        public void LateCall_OptionalValues(string memberName, object[] arguments, Type[] typeArguments, string expectedValue)
+        {
+            // NewLateBinding.LateCall() corresponds to a call to the member when using late binding:
+            //   Dim instance = New OptionalValuesType()
+            //   instance.Member(arguments)
+            var actualValue = NewLateBinding.LateCall(
+                Instance: new OptionalValuesType(),
+                Type: null,
+                MemberName: memberName,
+                Arguments: arguments,
+                ArgumentNames: null,
+                TypeArguments: typeArguments,
+                CopyBack: null,
+                IgnoreReturn: true);
+            Assert.Equal(expectedValue, actualValue);
+        }
+    }
+}


### PR DESCRIPTION
Support `System.Type.Missing` arguments to late bound calls to represent default values. See [system.reflection.missing](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.missing?view=netcore-3.1).

`System.Type.Missing` values were supported for calls with fewer than 8 arguments but not for 8 or more arguments.

The change ports the implementation of `IDOUtils.CreateRefCallSiteAndInvoke()` from .NET Framework.