### PR TITLE
Enables the interpreter on iOS

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -116,6 +116,7 @@
         MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackNativeDir)include\mono-2.0"
         Assemblies="@(BundleAssemblies)"
         MainLibraryFileName="AppleTestRunner.dll"
+        ForceInterpreter="$(MonoForceInterpreter)"
         UseConsoleUITemplate="True"
         GenerateXcodeProject="True"
         BuildAppBundle="True"

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -222,14 +222,11 @@
     </ItemGroup>
     <!-- iOS simulator specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' == 'true'">
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,gac"/>
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,eventpipe,gac"/>
     </ItemGroup>
     <!-- iOS device specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true'">
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,com,interpreter,jit,portability,assembly_remapping,attach,verifier,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters,gac,eventpipe" />
-      <_MonoCMakeArgs Include="-DENABLE_INTERP_LIB=1"/>
-      <_MonoCMakeArgs Include="-DDISABLE_ICALL_TABLES=1"/>
-      <_MonoCMakeArgs Include="-DENABLE_ICALL_EXPORT=0"/>
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,com,jit,portability,assembly_remapping,attach,verifier,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters,gac,eventpipe" />
       <_MonoCMakeArgs Include="-DENABLE_VISIBILITY_HIDDEN=1"/>
       <_MonoCMakeArgs Include="-DENABLE_LAZY_GC_THREAD_CREATION=1"/>
       <_MonoCMakeArgs Include="-DENABLE_SIGALTSTACK=0"/>
@@ -419,7 +416,7 @@
       <_MonoRuntimeFilePath Condition="'$(TargetsBrowser)' == 'true'">$(MonoObjDir)out\lib\libmonosgen-2.0.a</_MonoRuntimeFilePath>
       <_MonoRuntimeFilePath Condition="'$(_MonoRuntimeFilePath)' == ''">$(MonoObjDir)out\lib\libmonosgen-2.0.so</_MonoRuntimeFilePath>
       <_MonoRuntimeStaticFilePath Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsAndroid)' == 'true'">$(MonoObjDir)out\lib\libmonosgen-2.0.a</_MonoRuntimeStaticFilePath>
-      <_MonoIncludeInterpStaticFiles Condition="'$(TargetsBrowser)' == 'true' or ('$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true')">true</_MonoIncludeInterpStaticFiles>
+      <_MonoIncludeInterpStaticFiles Condition="'$(TargetsBrowser)' == 'true'">true</_MonoIncludeInterpStaticFiles>
     </PropertyGroup>
     <PropertyGroup Condition="'$(BuildMonoAOTCrossCompiler)' == 'true'">
       <_MonoAotCrossFilePath >$(MonoObjDir)cross\out\bin\mono-sgen</_MonoAotCrossFilePath>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -226,7 +226,7 @@
     </ItemGroup>
     <!-- iOS device specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true'">
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,com,jit,portability,assembly_remapping,attach,verifier,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters,gac" />
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,com,jit,portability,assembly_remapping,attach,verifier,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters,gac,eventpipe" />
       <_MonoCMakeArgs Include="-DENABLE_VISIBILITY_HIDDEN=1"/>
       <_MonoCMakeArgs Include="-DENABLE_LAZY_GC_THREAD_CREATION=1"/>
       <_MonoCMakeArgs Include="-DENABLE_SIGALTSTACK=0"/>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -226,7 +226,7 @@
     </ItemGroup>
     <!-- iOS device specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true'">
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,com,jit,portability,assembly_remapping,attach,verifier,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters,gac,eventpipe" />
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=ssa,com,jit,portability,assembly_remapping,attach,verifier,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters,gac" />
       <_MonoCMakeArgs Include="-DENABLE_VISIBILITY_HIDDEN=1"/>
       <_MonoCMakeArgs Include="-DENABLE_LAZY_GC_THREAD_CREATION=1"/>
       <_MonoCMakeArgs Include="-DENABLE_SIGALTSTACK=0"/>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -222,7 +222,7 @@
     </ItemGroup>
     <!-- iOS simulator specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' == 'true'">
-      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,eventpipe,gac"/>
+      <_MonoCMakeArgs Include="-DENABLE_MINIMAL=com,remoting,shared_perfcounters,gac"/>
     </ItemGroup>
     <!-- iOS device specific options -->
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true'">

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -72,6 +72,7 @@
         OutputDirectory="$(AppDir)"
         Optimized="$(Optimized)"
         UseAotForSimulator="$(UseAotForSimulator)"
+        ForceInterpreter="$(MonoForceInterpreter)"
         AppDir="$(MSBuildThisFileDirectory)$(PublishDir)">
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
         <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />

