### PR TITLE
Change SuperPMI collection to not use altjit mechanism

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -141,7 +141,7 @@ Optional. Default is 'spmi' within the repo 'artifacts' directory.
 
 superpmi_collect_help = """\
 Command to run SuperPMI collect over. Note that there cannot be any dotnet CLI commands
-invoked inside this command, as they will fail due to the shim altjit being set.
+invoked inside this command, as they will fail due to the shim JIT being set.
 """
 
 replay_mch_files_help = """\
@@ -750,9 +750,7 @@ class SuperPMICollect:
             env_copy = os.environ.copy()
             env_copy["SuperPMIShimLogPath"] = self.temp_location
             env_copy["SuperPMIShimPath"] = self.jit_path
-            env_copy["COMPlus_AltJit"] = "*"
-            env_copy["COMPlus_AltJitNgen"] = "*"
-            env_copy["COMPlus_AltJitName"] = self.collection_shim_name
+            env_copy["COMPlus_JitName"] = self.collection_shim_name
             env_copy["COMPlus_EnableExtraSuperPmiQueries"] = "1"
             env_copy["COMPlus_TieredCompilation"] = "0"
 
@@ -764,9 +762,7 @@ class SuperPMICollect:
             logging.debug("")
             print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "SuperPMIShimLogPath", self.temp_location)
             print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "SuperPMIShimPath", self.jit_path)
-            print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "COMPlus_AltJit", "*")
-            print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "COMPlus_AltJitNgen", "*")
-            print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "COMPlus_AltJitName", self.collection_shim_name)
+            print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "COMPlus_JitName", self.collection_shim_name)
             print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "COMPlus_EnableExtraSuperPmiQueries", "1")
             print_platform_specific_environment_vars(logging.DEBUG, self.coreclr_args, "COMPlus_TieredCompilation", "0")
             if self.coreclr_args.use_zapdisable:
@@ -1072,36 +1068,48 @@ class SuperPMIReplay:
             logging.debug("Temp Location: %s", temp_location)
             logging.debug("")
 
-            flags = [
+            # `repro_flags` are the subset of flags we tell the user to pass to superpmi when reproducing
+            # a failure. This won't include things like "-p" for parallelism or "-r" to create a repro .mc file.
+            repro_flags = []
+
+            common_flags = [
                 "-v", "ew",  # only display errors and warnings
                 "-r", os.path.join(temp_location, "repro")  # Repro name, create .mc repro files
             ]
 
-            altjit_string = "*" if self.coreclr_args.altjit else ""
-            altjit_replay_flags = [
-                "-jitoption", "force", "AltJit=" + altjit_string,
-                "-jitoption", "force", "AltJitNgen=" + altjit_string,
-                "-jitoption", "force", "EnableExtraSuperPmiQueries=0"
-            ]
-            flags += altjit_replay_flags
+            if self.coreclr_args.altjit:
+                repro_flags += [
+                    "-jitoption", "force", "AltJit=*",
+                    "-jitoption", "force", "AltJitNgen=*"
+                ]
+                if self.coreclr_args.arch == "arm":
+                    repro_flags += [ "-target", "arm" ]
+                elif self.coreclr_args.arch == "arm64":
+                    repro_flags += [ "-target", "arm64" ]
 
             if not self.coreclr_args.sequential:
-                flags += [ "-p" ]
+                common_flags += [ "-p" ]
 
             if self.coreclr_args.break_on_assert:
-                flags += [ "-boa" ]
+                common_flags += [ "-boa" ]
 
             if self.coreclr_args.break_on_error:
-                flags += [ "-boe" ]
+                common_flags += [ "-boe" ]
 
             if self.coreclr_args.spmi_log_file is not None:
-                flags += [ "-w", self.coreclr_args.spmi_log_file ]
+                common_flags += [ "-w", self.coreclr_args.spmi_log_file ]
 
-            if self.coreclr_args.altjit:
-                if self.coreclr_args.arch == "arm":
-                    flags += [ "-target", "arm" ]
-                elif self.coreclr_args.arch == "arm64":
-                    flags += [ "-target", "arm64" ]
+            # TEMPORARY: when we have collections that are done using COMPlus_JitName
+            # instead of COMPlus_AltJit, we can remove these.
+            if not self.coreclr_args.altjit:
+                repro_flags += [
+                    "-jitoption", "force", "AltJit=",
+                    "-jitoption", "force", "AltJitNgen="
+                ]
+            repro_flags += [ "-jitoption", "force", "EnableExtraSuperPmiQueries=0" ]
+            # END TEMPORARY
+
+            common_flags += repro_flags
 
             # For each MCH file that we are going to replay, do the replay and replay post-processing.
             #
@@ -1116,6 +1124,8 @@ class SuperPMIReplay:
             for mch_file in self.mch_files:
 
                 logging.info("Running SuperPMI replay of %s", mch_file)
+
+                flags = common_flags
 
                 fail_mcl_file = os.path.join(temp_location, os.path.basename(mch_file) + "_fail.mcl")
                 flags += [
@@ -1136,7 +1146,7 @@ class SuperPMIReplay:
                     if return_code == 0:
                         logging.warning("Warning: SuperPMI returned a zero exit code, but generated a non-zero-sized mcl file")
                     print_fail_mcl_file_method_numbers(fail_mcl_file)
-                    repro_base_command_line = "{} {} {}".format(self.superpmi_path, " ".join(altjit_replay_flags), self.jit_path)
+                    repro_base_command_line = "{} {} {}".format(self.superpmi_path, " ".join(repro_flags), self.jit_path)
                     save_repro_mc_files(temp_location, self.coreclr_args, repro_base_command_line)
 
                 if not self.coreclr_args.skip_cleanup:
@@ -1238,22 +1248,44 @@ class SuperPMIReplayAsmDiffs:
             "COMPlus_JitDump": "*",
             "COMPlus_NgenDump": "*" }
 
-        altjit_string = "*" if self.coreclr_args.altjit else ""
+        altjit_asm_diffs_flags = []
+        altjit_replay_flags = []
 
-        altjit_asm_diffs_flags = [
-            "-jitoption", "force", "AltJit=" + altjit_string,
-            "-jitoption", "force", "AltJitNgen=" + altjit_string,
-            "-jitoption", "force", "EnableExtraSuperPmiQueries=0",
-            "-jit2option", "force", "AltJit=" + altjit_string,
-            "-jit2option", "force", "AltJitNgen=" + altjit_string,
-            "-jit2option", "force", "EnableExtraSuperPmiQueries=0"
-        ]
+        if self.coreclr_args.altjit:
+            target_flags = []
+            if self.coreclr_args.arch == "arm":
+                target_flags += [ "-target", "arm" ]
+            elif self.coreclr_args.arch == "arm64":
+                target_flags += [ "-target", "arm64" ]
 
-        altjit_replay_flags = [
-            "-jitoption", "force", "AltJit=" + altjit_string,
-            "-jitoption", "force", "AltJitNgen=" + altjit_string,
-            "-jitoption", "force", "EnableExtraSuperPmiQueries=0"
-        ]
+            altjit_asm_diffs_flags = target_flags + [
+                "-jitoption", "force", "AltJit=*",
+                "-jitoption", "force", "AltJitNgen=*",
+                "-jit2option", "force", "AltJit=*",
+                "-jit2option", "force", "AltJitNgen=*"
+            ]
+
+            altjit_replay_flags = target_flags + [
+                "-jitoption", "force", "AltJit=*",
+                "-jitoption", "force", "AltJitNgen=*"
+            ]
+
+        # TEMPORARY: when we have collections that are done using COMPlus_JitName
+        # instead of COMPlus_AltJit, we can remove these.
+        if not self.coreclr_args.altjit:
+            altjit_asm_diffs_flags = [
+                "-jitoption", "force", "AltJit=",
+                "-jitoption", "force", "AltJitNgen=",
+                "-jit2option", "force", "AltJit=",
+                "-jit2option", "force", "AltJitNgen="
+            ]
+            altjit_replay_flags = [
+                "-jitoption", "force", "AltJit=",
+                "-jitoption", "force", "AltJitNgen="
+            ]
+        altjit_asm_diffs_flags += [ "-jitoption", "force", "EnableExtraSuperPmiQueries=0" ]
+        altjit_replay_flags    += [ "-jitoption", "force", "EnableExtraSuperPmiQueries=0" ]
+        # END TEMPORARY
 
         # Keep track if any MCH file replay had asm diffs
         files_with_asm_diffs = []
@@ -1303,12 +1335,6 @@ class SuperPMIReplayAsmDiffs:
 
                     if self.coreclr_args.spmi_log_file is not None:
                         flags += [ "-w", self.coreclr_args.spmi_log_file ]
-
-                    if self.coreclr_args.altjit:
-                        if self.coreclr_args.arch == "arm":
-                            flags += [ "-target", "arm" ]
-                        elif self.coreclr_args.arch == "arm64":
-                            flags += [ "-target", "arm64" ]
 
                     # Change the working directory to the Core_Root we will call SuperPMI from.
                     # This is done to allow libcoredistools to be loaded correctly on unix

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2725,7 +2725,7 @@ def setup_args(args):
                             "collection_args",
                             lambda unused: True,
                             "Unable to set collection_args",
-                            modify_arg=lambda collection_args: collection_args.split(" ") if collection_args is not None else collection_args)
+                            modify_arg=lambda collection_args: collection_args.split(" ") if collection_args is not None else [])
 
         coreclr_args.verify(args,
                             "pmi",

--- a/src/coreclr/src/ToolBox/superpmi/readme.md
+++ b/src/coreclr/src/ToolBox/superpmi/readme.md
@@ -121,9 +121,7 @@ Set the following environment variables:
 ```
 SuperPMIShimLogPath=<full path to an existing, empty temporary directory>
 SuperPMIShimPath=<full path to clrjit.dll, the "standalone" JIT>
-COMPlus_AltJit=*
-COMPlus_AltJitNgen=*
-COMPlus_AltJitName=superpmi-shim-collector.dll
+COMPlus_JitName=superpmi-shim-collector.dll
 ```
 
 for example, on Windows:
@@ -132,9 +130,7 @@ for example, on Windows:
 mkdir f:\spmi\temp
 set SuperPMIShimLogPath=f:\spmi\temp
 set SuperPMIShimPath=f:\gh\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\clrjit.dll
-set COMPlus_AltJit=*
-set COMPlus_AltJitNgen=*
-set COMPlus_AltJitName=superpmi-shim-collector.dll
+set COMPlus_JitName=superpmi-shim-collector.dll
 ```
 
 (On Linux, use `libclrjit.so` and `libsuperpmi-shim-collector.so`.

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/jithost.cpp
@@ -10,6 +10,33 @@
 
 JitHost* g_ourJitHost;
 
+// RecordVariable: return `true` if the given COMPlus variable `key` should be recorded
+// in the method context.
+bool RecordVariable(const WCHAR* key)
+{
+    // Special-case: we don't want to store some COMPlus variables during
+    // collections that we don't want to see on replay:
+    //   COMPlus_JitName -- used to get the VM to load the SuperPMI collection shim
+    //                      without requiring the shim to overwrite the original JIT.
+    //                      This JIT doesn't care about this on SuperPMI replay, but
+    //                      we don't need to waste the space in the MC file storing it.
+    //   COMPlus_AltJitName -- if collecting with an altjit, this is set. The JIT doesn't
+    //                      use this on replay, but it doesn't need to be stored.
+    //   COMPlus_EnableExtraSuperPmiQueries -- used to force the JIT to ask additional
+    //                      questions during SuperPMI collection. We don't want to store
+    //                      this variable because we don't want to replay using it.
+
+    if ((_wcsicmp(key, W("JitName")) == 0) ||
+        (_wcsicmp(key, W("AltJitName")) == 0) ||
+        (_wcsicmp(key, W("EnableExtraSuperPmiQueries")) == 0))
+    {
+        return false;
+    }
+
+    // By default, we record everything.
+    return true;
+}
+
 JitHost::JitHost(ICorJitHost* wrappedHost, MethodContext* methodContext) : wrappedHost(wrappedHost), mc(methodContext)
 {
 }
@@ -37,7 +64,7 @@ int JitHost::getIntConfigValue(const WCHAR* key, int defaultValue)
     // The JIT eagerly asks about every config value. If we store all these
     // queries, it takes almost half the MC file space. So only store the
     // non-default answers.
-    if (result != defaultValue)
+    if (RecordVariable(key) && (result != defaultValue))
     {
         mc->recGetIntConfigValue(key, defaultValue, result);
     }
@@ -50,7 +77,7 @@ const WCHAR* JitHost::getStringConfigValue(const WCHAR* key)
     const WCHAR* result = wrappedHost->getStringConfigValue(key);
 
     // Don't store null returns, which is the default
-    if (result != nullptr)
+    if (RecordVariable(key) && (result != nullptr))
     {
         mc->recGetStringConfigValue(key, result);
     }

--- a/src/coreclr/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -29,8 +29,8 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
     jit->options = options;
 
     // The flag to cause the JIT to be invoked as an altjit is stored in the jit flags, not in
-    // the environment. If the user uses the "-jitoption force" flag to force AltJit off (it was
-    // probably on during collection), or to force it on, then propagate that to the jit flags.
+    // the environment. If the user uses the "-jitoption force" flag to force AltJit off
+    // or to force it on, then propagate that to the jit flags.
     jit->forceClearAltJitFlag = false;
     jit->forceSetAltJitFlag = false;
     const WCHAR* altJitFlag = jit->getForceOption(W("AltJit"));

--- a/src/coreclr/src/zap/zapper.cpp
+++ b/src/coreclr/src/zap/zapper.cpp
@@ -580,11 +580,15 @@ void Zapper::InitEE(BOOL fForceDebug, BOOL fForceProfile, BOOL fForceInstrument)
     }
 #else
 
-    CorCompileRuntimeDlls ngenDllId;
+    LPCWSTR pwzJitName = nullptr;
 
-    ngenDllId = CROSSGEN_COMPILER_INFO;
+    // Try to obtain a name for the jit library from the env. variable
+    IfFailThrow(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_JitName, const_cast<LPWSTR*>(&pwzJitName)));
+    if (pwzJitName == nullptr)
+    {
+        pwzJitName = CorCompileGetRuntimeDllName(CROSSGEN_COMPILER_INFO);
+    }
 
-    LPCWSTR pwzJitName = CorCompileGetRuntimeDllName(ngenDllId);
     LoadAndInitializeJITForNgen(pwzJitName, &m_hJitLib, &m_pJitCompiler);
 
 #endif // FEATURE_MERGE_JIT_AND_ENGINE

--- a/src/tests/JIT/superpmi/collect_runtest.cmd
+++ b/src/tests/JIT/superpmi/collect_runtest.cmd
@@ -28,13 +28,11 @@ set testenvfile=%TEMP%\superpmitestenv_%RANDOM%.cmd
 
 echo set SuperPMIShimLogPath=%SuperPMIShimLogPath%> %testenvfile%
 echo set SuperPMIShimPath=%SuperPMIShimPath%>> %testenvfile%
-echo set COMPlus_AltJit=%COMPlus_AltJit%>> %testenvfile%
-echo set COMPlus_AltJitName=%COMPlus_AltJitName%>> %testenvfile%
+echo set COMPlus_JitName=%COMPlus_JitName%>> %testenvfile%
 
 set SuperPMIShimLogPath=
 set SuperPMIShimPath=
-set COMPlus_AltJit=
-set COMPlus_AltJitName=
+set COMPlus_JitName=
 
 set _nextcmd=call %runtestscript% testEnv %testenvfile%
 echo %0: Running: %_nextcmd%

--- a/src/tests/JIT/superpmi/superpmicollect.cs
+++ b/src/tests/JIT/superpmi/superpmicollect.cs
@@ -313,21 +313,18 @@ namespace SuperPMICollection
             Console.WriteLine("Setting environment variables:");
             Console.WriteLine("    SuperPMIShimLogPath=" + s_tempDir);
             Console.WriteLine("    SuperPMIShimPath=" + Global.JitPath);
-            Console.WriteLine("    COMPlus_AltJit=*");
-            Console.WriteLine("    COMPlus_AltJitName=" + Global.CollectorShimName);
+            Console.WriteLine("    COMPlus_JitName=" + Global.CollectorShimName);
 
             Environment.SetEnvironmentVariable("SuperPMIShimLogPath", s_tempDir);
             Environment.SetEnvironmentVariable("SuperPMIShimPath", Global.JitPath);
-            Environment.SetEnvironmentVariable("COMPlus_AltJit", "*");
-            Environment.SetEnvironmentVariable("COMPlus_AltJitName", Global.CollectorShimName);
+            Environment.SetEnvironmentVariable("COMPlus_JitName", Global.CollectorShimName);
 
             RunProgramsWhileCollecting(runProgramPath, runProgramArguments);
 
             // Un-set environment variables
             Environment.SetEnvironmentVariable("SuperPMIShimLogPath", "");
             Environment.SetEnvironmentVariable("SuperPMIShimPath", "");
-            Environment.SetEnvironmentVariable("COMPlus_AltJit", "");
-            Environment.SetEnvironmentVariable("COMPlus_AltJitName", "");
+            Environment.SetEnvironmentVariable("COMPlus_JitName", "");
 
             // Did any .mc files get generated?
             string[] mcFiles = Directory.GetFiles(s_tempDir, "*.mc");
@@ -606,7 +603,7 @@ namespace SuperPMICollection
             Console.WriteLine("If -mch is not given, all generated files are deleted, and the result is simply the exit code");
             Console.WriteLine("indicating whether the collection succeeded. This is useful as a test.");
             Console.WriteLine("");
-            Console.WriteLine("If the COMPlus_AltJit variable is already set, it is assumed SuperPMI collection is already happening,");
+            Console.WriteLine("If the COMPlus_JitName variable is already set, it is assumed SuperPMI collection is already happening,");
             Console.WriteLine("and the program exits with success.");
             Console.WriteLine("");
             Console.WriteLine("On success, the return code is 100.");
@@ -703,14 +700,14 @@ namespace SuperPMICollection
 
             // Done with argument parsing.
 
-            string altjitvar = System.Environment.GetEnvironmentVariable("COMPlus_AltJit");
-            if (!String.IsNullOrEmpty(altjitvar))
+            string jitnamevar = System.Environment.GetEnvironmentVariable("COMPlus_JitName");
+            if (!String.IsNullOrEmpty(jitnamevar))
             {
-                // Someone already has the COMPlus_AltJit variable set. We don't want to override
+                // Someone already has the COMPlus_JitName variable set. We don't want to override
                 // that. Perhaps someone is already doing a SuperPMI collection and invokes this
                 // program as part of a full test path in which this program exists.
 
-                Console.WriteLine("COMPlus_AltJit already exists: skipping SuperPMI collection and returning success");
+                Console.WriteLine("COMPlus_JitName already exists: skipping SuperPMI collection and returning success");
                 return 100;
             }
 


### PR DESCRIPTION
The SuperPMI collection process interposes a "shim" JIT between the JIT and EE.
As it is inconvenient to physically replace the existing JIT, currently this
is done by enabling altjit compilation and setting `COMPlus_AltJitName` to the
name of the shim JIT. This creates other inconvenience, especially with the
new way of saving the altjit flag in the JIT flags, by requiring us to
force the altjit flags bit to not be set, and force unset all the altjit flags.
It also makes it inconvenient to collect and/or replay with an actual altjit.

Change this collection mechanism to use the newly restored `COMPlus_JitName`
variable to allow specifying the JIT, and use that to specify the SuperPMI shim.

In addition, do not record in the MC file the `COMPlus_EnableExtraSuperPmiQueries`
variable. This is only used during collections to attempt to make replays more
flexible, but we never want to tell the JIT during replay that this is set.