### PR TITLE
Implement and use MultiArrayBuffer

### DIFF
--- a/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
+++ b/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
@@ -312,8 +312,8 @@ namespace System.Net
             else
             {
                 Debug.Assert(blocks is not null);
-                Debug.Assert(start >= 0);
-                Debug.Assert(length >= 0);
+                Debug.Assert(start <= int.MaxValue);
+                Debug.Assert(length <= int.MaxValue);
                 Debug.Assert(start + length <= blocks.Length * BlockSize);
 
                 _blocks = blocks;
@@ -348,7 +348,7 @@ namespace System.Net
 
         public Memory<byte> GetBlock(int blockIndex)
         {
-            if (blockIndex < 0 || blockIndex >= BlockCount)
+            if ((uint)blockIndex >= BlockCount)
             {
                 throw new IndexOutOfRangeException();
             }

--- a/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
+++ b/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
@@ -1,0 +1,319 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System.Buffers;
+using System.Diagnostics;
+
+namespace System.Net
+{
+    // Warning: Mutable struct!
+    // The purpose of this struct is to simplify buffer management in cases where the size of the buffer may grow large (e.g. >64K),
+    // thus making it worthwhile to add the overhead involved in managing multiple individual array allocations.
+    // Like ArrayBuffer, this manages a sliding buffer where bytes can be added at the end and removed at the beginning.
+    // Unlike ArrayBuffer, the buffer itself is managed using 16K blocks which are added/removed to the block list as necessary.
+
+    // [ActiveBuffer] contains the current buffer contents; these bytes will be preserved on any call to TryEnsureAvailableBytesUpToLimit.
+    // [AvailableBuffer] contains the available bytes past the end of the current content,
+    // and can be written to in order to add data to the end of the buffer.
+    // Commit(byteCount) will extend the ActiveBuffer by [byteCount] bytes into the AvailableBuffer.
+    // Discard(byteCount) will discard [byteCount] bytes as the beginning of the ActiveBuffer.
+    // TryEnsureAvailableBytesUpToLimit will grow the buffer if necessary; *however*, this may invalidate
+    // old values of [ActiveBuffer] and [AvailableBuffer], so they must be retrieved again.
+
+    internal struct MultiArrayBuffer : IDisposable
+    {
+        private byte[]?[]? _blocks;
+        private int _blockCount;
+        private int _activeStart;
+        private int _availableStart;
+
+        // Invariants:
+        // 0 <= _activeStart <= _availableStart <= total buffer size (i.e. _blockCount * BlockSize)
+
+        private const int BlockSize = 16 * 1024;
+
+        public MultiArrayBuffer(int initialBufferSize)
+        {
+            // [initialBufferSize] is ignored for now;
+            // I kept it because some callers are passing useful info here that we might want to act on in the future.
+
+            _blocks = null;
+            _blockCount = 0;
+            _activeStart = 0;
+            _availableStart = 0;
+        }
+
+        public void Dispose()
+        {
+            _activeStart = 0;
+            _availableStart = 0;
+
+            if (_blocks is not null)
+            {
+                for (int i = 0; i < _blocks.Length; i++)
+                {
+                    if (_blocks[i] is not null)
+                    {
+                        ArrayPool<byte>.Shared.Return(_blocks[i]!);
+                        _blocks[i] = null;
+                    }
+                }
+
+                _blocks = null;
+            }
+        }
+
+        public MultiMemory ActiveMemory => _blocks is null ? MultiMemory.Empty : new MultiMemory(_blocks!, _activeStart, _availableStart - _activeStart);
+
+        public MultiMemory AvailableMemory => _blocks is null ? MultiMemory.Empty : new MultiMemory(_blocks!, _availableStart, _blockCount * BlockSize - _availableStart);
+
+        public void Discard(int byteCount)
+        {
+            Debug.Assert(byteCount >= 0);
+            Debug.Assert(byteCount <= ActiveMemory.Length, $"MultiArrayBuffer.Discard: Expected byteCount={byteCount} <= {ActiveMemory.Length}");
+
+            int oldStartBlock = _activeStart / BlockSize;
+            _activeStart += byteCount;
+            int newStartBlock = _activeStart / BlockSize;
+
+            while (oldStartBlock < newStartBlock)
+            {
+                Debug.Assert(_blocks is not null);
+                Debug.Assert(_blocks[oldStartBlock] is not null, $"Discard: oldStartBlock is null?? byteCount={byteCount}, _activeStart={_activeStart}, oldStartBlock={oldStartBlock}, newStartBlock={newStartBlock}");
+
+                ArrayPool<byte>.Shared.Return(_blocks[oldStartBlock]!);
+                _blocks[oldStartBlock] = null;
+
+                oldStartBlock++;
+            }
+
+            if (_activeStart == _availableStart)
+            {
+                // Small optimization to restart at the beginning of the current block, since we have no active bytes.
+                // Note, we don't try to release buffers in this case. Maybe we should. But if we did,
+                // we'd need handle the fact that there could be more than one here, if we previously grew the buffer enough for that.
+
+                _activeStart = newStartBlock * BlockSize;
+                _availableStart = newStartBlock * BlockSize;
+            }
+        }
+
+        public void Commit(int byteCount)
+        {
+            Debug.Assert(byteCount >= 0);
+            Debug.Assert(byteCount <= AvailableMemory.Length, $"MultiArrayBuffer.Commit: Expected byteCount={byteCount} <= {AvailableMemory.Length}");
+
+            _availableStart += byteCount;
+        }
+
+        // Ensure at least [byteCount] bytes to write to, up to the specified limit
+        public void TryEnsureAvailableSpaceUpToLimit(int byteCount, int limit)
+        {
+            if (ActiveMemory.Length >= limit)
+            {
+                // Already past limit. Do nothing.
+                return;
+            }
+
+            byteCount = Math.Min(byteCount, limit - ActiveMemory.Length);
+            if (byteCount <= AvailableMemory.Length)
+            {
+                // We have enough space available already.
+                return;
+            }
+
+            int newBytesNeeded = byteCount - AvailableMemory.Length;
+            int newBlocksNeeded = (newBytesNeeded + BlockSize - 1) / BlockSize;
+            Debug.Assert(newBlocksNeeded > 0);
+
+            if (_blocks is null)
+            {
+                Debug.Assert(_blockCount == 0);
+                Debug.Assert(_activeStart == 0);
+                Debug.Assert(_availableStart == 0);
+
+                int blockArraySize = 4;
+                while (blockArraySize < newBlocksNeeded)
+                {
+                    blockArraySize *= 2;
+                }
+
+                _blocks = new byte[]?[blockArraySize];
+            }
+            else if (_blocks.Length < _blockCount + newBlocksNeeded)
+            {
+                int firstUsedBlock = _activeStart / BlockSize;
+                int usedBlockCount = _blockCount - firstUsedBlock;
+                if (usedBlockCount + newBlocksNeeded <= _blocks.Length)
+                {
+                    // We can shift the array down to make enough space
+                    _blocks.AsSpan().Slice(firstUsedBlock, usedBlockCount).CopyTo(_blocks);
+                }
+                else
+                {
+                    // Need to reallocate the array
+                    int blockArraySize = _blocks.Length;
+                    while (blockArraySize < usedBlockCount + newBlocksNeeded)
+                    {
+                        blockArraySize *= 2;
+                    }
+
+                    byte[]?[] newBlockArray = new byte[]?[blockArraySize];
+                    _blocks.AsSpan().Slice(firstUsedBlock, usedBlockCount).CopyTo(newBlockArray);
+                    _blocks = newBlockArray;
+                }
+
+                _blockCount = usedBlockCount;
+                _activeStart -= firstUsedBlock * BlockSize;
+                _availableStart -= firstUsedBlock * BlockSize;
+
+                Debug.Assert(_activeStart / BlockSize == 0, $"Start is not in first block after move or resize?? _activeStart={_activeStart}");
+            }
+
+            Debug.Assert(_blockCount + newBlocksNeeded <= _blocks.Length, $"Not enough room for new blocks?? _blockCount={_blockCount}, newBlocksNeeded={newBlocksNeeded}, _blocks.Length={_blocks.Length}");
+
+            // Allocate new blocks
+            for (int i = 0; i < newBlocksNeeded; i++)
+            {
+                _blocks[_blockCount + i] = ArrayPool<byte>.Shared.Rent(BlockSize);
+            }
+
+            _blockCount += newBlocksNeeded;
+
+            Debug.Assert(byteCount <= AvailableMemory.Length);
+        }
+    }
+
+    // This is a Memory-like struct for handling multi-array segments from MultiArrayBuffer above.
+    // It supports standard Span/Memory operations like indexing, Slice, Length, etc
+    // It also supports CopyTo/CopyFrom Span<byte>
+
+    internal readonly struct MultiMemory
+    {
+        private readonly byte[][] _blocks;
+        private readonly int _start;
+        private readonly int _length;
+
+        private const int BlockSize = 16 * 1024;
+
+        internal MultiMemory(byte[][] blocks, int start, int length)
+        {
+            if (length == 0)
+            {
+                _blocks = Array.Empty<byte[]>();
+                _start = 0;
+                _length = 0;
+            }
+            else
+            {
+                Debug.Assert(start >= 0);
+                Debug.Assert(length >= 0);
+                Debug.Assert(start + length <= blocks.Length * BlockSize);
+
+                _blocks = blocks;
+                _start = start;
+                _length = length;
+            }
+        }
+
+        private static int GetBlockIndex(int offset) => offset / BlockSize;
+        private static int GetOffsetInBlock(int offset) => offset % BlockSize;
+
+        public int Length => _length;
+
+        public ref byte this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= _length)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                int offset = _start + index;
+                return ref _blocks[GetBlockIndex(offset)][GetOffsetInBlock(offset)];
+            }
+        }
+
+        public int BlockCount => _length == 0 ? 0 : GetBlockIndex(_start + _length - 1) - GetBlockIndex(_start) + 1;
+
+        public Memory<byte> GetBlock(int blockIndex)
+        {
+            if (blockIndex < 0 || blockIndex >= BlockCount)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            Debug.Assert(_length > 0, "Length should never be 0 here because BlockCount would be 0");
+
+            int startInBlock = (blockIndex == 0 ? GetOffsetInBlock(_start) : 0);
+            int endInBlock = (blockIndex == BlockCount - 1 ? GetOffsetInBlock(_start + _length - 1) + 1 : BlockSize);
+
+            Debug.Assert(0 <= startInBlock, $"Invalid startInBlock={startInBlock}. blockIndex={blockIndex}, _blocks.Length={_blocks.Length}, _start={_start}, _length={_length}");
+            Debug.Assert(startInBlock < endInBlock, $"Invalid startInBlock={startInBlock}, endInBlock={endInBlock}. blockIndex={blockIndex}, _blocks.Length={_blocks.Length}, _start={_start}, _length={_length}");
+            Debug.Assert(endInBlock <= BlockSize, $"Invalid endInBlock={endInBlock}. blockIndex={blockIndex}, _blocks.Length={_blocks.Length}, _start={_start}, _length={_length}");
+
+            return new Memory<byte>(_blocks[GetBlockIndex(_start) + blockIndex], startInBlock, endInBlock - startInBlock);
+        }
+
+        public MultiMemory Slice(int start)
+        {
+            if (start < 0 || start > _length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            return new MultiMemory(_blocks, _start + start, _length - start);
+        }
+
+        public MultiMemory Slice(int start, int length)
+        {
+            if (start < 0 || length < 0 || start + length > _length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            return new MultiMemory(_blocks, _start + start, length);
+        }
+
+        public void CopyTo(Span<byte> destination)
+        {
+            if (destination.Length < _length)
+            {
+                throw new ArgumentException(nameof(destination));
+            }
+
+            for (int blockIndex = 0; blockIndex < BlockCount; blockIndex++)
+            {
+                Memory<byte> block = GetBlock(blockIndex);
+                block.Span.CopyTo(destination);
+                destination = destination.Slice(block.Length);
+            }
+        }
+
+        public void CopyFrom(ReadOnlySpan<byte> source)
+        {
+            if (_length < source.Length)
+            {
+                throw new ArgumentException(nameof(source));
+            }
+
+            for (int blockIndex = 0; blockIndex < BlockCount; blockIndex++)
+            {
+                Memory<byte> block = GetBlock(blockIndex);
+
+                if (source.Length <= block.Length)
+                {
+                    source.CopyTo(block.Span);
+                    break;
+                }
+
+                source.Slice(0, block.Length).CopyTo(block.Span);
+                source = source.Slice(block.Length);
+            }
+        }
+
+        public static MultiMemory Empty => default;
+    }
+}

--- a/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
+++ b/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
@@ -65,9 +65,9 @@ namespace System.Net
             }
         }
 
