### PR TITLE
Subtle R2RTest fixes for JIT build mode

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildFolderSet.cs
@@ -535,7 +535,7 @@ namespace R2RTest
                             foreach (ProcessInfo[] compilation in folder.Compilations)
                             {
                                 ProcessInfo runnerCompilation = compilation[(int)runner.Index];
-                                if (!runnerCompilation.Succeeded)
+                                if (!runnerCompilation.IsEmpty && !runnerCompilation.Succeeded)
                                 {
                                     compilationsSucceeded = false;
                                     break;
@@ -636,7 +636,7 @@ namespace R2RTest
                         bool anyCompilationFailed = false;
                         foreach (CompilerRunner runner in _compilerRunners)
                         {
-                            if (compilation[(int)runner.Index] != null)
+                            if (!compilation[(int)runner.Index].IsEmpty)
                             {
                                 CompilationOutcome outcome = GetCompilationOutcome(compilation[(int)runner.Index]);
                                 compilationOutcomes[(int)outcome, (int)runner.Index]++;


### PR DESCRIPTION
Maoni expressed interest in experimenting with the R2RTest tool
for the purpose of running arbitrary CoreCLR test subsets. As
until now we've seldom used the tool in JIT mode, this naturally
uncovered a bit of bitrot, frankly speaking less than I expected.

Thanks

Tomas