### PR TITLE
docs: fix MSBuild property InvariantGlobalization

### DIFF
--- a/docs/design/features/globalization-invariant-mode.md
+++ b/docs/design/features/globalization-invariant-mode.md
@@ -103,9 +103,9 @@ Applications can enable the invariant mode by either of the following:
 1. in project file:
 
     ```xml
-    <ItemGroup>
+    <PropertyGroup>
         <InvariantGlobalization>true</InvariantGlobalization>
-    </ItemGroup>
+    </PropertyGroup>
     ```
 
 2. in `runtimeconfig.json` file:

--- a/docs/design/features/globalization-invariant-mode.md
+++ b/docs/design/features/globalization-invariant-mode.md
@@ -104,7 +104,7 @@ Applications can enable the invariant mode by either of the following:
 
     ```xml
     <ItemGroup>
-      <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+        <InvariantGlobalization>true</InvariantGlobalization>
     </ItemGroup>
     ```
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/core/run-time-config/globalization

This option seems to have been changed.