### PR TITLE
Handle non-ASCII strings in GetNonRandomizedHashCodeOrdinalIgnoreCase

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -337,7 +337,7 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Dictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
         // https://github.com/dotnet/runtime/issues/44681
         public void DictionaryOrdinalIgnoreCaseCyrillicKeys()
         {

--- a/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -337,6 +337,22 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Dictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
         }
 
+        [Fact]
+        // https://github.com/dotnet/runtime/issues/44681
+        public void DictionaryOrdinalIgnoreCaseCyrillicKeys()
+        {
+            const string Lower = "абвгдеёжзийклмнопрстуфхцчшщьыъэюя";
+            const string Higher = "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭЮЯ";
+
+            var dictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < Lower.Length; i++)
+            {
+                dictionary[Lower[i].ToString()] = i;
+                Assert.Equal(i, dictionary[Higher[i].ToString()]);
+            }
+        }
+
         public static IEnumerable<object[]> CopyConstructorStringComparerData
         {
             get

--- a/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
@@ -54,56 +54,56 @@ namespace System.Collections.Tests
 
             RunDictionaryTest(
                 equalityComparer: null,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalComparerType);
 
             // EqualityComparer<string>.Default comparer
 
             RunDictionaryTest(
                 equalityComparer: EqualityComparer<string>.Default,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalComparerType);
 
             // Ordinal comparer
 
             RunDictionaryTest(
                 equalityComparer: StringComparer.Ordinal,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.Ordinal.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: StringComparer.Ordinal,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalComparerType);
 
             // OrdinalIgnoreCase comparer
 
             RunDictionaryTest(
                 equalityComparer: StringComparer.OrdinalIgnoreCase,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalIgnoreCaseComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.OrdinalIgnoreCase.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalIgnoreCaseComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalIgnoreCaseComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: StringComparer.OrdinalIgnoreCase,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalIgnoreCaseComparerType);
 
             // linguistic comparer (not optimized)
 
             RunDictionaryTest(
                 equalityComparer: StringComparer.InvariantCulture,
-                expectedInternalComparerBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
-                expectedComparerAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
+                expectedInternalComparerTypeBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
+                expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,
+                expectedInternalComparerTypeAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
 
             static void RunDictionaryTest(
                 IEqualityComparer<string> equalityComparer,
-                Type expectedInternalComparerBeforeCollisionThreshold,
-                Type expectedPublicComparerBeforeCollisionThreshold,
-                Type expectedComparerAfterCollisionThreshold)
+                Type expectedInternalComparerTypeBeforeCollisionThreshold,
+                IEqualityComparer<string> expectedPublicComparerBeforeCollisionThreshold,
+                Type expectedInternalComparerTypeAfterCollisionThreshold)
             {
                 RunCollectionTestCommon(
                     () => new Dictionary<string, object>(equalityComparer),
                     (dictionary, key) => dictionary.Add(key, null),
                     (dictionary, key) => dictionary.ContainsKey(key),
                     dictionary => dictionary.Comparer,
-                    expectedInternalComparerBeforeCollisionThreshold,
+                    expectedInternalComparerTypeBeforeCollisionThreshold,
                     expectedPublicComparerBeforeCollisionThreshold,
-                    expectedComparerAfterCollisionThreshold);
+                    expectedInternalComparerTypeAfterCollisionThreshold);
             }
         }
 
