### PR TITLE
Restore the Microsoft.NETCore.DotNetAppHost package

### DIFF
--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <VersionProp>AppHostVersion</VersionProp>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <NativeBinary Include="$(DotNetHostBinDir)/apphost$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/singlefilehost$(ApplicationFileExtension)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)nethost$(LibraryFileExtension)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)nethost$(StaticLibraryFileExtension)" />
+    <NativeBinary Include="$(DotNetHostBinDir)/coreclr_delegates.h" />
+    <NativeBinary Include="$(DotNetHostBinDir)/hostfxr.h" />
+    <NativeBinary Include="$(DotNetHostBinDir)/nethost.h" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
+    <NativeBinary Include="$(DotNetHostBinDir)/comhost.dll" />
+    <NativeBinary Include="$(DotNetHostBinDir)/ijwhost.dll" />
+    <NativeBinary Include="$(DotNetHostBinDir)/ijwhost.lib" />
+    <!-- The libnethost.lib is a static library for the nethost scenario.
+        The symbols file is also shipped to enable users to fully debug
+        binaries that link against the static version. -->
+    <NativeBinary Include="$(DotNetHostBinDir)/libnethost.lib" />
+    <NativeBinary Include="$(DotNetHostBinDir)/PDB/libnethost.pdb" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
+    <File Include="@(NativeBinary)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
+    </File>
+  </ItemGroup>
+</Project>

--- a/src/installer/pkg/projects/host-packages.proj
+++ b/src/installer/pkg/projects/host-packages.proj
@@ -2,6 +2,7 @@
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.props" />
 
   <ItemGroup>
+    <ProjectReference Include="Microsoft.NETCore.DotNetAppHost\Microsoft.NETCore.DotNetAppHost.pkgproj" />
     <ProjectReference Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
     <ProjectReference Include="Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
     <ProjectReference Include="Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />


### PR DESCRIPTION
Restore the Microsoft.NETCore.DotNetAppHost package since the SDK transitively uses it through the Microsoft.NETCore.DotNetHostResolver package.