### PR TITLE
Run class cctor in RuntimeHelpers.GetUninitializedObject(type).

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -277,7 +277,6 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Null(AppDomain.CurrentDomain.GetData("ClassWithBeforeFieldInitCctor_CctorRan"));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/44852", TestRuntimes.Mono)]
         [Fact]
         public static void GetUninitalizedObject_RunsNormalStaticCtors()
         {

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1372,6 +1372,7 @@ MonoObjectHandle
 ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectInternal (MonoType *handle, MonoError *error)
 {
 	MonoClass *klass;
+	MonoVTable *vtable;
 
 	g_assert (handle);
 
@@ -1400,6 +1401,12 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectI
 		mono_error_set_not_supported (error, NULL, NULL);
 		return NULL_HANDLE;
 	}
+
+	vtable = mono_class_vtable_checked (mono_domain_get (), klass, error);
+	return_val_if_nok (error, NULL_HANDLE);
+
+	mono_runtime_class_init_full (vtable, error);
+	return_val_if_nok (error, NULL_HANDLE);
 
 	if (m_class_is_nullable (klass))
 		return mono_object_new_handle (mono_domain_get (), m_class_get_nullable_elem_class (klass), error);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1402,11 +1402,13 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectI
 		return NULL_HANDLE;
 	}
 
-	vtable = mono_class_vtable_checked (mono_domain_get (), klass, error);
-	return_val_if_nok (error, NULL_HANDLE);
+	if (!mono_class_is_before_field_init (klass)) {
+		vtable = mono_class_vtable_checked (mono_domain_get (), klass, error);
+		return_val_if_nok (error, NULL_HANDLE);
 
-	mono_runtime_class_init_full (vtable, error);
-	return_val_if_nok (error, NULL_HANDLE);
+		mono_runtime_class_init_full (vtable, error);
+		return_val_if_nok (error, NULL_HANDLE);
+	}
 
 	if (m_class_is_nullable (klass))
 		return mono_object_new_handle (mono_domain_get (), m_class_get_nullable_elem_class (klass), error);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44852.