### PR TITLE
Improve dumping GC info in R2RDump

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
@@ -16,8 +16,9 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
         public UnwindInfo(byte[] image, int offset)
         {
+            int startOffset = offset;
             FunctionLength = NativeReader.DecodeUnsignedGc(image, ref offset);
-            Size = sizeof(int);
+            Size = offset - startOffset;
         }
 
         public override string ToString()

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -161,8 +161,7 @@ namespace R2RDump
 
                 if (_options.Raw)
                 {
-                    // TODO: Output RVAs for consistency with other DumpBytes calls
-                    DumpBytes(gcInfo.Offset, (uint)gcInfo.Size, "", false);
+                    DumpBytes(method.GcInfoRva, (uint)gcInfo.Size);
                 }
             }
             SkipLine();


### PR DESCRIPTION
The `--raw` command-line option dumps bytes prefixed with their RVAs for all structures except GC blobs, which are dumped with file offsets.  This PR fixes that inconsistency.  It also fixes the size reported by x86.GcInfo, which determines how many bytes to dump.  In addition, I simplified `ReadyToRunMethod`'s code to store just the GC blob's RVA and avoid the delegate allocation.