### PR TITLE
Don't build archives or installers for Mono builds.

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.targets
@@ -8,7 +8,7 @@
 
   <Target Name="ReturnProductVersion" Returns="$(Version)" />
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(RuntimeFlavor)' != 'Mono'">
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Building archives and installers here was leading to duplicate assets, which is causing publishing to BAR to fail.

This PR disables building the archives and installers for Mono builds (only build the packs).

Official build located at: https://dev.azure.com/dnceng/internal/_build/results?buildId=885715&view=results