### PR TITLE
Fix buffer comparison in stream conformance tests

### DIFF
--- a/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
@@ -905,7 +905,7 @@ namespace System.IO.Tests
                 Assert.Equal(size, stream.Seek(0, SeekOrigin.Current));
             }
 
-            Assert.Equal(expected, actual.ToArray());
+            Assert.True(expected.AsSpan().SequenceEqual(actual.ToArray()));
         }
 
         [Theory]
@@ -990,7 +990,7 @@ namespace System.IO.Tests
             stream.Position = 0;
             byte[] actual = (byte[])expected.Clone();
             Assert.Equal(actual.Length, await ReadAllAsync(ReadWriteMode.AsyncMemory, stream, actual, 0, actual.Length));
-            Assert.Equal(expected, actual);
+            Assert.True(expected.AsSpan().SequenceEqual(actual));
         }
 
         [Theory]
@@ -1032,7 +1032,7 @@ namespace System.IO.Tests
                 Assert.Equal(expected.Length, stream.Position);
             }
 
-            Assert.Equal(expected.AsSpan(position).ToArray(), destination.ToArray());
+            Assert.True(expected.AsSpan(position).SequenceEqual(destination.ToArray()));
         }
 
         public static IEnumerable<object[]> CopyTo_CopiesAllDataFromRightPosition_Success_MemberData()
@@ -1073,7 +1073,7 @@ namespace System.IO.Tests
             for (int i = 0; i < Copies; i++)
             {
                 int bytesRead = await ReadAllAsync(mode, stream, actual, 0, actual.Length);
-                Assert.Equal(expected, actual);
+                Assert.True(expected.AsSpan().SequenceEqual(actual));
                 Array.Clear(actual, 0, actual.Length);
             }
         }
@@ -1686,7 +1686,7 @@ namespace System.IO.Tests
                     readerBytes[i] = (byte)r;
                 }
 
-                Assert.Equal(writerBytes, readerBytes);
+                Assert.True(writerBytes.AsSpan().SequenceEqual(readerBytes));
 
                 await writes;
 
@@ -1760,7 +1760,7 @@ namespace System.IO.Tests
                     }
 
                     Assert.Equal(readerBytes.Length, n);
-                    Assert.Equal(writerBytes, readerBytes);
+                    Assert.True(writerBytes.AsSpan().SequenceEqual(readerBytes));
 
                     await writes;
 
@@ -2367,7 +2367,7 @@ namespace System.IO.Tests
             writeable.Dispose();
             await copyTask;
 
-            Assert.Equal(dataToCopy, results.ToArray());
+            Assert.True(dataToCopy.AsSpan().SequenceEqual(results.ToArray()));
         }
 
         [OuterLoop("May take several seconds")]

--- a/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/Tests/System/IO/StreamConformanceTests.cs
@@ -905,7 +905,7 @@ namespace System.IO.Tests
                 Assert.Equal(size, stream.Seek(0, SeekOrigin.Current));
             }
 
-            Assert.True(expected.AsSpan().SequenceEqual(actual.ToArray()));
+            AssertExtensions.Equal(expected, actual.ToArray());
         }
 
         [Theory]
@@ -990,7 +990,7 @@ namespace System.IO.Tests
             stream.Position = 0;
             byte[] actual = (byte[])expected.Clone();
             Assert.Equal(actual.Length, await ReadAllAsync(ReadWriteMode.AsyncMemory, stream, actual, 0, actual.Length));
-            Assert.True(expected.AsSpan().SequenceEqual(actual));
+            AssertExtensions.Equal(expected, actual);
         }
 
         [Theory]
@@ -1032,7 +1032,7 @@ namespace System.IO.Tests
                 Assert.Equal(expected.Length, stream.Position);
             }
 
-            Assert.True(expected.AsSpan(position).SequenceEqual(destination.ToArray()));
+            AssertExtensions.Equal(expected.AsSpan(position).ToArray(), destination.ToArray());
         }
 
         public static IEnumerable<object[]> CopyTo_CopiesAllDataFromRightPosition_Success_MemberData()
@@ -1073,7 +1073,7 @@ namespace System.IO.Tests
             for (int i = 0; i < Copies; i++)
             {
                 int bytesRead = await ReadAllAsync(mode, stream, actual, 0, actual.Length);
-                Assert.True(expected.AsSpan().SequenceEqual(actual));
+                AssertExtensions.Equal(expected, actual);
                 Array.Clear(actual, 0, actual.Length);
             }
         }
@@ -1686,7 +1686,7 @@ namespace System.IO.Tests
                     readerBytes[i] = (byte)r;
                 }
 
-                Assert.True(writerBytes.AsSpan().SequenceEqual(readerBytes));
+                AssertExtensions.Equal(writerBytes, readerBytes);
 
                 await writes;
 
@@ -1760,7 +1760,7 @@ namespace System.IO.Tests
                     }
 
                     Assert.Equal(readerBytes.Length, n);
-                    Assert.True(writerBytes.AsSpan().SequenceEqual(readerBytes));
+                    AssertExtensions.Equal(writerBytes, readerBytes);
 
                     await writes;
 
@@ -2367,7 +2367,7 @@ namespace System.IO.Tests
             writeable.Dispose();
             await copyTask;
 
-            Assert.True(dataToCopy.AsSpan().SequenceEqual(results.ToArray()));
+            AssertExtensions.Equal(dataToCopy, results.ToArray());
         }
 
         [OuterLoop("May take several seconds")]


### PR DESCRIPTION
Change stream conformance tests to use AssertExtensions.Equal instead of Assert.Equal for buffer comparison, as the latter is very, very slow.

@stephentoub 