### PR TITLE
Custom attribute properties were not always applied correctly

### DIFF
--- a/src/coreclr/src/vm/customattribute.cpp
+++ b/src/coreclr/src/vm/customattribute.cpp
@@ -908,7 +908,6 @@ FCIMPL7(void, COMCustomAttribute::GetPropertyOrFieldData, ReflectModuleBaseObjec
                 nullTH = th;
         }
 
-        //
         // get the string representing the field/property name
         *pName = ArgSlotToString(GetDataFromBlob(
             pCtorAssembly, SERIALIZATION_TYPE_STRING, nullTH, &pBlob, pBlobEnd, pModule, &bObjectCreated));
@@ -937,6 +936,7 @@ FCIMPL7(void, COMCustomAttribute::GetPropertyOrFieldData, ReflectModuleBaseObjec
                 break;
             case SERIALIZATION_TYPE_SZARRAY:
             {
+                *value = NULL;
                 int arraySize = (int)GetDataFromBlob(pCtorAssembly, SERIALIZATION_TYPE_I4, nullTH, &pBlob, pBlobEnd, pModule, &bObjectCreated);
 
                 if (arraySize != -1)

--- a/src/libraries/System.Reflection/tests/CustomAttributeTests.cs
+++ b/src/libraries/System.Reflection/tests/CustomAttributeTests.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.Reflection.Tests
+{
+    public class CustomAttributeTests
+    {
+        private class SameTypesAttribute : Attribute
+        {
+            public object[] ObjectArray1 { get; set; }
+            public object[] ObjectArray2 { get; set; }
+        }
+
+        [SameTypes(ObjectArray1 = null, ObjectArray2 = new object[] { "" })]
+        private class SameTypesClass1 { }
+
+        [SameTypes(ObjectArray1 = new object[] { "" }, ObjectArray2 = null)]
+        private class SameTypesClass2 { }
+
+        [Fact]
+        public void AttributeWithSamePropertyTypes()
+        {
+            SameTypesAttribute attr;
+
+            attr = typeof(SameTypesClass1)
+                .GetCustomAttributes(typeof(SameTypesAttribute), true)
+                .Cast<SameTypesAttribute>()
+                .Single();
+
+            Assert.Null(attr.ObjectArray1);
+            Assert.Equal(1, attr.ObjectArray2.Length);
+
+            attr = typeof(SameTypesClass2)
+                .GetCustomAttributes(typeof(SameTypesAttribute), true)
+                .Cast<SameTypesAttribute>()
+                .Single();
+
+            Assert.Equal(1, attr.ObjectArray1.Length);
+            Assert.Null(attr.ObjectArray2);
+        }
+
+        private class DifferentTypesAttribute : Attribute
+        {
+            public object[] ObjectArray { get; set; }
+            public string[] StringArray { get; set; }
+        }
+
+        [DifferentTypes(ObjectArray = null, StringArray = new[] { "" })]
+        private class DifferentTypesClass1 { }
+
+        [DifferentTypes(ObjectArray = new object[] { "" }, StringArray = null)]
+        private class DifferentTypesClass2 { }
+
+        [Fact]
+        public void AttributeWithDifferentPropertyTypes()
+        {
+            DifferentTypesAttribute attr;
+
+            attr = typeof(DifferentTypesClass1)
+                .GetCustomAttributes(typeof(DifferentTypesAttribute), true)
+                .Cast<DifferentTypesAttribute>()
+                .Single();
+
+            Assert.Null(attr.ObjectArray);
+            Assert.Equal(1, attr.StringArray.Length);
+
+            attr = typeof(DifferentTypesClass2)
+                .GetCustomAttributes(typeof(DifferentTypesAttribute), true)
+                .Cast<DifferentTypesAttribute>()
+                .Single();
+
+            Assert.Equal(1, attr.ObjectArray.Length);
+            Assert.Null(attr.StringArray);
+        }
+    }
+}

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="AssemblyNameTests.cs" />
     <Compile Include="AssemblyTests.cs" />
     <Compile Include="ConstructorInfoTests.cs" />
+    <Compile Include="CustomAttributeTests.cs" />
     <Compile Include="EventInfoTests.cs" />
     <Compile Include="FieldInfoTests.cs" />
     <Compile Include="GetTypeTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/31195

Note the two new tests were failing before this change with:
```
    System.Reflection.Tests.CustomAttributeTests.AttributeWithDifferentPropertyTypes [FAIL]
      System.Reflection.CustomAttributeFormatException : 'StringArray' property specified was not found.
    System.Reflection.Tests.CustomAttributeTests.AttributeWithSamePropertyTypes [FAIL]
      Assert.Null() Failure
      Expected: (null)
      Actual:   Object[] [""]
```
