### PR TITLE
Special-case zero parameter array allocations in GetParameters

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -15,24 +15,26 @@ namespace System.Reflection
         {
             Debug.Assert(method is RuntimeMethodInfo || method is RuntimeConstructorInfo);
 
-            return GetParameters(method, member, sig, out _, false);
+            return GetParameters(method, member, sig, out _, fetchReturnParameter: false);
         }
 
         internal static ParameterInfo GetReturnParameter(IRuntimeMethodInfo method, MemberInfo member, Signature sig)
         {
             Debug.Assert(method is RuntimeMethodInfo || method is RuntimeConstructorInfo);
 
-            ParameterInfo returnParameter;
-            GetParameters(method, member, sig, out returnParameter!, true);
-            return returnParameter;
+            GetParameters(method, member, sig, out ParameterInfo? returnParameter, fetchReturnParameter: true);
+            return returnParameter!;
         }
 
-        internal static ParameterInfo[] GetParameters(
+        private static ParameterInfo[] GetParameters(
             IRuntimeMethodInfo methodHandle, MemberInfo member, Signature sig, out ParameterInfo? returnParameter, bool fetchReturnParameter)
         {
             returnParameter = null;
             int sigArgCount = sig.Arguments.Length;
-            ParameterInfo[] args = fetchReturnParameter ? null! : new ParameterInfo[sigArgCount];
+            ParameterInfo[] args =
+                fetchReturnParameter ? null! :
+                sigArgCount == 0 ? Array.Empty<ParameterInfo>() :
+                new ParameterInfo[sigArgCount];
 
             int tkMethodDef = RuntimeMethodHandle.GetMethodDef(methodHandle);
             int cParamDefs = 0;


### PR DESCRIPTION
In an empty MVC app created with `dotnet new mvc`, this drops ParameterInfo[] allocations by 12% (from 758 to 667).

Related to #44598