### PR TITLE
Added condition of empty for concurrent dictionary

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -642,7 +642,7 @@ namespace System.Collections.Concurrent
             {
                 AcquireAllLocks(ref locksAcquired);
 
-                // If underlying bucket is already empty then just return
+                // If the dictionary is already empty, then there's nothing to clear.
                 if (AreAllBucketsEmpty())
                 {
                     return;

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -637,19 +637,22 @@ namespace System.Collections.Concurrent
         /// </summary>
         public void Clear()
         {
-            int locksAcquired = 0;
-            try
+            if (!IsEmpty)
             {
-                AcquireAllLocks(ref locksAcquired);
+                int locksAcquired = 0;
+                try
+                {
+                    AcquireAllLocks(ref locksAcquired);
 
-                Tables tables = _tables;
-                var newTables = new Tables(new Node[DefaultCapacity], tables._locks, new int[tables._countPerLock.Length]);
-                _tables = newTables;
-                _budget = Math.Max(1, newTables._buckets.Length / newTables._locks.Length);
-            }
-            finally
-            {
-                ReleaseLocks(0, locksAcquired);
+                    Tables tables = _tables;
+                    var newTables = new Tables(new Node[DefaultCapacity], tables._locks, new int[tables._countPerLock.Length]);
+                    _tables = newTables;
+                    _budget = Math.Max(1, newTables._buckets.Length / newTables._locks.Length);
+                }
+                finally
+                {
+                    ReleaseLocks(0, locksAcquired);
+                }
             }
         }
 


### PR DESCRIPTION
If the collection is already empty why to initialize it again with new empty tables.