### PR TITLE
Allow suspending the runtime while suspension for the debugger is pending in some cases

### DIFF
--- a/src/coreclr/src/debug/ee/debugger.h
+++ b/src/coreclr/src/debug/ee/debugger.h
@@ -2187,6 +2187,13 @@ public:
                             unsigned int errorLine,
                             bool exitThread);
 
+    virtual BOOL AreGarbageCollectionEventsEnabledForNextSuspension(void)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_isGarbageCollectionEventsEnabledLatch;
+    }
+
     virtual BOOL IsSynchronizing(void)
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/src/vm/dbginterface.h
+++ b/src/coreclr/src/vm/dbginterface.h
@@ -411,6 +411,7 @@ public:
     virtual void SuspendForGarbageCollectionStarted() = 0;
     virtual void SuspendForGarbageCollectionCompleted() = 0;
     virtual void ResumeForGarbageCollectionStarted() = 0;
+    virtual BOOL AreGarbageCollectionEventsEnabledForNextSuspension() = 0;
 #endif
     virtual BOOL IsSynchronizing() = 0;
 };


### PR DESCRIPTION
1. When suspending for the debugger is in progress (the debugger is waiting for some threads to reach a safe point for suspension), a thread that is not yet suspended may trigger another runtime suspension. This is currently not allowed because the order of operations conflicts with requirements to send GC events for managed data breakpoints to work correctly when suspending for a GC. Instead, the thread suspends for the debugger first, and after the runtime is resumed, continues suspending for GC.
2. At the same time, if the thread that is not suspended yet is in a forbid-suspend-for-debugger region, it cannot suspend for the debugger, which conflicts with the above scenario, but is currently necessary for the issue fixed by https://github.com/dotnet/runtime/pull/40060
3. The current plan is to change managed data breakpoints implementation to pin objects instead of using GC events to track object relocation, and to deprecate the GC events APIs
4. With that, the requirement in # 1 goes away, so this change conditions the check to avoid suspending the runtime during a pending suspension for the debugger based on whether GC events are enabled

- Verified that the latest deadlock seen in https://github.com/dotnet/runtime/issues/42375 manifests only when a data breakpoint is set and not otherwise
- Combined with https://github.com/dotnet/runtime/pull/44471 and a VS update to use that to switch to the pinning mechanism, the latest deadlock issue seen in https://github.com/dotnet/runtime/issues/42375 should disappear completely