### PR TITLE
Reduce StreamWriter allocation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
@@ -653,7 +653,7 @@ namespace System.IO
                 }
             }
 
-            if (AutoFlush)
+            if (_autoFlush)
             {
                 await FlushAsyncInternal(flushStream: true, flushEncoder: false).ConfigureAwait(false);
             }
@@ -744,9 +744,6 @@ namespace System.IO
             return task;
         }
 
-        // We pass in private instance fields of this MarshalByRefObject-derived type as local params
-        // to ensure performant access inside the state machine that corresponds this async method.
-        // Fields that are written to must be assigned at the end of the method *and* before instance invocations.
         private async Task WriteAsyncInternal(ReadOnlyMemory<char> source, bool appendNewLine, CancellationToken cancellationToken)
         {
             int copied = 0;
@@ -778,7 +775,7 @@ namespace System.IO
                 }
             }
 
-            if (AutoFlush)
+            if (_autoFlush)
             {
                 await FlushAsyncInternal(flushStream: true, flushEncoder: false, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
Two changes:
1. Lazily-allocate StreamWriter's byte[] buffer.  If the StreamWriter is only ever used for synchronous writing of small payloads, e.g. a typical Console.WriteLine scenario, then it won't ever allocate its byte[] buffer.  This relates to #44469, in that one of the byte[] arrays shown there is removed.
2. Undo use of static async helpers.  For legacy reasons, the async methods were wrapping static helpers and passing in all relevant instance state as arguments to those helpers.  This in turn bloats the size of those state machines, in addition to complicating the code / maintainability.

Contributes to https://github.com/dotnet/runtime/issues/44598