### PR TITLE
Fix building host lineup packages.

### DIFF
--- a/src/installer/pkg/projects/host-packages.proj
+++ b/src/installer/pkg/projects/host-packages.proj
@@ -2,10 +2,11 @@
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.props" />
 
   <ItemGroup>
-    <ProjectReference Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
-    <ProjectReference Include="Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
-    <ProjectReference Include="Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
-    <ProjectReference Update="@(ProjectReference)" AdditionalProperties="PackageTargetRuntime=$(PackageRID)" />
+    <Project Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
+    <Project Include="Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
+    <Project Include="Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
+    <ProjectReference Include="@(Project)" />
+    <ProjectReference Include="@(Project)" AdditionalProperties="PackageTargetRuntime=$(PackageRID)" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />

--- a/src/installer/pkg/projects/host-packages.proj
+++ b/src/installer/pkg/projects/host-packages.proj
@@ -2,11 +2,10 @@
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.props" />
 
   <ItemGroup>
-    <Project Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
-    <Project Include="Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
-    <Project Include="Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
-    <ProjectReference Include="@(Project)" />
-    <ProjectReference Include="@(Project)" AdditionalProperties="PackageTargetRuntime=$(PackageRID)" />
+    <ProjectReference Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
+    <ProjectReference Include="Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
+    <ProjectReference Include="Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
+    <ProjectReference Include="@(ProjectReference)" AdditionalProperties="PackageTargetRuntime=$(PackageRID)" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />


### PR DESCRIPTION
Fix an issue in the last cleanup PR that accidentally stopped us from producing the lineup packages in addition to the rid packages.