### PR TITLE
Use fcntl(F_FLUSHFSYNC) on OSX and make FlushAsync() to behave like Flush(false) on Unix

### DIFF
--- a/src/libraries/Native/Unix/Common/pal_config.h.in
+++ b/src/libraries/Native/Unix/Common/pal_config.h.in
@@ -7,6 +7,7 @@
 #cmakedefine01 HAVE_POSIX_FADVISE64
 #cmakedefine01 HAVE_FLOCK64
 #cmakedefine01 HAVE_F_DUPFD_CLOEXEC
+#cmakedefine01 HAVE_F_FULLFSYNC
 #cmakedefine01 HAVE_O_CLOEXEC
 #cmakedefine01 HAVE_GETIFADDRS
 #cmakedefine01 HAVE_UTSNAME_DOMAINNAME

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -632,8 +632,16 @@ int32_t SystemNative_FChMod(intptr_t fd, int32_t mode)
 
 int32_t SystemNative_FSync(intptr_t fd)
 {
+    int fileDescriptor = ToFileDescriptor(fd);
+
     int32_t result;
-    while ((result = fsync(ToFileDescriptor(fd))) < 0 && errno == EINTR);
+    while ((result = 
+#if HAVE_F_FULLFSYNC
+    fcntl(fileDescriptor, F_FULLFSYNC)
+#else
+    fsync(fileDescriptor)
+#endif
+    < 0) && errno == EINTR);
     return result;
 }
 

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -636,7 +636,7 @@ int32_t SystemNative_FSync(intptr_t fd)
 
     int32_t result;
     while ((result = 
-#if HAVE_F_FULLFSYNC
+#if defined(TARGET_OSX) && HAVE_F_FULLFSYNC
     fcntl(fileDescriptor, F_FULLFSYNC)
 #else
     fsync(fileDescriptor)

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -122,6 +122,11 @@ check_symbol_exists(
     HAVE_F_DUPFD_CLOEXEC)
 
 check_symbol_exists(
+    F_FULLFSYNC
+    fcntl.h
+    HAVE_F_FULLFSYNC)
+
+check_symbol_exists(
     getifaddrs
     ifaddrs.h
     HAVE_GETIFADDRS)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
@@ -373,21 +373,7 @@ namespace System.IO
                 return Task.FromException(e);
             }
 
-            // We then separately flush to disk asynchronously.  This is only
-            // necessary if we support writing; otherwise, we're done.
-            if (CanWrite)
-            {
-                return Task.Factory.StartNew(
-                    static state => ((FileStream)state!).FlushOSBuffer(),
-                    this,
-                    cancellationToken,
-                    TaskCreationOptions.DenyChildAttach,
-                    TaskScheduler.Default);
-            }
-            else
-            {
-                return Task.CompletedTask;
-            }
+            return Task.CompletedTask;
         }
 
         /// <summary>Sets the length of this stream to the given value.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
@@ -349,33 +349,6 @@ namespace System.IO
             }
         }
 
-        /// <summary>Asynchronously clears all buffers for this stream, causing any buffered data to be written to the underlying device.</summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task that represents the asynchronous flush operation.</returns>
-        private Task FlushAsyncInternal(CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
-            if (_fileHandle.IsClosed)
-            {
-                throw Error.GetFileNotOpen();
-            }
-
-            // As with Win32FileStream, flush the buffers synchronously to avoid race conditions.
-            try
-            {
-                FlushInternalBuffer();
-            }
-            catch (Exception e)
-            {
-                return Task.FromException(e);
-            }
-
-            return Task.CompletedTask;
-        }
-
         /// <summary>Sets the length of this stream to the given value.</summary>
         /// <param name="value">The new length of the stream.</param>
         private void SetLengthInternal(long value)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Windows.cs
@@ -1547,34 +1547,6 @@ namespace System.IO
             }
         }
 
-        private Task FlushAsyncInternal(CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-
-            if (_fileHandle.IsClosed)
-                throw Error.GetFileNotOpen();
-
-            // TODO: https://github.com/dotnet/runtime/issues/27643 (stop doing this synchronous work!!).
-            // The always synchronous data transfer between the OS and the internal buffer is intentional
-            // because this is needed to allow concurrent async IO requests. Concurrent data transfer
-            // between the OS and the internal buffer will result in race conditions. Since FlushWrite and
-            // FlushRead modify internal state of the stream and transfer data between the OS and the
-            // internal buffer, they cannot be truly async. We will, however, flush the OS file buffers
-            // asynchronously because it doesn't modify any internal state of the stream and is potentially
-            // a long running process.
-            try
-            {
-                FlushInternalBuffer();
-            }
-            catch (Exception e)
-            {
-                return Task.FromException(e);
-            }
-
-            return Task.CompletedTask;
-        }
-
         private void LockInternal(long position, long length)
         {
             int positionLow = unchecked((int)(position));

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -298,6 +298,40 @@ namespace System.IO
             return FlushAsyncInternal(cancellationToken);
         }
 
+        /// <summary>Asynchronously clears all buffers for this stream, causing any buffered data to be written to the underlying device.</summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous flush operation.</returns>
+        private Task FlushAsyncInternal(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            // TODO: https://github.com/dotnet/runtime/issues/27643 (stop doing this synchronous work!!).
+            // The always synchronous data transfer between the OS and the internal buffer is intentional
+            // because this is needed to allow concurrent async IO requests. Concurrent data transfer
+            // between the OS and the internal buffer will result in race conditions. Since FlushWrite and
+            // FlushRead modify internal state of the stream and transfer data between the OS and the
+            // internal buffer, they cannot be truly async. We will, however, flush the OS file buffers
+            // asynchronously because it doesn't modify any internal state of the stream and is potentially
+            // a long running process.
+            try
+            {
+                FlushInternalBuffer();
+            }
+            catch (Exception e)
+            {
+                return Task.FromException(e);
+            }
+
+            return Task.CompletedTask;
+        }
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             ValidateReadWriteArgs(buffer, offset, count);

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -1179,9 +1179,6 @@
 /* F_DUPFD_CLOEXEC */
 #cmakedefine HAVE_F_DUPFD_CLOEXEC 1
 
-/* F_FULLFSYNC */
-#cmakedefine HAVE_F_FULLFSYNC 1
-
 /* Qp2getifaddrs */
 #cmakedefine HAVE_QP2GETIFADDRS 1
 

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -1179,6 +1179,9 @@
 /* F_DUPFD_CLOEXEC */
 #cmakedefine HAVE_F_DUPFD_CLOEXEC 1
 
+/* F_FULLFSYNC */
+#cmakedefine HAVE_F_FULLFSYNC 1
+
 /* Qp2getifaddrs */
 #cmakedefine HAVE_QP2GETIFADDRS 1
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/28444