### PR TITLE
Fix discuss #44785：optimize constructor of ElapsedEventArgs

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
@@ -5,9 +5,13 @@ namespace System.Timers
 {
     public class ElapsedEventArgs : EventArgs
     {
-        internal ElapsedEventArgs(long fileTime)
+        internal ElapsedEventArgs(DateTime localTime)
         {
-            SignalTime = DateTime.FromFileTime(fileTime);
+            SignalTime = localTime;
+        }
+
+        internal ElapsedEventArgs(long fileTime) : this(DateTime.FromFileTime(fileTime))
+        {
         }
 
         public DateTime SignalTime { get; }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
@@ -10,10 +10,6 @@ namespace System.Timers
             SignalTime = localTime;
         }
 
-        internal ElapsedEventArgs(long fileTime) : this(DateTime.FromFileTime(fileTime))
-        {
-        }
-
         public DateTime SignalTime { get; }
     }
 }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/Timer.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/Timer.cs
@@ -290,7 +290,7 @@ namespace System.Timers
                 _enabled = false;
             }
 
-            ElapsedEventArgs elapsedEventArgs = new ElapsedEventArgs(DateTime.UtcNow.ToFileTime());
+            ElapsedEventArgs elapsedEventArgs = new ElapsedEventArgs(DateTime.Now);
             try
             {
                 // To avoid race between remove handler and raising the event


### PR DESCRIPTION
Details see the [discussion](https://github.com/dotnet/runtime/discussions/44785), please.

The current unit tests should have already covered this PR.