### PR TITLE
Fix regression in XDocumentType

### DIFF
--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocumentType.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocumentType.cs
@@ -15,7 +15,7 @@ namespace System.Xml.Linq
         private string _name;
         private string? _publicId;
         private string? _systemId;
-        private string _internalSubset;
+        private string? _internalSubset;
 
         /// <summary>
         /// Initializes an empty instance of the <see cref="XDocumentType"/> class.
@@ -25,7 +25,7 @@ namespace System.Xml.Linq
             _name = XmlConvert.VerifyName(name);
             _publicId = publicId;
             _systemId = systemId;
-            _internalSubset = internalSubset ?? string.Empty;
+            _internalSubset = internalSubset;
         }
 
         /// <summary>
@@ -54,8 +54,7 @@ namespace System.Xml.Linq
         /// <summary>
         /// Gets or sets the internal subset for this Document Type Definition (DTD).
         /// </summary>
-        [AllowNull]
-        public string InternalSubset
+        public string? InternalSubset
         {
             get
             {
@@ -64,7 +63,7 @@ namespace System.Xml.Linq
             set
             {
                 bool notify = NotifyChanging(this, XObjectChangeEventArgs.Value);
-                _internalSubset = value ?? string.Empty;
+                _internalSubset = value;
                 if (notify) NotifyChanged(this, XObjectChangeEventArgs.Value);
             }
         }
@@ -182,7 +181,7 @@ namespace System.Xml.Linq
             return _name.GetHashCode() ^
                 (_publicId != null ? _publicId.GetHashCode() : 0) ^
                 (_systemId != null ? _systemId.GetHashCode() : 0) ^
-                _internalSubset.GetHashCode();
+                (_internalSubset != null ? _internalSubset.GetHashCode() : 0);
         }
     }
 }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNodeReader.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNodeReader.cs
@@ -378,7 +378,7 @@ namespace System.Xml.Linq
                         case XmlNodeType.ProcessingInstruction:
                             return ((XProcessingInstruction)o).Data;
                         case XmlNodeType.DocumentType:
-                            return ((XDocumentType)o).InternalSubset;
+                            return ((XDocumentType)o).InternalSubset ?? string.Empty;
                         default:
                             return string.Empty;
                     }

--- a/src/libraries/System.Private.Xml.Linq/tests/Properties/FunctionalTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/Properties/FunctionalTests.cs
@@ -24,7 +24,7 @@ namespace CoreXml.Test.XLinq
             }
             module.Execute();
 
-            Assert.Equal(0, module.FailCount);
+            Assert.False(module.HasFailures, module.GetFailuresInfo());
         }
         #region Class
         public partial class PropertiesTests : XLinqTestCase

--- a/src/libraries/System.Private.Xml.Linq/tests/TreeManipulation/SimpleObjectsCreation.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/TreeManipulation/SimpleObjectsCreation.cs
@@ -933,7 +933,7 @@ namespace XLinqTests
             TestLog.Compare(dtd.Name, data[0], "dtd.Name, data[0]");
             TestLog.Compare(dtd.PublicId, data[1], "dtd.SystemId, data[1]");
             TestLog.Compare(dtd.SystemId, data[2], "dtd.PublicId, data[2]");
-            TestLog.Compare(dtd.InternalSubset, data[3], "dtd.InternalSubset, data[3]");
+            TestLog.Compare(dtd.InternalSubset, data[3], data[3], "dtd.InternalSubset, data[3]");
             TestLog.Compare(dtd.NodeType, XmlNodeType.DocumentType, "nodetype");
             TestLog.Compare(dtd.ToString(), serial, "DTD construction");
         }

--- a/src/libraries/System.Private.Xml.Linq/tests/TreeManipulation/TreeManipulationTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/TreeManipulation/TreeManipulationTests.cs
@@ -429,7 +429,7 @@ namespace XLinqTests
             module.AddChild(testCase);
             module.Execute();
 
-            Assert.Equal(0, module.FailCount);
+            Assert.False(module.HasFailures, module.GetFailuresInfo());
         }
     }
 }

