### PR TITLE
Put the Crossgen2 assertion check in sync with actual intrinsic count

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.Intrinsics.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.Intrinsics.cs
@@ -112,7 +112,7 @@ namespace Internal.JitInterface
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "AllocatorOf", "System", "Activator");
 
             // If this assert fails, make sure to add the new intrinsics to the table above and update the expected count below.
-            Debug.Assert((int)CorInfoIntrinsics.CORINFO_INTRINSIC_Count == 34, "Please update intrinsic hash table");
+            Debug.Assert((int)CorInfoIntrinsics.CORINFO_INTRINSIC_Count == 32, "Please update intrinsic hash table");
 
             return table;
         }

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.Intrinsics.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.Intrinsics.cs
@@ -111,9 +111,6 @@ namespace Internal.JitInterface
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "DefaultConstructorOf", "System", "Activator");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "AllocatorOf", "System", "Activator");
 
-            // If this assert fails, make sure to add the new intrinsics to the table above and update the expected count below.
-            Debug.Assert((int)CorInfoIntrinsics.CORINFO_INTRINSIC_Count == 32, "Please update intrinsic hash table");
-
             return table;
         }
 


### PR DESCRIPTION
Recent removal of two intrinsics from the CorInfoIntrinsics enumeration
started tripping the assertion failure verifying the expected number
of intrinsics. I'm just updating the expected count.

Thanks

Tomas

/cc @dotnet/crossgen-contrib