### PR TITLE
[release/5.0] Fix CFB8 with Zero padding

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -156,7 +156,7 @@ namespace Internal.Cryptography
                 //
                 //  xx 00 00 00 00 00 00 00
                 case PaddingMode.Zeros:
-                    if (padBytes == InputBlockSize)
+                    if (padBytes == PaddingSizeBytes)
                     {
                         padBytes = 0;
                     }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
@@ -127,17 +127,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         {
             byte[] encryptedBytes = new byte[]
             {
-                0x7C, 0xC6, 0xEE, 0xD8, 0xED, 0xB5, 0x3F, 0x8A, 
-                0x90, 0x95, 0x12, 0xD2, 0xBC, 0x9A, 0x96, 0x1E, 
-                0x4E, 0xC4, 0xD1, 0x15, 0xA4, 0x7F, 0x32, 0xA4, 
-                0xD1, 0xFD, 0x8E, 0x02, 0x45, 0xE8, 0x93, 0x3C, 
-                0x3C, 0x91, 0x3F, 0xA4, 0x7F, 0x99, 0xF7, 0x3A, 
-                0x53, 0x0C, 0x0B, 0xFD, 0x01, 0xC5, 0xBD, 0x76, 
-                0xB7, 0xCF, 0x2B, 0x52, 0x34, 0xB1, 0xA6, 0xA4, 
-                0x29, 0x2F, 0x7D, 0x1C, 0x97, 0x3A, 0xE2, 0x75, 
-                0x3E, 0xEB, 0xFC, 0xB7, 0xBB, 0x7A, 0xC0, 0x66, 
-                0x34, 0x25, 0xCF, 0x2D, 0xE2, 0x7E, 0x23, 0x06, 
-                0x10, 0xFE, 0xEA, 0xB3, 0x0F, 0x1D, 0x2C, 0xDD, 
+                0x7C, 0xC6, 0xEE, 0xD8, 0xED, 0xB5, 0x3F, 0x8A,
+                0x90, 0x95, 0x12, 0xD2, 0xBC, 0x9A, 0x96, 0x1E,
+                0x4E, 0xC4, 0xD1, 0x15, 0xA4, 0x7F, 0x32, 0xA4,
+                0xD1, 0xFD, 0x8E, 0x02, 0x45, 0xE8, 0x93, 0x3C,
+                0x3C, 0x91, 0x3F, 0xA4, 0x7F, 0x99, 0xF7, 0x3A,
+                0x53, 0x0C, 0x0B, 0xFD, 0x01, 0xC5, 0xBD, 0x76,
+                0xB7, 0xCF, 0x2B, 0x52, 0x34, 0xB1, 0xA6, 0xA4,
+                0x29, 0x2F, 0x7D, 0x1C, 0x97, 0x3A, 0xE2, 0x75,
+                0x3E, 0xEB, 0xFC, 0xB7, 0xBB, 0x7A, 0xC0, 0x66,
+                0x34, 0x25, 0xCF, 0x2D, 0xE2, 0x7E, 0x23, 0x06,
+                0x10, 0xFE, 0xEA, 0xB3, 0x0F, 0x1D, 0x2C, 0xDD,
                 0x72, 0x64, 0x51, 0x78, 0x1D, 0x75, 0xD2, 0x17
             };
 
@@ -149,17 +149,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         {
             byte[] encryptedBytes = new byte[]
             {
-                0x5B, 0x63, 0x3D, 0x1C, 0x0C, 0x8E, 0xD4, 0xF4, 
-                0xE5, 0x5F, 0xA0, 0xAF, 0x2F, 0xF5, 0xAE, 0x59, 
-                0xB9, 0xC4, 0xFA, 0x02, 0x11, 0x37, 0xEB, 0x38, 
-                0x5B, 0x2F, 0x1D, 0xF5, 0x03, 0xD1, 0xFD, 0x85, 
-                0x4B, 0xAA, 0x4F, 0x29, 0x94, 0x09, 0x31, 0x4C, 
-                0x4D, 0xD6, 0x99, 0xE3, 0x4D, 0xC4, 0x3A, 0x40, 
-                0x97, 0x58, 0xA5, 0x26, 0x80, 0xA8, 0xCA, 0xFA, 
-                0x6D, 0x19, 0x3B, 0x6B, 0x6F, 0x75, 0x76, 0x83, 
-                0x90, 0x31, 0x07, 0x86, 0x35, 0xD6, 0xAB, 0xB4, 
-                0x65, 0x07, 0x0A, 0x0A, 0xA3, 0x7A, 0xD7, 0x16, 
-                0xE2, 0xC5, 0x3B, 0xE0, 0x42, 0x5F, 0xFA, 0xEF, 
+                0x5B, 0x63, 0x3D, 0x1C, 0x0C, 0x8E, 0xD4, 0xF4,
+                0xE5, 0x5F, 0xA0, 0xAF, 0x2F, 0xF5, 0xAE, 0x59,
+                0xB9, 0xC4, 0xFA, 0x02, 0x11, 0x37, 0xEB, 0x38,
+                0x5B, 0x2F, 0x1D, 0xF5, 0x03, 0xD1, 0xFD, 0x85,
+                0x4B, 0xAA, 0x4F, 0x29, 0x94, 0x09, 0x31, 0x4C,
+                0x4D, 0xD6, 0x99, 0xE3, 0x4D, 0xC4, 0x3A, 0x40,
+                0x97, 0x58, 0xA5, 0x26, 0x80, 0xA8, 0xCA, 0xFA,
+                0x6D, 0x19, 0x3B, 0x6B, 0x6F, 0x75, 0x76, 0x83,
+                0x90, 0x31, 0x07, 0x86, 0x35, 0xD6, 0xAB, 0xB4,
+                0x65, 0x07, 0x0A, 0x0A, 0xA3, 0x7A, 0xD7, 0x16,
+                0xE2, 0xC5, 0x3B, 0xE0, 0x42, 0x5F, 0xFA, 0xEF,
                 0xE1, 0x2E, 0x40, 0x84, 0x36, 0x66, 0xB1, 0xBA
             };
 
@@ -655,7 +655,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                     feedbackSize: 128)
             );
         }
