### PR TITLE
Reduce Process test time

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1877,6 +1877,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<Win32Exception>(() => Process.Start("exe", string.Empty, new SecureString(), "thisDomain"));
         }
 
+        [OuterLoop("May take many seconds the first time it's run")]
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Starting process with authentication not supported on Unix
         public void Process_StartWithInvalidUserNamePassword()

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -637,17 +637,17 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [OuterLoop("As written, takes 30 seconds")]
         public async Task WaitAsyncForProcess()
         {
-            Process p = CreateSleepProcess(WaitInMS);
-            p.Start();
+            Process p = CreateDefaultProcess();
 
             Task processTask = p.WaitForExitAsync();
-            Task delayTask = Task.Delay(WaitInMS * 2);
+            Assert.False(p.HasExited);
+            Assert.False(processTask.IsCompleted);
 
-            Task result = await Task.WhenAny(processTask, delayTask);
-            Assert.Equal(processTask, result);
+            p.Kill();
+            await processTask;
+
             Assert.True(p.HasExited);
         }
 


### PR DESCRIPTION
Fix a test that was taking 30 seconds, and make another test outerloop.

cc: @danmosemsft