### PR TITLE
Harmonize pointer type handling

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1432,7 +1432,8 @@ namespace Internal.JitInterface
 
         private bool isValueClass(CORINFO_CLASS_STRUCT_* cls)
         {
-            return HandleToObject(cls).IsValueType;
+            TypeDesc type = HandleToObject(cls);
+            return type.IsValueType || type.IsPointer || type.IsFunctionPointer;
         }
 
         private CorInfoInlineTypeCheck canInlineTypeCheck(CORINFO_CLASS_STRUCT_* cls, CorInfoInlineTypeCheckSource source)
@@ -1453,6 +1454,10 @@ namespace Internal.JitInterface
             // TODO: Support for verification (CORINFO_FLG_GENERIC_TYPE_VARIABLE)
 
             CorInfoFlag result = (CorInfoFlag)0;
+
+            // CoreCLR uses UIntPtr in place of pointers here
+            if (type.IsPointer || type.IsFunctionPointer)
+                type = _compilation.TypeSystemContext.GetWellKnownType(WellKnownType.UIntPtr);
 
             var metadataType = type as MetadataType;
 

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -662,12 +662,13 @@ namespace Internal.JitInterface
                 return (CorInfoType)type.Category;
             }
 
-            typeIfNotPrimitive = type;
-
             if (type.IsPointer || type.IsFunctionPointer)
             {
+                typeIfNotPrimitive = null;
                 return CorInfoType.CORINFO_TYPE_PTR;
             }
+            
+            typeIfNotPrimitive = type;
 
             if (type.IsByRef)
             {

--- a/src/tests/Regressions/coreclr/44465/tst.il
+++ b/src/tests/Regressions/coreclr/44465/tst.il
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly tst { }
+ 
+.method static void* GetValue()
+{
+    .locals init ([0] void*)
+    ldc.i4 100
+    conv.i
+    stloc.0
+    ldloca 0
+    ldobj void*
+    ret
+}
+
+.method static int32 main()
+{
+    .entrypoint
+    call void* GetValue()
+    conv.i4
+    ret
+}

--- a/src/tests/Regressions/coreclr/44465/tst.ilproj
+++ b/src/tests/Regressions/coreclr/44465/tst.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="tst.il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
CoreCLR treats pointer types as UIntPtr in a couple places.