### PR TITLE
Add new StringInfo APIs and improve unit tests

### DIFF
--- a/src/libraries/System.Globalization/tests/System/Globalization/GraphemeBreakTest.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/GraphemeBreakTest.cs
@@ -24,30 +24,111 @@ namespace System.Globalization.Tests
             {
                 // Arrange
 
-                List<int> expected = new List<int>();
-                StringBuilder input = new StringBuilder();
+                StringBuilder inputString = new StringBuilder();
+                List<Range> expectedGraphemeClusterRanges = new List<Range>();
 
                 foreach (Rune[] cluster in clusters)
                 {
-                    expected.Add(input.Length); // we're about to start a new cluster
-                    foreach (Rune scalar in cluster)
+                    int start = inputString.Length;
+                    foreach (Rune rune in cluster)
                     {
-                        input.Append(scalar);
+                        inputString.Append(rune);
                     }
+                    int end = inputString.Length;
+                    expectedGraphemeClusterRanges.Add(start..end);
                 }
 
-                // Act
+                // Act & assert
 
-                int[] actual = StringInfo.ParseCombiningCharacters(input.ToString());
-
-                // Assert
-
-                if (!expected.SequenceEqual(actual))
+                try
                 {
-                    throw new AssertActualExpectedException(
-                        expected: expected.ToArray(),
-                        actual: actual,
-                        userMessage: "Grapheme break test failed on test case: " + line);
+                    RunStringInfoTestCase(inputString.ToString(), expectedGraphemeClusterRanges.ToArray());
+                }
+                catch (Exception ex)
+                {
+                    // include the failing line from the test case file for ease of debugging
+                    throw new Exception("Grapheme break test failed on test case: " + line, ex);
+                }
+            }
+        }
+
+        private static void RunStringInfoTestCase(string input, Range[] expectedGraphemeClusterRanges)
+        {
+            if (expectedGraphemeClusterRanges.Length == 0)
+            {
+                // Handle empty inputs
+
+                Assert.Equal(string.Empty, input); // Shouldn't have zero-length expected grapheme clusters for non-empty inputs
+                Assert.Equal(0, StringInfo.GetNextTextElementLength(input));
+                Assert.Equal(0, StringInfo.GetNextTextElementLength(input, 0));
+                Assert.Equal(0, StringInfo.GetNextTextElementLength(input.AsSpan()));
+                Assert.Equal(string.Empty, StringInfo.GetNextTextElement(input));
+                Assert.Equal(string.Empty, StringInfo.GetNextTextElement(input, 0));
+
+                StringInfo si = new StringInfo(input);
+                Assert.Equal(0, si.LengthInTextElements);
+
+                TextElementEnumerator enumerator = StringInfo.GetTextElementEnumerator(input);
+                Assert.False(enumerator.MoveNext());
+            }
+            else
+            {
+                // Handle non-empty inputs
+
+                // ParseCombiningCharacters returns the offset of each grapheme cluster start
+
+                int[] combiningCharOffsets = StringInfo.ParseCombiningCharacters(input);
+                Assert.Equal(
+                    expected: expectedGraphemeClusterRanges.Select(range => range.GetOffsetAndLength(input.Length).Offset).ToArray(),
+                    actual: combiningCharOffsets);
+
+                // GetNextTextElement[Length] returns the substring [length] of each grapheme cluster
+
+                foreach (Range range in expectedGraphemeClusterRanges)
+                {
+                    string expected = input[range];
+
+                    Assert.Equal(expected, StringInfo.GetNextTextElement(input[range.Start..]));
+                    Assert.Equal(expected, StringInfo.GetNextTextElement(input, range.GetOffsetAndLength(input.Length).Offset));
+                    Assert.Equal(expected.Length, StringInfo.GetNextTextElementLength(input[range.Start..]));
+                    Assert.Equal(expected.Length, StringInfo.GetNextTextElementLength(input, range.GetOffsetAndLength(input.Length).Offset));
+                    Assert.Equal(expected.Length, StringInfo.GetNextTextElementLength(input.AsSpan()[range]));
+                }
+
+                // StringInfo.LengthInTextElements returns the total grapheme cluster count
+
+                Assert.Equal(expectedGraphemeClusterRanges.Length, new StringInfo(input).LengthInTextElements);
+
+                // TextElementEnumerator returns an enumerator over each grapheme cluster
+
+                for (int i = 0; i < expectedGraphemeClusterRanges.Length; i++)
+                {
+                    Span<Range> remainingRanges = expectedGraphemeClusterRanges.AsSpan(i);
+
+                    int baseOffset = remainingRanges[0].GetOffsetAndLength(input.Length).Offset;
+                    TextElementEnumerator enumerator1 = StringInfo.GetTextElementEnumerator(input[baseOffset..]);
+                    TextElementEnumerator enumerator2 = StringInfo.GetTextElementEnumerator(input, baseOffset);
+
+                    foreach (Range innerRange in remainingRanges)
+                    {
+                        Assert.True(enumerator1.MoveNext()); // input string has already been substringed
+                        Assert.True(enumerator2.MoveNext()); // input string has been fully provided; enumerator has substringed
+
+                        string expectedSubstring = input[innerRange];
+                        int expectedRelativeOffset = innerRange.GetOffsetAndLength(input.Length).Offset - baseOffset;
+
+                        Assert.Equal(expectedRelativeOffset, enumerator1.ElementIndex);
+                        Assert.Equal(expectedRelativeOffset, enumerator2.ElementIndex);
+
+                        Assert.Equal(expectedSubstring, enumerator1.Current);
+                        Assert.Equal(expectedSubstring, enumerator1.GetTextElement());
+
+                        Assert.Equal(expectedSubstring, enumerator2.Current);
+                        Assert.Equal(expectedSubstring, enumerator2.GetTextElement());
+                    }
+
+                    Assert.False(enumerator1.MoveNext());
+                    Assert.False(enumerator2.MoveNext());
                 }
             }
         }

