### PR TITLE
Fix 5-minute hang in Process tests

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -83,8 +83,10 @@ namespace System.Diagnostics.Tests
                 processModule.Disposed += (_, __) => disposedCount += 1;
             }
 
-            process.Dispose();
+            KillWait(process);
+            Assert.Equal(0, disposedCount);
 
+            process.Dispose();
             Assert.Equal(expectedCount, disposedCount);
         }
     }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.NonUap.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.NonUap.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -11,14 +12,14 @@ namespace System.Diagnostics.Tests
 {
     partial class ProcessTestBase
     {
-        protected Process CreateProcessLong()
+        protected Process CreateProcessLong([CallerMemberName] string callerName = null)
         {
-            return CreateSleepProcess(RemotelyInvokable.WaitInMS);
+            return CreateSleepProcess(RemotelyInvokable.WaitInMS, callerName);
         }
 
-        protected Process CreateSleepProcess(int durationMs)
+        protected Process CreateSleepProcess(int durationMs, [CallerMemberName] string callerName = null)
         {
-            return CreateProcess(RemotelyInvokable.Sleep, durationMs.ToString());
+            return CreateProcess(RemotelyInvokable.Sleep, durationMs.ToString(), callerName);
         }
 
         protected Process CreateProcessPortable(Func<int> func)

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
@@ -17,12 +17,10 @@ namespace System.Diagnostics.Tests
         protected Process _process;
         protected readonly List<Process> _processes = new List<Process>();
 
-        protected Process CreateDefaultProcess()
+        protected Process CreateDefaultProcess([CallerMemberName] string callerName = null)
         {
-            if (_process != null)
-                throw new InvalidOperationException();
-
-            _process = CreateProcessLong();
+            Assert.Null(_process);
+            _process = CreateProcessLong(callerName);
             _process.Start();
             AddProcessForDispose(_process);
             return _process;
@@ -85,8 +83,28 @@ namespace System.Diagnostics.Tests
                 p = handle.Process;
                 handle.Process = null;
             }
+
             if (autoDispose)
+            {
                 AddProcessForDispose(p);
+            }
+
+            return p;
+        }
+
+        protected Process CreateProcess(Func<string, string, int> method, string arg1, string arg2, bool autoDispose = true)
+        {
+            Process p = null;
+            using (RemoteInvokeHandle handle = RemoteExecutor.Invoke(method, arg1, arg2, new RemoteInvokeOptions { Start = false }))
+            {
+                p = handle.Process;
+                handle.Process = null;
+            }
+
+            if (autoDispose)
+            {
+                AddProcessForDispose(p);
+            }
 
             return p;
         }
@@ -107,6 +125,11 @@ namespace System.Diagnostics.Tests
         {
             p.Start();
             Thread.Sleep(200);
+            KillWait(p);
+        }
+
+        protected void KillWait(Process p)
+        {
             p.Kill();
             Assert.True(p.WaitForExit(WaitInMS));
             p.WaitForExit(); // wait for event handlers to complete

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -82,8 +82,10 @@ namespace System.Diagnostics.Tests
                 processThread.Disposed += (_, __) => disposedCount += 1;
             }
 
-            process.Dispose();
+            KillWait(process);
+            Assert.Equal(0, disposedCount);
 
+            process.Dispose();
             Assert.Equal(expectedCount, disposedCount);
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/RemotelyInvokable.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/RemotelyInvokable.cs
@@ -28,8 +28,9 @@ namespace System.Diagnostics.Tests
             return SuccessExitCode;
         }
 
-        public static int Sleep(string duration)
+        public static int Sleep(string duration, string callerName)
         {
+            _ = callerName; // argument ignored, for debugging purposes
             Thread.Sleep(int.Parse(duration));
             return SuccessExitCode;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44537

These two tests were disposing of the Process object that had been registered in the base collection, which the base class uses to kill all such processes.  Because the Process object had been disposed (the test required it), it couldn't call Kill.

cc: @danmosemsft, @adamsitnik 