### PR TITLE
Avoid non-portable MemoryMarshal.Cast in Marvin library code

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
+++ b/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System.Buffers" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Numerics" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -153,6 +153,7 @@
     <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Security.Cryptography.Algorithms" />

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Text\StringBuilderCache.cs" Link="Common\System\StringBuilderCache.cs" />
-    <Compile Include="$(CommonPath)System\Marvin.cs" Link="Common\System\Marvin.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Common\System\HexConverter.cs" />
     <Compile Include="System\Xml\BinaryXml\XmlBinaryReader.cs" />
     <Compile Include="System\Xml\BinaryXml\BinXmlToken.cs" />

--- a/src/libraries/System.Private.Xml/src/System/Xml/NameTable.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/NameTable.cs
@@ -195,8 +195,11 @@ namespace System.Xml
 
         internal static int ComputeHash32(string key)
         {
-            ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(key.AsSpan());
-            return Marvin.ComputeHash32(bytes, Marvin.DefaultSeed);
+            // We rely on string.GetHashCode(ROS<char>) being randomized.
+            // n.b. not calling string.GetHashCode() because we want hash code computation to match
+            // char[]-based overload later in this file, so we normalize everything to ROS<char>.
+
+            return string.GetHashCode(key.AsSpan());
         }
 
         //
@@ -261,8 +264,9 @@ namespace System.Xml
 
         private static int ComputeHash32(char[] key, int start, int len)
         {
-            ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(new ReadOnlySpan<char>(key, start, len));
-            return Marvin.ComputeHash32(bytes, Marvin.DefaultSeed);
+            // We rely on string.GetHashCode(ROS<char>) being randomized.
+
+            return string.GetHashCode(key.AsSpan(start, len));
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/26653.

The shared library implementation of Marvin uses a non-portable `MemoryMarshal.Cast`, which could result in the creation of a span with misaligned addresses. This PR updates the implementation so that unaligned memory reads are explicit, which allows the JIT to emit the correct instructions across all architectures.

I tried using `MemoryMarshal.TryRead` and `ROS<byte>.Slice` in a loop in order to avoid the unsafe code, but bounds checks weren't being properly elided. I've instead opted to use standard unsafe pointer manipulation and `Unsafe.ReadUnaligned`. The pinning operation only spills one stack local, and using raw pointers reads more cleanly than using `Unsafe.Add` everywhere.

Had to add _System.Runtime.CompilerServices.Unsafe_ package refs to _System.Net.Primitives_ and _System.Formats.Cbor_ in order to get access to the `Unsafe` APIs. I also removed the custom Marvin implementation from _System.Private.Xml_, which can rely on existing in-box APIs.