### PR TITLE
Fix RCS1036: Remove redundant empty line in ComInterop

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComMethodDesc.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComMethodDesc.cs
@@ -31,7 +31,6 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
         internal ComMethodDesc(ITypeInfo typeInfo, FUNCDESC funcDesc)
             : this(funcDesc.memid)
         {
-
             _invokeKind = funcDesc.invkind;
 
             string[] rgNames = new string[1 + funcDesc.cParams];

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeDesc.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeDesc.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             TypeLib = typeLibDesc;
         }
 
-
         internal static ComTypeDesc FromITypeInfo(ITypeInfo typeInfo, TYPEATTR typeAttr)
         {
             switch (typeAttr.typekind)

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
@@ -73,7 +73,6 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
     /// just find and invoke the multicast delegate corresponding to the invoked
     /// dispid.
     ///  </summary>
-
     internal sealed class IDispatchComObject : ComObject, IDynamicMetaObjectProvider
     {
         private ComTypeDesc _comTypeDesc;

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/UnknownArgBuilder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/UnknownArgBuilder.cs
@@ -48,7 +48,6 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             );
         }
 
-
         internal override Expression UnmarshalFromRef(Expression value)
         {
             // value == IntPtr.Zero ? null : Marshal.GetObjectForIUnknown(value);

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/VarEnumSelector.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/VarEnumSelector.cs
@@ -187,7 +187,6 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 typeNames += typeName;
             }
 
-
             throw Error.AmbiguousConversion(argumentType.Name, typeNames);
         }
 


### PR DESCRIPTION
Changes were made to this code in PowerShell/PowerShell#13404, let's try to avoid the codebase diverging.