### PR TITLE
Use `argIsInvariant` instead of `argNode->OperIsConst()` for inlining observations.

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -5179,7 +5179,7 @@ void Compiler::fgObserveInlineConstants(OPCODE opcode, const FgStack& stack, boo
                     // Check for the double whammy of an incoming constant argument
                     // feeding a constant test.
                     unsigned varNum = FgStack::SlotTypeToArgNum(slot0);
-                    if (impInlineInfo->inlArgInfo[varNum].argNode->OperIsConst())
+                    if (impInlineInfo->inlArgInfo[varNum].argIsInvariant)
                     {
                         compInlineResult->Note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
                     }
@@ -5221,7 +5221,7 @@ void Compiler::fgObserveInlineConstants(OPCODE opcode, const FgStack& stack, boo
             compInlineResult->Note(InlineObservation::CALLEE_ARG_FEEDS_TEST);
 
             unsigned varNum = FgStack::SlotTypeToArgNum(slot0);
-            if (impInlineInfo->inlArgInfo[varNum].argNode->OperIsConst())
+            if (impInlineInfo->inlArgInfo[varNum].argIsInvariant)
             {
                 compInlineResult->Note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
             }
@@ -5232,7 +5232,7 @@ void Compiler::fgObserveInlineConstants(OPCODE opcode, const FgStack& stack, boo
             compInlineResult->Note(InlineObservation::CALLEE_ARG_FEEDS_TEST);
 
             unsigned varNum = FgStack::SlotTypeToArgNum(slot1);
-            if (impInlineInfo->inlArgInfo[varNum].argNode->OperIsConst())
+            if (impInlineInfo->inlArgInfo[varNum].argIsInvariant)
             {
                 compInlineResult->Note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
             }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_43130/Runtime_43130.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_43130/Runtime_43130.il
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Test several simple combinations when we inline a method which takes an argument
+// with an implicit cast, when we substitute the use as the argument in the inlined body
+// we should be careful about handling the 'PUTARG_TYPE' node that shows the cast.
+
+.assembly extern System.Runtime
+{
+}
+.assembly extern System.Runtime.Extensions
+{
+}
+.assembly Runtime_43130
+{
+}
+.module Runtime_43130.dll
+
+.class private auto ansi beforefieldinit Runtime_43130
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig static int32  Test1(int32 i1) cil managed noinlining
+  {
+    // Code size       20 (0x14)
+    .maxstack  2
+    .locals init (int32 V_0,
+             int32 V_1)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldc.i4.1
+    IL_0003:  add
+    IL_0004:  stloc.0
+    IL_0005:  ldloc.0
+    // IL_0006:  conv.i2
+    IL_0007:  call       void Runtime_43130::Inline1(int16)
+    IL_000c:  nop
+    IL_000d:  ldc.i4.s   100
+    IL_000f:  stloc.1
+    IL_0010:  br.s       IL_0012
+
+    IL_0012:  ldloc.1
+    IL_0013:  ret
+  } // end of method Runtime_43130::Test1
+
+  .method public hidebysig static void  Inline1(int16 s) cil managed aggressiveinlining
+  {
+    // Code size       9 (0x9)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  call       void Runtime_43130::CallAMethod1(int16)
+    IL_0007:  nop
+    IL_0008:  ret
+  } // end of method Runtime_43130::Inline1
+
+  .method public hidebysig static void  CallAMethod1(int16 s) cil managed noinlining
+  {
+    // Code size       4 (0x4)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  br.s       IL_0003
+
+    IL_0003:  ret
+  } // end of method Runtime_43130::CallAMethod1
+
+  .method public hidebysig static int32  Test2(int32 i1) cil managed noinlining
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    .locals init (int32 V_0,
+             int32 V_1)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldc.i4.1
+    IL_0003:  add
+    IL_0004:  stloc.0
+    IL_0005:  ldloc.0
+    // IL_0006:  conv.i2
+    IL_0007:  call       int32 Runtime_43130::Inline2(int16)
+    IL_000c:  stloc.1
+    IL_000d:  br.s       IL_000f
+
+    IL_000f:  ldloc.1
+    IL_0010:  ret
+  } // end of method Runtime_43130::Test2
+
+  .method public hidebysig static int32  Inline2(int16 s) cil managed aggressiveinlining
+  {
+    // Code size       12 (0xc)
+    .maxstack  2
+    .locals init (int32 V_0,
+             int32 V_1)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldc.i4.s   10
+    IL_0004:  add
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  stloc.1
+    IL_0008:  br.s       IL_000a
+
+    IL_000a:  ldloc.1
+    IL_000b:  ret
+  } // end of method Runtime_43130::Inline2
+
+  .method public hidebysig static int32  Test3(int32 i1) cil managed noinlining
+  {
+    // Code size       20 (0x14)
+    .maxstack  2
+    .locals init (int32 V_0,
+             int32 V_1)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldc.i4.1
+    IL_0003:  add
+    IL_0004:  stloc.0
+    IL_0005:  ldloc.0
+    // IL_0006:  conv.i2
+    IL_0007:  call       int32 Runtime_43130::Inline3(int16)
+    IL_000c:  pop
+    IL_000d:  ldc.i4.s   100
+    IL_000f:  stloc.1
+    IL_0010:  br.s       IL_0012
+
+    IL_0012:  ldloc.1
+    IL_0013:  ret
+  } // end of method Runtime_43130::Test3
+
+  .method public hidebysig static int32  Inline3(int16 s) cil managed aggressiveinlining
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    .locals init (int32 V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  call       void Runtime_43130::CallAMethod3(int16)
+    IL_0007:  nop
+    IL_0008:  ldarg.0
+    IL_0009:  ldc.i4.s   10
+    IL_000b:  add
+    IL_000c:  stloc.0
+    IL_000d:  br.s       IL_000f
+
+    IL_000f:  ldloc.0
+    IL_0010:  ret
+  } // end of method Runtime_43130::Inline3
+
+  .method public hidebysig static void  CallAMethod3(int16 s) cil managed noinlining
+  {
+    // Code size       4 (0x4)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  br.s       IL_0003
+
+    IL_0003:  ret
+  } // end of method Runtime_43130::CallAMethod3
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    // Code size       29 (0x1d)
+    .maxstack  1
+    .locals init (int32 V_0)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.1
+    IL_0002:  call       int32 Runtime_43130::Test1(int32)
+    IL_0007:  pop
+    IL_0008:  ldc.i4.1
+    IL_0009:  call       int32 Runtime_43130::Test2(int32)
+    IL_000e:  pop
+    IL_000f:  ldc.i4.1
+    IL_0010:  call       int32 Runtime_43130::Test3(int32)
+    IL_0015:  pop
+    IL_0016:  ldc.i4.s   100
+    IL_0018:  stloc.0
+    IL_0019:  br.s       IL_001b
+
+    IL_001b:  ldloc.0
+    IL_001c:  ret
+  } // end of method Runtime_43130::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method Runtime_43130::.ctor
+
+} // end of class Runtime_43130

