### PR TITLE
few minor MemoryCache perf improvements

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private static void ScanForExpiredItems(MemoryCache cache)
         {
-            DateTimeOffset now = cache._options.Clock.UtcNow;
+            DateTimeOffset now = cache._lastExpirationScan = cache._options.Clock.UtcNow;
             foreach (CacheEntry entry in cache._entries.Values)
             {
                 if (entry.CheckExpired(now))

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -500,16 +500,20 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                Throw();
             }
+
+            void Throw() => throw new ObjectDisposedException(typeof(MemoryCache).FullName);
         }
 
         private static void ValidateCacheKey(object key)
         {
             if (key == null)
             {
-                throw new ArgumentNullException(nameof(key));
+                Throw();
             }
+
+            void Throw() => throw new ArgumentNullException(nameof(key));
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -510,7 +510,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 Throw();
             }
 
-            void Throw() => throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+            static void Throw() => throw new ObjectDisposedException(typeof(MemoryCache).FullName);
         }
 
         private static void ValidateCacheKey(object key)
@@ -520,7 +520,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 Throw();
             }
 
-            void Throw() => throw new ArgumentNullException(nameof(key));
+            static void Throw() => throw new ArgumentNullException(nameof(key));
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
@@ -230,44 +231,45 @@ namespace Microsoft.Extensions.Caching.Memory
                 }
             }
 
-            StartScanForExpiredItems(utcNow);
+            StartScanForExpiredItemsIfNeeded(utcNow);
         }
 
         /// <inheritdoc />
         public bool TryGetValue(object key, out object result)
         {
             ValidateCacheKey(key);
-
             CheckDisposed();
 
-            result = null;
             DateTimeOffset utcNow = _options.Clock.UtcNow;
-            bool found = false;
 
             if (_entries.TryGetValue(key, out CacheEntry entry))
             {
                 // Check if expired due to expiration tokens, timers, etc. and if so, remove it.
                 // Allow a stale Replaced value to be returned due to concurrent calls to SetExpired during SetEntry.
-                if (entry.CheckExpired(utcNow) && entry.EvictionReason != EvictionReason.Replaced)
+                if (!(entry.CheckExpired(utcNow) && entry.EvictionReason != EvictionReason.Replaced))
                 {
-                    // TODO: For efficiency queue this up for batch removal
-                    RemoveEntry(entry);
-                }
-                else
-                {
-                    found = true;
                     entry.LastAccessed = utcNow;
                     result = entry.Value;
 
                     // When this entry is retrieved in the scope of creating another entry,
                     // that entry needs a copy of these expiration tokens.
                     entry.PropagateOptions(CacheEntryHelper.Current);
+
+                    StartScanForExpiredItemsIfNeeded(utcNow);
+
+                    return true;
+                }
+                else
+                {
+                    // TODO: For efficiency queue this up for batch removal
+                    RemoveEntry(entry);
                 }
             }
 
-            StartScanForExpiredItems(utcNow);
+            StartScanForExpiredItemsIfNeeded(utcNow);
 
-            return found;
+            result = null;
+            return false;
         }
 
         /// <inheritdoc />
@@ -287,7 +289,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 entry.InvokeEvictionCallbacks();
             }
 
-            StartScanForExpiredItems();
+            StartScanForExpiredItemsIfNeeded(_options.Clock.UtcNow);
         }
 
         private void RemoveEntry(CacheEntry entry)
@@ -306,18 +308,23 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             // TODO: For efficiency consider processing these expirations in batches.
             RemoveEntry(entry);
-            StartScanForExpiredItems();
+            StartScanForExpiredItemsIfNeeded(_options.Clock.UtcNow);
         }
 
         // Called by multiple actions to see how long it's been since we last checked for expired items.
         // If sufficient time has elapsed then a scan is initiated on a background task.
-        private void StartScanForExpiredItems(DateTimeOffset? utcNow = null)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void StartScanForExpiredItemsIfNeeded(DateTimeOffset utcNow)
         {
             // Since fetching time is expensive, minimize it in the hot paths
-            DateTimeOffset now = utcNow ?? _options.Clock.UtcNow;
-            if (_options.ExpirationScanFrequency < now - _lastExpirationScan)
+            if (_options.ExpirationScanFrequency < utcNow - _lastExpirationScan)
             {
-                _lastExpirationScan = now;
+                ScheduleTask(utcNow);
+            }
+
+            void ScheduleTask(DateTimeOffset utcNow)
+            {
+                _lastExpirationScan = utcNow;
                 Task.Factory.StartNew(state => ScanForExpiredItems((MemoryCache)state), this,
                     CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
             }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 // Check if expired due to expiration tokens, timers, etc. and if so, remove it.
                 // Allow a stale Replaced value to be returned due to concurrent calls to SetExpired during SetEntry.
-                if (!(entry.CheckExpired(utcNow) && entry.EvictionReason != EvictionReason.Replaced))
+                if (!entry.CheckExpired(utcNow) || entry.EvictionReason == EvictionReason.Replaced)
                 {
                     entry.LastAccessed = utcNow;
                     result = entry.Value;

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -316,7 +316,6 @@ namespace Microsoft.Extensions.Caching.Memory
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void StartScanForExpiredItemsIfNeeded(DateTimeOffset utcNow)
         {
-            // Since fetching time is expensive, minimize it in the hot paths
             if (_options.ExpirationScanFrequency < utcNow - _lastExpirationScan)
             {
                 ScheduleTask(utcNow);


### PR DESCRIPTION
I just took a quick look at the source code to see if we could get some gains in the Caching TechEmpower benchmark. This PR is a free lunch, there is definitely more low hanging fruits there and I hope that it becomes one of our .NET 6 goals.

The performance repo microbenchmarks (https://github.com/dotnet/performance/pull/1598) show 5 to 15% perf improvement

|          Method |           Toolchain |      Mean | Ratio |
|---------------- |-------------------- |----------:|------:|
|          GetHit |  \after\CoreRun.exe | 137.61 ns |  0.86 |
|          GetHit | \before\CoreRun.exe | 159.17 ns |  1.00 |
|                 |                     |           |       |
|  TryGetValueHit |  \after\CoreRun.exe | 131.57 ns |  0.84 |
|  TryGetValueHit | \before\CoreRun.exe | 157.07 ns |  1.00 |
|                 |                     |           |       |
|         GetMiss |  \after\CoreRun.exe |  98.56 ns |  0.87 |
|         GetMiss | \before\CoreRun.exe | 113.47 ns |  1.00 |
|                 |                     |           |       |
| TryGetValueMiss |  \after\CoreRun.exe |  97.62 ns |  0.86 |
| TryGetValueMiss | \before\CoreRun.exe | 113.05 ns |  1.00 |
|                 |                     |           |       |
|     SetOverride |  \after\CoreRun.exe | 362.80 ns |  0.95 |
|     SetOverride | \before\CoreRun.exe | 381.01 ns |  1.00 |

The TechEmpower benchmark shows +6k RPS (from 234,210 240,778) to which translates to +2.75% RPS