-        public MultiMemory ActiveMemory => _blocks is null ? MultiMemory.Empty : new MultiMemory(_blocks, _activeStart, _availableStart - _activeStart);
+        public MultiMemory ActiveMemory => new MultiMemory(_blocks, _activeStart, _availableStart - _activeStart);
 
-        public MultiMemory AvailableMemory => _blocks is null ? MultiMemory.Empty : new MultiMemory(_blocks, _availableStart, _blockCount * BlockSize - _availableStart);
+        public MultiMemory AvailableMemory => new MultiMemory(_blocks, _availableStart, _blockCount * BlockSize - _availableStart);
 
         public void Discard(int byteCount)
         {
@@ -269,7 +269,7 @@ namespace System.Net
             }
         }
 
-        public int BlockCount => _length == 0 ? 0 : GetBlockIndex(_start + _length - 1) - GetBlockIndex(_start) + 1;
+        public int BlockCount => GetBlockIndex(_start + _length + (BlockSize - 1)) - GetBlockIndex(_start);
 
         public Memory<byte> GetBlock(int blockIndex)
         {

--- a/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
+++ b/src/libraries/Common/src/System/Net/MultiArrayBuffer.cs
@@ -223,14 +223,14 @@ namespace System.Net
 
             // Allocate new blocks
             Debug.Assert(_allocatedEnd % BlockSize == 0);
-            uint blockCount = _allocatedEnd / BlockSize;
+            uint allocatedBlockCount = _allocatedEnd / BlockSize;
             for (uint i = 0; i < newBlocksNeeded; i++)
             {
-                Debug.Assert(_blocks[blockCount + i] is null);
-                _blocks[blockCount + i] = ArrayPool<byte>.Shared.Rent(BlockSize);
+                Debug.Assert(_blocks[allocatedBlockCount] is null);
+                _blocks[allocatedBlockCount++] = ArrayPool<byte>.Shared.Rent(BlockSize);
             }
 
-            _allocatedEnd += newBlocksNeeded + blockCount;
+            _allocatedEnd = allocatedBlockCount * BlockSize;
 
             // After all of that, we should have enough available memory now
             Debug.Assert(byteCount <= AvailableMemory.Length);

--- a/src/libraries/Common/src/System/Net/StreamBuffer.cs
+++ b/src/libraries/Common/src/System/Net/StreamBuffer.cs
@@ -13,7 +13,7 @@ namespace System.IO
 {
     internal sealed class StreamBuffer : IDisposable
     {
-        private ArrayBuffer _buffer; // mutable struct, do not make this readonly
+        private MultiArrayBuffer _buffer; // mutable struct, do not make this readonly
         private readonly int _maxBufferSize;
         private bool _writeEnded;
         private bool _readAborted;
@@ -25,7 +25,7 @@ namespace System.IO
 
         public StreamBuffer(int initialBufferSize = DefaultInitialBufferSize, int maxBufferSize = DefaultMaxBufferSize)
         {
-            _buffer = new ArrayBuffer(initialBufferSize, usePool: true);
+            _buffer = new MultiArrayBuffer(initialBufferSize);
             _maxBufferSize = maxBufferSize;
             _readTaskSource = new ResettableValueTaskSource();
             _writeTaskSource = new ResettableValueTaskSource();
@@ -40,7 +40,7 @@ namespace System.IO
                 Debug.Assert(!Monitor.IsEntered(SyncObject));
                 lock (SyncObject)
                 {
-                    return (_writeEnded && _buffer.ActiveLength == 0);
+                    return (_writeEnded && _buffer.ActiveMemory.Length == 0);
                 }
             }
         }
@@ -69,7 +69,7 @@ namespace System.IO
                         return 0;
                     }
 
-                    return _buffer.ActiveLength;
+                    return _buffer.ActiveMemory.Length;
                 }
             }
         }
