### PR TITLE
Speed up Crossgen2 by 10%

### DIFF
--- a/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
@@ -14,6 +14,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
     <Configurations>Debug;Release;Checked</Configurations>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup Label="Embedded Resources">


### PR DESCRIPTION
Server GC looks to improve Crossgen2 compile times by up to 15% so use it by default.

cc @dotnet/crossgen-contrib 