--- a/src/libraries/System.Globalization/tests/System/Globalization/GraphemeBreakTest.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/GraphemeBreakTest.cs
@@ -187,10 +187,10 @@ namespace System.Globalization.Tests
                     continue;
                 }
 
-                // Line has format "÷ (XXXX (× YYYY)* ÷)+ # <comment>"
+                // Line has format "Ã· (XXXX (Ã— YYYY)* Ã·)+ # <comment>"
                 // We'll yield return a Rune[][], representing a collection of clusters, where each cluster contains a collection of Runes.
                 //
-                // Example: "÷ AAAA ÷ BBBB × CCCC × DDDD ÷ EEEE × FFFF ÷ # <comment>"
+                // Example: "Ã· AAAA Ã· BBBB Ã— CCCC Ã— DDDD Ã· EEEE Ã— FFFF Ã· # <comment>"
                 // -> [ [ AAAA ], [ BBBB, CCCC, DDDD ], [ EEEE, FFFF ] ]
                 //
                 // We also return the line for ease of debugging any test failures.

--- a/src/libraries/System.Globalization/tests/System/Globalization/StringInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/StringInfoTests.cs
@@ -166,6 +166,28 @@ namespace System.Globalization.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => StringInfo.GetNextTextElement("abc", 4)); // Index > str.Length
         }
 
+        [Theory]
+        [MemberData(nameof(GetNextTextElement_TestData))]
+        public void GetNextTextElementLength(string str, int index, string expected)
+        {
+            if (index == 0)
+            {
+                Assert.Equal(expected.Length, StringInfo.GetNextTextElementLength(str));
+            }
+            Assert.Equal(expected.Length, StringInfo.GetNextTextElementLength(str, index));
+            Assert.Equal(expected.Length, StringInfo.GetNextTextElementLength(str.AsSpan(index)));
+        }
+
+        [Fact]
+        public void GetNextTextElementLength_Invalid()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("str", () => StringInfo.GetNextTextElementLength(null)); // Str is null
+            AssertExtensions.Throws<ArgumentNullException>("str", () => StringInfo.GetNextTextElementLength(null, 0)); // Str is null
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => StringInfo.GetNextTextElementLength("abc", -1)); // Index < 0
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => StringInfo.GetNextTextElementLength("abc", 4)); // Index > str.Length
+        }
+
         public static IEnumerable<object[]> GetTextElementEnumerator_TestData()
         {
             yield return new object[] { "", 0, new string[0] }; // Empty string

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/StringInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/StringInfo.cs
@@ -196,7 +196,7 @@ namespace System.Globalization
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.str);
             }
 
-            ValueListBuilder<int> builder = new ValueListBuilder<int>(stackalloc int[16]); // 16 arbitrarily chosen
+            ValueListBuilder<int> builder = new ValueListBuilder<int>(stackalloc int[64]); // 64 arbitrarily chosen
             ReadOnlySpan<char> remaining = str;
 
             while (!remaining.IsEmpty)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/StringInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/StringInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Unicode;
 