@@ -86,7 +86,7 @@ namespace System.IO
                         throw new InvalidOperationException();
                     }
 
-                    return _maxBufferSize - _buffer.ActiveLength;
+                    return _maxBufferSize - _buffer.ActiveMemory.Length;
                 }
             }
         }
@@ -110,10 +110,10 @@ namespace System.IO
 
                 _buffer.TryEnsureAvailableSpaceUpToLimit(buffer.Length, _maxBufferSize);
 
-                int bytesWritten = Math.Min(buffer.Length, _buffer.AvailableLength);
+                int bytesWritten = Math.Min(buffer.Length, _buffer.AvailableMemory.Length);
                 if (bytesWritten > 0)
                 {
-                    buffer.Slice(0, bytesWritten).CopyTo(_buffer.AvailableSpan);
+                    _buffer.AvailableMemory.CopyFrom(buffer.Slice(0, bytesWritten));
                     _buffer.Commit(bytesWritten);
 
                     _readTaskSource.SignalWaiter();
@@ -203,10 +203,10 @@ namespace System.IO
                     return (false, 0);
                 }
 
-                if (_buffer.ActiveLength > 0)
+                if (_buffer.ActiveMemory.Length > 0)
                 {
-                    int bytesRead = Math.Min(buffer.Length, _buffer.ActiveLength);
-                    _buffer.ActiveSpan.Slice(0, bytesRead).CopyTo(buffer);
+                    int bytesRead = Math.Min(buffer.Length, _buffer.ActiveMemory.Length);
+                    _buffer.ActiveMemory.Slice(0, bytesRead).CopyTo(buffer);
                     _buffer.Discard(bytesRead);
 
                     _writeTaskSource.SignalWaiter();
@@ -277,9 +277,9 @@ namespace System.IO
                 }
 
                 _readAborted = true;
