### PR TITLE
NetworkInterface.Linux: take into account physical link status for OperationalStatus and GetIsNetworkAvailable

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.NetworkChange.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.NetworkChange.cs
@@ -13,9 +13,7 @@ internal static partial class Interop
             None = -1,
             AddressAdded = 0,
             AddressRemoved = 1,
-            LinkAdded = 2,
-            LinkRemoved = 3,
-            AvailabilityChanged = 4
+            AvailabilityChanged = 2
         }
 
         public delegate void NetworkChangeEvent(int socket, NetworkChangeKind kind);

--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -325,8 +325,9 @@ int32_t SystemNative_GetNetworkInterfaces(int32_t * interfaceCount, NetworkInter
                 nii->SupportsMulticast = 1;
             }
 
-            // Get administrative state as best guess for now.
-            nii->OperationalState = (ifaddrsEntry->ifa_flags & IFF_UP) ? OperationalStatus_Up : OperationalStatus_Down;
+            // OperationalState returns whether the interface can transmit data packets.
+            // The administrator must have enabled the interface (IFF_UP), and the cable must be plugged in (IFF_RUNNING).
+            nii->OperationalState = ((ifaddrsEntry->ifa_flags & (IFF_UP|IFF_RUNNING)) == (IFF_UP|IFF_RUNNING)) ? OperationalStatus_Up : OperationalStatus_Down;
         }
 
         if (ifaddrsEntry->ifa_addr == NULL)

--- a/src/libraries/Native/Unix/System.Native/pal_networkchange.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkchange.c
@@ -68,12 +68,9 @@ static NetworkChangeKind ReadNewLinkMessage(struct nlmsghdr* hdr)
     assert(hdr != NULL);
     struct ifinfomsg* ifimsg;
     ifimsg = (struct ifinfomsg*)NLMSG_DATA(hdr);
-    if (ifimsg->ifi_family == AF_INET)
+    if (ifimsg->ifi_family == AF_UNSPEC)
     {
-        if ((ifimsg->ifi_flags & IFF_UP) != 0)
-        {
-            return LinkAdded;
-        }
+        return AvailabilityChanged;
     }
 
     return None;
@@ -110,9 +107,6 @@ void SystemNative_ReadEvents(int32_t sock, NetworkChangeEvent onNetworkChange)
                 break;
             case RTM_NEWLINK:
                 onNetworkChange(sock, ReadNewLinkMessage(hdr));
-                break;
-            case RTM_DELLINK:
-                onNetworkChange(sock, LinkRemoved);
                 break;
             case RTM_NEWROUTE:
             case RTM_DELROUTE:

--- a/src/libraries/Native/Unix/System.Native/pal_networkchange.h
+++ b/src/libraries/Native/Unix/System.Native/pal_networkchange.h
@@ -11,9 +11,7 @@ typedef enum
     None = -1,
     AddressAdded = 0,
     AddressRemoved = 1,
-    LinkAdded = 2,
-    LinkRemoved = 3,
-    AvailabilityChanged = 4,
+    AvailabilityChanged = 2,
 } NetworkChangeKind;
 
 typedef void (*NetworkChangeEvent)(int32_t sock, NetworkChangeKind notificationKind);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/30581

@wfurt ptal