### PR TITLE
Make DirectoryInfoWrapper better handle missing directories

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]
-        [OuterLoop]
         public void PollingFileProviderShouldntConsumeINotifyInstances()
         {
             List<IDisposable> disposables = new List<IDisposable>();

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
@@ -35,7 +35,17 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
         {
             if (_directoryInfo.Exists)
             {
-                foreach (FileSystemInfo fileSystemInfo in _directoryInfo.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly))
+                IEnumerable<FileSystemInfo> fileSystemInfos;
+                try
+                {
+                    fileSystemInfos = _directoryInfo.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly);
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    yield break;
+                }
+
+                foreach (FileSystemInfo fileSystemInfo in fileSystemInfos)
                 {
                     var directoryInfo = fileSystemInfo as DirectoryInfo;
                     if (directoryInfo != null)


### PR DESCRIPTION
EnumerateFileSystemInfos tries to noop when root directory does not exist
but the directory might be deleted between the time it checks Exists and
begins enumerating.  The value for Exists might also be stale as it is cached.