### PR TITLE
Don't allocate temp strings in AppendSpanFormattable for primitives

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1179,10 +1179,13 @@ namespace System.Text
                 return this;
             }
 
-            Span<char> tempBuffer = stackalloc char[24]; // should be enough for all primitives
-            if (value.TryFormat(tempBuffer, out int charsWritten, format: default, provider: null))
+            unsafe
             {
-                return Append(tempBuffer.Slice(0, charsWritten));
+                Span<char> tempBuffer = stackalloc char[24]; // should be enough for all primitives
+                if (value.TryFormat(tempBuffer, out int charsWritten, format: default, provider: null))
+                {
+                    return Append(tempBuffer.Slice(0, charsWritten));
+                }
             }
 
             return Append(value.ToString());

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1181,10 +1181,10 @@ namespace System.Text
 
             unsafe
             {
-                Span<char> tempBuffer = stackalloc char[24]; // should be enough for all primitives
-                if (value.TryFormat(tempBuffer, out int charsWritten, format: default, provider: null))
+                Span<char> tempBuffer = stackalloc char[28]; // should be enough for all primitives
+                if (value.TryFormat(tempBuffer, out int charsWrittenToTmp, format: default, provider: null))
                 {
-                    return Append(tempBuffer.Slice(0, charsWritten));
+                    return Append(tempBuffer.Slice(0, charsWrittenToTmp));
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1179,6 +1179,12 @@ namespace System.Text
                 return this;
             }
 
+            Span<char> tempBuffer = stackalloc char[24]; // should be enough for all primitives
+            if (value.TryFormat(tempBuffer, out int charsWritten, format: default, provider: null))
+            {
+                return Append(tempBuffer);
+            }
+
             return Append(value.ToString());
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1182,7 +1182,7 @@ namespace System.Text
             Span<char> tempBuffer = stackalloc char[24]; // should be enough for all primitives
             if (value.TryFormat(tempBuffer, out int charsWritten, format: default, provider: null))
             {
-                return Append(tempBuffer);
+                return Append(tempBuffer.Slice(0, charsWritten));
             }
 
             return Append(value.ToString());


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/44992

The longest string I found is `{؜-100000000000000٫00000000000000}` (`decimal` on `ar` culture) - 32 chars.

I'm leaving the `string` fallback for marginal cases (custom separators etc)