### PR TITLE
Remove unnecessary closure / delegate allocation from CallSiteFactory.GetCallSite

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -70,10 +70,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
         }
 
-        internal ServiceCallSite GetCallSite(Type serviceType, CallSiteChain callSiteChain)
-        {
-            return _callSiteCache.GetOrAdd(serviceType, type => CreateCallSite(type, callSiteChain));
-        }
+        internal ServiceCallSite GetCallSite(Type serviceType, CallSiteChain callSiteChain) =>
+            _callSiteCache.TryGetValue(serviceType, out ServiceCallSite site) ? site :
+            CreateCallSite(serviceType, callSiteChain);
 
         internal ServiceCallSite GetCallSite(ServiceDescriptor serviceDescriptor, CallSiteChain callSiteChain)
         {


### PR DESCRIPTION
Nothing is ever removed from the cache, and CreateCallSite is already storing the newly created ServiceCallSite into the dictionary, so GetOrAdd isn't providing any meaningful value: we can simply TryGetValue and then call CreateCallSite if it fails.

From startup of a `dotnet new mvc` app:
![image](https://user-images.githubusercontent.com/2642209/99302296-2d0e3300-281d-11eb-9029-13d89ca40ddf.png)

Related to #44598
