### PR TITLE
Fix NRE when default value is null and ServiceCallSite is not found

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
@@ -7,10 +7,16 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ConstantCallSite : ServiceCallSite
     {
+        private readonly Type _serviceType;
         internal object DefaultValue { get; }
 
         public ConstantCallSite(Type serviceType, object defaultValue): base(ResultCache.None)
         {
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+            _serviceType = serviceType;
             if (defaultValue != null && !serviceType.IsInstanceOfType(defaultValue))
             {
                 throw new ArgumentException(SR.Format(SR.ConstantCantBeConvertedToServiceType, defaultValue.GetType(), serviceType));
@@ -19,8 +25,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             DefaultValue = defaultValue;
         }
 
-        public override Type ServiceType => DefaultValue.GetType();
-        public override Type ImplementationType => DefaultValue.GetType();
+        public override Type ServiceType => DefaultValue?.GetType() ?? _serviceType;
+        public override Type ImplementationType => DefaultValue?.GetType() ?? _serviceType;
         public override CallSiteKind Kind { get; } = CallSiteKind.Constant;
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
@@ -12,11 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public ConstantCallSite(Type serviceType, object defaultValue): base(ResultCache.None)
         {
-            if (serviceType == null)
-            {
-                throw new ArgumentNullException(nameof(serviceType));
-            }
-            _serviceType = serviceType;
+            _serviceType = serviceType ?? throw new ArgumentNullException(nameof(serviceType));
             if (defaultValue != null && !serviceType.IsInstanceOfType(defaultValue))
             {
                 throw new ArgumentException(SR.Format(SR.ConstantCantBeConvertedToServiceType, defaultValue.GetType(), serviceType));

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
@@ -270,10 +270,10 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var descriptors = new ServiceCollection();
             descriptors.AddTransient<ServiceG>();
 
-            var provider = descriptors.BuildServiceProvider();
+            var provider = descriptors.BuildServiceProvider(ServiceProviderMode.ILEmit);
+            ServiceF instance = ActivatorUtilities.CreateInstance<ServiceF>(provider);
 
-            ActivatorUtilities.CreateInstance<ServiceF>(provider);
-            ActivatorUtilities.CreateInstance<ServiceF>(provider);
+            Assert.NotNull(instance);
         }
 
         private interface IServiceG

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
@@ -264,6 +264,32 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.NotNull(compileCallSite);
         }
 
+        [Fact]
+        public void NoServiceCallsite_DefaultValueNull_DoesNotThrow()
+        {
+            var descriptors = new ServiceCollection();
+            descriptors.AddTransient<ServiceG>();
+
+            var provider = descriptors.BuildServiceProvider();
+
+            ActivatorUtilities.CreateInstance<ServiceF>(provider);
+            ActivatorUtilities.CreateInstance<ServiceF>(provider);
+        }
+
+        private interface IServiceG
+        {
+        }
+
+        private class ServiceG
+        {
+            public ServiceG(IServiceG service = null) { }
+        }
+
+        private class ServiceF
+        {
+            public ServiceF(ServiceG service) { }
+        }
+
         private class ServiceD
         {
             public ServiceD(IEnumerable<ServiceA> services)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
@@ -264,13 +264,18 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.NotNull(compileCallSite);
         }
 
-        [Fact]
-        public void NoServiceCallsite_DefaultValueNull_DoesNotThrow()
+        [Theory]
+        [InlineData(ServiceProviderMode.Default)]
+        [InlineData(ServiceProviderMode.Dynamic)]
+        [InlineData(ServiceProviderMode.Runtime)]
+        [InlineData(ServiceProviderMode.Expressions)]
+        [InlineData(ServiceProviderMode.ILEmit)]
+        private void NoServiceCallsite_DefaultValueNull_DoesNotThrow(ServiceProviderMode mode)
         {
             var descriptors = new ServiceCollection();
             descriptors.AddTransient<ServiceG>();
 
-            var provider = descriptors.BuildServiceProvider(ServiceProviderMode.ILEmit);
+            var provider = descriptors.BuildServiceProvider(mode);
             ServiceF instance = ActivatorUtilities.CreateInstance<ServiceF>(provider);
 
             Assert.NotNull(instance);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderCompilationTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderCompilationTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     public class ServiceProviderCompilationTest
     {
         [Theory]
+        [InlineData(ServiceProviderMode.Default, typeof(I999))]
         [InlineData(ServiceProviderMode.Dynamic, typeof(I999))]
         [InlineData(ServiceProviderMode.Runtime, typeof(I999))]
         [InlineData(ServiceProviderMode.ILEmit, typeof(I999))]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37337

The NRE is being swallowed by https://github.com/dotnet/runtime/blob/095adbd3503605af2723727c5dae6d7855756a8b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs#L33-L40

But when running on VS with default settings, VS will break when NRE is thrown. (Refer to comment https://github.com/dotnet/runtime/issues/37337#issuecomment-726396336)

cc: @eerhardt @davidfowl 