### PR TITLE
Update the minimum and target version of the SDK to 5.0.100

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.8.20417.9",
+    "version": "5.0.100",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-rc.2.20479.15"
+    "dotnet": "5.0.100"
   },
   "native-tools": {
     "cmake": "3.16.4",


### PR DESCRIPTION
**Part of December's batched rollout: https://github.com/dotnet/runtime/issues/44524**

The release/5.0 branch will automatically be updated via Arcade to 5.0.100. Updating master as well to be on the same sdk and use the latest released bits instead of a preview version. This also bumps the minimum required version as illink needs a >= 5.0 RC2 SDK anyway.