@@ -119,56 +119,56 @@ namespace System.Collections.Tests
 
             RunHashSetTest(
                 equalityComparer: null,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalComparerType);
 
             // EqualityComparer<string>.Default comparer
 
             RunHashSetTest(
                 equalityComparer: EqualityComparer<string>.Default,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: EqualityComparer<string>.Default,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalComparerType);
 
             // Ordinal comparer
 
             RunHashSetTest(
                 equalityComparer: StringComparer.Ordinal,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.Ordinal.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: StringComparer.Ordinal,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalComparerType);
 
             // OrdinalIgnoreCase comparer
 
             RunHashSetTest(
                 equalityComparer: StringComparer.OrdinalIgnoreCase,
-                expectedInternalComparerBeforeCollisionThreshold: nonRandomizedOrdinalIgnoreCaseComparerType,
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.OrdinalIgnoreCase.GetType(),
-                expectedComparerAfterCollisionThreshold: randomizedOrdinalIgnoreCaseComparerType);
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalIgnoreCaseComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: StringComparer.OrdinalIgnoreCase,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalIgnoreCaseComparerType);
 
             // linguistic comparer (not optimized)
 
             RunHashSetTest(
                 equalityComparer: StringComparer.InvariantCulture,
-                expectedInternalComparerBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
-                expectedComparerAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
+                expectedInternalComparerTypeBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
+                expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,
+                expectedInternalComparerTypeAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
 
             static void RunHashSetTest(
                 IEqualityComparer<string> equalityComparer,
-                Type expectedInternalComparerBeforeCollisionThreshold,
-                Type expectedPublicComparerBeforeCollisionThreshold,
-                Type expectedComparerAfterCollisionThreshold)
+                Type expectedInternalComparerTypeBeforeCollisionThreshold,
+                IEqualityComparer<string> expectedPublicComparerBeforeCollisionThreshold,
+                Type expectedInternalComparerTypeAfterCollisionThreshold)
             {
                 RunCollectionTestCommon(
                     () => new HashSet<string>(equalityComparer),
                     (set, key) => Assert.True(set.Add(key)),
                     (set, key) => set.Contains(key),
                     set => set.Comparer,
-                    expectedInternalComparerBeforeCollisionThreshold,
+                    expectedInternalComparerTypeBeforeCollisionThreshold,
                     expectedPublicComparerBeforeCollisionThreshold,
-                    expectedComparerAfterCollisionThreshold);
+                    expectedInternalComparerTypeAfterCollisionThreshold);
             }
         }
 
@@ -177,24 +177,18 @@ namespace System.Collections.Tests
             Action<TCollection, string> addKeyCallback,
             Func<TCollection, string, bool> containsKeyCallback,
             Func<TCollection, IEqualityComparer<string>> getComparerCallback,
