### PR TITLE
Avoid string.Concat(params string[]) in SimpleConsoleFormatter.CreateDefaultLogMessage

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -3,10 +3,6 @@
 
 using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -78,7 +74,19 @@ namespace Microsoft.Extensions.Logging.Console
             //       Request received
 
             // category and event id
-            textWriter.Write(LoglevelPadding + logEntry.Category + '[' + eventId + "]");
+            textWriter.Write(LoglevelPadding);
+            textWriter.Write(logEntry.Category);
+            textWriter.Write('[');
+
+#if NETCOREAPP
+            Span<char> span = stackalloc char[10];
+            if (eventId.TryFormat(span, out int charsWritten))
+                textWriter.Write(span.Slice(0, charsWritten));
+            else
+#endif
+                textWriter.Write(eventId.ToString());
+
+            textWriter.Write(']');
             if (!singleLine)
             {
                 textWriter.Write(Environment.NewLine);
@@ -177,7 +185,8 @@ namespace Microsoft.Extensions.Logging.Console
                     if (paddingNeeded)
                     {
                         paddingNeeded = false;
-                        state.Write(_messagePadding + "=> ");
+                        state.Write(_messagePadding);
+                        state.Write("=> ");
                     }
                     else
                     {


### PR DESCRIPTION
It's resulting in a string[] allocation and a string allocation, when we can instead just make a few more individual calls to Write.  (The writer here is generally a StringWriter.)

Related to #44598