### PR TITLE
Include 5.0.0 to all packages to avoid harvesting errors

### DIFF
--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -22,7 +22,8 @@
     },
     "Microsoft.Bcl.AsyncInterfaces": {
       "StableVersions": [
-        "1.0.0"
+        "1.0.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -135,7 +136,8 @@
         "1.1.28",
         "2.0.0",
         "2.0.1",
-        "2.1.0"
+        "2.1.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -167,7 +169,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -195,7 +198,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -222,7 +226,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -249,7 +254,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -278,7 +284,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -305,7 +312,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -333,7 +341,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -360,7 +369,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -387,7 +397,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -414,7 +425,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -441,7 +453,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -468,7 +481,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -492,7 +506,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -516,7 +531,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -547,7 +563,8 @@
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -576,7 +593,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -600,7 +618,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -624,7 +643,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -646,7 +666,8 @@
         "3.0.1",
         "3.0.2",
         "3.1.0",
-        "3.1.1"
+        "3.1.1",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -667,7 +688,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -689,7 +711,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -707,7 +730,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -734,7 +758,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -761,7 +786,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -782,7 +808,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -809,7 +836,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -836,7 +864,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -863,7 +892,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -887,7 +917,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -914,7 +945,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -941,7 +973,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -968,7 +1001,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -984,7 +1018,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -1008,7 +1043,8 @@
         "3.0.3",
         "3.1.0",
         "3.1.1",
-        "3.1.2"
+        "3.1.2",
+        "5.0.0"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
@@ -1017,7 +1053,8 @@
     },
     "Microsoft.IO.Redist": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -1051,7 +1088,8 @@
         "2.2.0",
         "2.2.1",
         "2.2.2",
-        "3.0.0"
+        "3.0.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {}
@@ -1073,7 +1111,8 @@
         "1.1.4",
         "2.0.0",
         "2.1.0",
-        "3.0.0"
+        "3.0.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {}
@@ -1208,7 +1247,8 @@
         "4.3.0",
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -1227,7 +1267,8 @@
         "4.3.0",
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -1243,7 +1284,8 @@
     "Microsoft.Win32.SystemEvents": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -1260,7 +1302,8 @@
         "2.1.0",
         "2.1.1",
         "3.0.0",
-        "3.0.1"
+        "3.0.1",
+        "5.0.0"
       ],
       "InboxOn": {}
     },
@@ -1275,7 +1318,8 @@
       "StableVersions": [
         "1.0.0",
         "2.0.0",
-        "2.1.0"
+        "2.1.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -1458,7 +1502,8 @@
     },
     "runtime.native.System.IO.Ports": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {}
@@ -1590,7 +1635,8 @@
       "StableVersions": [
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -1693,7 +1739,8 @@
         "1.5.0",
         "1.6.0",
         "1.7.0",
-        "1.7.1"
+        "1.7.1",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -1817,7 +1864,8 @@
         "4.4.0",
         "4.4.1",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -1852,7 +1900,8 @@
     "System.ComponentModel.Composition": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -1871,7 +1920,8 @@
     },
     "System.ComponentModel.Composition.Registration": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -2001,7 +2051,8 @@
         "1.0.31",
         "1.1.0",
         "1.2.0",
-        "1.3.0"
+        "1.3.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {}
@@ -2011,7 +2062,8 @@
         "1.0.31",
         "1.1.0",
         "1.2.0",
-        "1.3.0"
+        "1.3.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2028,7 +2080,8 @@
         "1.0.31",
         "1.1.0",
         "1.2.0",
-        "1.3.0"
+        "1.3.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2045,7 +2098,8 @@
         "1.0.31",
         "1.1.0",
         "1.2.0",
-        "1.3.0"
+        "1.3.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2062,7 +2116,8 @@
         "1.0.31",
         "1.1.0",
         "1.2.0",
-        "1.3.0"
+        "1.3.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2079,7 +2134,8 @@
         "1.0.31",
         "1.1.0",
         "1.2.0",
-        "1.3.0"
+        "1.3.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2103,7 +2159,8 @@
         "4.4.0",
         "4.4.1",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2248,7 +2305,8 @@
     "System.Data.Odbc": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2260,7 +2318,8 @@
     },
     "System.Data.OleDb": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2449,7 +2508,8 @@
         "4.4.1",
         "4.5.0",
         "4.5.1",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -2472,7 +2532,8 @@
     "System.Diagnostics.EventLog": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -2510,7 +2571,8 @@
     "System.Diagnostics.PerformanceCounter": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -2728,7 +2790,8 @@
     "System.DirectoryServices": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -2741,7 +2804,8 @@
     "System.DirectoryServices.AccountManagement": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -2754,7 +2818,8 @@
     "System.DirectoryServices.Protocols": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -2780,7 +2845,8 @@
         "4.6.1",
         "4.6.2",
         "4.7.0",
