### PR TITLE
Add libs.native subset when using the runtime helper target in the wasm makefile

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -122,9 +122,6 @@ clean-emsdk:
 clean:
 	$(RM) -rf $(BUILDS_OBJ_DIR)
 
-# Helper targets
-.PHONY: runtime
-
 icu-files: $(wildcard $(ICU_LIBDIR)/*.dat) $(ICU_LIBDIR)/libicuuc.a $(ICU_LIBDIR)/libicui18n.a | $(NATIVE_BIN_DIR)
 	cp $^ $(NATIVE_BIN_DIR)
 
@@ -134,6 +131,9 @@ source-files: runtime/driver.c runtime/pinvoke.c runtime/corebindings.c runtime/
 header-files: runtime/pinvoke.h $(BUILDS_OBJ_DIR)/pinvoke-table.h | $(NATIVE_BIN_DIR)/include/wasm
 	cp $^ $(NATIVE_BIN_DIR)/include/wasm
 
+# Helper targets
+.PHONY: runtime
+
 build:
 	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono+libs.pretest -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true
 
@@ -141,7 +141,7 @@ build-all:
 	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono+libs -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true
 
 runtime:
-	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono.runtime+mono.wasmruntime+libs.pretest -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true
+	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono.runtime+mono.wasmruntime+libs.native+libs.pretest -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true
 
 corlib:
 	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono.corelib+mono.wasmruntime+libs.pretest -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true


### PR DESCRIPTION
Ensures libSystem.Native.a/libSystem.IO.Compression.Native.a end up in the runtime pack.