### PR TITLE
Module token resolver fix

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -304,6 +304,9 @@ namespace ILCompiler
 
             nodes = _fileLayoutOptimizer.ApplyProfilerGuidedMethodSort(nodes);
 
+            //var resolverDumpFile = Path.ChangeExtension(outputFile, "resolvermap.txt");
+            //_nodeFactory.Resolver.DumpMaps(resolverDumpFile);
+
             using (PerfEventSource.StartStopEvents.EmittingEvents())
             {
                 NodeFactory.SetMarkingComplete();


### PR DESCRIPTION
Fixes an unhandled case where a module token is requested for a typeref
to a generic instantiation and the instantiation is local to the module.

Fixes #43498