### PR TITLE
Disable on Server Core 3 tests that use Notepad

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -957,6 +957,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), // Nano does not support UseShellExecute
+                                                    nameof(PlatformDetection.IsNotWindowsServerCore), // https://github.com/dotnet/runtime/issues/26231
                                                     nameof(PlatformDetection.IsNotWindows8x))] // https://github.com/dotnet/runtime/issues/22007
         [OuterLoop("Launches notepad")]
         [PlatformSpecific(TestPlatforms.Windows)]
@@ -1168,6 +1169,11 @@ namespace System.Diagnostics.Tests
 
         private void VerifyNotepadMainWindowTitle(Process process, string filename)
         {
+            if (PlatformDetection.IsWindowsServerCore)
+            {
+                return; // On Server Core, notepad exists but does not return a title
+            }
+
             // On some Windows versions, the file extension is not included in the title
             string expected = Path.GetFileNameWithoutExtension(filename);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/26231
Fixes https://github.com/dotnet/runtime/issues/44239 

Since a207c7f5df922560aac9028a2d7416116d38fce6 3 Process tests still fail consistently, and only on Server Core:
```
StartInfo_TextFile_ShellExecute
```
This means `ShellExecuteExW` succeeded, but even though we passed SEE_MASK_NOCLOSEPROCESS it did not fill in the hProcess. The docs say

> Even if fMask is set to SEE_MASK_NOCLOSEPROCESS, hProcess will be NULL if no process was launched. For example, if a document to be launched is a URL and an instance of Internet Explorer is already running, it will display the document. No new process is launched, and hProcess will be NULL.

Yet it does launch notepad. Although the failure is consistent I am not able to repro locally on a Server Core container, ie the following works
```psh
PS C:\Users\danmose> $psi = new-object System.Diagnostics.ProcessStartInfo
PS C:\Users\danmose> $psi.UseShellExecute = $true
PS C:\Users\danmose> dir >c:\temp\foo.txt
PS C:\Users\danmose> $psi.FileName = "c:\temp\foo.txt"
PS C:\Users\danmose> $ps = [System.Diagnostics.Process]::Start($psi)
PS C:\Users\danmose> $ps -eq $null
False
```
So I am just disabling this test for Server Core.

```
StartInfo_NotepadWithContent_withArgumentList
StartInfo_NotepadWithContent
```

I tried both notepad and regedit on Server Core -- the process launches, but GetWindowText always returns blank. So, disabling checking the title on Server Core.