### PR TITLE
Enables the interpreter on Android

### DIFF
--- a/eng/pipelines/libraries/helix.yml
+++ b/eng/pipelines/libraries/helix.yml
@@ -21,7 +21,7 @@ steps:
             /p:TargetRuntimeIdentifier=${{ parameters.targetRid }}
             /p:Configuration=${{ parameters.buildConfig }}
             /p:TargetOS=${{ parameters.osGroup }}
-            /p:MonoEnableInterpreter=${{ parameters.interpreter }}
+            /p:MonoForceInterpreter=${{ parameters.interpreter }}
             /p:TestScope=${{ parameters.testScope }}
             /p:TestRunNamePrefixSuffix=${{ parameters.testRunNamePrefixSuffix }}
             /p:HelixBuild=$(Build.BuildNumber)

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -52,6 +52,7 @@
         ProjectName="$(AssemblyName)"
         MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackNativeDir)include\mono-2.0"
         MainLibraryFileName="AndroidTestRunner.dll"
+        EnableInterpreter="$(MonoEnableInterpreter)"
         StripDebugSymbols="False"
         OutputDir="$(BundleDir)"
         SourceDir="$(PublishDir)">

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -52,7 +52,7 @@
         ProjectName="$(AssemblyName)"
         MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackNativeDir)include\mono-2.0"
         MainLibraryFileName="AndroidTestRunner.dll"
-        EnableInterpreter="$(MonoEnableInterpreter)"
+        ForceInterpreter="$(MonoForceInterpreter)"
         StripDebugSymbols="False"
         OutputDir="$(BundleDir)"
         SourceDir="$(PublishDir)">

--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <!-- Provide runtime options to Mono (interpreter, aot, debugging, etc) -->
-  <ItemGroup Condition="'$(MonoEnvOptions)' != ''">
+  <ItemGroup Condition="'$(MonoEnvOptions)' != '' and '$(TargetsMobile)' != 'true'">
     <RunScriptCommands Condition="'$(TargetsWindows)' == 'true'" Include="set MONO_ENV_OPTIONS='$(MonoEnvOptions)'" />
     <RunScriptCommands Condition="'$(TargetsWindows)' != 'true'" Include="export MONO_ENV_OPTIONS='$(MonoEnvOptions)'" />
   </ItemGroup>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -298,9 +298,9 @@
     <EnableCoverageSupport Condition="'$(ContinuousIntegrationBuild)' != 'true'">true</EnableCoverageSupport>
   </PropertyGroup>
 
-  <!-- To enable the interpreter for mono, we need to pass an env switch -->
+  <!-- To enable the interpreter for mono desktop, we need to pass an env switch -->
   <PropertyGroup>
-    <MonoEnvOptions Condition="'$(MonoEnvOptions)' == '' and '$(MonoEnableInterpreter)' == 'true'">--interpreter</MonoEnvOptions>
+    <MonoEnvOptions Condition="'$(MonoEnvOptions)' == '' and '$(TargetsMobile)' != 'true' and '$(MonoForceInterpreter)' == 'true'">--interpreter</MonoEnvOptions>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)testing\tests.props" Condition="'$(EnableTestSupport)' == 'true'" />

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -2,7 +2,7 @@
 
   <!--
       Build properties:
-      - MonoEnableInterpreter - enable the interpreter
+      - MonoForceInterpreter - enable the interpreter
       - MonoEnableLLVM - enable LLVM
       - MonoLLVMDir - [optional] the directory where LLVM is located
       - MonoAOTEnableLLVM - enable LLVM for an AOT-only Mono
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <MonoCrossDir Condition="'$(MonoCrossDir)' == '' and '$(ROOTFS_DIR)' != ''">$(ROOTFS_DIR)</MonoCrossDir>
-    <MonoEnableInterpreter Condition="'$(MonoEnableInterpreter)' == ''">false</MonoEnableInterpreter>
+    <MonoForceInterpreter Condition="'$(MonoForceInterpreter)' == ''">false</MonoForceInterpreter>
     <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</ScriptExt>
     <ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</ScriptExt>
     <CoreClrFileName Condition="'$(TargetsWindows)' == 'true'">coreclr.dll</CoreClrFileName>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -252,7 +252,7 @@
       <_MonoCMakeArgs Condition="'$(Platform)' == 'arm'" Include="-DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a" />
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x86'" Include="-DCMAKE_ANDROID_ARCH_ABI=x86" />
       <_MonoCMakeArgs Condition="'$(Platform)' == 'x64'" Include="-DCMAKE_ANDROID_ARCH_ABI=x86_64" />
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,portability,attach,verifier,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,interpreter,gac,cfgdir_config" />
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,portability,attach,verifier,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles,gac,cfgdir_config" />
       <_MonoCMakeArgs Include="-DENABLE_SIGALTSTACK=1"/>
       <_MonoCMakeArgs Include="-DDISABLE_CRASH_REPORTING=1"/>
       <_MonoCMakeArgs Include="-DENABLE_PERFTRACING=0"/>

