### PR TITLE
Use TryParseUInt32HexNumberStyle directly from Guid.TryParse

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -362,7 +362,7 @@ namespace System
         }
 
         // Two helpers used for parsing components:
-        // - uint.TryParse(..., NumberStyles.AllowHexSpecifier, ...)
+        // - Number.TryParseUInt32HexNumberStyle(..., NumberStyles.AllowHexSpecifier, ...)
         //       Used when we expect the entire provided span to be filled with and only with hex digits and no overflow is possible
         // - TryParseHex
         //       Used when the component may have an optional '+' and "0x" prefix, when it may overflow, etc.
@@ -421,7 +421,7 @@ namespace System
                             // _f, _g must be stored as a big-endian ushort
                             result._fg = BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness((ushort)uintTmp) : (ushort)uintTmp;
 
-                            if (uint.TryParse(guidString.Slice(28, 8), NumberStyles.AllowHexSpecifier, null, out uintTmp)) // _h, _i, _j, _k
+                            if (Number.TryParseUInt32HexNumberStyle(guidString.Slice(28, 8), NumberStyles.AllowHexSpecifier, out uintTmp) == Number.ParsingStatus.OK) // _h, _i, _j, _k
                             {
                                 // _h, _i, _j, _k must be stored as a big-endian uint
                                 result._hijk = BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(uintTmp) : uintTmp;
@@ -447,20 +447,20 @@ namespace System
                 return false;
             }
 
-            if (uint.TryParse(guidString.Slice(0, 8), NumberStyles.AllowHexSpecifier, null, out result._a) && // _a
-                uint.TryParse(guidString.Slice(8, 8), NumberStyles.AllowHexSpecifier, null, out uint uintTmp)) // _b, _c
+            if (Number.TryParseUInt32HexNumberStyle(guidString.Slice(0, 8), NumberStyles.AllowHexSpecifier, out result._a) == Number.ParsingStatus.OK && // _a
+                Number.TryParseUInt32HexNumberStyle(guidString.Slice(8, 8), NumberStyles.AllowHexSpecifier, out uint uintTmp) == Number.ParsingStatus.OK) // _b, _c
             {
                 // _b, _c are independently in machine-endian order
                 if (BitConverter.IsLittleEndian) { uintTmp = BitOperations.RotateRight(uintTmp, 16); }
                 result._bc = uintTmp;
 
-                if (uint.TryParse(guidString.Slice(16, 8), NumberStyles.AllowHexSpecifier, null, out uintTmp)) // _d, _e, _f, _g
+                if (Number.TryParseUInt32HexNumberStyle(guidString.Slice(16, 8), NumberStyles.AllowHexSpecifier, out uintTmp) == Number.ParsingStatus.OK) // _d, _e, _f, _g
                 {
                     // _d, _e, _f, _g must be stored as a big-endian uint
                     if (BitConverter.IsLittleEndian) { uintTmp = BinaryPrimitives.ReverseEndianness(uintTmp); }
                     result._defg = uintTmp;
 
-                    if (uint.TryParse(guidString.Slice(24, 8), NumberStyles.AllowHexSpecifier, null, out uintTmp)) // _h, _i, _j, _k
+                    if (Number.TryParseUInt32HexNumberStyle(guidString.Slice(24, 8), NumberStyles.AllowHexSpecifier, out uintTmp) == Number.ParsingStatus.OK) // _h, _i, _j, _k
                     {
                         // _h, _i, _j, _k must be stored as big-endian uint
                         if (BitConverter.IsLittleEndian) { uintTmp = BinaryPrimitives.ReverseEndianness(uintTmp); }

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -1096,7 +1096,7 @@ namespace System
         }
 
         /// <summary>Parses uint limited to styles that make up NumberStyles.HexNumber.</summary>
-        private static ParsingStatus TryParseUInt32HexNumberStyle(ReadOnlySpan<char> value, NumberStyles styles, out uint result)
+        internal static ParsingStatus TryParseUInt32HexNumberStyle(ReadOnlySpan<char> value, NumberStyles styles, out uint result)
         {
             Debug.Assert((styles & ~NumberStyles.HexNumber) == 0, "Only handles subsets of HexNumber format");
 


### PR DESCRIPTION
Skips public entry points of uint.TryParse, including argument validation, branches for style, but most impactfully fetching the current number culture when it won't actually be needed.

Noticed while looking at startup costs, as it was causing current culture to be initialized unexpectedly.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    [Benchmark]
    public bool TryParse() => Guid.TryParse("dd16f057-4f29-495c-9f09-7201d8bee53d", out _);

    [Benchmark]
    public bool TryParseD() => Guid.TryParseExact("dd16f057-4f29-495c-9f09-7201d8bee53d", "D", out _);

    [Benchmark]
    public bool TryParseN() => Guid.TryParseExact("6e76bbd10361464b980309a281d17180", "N", out _);
}
```

|    Method |           Toolchain |     Mean | Ratio |
|---------- |-------------------- |---------:|------:|
|  TryParse | \master\corerun.exe | 86.38 ns |  1.00 |
|  TryParse |     \pr\corerun.exe | 74.42 ns |  0.87 |
|           |                     |          |       |
| TryParseD | \master\corerun.exe | 82.14 ns |  1.00 |
| TryParseD |     \pr\corerun.exe | 71.21 ns |  0.89 |
|           |                     |          |       |
| TryParseN | \master\corerun.exe | 96.77 ns |  1.00 |
| TryParseN |     \pr\corerun.exe | 60.36 ns |  0.62 |

Contributes to https://github.com/dotnet/runtime/issues/44598