### PR TITLE
Delete now unused target in crossgen2.csproj.

### DIFF
--- a/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
@@ -129,21 +129,4 @@
       />
 
   </Target>
-
-  <Target Name="GenerateDepsJsonFile" Returns="$(ProjectDepsFilePath)" DependsOnTargets="GenerateBuildDependencyFile" />
-
-  <Target Name="RemoveUnusedFilesFromDepsJson" AfterTargets="ResolveRuntimePackAssets" BeforeTargets="GenerateBuildDependencyFile">
-    <PropertyGroup>
-      <StaticLibraryFileExtension>.a</StaticLibraryFileExtension>
-      <StaticLibraryFileExtension Condition="'$(TargetOS)' == 'windows'">.lib</StaticLibraryFileExtension>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <RuntimePackAsset Remove="@(RuntimePackAsset)" Condition="'%(Extension)' == '$(StaticLibraryFileExtension)'" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(RemoveLongNameDac)' == 'true'">
-      <RuntimePackAsset Remove="@(RuntimePackAsset)" Condition="$([System.String]::new('%(FileName)').StartsWith('mscordaccore_'))" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
This target was used by the old framework pack tooling to create the crossgen2 pack. The new tooling doesn't use this target.