### PR TITLE
Remove some allocation at "hello world" startup

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ComparerHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ComparerHelpers.cs
@@ -133,7 +133,7 @@ namespace System.Collections.Generic
             else if (type.IsAssignableTo(typeof(IEquatable<>).MakeGenericType(type)))
             {
                 // If T implements IEquatable<T> return a GenericEqualityComparer<T>
-                result = CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericEqualityComparer<int>), runtimeType);
+                result = CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericEqualityComparer<string>), runtimeType);
             }
             else if (type.IsGenericType)
             {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ComparerHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ComparerHelpers.cs
@@ -120,28 +120,33 @@ namespace System.Collections.Generic
             object? result = null;
             var runtimeType = (RuntimeType)type;
 
-            // Specialize for byte so Array.IndexOf is faster.
             if (type == typeof(byte))
             {
+                // Specialize for byte so Array.IndexOf is faster.
                 result = new ByteEqualityComparer();
             }
-            // If T implements IEquatable<T> return a GenericEqualityComparer<T>
+            else if (type == typeof(string))
+            {
+                // Specialize for string, as EqualityComparer<string>.Default is on the startup path
+                result = new GenericEqualityComparer<string>();
+            }
             else if (type.IsAssignableTo(typeof(IEquatable<>).MakeGenericType(type)))
             {
+                // If T implements IEquatable<T> return a GenericEqualityComparer<T>
                 result = CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericEqualityComparer<int>), runtimeType);
             }
-            // Nullable does not implement IEquatable<T?> directly because that would add an extra interface call per comparison.
-            // Instead, it relies on EqualityComparer<T?>.Default to specialize for nullables and do the lifted comparisons if T implements IEquatable.
             else if (type.IsGenericType)
             {
+                // Nullable does not implement IEquatable<T?> directly because that would add an extra interface call per comparison.
+                // Instead, it relies on EqualityComparer<T?>.Default to specialize for nullables and do the lifted comparisons if T implements IEquatable.
                 if (type.GetGenericTypeDefinition() == typeof(Nullable<>))
                 {
                     result = TryCreateNullableEqualityComparer(runtimeType);
                 }
             }
-            // The equality comparer for enums is specialized to avoid boxing.
             else if (type.IsEnum)
             {
+                // The equality comparer for enums is specialized to avoid boxing.
                 result = TryCreateEnumEqualityComparer(runtimeType);
             }
 

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EventSetInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EventSetInformation.cs
@@ -12,6 +12,6 @@ internal static partial class Interop
             long registrationHandle,
             EVENT_INFO_CLASS informationClass,
             void* eventInformation,
-            int informationLength);
+            uint informationLength);
     }
 }

