### PR TITLE
log exception if Timeout_SetTenMillisecondsOnLoopback_ThrowsWebException test fails

### DIFF
--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -522,6 +522,8 @@ namespace System.Net.Tests
                 WebException exception = Assert.Throws<WebException>(() => request.GetResponse());
                 sw.Stop();
 
+                _output.WriteLine(exception.ToString());
+
                 Assert.InRange(sw.ElapsedMilliseconds, 1, 15 * 1000);
                 Assert.Equal(WebExceptionStatus.Timeout, exception.Status);
                 Assert.Null(exception.InnerException);

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -524,10 +524,10 @@ namespace System.Net.Tests
 
                 _output.WriteLine(exception.ToString());
 
-                Assert.InRange(sw.ElapsedMilliseconds, 1, 15 * 1000);
                 Assert.Equal(WebExceptionStatus.Timeout, exception.Status);
                 Assert.Null(exception.InnerException);
                 Assert.Null(exception.Response);
+                Assert.InRange(sw.ElapsedMilliseconds, 1, 15 * 1000);
 
                 return Task.FromResult<object>(null);
             });


### PR DESCRIPTION
This will dump exception if the test fails. We expect Timeout exception after 10s but we don't really know what happened if the test fails end elapsed time is 0. 

contributes #44494