### PR TITLE
improve parsing network files on WSL

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -42,8 +42,20 @@ namespace System.Net.NetworkInformation
             string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
+            // First line is header in each file. on WSL, this file may be empty
+            int count = 0;
+            if (v4connections.Length > 0)
+            {
+                count += v4connections.Length - 1;
+            }
+
+            if (v6connections.Length > 0)
+            {
+                count += v6connections.Length - 1;
+            }
+
             // First line is header in each file.
-            TcpConnectionInformation[] connections = new TcpConnectionInformation[v4connections.Length + v6connections.Length - 2];
+            TcpConnectionInformation[] connections = new TcpConnectionInformation[count];
             int index = 0;
             int skip = 0;
 
@@ -98,8 +110,20 @@ namespace System.Net.NetworkInformation
             string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
+            // First line is header in each file. on WSL, this file may be empty
+            int count = 0;
+            if (v4connections.Length > 0)
+            {
+                count += v4connections.Length - 1;
+            }
+
+            if (v6connections.Length > 0)
+            {
+                count += v6connections.Length - 1;
+            }
+
             // First line is header in each file.
-            IPEndPoint[] endPoints = new IPEndPoint[v4connections.Length + v6connections.Length - 2];
+            IPEndPoint[] endPoints = new IPEndPoint[count];
             int index = 0;
             int skip = 0;
 
@@ -154,8 +178,19 @@ namespace System.Net.NetworkInformation
             string udp6FileContents = File.ReadAllText(udp6File);
             string[] v6connections = udp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-            // First line is header in each file.
-            IPEndPoint[] endPoints = new IPEndPoint[v4connections.Length + v6connections.Length - 2];
+            // First line is header in each file. on WSL, this file may be empty
+            int count = 0;
+            if (v4connections.Length > 0)
+            {
+                count += v4connections.Length - 1;
+            }
+
+            if (v6connections.Length > 0)
+            {
+                count += v6connections.Length - 1;
+            }
+
+            IPEndPoint[] endPoints = new IPEndPoint[count];
             int index = 0;
 
             // UDP Connections

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -42,7 +42,7 @@ namespace System.Net.NetworkInformation
             string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-            // First line is header in each file. on WSL, this file may be empty
+            // First line is header in each file. On WSL, this file may be empty.
             int count = 0;
             if (v4connections.Length > 0)
             {
@@ -110,7 +110,7 @@ namespace System.Net.NetworkInformation
             string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-            // First line is header in each file. on WSL, this file may be empty
+            // First line is header in each file. On WSL, this file may be empty.
             int count = 0;
             if (v4connections.Length > 0)
             {
@@ -178,7 +178,7 @@ namespace System.Net.NetworkInformation
             string udp6FileContents = File.ReadAllText(udp6File);
             string[] v6connections = udp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-            // First line is header in each file. on WSL, this file may be empty
+            // First line is header in each file. On WSL, this file may be empty.
             int count = 0;
             if (v4connections.Length > 0)
             {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
@@ -128,6 +128,22 @@ namespace System.Net.NetworkInformation.Tests
             Assert.Equal(listeners[16], new IPEndPoint(IPAddress.Parse("fe80::215:5dff:fe00:402"), 123));
         }
 
+        [Fact]
+        public void WSLListenersParsing()
+        {
+            // WSL1 may have files empty
+            string emptyFile = GetTestFilePath();
+            FileUtil.NormalizeLineEndings("NetworkFiles/empty", emptyFile);
+
+            IPEndPoint[] tcpListeners = StringParsingHelpers.ParseActiveTcpListenersFromFiles(emptyFile, emptyFile);
+            IPEndPoint[] udpListeners = StringParsingHelpers.ParseActiveUdpListenersFromFiles(emptyFile, emptyFile);
+            TcpConnectionInformation[] tcpConnections = StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(emptyFile, emptyFile);
+
+            Assert.Equal(0, tcpListeners.Length);
+            Assert.Equal(0, udpListeners.Length);
+            Assert.Equal(0, tcpConnections.Length);
+        }
+
         private static void ValidateInfo(TcpConnectionInformation tcpConnectionInformation, IPEndPoint localEP, IPEndPoint remoteEP, TcpState state)
         {
             Assert.Equal(localEP, tcpConnectionInformation.LocalEndPoint);


### PR DESCRIPTION
WSL may be slowly obsolete but right now the code throws Arithmetic operation overflow and that seems unpleasant.
This change makes the parsing little bit more resilient and returns empty list if the file is empty.

fixes #44500