### PR TITLE
Added Clear method for IMemoryCache to remove all entries.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Extensions.Caching.Memory
         Microsoft.Extensions.Caching.Memory.ICacheEntry CreateEntry(object key);
         void Remove(object key);
         bool TryGetValue(object key, out object value);
+        void Clear();
     }
     public static partial class MemoryCacheEntryExtensions
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/IMemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/IMemoryCache.cs
@@ -30,5 +30,10 @@ namespace Microsoft.Extensions.Caching.Memory
         /// </summary>
         /// <param name="key">An object identifying the entry.</param>
         void Remove(object key);
+
+        /// <summary>
+        /// Removes all <see cref="ICacheEntry"/> object instances.
+        /// </summary>
+        void Clear();
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Extensions.Caching.Memory
         ~MemoryCache() { }
         public void Remove(object key) { }
         public bool TryGetValue(object key, out object result) { throw null; }
+        public void Clear() { }
     }
     public partial class MemoryCacheOptions : Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions>
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -521,7 +521,5 @@ namespace Microsoft.Extensions.Caching.Memory
                 throw new ArgumentNullException(nameof(key));
             }
         }
-
-
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -290,6 +290,16 @@ namespace Microsoft.Extensions.Caching.Memory
             StartScanForExpiredItems();
         }
 
+        /// <inheritdoc />
+        public void Clear()
+        {
+            CheckDisposed();
+            if (!_entries.IsEmpty)
+            {
+                _entries.Clear();
+            }
+        }
+
         private void RemoveEntry(CacheEntry entry)
         {
             if (EntriesCollection.Remove(new KeyValuePair<object, CacheEntry>(entry.Key, entry)))
@@ -511,5 +521,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 throw new ArgumentNullException(nameof(key));
             }
         }
+
+
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheServiceExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheServiceExtensionsTests.cs
@@ -125,6 +125,8 @@ namespace Microsoft.Extensions.Caching.Distributed
             {
                 throw new NotImplementedException();
             }
+
+            public void Clear() => throw new NotImplementedException();
         }
 
         private class TestDistributedCache : IDistributedCache

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
@@ -361,6 +361,41 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        public void Clear_ClearAllEntries()
+        {
+            var cache = CreateCache();
+
+            var obj = new object();
+            string key = "myKey";
+            var result = cache.Set(key, obj);
+            Assert.Same(obj, result);
+
+            var secondObject = new object();
+            string secondKey = "mySecondKey";
+            var secondResult = cache.Set(secondKey, secondObject);
+            Assert.Same(secondObject, secondResult);
+
+            cache.Clear();
+
+            result = cache.Get(key);
+            secondResult = cache.Get(secondKey);
+
+            Assert.Null(result);
+            Assert.Null(secondResult);
+        }
+
+        [Fact]
+        public void Clear_ThrowsExceptionIfCalledAfterDisposed()
+        {
+            var cache = CreateCache();
+            cache.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => {
+                cache.Clear();
+            });
+        }
+
+        [Fact]
         public void RemoveRemovesAndInvokesCallback()
         {
             var cache = CreateCache();


### PR DESCRIPTION
1. Added Clear method for IMemoryCache to remove all entries.
2. Added corresponding test scenarios as well.

As part of https://github.com/dotnet/runtime/issues/44512