### PR TITLE
Fix non-thread-safe EntityTagHeaderValue.Any

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
@@ -8,8 +8,6 @@ namespace System.Net.Http.Headers
 {
     public class EntityTagHeaderValue : ICloneable
     {
-        private static volatile EntityTagHeaderValue? s_any;
-
         private string _tag;
         private bool _isWeak;
 
@@ -23,7 +21,7 @@ namespace System.Net.Http.Headers
             get { return _isWeak; }
         }
 
-        public static EntityTagHeaderValue Any => s_any ??= new EntityTagHeaderValue();
+        public static EntityTagHeaderValue Any { get; } = new EntityTagHeaderValue();
 
         private EntityTagHeaderValue()
         {
@@ -177,16 +175,6 @@ namespace System.Net.Http.Headers
             return current - startIndex;
         }
 
-        object ICloneable.Clone()
-        {
-            if (this == s_any)
-            {
-                return s_any;
-            }
-            else
-            {
-                return new EntityTagHeaderValue(this);
-            }
-        }
+        object ICloneable.Clone() => ReferenceEquals(this, Any) ? Any : new EntityTagHeaderValue(this);
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
@@ -10,7 +10,7 @@ namespace System.Net.Http.Headers
     {
         private static volatile EntityTagHeaderValue? s_any;
 
-        private string _tag = null!;
+        private string _tag;
         private bool _isWeak;
 
         public string Tag
@@ -23,7 +23,12 @@ namespace System.Net.Http.Headers
             get { return _isWeak; }
         }
 
-        public static EntityTagHeaderValue Any => s_any ??= new EntityTagHeaderValue() { _tag = "*" };
+        public static EntityTagHeaderValue Any => s_any ??= new EntityTagHeaderValue();
+
+        private EntityTagHeaderValue()
+        {
+            _tag = "*";
+        }
 
         public EntityTagHeaderValue(string tag)
             : this(tag, false)
@@ -55,10 +60,6 @@ namespace System.Net.Http.Headers
 
             _tag = source._tag;
             _isWeak = source._isWeak;
-        }
-
-        private EntityTagHeaderValue()
-        {
         }
 
         public override string ToString()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
@@ -8,7 +8,7 @@ namespace System.Net.Http.Headers
 {
     public class EntityTagHeaderValue : ICloneable
     {
-        private static EntityTagHeaderValue? s_any;
+        private static volatile EntityTagHeaderValue? s_any;
 
         private string _tag = null!;
         private bool _isWeak;
@@ -23,19 +23,7 @@ namespace System.Net.Http.Headers
             get { return _isWeak; }
         }
 
-        public static EntityTagHeaderValue Any
-        {
-            get
-            {
-                if (s_any == null)
-                {
-                    s_any = new EntityTagHeaderValue();
-                    s_any._tag = "*";
-                    s_any._isWeak = false;
-                }
-                return s_any;
-            }
-        }
+        public static EntityTagHeaderValue Any => s_any ??= new EntityTagHeaderValue() { _tag = "*" };
 
         public EntityTagHeaderValue(string tag)
             : this(tag, false)


### PR DESCRIPTION
It was being published before fully populated.  Spotted by @GrabYourPitchforks.

@Tratcher, it looks like ASP.NET's fork has the same issue here:
https://github.com/dotnet/aspnetcore/blob/634b50eeee1311382aee774ff32f0b54fdbb7c0f/src/Http/Headers/src/EntityTagHeaderValue.cs#L69-L75