### PR TITLE
Remove dependency on System.Linq from debug build

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;netcoreapp3.0;net461</TargetFrameworks>
@@ -237,7 +237,6 @@
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Linq" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Reflection.Emit.ILGeneration" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/MemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/MemberAccessor.cs
@@ -28,5 +28,20 @@ namespace System.Text.Json
         public abstract Func<object, TProperty> CreateFieldGetter<TProperty>(FieldInfo fieldInfo);
 
         public abstract Action<object, TProperty> CreateFieldSetter<TProperty>(FieldInfo fieldInfo);
+
+#if DEBUG
+        public static bool HasConstructor(Type type, ConstructorInfo constructor)
+        {
+            foreach (ConstructorInfo candidate in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (ReferenceEquals(candidate, constructor))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+#endif
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/MemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/MemberAccessor.cs
@@ -28,20 +28,5 @@ namespace System.Text.Json
         public abstract Func<object, TProperty> CreateFieldGetter<TProperty>(FieldInfo fieldInfo);
 
         public abstract Action<object, TProperty> CreateFieldSetter<TProperty>(FieldInfo fieldInfo);
-
-#if DEBUG
-        public static bool HasConstructor(Type type, ConstructorInfo constructor)
-        {
-            foreach (ConstructorInfo candidate in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (ReferenceEquals(candidate, constructor))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-#endif
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization
 
             Debug.Assert(type != null);
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Contains(constructor));
+            Debug.Assert(HasConstructor(type, constructor));
 
             ParameterInfo[] parameters = constructor.GetParameters();
             int parameterCount = parameters.Length;
@@ -111,7 +111,7 @@ namespace System.Text.Json.Serialization
 
             Debug.Assert(type != null);
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Contains(constructor));
+            Debug.Assert(HasConstructor(type, constructor));
 
             ParameterInfo[] parameters = constructor.GetParameters();
             int parameterCount = parameters.Length;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization
 
             Debug.Assert(type != null);
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(HasConstructor(type, constructor));
+            Debug.Assert(Array.IndexOf(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance), constructor) >= 0);
 
             ParameterInfo[] parameters = constructor.GetParameters();
             int parameterCount = parameters.Length;
@@ -111,7 +111,7 @@ namespace System.Text.Json.Serialization
 
             Debug.Assert(type != null);
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(HasConstructor(type, constructor));
+            Debug.Assert(Array.IndexOf(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance), constructor) >= 0);
 
             ParameterInfo[] parameters = constructor.GetParameters();
             int parameterCount = parameters.Length;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 
 namespace System.Text.Json.Serialization
@@ -33,7 +32,7 @@ namespace System.Text.Json.Serialization
             Type type = typeof(T);
 
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Contains(constructor));
+            Debug.Assert(HasConstructor(type, constructor));
 
             int parameterCount = constructor.GetParameters().Length;
 
@@ -73,7 +72,7 @@ namespace System.Text.Json.Serialization
             Type type = typeof(T);
 
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Contains(constructor));
+            Debug.Assert(HasConstructor(type, constructor));
 
             int parameterCount = constructor.GetParameters().Length;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json.Serialization
             Type type = typeof(T);
 
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(HasConstructor(type, constructor));
+            Debug.Assert(Array.IndexOf(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance), constructor) >= 0);
 
             int parameterCount = constructor.GetParameters().Length;
 
@@ -72,7 +72,7 @@ namespace System.Text.Json.Serialization
             Type type = typeof(T);
 
             Debug.Assert(!type.IsAbstract);
-            Debug.Assert(HasConstructor(type, constructor));
+            Debug.Assert(Array.IndexOf(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance), constructor) >= 0);
 
             int parameterCount = constructor.GetParameters().Length;
 


### PR DESCRIPTION
Only the debug build had the dependency; removing it from csproj as well since we don't want to take an unnecessary dependency that would increase deployment size of stand-alone and Blazor-client scenarios.