-                if (_buffer.ActiveLength != 0)
+                if (_buffer.ActiveMemory.Length != 0)
                 {
-                    _buffer.Discard(_buffer.ActiveLength);
+                    _buffer.Discard(_buffer.ActiveMemory.Length);
                 }
 
                 _readTaskSource.SignalWaiter();

--- a/src/libraries/Common/src/System/Net/StreamBuffer.cs
+++ b/src/libraries/Common/src/System/Net/StreamBuffer.cs
@@ -40,7 +40,7 @@ namespace System.IO
                 Debug.Assert(!Monitor.IsEntered(SyncObject));
                 lock (SyncObject)
                 {
-                    return (_writeEnded && _buffer.ActiveMemory.Length == 0);
+                    return (_writeEnded && _buffer.IsEmpty);
                 }
             }
         }
@@ -203,7 +203,7 @@ namespace System.IO
                     return (false, 0);
                 }
 
-                if (_buffer.ActiveMemory.Length > 0)
+                if (!_buffer.IsEmpty)
                 {
                     int bytesRead = Math.Min(buffer.Length, _buffer.ActiveMemory.Length);
                     _buffer.ActiveMemory.Slice(0, bytesRead).CopyTo(buffer);
@@ -277,7 +277,7 @@ namespace System.IO
                 }
 
                 _readAborted = true;
-                if (_buffer.ActiveMemory.Length != 0)
+                if (!_buffer.IsEmpty)
                 {
                     _buffer.Discard(_buffer.ActiveMemory.Length);
                 }

--- a/src/libraries/Common/src/System/Net/StreamBuffer.cs
+++ b/src/libraries/Common/src/System/Net/StreamBuffer.cs
@@ -277,10 +277,7 @@ namespace System.IO
                 }
 
                 _readAborted = true;
