### PR TITLE
[wasm] Add WasmAppBuilder pkgproj for wasm sample

### DIFF
--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.wasm.Sample.Mono/Microsoft.NET.Runtime.wasm.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.wasm.Sample.Mono/Microsoft.NET.Runtime.wasm.Sample.Mono.pkgproj
@@ -7,9 +7,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_wasmSampleFiles Include="$(ArtifactsDir)bin\WasmAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\WasmAppBuilder.dll" />
+    <_wasmSampleFiles Include="$(ArtifactsDir)bin\WasmAppBuilder\$(Configuration)\$(NetCoreAppToolCurrent)\WasmAppBuilder.dll" />
 
-    <PackageFile Include="@(_wasmSampleFiles)" TargetPath="tools\$(NetCoreAppCurrent)\" />
+    <PackageFile Include="@(_wasmSampleFiles)" TargetPath="tools\$(NetCoreAppToolCurrent)\" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/mono/netcore/nuget/Microsoft.NET.Runtime.wasm.Sample.Mono/Microsoft.NET.Runtime.wasm.Sample.Mono.pkgproj
+++ b/src/mono/netcore/nuget/Microsoft.NET.Runtime.wasm.Sample.Mono/Microsoft.NET.Runtime.wasm.Sample.Mono.pkgproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoToolsLocalDir)tasks\mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <_wasmSampleFiles Include="$(ArtifactsDir)bin\WasmAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\WasmAppBuilder.dll" />
+
+    <PackageFile Include="@(_wasmSampleFiles)" TargetPath="tools\$(NetCoreAppCurrent)\" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/mono/netcore/nuget/descriptions.json
+++ b/src/mono/netcore/nuget/descriptions.json
@@ -10,13 +10,18 @@
         "CommonTypes": [ ]
     },
     {
-        "Name": "Microsoft.NETCore.BrowserDebugHost.Transport",
-        "Description": "Internal package for sharing BrowserDebugHost.",
+        "Name": "Microsoft.NET.Runtime.iOS.Sample.Mono",
+        "Description": "Internal package for sharing embedded Mono runtime and iOS App Builder.",
         "CommonTypes": [ ]
     },
     {
-        "Name": "Microsoft.NET.Runtime.iOS.Sample.Mono",
-        "Description": "Internal package for sharing embedded Mono runtime and iOS App Builder.",
+        "Name": "Microsoft.NET.Runtime.wasm.Sample.Mono",
+        "Description": "Internal package for sharing wasm App Builder.",
+        "CommonTypes": [ ]
+    },
+    {
+        "Name": "Microsoft.NETCore.BrowserDebugHost.Transport",
+        "Description": "Internal package for sharing BrowserDebugHost.",
         "CommonTypes": [ ]
     }
 ]

--- a/src/mono/netcore/nuget/mono-packages.proj
+++ b/src/mono/netcore/nuget/mono-packages.proj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
+    <ProjectReference Include="Microsoft.NET.Runtime.wasm.Sample.Mono\Microsoft.NET.Runtime.wasm.Sample.Mono.pkgproj" />
     <ProjectReference Include="Microsoft.NETCore.BrowserDebugHost.Transport\Microsoft.NETCore.BrowserDebugHost.Transport.pkgproj" />
   </ItemGroup>
 

--- a/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.csproj
+++ b/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.csproj
@@ -21,4 +21,7 @@
   <Target Name="PublishBuilder"
           AfterTargets="Build"
           DependsOnTargets="Publish" />
+
+  <Target Name="GetFilesToPackage" />
+
 </Project>


### PR DESCRIPTION
In preparation to bring mono samples to `dotnet/samples`, files that are most likely to change will be packaged into a nuget package to be downloaded and consumed on the `dotnet/samples` end rather than mirroring changes.

This PR expands the process that created the NuGet package for `Microsoft.NETCore.BrowserDebugHost.Transport` to build a NuGet package for the wasm sample.