### PR TITLE
[browser][wasm] Cleanup debug statement

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -301,7 +301,6 @@ namespace System.Net.WebSockets
 
         public override void Dispose()
         {
-            System.Diagnostics.Debug.WriteLine("BrowserWebSocket::Dispose");
             int priorState = Interlocked.Exchange(ref _state, (int)InternalState.Disposed);
             if (priorState == (int)InternalState.Disposed)
             {


### PR DESCRIPTION
Small cleanup to stop debug messages:  `WASM-ERR: BrowserWebSocket::Dispose`

```
Initializing.....
  info: Discovering: System.Net.WebSockets.Client.Tests.dll (method display = ClassAndMethod, method display options = None)
  info: Discovered:  System.Net.WebSockets.Client.Tests.dll (found 17 of 84 test cases)
  info: Starting:    System.Net.WebSockets.Client.Tests.dll
  info: WASM-ERR: BrowserWebSocket::Dispose
  info: WASM-ERR: BrowserWebSocket::Dispose
```