### PR TITLE
Add interned string support to the JS<->WASM bindings layer

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -502,5 +502,12 @@ namespace System.Runtime.InteropServices.JavaScript
             return safeHandle.DangerousGetHandle();
         }
 
+        private static string? FindInternedString (string str) {
+            return string.IsInterned(str);
+        }
+
+        private static string InternString (string str) {
+            return string.Intern(str);
+        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -501,9 +501,5 @@ namespace System.Runtime.InteropServices.JavaScript
             if (addRef && !SafeHandleAddRef(safeHandle)) return IntPtr.Zero;
             return safeHandle.DangerousGetHandle();
         }
-
-        private static string InternString (string str) {
-            return string.Intern(str);
-        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -502,10 +502,6 @@ namespace System.Runtime.InteropServices.JavaScript
             return safeHandle.DangerousGetHandle();
         }
 
-        private static string? FindInternedString (string str) {
-            return string.IsInterned(str);
-        }
-
         private static string InternString (string str) {
             return string.Intern(str);
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -501,5 +501,6 @@ namespace System.Runtime.InteropServices.JavaScript
             if (addRef && !SafeHandleAddRef(safeHandle)) return IntPtr.Zero;
             return safeHandle.DangerousGetHandle();
         }
+
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -60,6 +60,12 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             _stringResource = s;
         }
 
+        internal static string _stringResource2;
+        private static void InvokeString2(string s)
+        {
+            _stringResource2 = s;
+        }
+
         internal static string _marshalledString;
         private static string InvokeMarshalString()
         {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -748,5 +748,31 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             );
             Assert.StartsWith("Error: int64 not available", exc.Message);
         }
