### PR TITLE
Fix build script on ARM Linux builds

### DIFF
--- a/eng/native/init-os-and-arch.sh
+++ b/eng/native/init-os-and-arch.sh
@@ -17,7 +17,7 @@ Darwin)
     os=Linux ;;
 esac
 
-# On Solaris, `uname -m` is discoragued, see https://docs.oracle.com/cd/E36784_01/html/E36870/uname-1.html
+# On Solaris, `uname -m` is discouraged, see https://docs.oracle.com/cd/E36784_01/html/E36870/uname-1.html
 # and `uname -p` returns processor type (e.g. i386 on amd64).
 # The appropriate tool to determine CPU is isainfo(1) https://docs.oracle.com/cd/E36784_01/html/E36870/isainfo-1.html.
 if [ "$os" = "SunOS" ]; then
@@ -28,9 +28,9 @@ if [ "$os" = "SunOS" ]; then
     fi
     CPUName=$(isainfo -n)
 elif [ "$os" = "OSX" ]; then
-    # On OSX universal binaries make uname -m unreliable.  The uname -m response changes
+    # On OSX, universal binaries make uname -m unreliable. The uname -m response changes
     # based on what hardware is being emulated.
-    # Use sysctl instead
+    # Use sysctl instead.
     if [ "$(sysctl -q -n hw.optional.arm64)" = "1" ]; then
         CPUName=arm64
     elif [ "$(sysctl -q -n hw.optional.x86_64)" = "1" ]; then
@@ -39,7 +39,7 @@ elif [ "$os" = "OSX" ]; then
         CPUName=$(uname -m)
     fi
 else
-    # For rest of the operating systems, use uname(1) to determine what the CPU is.
+    # For the rest of the operating systems, use uname(1) to determine what the CPU is.
     CPUName=$(uname -m)
 fi
 
@@ -54,11 +54,9 @@ case "$CPUName" in
 
     armv7l)
         if (NAME=""; . /etc/os-release; test "$NAME" = "Tizen"); then
-            __BuildArch=armel
-            __HostArch=armel
+            arch=armel
         else
-            __BuildArch=arm
-            __HostArch=arm
+            arch=arm
         fi
         ;;
 


### PR DESCRIPTION
On ARM Linux distros that are not Android, the error "unbound variable" occurs as the "arch" variable is not assigned to, even though every other script path assigns a value to arch. For this reason, I changed the script so that arch is assigned on all possible paths, so that building on ARM Linux distros is possible.

Fixes #44929 