### PR TITLE
Fix emitted IgnoresAccessChecksToAttribute.AssemblyName property

### DIFF
--- a/src/libraries/Common/src/System/Reflection/Emit/IgnoreAccessChecksToAttributeBuilder.cs
+++ b/src/libraries/Common/src/System/Reflection/Emit/IgnoreAccessChecksToAttributeBuilder.cs
@@ -47,7 +47,7 @@ namespace System.Reflection.Emit
 
             // Define property as:
             // public string AssemblyName {get { return this.assemblyName; } }
-            _ = attributeTypeBuilder.DefineProperty(
+            PropertyBuilder propertyBuilder = attributeTypeBuilder.DefineProperty(
                     "AssemblyName",
                     PropertyAttributes.None,
                     CallingConventions.HasThis,
@@ -60,6 +60,7 @@ namespace System.Reflection.Emit
                                                    CallingConventions.HasThis,
                                                    returnType: typeof(string),
                                                    parameterTypes: null);
+            propertyBuilder.SetGetMethod(getterMethodBuilder);
 
             // Generate body:
             // return this.assemblyName;

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -47,6 +47,21 @@ namespace DispatchProxyTests
         {
             TestType_InternalInterfaceService proxy = DispatchProxy.Create<TestType_PublicInterfaceService_Implements_Internal, TestDispatchProxy>();
             Assert.NotNull(proxy);
+
+            // ensure we emit a valid attribute definition
+            Type iactAttributeType = proxy.GetType().Assembly.GetType("System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute");
+            Assert.NotNull(iactAttributeType);
+            ConstructorInfo constructor = iactAttributeType.GetConstructor(new[] { typeof(string) });
+            Assert.NotNull(constructor);
+            PropertyInfo propertyInfo = iactAttributeType.GetProperty("AssemblyName");
+            Assert.NotNull(propertyInfo);
+            Assert.NotNull(propertyInfo.GetMethod);
+
+            string name = "anAssemblyName";
+            object attributeInstance = constructor.Invoke(new object[] { name });
+            Assert.NotNull(attributeInstance);
+            object actualName = propertyInfo.GetMethod.Invoke(attributeInstance, null);
+            Assert.Equal(name, actualName);
         }
 
         [Fact]


### PR DESCRIPTION
Previously this would emit an empty property.
```
.property instance string AssemblyName()
{
}
```

Now it correctly emits a property with getter.
```
.property instance string AssemblyName()
{
	.get instance string System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute::get_AssemblyName()
}
```