### PR TITLE
Fix trimming linker tests

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -29,19 +29,19 @@
   -->
   <ItemGroup>
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
-      DefaultRuntimeFrameworkVersion="5.0.0-rc.1.20451.14"
+      DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppVersion)"
       IsTrimmable="true"
-      LatestRuntimeFrameworkVersion="5.0.0-rc.1.20451.14"
+      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppVersion)"
       RuntimeFrameworkName="Microsoft.NETCore.App"
       RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
       RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;ios-arm64;ios-arm;ios-x64;ios-x86;tvos-arm64;tvos-x64;android-arm64;android-arm;android-x64;android-x86;browser-wasm"
       TargetFramework="$(NetCoreAppCurrent)"
       TargetingPackName="Microsoft.NETCore.App.Ref"
-      TargetingPackVersion="5.0.0-rc.1.20451.14" />
+      TargetingPackVersion="$(MicrosoftNETCoreAppVersion)" />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App" 
       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
-      AppHostPackVersion="5.0.0-rc.1.20451.14"
+      AppHostPackVersion="$(MicrosoftNETCoreAppVersion)"
       AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
       TargetFramework="$(NetCoreAppCurrent)" />
   </ItemGroup>

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -8,4 +8,8 @@
     <PlatformManifestFile />
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.NETCore.App" />
+  </ItemGroup>
 </Project>

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -1,18 +1,20 @@
 <Project>
   <Target Name="RestoreProject">
     <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Properties="Configuration=$(Configuration)"
+             Properties="Configuration=$(Configuration);ForceEvaluation=true"
              Targets="Restore" />
   </Target>
 
-  <Target Name="AddFrameworkReference">
+  <Target Name="RemoveRuntimePackFromDownloadItem"
+          AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
-      <FrameworkReference Include="Microsoft.NETCore.App" />
+      <PackageDownload Remove="@(PackageDownload)"
+                       Condition="$([System.String]::Copy('%(Identity)').StartsWith('Microsoft.NETCore.App.Runtime'))" />
     </ItemGroup>
   </Target>
 
   <Target Name="UpdateRuntimePack"
-          DependsOnTargets="AddFrameworkReference;ResolveFrameworkReferences">
+          DependsOnTargets="ResolveFrameworkReferences">
     <ItemGroup>
       <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(RuntimePackDir)" />
       <ResolvedTargetingPack Update="@(ResolvedTargetingPack)" Path="$(TargetingPackDir)" />
@@ -31,23 +33,23 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishTrimmed" DependsOnTargets="RestoreProject;UpdateRuntimePack;Publish" />
+  <Target Name="PublishTrimmed" DependsOnTargets="ProcessFrameworkReferences;RestoreProject;UpdateRuntimePack;Publish" />
 
   <ItemGroup>
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
-      DefaultRuntimeFrameworkVersion="5.0.0-rc.1.20451.14"
+      DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppVersion)"
       IsTrimmable="true"
-      LatestRuntimeFrameworkVersion="5.0.0-rc.1.20451.14"
+      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppVersion)"
       RuntimeFrameworkName="Microsoft.NETCore.App"
       RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
       RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;ios-arm64;ios-arm;ios-x64;ios-x86;tvos-arm64;tvos-x64;android-arm64;android-arm;android-x64;android-x86;browser-wasm"
       TargetFramework="net6.0"
       TargetingPackName="Microsoft.NETCore.App.Ref"
-      TargetingPackVersion="5.0.0-rc.1.20451.14" />
+      TargetingPackVersion="$(MicrosoftNETCoreAppVersion)" />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App" 
       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
-      AppHostPackVersion="5.0.0-rc.1.20451.14"
+      AppHostPackVersion="$(MicrosoftNETCoreAppVersion)"
       AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
       TargetFramework="net6.0" />
   </ItemGroup>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -7,6 +7,7 @@
     <RuntimePackDir>{RuntimePackDir}</RuntimePackDir>
     <TargetingPackDir>{TargetingPackDir}</TargetingPackDir>
     <NETCoreAppMaximumVersion>{NetCoreAppMaximumVersion}</NETCoreAppMaximumVersion>
