### PR TITLE
Optimize HelloWorld usage

### DIFF
--- a/src/coreclr/src/tools/r2rdump/R2RDiff.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDiff.cs
@@ -90,13 +90,28 @@ namespace R2RDump
             }
         }
 
+        private bool TryGetMethods(ReadyToRunReader reader, ReadyToRunSection section, out IReadOnlyList<ReadyToRunMethod> methods)
+        {
+            int assemblyIndex = reader.GetAssemblyIndex(section);
+            if (assemblyIndex == -1)
+            {
+                methods = null;
+                return false;
+            }
+            else
+            {
+                methods = reader.ReadyToRunAssemblies[assemblyIndex].Methods;
+                return true;
+            }
+        }
+
         private void DiffMethodsForModule(ReadyToRunSection leftSection, ReadyToRunSection rightSection)
         {
-            if (!_leftDumper.Reader.Methods.TryGetValue(leftSection, out List<ReadyToRunMethod> leftSectionMethods))
+            if (!TryGetMethods(_leftDumper.Reader, leftSection, out IReadOnlyList<ReadyToRunMethod> leftSectionMethods))
             {
                 leftSectionMethods = new List<ReadyToRunMethod>();
             }
-            if (!_rightDumper.Reader.Methods.TryGetValue(rightSection, out List<ReadyToRunMethod> rightSectionMethods))
+            if (!TryGetMethods(_rightDumper.Reader, rightSection, out IReadOnlyList<ReadyToRunMethod> rightSectionMethods))
             {
                 rightSectionMethods = new List<ReadyToRunMethod>();
             }
@@ -290,7 +305,7 @@ namespace R2RDump
         {
             Dictionary<string, int> methodMap = new Dictionary<string, int>();
 
-            if (reader.Methods.TryGetValue(section, out List<ReadyToRunMethod> sectionMethods))
+            if (TryGetMethods(reader, section, out IReadOnlyList<ReadyToRunMethod> sectionMethods))
             {
                 foreach (ReadyToRunMethod method in sectionMethods)
                 {
@@ -309,7 +324,7 @@ namespace R2RDump
         /// <param name="signatureFilter">Set of common signatures of methods to dump</param>
         private void DumpCommonMethods(Dumper dumper, ReadyToRunSection section, Dictionary<string, MethodPair> signatureFilter)
         {
-            if (dumper.Reader.Methods.TryGetValue(section, out List<ReadyToRunMethod> sectionMethods))
+            if (!TryGetMethods(dumper.Reader, section, out IReadOnlyList<ReadyToRunMethod> sectionMethods))
             {
                 IEnumerable<ReadyToRunMethod> filteredMethods = sectionMethods
                     .Where(method => signatureFilter.ContainsKey(method.SignatureString))

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -176,7 +176,7 @@ namespace R2RDump
 
         public IEnumerable<ReadyToRunMethod> NormalizedMethods()
         {
-            IEnumerable<ReadyToRunMethod> methods = _r2r.Methods.Values.SelectMany(sectionMethods => sectionMethods);
+            IEnumerable<ReadyToRunMethod> methods = _r2r.Methods;
             if (_options.Normalize)
             {
                 methods = methods.OrderBy((m) => m.SignatureString);
@@ -492,7 +492,7 @@ namespace R2RDump
         public IList<ReadyToRunMethod> FindMethod(ReadyToRunReader r2r, string query, bool exact)
         {
             List<ReadyToRunMethod> res = new List<ReadyToRunMethod>();
-            foreach (ReadyToRunMethod method in r2r.Methods.Values.SelectMany(sectionMethods => sectionMethods))
+            foreach (ReadyToRunMethod method in r2r.Methods)
             {
                 if (Match(method, query, exact))
                 {
@@ -529,7 +529,7 @@ namespace R2RDump
         /// <param name="rtfQuery">The name or value to search for</param>
         public RuntimeFunction FindRuntimeFunction(ReadyToRunReader r2r, int rtfQuery)
         {
-            foreach (ReadyToRunMethod m in r2r.Methods.Values.SelectMany(sectionMethods => sectionMethods))
+            foreach (ReadyToRunMethod m in r2r.Methods)
             {
                 foreach (RuntimeFunction rtf in m.RuntimeFunctions)
                 {

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -133,7 +133,7 @@ namespace R2RDump
         internal override void DumpAllMethods()
         {
             WriteDivider("R2R Methods");
-            _writer.WriteLine($"{_r2r.Methods.Sum(kvp => kvp.Value.Count)} methods");
+            _writer.WriteLine($"{_r2r.Methods.Count()} methods");
             SkipLine();
             foreach (ReadyToRunMethod method in NormalizedMethods())
             {
@@ -303,10 +303,11 @@ namespace R2RDump
                         _writer.WriteLine(availableTypes.ToString());
                     }
 
-                    if (_r2r.AvailableTypes.TryGetValue(section, out List<string> sectionTypes))
+                    int assemblyIndex1 = _r2r.GetAssemblyIndex(section);
+                    if (assemblyIndex1 != -1)
                     {
                         _writer.WriteLine();
-                        foreach (string name in sectionTypes)
+                        foreach (string name in _r2r.ReadyToRunAssemblies[assemblyIndex1].AvailableTypes)
                         {
                             _writer.WriteLine(name);
                         }
@@ -319,10 +320,11 @@ namespace R2RDump
                         _writer.Write(methodEntryPoints.ToString());
                     }
 
-                    if (_r2r.Methods.TryGetValue(section, out List<ReadyToRunMethod> sectionMethods))
+                    int assemblyIndex2 = _r2r.GetAssemblyIndex(section);
+                    if (assemblyIndex2 != -1)
                     {
                         _writer.WriteLine();
-                        foreach (ReadyToRunMethod method in sectionMethods)
+                        foreach (ReadyToRunMethod method in _r2r.ReadyToRunAssemblies[assemblyIndex2].Methods)
                         {
                             _writer.WriteLine($@"{MetadataTokens.GetToken(method.MethodHandle):X8}: {method.SignatureString}");
                         }


### PR DESCRIPTION
This change intends to make `ReadyToRunReader` easier to use for first time user. 

Before the change, here is the code needed to iterate through the set of methods:

```c#
foreach (var section in r2r.Methods) {
  foreach (var method in section.Value) {
    // Do something with the method
  }
}
```

The API is just weird, the `Method` properties actually give us a section, and the section is not actually a section, it is a key-value pair. 

My goal is to make this anomaly goes away, and with my change, now we can have two modes of iterations, in the simple case that we simply want everything, we can use the `Method` property. 

```c#
foreach (var method in r2r.Methods) {
  // Do something with the method
}
```
or if we wanted to be specific about the component assemblies (in the composite case)

```c#
foreach (var assembly in r2r.ReadyToRunAssemblies) {
  foreach (var method in assembly.Methods) {
    // Do something with the method
  }
}
foreach (var instanceMethod in r2r.InstanceMethod) {
  // Do something with instanceMethod.Method
}
```

This should also expose the underlying structure that instance methods are stored differently.