### PR TITLE
Mark stress log critical section as compatible with shutdown

### DIFF
--- a/src/coreclr/src/utilcode/stresslog.cpp
+++ b/src/coreclr/src/utilcode/stresslog.cpp
@@ -151,7 +151,7 @@ void StressLog::Initialize(unsigned facilities,  unsigned level, unsigned maxByt
         return;
     }
 
-    theLog.lock = ClrCreateCriticalSection(CrstStressLog,(CrstFlags)(CRST_UNSAFE_ANYMODE|CRST_DEBUGGER_THREAD));
+    theLog.lock = ClrCreateCriticalSection(CrstStressLog,(CrstFlags)(CRST_UNSAFE_ANYMODE|CRST_DEBUGGER_THREAD|CRST_TAKEN_DURING_SHUTDOWN));
     // StressLog::Terminate is going to free memory.
     if (maxBytesPerThread < STRESSLOG_CHUNK_SIZE)
     {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/43571

/cc @dotnet/dotnet-coreclr 