### PR TITLE
Special-case SocketsHttpHandler.MaxResponseDrainTime == 0

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -463,6 +463,12 @@ namespace System.Net.Http
                         if (cts == null) // only create the drain timer if we have to go async
                         {
                             TimeSpan drainTime = _connection._pool.Settings._maxResponseDrainTime;
+
+                            if (drainTime == TimeSpan.Zero)
+                            {
+                                return false;
+                            }
+
                             if (drainTime != Timeout.InfiniteTimeSpan)
                             {
                                 cts = new CancellationTokenSource((int)drainTime.TotalMilliseconds);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -212,11 +212,18 @@ namespace System.Net.Http
                 CancellationTokenSource? cts = null;
                 CancellationTokenRegistration ctr = default;
                 TimeSpan drainTime = _connection._pool.Settings._maxResponseDrainTime;
+
+                if (drainTime == TimeSpan.Zero)
+                {
+                    return false;
+                }
+
                 if (drainTime != Timeout.InfiniteTimeSpan)
                 {
                     cts = new CancellationTokenSource((int)drainTime.TotalMilliseconds);
                     ctr = cts.Token.Register(static s => ((HttpConnection)s!).Dispose(), _connection);
                 }
+
                 try
                 {
                     while (true)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -70,7 +70,7 @@ namespace System.Net.Http
                     {
                         connection.Trace(drained ?
                             "Connection drain succeeded" :
-                            $"Connection drain failed because MaxResponseDrainSize of {connection._pool.Settings._maxResponseDrainSize} bytes was exceeded");
+                            $"Connection drain failed when MaxResponseDrainSize={connection._pool.Settings._maxResponseDrainSize} bytes or MaxResponseDrainTime=={connection._pool.Settings._maxResponseDrainTime} exceeded");
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
If the drain size is set to 0, any attempts to drain end up failing with a 1st-chance ObjectDisposedException that's logged and eaten, when we should just be skipping all the associated work and failing immediately.

cc: @geoffkizer 