### PR TITLE
JsonConverterAttribute: Allow usage at interfaces.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonConverterAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonConverterAttribute.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json.Serialization
     /// <see cref="JsonSerializerOptions.Converters"/> or there is another <see cref="JsonConverterAttribute"/> on a property or field
     /// of the same type.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class JsonConverterAttribute : JsonAttribute
     {
         /// <summary>


### PR DESCRIPTION
JsonConverterAttribute and JsonConverter are working already for interfaces if the interface is used as a type of a field or property.
However this attribute can't currently be applied to the interface itself. This is currently only possible for classes and structs.

This PR allows that JsonConverterAttribute can be directly applied to interfaces. This makes classes, structs and interfaces on par regarding converters. Only the JsonConverterAttribute needs to be changed for that. Other code pieces are already in place to support this (because it works already if the "interface converter" is registered as JsonSerializerOptions or on the fields/properties).