### PR TITLE
disable apphost in ILVerify

### DIFF
--- a/src/coreclr/tools/ILVerify/ILVerify.csproj
+++ b/src/coreclr/tools/ILVerify/ILVerify.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseAppHost>false</UseAppHost>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 


### PR DESCRIPTION
It doesn't appear to be needed and ends up as a prebuilt for source-build.

We are using this in source-build via https://github.com/dotnet/source-build/pull/1909