-        
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         public static void VerifyKnownTransform_CFB128_128_PKCS7_4()
         {
@@ -682,15 +682,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_128_NoPadding_0_Extended()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_128_NoOrZeroPadding_0_Extended(PaddingMode paddingMode)
         {
             // NIST CAVP AESMMT.ZIP CFB8MMT128.rsp, [ENCRYPT] COUNT=0
             // plaintext zero-extended to a full block, cipherBytes extended value
             // provided by .NET Framework
             TestAesTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "c57d699d89df7cfbef71c080a6b10ac3".HexToByteArray(),
                 iv: "fcb2bc4c006b87483978796a2ae2c42e".HexToByteArray(),
                 plainBytes: ("61" + "000000000000000000000000000000").HexToByteArray(),
@@ -698,15 +700,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_128_NoPadding_9_Extended()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_128_NoOrZeroPadding_9_Extended(PaddingMode paddingMode)
         {
             // NIST CAVP AESMMT.ZIP CFB8MMT128.rsp, [ENCRYPT] COUNT=9
             // plaintext zero-extended to a full block, cipherBytes extended value
             // provided by .NET Framework
             TestAesTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "3a6f9159263fa6cef2a075caface5817".HexToByteArray(),
                 iv: "0fc23662b7dbf73827f0c7de321ca36e".HexToByteArray(),
                 plainBytes: ("87efeb8d559ed3367728" + "000000000000").HexToByteArray(),
@@ -714,15 +718,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_192_NoPadding_0_Extended()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_192_NoOrZeroPadding_0_Extended(PaddingMode paddingMode)
         {
             // NIST CAVP AESMMT.ZIP CFB8MMT192.rsp, [ENCRYPT] COUNT=0
             // plaintext zero-extended to a full block, cipherBytes extended value
             // provided by .NET Framework
             TestAesTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "32a1b0e3da368db563d7316b9779d3327e53d9a6d287ed97".HexToByteArray(),
                 iv: "3dd0e7e21f09d5842f3a699da9b57346".HexToByteArray(),
                 plainBytes: ("54" + "000000000000000000000000000000").HexToByteArray(),
@@ -730,15 +736,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_192_NoPadding_9_Extended()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_192_NoOrZeroPadding_9_Extended(PaddingMode paddingMode)
         {
             // NIST CAVP AESMMT.ZIP CFB8MMT192.rsp, [ENCRYPT] COUNT=9
             // plaintext zero-extended to a full block, cipherBytes extended value
             // provided by .NET Framework
             TestAesTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "537e7bf661fd4024a024613f15b13690f7d0c847c1e18965".HexToByteArray(),
                 iv: "3a81f9d9d3c155b0caad5d73349476fc".HexToByteArray(),
                 plainBytes: ("d3d8b9b984adc24237ee" + "000000000000").HexToByteArray(),
@@ -746,15 +754,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_256_NoPadding_0_Extended()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_256_NoOrZeroPadding_0_Extended(PaddingMode paddingMode)
         {
             // NIST CAVP AESMMT.ZIP CFB8MMT256.rsp, [ENCRYPT] COUNT=0
             // plaintext zero-extended to a full block, cipherBytes extended value
             // provided by .NET Framework
             TestAesTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "34e8091cee09f1bd3ebf1e8f05f51bfbd4899ef2ae006a3a0f7875052cdd46c8".HexToByteArray(),
                 iv: "43eb4dcc4b04a80216a20e4a09a7abb5".HexToByteArray(),
                 plainBytes: ("f9" + "000000000000000000000000000000").HexToByteArray(),
@@ -762,15 +772,17 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_256_NoPadding_9_Extended()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_256_NoOrZeroPadding_9_Extended(PaddingMode paddingMode)
         {
             // NIST CAVP AESMMT.ZIP CFB8MMT256.rsp, [ENCRYPT] COUNT=9
             // plaintext zero-extended to a full block, cipherBytes extended value
             // provided by .NET Framework
             TestAesTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "ebbb4566b5e182e0f072466b0b311df38f9175bc0213a5530bce2ec4d74f400d".HexToByteArray(),
                 iv: "0956a48e01002c9e16376d6e308dbad1".HexToByteArray(),
                 plainBytes: ("b0fe25ac8d3d28a2f471" + "000000000000").HexToByteArray(),
@@ -927,18 +939,28 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 128);
         }
 
-        [Fact]
-        public static void AesZeroPad()
+        [Theory]
+        [InlineData(CipherMode.CBC)]
+        [InlineData(CipherMode.CFB)]
+        public static void AesZeroPad(CipherMode cipherMode)
         {
+            if (cipherMode == CipherMode.CFB && PlatformDetection.IsWindows7)
+            {
+                // Windows 7 does not support CFB.
+                return;
+            }
+
             byte[] decryptedBytes;
             byte[] expectedAnswer;
 
             using (Aes aes = AesFactory.Create())
             {
+                aes.Mode = cipherMode;
                 aes.Padding = PaddingMode.Zeros;
+                aes.FeedbackSize = 128;
 
-                int blockBytes = aes.BlockSize / 8;
-                int missingBytes = blockBytes - (s_multiBlockBytes.Length % blockBytes);
+                int alignBytes = aes.BlockSize / 8; // Feedback size is same as block size, both are 128 bits
+                int missingBytes = alignBytes - (s_multiBlockBytes.Length % alignBytes);
 
                 // Zero-padding doesn't have enough information to remove the trailing zeroes.
                 // Therefore we expect the answer of ZeroPad(s_multiBlockBytes).
@@ -1049,7 +1071,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             {
                 aes.Mode = mode;
                 aes.Key = key;
-                
+
                 if (feedbackSize.HasValue)
                 {
                     aes.FeedbackSize = feedbackSize.Value;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
@@ -254,14 +254,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_0()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_0(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=0
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "fb978a0b6dc2c467".HexToByteArray(),
                 iv: "8b97579ea5ac300f".HexToByteArray(),
                 plainBytes: "80".HexToByteArray(),
@@ -270,14 +272,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_1()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_1(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=1
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "9b04c86dd31a8a58".HexToByteArray(),
                 iv: "52cd77d49fc72347".HexToByteArray(),
                 plainBytes: "2fef".HexToByteArray(),
@@ -286,14 +290,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_2()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_2(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=2
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "fbb667e340586b5b".HexToByteArray(),
                 iv: "459e8b8736715791".HexToByteArray(),
                 plainBytes: "061704".HexToByteArray(),
@@ -365,14 +371,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_3()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_3(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=3
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "4a575d02515d40b0".HexToByteArray(),
                 iv: "ab27e9f02affa532".HexToByteArray(),
                 plainBytes: "55f75b95".HexToByteArray(),
@@ -397,14 +405,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_4()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_4(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=4
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "91a834855e6bab31".HexToByteArray(),
                 iv: "7838aaad4e64640b".HexToByteArray(),
                 plainBytes: "c3851c0ab4".HexToByteArray(),
@@ -413,14 +423,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_5()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_5(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=5
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "04d923abd9291c3e".HexToByteArray(),
                 iv: "191f8794944e601c".HexToByteArray(),
                 plainBytes: "6fe8f67d2af1".HexToByteArray(),
@@ -429,14 +441,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_6()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_6(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=6
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "a7799e7f5dfe54ce".HexToByteArray(),
                 iv: "370184c749d04a20".HexToByteArray(),
                 plainBytes: "2b4228b769795b".HexToByteArray(),
@@ -445,14 +459,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_7()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_7(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=7
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "6bfe3d3df8c1e0d3".HexToByteArray(),
                 iv: "51e4c5c29e858da6".HexToByteArray(),
                 plainBytes: "4cb3554fd0b9ec82".HexToByteArray(),
@@ -461,14 +477,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_8()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_8(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=8
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "e0264aec13e63db9".HexToByteArray(),
                 iv: "bd8795dba79930d6".HexToByteArray(),
                 plainBytes: "79068e2943f02914af".HexToByteArray(),
@@ -477,14 +495,16 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_9()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_9(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=9
             // used only key1, cipherBytes computed using openssl
             TestDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "7ca28938ba6bec1f".HexToByteArray(),
                 iv: "953896586e49d38f".HexToByteArray(),
                 plainBytes: "2ea956d4a211db6859b7".HexToByteArray(),

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -42,13 +42,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_0()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_0(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=0
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "fb978a0b6dc2c467e3cb52329de95161fb978a0b6dc2c467".HexToByteArray(),
                 iv: "8b97579ea5ac300f".HexToByteArray(),
                 plainBytes: "80".HexToByteArray(),
@@ -57,13 +59,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_1()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_1(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=1
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "9b04c86dd31a8a589876101549d6e0109b04c86dd31a8a58".HexToByteArray(),
                 iv: "52cd77d49fc72347".HexToByteArray(),
                 plainBytes: "2fef".HexToByteArray(),
@@ -72,13 +76,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_2()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_2(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=2
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "fbb667e340586b5b5ef7c87049b93257fbb667e340586b5b".HexToByteArray(),
                 iv: "459e8b8736715791".HexToByteArray(),
                 plainBytes: "061704".HexToByteArray(),
@@ -117,13 +123,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_3()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_3(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=3
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "4a575d02515d40b0a40d830bd9b315134a575d02515d40b0".HexToByteArray(),
                 iv: "ab27e9f02affa532".HexToByteArray(),
                 plainBytes: "55f75b95".HexToByteArray(),
@@ -132,13 +140,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_4()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_4(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=4
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "91a834855e6bab31c7fd6be657ceb9ec91a834855e6bab31".HexToByteArray(),
                 iv: "7838aaad4e64640b".HexToByteArray(),
                 plainBytes: "c3851c0ab4".HexToByteArray(),
@@ -147,13 +157,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_5()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_5(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=5
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "04d923abd9291c3e4954a8b52fdabcc804d923abd9291c3e".HexToByteArray(),
                 iv: "191f8794944e601c".HexToByteArray(),
                 plainBytes: "6fe8f67d2af1".HexToByteArray(),
@@ -162,13 +174,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_6()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_6(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=6
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "a7799e7f5dfe54ce13376401e96de075a7799e7f5dfe54ce".HexToByteArray(),
                 iv: "370184c749d04a20".HexToByteArray(),
                 plainBytes: "2b4228b769795b".HexToByteArray(),
@@ -177,13 +191,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_7()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_7(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=7
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "6bfe3d3df8c1e0d34ffe0dbf854c940e6bfe3d3df8c1e0d3".HexToByteArray(),
                 iv: "51e4c5c29e858da6".HexToByteArray(),
                 plainBytes: "4cb3554fd0b9ec82".HexToByteArray(),
@@ -192,13 +208,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_8()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_8(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=8
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "e0264aec13e63db991f8c120c4b9b6dae0264aec13e63db9".HexToByteArray(),
                 iv: "bd8795dba79930d6".HexToByteArray(),
                 plainBytes: "79068e2943f02914af".HexToByteArray(),
@@ -207,13 +225,15 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
-        public static void VerifyKnownTransform_CFB8_NoPadding_9()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(PaddingMode.None)]
+        [InlineData(PaddingMode.Zeros)]
+        public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_9(PaddingMode paddingMode)
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=9
             TestTripleDESTransformDirectKey(
                 CipherMode.CFB,
-                PaddingMode.None,
+                paddingMode,
                 key: "7ca28938ba6bec1ffec78f7cd69761947ca28938ba6bec1f".HexToByteArray(),
                 iv: "953896586e49d38f".HexToByteArray(),
                 plainBytes: "2ea956d4a211db6859b7".HexToByteArray(),


### PR DESCRIPTION
Manual port of #44959.

## Customer Impact

A new mode of symmetric encryption was introduced in .NET 5, CFB. This mode did not correctly handle padding length calculations when using CFB8 and a `PaddingMode` of `Zeros` and will always produce an exception.

## Testing

Several tests were added to ensure correct behavior and to prevent it from regressing. Existing tests exist for other modes to cover `PaddingMode.Zeros`.

## Risk

Low. It's a single line change just in the area affected.