### PR TITLE
Add support for Apple Silicon on Xamarin.Mac SDK

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -4788,10 +4788,12 @@ if test "x$host" != "x$target"; then
 		sizeof_register=8
 		AC_DEFINE(TARGET_WATCHOS, 1, [...])
 		;;
+	aarch64*darwin20*)
+		TARGET=ARM64
+		TARGET_SYS=OSX
+		;;
 	aarch64*darwin*)
 		TARGET=ARM64
-		# Both ios and osx/arm64 have the same aarc64-darwin triple,
-		# assume ios for now when cross compiling
 		TARGET_SYS=IOS
 		;;
 	aarch64-*)

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12378,6 +12378,10 @@ compile_asm (MonoAotCompile *acfg)
 #define AS_OPTIONS "-arch i386"
 #elif defined(TARGET_X86) && !defined(TARGET_MACH)
 #define AS_OPTIONS "--32"
+#elif defined(TARGET_AMD64) && defined(TARGET_OSX)
+#define AS_OPTIONS "-arch x86_64"
+#elif defined(TARGET_ARM64) && defined(TARGET_OSX)
+#define AS_OPTIONS "-arch arm64"
 #else
 #define AS_OPTIONS ""
 #endif
@@ -12407,7 +12411,7 @@ compile_asm (MonoAotCompile *acfg)
 #define LD_OPTIONS "--shared"
 #elif defined(TARGET_ARM64) && defined(TARGET_OSX)
 #define LD_NAME "clang"
-#define LD_OPTIONS "--shared"
+#define LD_OPTIONS "--shared -arch arm64"
 #elif defined(TARGET_WIN32_MSVC)
 #define LD_NAME "link.exe"
 #define LD_OPTIONS "/DLL /MACHINE:X64 /NOLOGO /INCREMENTAL:NO"

--- a/src/mono/mono/tools/offsets-tool/offsets-tool.py
+++ b/src/mono/mono/tools/offsets-tool/offsets-tool.py
@@ -151,6 +151,11 @@ class OffsetsTool:
 			self.target = Target ("TARGET_AMD64", "", IOS_DEFINES)
 			self.target_args += ["-arch", "x86_64"]
 			self.target_args += ["-isysroot", args.sysroot]
+		elif "aarch64-apple-darwin20" == args.abi:
+			require_sysroot (args)
+			self.target = Target ("TARGET_ARM64", "TARGET_OSX", IOS_DEFINES)
+			self.target_args += ["-arch", "arm64"]
+			self.target_args += ["-isysroot", args.sysroot]
 
 		# watchOS
 		elif "armv7k-apple-darwin" == args.abi:

--- a/src/mono/mono/utils/mono-codeman.c
+++ b/src/mono/mono/utils/mono-codeman.c
@@ -4,6 +4,11 @@
 
 #include "config.h"
 
+#if defined(TARGET_OSX)
+/* So we can use the declaration of pthread_jit_write_protect_np () */
+#define _DARWIN_C_SOURCE
+#endif
+
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -661,7 +666,7 @@ mono_code_manager_size (MonoCodeManager *cman, int *used_size)
 void
 mono_codeman_enable_write (void)
 {
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+#if defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP) && defined(TARGET_OSX)
 	if (__builtin_available (macOS 11, *)) {
 		int level = GPOINTER_TO_INT (mono_native_tls_get_value (write_level_tls_id));
 		level ++;
@@ -680,7 +685,7 @@ mono_codeman_enable_write (void)
 void
 mono_codeman_disable_write (void)
 {
-#ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+#if defined(HAVE_PTHREAD_JIT_WRITE_PROTECT_NP) && defined(TARGET_OSX)
 	if (__builtin_available (macOS 11, *)) {
 		int level = GPOINTER_TO_INT (mono_native_tls_get_value (write_level_tls_id));
 		g_assert (level);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20597,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This PR implements changes that lets us build Xamarin.iOS/Xamarin.Mac SDKs so that it is possible for a Xamarin.Mac project to target x86_64+arm64 (i.e. Apple Silicon). Most of the changes are related to the mac Sdk build, but there are some extra changes as well :

- Fix configure to not automatically target iOS when targeting aarch64
  - Necessary to compile a cross-compiler targetting macOS arm64
- Fix aot compiler to target macOS arm64 when running on x64 (missing arch parameters)
- Support offset tool for aarch64
  - Necessary to compile macOS arm64 cross-compiler
- Fix pthread_jit_write_protect_np and preadv usage
  - Missing define meant the function wasn't found (at least on Xcode 12.2)
  - Restrict usage to macOS
- Fix crash on launch on iOS/tvOS arm64 caused by invalidly setting `MAP_JIT` on those platforms even though it's not a valid option.
- Fix small error in sdk configuration (dependency relying on improper variable)
- Adapt macOS SDK
  - Build libraries for x64+arm64 and lipo them together
  - Create a aarch64 cross-compiler for macOS, similar to the iOS Sdk

The arm64 support will only work with Xcode 12.2. To support in Xamarin.Mac, it also doesn't work if built from stable branches (because the rest of the arm64 support hasn't made it to the latest stable branch from what I can figure out)