### PR TITLE
Move xunit test harness to its own directory under core_root

### DIFF
--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -41,6 +41,7 @@
       <RunTimeDependencyCopyLocalFile Include="@(AllResolvedRuntimeDependencies)"  Exclude="@(RunTimeDependencyExcludeFiles)"/>
       <RunTimeDependencyCopyLocal Include="@(RunTimeDependencyCopyLocalFile -> '%(File)')"  />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/*" />
+      <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/xunit.*" TargetDir="xunit/" />
     </ItemGroup>
 
     <ItemGroup>
@@ -84,6 +85,9 @@
       <RunTimeArtifactsIncludeFolders Include="R2RTest/">
         <IncludeSubFolders>True</IncludeSubFolders>
       </RunTimeArtifactsIncludeFolders>
+
+      <!-- XUnit runner harness assemblies that we don't want to mix in with the framework in Core_Root -->
+      <RunTimeArtifactsIncludeFolders Include="xunit/" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -182,7 +182,7 @@
       <_XUnitConsoleRunnerFiles Include="$(NuGetPackageRoot)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerVersion)\**\xunit.console.*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(_XUnitConsoleRunnerFiles)" DestinationFolder="$(CoreRootDirectory)" />
+    <Copy SourceFiles="@(_XUnitConsoleRunnerFiles)" DestinationFolder="$(CoreRootDirectory)\xunit" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts\runincontext.cmd" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TargetsWindows)' == 'true' and '$(_RunInUnloadableContext)' == 'true'" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/runincontext.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TargetsWindows)' != 'true' and '$(_RunInUnloadableContext)' == 'true'" />
   </Target>
@@ -289,11 +289,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <XUnitRunnerDll>%CORE_ROOT%\xunit.console.dll</XUnitRunnerDll>
+    <XUnitRunnerDll>%CORE_ROOT%\xunit\xunit.console.dll</XUnitRunnerDll>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
-    <XUnitRunnerDll>$CORE_ROOT/xunit.console.dll</XUnitRunnerDll>
+    <XUnitRunnerDll>$CORE_ROOT/xunit/xunit.console.dll</XUnitRunnerDll>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(UsesHelixSdk)' == 'true' ">

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -41,7 +41,7 @@
 
     <Error Condition="'$(CORE_ROOT)' == ''" Text="CORE_ROOT is not set." />
     <PropertyGroup>
-      <XunitConsoleRunner>$(CORE_ROOT)\xunit.console.dll</XunitConsoleRunner>
+      <XunitConsoleRunner>$(CORE_ROOT)\xunit\xunit.console.dll</XunitConsoleRunner>
 
       <XunitArgs Condition="'$(TargetOS)' == 'Android'">-parallel none</XunitArgs>
       <XunitArgs Condition="'$(TargetOS)' != 'Android'">-parallel $(ParallelRun)</XunitArgs>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -275,6 +275,7 @@
       <RunTimeDependencyCopyLocalFile Include="@(AllResolvedRuntimeDependencies)"  Exclude="@(RunTimeDependencyExcludeFiles)"/>
       <RunTimeDependencyCopyLocal Include="@(RunTimeDependencyCopyLocalFile -> '%(File)')"  />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/*" />
+      <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/xunit.*" TargetDir="xunit/" />
     </ItemGroup>
 
     <ItemGroup>
@@ -315,6 +316,9 @@
       <RunTimeArtifactsIncludeFolders Include="R2RTest/">
         <IncludeSubFolders>True</IncludeSubFolders>
       </RunTimeArtifactsIncludeFolders>
+
+      <!-- XUnit runner harness assemblies that we don't want to mix in with the framework in Core_Root -->
+      <RunTimeArtifactsIncludeFolders Include="xunit/" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -984,7 +984,7 @@ def run_tests(args,
     urlretrieve(url, zipfilename)
 
     with zipfile.ZipFile(zipfilename,"r") as ziparch:
-        ziparch.extractall(args.core_root)
+        ziparch.extractall(os.path.join(args.core_root, "xunit"))
 
     os.remove(zipfilename)
     assert not os.path.isfile(zipfilename)


### PR DESCRIPTION
Running `xunit.console` from within the CoreRoot directory is problematic. It is executed by the shared runtime but has a full copy of the runtime and framework libraries next to it from which assemblies are getting loaded despite being for a pre-release test runtime.

Place the xunit assemblies under `<core_root>/xunit` and update the places that invoke it in local and Helix test runs.

The loaded tests do reference the xunit assemblies so they need to also be available in core_root for when the tests run (with the exception of the harness specific assemblies like xunit.console).