--- a/src/libraries/Common/src/System/Text/EncodingHelper.Windows.cs
+++ b/src/libraries/Common/src/System/Text/EncodingHelper.Windows.cs
@@ -1,14 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Text;
+using System.Diagnostics;
 
 namespace System.Text
 {
     // If we find issues with this or if more libraries need this behavior we will revisit the solution.
     internal static partial class EncodingHelper
     {
+        /// <summary>Hardcoded Encoding.UTF8.CodePage to avoid accessing Encoding.Unicode and forcing it into existence unnecessarily.</summary>
+        private const int Utf8CodePage = 65001;
+
+#if DEBUG
+        static EncodingHelper() => Debug.Assert(Utf8CodePage == Encoding.UTF8.CodePage);
+#endif
+
         // Since only a minimum set of encodings are available by default,
         // Console encoding might not be available and require provider registering.
         // To avoid encoding exception in Console APIs we fallback to OSEncoding.
@@ -27,12 +33,12 @@ namespace System.Text
         {
             int defaultEncCodePage = Encoding.GetEncoding(0).CodePage;
 
-            if ((defaultEncCodePage == codepage) || defaultEncCodePage != Encoding.UTF8.CodePage)
+            if (defaultEncCodePage == codepage || defaultEncCodePage != Utf8CodePage)
             {
                 return Encoding.GetEncoding(codepage);
             }
 
-            if (codepage != Encoding.UTF8.CodePage)
+            if (codepage != Utf8CodePage)
             {
                 return new OSEncoding(codepage);
             }

--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -11,6 +11,13 @@ namespace System
     // Provides Windows-based support for System.Console.
     internal static class ConsolePal
     {
+        /// <summary>Hardcoded Encoding.Unicode.CodePage to avoid accessing Encoding.Unicode and forcing it into existence unnecessarily.</summary>
+        private const int UnicodeCodePage = 1200;
+
+#if DEBUG
+        static ConsolePal() => Debug.Assert(UnicodeCodePage == Encoding.Unicode.CodePage);
+#endif
+
         private static IntPtr InvalidHandleValue => new IntPtr(-1);
 
         /// <summary>Ensures that the console has been initialized for use.</summary>
@@ -29,19 +36,19 @@ namespace System
             GetStandardFile(
                 Interop.Kernel32.HandleTypes.STD_INPUT_HANDLE,
                 FileAccess.Read,
-                useFileAPIs: Console.InputEncoding.CodePage != Encoding.Unicode.CodePage || Console.IsInputRedirected);
+                useFileAPIs: Console.InputEncoding.CodePage != UnicodeCodePage || Console.IsInputRedirected);
 
         public static Stream OpenStandardOutput() =>
             GetStandardFile(
                 Interop.Kernel32.HandleTypes.STD_OUTPUT_HANDLE,
                 FileAccess.Write,
-                useFileAPIs: Console.OutputEncoding.CodePage != Encoding.Unicode.CodePage || Console.IsOutputRedirected);
+                useFileAPIs: Console.OutputEncoding.CodePage != UnicodeCodePage || Console.IsOutputRedirected);
 
         public static Stream OpenStandardError() =>
             GetStandardFile(
                 Interop.Kernel32.HandleTypes.STD_ERROR_HANDLE,
                 FileAccess.Write,
-                useFileAPIs: Console.OutputEncoding.CodePage != Encoding.Unicode.CodePage || Console.IsErrorRedirected);
+                useFileAPIs: Console.OutputEncoding.CodePage != UnicodeCodePage || Console.IsErrorRedirected);
 
         private static IntPtr InputHandle =>
             Interop.Kernel32.GetStdHandle(Interop.Kernel32.HandleTypes.STD_INPUT_HANDLE);
@@ -99,7 +106,7 @@ namespace System
 
         public static void SetConsoleInputEncoding(Encoding enc)
         {
-            if (enc.CodePage != Encoding.Unicode.CodePage)
+            if (enc.CodePage != UnicodeCodePage)
             {
                 if (!Interop.Kernel32.SetConsoleCP(enc.CodePage))
                     throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
@@ -113,7 +120,7 @@ namespace System
 
         public static void SetConsoleOutputEncoding(Encoding enc)
         {
-            if (enc.CodePage != Encoding.Unicode.CodePage)
+            if (enc.CodePage != UnicodeCodePage)
             {
                 if (!Interop.Kernel32.SetConsoleOutputCP(enc.CodePage))
                     throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
+using System.Diagnostics.Tracing;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Runtime.Loader;
@@ -64,14 +64,18 @@ namespace System
 #pragma warning disable CS0067 // events raised by the VM
         public static event UnhandledExceptionEventHandler? UnhandledException;
 
-        public static event System.EventHandler<FirstChanceExceptionEventArgs>? FirstChanceException;
+        public static event EventHandler<FirstChanceExceptionEventArgs>? FirstChanceException;
 #pragma warning restore CS0067
 
-        public static event System.EventHandler? ProcessExit;
+        public static event EventHandler? ProcessExit;
 
         internal static void OnProcessExit()
         {
             AssemblyLoadContext.OnProcessExit();
+            if (EventSource.IsSupported)
+            {
+                EventListener.DisposeOnShutdown();
+            }
 
             ProcessExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -20,7 +20,6 @@ namespace System
     public sealed partial class AppDomain : MarshalByRefObject
     {
         private static readonly AppDomain s_domain = new AppDomain();
-        private readonly object _forLock = new object();
         private IPrincipal? _defaultPrincipal;
         private PrincipalPolicy _principalPolicy = PrincipalPolicy.NoPrincipal;
         private Func<IPrincipal>? s_getWindowsPrincipal;
@@ -272,14 +271,10 @@ namespace System
                 throw new ArgumentNullException(nameof(principal));
             }
 
-            lock (_forLock)
+            // Set the principal while checking it has not been set previously.
+            if (Interlocked.CompareExchange(ref _defaultPrincipal, principal, null) is not null)
             {
-                // Check that principal has not been set previously.
-                if (_defaultPrincipal != null)
-                {
-                    throw new SystemException(SR.AppDomain_Policy_PrincipalTwice);
-                }
-                _defaultPrincipal = principal;
+                throw new SystemException(SR.AppDomain_Policy_PrincipalTwice);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -1235,7 +1235,7 @@ namespace System.Diagnostics.Tracing
 
         internal unsafe int SetInformation(
             Interop.Advapi32.EVENT_INFO_CLASS eventInfoClass,
-            IntPtr data,
+            void* data,
             uint dataSize)
         {
             int status = Interop.Errors.ERROR_NOT_SUPPORTED;
@@ -1247,8 +1247,8 @@ namespace System.Diagnostics.Tracing
                     status = Interop.Advapi32.EventSetInformation(
                         m_regHandle,
                         eventInfoClass,
-                        (void*)data,
-                        (int)dataSize);
+                        data,
+                        dataSize);
                 }
                 catch (TypeLoadException)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2237,6 +2237,11 @@ namespace System.Diagnostics.Tracing
                     {
                         if (m_writeEventStringEventHandle == IntPtr.Zero)
                         {
+                            if (m_createEventLock is null)
+                            {
+                                Interlocked.CompareExchange(ref m_createEventLock, new object(), null);
+                            }
+
                             lock (m_createEventLock)
                             {
                                 if (m_writeEventStringEventHandle == IntPtr.Zero)
@@ -3767,7 +3772,7 @@ namespace System.Diagnostics.Tracing
         private volatile OverideEventProvider m_etwProvider = null!;   // This hooks up ETW commands to our 'OnEventCommand' callback
 #endif
 #if FEATURE_PERFTRACING
-        private object m_createEventLock = new object();
+        private object? m_createEventLock;
         private IntPtr m_writeEventStringEventHandle = IntPtr.Zero;
         private volatile OverideEventProvider m_eventPipeProvider = null!;
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1508,17 +1508,13 @@ namespace System.Diagnostics.Tracing
                 if (this.Name != "System.Diagnostics.Eventing.FrameworkEventSource" || Environment.IsWindows8OrAbove)
 #endif
                 {
-                    int setInformationResult;
-                    System.Runtime.InteropServices.GCHandle metadataHandle =
-                        System.Runtime.InteropServices.GCHandle.Alloc(this.providerMetadata, System.Runtime.InteropServices.GCHandleType.Pinned);
-                    IntPtr providerMetadata = metadataHandle.AddrOfPinnedObject();
-
-                    setInformationResult = m_etwProvider.SetInformation(
-                        Interop.Advapi32.EVENT_INFO_CLASS.SetTraits,
-                        providerMetadata,
-                        (uint)this.providerMetadata.Length);
-
-                    metadataHandle.Free();
+                    fixed (byte* providerMetadata = this.providerMetadata)
+                    {
+                        m_etwProvider.SetInformation(
+                            Interop.Advapi32.EVENT_INFO_CLASS.SetTraits,
+                            providerMetadata,
+                            (uint)this.providerMetadata.Length);
+                    }
                 }
 #endif // TARGET_WINDOWS
 #endif // FEATURE_MANAGED_ETW

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -4190,10 +4190,7 @@ namespace System.Diagnostics.Tracing
         internal static void DisposeOnShutdown()
 #endif
         {
-            if (!EventSource.IsSupported)
-            {
-                return;
-            }
+            Debug.Assert(EventSource.IsSupported);
 
             lock (EventListenersLock)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -703,9 +703,11 @@ namespace System.IO
 
         private sealed class NullTextWriter : TextWriter
         {
-            internal NullTextWriter() : base(CultureInfo.InvariantCulture)
+            internal NullTextWriter()
             {
             }
+
+            public override IFormatProvider FormatProvider => CultureInfo.InvariantCulture;
 
             public override Encoding Encoding => Encoding.Unicode;
 
@@ -748,7 +750,7 @@ namespace System.IO
         {
             private readonly TextWriter _out;
 
-            internal SyncTextWriter(TextWriter t) : base(t.FormatProvider)
+            internal SyncTextWriter(TextWriter t)
             {
                 _out = t;
             }


### PR DESCRIPTION
Measuring `dotnet helloworld.dll` that just does `Console.WriteLine(“hello world”);`, on my machine this reduces startup allocation by ~200 objects / 12Kbytes, and reduces wall-clock time by ~8% (from ~80ms to ~73ms). Wall-clock measurement done with `Measure-Command { dotnet helloworld.dll }`.  Allocation measurements done with VS .NET allocation profiler.

@jkotas, please let me know if you think any of these aren't worthwhile or are problematic in some way and I can roll them back.

Contributes to https://github.com/dotnet/runtime/issues/44598

cc: @brianrob, @DamianEdwards 

---

For future reference, after this there's still quite a bit of allocation, but it's hard to get rid of a lot more without disabling whole swaths of functionality (e.g. disabling EventSource).  Here's what remains:

| Type                                                                                             | Allocations | Bytes  |
| ------------------------------------------------------------------------------------------------ | ----------- | ------ |
|  - System.SByte\[\]                                                                              | 216         | 9,456  |
|  - System.String                                                                                 | 43          | 34,040 |
|  - System.Object\[\]                                                                             | 14          | 24,040 |
|  - System.Byte\[\]                                                                               | 4           | 3,731  |
|  - System.Int32\[\]                                                                              | 4           | 3,580  |
|  - System.Diagnostics.Tracing.EventSource.OverideEventProvider                                   | 4           | 448    |
|  - Interop.Advapi32.EtwEnableCallback                                                            | 4           | 256    |
|  - System.Runtime.CompilerServices.GCHeapHash                                                    | 4           | 128    |
|  - System.Object                                                                                 | 3           | 72     |
|  - System.Text.EncoderReplacementFallback                                                        | 3           | 72     |
|  - System.Text.DecoderReplacementFallback                                                        | 3           | 72     |
|  - System.Char\[\]                                                                               | 2           | 564    |
|  - System.Threading.ThreadAbortException                                                         | 2           | 256    |
|  - System.IntPtr\[\]                                                                             | 2           | 208    |
|  - System.Text.UTF8Encoding.UTF8EncodingSealed                                                   | 2           | 96     |
|  - System.RuntimeType                                                                            | 2           | 80     |
|  - System.String\[\]                                                                             | 2           | 56     |
|  - System.Collections.Generic.NonRandomizedStringEqualityComparer.OrdinalComparer                | 2           | 48     |
|  - System.Diagnostics.Tracing.TraceLoggingEventHandleTable                                       | 2           | 48     |
|  - System.Diagnostics.Tracing.EtwEventProvider                                                   | 2           | 48     |
|  - System.Diagnostics.Tracing.EventPipeEventProvider                                             | 2           | 48     |
|  - System.WeakReference<System.Diagnostics.Tracing.EventSource>                                  | 2           | 48     |
|  - System.Diagnostics.Tracing.RuntimeEventSource                                                 | 1           | 368    |
|  - System.Collections.Generic.Dictionary<System.String, System.Object>.Entry\[\]                 | 1           | 192    |
|  - System.Diagnostics.Tracing.NativeRuntimeEventSource                                           | 1           | 184    |
|  - System.Exception                                                                              | 1           | 128    |
|  - System.OutOfMemoryException                                                                   | 1           | 128    |
|  - System.StackOverflowException                                                                 | 1           | 128    |
|  - System.ExecutionEngineException                                                               | 1           | 128    |
|  - System.IO.StreamWriter                                                                        | 1           | 104    |
|  - System.Collections.Generic.Dictionary<System.String, System.Object>                           | 1           | 80     |
|  - System.Threading.Tasks.Task<System.Threading.Tasks.VoidTaskResult>                            | 1           | 72     |
|  - System.RuntimeFieldInfoStub                                                                   | 1           | 64     |
|  - System.EventHandler                                                                           | 1           | 64     |
|  - System.Text.OSEncoding                                                                        | 1           | 64     |
|  - System.Threading.ContextCallback                                                              | 1           | 64     |
|  - System.AppDomain                                                                              | 1           | 64     |
|  - System.Reflection.RuntimeAssembly                                                             | 1           | 48     |
|  - System.Text.OSEncoder                                                                         | 1           | 48     |
|  - System.IO.TextWriter.SyncTextWriter                                                           | 1           | 48     |
|  - System.WeakReference<System.Diagnostics.Tracing.EventSource>\[\]                              | 1           | 40     |
|  - System.ConsolePal.WindowsConsoleStream                                                        | 1           | 40     |
|  - System.Threading.Tasks.TaskFactory                                                            | 1           | 40     |
|  - System.IO.TextWriter.NullTextWriter                                                           | 1           | 40     |
|  - System.Guid                                                                                   | 1           | 32     |
|  - System.Diagnostics.Tracing.ActivityTracker                                                    | 1           | 32     |
|  - System.Collections.Generic.List<System.WeakReference<System.Diagnostics.Tracing.EventSource>> | 1           | 32     |
|  - System.Collections.Generic.GenericEqualityComparer<System.String>                             | 1           | 24     |
|  - System.OrdinalCaseSensitiveComparer                                                           | 1           | 24     |
|  - System.Collections.Generic.NonRandomizedStringEqualityComparer.OrdinalIgnoreCaseComparer      | 1           | 24     |
|  - System.OrdinalIgnoreCaseComparer                                                              | 1           | 24     |
|  - System.IO.Stream.NullStream                                                                   | 1           | 24     |
|  - System.Threading.Tasks.Task.<>c                                                               | 1           | 24     |
|  - System.EventArgs                                                                              | 1           | 24     |

A few notes on the remaining allocations:
- The sbyte[]s are mainly from the JIT reporting inlining decisions, and these are on the managed heap as of https://github.com/dotnet/coreclr/pull/22285.  Most of the `object[]`s appear to be as well, coming from reportInliningDecision using GCHeapHash which grows an array.
- The strings are mainly consts as well as initialization key/value pairs passed into AppContext.Setup.
- The byte[]s are from StreamWriter's byte[] buffer, Array.Empty, and EventSource "MetadataForString".
- The char[]s are from StreamWriter's char[] buffer and TextWriter's newline characters array.
- The int[]s are from Dictionary / HashHelpers as well as invariant culture data.
- The IntPtr[]s are from one per EventSource instance, used for its TraceLoggingEventHandleTable.
- The objects are remaining lock objects.
- The EtwEnableCallback / OverideEvent (sic) / EtwEventProvider / EventPipeEventProvider are from EventSource, incurring one for ETW (on Windows) and one for EventPipe multiplied by RuntimeEventSource and NativeRuntimeEventSource.
- Encoding-related objects mostly come from Console's output encoding.
- Exception objects are all singletons pre-allocated by the runtime.
- There's a boxed Guid coming from native runtime code invoked by EventSource.Initialize
- API design of yore led to public readonly static fields for Stream.Null, StreamWriter.Null, and TextWriter.Null, causing Stream/StreamWriter/TextWriter instances to be created when these types are first used.
- Creating a Dictionary causes it to access statics on NonRandomizedStringEqualityComparer, which forces into existence the various singletons on both that class and on StringComparer.
- Task.CompletedTask forces Task's cctor to run which also allocates TaskFactory, a ContextCallback for running Tasks with ExecutionContext, and a closure `<>c`-related object.
- There are couple more we could easily remove (AppDomain, EventArgs, EventHandler) if we were willing to couple AppContext.OnProcessExit with EventListener.DisposeOnShutdown: right now those are connected by EventSource registering an event handler with AppContext.ProcessExit.