### PR TITLE
Fix race condition in Hosting test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -1372,7 +1372,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
-                await Task.Delay(1);
+                await Task.Yield();
 
                 throw new Exception("Background Exception");
             }


### PR DESCRIPTION
Change Task.Delay(1) to Task.Yield() to avoid a super race condition.

Fix #43389