-            Type expectedInternalComparerBeforeCollisionThreshold,
-            Type expectedPublicComparerBeforeCollisionThreshold,
-            Type expectedComparerAfterCollisionThreshold)
+            Type expectedInternalComparerTypeBeforeCollisionThreshold,
+            IEqualityComparer<string> expectedPublicComparerBeforeCollisionThreshold,
+            Type expectedInternalComparerTypeAfterCollisionThreshold)
         {
             TCollection collection = collectionFactory();
             List<string> allKeys = new List<string>();
-
-            const int StartOfRange = 0xE020; // use the Unicode Private Use range to avoid accidentally creating strings that really do compare as equal OrdinalIgnoreCase
-            const int Stride = 0x40; // to ensure we don't accidentally reset the 0x20 bit of the seed, which is used to negate OrdinalIgnoreCase effects
 
             // First, go right up to the collision threshold, but don't exceed it.
 
             for (int i = 0; i < 100; i++)
             {
-                string newKey = GenerateCollidingString(i * Stride + StartOfRange);
-                Assert.Equal(0, _lazyGetNonRandomizedHashCodeDel.Value(newKey)); // ensure has a zero hash code Ordinal
-                Assert.Equal(0x24716ca0, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
-
+                string newKey = _collidingStrings[i];
                 addKeyCallback(collection, newKey);
                 allKeys.Add(newKey);
             }
@@ -202,15 +196,18 @@ namespace System.Collections.Tests
             FieldInfo internalComparerField = collection.GetType().GetField("_comparer", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(internalComparerField);
 
-            Assert.Equal(expectedInternalComparerBeforeCollisionThreshold, internalComparerField.GetValue(collection)?.GetType());
-            Assert.Equal(expectedPublicComparerBeforeCollisionThreshold, getComparerCallback(collection).GetType());
+            IEqualityComparer<string> actualInternalComparerBeforeCollisionThreshold = (IEqualityComparer<string>)internalComparerField.GetValue(collection);
+            ValidateBehaviorOfInternalComparerVsPublicComparer(actualInternalComparerBeforeCollisionThreshold, expectedPublicComparerBeforeCollisionThreshold);
+
+            Assert.Equal(expectedInternalComparerTypeBeforeCollisionThreshold, actualInternalComparerBeforeCollisionThreshold?.GetType());
+            Assert.Equal(expectedPublicComparerBeforeCollisionThreshold, getComparerCallback(collection));
 
             // Now exceed the collision threshold, which should rebucket entries.
             // Continue adding a few more entries to ensure we didn't corrupt internal state.
 
             for (int i = 100; i < 110; i++)
             {
-                string newKey = GenerateCollidingString(i * Stride + StartOfRange);
+                string newKey = _collidingStrings[i];
                 Assert.Equal(0, _lazyGetNonRandomizedHashCodeDel.Value(newKey)); // ensure has a zero hash code Ordinal
                 Assert.Equal(0x24716ca0, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
 
@@ -218,8 +215,11 @@ namespace System.Collections.Tests
                 allKeys.Add(newKey);
             }
 
-            Assert.Equal(expectedComparerAfterCollisionThreshold, internalComparerField.GetValue(collection)?.GetType());
-            Assert.Equal(expectedPublicComparerBeforeCollisionThreshold, getComparerCallback(collection).GetType()); // shouldn't change this return value after collision threshold met
+            IEqualityComparer<string> actualInternalComparerAfterCollisionThreshold = (IEqualityComparer<string>)internalComparerField.GetValue(collection);
+            ValidateBehaviorOfInternalComparerVsPublicComparer(actualInternalComparerAfterCollisionThreshold, expectedPublicComparerBeforeCollisionThreshold);
+
+            Assert.Equal(expectedInternalComparerTypeAfterCollisionThreshold, actualInternalComparerAfterCollisionThreshold?.GetType());
+            Assert.Equal(expectedPublicComparerBeforeCollisionThreshold, getComparerCallback(collection)); // shouldn't change this return value after collision threshold met
 
             // And validate that all strings are present in the dictionary.
 
@@ -235,7 +235,7 @@ namespace System.Collections.Tests
             ((ISerializable)collection).GetObjectData(si, new StreamingContext());
 
             object serializedComparer = si.GetValue("Comparer", typeof(IEqualityComparer<string>));
-            Assert.Equal(expectedPublicComparerBeforeCollisionThreshold, serializedComparer.GetType());
+            Assert.Equal(expectedPublicComparerBeforeCollisionThreshold, serializedComparer);
         }
 
         private static Lazy<Func<string, int>> _lazyGetNonRandomizedHashCodeDel = new Lazy<Func<string, int>>(
@@ -244,27 +244,63 @@ namespace System.Collections.Tests
         private static Lazy<Func<string, int>> _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel = new Lazy<Func<string, int>>(
             () => GetStringHashCodeOpenDelegate("GetNonRandomizedHashCodeOrdinalIgnoreCase"));
 
-        // Generates a string with a well-known non-randomized hash code:
-        // - string.GetNonRandomizedHashCode returns 0.
-        // - string.GetNonRandomizedHashCodeOrdinalIgnoreCase returns 0x24716ca0.
-        // Provide a different seed to produce a different string.
-        private static string GenerateCollidingString(int seed)
+        // n.b., must be initialized *after* delegate fields above
+        private static readonly List<string> _collidingStrings = GenerateCollidingStrings(110);
+
+        private static List<string> GenerateCollidingStrings(int count)
         {
-            return string.Create(8, seed, (span, seed) =>
+            const int StartOfRange = 0xE020; // use the Unicode Private Use range to avoid accidentally creating strings that really do compare as equal OrdinalIgnoreCase
+            const int Stride = 0x40; // to ensure we don't accidentally reset the 0x20 bit of the seed, which is used to negate OrdinalIgnoreCase effects
+
+            int currentSeed = StartOfRange;
+
+            List<string> collidingStrings = new List<string>(count);
+            while (collidingStrings.Count < count)
             {
-                Span<byte> asBytes = MemoryMarshal.AsBytes(span);
+                if (currentSeed > ushort.MaxValue)
+                {
+                    throw new Exception($"Couldn't create enough colliding strings? Created {collidingStrings.Count}, needed {count}.");
+                }
 
-                uint hash1 = (5381 << 16) + 5381;
-                uint hash2 = BitOperations.RotateLeft(hash1, 5) + hash1;
+                string candidate = GenerateCollidingStringCandidate(currentSeed);
 
-                MemoryMarshal.Write(asBytes, ref seed);
-                MemoryMarshal.Write(asBytes.Slice(4), ref hash2); // set hash2 := 0 (for Ordinal)
+                int ordinalHashCode = _lazyGetNonRandomizedHashCodeDel.Value(candidate);
+                Assert.Equal(0, ordinalHashCode); // ensure has a zero hash code Ordinal
 
-                hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (uint)seed;
-                hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1);
+                int ordinalIgnoreCaseHashCode = _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(candidate);
+                if (ordinalIgnoreCaseHashCode == 0x24716ca0) // ensure has a zero hash code OrdinalIgnoreCase (might not have one)
+                {
+                    collidingStrings.Add(candidate); // success!
+                }
 
-                MemoryMarshal.Write(asBytes.Slice(8), ref hash1); // set hash1 := 0 (for Ordinal)
-            });
+                currentSeed += Stride;
+            }
+
+            return collidingStrings;
+
+            // Generates a possible string with a well-known non-randomized hash code:
+            // - string.GetNonRandomizedHashCode returns 0.
+            // - string.GetNonRandomizedHashCodeOrdinalIgnoreCase returns 0x24716ca0.
+            // Provide a different seed to produce a different string.
+            // Caller must check OrdinalIgnoreCase hash code to ensure correctness.
+            static string GenerateCollidingStringCandidate(int seed)
+            {
+                return string.Create(8, seed, (span, seed) =>
+                {
+                    Span<byte> asBytes = MemoryMarshal.AsBytes(span);
+
+                    uint hash1 = (5381 << 16) + 5381;
+                    uint hash2 = BitOperations.RotateLeft(hash1, 5) + hash1;
+
+                    MemoryMarshal.Write(asBytes, ref seed);
+                    MemoryMarshal.Write(asBytes.Slice(4), ref hash2); // set hash2 := 0 (for Ordinal)
+
+                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (uint)seed;
+                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1);
+
+                    MemoryMarshal.Write(asBytes.Slice(8), ref hash1); // set hash1 := 0 (for Ordinal)
+                });
+            }
         }
 
         private static Func<string, int> GetStringHashCodeOpenDelegate(string methodName)
@@ -273,6 +309,45 @@ namespace System.Collections.Tests
             Assert.NotNull(method);
 
             return method.CreateDelegate<Func<string, int>>(target: null); // create open delegate unbound to 'this'
+        }
+
+        private static void ValidateBehaviorOfInternalComparerVsPublicComparer(IEqualityComparer<string> internalComparer, IEqualityComparer<string> publicComparer)
+        {
+            // This helper ensures that when we substitute one of our internal comparers
+            // in place of the expected public comparer, the internal comparer's Equals
+            // and GetHashCode behavior are consistent with the public comparer's.
+
+            if (internalComparer is null)
+            {
+                internalComparer = EqualityComparer<string>.Default;
+            }
+            if (publicComparer is null)
+            {
+                publicComparer = EqualityComparer<string>.Default;
+            }
+
+            foreach (var pair in new[] {
+                ("Hello", "Hello"), // exactly equal
+                ("Hello", "Goodbye"), // not equal at all
+                ("Hello", "hello"), // case-insensitive equal
+                ("Hello", "He\u200dllo"), // equal under linguistic comparer
+                ("Hello", "HE\u200dLLO"), // equal under case-insensitive linguistic comparer
+                ("абвгдеёжзийклмнопрстуфхцчшщьыъэюя", "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭЮЯ"), // Cyrillic, case-insensitive equal
+            })
+            {
+                bool arePairElementsExpectedEqual = publicComparer.Equals(pair.Item1, pair.Item2);
+                Assert.Equal(arePairElementsExpectedEqual, internalComparer.Equals(pair.Item1, pair.Item2));
+
+                bool areInternalHashCodesEqual = internalComparer.GetHashCode(pair.Item1) == internalComparer.GetHashCode(pair.Item2);
+                if (arePairElementsExpectedEqual)
+                {
+                    Assert.True(areInternalHashCodesEqual);
+                }
+                else if (!areInternalHashCodesEqual)
+                {
+                    Assert.False(arePairElementsExpectedEqual);
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
@@ -193,7 +193,7 @@ namespace System.Collections.Tests
             {
                 string newKey = GenerateCollidingString(i * Stride + StartOfRange);
                 Assert.Equal(0, _lazyGetNonRandomizedHashCodeDel.Value(newKey)); // ensure has a zero hash code Ordinal
-                Assert.Equal(0x24716ca0, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
+                Assert.Equal(0x6C3F4A5C, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
 
                 addKeyCallback(collection, newKey);
                 allKeys.Add(newKey);
@@ -212,7 +212,7 @@ namespace System.Collections.Tests
             {
                 string newKey = GenerateCollidingString(i * Stride + StartOfRange);
                 Assert.Equal(0, _lazyGetNonRandomizedHashCodeDel.Value(newKey)); // ensure has a zero hash code Ordinal
-                Assert.Equal(0x24716ca0, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
+                Assert.Equal(0x6C3F4A5C, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
 
                 addKeyCallback(collection, newKey);
                 allKeys.Add(newKey);

--- a/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
@@ -193,7 +193,7 @@ namespace System.Collections.Tests
             {
                 string newKey = GenerateCollidingString(i * Stride + StartOfRange);
                 Assert.Equal(0, _lazyGetNonRandomizedHashCodeDel.Value(newKey)); // ensure has a zero hash code Ordinal
-                Assert.Equal(0x6C3F4A5C, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
+                Assert.Equal(0x24716ca0, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
 
                 addKeyCallback(collection, newKey);
                 allKeys.Add(newKey);
@@ -212,7 +212,7 @@ namespace System.Collections.Tests
             {
                 string newKey = GenerateCollidingString(i * Stride + StartOfRange);
                 Assert.Equal(0, _lazyGetNonRandomizedHashCodeDel.Value(newKey)); // ensure has a zero hash code Ordinal
-                Assert.Equal(0x6C3F4A5C, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
+                Assert.Equal(0x24716ca0, _lazyGetNonRandomizedOrdinalIgnoreCaseHashCodeDel.Value(newKey)); // ensure has a zero hash code OrdinalIgnoreCase
 
                 addKeyCallback(collection, newKey);
                 allKeys.Add(newKey);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/RandomizedStringEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/RandomizedStringEqualityComparer.cs
@@ -87,31 +87,6 @@ namespace System.Collections.Generic
                     return 0;
                 }
 
-                // The Ordinal version of Marvin32 operates over bytes, so convert
-                // char count -> byte count. Guaranteed not to integer overflow.
-                return Marvin.ComputeHash32(
-                    ref Unsafe.As<char, byte>(ref obj.GetRawStringData()),
-                    (uint)obj.Length * sizeof(char),
-                    _seed.p0, _seed.p1);
-            }
-        }
-
-        private sealed class RandomizedOrdinalIgnoreCaseComparer : RandomizedStringEqualityComparer
-        {
-            internal RandomizedOrdinalIgnoreCaseComparer(IEqualityComparer<string?> underlyingComparer)
-                : base(underlyingComparer)
-            {
-            }
-
-            public override bool Equals(string? x, string? y) => string.EqualsOrdinalIgnoreCase(x, y);
-
-            public override int GetHashCode(string? obj)
-            {
-                if (obj is null)
-                {
-                    return 0;
-                }
-
                 // The OrdinalIgnoreCase version of Marvin32 operates over chars,
                 // so pass in the char count directly.
                 return Marvin.ComputeHash32OrdinalIgnoreCase(

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -885,7 +885,7 @@ namespace System
 
             // Slow Non-ASCII fallback
             NotAscii:
-            return Marvin.ComputeHash32OrdinalIgnoreCase(ref _firstChar, _stringLength, 0, 0); // zero seed to make non-random
+            return Marvin.ComputeHash32OrdinalIgnoreCase(ref _firstChar, _stringLength, 0, 0); // zero seed to make it non-random
         }
 
         // Determines whether a specified string is a prefix of the current instance

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -864,7 +864,7 @@ namespace System
                     ref byte firstByte = ref Unsafe.As<char, byte>(ref firstChar);
                     uint p0 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref firstByte, i));
                     uint p1 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref firstByte, i + 4));
-                    if (!AllCharsInUInt32AreAscii(p0 | p1))
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(p0 | p1))
                     {
                         goto NotAscii;
                     }
@@ -880,7 +880,7 @@ namespace System
                 if (count > 0)
                 {
                     uint p0 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref Unsafe.As<char, byte>(ref firstChar), i));
-                    if (!AllCharsInUInt32AreAscii(p0))
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(p0))
                     {
                         goto NotAscii;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -853,21 +853,21 @@ namespace System
                 // a very wide net because it will change, e.g., '^' to '~'. But that should
                 // be ok because we expect this to be very rare in practice.
 
-                const uint NormalizeToLowercase = 0x0020_0020u; // valid both for big-endian and for little-endian
+                uint normalizeToLowercase = BitConverter.IsLittleEndian ? 0x0000_0020u : 0x0020_0000u;
 
                 while (length > 2)
                 {
                     length -= 4;
                     // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
-                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | NormalizeToLowercase);
-                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[1] | NormalizeToLowercase);
+                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | normalizeToLowercase);
+                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[1] | normalizeToLowercase);
                     ptr += 2;
                 }
 
                 if (length > 0)
                 {
                     // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
-                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[0] | NormalizeToLowercase);
+                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[0] | normalizeToLowercase);
                 }
 
                 return (int)(hash1 + (hash2 * 1566083941));

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Unicode;
 
 using Internal.Runtime.CompilerServices;
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -855,7 +855,7 @@ namespace System
             const uint NormalizeToLowercase = 0x0020_0020u; // valid both for big-endian and for little-endian
 
             int i = 0;
-            int count = 0;
+            int count = length;
 
             while (count > 2)
             {
@@ -894,14 +894,15 @@ namespace System
             static int GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(ref char firstChar, int length)
             {
                 char[]? borrowedArr = null;
-                Span<char> scratch = (uint)length <= 64 ?
-                    stackalloc char[64] : (borrowedArr = ArrayPool<char>.Shared.Rent(length));
+                Span<char> scratch = (uint)length < 64 ?
+                    stackalloc char[64] : (borrowedArr = ArrayPool<char>.Shared.Rent(length + 1));
 
                 int charsWritten = System.Globalization.Ordinal.ToUpperOrdinal(
                     MemoryMarshal.CreateReadOnlySpan(ref firstChar, length), scratch);
 
                 Debug.Assert(charsWritten == length);
 
+                scratch[length] = '\0';
                 int hashCode = GetNonRandomizedHashCodeOrdinalIgnoreCaseStatic(
                     ref MemoryMarshal.GetReference(scratch), length, false);
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -853,7 +853,7 @@ namespace System
                 // a very wide net because it will change, e.g., '^' to '~'. But that should
                 // be ok because we expect this to be very rare in practice.
 
-                uint normalizeToLowercase = BitConverter.IsLittleEndian ? 0x0000_0020u : 0x0020_0000u;
+                const uint NormalizeToLowercase = 0x0020_0020u; // valid both for big-endian and for little-endian
 
                 while (length > 2)
                 {
@@ -882,8 +882,10 @@ namespace System
 
                 return (int)(hash1 + (hash2 * 1566083941));
             }
+
+            // Slow Non-ASCII fallback
             NotAscii:
-            return str.GetHashCodeOrdinalIgnoreCase();
+            return Marvin.ComputeHash32OrdinalIgnoreCase(ref _firstChar, _stringLength, 0, 0); // zero seed to make non-random
         }
 
         // Determines whether a specified string is a prefix of the current instance

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -858,15 +858,17 @@ namespace System
 
                 while (length > 2)
                 {
-                    if (!Utf16Utility.AllCharsInUInt32AreAscii(ptr[0]) || !Utf16Utility.AllCharsInUInt32AreAscii(ptr[1]))
+                    uint p0 = ptr[0];
+                    uint p1 = ptr[1];
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(p0 | p1))
                     {
                         goto NotAscii;
                     }
 
                     length -= 4;
                     // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
-                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | NormalizeToLowercase);
-                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[1] | NormalizeToLowercase);
+                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (p0 | NormalizeToLowercase);
+                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (p1 | NormalizeToLowercase);
                     ptr += 2;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -864,8 +864,8 @@ namespace System
 
                     length -= 4;
                     // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
