### PR TITLE
OSX Add option -no_code_signature_warning

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -268,7 +268,7 @@ function(strip_symbols targetName outputFilename)
 
       string(TOLOWER "${CMAKE_BUILD_TYPE}" LOWERCASE_CMAKE_BUILD_TYPE)
       if (LOWERCASE_CMAKE_BUILD_TYPE STREQUAL release)
-        set(strip_command ${STRIP} -S ${strip_source_file})
+        set(strip_command ${STRIP} -no_code_signature_warning -S ${strip_source_file})
       else ()
         set(strip_command)
       endif ()


### PR DESCRIPTION
When building on Apple Silicon the stripping pass warns about breaking signing
despite not having signed the binary yet (failing the build). Disable the warning

