### PR TITLE
Fix post build signing props and enable post build signing.

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -44,6 +44,15 @@
     <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />
     <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
   </ItemGroup>
+  <ItemGroup Condition="'$(PrepareArtifacts) == 'true' and '$(PostBuildSign)' == 'true'">
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.msi" />
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.exe" />
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.nupkg" />
+    <ItemsToSignWithPaths Include="$(DownloadDirectory)**/*.zip" />
+
+    <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
+    <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" />
+  </ItemGroup>
 
   <Target Name="SetupFilesToSign">
     <!-- Ensure that we don't miss the DAC or DBI with the globbing below -->

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -33,7 +33,7 @@ variables:
 - name: _DotNetValidationArtifactsCategory
   value: .NETCoreValidation
 - name: PostBuildSign
-  value: false
+  value: true
 
 stages:
 - stage: Build


### PR DESCRIPTION
Add back post-build specific signing items to Signing.props and enable PostBuildSign in the official build.