--- a/src/libraries/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/testcase.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/testcase.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Test.ModuleCore
                             {
                                 System.Console.WriteLine(indent + var.Desc);
                                 System.Console.WriteLine(indent + " FAILED");
-                                module.FailCount++;
+                                module.AddFailure(var.Desc);
                             }
                             else
                             {
@@ -116,7 +116,7 @@ namespace Microsoft.Test.ModuleCore
                             System.Console.WriteLine(indent + var.Desc);
                             System.Console.WriteLine(e);
                             System.Console.WriteLine(indent + " FAILED");
-                            module.FailCount++;
+                            module.AddFailure(var.Desc + Environment.NewLine + e.ToString());
                         }
                     }
                 }

--- a/src/libraries/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/testmodule.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/XDocument.Test.ModuleCore/testmodule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Microsoft.Test.ModuleCore
 {
@@ -19,22 +20,32 @@ namespace Microsoft.Test.ModuleCore
         private int _ppass = 0;
         private int _pfail = 0;
         private int _pskip = 0;
+        private StringBuilder _failureInfo;
         public int PassCount
         {
             get { return _ppass; }
             set { _ppass = value; }
         }
 
-        public int FailCount
-        {
-            get { return _pfail; }
-            set { _pfail = value; }
-        }
+        public int FailCount => _pfail;
+        public bool HasFailures => _pfail > 0;
 
         public int SkipCount
         {
             get { return _pskip; }
             set { _pskip = value; }
+        }
+
+        public void AddFailure(string description)
+        {
+            _failureInfo = _failureInfo ?? new StringBuilder();
+            _failureInfo.AppendLine(description);
+            _pfail++;
+        }
+
+        public string GetFailuresInfo()
+        {
+            return _failureInfo?.ToString() ?? string.Empty;
         }
 
         //Constructors

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/FunctionalTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/FunctionalTests.cs
@@ -24,7 +24,7 @@ namespace CoreXml.Test.XLinq
             module.AddChild(new MiscTests() { Attribute = new TestCaseAttribute() { Name = "Misc", Desc = "XLinq Misc. Tests" } });
             module.Execute();
 
-            Assert.Equal(0, module.FailCount);
+            Assert.False(module.HasFailures, module.GetFailuresInfo());
         }
         public partial class MiscTests : XLinqTestCase
         {

--- a/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/FunctionalTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/FunctionalTests.cs
@@ -29,7 +29,7 @@ namespace CoreXml.Test.XLinq
             }
             module.Execute();
 
-            Assert.Equal(0, module.FailCount);
+            Assert.False(module.HasFailures, module.GetFailuresInfo());
         }
 
         #region Code

--- a/src/libraries/System.Private.Xml.Linq/tests/xNodeReader/FunctionalTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/xNodeReader/FunctionalTests.cs
@@ -26,7 +26,7 @@ namespace CoreXml.Test.XLinq
             module.AddChild(new XNodeReaderTests() { Attribute = new TestCaseAttribute() { Name = "XNodeReader", Desc = "XLinq XNodeReader Tests" } });
             module.Execute();
 
-            Assert.Equal(0, module.FailCount);
+            Assert.False(module.HasFailures, module.GetFailuresInfo());
         }
 
         #region Class

--- a/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
+++ b/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
@@ -214,8 +214,7 @@ namespace System.Xml.Linq
     {
         public XDocumentType(string name, string? publicId, string? systemId, string? internalSubset) { }
         public XDocumentType(System.Xml.Linq.XDocumentType other) { }
-        [System.Diagnostics.CodeAnalysis.AllowNull]
-        public string InternalSubset { get { throw null; } set { } }
+        public string? InternalSubset { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
         public override System.Xml.XmlNodeType NodeType { get { throw null; } }
         public string? PublicId { get { throw null; } set { } }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/44489

- partially revert https://github.com/dotnet/runtime/pull/44300/files#diff-6dcf882a73b2db05168fe9308ac11aca79bad7100caaabdefdbbedec9f3e25f0R23 (constructor argument will remain nullable but we will handle null in XNodeReader now)
- improve error messages in XLinq tests (before this it displayed number of failures and it's hard to pinpoint what actually failed, now it will show all failures)
- I have created https://github.com/dotnet/runtime/issues/44866 to open conversation what the correct behavior for internal subset for both XDocumentType and XmlDocumentType should be and summarized inconsistencies