### PR TITLE
Fix ComponentDocumentDesigner references in DesignerAttribute to include right base type (#44774)

### DIFF
--- a/src/libraries/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
+++ b/src/libraries/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
@@ -181,7 +181,7 @@ namespace System.ComponentModel
         public void RemoveHandler(object key, System.Delegate? value) { }
     }
     [System.ComponentModel.DesignerAttribute("System.ComponentModel.Design.ComponentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
-    [System.ComponentModel.DesignerAttribute("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+    [System.ComponentModel.DesignerAttribute("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.ComponentModel.Design.IRootDesigner, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     [System.ComponentModel.TypeConverterAttribute("System.ComponentModel.ComponentConverter, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial interface IComponent : System.IDisposable
     {

--- a/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
+++ b/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 
 namespace System.ComponentModel
@@ -20,7 +21,8 @@ namespace System.ComponentModel
     /// Provides functionality required by all components.
     /// </summary>
     [Designer("System.ComponentModel.Design.ComponentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
-    [Designer("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+    [Designer("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+              "System.ComponentModel.Design.IRootDesigner, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     [TypeConverter("System.ComponentModel.ComponentConverter, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public interface IComponent : IDisposable
     {

--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -809,7 +809,7 @@ namespace System.ComponentModel
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
     }
-    [System.ComponentModel.DesignerAttribute("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(System.ComponentModel.Design.IRootDesigner))]
+    [System.ComponentModel.DesignerAttribute("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.ComponentModel.Design.IRootDesigner, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     [System.ComponentModel.DesignerCategoryAttribute("Component")]
     [System.ComponentModel.TypeConverterAttribute(typeof(System.ComponentModel.ComponentConverter))]
     public partial class MarshalByValueComponent : System.ComponentModel.IComponent, System.IDisposable, System.IServiceProvider

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MarshalByValueComponent.cs
@@ -10,7 +10,8 @@ namespace System.ComponentModel
     /// Provides the base implementation for <see cref='System.ComponentModel.IComponent'/>,
     /// which is the base class for all components in Win Forms.
     /// </summary>
-    [Designer("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(IRootDesigner))]
+    [Designer("System.Windows.Forms.Design.ComponentDocumentDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+              "System.ComponentModel.Design.IRootDesigner, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     [DesignerCategory("Component")]
     [TypeConverter(typeof(ComponentConverter))]
     public class MarshalByValueComponent : IComponent, IServiceProvider


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/31428

Backport of https://github.com/dotnet/runtime/pull/44774 to release/5.0

## Customer Impact
This blocks designer scenarios where the user opens a component or control as a root designer. When the user drops some component on a form designer, the designer host will already had a root component. So, it'll ask to create a designer with a base type of IDesigner. However, if the user double-clicks a component or control in the Solution Explorer, it'll be opened as the root component. So, the designer host will ask to create a designer with a base type of IRootDesigner. Without this change, the latter case is broken. I can work around it in the new designer, but'll still be broken from runtime designer hosting scenarios.

## Testing

I manually tested this by creating a winforms app with the fix and follwing:
> The repro would be to create an IComponent instance and call TypeDescriptor.CreateDesigner(...) with the base type as typeof(IDesigner) and then again with typeof(IRootDesigner). Today, both calls will return ComponentDesigner, but the second should return ComponentDocumentDesigner.

and now `ComponentDocumentDesigner` is returned correctly when using `typeof(IRootDesigner)`.


## Risk

I believe the risk is low as it is just updating an attribute that is used by the winforms designer. 

cc: @danmosemsft @DustinCampbell 
