### PR TITLE
Fix pal cgroup v2 implementation

### DIFF
--- a/src/coreclr/src/gc/unix/cgroup.cpp
+++ b/src/coreclr/src/gc/unix/cgroup.cpp
@@ -66,8 +66,8 @@ public:
     static void Initialize()
     {
         s_cgroup_version = FindCGroupVersion();
-        s_memory_cgroup_path = FindCGroupPath(&IsCGroup1MemorySubsystem);
-        s_cpu_cgroup_path = FindCGroupPath(&IsCGroup1CpuSubsystem);
+        s_memory_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1MemorySubsystem : nullptr);
+        s_cpu_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1CpuSubsystem : nullptr);
     }
 
     static void Cleanup()
@@ -257,12 +257,19 @@ private:
 
             if (strncmp(filesystemType, "cgroup", 6) == 0)
             {
-                char* context = nullptr;
-                char* strTok = strtok_r(options, ",", &context);
-                while (strTok != nullptr)
+                bool is_subsystem_match = is_subsystem == nullptr;
+                if (!is_subsystem_match)
                 {
-                    if ((s_cgroup_version == 2) || ((s_cgroup_version == 1) && is_subsystem(strTok)))
+                    char* context = nullptr;
+                    char* strTok = strtok_r(options, ",", &context);
+                    while (!is_subsystem_match && strTok != nullptr)
                     {
+                        is_subsystem_match = is_subsystem(strTok);
+                        strTok = strtok_r(nullptr, ",", &context);
+                    }
+                }
+                if (is_subsystem_match)
+                {
                         mountpath = (char*)malloc(lineLen+1);
                         if (mountpath == nullptr)
                             goto done;
@@ -281,9 +288,6 @@ private:
                         *pmountpath = mountpath;
                         *pmountroot = mountroot;
                         mountpath = mountroot = nullptr;
-                        goto done;
-                    }
-                    strTok = strtok_r(nullptr, ",", &context);
                 }
             }
         }