-                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | normalizeToLowercase);
-                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[1] | normalizeToLowercase);
+                    hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | NormalizeToLowercase);
+                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[1] | NormalizeToLowercase);
                     ptr += 2;
                 }
 
@@ -877,7 +877,7 @@ namespace System
                     }
 
                     // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
-                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[0] | normalizeToLowercase);
+                    hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[0] | NormalizeToLowercase);
                 }
 
                 return (int)(hash1 + (hash2 * 1566083941));

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -886,9 +886,9 @@ namespace System
             return (int)(hash1 + (hash2 * 1566083941));
 
         NotAscii:
-            return GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(this, hash1, hash2);
+            return GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(this);
 
-            static int GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(string str, uint hash1, uint hash2)
+            static int GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(string str)
             {
                 int length = str.Length;
                 char[]? borrowedArr = null;
@@ -901,6 +901,8 @@ namespace System
                 scratch[length] = '\0';
 
                 const uint NormalizeToLowercase = 0x0020_0020u;
+                uint hash1 = (5381 << 16) + 5381;
+                uint hash2 = hash1;
 
                 // Duplicate the main loop, can be removed once JIT gets "Loop Unswitching" optimization
                 fixed (char* src = scratch)
@@ -909,7 +911,6 @@ namespace System
                     while (length > 2)
                     {
                         length -= 4;
-                        // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
                         hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | NormalizeToLowercase);
                         hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[1] | NormalizeToLowercase);
                         ptr += 2;