--- a/src/tests/JIT/Regression/JitBlue/Runtime_43130/Runtime_43130.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_43130/Runtime_43130.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This produces many diffs, the reason is that for a test like this:
```
class GitHub_43342
{
    public static int Test1(int a, int b)
    {
        if (GetA(a) != GetB(b))
        {
            return 1;
        }
        return 100;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]

    public static int GetA(int a)
    {
        return 1;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]

    public static int GetB(int a)
    {
        return 2;
    }


    public static int Main()
    {
        Test1(1, 2);
        return 100;
    }
}

```

when we consider to inline `Test1` into `Main` `fgFindJumpTargets` marks both arguments as `CALLSITE_CONSTANT_ARG_FEEDS_TEST` and it bumps its inlining score. In this case, the const arguments are not feeding the condition directly and inlining of the `Test1` does not help to fold the condition.

Is such behavior desirable or should we improve stack simulation in `fgFindJumpTargets` so it pops args that are used by calls?

After the change, it also happens for methods like `if (callA(this) != callB(this))` because this is an invariant.
It causes more inlining to happen and the diff looks like a size regression:
x64 crossgen: Total bytes of delta: 46090 (0.14% of base)
x64 pmi:  Total bytes of delta: 170421 (0.34% of base)


also, we can change the test a little:
```
class GitHub_43342
{
    public static int Test1(int a, int b)
    {
        int c = 5;
        int d = GetD();
        GetA(a);
        GetB(b);
        if (c != d)
        {
            return 1;
        }
        return 100;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]

    public static int GetA(int a)
    {
        return 1;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]

    public static int GetB(int a)
    {
        return 2;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]

    public static int GetD()
    {
        return 3;
    }


    public static int Main()
    {
        Test1(1, 2);
        return 100;
    }
}
```
now the constant arguments are not fed to the condition (even indirectly) but the current master still marks `Inline candidate has const arg that feeds a conditional.  Multiplier increased to 3.`

PTAL @AndyAyersMS, does it looks like an issue or is `CALLSITE_CONSTANT_ARG_FEEDS_TEST` an approximation that should not be precise?