### PR TITLE
Remove unnecessary GetTypeInfo from Microsoft.Extensions.

### DIFF
--- a/src/libraries/Common/src/Extensions/ActivatorUtilities/ActivatorUtilities.cs
+++ b/src/libraries/Common/src/Extensions/ActivatorUtilities/ActivatorUtilities.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.Internal
 
             ConstructorMatcher bestMatcher = default;
 
-            if (!instanceType.GetTypeInfo().IsAbstract)
+            if (!instanceType.IsAbstract)
             {
                 foreach (ConstructorInfo? constructor in instanceType.GetConstructors())
                 {
@@ -323,7 +323,7 @@ namespace Microsoft.Extensions.Internal
             for (int i = 0; i < argumentTypes.Length; i++)
             {
                 bool foundMatch = false;
-                TypeInfo? givenParameter = argumentTypes[i].GetTypeInfo();
+                Type? givenParameter = argumentTypes[i];
 
                 for (int j = 0; j < constructorParameters.Length; j++)
                 {
@@ -333,7 +333,7 @@ namespace Microsoft.Extensions.Internal
                         continue;
                     }
 
-                    if (constructorParameters[j].ParameterType.GetTypeInfo().IsAssignableFrom(givenParameter))
+                    if (constructorParameters[j].ParameterType.IsAssignableFrom(givenParameter))
                     {
                         foundMatch = true;
                         parameterMap[j] = i;
@@ -369,13 +369,13 @@ namespace Microsoft.Extensions.Internal
                 int applyExactLength = 0;
                 for (int givenIndex = 0; givenIndex != givenParameters.Length; givenIndex++)
                 {
-                    TypeInfo? givenType = givenParameters[givenIndex]?.GetType().GetTypeInfo();
+                    Type? givenType = givenParameters[givenIndex]?.GetType();
                     bool givenMatched = false;
 
                     for (int applyIndex = applyIndexStart; givenMatched == false && applyIndex != _parameters.Length; ++applyIndex)
                     {
                         if (_parameterValues[applyIndex] == null &&
-                            _parameters[applyIndex].ParameterType.GetTypeInfo().IsAssignableFrom(givenType))
+                            _parameters[applyIndex].ParameterType.IsAssignableFrom(givenType))
                         {
                             givenMatched = true;
                             _parameterValues[applyIndex] = givenParameters[givenIndex];

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/UserSecretsConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/UserSecretsConfigurationExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>The configuration builder.</returns>
         public static IConfigurationBuilder AddUserSecrets<T>(this IConfigurationBuilder configuration)
             where T : class
-            => configuration.AddUserSecrets(typeof(T).GetTypeInfo().Assembly, optional: false, reloadOnChange: false);
+            => configuration.AddUserSecrets(typeof(T).Assembly, optional: false, reloadOnChange: false);
 
         /// <summary>
         /// <para>
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>The configuration builder.</returns>
         public static IConfigurationBuilder AddUserSecrets<T>(this IConfigurationBuilder configuration, bool optional)
             where T : class
-            => configuration.AddUserSecrets(typeof(T).GetTypeInfo().Assembly, optional, reloadOnChange: false);
+            => configuration.AddUserSecrets(typeof(T).Assembly, optional, reloadOnChange: false);
 
         /// <summary>
         /// <para>
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>The configuration builder.</returns>
         public static IConfigurationBuilder AddUserSecrets<T>(this IConfigurationBuilder configuration, bool optional, bool reloadOnChange)
             where T : class
-            => configuration.AddUserSecrets(typeof(T).GetTypeInfo().Assembly, optional, reloadOnChange);
+            => configuration.AddUserSecrets(typeof(T).Assembly, optional, reloadOnChange);
 
         /// <summary>
         /// <para>

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/ConfigurationExtensionTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/ConfigurationExtensionTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
 
             SetSecret(TestSecretsId, configKey, randValue);
             var config = new ConfigurationBuilder()
-                .AddUserSecrets(typeof(ConfigurationExtensionTest).GetTypeInfo().Assembly)
+                .AddUserSecrets(typeof(ConfigurationExtensionTest).Assembly)
                 .Build();
 
             Assert.Equal(randValue, config[configKey]);
@@ -86,12 +86,12 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 new ConfigurationBuilder().AddUserSecrets<string>());
-            Assert.Equal(SR.Format(SR.Error_Missing_UserSecretsIdAttribute, typeof(string).GetTypeInfo().Assembly.GetName().Name),
+            Assert.Equal(SR.Format(SR.Error_Missing_UserSecretsIdAttribute, typeof(string).Assembly.GetName().Name),
                 ex.Message);
 
             ex = Assert.Throws<InvalidOperationException>(() =>
                 new ConfigurationBuilder().AddUserSecrets(typeof(JObject).Assembly));
-            Assert.Equal(SR.Format(SR.Error_Missing_UserSecretsIdAttribute, typeof(JObject).GetTypeInfo().Assembly.GetName().Name),
+            Assert.Equal(SR.Format(SR.Error_Missing_UserSecretsIdAttribute, typeof(JObject).Assembly.GetName().Name),
                 ex.Message);
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal class CallSiteFactory
     {
         private const int DefaultSlot = 0;
-        private readonly List<ServiceDescriptor> _descriptors;
+        private readonly ServiceDescriptor[] _descriptors;
         private readonly ConcurrentDictionary<Type, ServiceCallSite> _callSiteCache = new ConcurrentDictionary<Type, ServiceCallSite>();
         private readonly Dictionary<Type, ServiceDescriptorCacheItem> _descriptorLookup = new Dictionary<Type, ServiceDescriptorCacheItem>();
 
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public CallSiteFactory(IEnumerable<ServiceDescriptor> descriptors)
         {
             _stackGuard = new StackGuard();
-            _descriptors = descriptors.ToList();
+            _descriptors = descriptors.ToArray();
             Populate();
         }
 
@@ -32,19 +32,19 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             foreach (ServiceDescriptor descriptor in _descriptors)
             {
-                TypeInfo serviceTypeInfo = descriptor.ServiceType.GetTypeInfo();
-                if (serviceTypeInfo.IsGenericTypeDefinition)
+                Type serviceType = descriptor.ServiceType;
+                if (serviceType.IsGenericTypeDefinition)
                 {
-                    TypeInfo implementationTypeInfo = descriptor.ImplementationType?.GetTypeInfo();
+                    Type implementationType = descriptor.ImplementationType;
 
-                    if (implementationTypeInfo == null || !implementationTypeInfo.IsGenericTypeDefinition)
+                    if (implementationType == null || !implementationType.IsGenericTypeDefinition)
                     {
                         throw new ArgumentException(
                             SR.Format(SR.OpenGenericServiceRequiresOpenGenericImplementation, descriptor.ServiceType),
                             "descriptors");
                     }
 
-                    if (implementationTypeInfo.IsAbstract || implementationTypeInfo.IsInterface)
+                    if (implementationType.IsAbstract || implementationType.IsInterface)
                     {
                         throw new ArgumentException(
                             SR.Format(SR.TypeCannotBeActivated, descriptor.ImplementationType, descriptor.ServiceType));
@@ -53,11 +53,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 else if (descriptor.ImplementationInstance == null && descriptor.ImplementationFactory == null)
                 {
                     Debug.Assert(descriptor.ImplementationType != null);
-                    TypeInfo implementationTypeInfo = descriptor.ImplementationType.GetTypeInfo();
+                    Type implementationType = descriptor.ImplementationType;
 
-                    if (implementationTypeInfo.IsGenericTypeDefinition ||
-                        implementationTypeInfo.IsAbstract ||
-                        implementationTypeInfo.IsInterface)
+                    if (implementationType.IsGenericTypeDefinition ||
+                        implementationType.IsAbstract ||
+                        implementationType.IsInterface)
                     {
                         throw new ArgumentException(
                             SR.Format(SR.TypeCannotBeActivated, descriptor.ImplementationType, descriptor.ServiceType));
@@ -161,7 +161,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     {
                         int slot = 0;
                         // We are going in reverse so the last service in descriptor list gets slot 0
-                        for (int i = _descriptors.Count - 1; i >= 0; i--)
+                        for (int i = _descriptors.Length - 1; i >= 0; i--)
                         {
                             ServiceDescriptor descriptor = _descriptors[i];
                             ServiceCallSite callSite = TryCreateExact(descriptor, itemType, callSiteChain, slot) ??

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private static Expression Convert(Expression expression, Type type, bool forceValueTypeConversion = false)
         {
             // Don't convert if the expression is already assignable
-            if (type.GetTypeInfo().IsAssignableFrom(expression.Type.GetTypeInfo())
+            if (type.IsAssignableFrom(expression.Type)
                 && (!expression.Type.GetTypeInfo().IsValueType || !forceValueTypeConversion))
             {
                 return expression;

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/TestUtility/FileSystemOperationRecorder.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/TestUtility/FileSystemOperationRecorder.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility
 {
     internal class FileSystemOperationRecorder
     {
+        private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
         public IList<IDictionary<string, object>> Records = new List<IDictionary<string, object>>();
 
         public void Add(string action, object values)
@@ -17,7 +19,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility
                 {"action", action }
             };
 
-            foreach (var p in values.GetType().GetTypeInfo().DeclaredProperties)
+            foreach (var p in values.GetType().GetProperties(DeclaredOnlyLookup))
             {
                 record[p.Name] = p.GetValue(values);
             }

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Extensions.Hosting
 {
     internal class HostFactoryResolver
     {
+        private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
         public static readonly string BuildWebHost = nameof(BuildWebHost);
         public static readonly string CreateWebHostBuilder = nameof(CreateWebHostBuilder);
         public static readonly string CreateHostBuilder = nameof(CreateHostBuilder);
@@ -35,7 +37,7 @@ namespace Microsoft.Extensions.Hosting
                 return null;
             }
 
-            var factory = programType.GetTypeInfo().GetDeclaredMethod(name);
+            var factory = programType.GetMethod(name, DeclaredOnlyLookup);
             if (!IsFactory<T>(factory))
             {
                 return null;
@@ -105,7 +107,7 @@ namespace Microsoft.Extensions.Hosting
                 return null;
             }
             var hostType = host.GetType();
-            var servicesProperty = hostType.GetTypeInfo().GetDeclaredProperty("Services");
+            var servicesProperty = hostType.GetProperty("Services", DeclaredOnlyLookup);
             return (IServiceProvider)servicesProperty.GetValue(host);
         }
     }

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
@@ -147,14 +147,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 => services.ConfigureOptions(typeof(TConfigureOptions));
 
         private static bool IsAction(Type type)
-            => (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Action<>));
+            => (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Action<>));
 
         private static IEnumerable<Type> FindConfigurationServices(Type type)
         {
             IEnumerable<Type> serviceTypes = type
-                .GetTypeInfo()
-                .ImplementedInterfaces
-                .Where(t => t.GetTypeInfo().IsGenericType)
+                .GetInterfaces()
+                .Where(t => t.IsGenericType)
                 .Where(t =>
                     t.GetGenericTypeDefinition() == typeof(IConfigureOptions<>) ||
                     t.GetGenericTypeDefinition() == typeof(IPostConfigureOptions<>) ||


### PR DESCRIPTION
I also made a slight optimization to CallSiteFactory to use ToArray instead of ToList.

These were showing up as 5% of `ServiceCollection.BuildServiceProvider()` in a simple benchmark:

![image](https://user-images.githubusercontent.com/8291187/99587718-1992d180-29af-11eb-9e9c-1db5e050f72c.png)

```C#
    public class DIBench
    {
        private readonly ServiceCollection services = new ServiceCollection();

        public DIBench()
        {
            services.AddTransient<Service1>();
            services.AddTransient<Service2a>();
            services.AddTransient<Service2b>();
            services.AddTransient<Service3a>();
            services.AddTransient<Service4>();
            services.AddTransient<Service4>();
            services.AddTransient<Service5>();
            services.AddTransient<Service6>();
            services.AddTransient<Service7>();
            services.AddTransient<Service8>();
            services.AddTransient<Service9>();
            services.AddTransient<Service10>();
            services.AddTransient<Service11>();
            services.AddTransient<Service12>();
            services.AddTransient<Service13>();
            services.AddTransient<Service14>();
            services.AddTransient<Service15>();
            services.AddTransient<Service16>();
            services.AddTransient<Service17>();
            services.AddTransient<Service18>();
            services.AddTransient<Service19>();
            services.AddTransient<Service20>();
            services.AddTransient<Service21>();
            services.AddTransient<Service22>();
            services.AddTransient<Service23>();
            services.AddTransient<Service24>();
            services.AddTransient<Service25>();
            services.AddTransient<Service26>();
            services.AddTransient<Service27>();
            services.AddTransient<Service28>();
            services.AddTransient<Service29>();
        }

        [Benchmark]
        public object BuildServiceProvider()
        {
            var sp = services.BuildServiceProvider();

            return sp;
        }
    }
```