@@ -917,7 +918,6 @@ namespace System
 
                     if (length > 0)
                     {
-                        // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
                         hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[0] | NormalizeToLowercase);
                     }
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -857,6 +857,11 @@ namespace System
 
                 while (length > 2)
                 {
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(ptr[0]) || !Utf16Utility.AllCharsInUInt32AreAscii(ptr[1]))
+                    {
+                        goto NotAscii;
+                    }
+
                     length -= 4;
                     // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
                     hash1 = (BitOperations.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | normalizeToLowercase);
@@ -866,12 +871,19 @@ namespace System
 
                 if (length > 0)
                 {
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(ptr[0]))
+                    {
+                        goto NotAscii;
+                    }
+
                     // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
                     hash2 = (BitOperations.RotateLeft(hash2, 5) + hash2) ^ (ptr[0] | normalizeToLowercase);
                 }
 
                 return (int)(hash1 + (hash2 * 1566083941));
             }
+            NotAscii:
+            return str.GetHashCodeOrdinalIgnoreCase();
         }
 
         // Determines whether a specified string is a prefix of the current instance

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -1,13 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Unicode;
-using System.Buffers;
 
 using Internal.Runtime.CompilerServices;
 
@@ -854,7 +854,7 @@ namespace System
 
             const uint NormalizeToLowercase = 0x0020_0020u; // valid both for big-endian and for little-endian
 
-            int i = 0;
+            nint i = 0;
             int count = length;
 
             while (count > 2)
@@ -889,11 +889,14 @@ namespace System
             return (int)(hash1 + (hash2 * 1566083941));
 
         NotAscii:
+            // Convert the string to upper case using Globalization
+            // and try again the same algorithm (without IsAscii validation this time)
             return GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(ref firstChar, length);
 
             static int GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(ref char firstChar, int length)
             {
                 char[]? borrowedArr = null;
+                // Important: add an additional char for '\0'
                 Span<char> scratch = (uint)length < 64 ?
                     stackalloc char[64] : (borrowedArr = ArrayPool<char>.Shared.Rent(length + 1));
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44681