### PR TITLE
Fix zh cultures parent chain

### DIFF
--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoParent.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoParent.cs
@@ -11,6 +11,11 @@ namespace System.Globalization.Tests
         [InlineData("en-US", "en")]
         [InlineData("en", "")]
         [InlineData("", "")]
+        [InlineData("zh-CN", "zh-Hans")]
+        [InlineData("zh-SG", "zh-Hans")]
+        [InlineData("zh-HK", "zh-Hant")]
+        [InlineData("zh-MO", "zh-Hant")]
+        [InlineData("zh-TW", "zh-Hant")]
         public void Parent(string name, string expectedParentName)
         {
             CultureInfo culture = new CultureInfo(name);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -496,6 +496,28 @@ namespace System.Globalization
                     CultureInfo culture;
                     string parentName = _cultureData.ParentName;
 
+                    if (parentName == "zh" && _name.Length == 5 && _name[2] == '-')
+                    {
+                        // We need to keep the parent chain for the zh cultures as follows to preserve the resource lookup compatability
+                        //      zh-CN -> zh-Hans -> zh -> Invariant
+                        //      zh-HK -> zh-Hant -> zh -> Invariant
+                        //      zh-MO -> zh-Hant -> zh -> Invariant
+                        //      zh-SG -> zh-Hans -> zh -> Invariant
+                        //      zh-TW -> zh-Hant -> zh -> Invariant
+
+                        if ((_name[3] == 'C' && _name[4] == 'N' ) || // zh-CN
+                            (_name[3] == 'S' && _name[4] == 'G' ))   // zh-SG
+                        {
+                            parentName = "zh-Hans";
+                        }
+                        else if ((_name[3] == 'H' && _name[4] == 'K' ) || // zh-HK
+                                 (_name[3] == 'M' && _name[4] == 'O' ) || // zh-MO
+                                 (_name[3] == 'T' && _name[4] == 'W' ))   // zh-TW
+                        {
+                            parentName = "zh-Hant";
+                        }
+                    }
+
                     if (string.IsNullOrEmpty(parentName))
                     {
                         culture = InvariantCulture;


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/44502

After switching to use ICU, the parent chain of the following cultures changed from:

```
    zh-CN -> zh-Hans -> zh -> Invariant
    zh-HK -> zh-Hant -> zh -> Invariant
    zh-MO -> zh-Hant -> zh -> Invariant
    zh-SG -> zh-Hans -> zh -> Invariant
    zh-TW -> zh-Hant -> zh -> Invariant
```

to 

```
    zh-CN -> zh -> Invariant
    zh-HK -> zh -> Invariant
    zh-MO -> zh -> Invariant
    zh-SG -> zh -> Invariant
    zh-TW -> zh -> Invariant
```

It is important to keep the old parent chains because these used in the resource lookup fallback. For example, if the app/library created a resources for `zh-Hans`, when running on system using `zh-CN` UI culture, the resources lookup will not be able to find `zh-Hans` because it is not part of the parent chain. Inserting back `zh-Hans` in the parent chain will make it work again.  
