### PR TITLE
Override Read/Write for spans on ConsoleStream

### DIFF
--- a/src/libraries/System.Console/src/Resources/Strings.resx
+++ b/src/libraries/System.Console/src/Resources/Strings.resx
@@ -182,9 +182,6 @@
   <data name="IO_SharingViolation_NoFileName" xml:space="preserve">
     <value>The process cannot access the file because it is being used by another process.</value>
   </data>
-  <data name="IndexOutOfRange_IORaceCondition" xml:space="preserve">
-    <value>Probable I/O race condition detected while copying memory. The I/O package is not thread safe by default. In multithreaded applications, a stream must be accessed in a thread-safe way, such as a thread-safe wrapper returned by TextReader's or TextWriter's Synchronized methods. This also applies to classes like StreamWriter and StreamReader.</value>
-  </data>
   <data name="Arg_InvalidConsoleColor" xml:space="preserve">
     <value>The ConsoleColor enum value was not defined on that enum. Please use a defined color from the enum.</value>
   </data>

--- a/src/libraries/System.Console/src/System/ConsolePal.Android.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Android.cs
@@ -11,11 +11,11 @@ namespace System
     {
         public LogcatStream() : base(FileAccess.Write) {}
 
-        public override int Read(byte[] buffer, int offset, int count) => throw Error.GetReadNotSupported();
+        public override int Read(Span<byte> buffer) => throw Error.GetReadNotSupported();
 
-        public override unsafe void Write(byte[] buffer, int offset, int count)
+        public override unsafe void Write(ReadOnlySpan<byte> buffer)
         {
-            string log = ConsolePal.OutputEncoding.GetString(buffer, offset, count);
+            string log = ConsolePal.OutputEncoding.GetString(buffer);
             Interop.Logcat.AndroidLogPrint(Interop.Logcat.LogLevel.Info, "DOTNET", log);
         }
     }

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1212,15 +1212,13 @@ namespace System
         /// <summary>Reads data from the file descriptor into the buffer.</summary>
         /// <param name="fd">The file descriptor.</param>
         /// <param name="buffer">The buffer to read into.</param>
-        /// <param name="offset">The offset at which to start writing into the buffer.</param>
-        /// <param name="count">The maximum number of bytes to read.</param>
         /// <returns>The number of bytes read, or a negative value if there's an error.</returns>
-        internal static unsafe int Read(SafeFileHandle fd, byte[] buffer, int offset, int count)
+        internal static unsafe int Read(SafeFileHandle fd, Span<byte> buffer)
         {
             fixed (byte* bufPtr = buffer)
             {
-                int result = Interop.CheckIo(Interop.Sys.Read(fd, (byte*)bufPtr + offset, count));
-                Debug.Assert(result <= count);
+                int result = Interop.CheckIo(Interop.Sys.Read(fd, bufPtr, buffer.Length));
+                Debug.Assert(result <= buffer.Length);
                 return result;
             }
         }
@@ -1424,26 +1422,13 @@ namespace System
                 base.Dispose(disposing);
             }
 
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                ValidateRead(buffer, offset, count);
+            public override int Read(Span<byte> buffer) =>
+                _useReadLine ?
+                    ConsolePal.StdInReader.ReadLine(buffer) :
+                    ConsolePal.Read(_handle, buffer);
 
-                if (_useReadLine)
-                {
-                    return ConsolePal.StdInReader.ReadLine(buffer, offset, count);
-                }
-                else
-                {
-                    return ConsolePal.Read(_handle, buffer, offset, count);
-                }
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                ValidateWrite(buffer, offset, count);
-
-                ConsolePal.Write(_handle, buffer.AsSpan(offset, count));
-            }
+            public override void Write(ReadOnlySpan<byte> buffer) =>
+                ConsolePal.Write(_handle, buffer);
 
             public override void Flush()
             {

--- a/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
@@ -29,15 +29,13 @@ namespace System
             base.Dispose(disposing);
         }
 
-        public override int Read(byte[] buffer, int offset, int count) => throw Error.GetReadNotSupported();
+        public override int Read(Span<byte> buffer) => throw Error.GetReadNotSupported();
 
-        public override unsafe void Write(byte[] buffer, int offset, int count)
+        public override unsafe void Write(ReadOnlySpan<byte> buffer)
         {
-            ValidateWrite(buffer, offset, count);
-
             fixed (byte* bufPtr = buffer)
             {
-                Write(_handle, bufPtr + offset, count);
+                Write(_handle, bufPtr, buffer.Length);
             }
         }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -10,15 +10,13 @@ namespace System
     {
         public NSLogStream() : base(FileAccess.Write) {}
 
-        public override int Read(byte[] buffer, int offset, int count) => throw Error.GetReadNotSupported();
+        public override int Read(Span<byte> buffer) => throw Error.GetReadNotSupported();
 
-        public override unsafe void Write(byte[] buffer, int offset, int count)
+        public override unsafe void Write(ReadOnlySpan<byte> buffer)
         {
-            ValidateWrite(buffer, offset, count);
-
             fixed (byte* ptr = buffer)
             {
-                Interop.Sys.Log(ptr + offset, count);
+                Interop.Sys.Log(ptr, buffer.Length);
             }
         }
     }

