### PR TITLE
Use simple convert method for internal bool to ulong enum conversion

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -934,7 +934,7 @@ namespace System
                 case CorElementType.ELEMENT_TYPE_U1:
                     return data;
                 case CorElementType.ELEMENT_TYPE_BOOLEAN:
-                    return Convert.ToByte(Unsafe.As<byte, bool>(ref data));
+                    return data != 0 ? 1UL : 0UL;
                 case CorElementType.ELEMENT_TYPE_I2:
                     return (ulong)Unsafe.As<byte, short>(ref data);
                 case CorElementType.ELEMENT_TYPE_U2:

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -934,7 +934,7 @@ namespace System
                 case CorElementType.ELEMENT_TYPE_U1:
                     return data;
                 case CorElementType.ELEMENT_TYPE_BOOLEAN:
-                    return Convert.ToUInt64(Unsafe.As<byte, bool>(ref data), CultureInfo.InvariantCulture);
+                    return Convert.ToByte(Unsafe.As<byte, bool>(ref data));
                 case CorElementType.ELEMENT_TYPE_I2:
                     return (ulong)Unsafe.As<byte, short>(ref data);
                 case CorElementType.ELEMENT_TYPE_U2:


### PR DESCRIPTION
This allows to drop whole IConvertible dependency chain for simple apps