@@ -95,16 +94,52 @@ namespace System.Globalization
             return String[start..end];
         }
 
+        /// <summary>
+        /// Returns the first text element (extended grapheme cluster) that occurs in the input string.
+        /// </summary>
+        /// <param name="str">The input string to analyze.</param>
+        /// <returns>The substring corresponding to the first text element within <paramref name="str"/>,
+        /// or the empty string if <paramref name="str"/> is empty.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is null.</exception>
         public static string GetNextTextElement(string str) => GetNextTextElement(str, 0);
 
         /// <summary>
-        /// Returns the str containing the next text element in str starting at
-        /// index index. If index is not supplied, then it will start at the beginning
-        /// of str. It recognizes a base character plus one or more combining
-        /// characters or a properly formed surrogate pair as a text element.
-        /// See also the ParseCombiningCharacters() and the ParseSurrogates() methods.
+        /// Returns the first text element (extended grapheme cluster) that occurs in the input string
+        /// starting at the specified index.
         /// </summary>
+        /// <param name="str">The input string to analyze.</param>
+        /// <param name="index">The char offset in <paramref name="str"/> at which to begin analysis.</param>
+        /// <returns>The substring corresponding to the first text element within <paramref name="str"/> starting
+        /// at index <paramref name="index"/>, or the empty string if <paramref name="index"/> corresponds to
+        /// the end of <paramref name="str"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative or beyond the end of <paramref name="str"/>.</exception>
         public static string GetNextTextElement(string str, int index)
+        {
+            int nextTextElementLength = GetNextTextElementLength(str, index);
+            return str.Substring(index, nextTextElementLength);
+        }
+
+        /// <summary>
+        /// Returns the length of the first text element (extended grapheme cluster) that occurs in the input string.
+        /// </summary>
+        /// <param name="str">The input string to analyze.</param>
+        /// <returns>The length (in chars) of the substring corresponding to the first text element within <paramref name="str"/>,
+        /// or 0 if <paramref name="str"/> is empty.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is null.</exception>
+        public static int GetNextTextElementLength(string str) => GetNextTextElementLength(str, 0);
+
+        /// <summary>
+        /// Returns the length of the first text element (extended grapheme cluster) that occurs in the input string
+        /// starting at the specified index.
+        /// </summary>
+        /// <param name="str">The input string to analyze.</param>
+        /// <param name="index">The char offset in <paramref name="str"/> at which to begin analysis.</param>
+        /// <returns>The length (in chars) of the substring corresponding to the first text element within <paramref name="str"/> starting
+        /// at index <paramref name="index"/>, or 0 if <paramref name="index"/> corresponds to the end of <paramref name="str"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative or beyond the end of <paramref name="str"/>.</exception>
+        public static int GetNextTextElementLength(string str, int index)
         {
             if (str is null)
             {
@@ -115,8 +150,16 @@ namespace System.Globalization
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }
 
-            return str.Substring(index, TextSegmentationUtility.GetLengthOfFirstUtf16ExtendedGraphemeCluster(str.AsSpan(index)));
+            return GetNextTextElementLength(str.AsSpan(index));
         }
+
+        /// <summary>
+        /// Returns the length of the first text element (extended grapheme cluster) that occurs in the input span.
+        /// </summary>
+        /// <param name="str">The input span to analyze.</param>
+        /// <returns>The length (in chars) of the substring corresponding to the first text element within <paramref name="str"/>,
+        /// or 0 if <paramref name="str"/> is empty.</returns>
+        public static int GetNextTextElementLength(ReadOnlySpan<char> str) => TextSegmentationUtility.GetLengthOfFirstUtf16ExtendedGraphemeCluster(str);
 
         public static TextElementEnumerator GetTextElementEnumerator(string str) => GetTextElementEnumerator(str, 0);
 
@@ -153,44 +196,19 @@ namespace System.Globalization
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.str);
             }
 
-            // This method is optimized for small-ish strings.
-            // If a large string is seen we'll go down a slower code path.
-
-            if (str.Length > 256)
-            {
-                return ParseCombiningCharactersForLargeString(str);
-            }
-
-            Span<int> baseOffsets = stackalloc int[str.Length];
-            int graphemeClusterCount = 0;
-
+            ValueListBuilder<int> builder = new ValueListBuilder<int>(stackalloc int[16]); // 16 arbitrarily chosen
             ReadOnlySpan<char> remaining = str;