-        "4.7.1"
+        "4.7.1",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -2886,12 +2952,18 @@
       }
     },
     "System.Formats.Asn1": {
+      "StableVersions": [
+        "5.0.0"
+      ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "5.0.0.0": "6.0.0"
       }
     },
     "System.Formats.Cbor": {
+      "StableVersions": [
+        "5.0.0"
+      ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "5.0.0.0": "6.0.0"
@@ -3177,7 +3249,8 @@
         "4.3.0",
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -3333,7 +3406,8 @@
         "4.4.0",
         "4.4.1",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -3352,7 +3426,8 @@
         "4.5.1",
         "4.5.2",
         "4.5.3",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -3387,7 +3462,8 @@
         "4.3.0",
         "4.4.0",
         "4.5.0",
-        "4.5.1"
+        "4.5.1",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -3402,7 +3478,8 @@
       "StableVersions": [
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -3627,7 +3704,8 @@
     "System.Management": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -3769,6 +3847,9 @@
       }
     },
     "System.Net.Http.Json": {
+      "StableVersions": [
+        "5.0.0"
+      ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "5.0.0.0": "6.0.0"
@@ -3825,7 +3906,8 @@
         "4.5.2",
         "4.5.3",
         "4.5.4",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -4249,7 +4331,8 @@
         "4.5.1",
         "4.5.2",
         "4.5.3",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -4414,6 +4497,11 @@
         "4.1.2.0": "4.3.0"
       }
     },
+    "System.Private.Runtime.InteropServices.JavaScript": {
+      "InboxOn": {
+        "net5.0": "5.0.0.0"
+      }
+    },
     "System.Private.Uri": {
       "StableVersions": [
         "4.0.0",
@@ -4482,7 +4570,8 @@
         "4.0.0",
         "4.0.1",
         "4.3.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -4516,8 +4605,8 @@
         "netcoreapp2.0": "4.0.3.0",
         "netcoreapp2.1": "4.0.4.0",
         "netcoreapp3.0": "4.0.5.0",
-        "netstandard2.1": "4.0.5.0",
         "net5.0": "5.0.0.0",
+        "netstandard2.1": "4.0.5.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
         "uap10.0.16299": "4.0.4.0",
@@ -4678,7 +4767,8 @@
         "1.4.3",
         "1.5.0",
         "1.6.0",
-        "1.7.0"
+        "1.7.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -4702,7 +4792,8 @@
     },
     "System.Reflection.MetadataLoadContext": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -4788,7 +4879,8 @@
     },
     "System.Resources.Extensions": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -4941,7 +5033,8 @@
     "System.Runtime.Caching": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -4966,7 +5059,8 @@
         "4.5.1",
         "4.5.2",
         "4.6.0",
-        "4.7.0"
+        "4.7.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -5126,11 +5220,6 @@
         "4.0.20.0": "4.0.20",
         "4.1.0.0": "4.1.0",
         "4.1.1.0": "4.3.0"
-      }
-    },
-    "System.Private.Runtime.InteropServices.JavaScript": {
-      "InboxOn": {
-        "net5.0": "5.0.0.0"
       }
     },
     "System.Runtime.InteropServices.RuntimeInformation": {
@@ -5522,7 +5611,8 @@
         "4.4.0",
         "4.4.1",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -5599,7 +5689,8 @@
         "4.4.0",
         "4.5.0",
         "4.6.0",
-        "4.6.1"
+        "4.6.1",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -5682,7 +5773,8 @@
         "4.4.0",
         "4.5.0",
         "4.5.1",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -5704,7 +5796,8 @@
         "4.5.0",
         "4.5.1",
         "4.5.2",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -5751,7 +5844,8 @@
         "4.3.0",
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -5807,7 +5901,8 @@
         "4.4.1",
         "4.4.2",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -5823,7 +5918,8 @@
         "4.4.0",
         "4.4.1",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -5883,7 +5979,8 @@
         "4.4.1",
         "4.5.0",
         "4.5.1",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -6063,7 +6160,8 @@
     "System.ServiceModel.Syndication": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -6113,7 +6211,8 @@
         "4.4.0",
         "4.4.1",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -6183,7 +6282,8 @@
         "4.4.0",
         "4.5.0",
         "4.5.1",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -6259,7 +6359,8 @@
         "4.3.1",
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -6277,7 +6378,8 @@
     },
     "System.Text.Json": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -6386,7 +6488,8 @@
         "4.3.0",
         "4.4.0",
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},
@@ -6402,7 +6505,8 @@
     "System.Threading.Channels": {
       "StableVersions": [
         "4.5.0",
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -6496,7 +6600,8 @@
         "4.7.0",
         "4.8.0",
         "4.9.0",
-        "4.10.0"
+        "4.10.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {
@@ -6848,7 +6953,8 @@
     },
     "System.Windows.Extensions": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "5.0.0"
       ],
       "BaselineVersion": "6.0.0",
       "InboxOn": {},


### PR DESCRIPTION
This is related to: https://github.com/dotnet/runtime/issues/44480 and to avoid harvesting errors now that 5.0.0 was shipped. 