### PR TITLE
Fix "Coersion" Typos

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -168,7 +168,7 @@ namespace System.Reflection.Emit
                 }
 
                 // Make sure the property's type can take the given value.
-                // Note that there will be no coersion.
+                // Note that there will be no coercion.
                 if (propertyValue != null)
                 {
                     VerifyTypeAndPassedObjectType(propType, propertyValue.GetType(), $"{nameof(propertyValues)}[{i}]");
@@ -222,7 +222,7 @@ namespace System.Reflection.Emit
                 }
 
                 // Make sure the field's type can take the given value.
-                // Note that there will be no coersion.
+                // Note that there will be no coercion.
                 if (fieldValue != null)
                 {
                     VerifyTypeAndPassedObjectType(fldType, fieldValue.GetType(), $"{nameof(fieldValues)}[{i}]");
@@ -271,9 +271,7 @@ namespace System.Reflection.Emit
             }
             if (t.IsArray)
             {
-                if (t.GetArrayRank() != 1)
-                    return false;
-                return ValidateType(t.GetElementType()!);
+                return t.GetArrayRank() == 1 && ValidateType(t.GetElementType()!);
             }
             return t == typeof(object);
         }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -287,7 +287,7 @@ namespace System.Runtime.CompilerServices
         private static extern IntPtr AllocTailCallArgBuffer(int size, IntPtr gcDesc);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static unsafe extern TailCallTls* GetTailCallInfo(IntPtr retAddrSlot, IntPtr* retAddr);
+        private static extern unsafe TailCallTls* GetTailCallInfo(IntPtr retAddrSlot, IntPtr* retAddr);
 
         [StackTraceHidden]
         private static unsafe void DispatchTailCalls(


### PR DESCRIPTION
"Coercion" is spelled as "Coersion", which is a spelling mistake.