### PR TITLE
Only sign in the official build pipeline, not in any other pipeline

### DIFF
--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -267,7 +267,7 @@ jobs:
           archType: ${{ parameters.archType }}
           osGroup: ${{ parameters.osGroup }}
           osSubgroup: ${{ parameters.osSubgroup }}
-          signCrossDac: ${{ and(eq(parameters.isOfficialBuild, true), eq(parameters.signBinaries, true)) }}
+          signCrossDac: ${{ parameters.signBinaries }}
 
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools')) }}:
       # Publish test native components for consumption by test execution.

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -131,25 +131,6 @@ jobs:
 
     steps:
 
-    # Install MicroBuild for signing the DAC and DBI
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: NuGetAuthenticate@0
-
-      - ${{ if eq(parameters.osGroup, 'windows') }}:
-        # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
-        # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
-        - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-          displayName: Clear NuGet http cache (if exists)
-
-        - task: MicroBuildSigningPlugin@2
-          displayName: Install MicroBuild plugin for Signing
-          inputs:
-            signType: $(SignType)
-            zipSources: false
-            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-          continueOnError: false
-          condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
     # Install native dependencies
     # Linux builds use docker images with dependencies preinstalled,
     # and FreeBSD builds use a build agent with dependencies
@@ -168,6 +149,17 @@ jobs:
     # We can't do this from within the build, so we need to do this as a separate step.
     - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/pipelines/common/restore-internal-tools.yml
+
+    # Install MicroBuild for signing the DAC and DBI
+    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.signBinaries, true), eq(parameters.osGroup, 'windows')) }}:
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild plugin for Signing
+        inputs:
+          signType: $(SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+        continueOnError: false
+        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS','tvOS') }}:
       - script: |

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -231,7 +231,7 @@ jobs:
             overWrite: true
 
     # Sign diagnostic files on Windows
-    - ${{ if and(eq(parameters.osGroup, 'windows'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.testGroup, 'clrTools')) }}:
+    - ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.signBinaries, true)) }}:
       - powershell: >-
           eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0
           /p:DiagnosticsFilesRoot="$(buildProductRootFolderPath)"
@@ -267,6 +267,7 @@ jobs:
           archType: ${{ parameters.archType }}
           osGroup: ${{ parameters.osGroup }}
           osSubgroup: ${{ parameters.osSubgroup }}
+          signCrossDac: ${{ and(eq(parameters.isOfficialBuild, true), eq(parameters.signBinaries, true)) }}
 
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools')) }}:
       # Publish test native components for consumption by test execution.

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -2,6 +2,7 @@ parameters:
   archType: ''
   osGroup: ''
   osSubgroup: ''
+  signCrossDac: false
 
 steps:
   # Always build the crossdac, that way we know in CI/PR if things break to build.
@@ -31,7 +32,7 @@ steps:
         TargetFolder: '$(buildMuslDacStagingPath)'
 
     # Sign diagnostic files on Windows
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if eq(parameters.signCrossDac, true) }}:
       - powershell: >-
           eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0
           /p:DiagnosticsFilesRoot="$(buildLinuxDacStagingPath)"

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -65,6 +65,7 @@ stages:
       - windows_arm64
       jobParameters:
         isOfficialBuild: ${{ variables.isOfficialBuild }}
+        signBinaries: ${{ variables.isOfficialBuild }}
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:


### PR DESCRIPTION
Use the unused `signBinaries` parameter to control when we sign so we only sign during the official build.

Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=886183&view=results

Perf build: https://dev.azure.com/dnceng/internal/_build/results?buildId=886184&view=results