-                if (!_buffer.IsEmpty)
-                {
-                    _buffer.Discard(_buffer.ActiveMemory.Length);
-                }
+                _buffer.DiscardAll();
 
                 _readTaskSource.SignalWaiter();
                 _writeTaskSource.SignalWaiter();

--- a/src/libraries/Common/src/System/Net/StreamBuffer.cs
+++ b/src/libraries/Common/src/System/Net/StreamBuffer.cs
@@ -108,7 +108,7 @@ namespace System.IO
                     return (false, buffer.Length);
                 }
 
-                _buffer.TryEnsureAvailableSpaceUpToLimit(buffer.Length, _maxBufferSize);
+                _buffer.EnsureAvailableSpaceUpToLimit(buffer.Length, _maxBufferSize);
 
                 int bytesWritten = Math.Min(buffer.Length, _buffer.AvailableMemory.Length);
                 if (bytesWritten > 0)

--- a/src/libraries/Common/src/System/Net/StreamBuffer.cs
+++ b/src/libraries/Common/src/System/Net/StreamBuffer.cs
@@ -292,7 +292,10 @@ namespace System.IO
             AbortRead();
             EndWrite();
 
-            _buffer.Dispose();
+            lock (SyncObject)
+            {
+                _buffer.Dispose();
+            }
         }
 
         private sealed class ResettableValueTaskSource : IValueTaskSource

--- a/src/libraries/Common/tests/Common.Tests.csproj
+++ b/src/libraries/Common/tests/Common.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Tests\System\Collections\Generic\LargeArrayBuilderTests.cs" />
     <Compile Include="Tests\System\IO\RowConfigReaderTests.cs" />
     <Compile Include="Tests\System\Net\HttpKnownHeaderNamesTests.cs" />
+    <Compile Include="Tests\System\Net\MultiArrayBufferTests.cs" />
     <Compile Include="Tests\System\Net\aspnetcore\Http2\DynamicTableTest.cs" />
     <Compile Include="Tests\System\Net\aspnetcore\Http2\HPackDecoderTest.cs" />
     <Compile Include="Tests\System\Net\aspnetcore\Http2\HPackIntegerTest.cs" />
@@ -106,6 +107,7 @@
     <Compile Include="Tests\System\IO\ConnectedStreamsTests.cs" />
     <Compile Include="Tests\System\IO\StreamConformanceTests.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
   </ItemGroup>

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -351,6 +351,8 @@ namespace System
                 throw new XunitException(AddOptionalUserMessage($"Expected: {actual} to be greater than or equal to {greaterThanOrEqualTo}", userMessage));
         }
 
+        // NOTE: Consider using SequenceEqual below instead, as it will give more useful information about what
+        // the actual differences are, especially for large arrays/spans.
         /// <summary>
         /// Validates that the actual array is equal to the expected array. XUnit only displays the first 5 values
         /// of each collection if the test fails. This doesn't display at what point or how the equality assertion failed.
@@ -430,6 +432,53 @@ namespace System
             }
         }
 		
+        /// <summary>
+        /// Validates that the actual span is equal to the expected span.
+        /// If this fails, determine where the differences are and create an exception with that information.
+        /// </summary>
+        /// <param name="expected">The array that <paramref name="actual"/> should be equal to.</param>
+        /// <param name="actual"></param>
+        public static void SequenceEqual<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual) where T : IEquatable<T>
+        {
+            // Use the SequenceEqual to compare the arrays for better performance. The default Assert.Equal method compares
+            // the arrays by boxing each element that is very slow for large arrays.
+            if (!expected.SequenceEqual(actual))
+            {
+                if (expected.Length != actual.Length)
+                {
+                    throw new XunitException($"Expected: Span of length {expected.Length}{Environment.NewLine}Actual: Span of length {actual.Length}");
+                }
+                else
+                {
+                    const int maxDiffsToShow = 10;      // arbitrary; enough to be useful, hopefully, but still manageable
+
+                    int diffCount = 0;
+                    string message = $"Showing first {maxDiffsToShow} differences{Environment.NewLine}";
+                    for (int i = 0; i < expected.Length; i++)
+                    {
+                        if (!expected[i].Equals(actual[i]))
+                        {
+                            diffCount++;
+
+                            // Add up to 10 differences to the exception message
+                            if (diffCount <= maxDiffsToShow)
+                            {
+                                message += $"  Position {i}: Expected: {expected[i]}, Actual: {actual[i]}{Environment.NewLine}";
+                            }
+                        }
+                    }
+
+                    message += $"Total number of differences: {diffCount} out of {expected.Length}";
+
+                    throw new XunitException(message);
+                }
+            }
+        }
+
+        public static void SequenceEqual<T>(Span<T> expected, Span<T> actual) where T : IEquatable<T> => SequenceEqual((ReadOnlySpan<T>)expected, (ReadOnlySpan<T>)actual);
+
+        public static void SequenceEqual<T>(T[] expected, T[] actual) where T : IEquatable<T> => SequenceEqual(expected.AsSpan(), actual.AsSpan());
+
         public static void AtLeastOneEquals<T>(T expected1, T expected2, T value)
         {
             EqualityComparer<T> comparer = EqualityComparer<T>.Default;

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -450,10 +450,10 @@ namespace System
                 }
                 else
                 {
-                    const int maxDiffsToShow = 10;      // arbitrary; enough to be useful, hopefully, but still manageable
+                    const int MaxDiffsToShow = 10;      // arbitrary; enough to be useful, hopefully, but still manageable
 
                     int diffCount = 0;
-                    string message = $"Showing first {maxDiffsToShow} differences{Environment.NewLine}";
+                    string message = $"Showing first {MaxDiffsToShow} differences{Environment.NewLine}";
                     for (int i = 0; i < expected.Length; i++)
                     {
                         if (!expected[i].Equals(actual[i]))
@@ -461,7 +461,7 @@ namespace System
                             diffCount++;
 
                             // Add up to 10 differences to the exception message
-                            if (diffCount <= maxDiffsToShow)
+                            if (diffCount <= MaxDiffsToShow)
                             {
                                 message += $"  Position {i}: Expected: {expected[i]}, Actual: {actual[i]}{Environment.NewLine}";
                             }

--- a/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
@@ -905,7 +905,7 @@ namespace System.IO.Tests
                 Assert.Equal(size, stream.Seek(0, SeekOrigin.Current));
             }
 
-            AssertExtensions.Equal(expected, actual.ToArray());
+            AssertExtensions.SequenceEqual(expected, actual.ToArray());
         }
 
         [Theory]