+
+        [Fact]
+        public static void BareStringArgumentsAreNotInterned()
+        {
+            HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
+            Runtime.InvokeJS(@"
+                var jsLiteral = ""hello world"";
+                App.call_test_method (""InvokeString"", [ jsLiteral ]);
+                App.call_test_method (""InvokeString2"", [ jsLiteral ]);
+            ");
+            Assert.Equal(HelperMarshal._stringResource, HelperMarshal._stringResource2);
+            Assert.False(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
+        }
+
+        [Fact]
+        public static void SymbolArgumentsAreConvertedToInternedStrings()
+        {
+            HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
+            Runtime.InvokeJS(@"
+                var sym = Symbol.for(""interned string"");
+                App.call_test_method (""InvokeString"", [ sym ]);
+                App.call_test_method (""InvokeString2"", [ sym ]);
+            ");
+            Assert.Equal(HelperMarshal._stringResource, HelperMarshal._stringResource2);
+            Assert.True(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
+        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -763,14 +763,15 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        public static void SymbolArgumentsAreConvertedToInternedStrings()
+        public static void InternedStringSignaturesAreInternedOnJavascriptSide()
         {
             HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
             Runtime.InvokeJS(@"
-                var sym = Symbol.for(""interned string"");
-                App.call_test_method (""InvokeString"", [ sym ]);
-                App.call_test_method (""InvokeString2"", [ sym ]);
+                var sym = ""interned string"";
+                App.call_test_method (""InvokeString"", [ sym ], ""S"");
+                App.call_test_method (""InvokeString2"", [ sym ], ""S"");
             ");
+            Assert.Equal("interned string", HelperMarshal._stringResource);
             Assert.Equal(HelperMarshal._stringResource, HelperMarshal._stringResource2);
             Assert.True(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -758,6 +758,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 App.call_test_method (""InvokeString"", [ jsLiteral ]);
                 App.call_test_method (""InvokeString2"", [ jsLiteral ]);
             ");
+            Assert.Equal("hello world", HelperMarshal._stringResource);
             Assert.Equal(HelperMarshal._stringResource, HelperMarshal._stringResource2);
             Assert.False(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
         }
@@ -831,6 +832,20 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal("s5000", HelperMarshal._stringResource);
             Assert.Equal(HelperMarshal._stringResource, string.IsInterned(HelperMarshal._stringResource));
+        }
+
+        [Fact]
+        public static void SymbolsAreMarshaledAsStrings()
+        {
+            HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
+            Runtime.InvokeJS(@"
+                var jsLiteral = Symbol(""custom symbol"");
+                App.call_test_method (""InvokeString"", [ jsLiteral ]);
+                App.call_test_method (""InvokeString2"", [ jsLiteral ]);
+            ");
+            Assert.Equal("custom symbol", HelperMarshal._stringResource);
+            Assert.Equal(HelperMarshal._stringResource, HelperMarshal._stringResource2);
+            Assert.True(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -795,7 +795,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
             Runtime.InvokeJS(@"
-                var sym = BINDING.intern_string(""interned string 3"");
+                var sym = BINDING.mono_intern_string(""interned string 3"");
                 App.call_test_method (""InvokeString"", [ sym ], ""s"");
                 App.call_test_method (""InvokeString2"", [ sym ], ""s"");
             ");
@@ -812,12 +812,25 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var s = ""long interned string"";
                 for (var i = 0; i < 1024; i++)
                     s += String(i % 10);
-                var sym = BINDING.intern_string(s);
+                var sym = BINDING.mono_intern_string(s);
                 App.call_test_method (""InvokeString"", [ sym ], ""S"");
                 App.call_test_method (""InvokeString2"", [ sym ], ""s"");
             ");
             Assert.Equal(HelperMarshal._stringResource, HelperMarshal._stringResource2);
             Assert.False(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
+        }
+
+        [Fact]
+        public static void CanInternVeryManyStrings()
+        {
+            HelperMarshal._stringResource = null;
+            Runtime.InvokeJS(@"
+                for (var i = 0; i < 10240; i++)
+                    BINDING.mono_intern_string('s' + i);
+                App.call_test_method (""InvokeString"", [ 's5000' ], ""S"");
+            ");
+            Assert.Equal("s5000", HelperMarshal._stringResource);
+            Assert.Equal(HelperMarshal._stringResource, string.IsInterned(HelperMarshal._stringResource));
         }
     }
 }

--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -391,13 +391,13 @@ var App = {
 			fail_exec ("Unhandled argument: " + args [0]);
 		}
 	},
-	call_test_method: function (method_name, args) {
-		if (arguments.length > 2)
+	call_test_method: function (method_name, args, signature) {
+		if ((arguments.length > 2) && (typeof (signature) !== "string"))
 			throw new Error("Invalid number of arguments for call_test_method");
 
 		var fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:" + method_name;
 		try {
-			return BINDING.call_static_method(fqn, args || []);
+			return BINDING.call_static_method(fqn, args || [], signature);
 		} catch (exc) {
 			console.error("exception thrown in", fqn);
 			throw exc;

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -145,7 +145,6 @@ var BindingSupportLib = {
 			this.safehandle_release_by_handle = get_method ("SafeHandleReleaseByHandle");
 
 			this._intern_string = bind_runtime_method ("InternString", "m!");
-			this._find_interned_string = bind_runtime_method ("FindInternedString", "m!");
 
 			this._are_promises_supported = ((typeof Promise === "object") || (typeof Promise === "function")) && (typeof Promise.resolve === "function");
 

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -145,8 +145,6 @@ var BindingSupportLib = {
 			this.safehandle_get_handle = get_method ("SafeHandleGetHandle");
 			this.safehandle_release_by_handle = get_method ("SafeHandleReleaseByHandle");
 
-			this._intern_string = bind_runtime_method ("InternString", "m!");
-
 			this._are_promises_supported = ((typeof Promise === "object") || (typeof Promise === "function")) && (typeof Promise.resolve === "function");
 
 			this._empty_string = "";

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -291,20 +291,6 @@ var BindingSupportLib = {
 			return this._is_simple_array(ele);
 		},
 
-		js_string_to_mono_string: function (string) {
-			if (string === null || typeof string === "undefined")
-				return 0;
-
-			var buffer = Module._malloc ((string.length + 1) * 2);
-			var buffer16 = (buffer / 2) | 0;
-			for (var i = 0; i < string.length; i++)
-				Module.HEAP16[buffer16 + i] = string.charCodeAt (i);
-			Module.HEAP16[buffer16 + string.length] = 0;
-			var result = this.mono_wasm_string_from_utf16 (buffer, string.length);
-			Module._free (buffer);
-			return result;
-		},
-
 		mono_array_to_js_array: function (mono_array) {
 			if (mono_array === 0)
 				return null;
@@ -564,7 +550,7 @@ var BindingSupportLib = {
 				} case typeof js_obj === "string":
 					return this.js_string_to_mono_string (js_obj);
 				case typeof js_obj === "symbol":
-					return this.js_string_to_mono_string_interned (js_obj.description || Symbol.keyFor(js_obj) || "<unknown Symbol>");
+					return this.js_string_to_mono_string_interned (js_obj);
 				case typeof js_obj === "boolean":
 					return this._box_js_bool (js_obj);
 				case isThenable() === true:

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -168,6 +168,9 @@ var BindingSupportLib = {
 		},
 
 		_store_string_in_intern_table: function (string, ptr, internIt) {
+			if (!ptr)
+				throw new Error ("null pointer passed to _store_string_in_intern_table");
+
 			var originalArg = ptr;
 			
 			const internBufferSize = 8192;
@@ -191,14 +194,15 @@ var BindingSupportLib = {
 			if (internIt)
 				rootBuffer.set (index, ptr = this.mono_wasm_intern_string (ptr));
 
+			if (!ptr)
+				throw new Error ("mono_wasm_intern_string produced a null pointer");
+
 			this._interned_string_table.set (string, ptr);
 			this._managed_pointer_to_interned_string_table.set (ptr, string);
 
 			if ((string.length === 0) && !this._empty_string_ptr)
 				this._empty_string_ptr = ptr;
 			
-			if (!ptr)
-				throw new Error("what");
 			return ptr;
 		},
 
@@ -212,8 +216,6 @@ var BindingSupportLib = {
 
 			ptr = this.js_string_to_mono_string_new (string);
 			ptr = this._store_string_in_intern_table (string, ptr, true);
-			if (!ptr)
-				throw new Error("what");
 
 			return ptr;
 		},

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -25,7 +25,7 @@ var BindingSupportLib = {
 			module ["mono_call_static_method"] = BINDING.call_static_method.bind(BINDING);
 			module ["mono_bind_assembly_entry_point"] = BINDING.bind_assembly_entry_point.bind(BINDING);
 			module ["mono_call_assembly_entry_point"] = BINDING.call_assembly_entry_point.bind(BINDING);
-			module ["mono_intern_string"] = BINDING.intern_string.bind(BINDING);
+			module ["mono_intern_string"] = BINDING.mono_intern_string.bind(BINDING);
 		},
 
 		bindings_lazy_init: function () {
@@ -67,6 +67,7 @@ var BindingSupportLib = {
 			this.mono_wasm_register_bundled_satellite_assemblies = Module.cwrap ('mono_wasm_register_bundled_satellite_assemblies', 'void', [ ]);
 			this.mono_wasm_try_unbox_primitive_and_get_type = Module.cwrap ('mono_wasm_try_unbox_primitive_and_get_type', 'number', ['number', 'number']);
 			this.mono_wasm_box_primitive = Module.cwrap ('mono_wasm_box_primitive', 'number', ['number', 'number', 'number']);
+			this.mono_wasm_intern_string = Module.cwrap ('mono_wasm_intern_string', 'number', ['number']);
 			this.assembly_get_entry_point = Module.cwrap ('mono_wasm_assembly_get_entry_point', 'number', ['number']);
 
 			this._box_buffer = Module._malloc(16);
@@ -154,7 +155,7 @@ var BindingSupportLib = {
 
 		// Ensures the string is already interned on both the managed and JavaScript sides,
 		//  then returns the interned string value (to provide fast reference comparisons like C#)
-		intern_string: function (string) {
+		mono_intern_string: function (string) {
 			var ptr = this.js_string_to_mono_string_interned (string);
 			var result = this._managed_pointer_to_interned_string_table.get (ptr);
 			return result;
@@ -167,7 +168,7 @@ var BindingSupportLib = {
 			//  provide a different managed object than the one we passed in, so update our
 			//  pointer (stored in the root) with the result.
 			if (internIt)
-				resultRoot.value = this._intern_string (ptr);
+				resultRoot.value = this.mono_wasm_intern_string (ptr);
 
 			this._interned_string_table.set (string, resultRoot);
 			this._managed_pointer_to_interned_string_table.set (resultRoot.value, string);

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -1080,3 +1080,9 @@ mono_wasm_enable_on_demand_gc (int enable)
 {
 	mono_wasm_enable_gc = enable ? 1 : 0;
 }
+
+EMSCRIPTEN_KEEPALIVE MonoString *
+mono_wasm_intern_string (MonoString *string) 
+{
+	return mono_string_intern (string);
+}

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -775,6 +775,7 @@ MonoClass* mono_get_uri_class(MonoException** exc)
 #define MARSHAL_TYPE_INT64 26
 #define MARSHAL_TYPE_UINT64 27
 #define MARSHAL_TYPE_CHAR 28
+#define MARSHAL_TYPE_STRING_INTERNED 29
 
 void mono_wasm_ensure_classes_resolved ()
 {
@@ -884,6 +885,12 @@ mono_wasm_get_obj_type (MonoObject *obj)
 
 	/* Process obj before calling into the runtime, class_from_name () can invoke managed code */
 	MonoClass *klass = mono_object_get_class (obj);
+	if (
+		(klass == mono_get_string_class ()) &&
+		(mono_string_is_interned (obj) == obj)
+	)
+		return MARSHAL_TYPE_STRING_INTERNED;
+
 	MonoType *type = mono_class_get_type (klass);
 	obj = NULL;
 
@@ -907,6 +914,14 @@ mono_wasm_try_unbox_primitive_and_get_type (MonoObject *obj, void *result)
 
 	/* Process obj before calling into the runtime, class_from_name () can invoke managed code */
 	MonoClass *klass = mono_object_get_class (obj);
+	if (
+		(klass == mono_get_string_class ()) &&
+		(mono_string_is_interned (obj) == obj)
+	) {
+		*resultL = 0;
+		return MARSHAL_TYPE_STRING_INTERNED;
+	}
+
 	MonoType *type = mono_class_get_type (klass), *original_type = type;
 
 	if (mono_class_is_enum (klass))


### PR DESCRIPTION
This PR introduces interned string support to the bindings layer along with some related changes:
* The JS bindings layer maintains a pair of string intern tables, one mapping JS string -> managed pointer and the other mapping managed pointer -> JS string.
* Any interned managed string is automatically added to the JS intern tables when it crosses the bindings boundary, to avoid duplicate allocations + reduce time spent copying/decoding text.
* Signatures gain a new type token ```S``` which specifies that the argument is an interned string. If the string passed is not already interned, the JS bindings will automatically intern it on both sides.
* The bindings layer logic for creating a new managed string will automatically look it up in the local intern table (unless it is large) and use the existing managed string if an interned string is found.
* mono_wasm_get_obj_type and similar APIs now return a distinct type ID for interned strings. The logic for this is awkward but doing it in the driver is *much* faster than trying to do it from JS.
* Partial support for converting JS ```Symbol``` instances to interned managed strings in the bindings layer. I didn't finish this yet because v8 shell's Symbol support is broken, but it's a good way to achieve interning because the JS runtime exposes interning for symbols.

I added some test coverage but I have some ideas for more tests to add, and I want to complete the symbol support.