--- a/src/mono/netcore/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/netcore/sample/Android/AndroidSampleApp.csproj
@@ -36,6 +36,7 @@
         RuntimeIdentifier="$(RuntimeIdentifier)"
         SourceDir="$(OutputPath)"
         ProjectName="HelloAndroid"
+        EnableInterpreter="true"
         MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)\native\include\mono-2.0"
         MainLibraryFileName="$(AssemblyName).dll"
         StripDebugSymbols="$(StripDebugSymbols)"

--- a/src/mono/netcore/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/netcore/sample/Android/AndroidSampleApp.csproj
@@ -36,7 +36,7 @@
         RuntimeIdentifier="$(RuntimeIdentifier)"
         SourceDir="$(OutputPath)"
         ProjectName="HelloAndroid"
-        EnableInterpreter="true"
+        ForceInterpreter="$(MonoForceInterpreter)"
         MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)\native\include\mono-2.0"
         MainLibraryFileName="$(AssemblyName).dll"
         StripDebugSymbols="$(StripDebugSymbols)"

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -47,6 +47,8 @@ public class AndroidAppBuilderTask : Task
 
     public string? KeyStorePath { get; set; }
 
+    public bool EnableInterpreter { get; set; }
+
     [Output]
     public string ApkBundlePath { get; set; } = ""!;
 
@@ -70,6 +72,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.StripDebugSymbols = StripDebugSymbols;
         apkBuilder.NativeMainSource = NativeMainSource;
         apkBuilder.KeyStorePath = KeyStorePath;
+        apkBuilder.EnableInterpreter = EnableInterpreter;
         (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, abi, MainLibraryFileName, MonoRuntimeHeaders);
 
         return true;

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -47,7 +47,7 @@ public class AndroidAppBuilderTask : Task
 
     public string? KeyStorePath { get; set; }
 
-    public bool EnableInterpreter { get; set; }
+    public bool ForceInterpreter { get; set; }
 
     [Output]
     public string ApkBundlePath { get; set; } = ""!;
@@ -72,7 +72,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.StripDebugSymbols = StripDebugSymbols;
         apkBuilder.NativeMainSource = NativeMainSource;
         apkBuilder.KeyStorePath = KeyStorePath;
-        apkBuilder.EnableInterpreter = EnableInterpreter;
+        apkBuilder.ForceInterpreter = ForceInterpreter;
         (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, abi, MainLibraryFileName, MonoRuntimeHeaders);
 
         return true;

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -20,7 +20,7 @@ public class ApkBuilder
     public bool StripDebugSymbols { get; set; }
     public string? NativeMainSource { get; set; }
     public string? KeyStorePath { get; set; }
-    public bool EnableInterpreter { get; set; }
+    public bool ForceInterpreter { get; set; }
 
     public (string apk, string packageId) BuildApk(
         string sourceDir,
@@ -196,7 +196,7 @@ public class ApkBuilder
 
         string monoRunner = Utils.GetEmbeddedResource("MonoRunner.java")
             .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib))