+
             while (!remaining.IsEmpty)
             {
-                baseOffsets[graphemeClusterCount++] = str.Length - remaining.Length;
-                remaining = remaining.Slice(TextSegmentationUtility.GetLengthOfFirstUtf16ExtendedGraphemeCluster(remaining));
+                builder.Append(str.Length - remaining.Length); // a new extended grapheme cluster begins at this offset
+                remaining = remaining.Slice(GetNextTextElementLength(remaining)); // consume this cluster
             }
 
-            return baseOffsets.Slice(0, graphemeClusterCount).ToArray();
-        }
+            int[] retVal = builder.AsSpan().ToArray();
+            builder.Dispose();
 
-        private static int[] ParseCombiningCharactersForLargeString(string str)
-        {
-            Debug.Assert(str != null);
-
-            // If we have a large string, we may as well take the hit of using a List<int>
-            // instead of trying the stackalloc optimizations we have for smaller strings.
-
-            List<int> baseOffsets = new List<int>();
-
-            ReadOnlySpan<char> remaining = str;
-            while (!remaining.IsEmpty)
-            {
-                baseOffsets.Add(str.Length - remaining.Length);
-                remaining = remaining.Slice(TextSegmentationUtility.GetLengthOfFirstUtf16ExtendedGraphemeCluster(remaining));
-            }
-
-            return baseOffsets.ToArray();
+            return retVal;
         }
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6673,6 +6673,9 @@ namespace System.Globalization
         public override int GetHashCode() { throw null; }
         public static string GetNextTextElement(string str) { throw null; }
         public static string GetNextTextElement(string str, int index) { throw null; }
+        public static int GetNextTextElementLength(string str) { throw null; }
+        public static int GetNextTextElementLength(string str, int index) { throw null; }
+        public static int GetNextTextElementLength(System.ReadOnlySpan<char> str) { throw null; }
         public static System.Globalization.TextElementEnumerator GetTextElementEnumerator(string str) { throw null; }
         public static System.Globalization.TextElementEnumerator GetTextElementEnumerator(string str, int index) { throw null; }
         public static int[] ParseCombiningCharacters(string str) { throw null; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/28704.

This introduces `StringInfo.GetNextTextElementLength`, which allows allocation-free inspection of grapheme clusters within a string or a span. In addition to the new APIs, I refactored the existing `StringInfo` logic a bit to remove some duplicate code, including taking advantage of the runtime's `ValueListBuilder<T>` struct.

I also improved unit test coverage of the `StringInfo` APIs. When we're reading the UCD test files, we're now running every line from _GraphemeBreakTest.txt_ through all of the `StringInfo` APIs, exercising all of them against the Unicode-provided edge cases. I decided to exercise all of the APIs from a single unit test helper, as otherwise we'd be copying + pasting a lot of code across all the different unit tests. To improve debuggability of failed tests, I include the failing line from UCD as part of the test message. Here's an example of what a failure looks like:

```txt
[xUnit.net 00:00:02.36]     System.Globalization.Tests.GraphemeBreakTest.CompareRuntimeImplementationAgainstUnicodeTestData [FAIL]
  Failed System.Globalization.Tests.GraphemeBreakTest.CompareRuntimeImplementationAgainstUnicodeTestData [6 ms]
  Error Message:
   System.Exception : Grapheme break test failed on test case: ÷ 0020 ÷ 0020 ÷  #  ÷ [0.2] SPACE (Other) ÷ [999.0] SPACE (Other) ÷ [0.3]
---- Assert.Equal() Failure
Expected: 1
Actual:   0
  Stack Trace:
     at System.Globalization.Tests.GraphemeBreakTest.CompareRuntimeImplementationAgainstUnicodeTestData() in C:\runtime.io\src\libraries\System.Globalization\tests\System\Globalization\GraphemeBreakTest.cs:line 50
----- Inner Stack Trace -----
   at System.Globalization.Tests.GraphemeBreakTest.RunStringInfoTestCase(String input, Range[] expectedGraphemeClusterRanges) in C:\runtime.io\src\libraries\System.Globalization\tests\System\Globalization\GraphemeBreakTest.cs:line 121
   at System.Globalization.Tests.GraphemeBreakTest.CompareRuntimeImplementationAgainstUnicodeTestData() in C:\runtime.io\src\libraries\System.Globalization\tests\System\Globalization\GraphemeBreakTest.cs:line 45
```

Digging into this, there's a failure on line 121 of the test suite, and the failing test case was the string `"  "` (two space characters). So even with the large unit test function, I think the failure messages are friendly enough where it's easy to pinpoint exactly what failed.