--- a/src/native/eventpipe/ds-ipc-posix.c
+++ b/src/native/eventpipe/ds-ipc-posix.c
@@ -120,7 +120,6 @@ ipc_init_listener (
 	result_bind = bind (server_socket, server_address, server_address_len);
 	DS_EXIT_BLOCKING_PAL_SECTION;
 
-	EP_ASSERT (result_bind != -1);
 	if (result_bind == -1) {
 		if (callback)
 			callback (strerror (errno), errno);

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -102,6 +102,11 @@ public class AppleAppBuilderTask : Task
     public bool UseAotForSimulator { get; set; }
 
     /// <summary>
+    /// Forces the runtime to use the interpreter
+    /// </summary>
+    public bool ForceInterpreter { get; set; }
+
+    /// <summary>
     /// Path to xcode project
     /// </summary>
     [Output]
@@ -149,15 +154,20 @@ public class AppleAppBuilderTask : Task
             }
         }
 
-        if ((isDevice || UseAotForSimulator) && !assemblerFiles.Any())
+        if (((!ForceInterpreter && (isDevice || UseAotForSimulator)) && !assemblerFiles.Any()))
         {
             throw new InvalidOperationException("Need list of AOT files for device builds.");
+        }
+
+        if (ForceInterpreter && UseAotForSimulator)
+        {
+            throw new InvalidOperationException("Interpreter and AOT cannot be enabled at the same time");
         }
 
         if (GenerateXcodeProject)
         {
             XcodeProjectPath = Xcode.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles,
-                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, UseAotForSimulator, Optimized, NativeMainSource);
+                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, UseAotForSimulator, ForceInterpreter, Optimized, NativeMainSource);
 
             if (BuildAppBundle)
             {

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/Templates/runtime.m
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/Templates/runtime.m
@@ -196,7 +196,7 @@ register_dllmap (void)
 //%DllMap%
 }
 
-#if TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || USE_AOT_FOR_SIMULATOR)
+#if FORCE_INTERPRETER || (TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || USE_AOT_FOR_SIMULATOR))
 void mono_jit_set_aot_mode (MonoAotMode mode);
 void register_aot_modules (void);
 #endif
@@ -228,7 +228,10 @@ mono_ios_runtime_init (void)
     // TODO: set TRUSTED_PLATFORM_ASSEMBLIES, APP_PATHS and NATIVE_DLL_SEARCH_DIRECTORIES
     monovm_initialize(0, NULL, NULL);
 
-#if TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || USE_AOT_FOR_SIMULATOR)
+#if FORCE_INTERPRETER
+    os_log_info (OS_LOG_DEFAULT, "INTERP Enabled");
+    mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_ONLY);
+#elif TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || USE_AOT_FOR_SIMULATOR)
     register_dllmap ();
     // register modules
     register_aot_modules ();
@@ -249,7 +252,7 @@ mono_ios_runtime_init (void)
     }
     mono_jit_init_version ("dotnet.ios", "mobile");
 
-#if TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || USE_AOT_FOR_SIMULATOR)
+#if !FORCE_INTERPRETER && TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || USE_AOT_FOR_SIMULATOR)
     // device runtimes are configured to use lazy gc thread creation
     MONO_ENTER_GC_UNSAFE;
     mono_gc_init_finalizer_thread ();

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/Xcode.cs
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/Xcode.cs
@@ -21,6 +21,7 @@ internal class Xcode
         bool preferDylibs,
         bool useConsoleUiTemplate,
         bool useAotForSimulator,
+        bool forceInterpreter,
         bool stripDebugSymbols,
         string? nativeMainSource = null)
     {
@@ -86,8 +87,17 @@ internal class Xcode
         cmakeLists = cmakeLists.Replace("%NativeLibrariesToLink%", toLink);
         cmakeLists = cmakeLists.Replace("%AotSources%", aotSources);
         cmakeLists = cmakeLists.Replace("%AotModulesSource%", string.IsNullOrEmpty(aotSources) ? "" : "modules.m");
-        cmakeLists = cmakeLists.Replace("%Defines%",
-            useAotForSimulator ? "add_definitions(-DUSE_AOT_FOR_SIMULATOR=1)" : "");
+
+        string defines = "";
+        if (forceInterpreter)
+        {
+            defines = "add_definitions(-DFORCE_INTERPRETER=1)";
+        }
+        else if (useAotForSimulator)
+        {
+            defines = "add_definitions(-DUSE_AOT_FOR_SIMULATOR=1)";
+        }
+        cmakeLists = cmakeLists.Replace("%Defines%", defines);
 
         string plist = Utils.GetEmbeddedResource("Info.plist.template")
             .Replace("%BundleIdentifier%", projectName);


### PR DESCRIPTION
To enable on tests, you can pass MonoForceInterpreter=true as an extra MSBuild property.

AppleAppBuilder will also have a `ForceInterpreter` property on it in order to flow down to device / simulator.  