### PR TITLE
Increase Hosting test delay to fix flaky BackgroundServiceAsyncExceptionGetsLogged test.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -1227,6 +1227,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         public async Task BackgroundServiceAsyncExceptionGetsLogged()
         {
             using TestEventListener listener = new TestEventListener();
+            var backgroundDelayTaskSource = new TaskCompletionSource<bool>();
 
             using IHost host = CreateBuilder()
                 .ConfigureLogging(logging =>
@@ -1235,9 +1236,11 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddHostedService<AsyncThrowingService>();
+                    services.AddHostedService(sp => new AsyncThrowingService(backgroundDelayTaskSource.Task));
                 })
                 .Start();
+
+            backgroundDelayTaskSource.SetResult(true);
 
             // give the background service 1 minute to log the failure
             TimeSpan timeout = TimeSpan.FromMinutes(1);
@@ -1370,11 +1373,16 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private class AsyncThrowingService : BackgroundService
         {
+            private readonly Task _executeDelayTask;
+
+            public AsyncThrowingService(Task executeDelayTask)
+            {
+                _executeDelayTask = executeDelayTask;
+            }
+
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
-                // Delay long enough that BackgroundService.StartAsync gets a chance to complete
-                // before the exception is thrown. But don't delay for too long so the test completes quickly.
-                await Task.Delay(50);
+                await _executeDelayTask;
 
                 throw new Exception("Background Exception");
             }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -1372,7 +1372,9 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
-                await Task.Yield();
+                // Delay long enough that BackgroundService.StartAsync gets a chance to complete
+                // before the exception is thrown. But don't delay for too long so the test completes quickly.
+                await Task.Delay(50);
 
                 throw new Exception("Background Exception");
             }


### PR DESCRIPTION
Fix #43389