--- a/src/coreclr/src/gc/unix/cgroup.cpp
+++ b/src/coreclr/src/gc/unix/cgroup.cpp
@@ -257,18 +257,18 @@ private:
 
             if (strncmp(filesystemType, "cgroup", 6) == 0)
             {
-                bool is_subsystem_match = is_subsystem == nullptr;
-                if (!is_subsystem_match)
+                bool isSubsystemMatch = is_subsystem == nullptr;
+                if (!isSubsystemMatch)
                 {
                     char* context = nullptr;
                     char* strTok = strtok_r(options, ",", &context);
-                    while (!is_subsystem_match && strTok != nullptr)
+                    while (!isSubsystemMatch && strTok != nullptr)
                     {
-                        is_subsystem_match = is_subsystem(strTok);
+                        isSubsystemMatch = is_subsystem(strTok);
                         strTok = strtok_r(nullptr, ",", &context);
                     }
                 }
-                if (is_subsystem_match)
+                if (isSubsystemMatch)
                 {
                         mountpath = (char*)malloc(lineLen+1);
                         if (mountpath == nullptr)

--- a/src/coreclr/src/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/src/pal/src/misc/cgroup.cpp
@@ -53,8 +53,8 @@ public:
     static void Initialize()
     {
         s_cgroup_version = FindCGroupVersion();
-        s_memory_cgroup_path = FindCGroupPath(&IsCGroup1MemorySubsystem);
-        s_cpu_cgroup_path = FindCGroupPath(&IsCGroup1CpuSubsystem);
+        s_memory_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1MemorySubsystem : nullptr);
+        s_cpu_cgroup_path = FindCGroupPath(s_cgroup_version == 1 ? &IsCGroup1CpuSubsystem : nullptr);
     }
 
     static void Cleanup()
@@ -245,33 +245,37 @@ private:
 
             if (strncmp(filesystemType, "cgroup", 6) == 0)
             {
-                char* context = nullptr;
-                char* strTok = strtok_s(options, ",", &context);
-                while (strTok != nullptr)
+                bool is_subsystem_match = is_subsystem == nullptr;
+                if (!is_subsystem_match)
                 {
-                    if (is_subsystem(strTok))
+                    char* context = nullptr;
+                    char* strTok = strtok_s(options, ",", &context);
+                    while (!is_subsystem_match && strTok != nullptr)
                     {
-                        mountpath = (char*)PAL_malloc(lineLen+1);
-                        if (mountpath == nullptr)
-                            goto done;
-                        mountroot = (char*)PAL_malloc(lineLen+1);
-                        if (mountroot == nullptr)
-                            goto done;
-
-                        sscanfRet = sscanf_s(line,
-                                             "%*s %*s %*s %s %s ",
-                                             mountroot, lineLen+1,
-                                             mountpath, lineLen+1);
-                        if (sscanfRet != 2)
-                            _ASSERTE(!"Failed to parse mount info file contents with sscanf_s.");
-
-                        // assign the output arguments and clear the locals so we don't free them.
-                        *pmountpath = mountpath;
-                        *pmountroot = mountroot;
-                        mountpath = mountroot = nullptr;
-                        goto done;
+                        is_subsystem_match = is_subsystem(strTok);
+                        strTok = strtok_s(nullptr, ",", &context);
                     }
-                    strTok = strtok_s(nullptr, ",", &context);
+                }
+                if (is_subsystem_match)
+                {
+                    mountpath = (char*)PAL_malloc(lineLen+1);
+                    if (mountpath == nullptr)
+                        goto done;
+                    mountroot = (char*)PAL_malloc(lineLen+1);
+                    if (mountroot == nullptr)
+                        goto done;
+
+                    sscanfRet = sscanf_s(line,
+                                        "%*s %*s %*s %s %s ",
+                                        mountroot, lineLen+1,
+                                        mountpath, lineLen+1);
+                    if (sscanfRet != 2)
+                        _ASSERTE(!"Failed to parse mount info file contents with sscanf_s.");
+
+                    // assign the output arguments and clear the locals so we don't free them.
+                    *pmountpath = mountpath;
+                    *pmountroot = mountroot;
+                    mountpath = mountroot = nullptr;
                 }
             }
         }
@@ -343,7 +347,7 @@ private:
                 // See https://www.kernel.org/doc/Documentation/cgroup-v2.txt
                 // Look for a "0::/some/path"
                 int sscanfRet = sscanf_s(line,
-                                         "0::%s", lineLen+1,
+                                         "0::%s",
                                          cgroup_path, lineLen+1);
                 if (sscanfRet == 1)
                 {

--- a/src/coreclr/src/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/src/pal/src/misc/cgroup.cpp
@@ -245,18 +245,18 @@ private:
 
             if (strncmp(filesystemType, "cgroup", 6) == 0)
             {
-                bool is_subsystem_match = is_subsystem == nullptr;
-                if (!is_subsystem_match)
+                bool isSubsystemMatch = is_subsystem == nullptr;
+                if (!isSubsystemMatch)
                 {
                     char* context = nullptr;
                     char* strTok = strtok_s(options, ",", &context);
-                    while (!is_subsystem_match && strTok != nullptr)
+                    while (!isSubsystemMatch && strTok != nullptr)
                     {
-                        is_subsystem_match = is_subsystem(strTok);
+                        isSubsystemMatch = is_subsystem(strTok);
                         strTok = strtok_s(nullptr, ",", &context);
                     }
                 }
-                if (is_subsystem_match)
+                if (isSubsystemMatch)
                 {
                     mountpath = (char*)PAL_malloc(lineLen+1);
                     if (mountpath == nullptr)


### PR DESCRIPTION
Fixes two issues in src/pal/src/misc/cgroup.cpp:

* No subsystem match must be performed for cgroup v2.
* Incorrect arguments for sscanf_s when reading cgroup path.

The src/gc/unix/cgroup.cpp implementation doesn't have these issues.

cc @janvorli @omajid 