-            .Replace("%IsInterpreterEnabled%", EnableInterpreter.ToString().ToLower());
+            .Replace("%ForceInterpreter%", ForceInterpreter.ToString().ToLower());
         File.WriteAllText(monoRunnerPath, monoRunner);
 
         File.WriteAllText(Path.Combine(OutputDir, "AndroidManifest.xml"),

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -20,6 +20,7 @@ public class ApkBuilder
     public bool StripDebugSymbols { get; set; }
     public string? NativeMainSource { get; set; }
     public string? KeyStorePath { get; set; }
+    public bool EnableInterpreter { get; set; }
 
     public (string apk, string packageId) BuildApk(
         string sourceDir,
@@ -194,7 +195,8 @@ public class ApkBuilder
             File.Copy(NativeMainSource, javaActivityPath, true);
 
         string monoRunner = Utils.GetEmbeddedResource("MonoRunner.java")
-            .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib));
+            .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib))
+            .Replace("%IsInterpreterEnabled%", EnableInterpreter.ToString().ToLower());
         File.WriteAllText(monoRunnerPath, monoRunner);
 
         File.WriteAllText(Path.Combine(OutputDir, "AndroidManifest.xml"),

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -36,6 +36,7 @@ public class MonoRunner extends Instrumentation
 
     static String entryPointLibName = "%EntryPointLibName%";
     static Bundle result = new Bundle();
+    static String isInterpreterEnabled = "%IsInterpreterEnabled%";
 
     @Override
     public void onCreate(Bundle arguments) {
@@ -66,8 +67,8 @@ public class MonoRunner extends Instrumentation
         // unzip libs and test files to filesDir
         unzipAssets(context, filesDir, "assets.zip");
 
-        Log.i("DOTNET", "MonoRunner initialize, entryPointLibName=" + entryPointLibName);
-        return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName);
+        Log.i("DOTNET", "initRuntime, entryPointLibName=" + entryPointLibName);
+        return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName, isInterpreterEnabled);
     }
 
     @Override
@@ -128,5 +129,5 @@ public class MonoRunner extends Instrumentation
         }
     }
 
-    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName);
+    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName, String isInterpreterEnabled);
 }

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -36,7 +36,7 @@ public class MonoRunner extends Instrumentation
 
     static String entryPointLibName = "%EntryPointLibName%";
     static Bundle result = new Bundle();
-    static boolean isInterpreterEnabled = %IsInterpreterEnabled%;
+    static boolean forceInterpreter = %ForceInterpreter%;
 
     @Override
     public void onCreate(Bundle arguments) {
@@ -68,7 +68,7 @@ public class MonoRunner extends Instrumentation
         unzipAssets(context, filesDir, "assets.zip");
 
         Log.i("DOTNET", "MonoRunner initialize,, entryPointLibName=" + entryPointLibName);
-        return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName, isInterpreterEnabled);
+        return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName, forceInterpreter);
     }
 
     @Override
@@ -129,5 +129,5 @@ public class MonoRunner extends Instrumentation
         }
     }
 
-    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName, boolean isInterpreterEnabled);
+    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName, boolean forceInterpreter);
 }

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -36,7 +36,7 @@ public class MonoRunner extends Instrumentation
 
     static String entryPointLibName = "%EntryPointLibName%";
     static Bundle result = new Bundle();
-    static String isInterpreterEnabled = "%IsInterpreterEnabled%";
+    static boolean isInterpreterEnabled = %IsInterpreterEnabled%;
 
     @Override
     public void onCreate(Bundle arguments) {
@@ -67,7 +67,7 @@ public class MonoRunner extends Instrumentation
         // unzip libs and test files to filesDir
         unzipAssets(context, filesDir, "assets.zip");
 
-        Log.i("DOTNET", "initRuntime, entryPointLibName=" + entryPointLibName);
+        Log.i("DOTNET", "MonoRunner initialize,, entryPointLibName=" + entryPointLibName);
         return initRuntime(filesDir, cacheDir, docsDir, entryPointLibName, isInterpreterEnabled);
     }
 
@@ -129,5 +129,5 @@ public class MonoRunner extends Instrumentation
         }
     }
 
-    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName, String isInterpreterEnabled);
+    static native int initRuntime(String libsDir, String cacheDir, String docsDir, String entryPointLibName, boolean isInterpreterEnabled);
 }

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -22,7 +22,7 @@
 
 static char *bundle_path;
 static char *executable;
-static char *interp_enabled;
+static bool force_interpreter;
 
 #define LOG_INFO(fmt, ...) __android_log_print(ANDROID_LOG_DEBUG, "DOTNET", fmt, ##__VA_ARGS__)
 #define LOG_ERROR(fmt, ...) __android_log_print(ANDROID_LOG_ERROR, "DOTNET", fmt, ##__VA_ARGS__)
@@ -183,7 +183,7 @@ mono_droid_runtime_init (void)
         mono_jit_parse_options (1, options);
     }
 
-    if (interp_enabled) {
+    if (force_interpreter) {
         LOG_INFO("Interp Enabled");
         mono_jit_set_aot_mode(MONO_AOT_MODE_INTERP_ONLY);
     }
@@ -213,7 +213,7 @@ strncpy_str (JNIEnv *env, char *buff, jstring str, int nbuff)
 }
 
 int
-Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName, jboolean j_isInterpreterEnabled)
+Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName, jboolean j_forceInterpreter)
 {
     char file_dir[2048];
     char cache_dir[2048];
@@ -226,7 +226,7 @@ Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_
 
     bundle_path = file_dir;
     executable = entryPointLibName;
-    interp_enabled = (bool)j_isInterpreterEnabled;
+    force_interpreter = (bool)j_forceInterpreter;
 
     setenv ("HOME", bundle_path, true);
     setenv ("TMPDIR", cache_dir, true);

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -22,6 +22,7 @@
 
 static char *bundle_path;
 static char *executable;
+static char *interp_enabled;
 
 #define LOG_INFO(fmt, ...) __android_log_print(ANDROID_LOG_DEBUG, "DOTNET", fmt, ##__VA_ARGS__)
 #define LOG_ERROR(fmt, ...) __android_log_print(ANDROID_LOG_ERROR, "DOTNET", fmt, ##__VA_ARGS__)
@@ -39,7 +40,7 @@ static char *executable;
 #endif
 
 static MonoAssembly*
-load_assembly (const char *name, const char *culture)
+mono_droid_load_assembly (const char *name, const char *culture)
 {
     char filename [1024];
     char path [1024];
@@ -72,11 +73,11 @@ load_assembly (const char *name, const char *culture)
 }
 
 static MonoAssembly*
-assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* user_data)
+mono_droid_assembly_preload_hook (MonoAssemblyName *aname, char **assemblies_path, void* user_data)
 {
     const char *name = mono_assembly_name_get_name (aname);
     const char *culture = mono_assembly_name_get_culture (aname);
-    return load_assembly (name, culture);
+    return mono_droid_load_assembly (name, culture);
 }
 
 char *
@@ -91,7 +92,7 @@ strdup_printf (const char *msg, ...)
 }
 
 static MonoObject *
-fetch_exception_property (MonoObject *obj, const char *name, bool is_virtual)
+mono_droid_fetch_exception_property (MonoObject *obj, const char *name, bool is_virtual)
 {
     MonoMethod *get = NULL;
     MonoMethod *get_virt = NULL;
@@ -114,9 +115,9 @@ fetch_exception_property (MonoObject *obj, const char *name, bool is_virtual)
 }
 
 static char *
-fetch_exception_property_string (MonoObject *obj, const char *name, bool is_virtual)
+mono_droid_fetch_exception_property_string (MonoObject *obj, const char *name, bool is_virtual)
 {
-    MonoString *str = (MonoString *) fetch_exception_property (obj, name, is_virtual);
+    MonoString *str = (MonoString *) mono_droid_fetch_exception_property (obj, name, is_virtual);
     return str ? mono_string_to_utf8 (str) : NULL;
 }
 
@@ -125,8 +126,8 @@ unhandled_exception_handler (MonoObject *exc, void *user_data)
 {
     MonoClass *type = mono_object_get_class (exc);
     char *type_name = strdup_printf ("%s.%s", mono_class_get_namespace (type), mono_class_get_name (type));
-    char *trace = fetch_exception_property_string (exc, "get_StackTrace", true);
-    char *message = fetch_exception_property_string (exc, "get_Message", true);
+    char *trace = mono_droid_fetch_exception_property_string (exc, "get_StackTrace", true);
+    char *message = mono_droid_fetch_exception_property_string (exc, "get_Message", true);
     
     LOG_ERROR("UnhandledException: %s %s %s", type_name, message, trace);
 
@@ -147,13 +148,13 @@ log_callback (const char *log_domain, const char *log_level, const char *message
 }
 
 int
-mono_mobile_runtime_init (void)
+mono_droid_runtime_init (void)
 {
     // uncomment for debug output:
     //
-    // setenv ("XUNIT_VERBOSE", "true", true);
-    // setenv ("MONO_LOG_LEVEL", "debug", true);
-    // setenv ("MONO_LOG_MASK", "all", true);
+    //setenv ("XUNIT_VERBOSE", "true", true);
+    //setenv ("MONO_LOG_LEVEL", "debug", true);
+    //setenv ("MONO_LOG_MASK", "all", true);
 
     bool wait_for_debugger = false;
     chdir (bundle_path);
@@ -171,7 +172,7 @@ mono_mobile_runtime_init (void)
     monovm_initialize(2, appctx_keys, appctx_values);
 
     mono_debug_init (MONO_DEBUG_FORMAT_MONO);
-    mono_install_assembly_preload_hook (assembly_preload_hook, NULL);
+    mono_install_assembly_preload_hook (mono_droid_assembly_preload_hook, NULL);
     mono_install_unhandled_exception_hook (unhandled_exception_handler, NULL);
     mono_trace_set_log_handler (log_callback, NULL);
     mono_set_signal_chaining (true);
@@ -181,9 +182,16 @@ mono_mobile_runtime_init (void)
         char* options[] = { "--debugger-agent=transport=dt_socket,server=y,address=0.0.0.0:55555" };
         mono_jit_parse_options (1, options);
     }
+
+    int interp_res = strncmp(interp_enabled, "true", strlen(interp_enabled));
+    if (interp_res == 0) {
+        LOG_INFO("Interp Enabled");
+        mono_jit_set_aot_mode(MONO_AOT_MODE_INTERP_ONLY);
+    }
+
     mono_jit_init_version ("dotnet.android", "mobile");
 
-    MonoAssembly *assembly = load_assembly (executable, NULL);
+    MonoAssembly *assembly = mono_droid_load_assembly (executable, NULL);
     assert (assembly);
     LOG_INFO ("Executable: %s", executable);
 
@@ -206,21 +214,25 @@ strncpy_str (JNIEnv *env, char *buff, jstring str, int nbuff)
 }
 
 int
-Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName)
+Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName, jstring j_isInterpreterEnabled)
 {
     char file_dir[2048];
     char cache_dir[2048];
     char docs_dir[2048];
     char entryPointLibName[2048];
+    char isInterpreterEnabled[2048];
     strncpy_str (env, file_dir, j_files_dir, sizeof(file_dir));
     strncpy_str (env, cache_dir, j_cache_dir, sizeof(cache_dir));
     strncpy_str (env, docs_dir, j_docs_dir, sizeof(docs_dir));
     strncpy_str (env, entryPointLibName, j_entryPointLibName, sizeof(entryPointLibName));
+    strncpy_str (env, isInterpreterEnabled, j_isInterpreterEnabled, sizeof(isInterpreterEnabled));
 
     bundle_path = file_dir;
     executable = entryPointLibName;
+    interp_enabled = isInterpreterEnabled;
     setenv ("HOME", bundle_path, true);
-    setenv ("TMPDIR", cache_dir, true); 
-    setenv ("DOCSDIR", docs_dir, true); 
-    return mono_mobile_runtime_init ();
+    setenv ("TMPDIR", cache_dir, true);
+    setenv ("DOCSDIR", docs_dir, true);
+
+    return mono_droid_runtime_init ();
 }

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -183,8 +183,7 @@ mono_droid_runtime_init (void)
         mono_jit_parse_options (1, options);
     }
 
-    int interp_res = strncmp(interp_enabled, "true", strlen(interp_enabled));
-    if (interp_res == 0) {
+    if (interp_enabled) {
         LOG_INFO("Interp Enabled");
         mono_jit_set_aot_mode(MONO_AOT_MODE_INTERP_ONLY);
     }
@@ -214,22 +213,21 @@ strncpy_str (JNIEnv *env, char *buff, jstring str, int nbuff)
 }
 
 int
-Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName, jstring j_isInterpreterEnabled)
+Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir, jstring j_entryPointLibName, jboolean j_isInterpreterEnabled)
 {
     char file_dir[2048];
     char cache_dir[2048];
     char docs_dir[2048];
     char entryPointLibName[2048];
-    char isInterpreterEnabled[2048];
     strncpy_str (env, file_dir, j_files_dir, sizeof(file_dir));
     strncpy_str (env, cache_dir, j_cache_dir, sizeof(cache_dir));
     strncpy_str (env, docs_dir, j_docs_dir, sizeof(docs_dir));
     strncpy_str (env, entryPointLibName, j_entryPointLibName, sizeof(entryPointLibName));
-    strncpy_str (env, isInterpreterEnabled, j_isInterpreterEnabled, sizeof(isInterpreterEnabled));
 
     bundle_path = file_dir;
     executable = entryPointLibName;
-    interp_enabled = isInterpreterEnabled;
+    interp_enabled = (bool)j_isInterpreterEnabled;
+
     setenv ("HOME", bundle_path, true);
     setenv ("TMPDIR", cache_dir, true);
     setenv ("DOCSDIR", docs_dir, true);


### PR DESCRIPTION
To enable on tests, you can pass `MonoForceInterpreter=true` as an extra MSBuild property.

AndroidAppBuilder now has an ForceInterpreter property which will flow the setting down
to the device / simluator.