@@ -990,7 +990,7 @@ namespace System.IO.Tests
             stream.Position = 0;
             byte[] actual = (byte[])expected.Clone();
             Assert.Equal(actual.Length, await ReadAllAsync(ReadWriteMode.AsyncMemory, stream, actual, 0, actual.Length));
-            AssertExtensions.Equal(expected, actual);
+            AssertExtensions.SequenceEqual(expected, actual);
         }
 
         [Theory]
@@ -1032,7 +1032,7 @@ namespace System.IO.Tests
                 Assert.Equal(expected.Length, stream.Position);
             }
 
-            AssertExtensions.Equal(expected.AsSpan(position).ToArray(), destination.ToArray());
+            AssertExtensions.SequenceEqual(expected.AsSpan(position).ToArray(), destination.ToArray());
         }
 
         public static IEnumerable<object[]> CopyTo_CopiesAllDataFromRightPosition_Success_MemberData()
@@ -1073,7 +1073,7 @@ namespace System.IO.Tests
             for (int i = 0; i < Copies; i++)
             {
                 int bytesRead = await ReadAllAsync(mode, stream, actual, 0, actual.Length);
-                AssertExtensions.Equal(expected, actual);
+                AssertExtensions.SequenceEqual(expected, actual);
                 Array.Clear(actual, 0, actual.Length);
             }
         }
@@ -1686,7 +1686,7 @@ namespace System.IO.Tests
                     readerBytes[i] = (byte)r;
                 }
 
-                AssertExtensions.Equal(writerBytes, readerBytes);
+                AssertExtensions.SequenceEqual(writerBytes, readerBytes);
 
                 await writes;
 
@@ -1760,7 +1760,7 @@ namespace System.IO.Tests
                     }
 
                     Assert.Equal(readerBytes.Length, n);
-                    AssertExtensions.Equal(writerBytes, readerBytes);
+                    AssertExtensions.SequenceEqual(writerBytes, readerBytes);
 
                     await writes;
 
@@ -2369,7 +2369,7 @@ namespace System.IO.Tests
             writeable.Dispose();
             await copyTask;
 
-            AssertExtensions.Equal(dataToCopy, results.ToArray());
+            AssertExtensions.SequenceEqual(dataToCopy, results.ToArray());
         }
 
         [OuterLoop("May take several seconds")]

