### PR TITLE
Removed unneeded variable

### DIFF
--- a/src/native/eventpipe/ds-server.c
+++ b/src/native/eventpipe/ds-server.c
@@ -196,8 +196,7 @@ ds_server_init (void)
 	ds_ipc_advertise_cookie_v1_init ();
 
 	// Ports can fail to be configured
-	bool any_errors = !ds_ipc_stream_factory_configure (server_error_callback_create);
-	if (any_errors)
+	if (!ds_ipc_stream_factory_configure (server_error_callback_create))
 		DS_LOG_ERROR_0 ("At least one Diagnostic Port failed to be configured.\n");
 
 	if (ds_ipc_stream_factory_any_suspended_ports ()) {


### PR DESCRIPTION
No other function in the project has a variable like this. Why not directly compare like the other functions do?