### PR TITLE
Remove closure allocations from ServiceCollectionDescriptorExtensions

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection.Extensions
 {
@@ -85,10 +84,17 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            if (!collection.Any(d => d.ServiceType == descriptor.ServiceType))
+            int count = collection.Count;
+            for (int i = 0; i < count; i++)
             {
-                collection.Add(descriptor);
+                if (collection[i].ServiceType == descriptor.ServiceType)
+                {
+                    // Already added
+                    return;
+                }
             }
+
+            collection.Add(descriptor);
         }
 
         /// <summary>
@@ -608,12 +614,19 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
                     nameof(descriptor));
             }
 
-            if (!services.Any(d =>
-                              d.ServiceType == descriptor.ServiceType &&
-                              d.GetImplementationType() == implementationType))
+            int count = services.Count;
+            for (int i = 0; i < count; i++)
             {
-                services.Add(descriptor);
+                ServiceDescriptor service = services[i];
+                if (service.ServiceType == descriptor.ServiceType &&
+                    service.GetImplementationType() == implementationType)
+                {
+                    // Already added
+                    return;
+                }
             }
+
+            services.Add(descriptor);
         }
 
         /// <summary>
@@ -674,10 +687,15 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            ServiceDescriptor? registeredServiceDescriptor = collection.FirstOrDefault(s => s.ServiceType == descriptor.ServiceType);
-            if (registeredServiceDescriptor != null)
+            // Remove existing
+            int count = collection.Count;
+            for (int i = 0; i < count; i++)
             {
-                collection.Remove(registeredServiceDescriptor);
+                if (collection[i].ServiceType == descriptor.ServiceType)
+                {
+                    collection.RemoveAt(i);
+                    break;
+                }
             }
 
             collection.Add(descriptor);


### PR DESCRIPTION
Drops the closure allocations for `Func<ServiceDescriptor, Boolean>` from 754 objects to 2 for startup allocations of an ASP.NET MVC app

Before

![image](https://user-images.githubusercontent.com/1142958/99161230-ef5bbe00-26e7-11eb-80a5-5e63aefd0463.png)

After

![image](https://user-images.githubusercontent.com/1142958/99161237-faaee980-26e7-11eb-95cd-b748c0c4f914.png)

Contributes to #44598