### PR TITLE
Check args before asking runtime to resolve fqns to avoid assert

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1388,6 +1388,13 @@ var BindingSupportLib = {
 				classname = fqn.substring (idx + 1);
 			}
 
+			if (!assembly.trim())
+				throw new Error("No assembly name specified");
+			if (!classname.trim())
+				throw new Error("No class name specified");
+			if (!methodname.trim())
+				throw new Error("No method name specified");
+
 			var asm = this.assembly_load (assembly);
 			if (!asm)
 				throw new Error ("Could not find assembly: " + assembly);


### PR DESCRIPTION
Right now if ```resolve_method_fqn``` fails it will typically cause an assert in the runtime which obliterates the v8 process (seemingly with an exit code of 0). Checking more of the args before calling into the runtime mitigates this.