--- a/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
+++ b/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace System.IO
 {
@@ -21,6 +20,27 @@ namespace System.IO
             _canWrite = ((access & FileAccess.Write) == FileAccess.Write);
         }
 
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ValidateWrite(buffer, offset, count);
+            Write(new ReadOnlySpan<byte>(buffer, offset, count));
+        }
+
+        public override void WriteByte(byte value) => Write(MemoryMarshal.CreateReadOnlySpan(ref value, 1));
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateRead(buffer, offset, count);
+            return Read(new Span<byte>(buffer, offset, count));
+        }
+
+        public override int ReadByte()
+        {
+            byte b = 0;
+            int result = Read(MemoryMarshal.CreateSpan(ref b, 1));
+            return result != 0 ? b : -1;
+        }
+
         protected override void Dispose(bool disposing)
         {
             _canRead = false;
@@ -28,30 +48,18 @@ namespace System.IO
             base.Dispose(disposing);
         }
 
-        public sealed override bool CanRead
-        {
-            get { return _canRead; }
-        }
+        public sealed override bool CanRead => _canRead;
 
-        public sealed override bool CanWrite
-        {
-            get { return _canWrite; }
-        }
+        public sealed override bool CanWrite => _canWrite;
 
-        public sealed override bool CanSeek
-        {
-            get { return false; }
-        }
+        public sealed override bool CanSeek => false;
 
-        public sealed override long Length
-        {
-            get { throw Error.GetSeekNotSupported(); }
-        }
+        public sealed override long Length => throw Error.GetSeekNotSupported();
 
         public sealed override long Position
         {
-            get { throw Error.GetSeekNotSupported(); }
-            set { throw Error.GetSeekNotSupported(); }
+            get => throw Error.GetSeekNotSupported();
+            set => throw Error.GetSeekNotSupported();
         }
 
         public override void Flush()
@@ -59,28 +67,28 @@ namespace System.IO
             if (!CanWrite) throw Error.GetWriteNotSupported();
         }
 
-        public sealed override void SetLength(long value)
-        {
-            throw Error.GetSeekNotSupported();
-        }
+        public sealed override void SetLength(long value) => throw Error.GetSeekNotSupported();
 
-        public sealed override long Seek(long offset, SeekOrigin origin)
-        {
-            throw Error.GetSeekNotSupported();
-        }
+        public sealed override long Seek(long offset, SeekOrigin origin) => throw Error.GetSeekNotSupported();
 
         protected void ValidateRead(byte[] buffer, int offset, int count)
         {
             ValidateBufferArguments(buffer, offset, count);
 
-            if (!_canRead) throw Error.GetReadNotSupported();
+            if (!_canRead)
+            {
+                throw Error.GetReadNotSupported();
+            }
         }
 
         protected void ValidateWrite(byte[] buffer, int offset, int count)
         {
             ValidateBufferArguments(buffer, offset, count);
 
-            if (!_canWrite) throw Error.GetWriteNotSupported();
+            if (!_canWrite)
+            {
+                throw Error.GetWriteNotSupported();
+            }
         }
     }
 }

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -93,9 +93,9 @@ namespace System.IO
             return line;
         }
 
-        public int ReadLine(byte[] buffer, int offset, int count)
+        public int ReadLine(Span<byte> buffer)
         {
-            if (count == 0)
+            if (buffer.IsEmpty)
             {
                 return 0;
             }
@@ -114,11 +114,10 @@ namespace System.IO
             Encoder encoder = _bufferReadEncoder ??= _encoding.GetEncoder();
             int bytesUsedTotal = 0;
             int charsUsedTotal = 0;
-            Span<byte> destination = buffer.AsSpan(offset, count);
             foreach (ReadOnlyMemory<char> chunk in _readLineSB.GetChunks())
             {
-                encoder.Convert(chunk.Span, destination, flush: false, out int charsUsed, out int bytesUsed, out bool completed);
-                destination = destination.Slice(bytesUsed);
+                encoder.Convert(chunk.Span, buffer, flush: false, out int charsUsed, out int bytesUsed, out bool completed);
+                buffer = buffer.Slice(bytesUsed);
                 bytesUsedTotal += bytesUsed;
                 charsUsedTotal += charsUsed;
 

--- a/src/libraries/System.Console/src/System/IO/SyncTextReader.Unix.cs
+++ b/src/libraries/System.Console/src/System/IO/SyncTextReader.Unix.cs
@@ -40,7 +40,6 @@ namespace System.IO
             }
         }
 
-        public int ReadLine(byte[] buffer, int offset, int count)
-            => Inner.ReadLine(buffer, offset, count);
+        public int ReadLine(Span<byte> buffer) => Inner.ReadLine(buffer);
     }
 }

--- a/src/libraries/System.Console/src/System/TermInfo.cs
+++ b/src/libraries/System.Console/src/System/TermInfo.cs
@@ -262,10 +262,9 @@ namespace System
                     {
                         throw new InvalidOperationException(SR.IO_TermInfoInvalid);
                     }
-                    int fileLen = (int)termInfoLength;
 
-                    byte[] data = new byte[fileLen];
-                    if (ConsolePal.Read(fd, data, 0, fileLen) != fileLen)
+                    byte[] data = new byte[(int)termInfoLength];
+                    if (ConsolePal.Read(fd, data) != data.Length)
                     {
                         throw new InvalidOperationException(SR.IO_TermInfoInvalid);
                     }


### PR DESCRIPTION
Console.WriteLine ends up calling Write(span) in some cases, which incurs unnecessary additional cost to call through to Write(byte[], ...).

Contributes to https://github.com/dotnet/runtime/issues/44598

cc: @adamsitnik @eiriktsarpalis @egorbo