### PR TITLE
Compile System.Private.CoreLib with Crossgen2 by default

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -19,7 +19,7 @@ trigger:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
   
-# pr: none
+pr: none
 
 jobs:
 #

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -19,7 +19,7 @@ trigger:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
   
-pr: none
+# pr: none
 
 jobs:
 #

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -5,7 +5,7 @@
   <Target Name="Build">
     <PropertyGroup>
       <!-- Default for using Crossgen2 when not set externally -->
-      <UseCrossgen2 Condition="'$(UseCrossgen2)' == ''">false</UseCrossgen2>
+      <UseCrossgen2 Condition="'$(UseCrossgen2)' == ''">true</UseCrossgen2>
 
       <OSPlatformConfig>$(TargetOS).$(TargetArchitecture).$(Configuration)</OSPlatformConfig>
       <RootBinDir>$(RepoRoot)\artifacts</RootBinDir>


### PR DESCRIPTION
After I deleted the Utf8String-related experimental code from the
runtime repo per JanK's suggestion, I can now enable Crossgen2
compilation for System.Private.CoreLib by default.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib