### PR TITLE
Fix decoding GC information in R2RDump

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -199,8 +199,8 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 }
             }
 
-            int endByteOffset = (bitOffset + 7) >> 3;
-            Size = endByteOffset - offset;
+            int nextByteOffset = (bitOffset + 7) >> 3;
+            Size = nextByteOffset - offset;
         }
 
         public override string ToString()

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -103,7 +103,6 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
 
             Version = ReadyToRunVersionToGcInfoVersion(majorVersion);
             int bitOffset = offset * 8;
-            int startBitOffset = bitOffset;
 
             ParseHeaderFlags(image, ref bitOffset);
 
@@ -185,17 +184,23 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
 
             SlotTable = new GcSlotTable(image, machine, _gcInfoTypes, ref bitOffset);
 
-            // Try partially interruptible first
-            if (NumSafePoints > 0)
+            if (SlotTable.NumSlots > 0)
             {
-                LiveSlotsAtSafepoints = GetLiveSlotsAtSafepoints(image, ref bitOffset);
-            }
-            else
-            {
-                Transitions = GetTransitions(image, ref bitOffset);
+                if (NumSafePoints > 0)
+                {
+                    // Partially interruptible code
+                    LiveSlotsAtSafepoints = GetLiveSlotsAtSafepoints(image, ref bitOffset);
+                }
+                else
+                {
+                    // Fully interruptible code
+                    Debug.Assert(NumInterruptibleRanges > 0);
+                    Transitions = GetTransitions(image, ref bitOffset);
+                }
             }
 
-            Size = bitOffset - startBitOffset;
+            int endByteOffset = (bitOffset + 7) >> 3;
+            Size = endByteOffset - offset;
         }
 
         public override string ToString()
@@ -482,7 +487,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         /// <summary>
         /// based on end of <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/gcinfodecoder.cpp">GcInfoDecoder::EnumerateLiveSlots and GcInfoEncoder::Build</a>
         /// </summary>
-        public Dictionary<int, List<BaseGcTransition>> GetTransitions(byte[] image, ref int bitOffset)
+        private Dictionary<int, List<BaseGcTransition>> GetTransitions(byte[] image, ref int bitOffset)
         {
             int totalInterruptibleLength = 0;
             if (NumInterruptibleRanges == 0)
@@ -511,8 +516,8 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 chunkPointers[i] = NativeReader.ReadBits(image, numBitsPerPointer, ref bitOffset);
             }
 
-            // Offset to m_Info2 containing all the info on register liveness
-            int info2Offset = (int)Math.Ceiling(bitOffset / 8.0) * 8;
+            // Offset to m_Info2 containing all the info on register liveness, which starts at the next byte
+            int info2Offset = (bitOffset + 7) & ~7;
 
             List<GcTransition> transitions = new List<GcTransition>();
             bool[] liveAtEnd = new bool[SlotTable.NumTracked]; // true if slot is live at the end of the chunk

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -161,6 +161,7 @@ namespace R2RDump
 
                 if (_options.Raw)
                 {
+                    // TODO: Output RVAs for consistency with other DumpBytes calls
                     DumpBytes(gcInfo.Offset, (uint)gcInfo.Size, "", false);
                 }
             }


### PR DESCRIPTION
For fully interruptible methods with no GC slots, R2RDump would overread the input bit stream due to a missing check corresponding to this one in gcinfoencoder.cpp: https://github.com/dotnet/runtime/blob/cd7c163b2fa1958f498890c8897d4a218b01012e/src/coreclr/src/gcinfo/gcinfoencoder.cpp#L1562-L1563 That might crash the process with an `IndexOutOfRangeException` exception.  Additionally R2RDump would incorrectly report the GC blob size in bits instead of bytes, which led to dumping unrelated bytes with the `--raw` switch.  Fixes #44296.