### PR TITLE
Mark R2RDumpTests as incompatible with GC stress

### DIFF
--- a/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
+++ b/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' != 'coreclr'">true</DisableProjectBuild>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+    <!-- The test is lengthy as it scans the entire System.Private.CoreLib so that it times out in GC stress runs. -->
+    <!-- The purpose of the test is functional testing of the R2R reader, not runtime stress testing. -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
+++ b/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' != 'coreclr'">true</DisableProjectBuild>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="R2RDumpTester.cs" />


### PR DESCRIPTION
The purpose of this test is not to stress the runtime, it's relatively
lengthy as it processes the entire System.Private.CoreLib framework
assembly and so it's timing out in GC stress runs.

Thanks

Tomas