+    <MicrosoftNETCoreAppVersion>{MicrosoftNETCoreAppVersion}</MicrosoftNETCoreAppVersion>
 
     <!-- These can be removed once we get an SDK with https://github.com/mono/linker/pull/1385. -->
     <LinkerNoWarn>IL2026</LinkerNoWarn>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TrimmingTestDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'trimmingTests'))</TrimmingTestDir>
     <TrimmingTestProjectsDir>$([MSBuild]::NormalizeDirectory('$(TrimmingTestDir)', 'projects'))</TrimmingTestProjectsDir>
-    <TestDotNetPath>$([MSBuild]::NormalizePath('$(DotNetRoot)', 'dotnet'))</TestDotNetPath>
     <ProjectTemplate>$(MSBuildThisFileDirectory)project.csproj.template</ProjectTemplate>
   </PropertyGroup>
 
@@ -73,6 +72,7 @@
     <MakeDir Directories="$(_projectDir)" />
     <WriteLinesToFile File="$(_projectFile)"
                       Lines="$([System.IO.File]::ReadAllText('$(ProjectTemplate)')
+                                                 .Replace('{MicrosoftNETCoreAppVersion}', '$(MicrosoftNETCoreAppVersion)')
                                                  .Replace('{NetCoreAppCurrent}', '$(NetCoreAppCurrent)')
                                                  .Replace('{NetCoreAppMaximumVersion}', '$(NetCoreAppMaximumVersion)')
                                                  .Replace('{RuntimePackDir}', '%(TestConsoleApps.RuntimePackDirectory)')
@@ -93,7 +93,7 @@
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
     <PropertyGroup>
-      <TestPublishTrimmedCommand>"$(TestDotNetPath)"</TestPublishTrimmedCommand>
+      <TestPublishTrimmedCommand>"$(DotNetTool)"</TestPublishTrimmedCommand>
       <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) build /t:PublishTrimmed</TestPublishTrimmedCommand>
       <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) /nr:false</TestPublishTrimmedCommand>
       <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) /warnaserror</TestPublishTrimmedCommand>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/44559

The reason why the tests were failing was kind of tricky. 

- We set, disable implicit references, which means Microsoft.NETCore.App is not a reference when restore happens.
- Because of that, the AppHost package is not downloaded at all, however when we targeted net5.0 for the tests, the AppHost package was found on the SDK packs directory. Now that NetCoreAppCurrent moved to net6.0, it does add the AppHost package to `PackageDownload` but it never downloads it because there are no FrameworkReferences when ProcessFrameworkReferences is executed. 
- The fix was to move `FrameworkReference` out of the target so that the framework reference is picked up by restore and the runtime packs are downloaded correctly.
- Also I removed the `RuntimePack` from `PackageDownload` to not download un necessary stuff.

I validated that we still build and publish using the local built runtime and ref packs:

![image](https://user-images.githubusercontent.com/22899328/99005190-33d33800-24f5-11eb-8994-4bd76c05fcf3.png)

![image](https://user-images.githubusercontent.com/22899328/99005249-52393380-24f5-11eb-8808-f0fecf074e7d.png)

I also did some cleanup to use the `MicrosoftNETCoreAppVersion` property instead of hardcoding the version in the `KnownFrameworkReference` and `KnownAppHostPack`.

When trying to run an individual project I noticed that the way we were invoking `dotnet` was wrong because we were using `DotNetRoot` which is empty if arcade is using the globally installed SDK so we were resolving `TestDotNetPath` to the test project path... I changed it to use `DotNetTool` which is handled by arcade: https://github.com/dotnet/arcade/blob/4873d157a8f34f8cc7e28b3f9938b32c642ef542/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props#L35