### PR TITLE
Remove unnecessary suppression

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.cs
@@ -9,7 +9,7 @@ namespace System.Linq
     public static partial class Enumerable
     {
         public static IEnumerable<TSource?> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source) =>
-            DefaultIfEmpty(source, default!);
+            DefaultIfEmpty(source, default);
 
         public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {


### PR DESCRIPTION
It turns out that [recent compilers](https://sharplab.io/#v2:EYLgtghgzgLgpgJwDQxAN0QSwGYE8A+AxAHYCuANuRMOXAARzHW0CwAUOwAIAMdnAjABYA3Oy4BmPvwBsfAEx0AwnQDe7OhrrrNnSQNkDxAHgAqAZQD2pBAGM4AfgB8dACJxsECjACS2AKJgAA4wuKaW1naOABQwABaYUFLG5la2cM5QqXYAlNqamgC8zm4eXr4BwbhRmRFwSHQAJu6e5DDZomz5eXQA9D10pFBwDXQQjTjYiIwwdCGB9BAIAOakYNN0mXQAiqSYNgDWdN7E2BZ0FsSzsfQ2EJQbmPCjwBYYdADuVuQjwPRgFggbrRFt1dFIDPxkgB5OKIYrNMr+IIhUww64IaJxBJJVGwjEbLJ1OgmNGIRoI1oANTupDguU6mjUDPyGjiCAs7zoZEoAEIOvkAL7sIVsIA==) will see the `default` literal argument and infer a `TResult?` type argument in this context--so everything just works. You love to see it. /cc @cston