### PR TITLE
Use commit parents instead of branch names to evaulate changed paths.

### DIFF
--- a/eng/pipelines/common/checkout-job.yml
+++ b/eng/pipelines/common/checkout-job.yml
@@ -52,7 +52,9 @@ jobs:
         parameters:
           subsetName: ${{ path.subset }} 
           arguments:
-          - --difftarget origin/$(System.PullRequest.TargetBranch)
+          # The commit that we're building is always a merge commit that is merging into the target branch.
+          # So the first parent of the commit is on the target branch and the second parent is on the source branch.
+          - --difftarget HEAD^1
           - --subset ${{ path.subset }}
           - ${{ if ne(path.include[0], '') }}:
             - --includepaths '${{ join('+', path.include) }}'


### PR DESCRIPTION
Instead of using branch names, use the fact that the first commit parent is on the target branch (since we're merging into the target branch) to find our diff parent.

Currently this is just a WIP to see if this works.