### PR TITLE
Skip zip target if there are no packages produces 

### DIFF
--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -157,6 +157,7 @@
 
     <MakeDir Directories="$(TestArchiveTestsRoot)" />
     <ZipDirectory
+        Condition="'@(SupportedPackage)' != ''"
         SourceDirectory="$(TestProjectDir)%(SupportedPackage.Identity)"
         DestinationFile="$(TestArchiveTestsRoot)%(SupportedPackage.Identity).zip"
         Overwrite="true" />


### PR DESCRIPTION
port of https://github.com/dotnet/corefx/pull/41486

We just hit this in 5.0 because we failed to port the fix in 5.0. This is to avoid hitting this in 6.0