### PR TITLE
[Release/5.0] Port [RyuJIT] Propagate gtFlags in Vector.Create to .NET 5.0

### DIFF
--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -396,11 +396,10 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmp        = gtNewArgList(impPopStack().val);
-                    tmp->gtOp2 = op1;
-                    op1        = tmp;
+                    tmp = gtNewListNode(impPopStack().val, tmp);
                 }
 
+                op1     = tmp;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -774,11 +774,10 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
 
                 for (unsigned i = 0; i < sig->numArgs; i++)
                 {
-                    tmp        = gtNewArgList(impPopStack().val);
-                    tmp->gtOp2 = op1;
-                    op1        = tmp;
+                    tmp = gtNewListNode(impPopStack().val, tmp);
                 }
 
+                op1     = tmp;
                 retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, baseType, simdSize);
             }
             break;

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -955,6 +955,12 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/**">
+            <Issue>https://github.com/dotnet/runtime/issues/43676</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
+            <Issue>Tests features specific to coreclr</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/CollectibleAssemblies/ByRefLocals/**">
             <Issue>https://github.com/dotnet/runtime/issues/40394</Issue>
         </ExcludeList>

--- a/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace GitHub_43569
+{
+    class Program
+    {
+        public static int Main()
+        {
+            if ((int)Vector64_Create_short(100) != 100)
+                return 1;
+            if ((int)Vector128_Create_float(100) != 100)
+                return 2;
+            if ((int)Vector128_Create_byte(100) != 100)
+                return 3;
+            if ((int)Vector256_Create_float(100) != 100)
+                return 4;
+            if ((int)Vector256_Create_double(100) != 100)
+                return 5;
+            return 100;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Inline<T>(T t) => t;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static short Vector64_Create_short(short a)
+        {
+            Vector64<short> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector64.Create(1, 2, 3, Inline(a));
+            return x.GetElement(3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static float Vector128_Create_float(float a)
+        {
+            Vector128<float> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector128.Create(1, 2, 3, Inline(a));
+            return x.GetElement(3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static byte Vector128_Create_byte(byte a)
+        {
+            Vector128<byte> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector128.Create(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, Inline(a));
+            return x.GetElement(15);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static float Vector256_Create_float(float a)
+        {
+            Vector256<float> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector256.Create(1, 2, 3, 4, 5, 6, 7, Inline(a));
+            return x.GetElement(7);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static double Vector256_Create_double(double a)
+        {
+            Vector256<double> x = default;
+            for (int i = 0; i < 1; i++)
+                x = Vector256.Create(1, 2, 3, Inline(a));
+            return x.GetElement(3);
+        }
+    }
+}

--- a/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Embedded</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_43569.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/43578

## Customer Impact

Customer reported silent bad codegen when using hardware intrinsics (see #43569, #44704).

## Testing

Missing test case. Checked builds were able to see the problem so this is just a case we never tested for.

## Regression?

Yes; worked in 3.1.

## Risk

Low, fix is very small and easy to understand