### PR TITLE
Fix vswhere path to work with spaces by surrounding it with quotes

### DIFF
--- a/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
+++ b/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
@@ -14,7 +14,7 @@
 
   <Target Name="ResolveDIALibToCopy" BeforeTargets="AssignTargetPaths">
     <PropertyGroup>
-      <VSWherePath>$([MSBuild]::NormalizePath('$(Pkgvswhere)','tools','vswhere.exe'))</VSWherePath>
+      <VSWherePath>"$([MSBuild]::NormalizePath('$(Pkgvswhere)','tools','vswhere.exe'))"</VSWherePath>
     </PropertyGroup>
     <Exec
       Command="$(VSWherePath) -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath"


### PR DESCRIPTION
Some local .nuget paths may contain spaces (ex. `C:\Users\First Last\.nuget`). Surrounding it with quotes allows the command path to have spaces and execute correctly.