--- a/src/libraries/Common/tests/Tests/System/Net/MultiArrayBufferTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/MultiArrayBufferTests.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Linq;
+using Xunit;
+
+namespace Tests.System.Net
+{
+    public sealed class MultiArrayBufferTests
+    {
+        [Fact]
+        public void BasicTest()
+        {
+            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+            Assert.Equal(0, buffer.ActiveMemory.BlockCount);
+
+            buffer.TryEnsureAvailableSpaceUpToLimit(3, int.MaxValue);
+
+            int available = buffer.AvailableMemory.Length;
+            Assert.True(available >= 3);
+
+            buffer.AvailableMemory[0] = 10;
+            buffer.Commit(1);
+
+            Assert.Equal(1, buffer.ActiveMemory.Length);
+            Assert.Equal(10, buffer.ActiveMemory[0]);
+            Assert.Equal(available - 1, buffer.AvailableMemory.Length);
+            Assert.Equal(1, buffer.ActiveMemory.BlockCount);
+            Assert.Equal(10, buffer.ActiveMemory.GetBlock(0).Span[0]);
+
+            buffer.AvailableMemory[0] = 20;
+            buffer.Commit(1);
+
+            Assert.Equal(2, buffer.ActiveMemory.Length);
+            Assert.Equal(20, buffer.ActiveMemory[1]);
+            Assert.Equal(available - 2, buffer.AvailableMemory.Length);
+            Assert.InRange(buffer.ActiveMemory.BlockCount, 1, 2);
+
+            buffer.AvailableMemory[0] = 30;
+            buffer.Commit(1);
+
+            Assert.Equal(3, buffer.ActiveMemory.Length);
+            Assert.Equal(30, buffer.ActiveMemory[2]);
+            Assert.Equal(available - 3, buffer.AvailableMemory.Length);
+            Assert.InRange(buffer.ActiveMemory.BlockCount, 1, 2);
+
+            buffer.Discard(1);
+            Assert.Equal(2, buffer.ActiveMemory.Length);
+            Assert.Equal(20, buffer.ActiveMemory[0]);
+            Assert.InRange(buffer.ActiveMemory.BlockCount, 1, 2);
+            Assert.Equal(20, buffer.ActiveMemory.GetBlock(0).Span[0]);
+
+            buffer.Discard(1);
+            Assert.Equal(1, buffer.ActiveMemory.Length);
+            Assert.Equal(30, buffer.ActiveMemory[0]);
+            Assert.Equal(1, buffer.ActiveMemory.BlockCount);
+            Assert.Equal(30, buffer.ActiveMemory.GetBlock(0).Span[0]);
+
+            buffer.Discard(1);
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+            Assert.Equal(0, buffer.ActiveMemory.BlockCount);
+        }
+
+        [Fact]
+        public void AddByteByByteAndConsumeByteByByte_Success()
+        {
+            const int Size = 64 * 1024 + 1;
+
+            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+
+            for (int i = 0; i < Size; i++)
+            {
+                buffer.TryEnsureAvailableSpaceUpToLimit(1, int.MaxValue);
+                buffer.AvailableMemory[0] = (byte)i;
+                buffer.Commit(1);
+            }
+
+            for (int i = 0; i < Size; i++)
+            {
+                Assert.Equal((byte)i, buffer.ActiveMemory[0]);
+                buffer.Discard(1);
+            }
+
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+        }
+
+        [Fact]
+        public void AddSeveralBytesRepeatedlyAndConsumeSeveralBytesRepeatedly_Success()
+        {
+            const int ByteCount = 7;
+            const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
+
+            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                buffer.TryEnsureAvailableSpaceUpToLimit(ByteCount, int.MaxValue);
+                for (int j = 0; j < ByteCount; j++)
+                {
+                    buffer.AvailableMemory[j] = (byte)(j + 1);
+                }
+                buffer.Commit(ByteCount);
+            }
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                for (int j = 0; j < ByteCount; j++)
+                {
+                    Assert.Equal(j + 1, buffer.ActiveMemory[j]);
+                }
+                buffer.Discard(ByteCount);
+            }
+
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+        }
+
+        [Fact]
+        public void AddSeveralBytesRepeatedlyAndConsumeSeveralBytesRepeatedly_UsingSlice_Success()
+        {
+            const int ByteCount = 7;
+            const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
+
+            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                buffer.TryEnsureAvailableSpaceUpToLimit(ByteCount, int.MaxValue);
+                for (int j = 0; j < ByteCount; j++)
+                {
+                    buffer.AvailableMemory.Slice(j)[0] = (byte)(j + 1);
+                }
+                buffer.Commit(ByteCount);
+            }
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                for (int j = 0; j < ByteCount; j++)
+                {
+                    Assert.Equal(j + 1, buffer.ActiveMemory.Slice(j)[0]);
+                }
+                buffer.Discard(ByteCount);
+            }
+
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+        }
+
+        [Fact]
+        public void AddSeveralBytesRepeatedlyAndConsumeSeveralBytesRepeatedly_UsingSliceWithLength_Success()
+        {
+            const int ByteCount = 7;
+            const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
+
+            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                buffer.TryEnsureAvailableSpaceUpToLimit(ByteCount, int.MaxValue);
+                for (int j = 0; j < ByteCount; j++)
+                {
+                    buffer.AvailableMemory.Slice(j, ByteCount - j)[0] = (byte)(j + 1);
+                }
+                buffer.Commit(ByteCount);
+            }
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                for (int j = 0; j < ByteCount; j++)
+                {
+                    Assert.Equal(j + 1, buffer.ActiveMemory.Slice(j, ByteCount - j)[0]);
+                }
+                buffer.Discard(ByteCount);
+            }
+
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+        }
+
+        [Fact]
+        public void CopyFromRepeatedlyAndCopyToRepeatedly_Success()
+        {
+            ReadOnlySpan<byte> source = new byte[] { 1, 2, 3, 4, 5, 6, 7 }.AsSpan();
+
+            const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
+
+            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                buffer.TryEnsureAvailableSpaceUpToLimit(source.Length, int.MaxValue);
+                buffer.AvailableMemory.CopyFrom(source);
+                buffer.Commit(source.Length);
+            }
+
+            Span<byte> destination = new byte[source.Length].AsSpan();
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                buffer.ActiveMemory.Slice(0, source.Length).CopyTo(destination);
+                Assert.True(source.SequenceEqual(destination));
+                buffer.Discard(source.Length);
+            }
+
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+        }
+
+        [Fact]
+        public void CopyFromRepeatedlyAndCopyToRepeatedly_LargeCopies_Success()
+        {
+            ReadOnlySpan<byte> source = Enumerable.Range(0, 64 * 1024 - 1).Select(x => (byte)x).ToArray().AsSpan();
+
+            const int RepeatCount = 13;
+
+            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                buffer.TryEnsureAvailableSpaceUpToLimit(source.Length, int.MaxValue);
+                buffer.AvailableMemory.CopyFrom(source);
+                buffer.Commit(source.Length);
+            }
+
+            Span<byte> destination = new byte[source.Length].AsSpan();
+            for (int i = 0; i < RepeatCount; i++)
+            {
+                buffer.ActiveMemory.Slice(0, source.Length).CopyTo(destination);
+                Assert.True(source.SequenceEqual(destination));
+                buffer.Discard(source.Length);
+            }
+
+            Assert.Equal(0, buffer.ActiveMemory.Length);
+        }
+
+        [Fact]
+        public void EmptyMultiMemoryTest()
+        {
+            MultiMemory mm = MultiMemory.Empty;
+
+            Assert.Equal(0, mm.Length);
+            Assert.Equal(0, mm.BlockCount);
+            Assert.Equal(0, mm.Slice(0).Length);
+            Assert.Equal(0, mm.Slice(0, 0).Length);
+
+            // These should not throw
+            mm.CopyTo(new byte[0]);
+            mm.CopyFrom(new byte[0]);
+        }
+    }
+}

