### PR TITLE
Don't use interfaces for sharing Tuple implementation methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Tuple.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Tuple.cs
@@ -114,10 +114,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -131,10 +136,15 @@ namespace System
 
         int IComparable.CompareTo(object? obj)
         {
-            return ((IStructuralComparable)this).CompareTo(obj, Comparer<object>.Default);
+            return CompareTo(obj, Comparer<object>.Default);
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -148,26 +158,37 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
-            return comparer.GetHashCode(m_Item1!);
+            return GetHashCode(comparer);
         }
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
+        private int GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(m_Item1!);
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(')');
@@ -213,10 +234,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -230,10 +256,15 @@ namespace System
 
         int IComparable.CompareTo(object? obj)
         {
-            return ((IStructuralComparable)this).CompareTo(obj, Comparer<object>.Default);
+            return CompareTo(obj, Comparer<object>.Default);
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -251,26 +282,37 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
-            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!));
+            return GetHashCode(comparer);
         }
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
+        private int GetHashCode(IEqualityComparer comparer)
+        {
+            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -317,10 +359,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -334,10 +381,15 @@ namespace System
 
         int IComparable.CompareTo(object? obj)
         {
-            return ((IStructuralComparable)this).CompareTo(obj, Comparer<object>.Default);
+            return CompareTo(obj, Comparer<object>.Default);
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -359,26 +411,37 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
-            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!));
+            return GetHashCode(comparer);
         }
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
+        private int GetHashCode(IEqualityComparer comparer)
+        {
+            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -431,10 +494,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -448,10 +516,15 @@ namespace System
 
         int IComparable.CompareTo(object? obj)
         {
-            return ((IStructuralComparable)this).CompareTo(obj, Comparer<object>.Default);
+            return CompareTo(obj, Comparer<object>.Default);
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -477,26 +550,37 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
-            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!));
+            return GetHashCode(comparer);
         }
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
+        private int GetHashCode(IEqualityComparer comparer)
+        {
+            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -555,10 +639,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -572,10 +661,15 @@ namespace System
 
         int IComparable.CompareTo(object? obj)
         {
-            return ((IStructuralComparable)this).CompareTo(obj, Comparer<object>.Default);
+            return CompareTo(obj, Comparer<object>.Default);
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -605,26 +699,37 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
-            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!), comparer.GetHashCode(m_Item5!));
+            return GetHashCode(comparer);
         }
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
+        private int GetHashCode(IEqualityComparer comparer)
+        {
+            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!), comparer.GetHashCode(m_Item5!));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -689,10 +794,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -706,10 +816,15 @@ namespace System
 
         int IComparable.CompareTo(object? obj)
         {
-            return ((IStructuralComparable)this).CompareTo(obj, Comparer<object>.Default);
+            return CompareTo(obj, Comparer<object>.Default);
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -743,26 +858,37 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
-            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!), comparer.GetHashCode(m_Item5!), comparer.GetHashCode(m_Item6!));
+            return GetHashCode(comparer);
         }
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
+        private int GetHashCode(IEqualityComparer comparer)
+        {
+            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!), comparer.GetHashCode(m_Item5!), comparer.GetHashCode(m_Item6!));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -833,10 +959,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -854,6 +985,11 @@ namespace System
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -891,26 +1027,37 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
-            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!), comparer.GetHashCode(m_Item5!), comparer.GetHashCode(m_Item6!), comparer.GetHashCode(m_Item7!));
+            return GetHashCode(comparer);
         }
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
+        private int GetHashCode(IEqualityComparer comparer)
+        {
+            return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1!), comparer.GetHashCode(m_Item2!), comparer.GetHashCode(m_Item3!), comparer.GetHashCode(m_Item4!), comparer.GetHashCode(m_Item5!), comparer.GetHashCode(m_Item6!), comparer.GetHashCode(m_Item7!));
+        }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -992,10 +1139,15 @@ namespace System
 
         public override bool Equals(object? obj)
         {
-            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<object>.Default);
+            return Equals(obj, EqualityComparer<object>.Default);
         }
 
         bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        {
+            return Equals(other, comparer);
+        }
+
+        private bool Equals(object? other, IEqualityComparer comparer)
         {
             if (other == null) return false;
 
@@ -1009,10 +1161,15 @@ namespace System
 
         int IComparable.CompareTo(object? obj)
         {
-            return ((IStructuralComparable)this).CompareTo(obj, Comparer<object>.Default);
+            return CompareTo(obj, Comparer<object>.Default);
         }
 
         int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        {
+            return CompareTo(other, comparer);
+        }
+
+        private int CompareTo(object? other, IComparer comparer)
         {
             if (other == null) return 1;
 
@@ -1054,10 +1211,15 @@ namespace System
 
         public override int GetHashCode()
         {
-            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<object>.Default);
+            return GetHashCode(EqualityComparer<object>.Default);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCode(comparer);
+        }
+
+        private int GetHashCode(IEqualityComparer comparer)
         {
             // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
             ITupleInternal t = (ITupleInternal)m_Rest;
@@ -1088,16 +1250,22 @@ namespace System
 
         int ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
-            return ((IStructuralEquatable)this).GetHashCode(comparer);
+            return GetHashCode(comparer);
         }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append('(');
-            return ((ITupleInternal)this).ToString(sb);
+            return ToString(sb);
         }
 
         string ITupleInternal.ToString(StringBuilder sb)
+        {
+            return ToString(sb);
+        }
+
+        private string ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");


### PR DESCRIPTION
Tuples add a dependency on rarely used interfaces which block them from
trimming everywhere. Instead of virtual call over interface share
the implementation as a separate method.

There is a corner case change in behaviour.

As Tuple classes are not sealed, it was possible to override them with
another custom IStructuralEquatable implementation. The object-based
Equals implementation would end up calling custom explicit interface
which I guess is unintended behaviour. The same would happen with 
IStructuralComparable.

@stephentoub @jkotas (I'll fix the remaining Tuples if there are no objections)