--- a/src/libraries/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
+++ b/src/libraries/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.BOOL.cs" Link="ProductionCode\Common\Interop\Windows\Interop.BOOL.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="ProductionCode\Common\Interop\Windows\Interop.Libraries.cs" />

--- a/src/libraries/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
+++ b/src/libraries/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />

--- a/src/libraries/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
+++ b/src/libraries/System.IO.UnmanagedMemoryStream/tests/System.IO.UnmanagedMemoryStream.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />

--- a/src/libraries/System.IO/tests/System.IO.Tests.csproj
+++ b/src/libraries/System.IO/tests/System.IO.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
   </ItemGroup>

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -122,6 +122,8 @@
              Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs"
              Link="Common\System\Net\ArrayBuffer.cs"/>
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs"
+             Link="Common\System\Net\MultiArrayBuffer.cs"/>
   </ItemGroup>
   <!-- SocketsHttpHandler implementation -->
   <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -810,7 +810,7 @@ namespace System.Net.Http
                         ThrowProtocolError(Http2ProtocolErrorCode.FlowControlError);
                     }
 
-                    _responseBuffer.TryEnsureAvailableSpaceUpToLimit(buffer.Length, int.MaxValue);
+                    _responseBuffer.EnsureAvailableSpace(buffer.Length);
                     _responseBuffer.AvailableMemory.CopyFrom(buffer);
                     _responseBuffer.Commit(buffer.Length);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1280,7 +1280,10 @@ namespace System.Net.Http
                     Cancel();
                 }
 
-                _responseBuffer.Dispose();
+                lock (SyncObject)
+                {
+                    _responseBuffer.Dispose();
+                }
             }
 
             private CancellationTokenRegistration RegisterRequestBodyCancellation(CancellationToken cancellationToken) =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -172,6 +172,8 @@
              Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs"
              Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs"
+             Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs"
              Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
   </ItemGroup>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -21,6 +21,7 @@
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs" Link="Common\System\Net\Logging\NetEventSource.Common.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="Common\System\Net\StreamBuffer.cs" />
   </ItemGroup>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="TestCommon\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
   </ItemGroup>

--- a/src/libraries/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/EnterpriseTests/System.Net.Security.Enterprise.Tests.csproj
@@ -9,6 +9,8 @@
     <!-- Common test files -->
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs"
              Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs"
+             Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs"
              Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs"

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -83,6 +83,8 @@
              Link="ProductionCode\Common\System\IO\DelegatingStream.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs"
              Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs"
+             Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs"
              Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="..\..\src\System\Net\Security\TlsFrameHelper.cs"

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
   </ItemGroup>

--- a/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
+    <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
MultiArrayBuffer is a struct that manages a sliding buffer, where bytes be added at the end and removed at the beginning, similar to existing ArrayBuffer. Unlike ArrayBuffer, it manages a list of fixed-size (16K) blocks internally.

This is most useful for scenarios where the buffer may grow large, and thus managing it as a single array is probably not efficient.

MultiArrayBuffer is now used in the HTTP2 response buffer code, as well as in StreamBuffer (used by ConnectedStreams and mock QUIC provider).

(Edit: This got moved to a separate PR, now merged) Also, change stream conformance tests to not use Assert.Equals for buffer comparsion, as it is very, very slow. This reduces the time of outerloop StreamConformanceTests by approximately 99%.

Edit: Also add AssertExtensions.SequenceEqual to provide more useful diff information when sequence comparison fails, and use it in stream conformance tests.

@stephentoub @dotnet/ncl