### PR TITLE
[release/5.0] Browser support for Debugger::Break.

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -416,6 +416,7 @@ mono_wasm_debugger_init (void)
 	objrefs = g_hash_table_new_full (NULL, NULL, NULL, mono_debugger_free_objref);
 
 	mini_get_dbg_callbacks ()->handle_exception = handle_exception;
+	mini_get_dbg_callbacks ()->user_break = mono_wasm_user_break;
 }
 
 MONO_API void
@@ -624,6 +625,12 @@ mono_wasm_breakpoint_hit (void)
 {
 	mono_de_process_breakpoint (NULL, FALSE);
 	// mono_wasm_fire_bp ();
+}
+
+void
+mono_wasm_user_break (void)
+{
+	mono_wasm_fire_bp ();
 }
 
 EMSCRIPTEN_KEEPALIVE int

--- a/src/mono/mono/mini/mini-wasm.h
+++ b/src/mono/mono/mini/mini-wasm.h
@@ -111,5 +111,6 @@ void mono_wasm_set_timeout (int timeout, int id);
 
 void mono_wasm_single_step_hit (void);
 void mono_wasm_breakpoint_hit (void);
+void mono_wasm_user_break (void);
 
 #endif /* __MONO_MINI_WASM_H__ */  

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1996,7 +1996,7 @@ namespace DebuggerTests
                 ctx = new DebugTestContext(cli, insp, token, scripts);
                 await EvaluateAndCheck(
                     "window.setTimeout(function() { invoke_static_method_async('[debugger-test] UserBreak:BreakOnDebuggerBreakCommand'); }, 1);",
-                    "dotnet://debugger-test.dll/debugger-test2.cs", 56, 4,
+                    "dotnet://debugger-test.dll/debugger-test2.cs", 54, 4,
                     "BreakOnDebuggerBreakCommand");
             });
         }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1984,10 +1984,9 @@ namespace DebuggerTests
         }
 
         [Fact]
-        public async Task StepOverHiddenSequencePoint()
+        public async Task BreakOnDebuggerBreak()
         {
             var insp = new Inspector();
-
             //Collect events
             var scripts = SubscribeToScripts(insp);
 
@@ -1996,6 +1995,23 @@ namespace DebuggerTests
             {
                 ctx = new DebugTestContext(cli, insp, token, scripts);
 
+                await EvaluateAndCheck(
+                    "window.setTimeout(function() { invoke_static_method_async('[debugger-test] UserBreak:BreakOnDebuggerBreakCommand'); }, 1);",
+                    "dotnet://debugger-test.dll/debugger-test2.cs", 56, 4,
+                    "BreakOnDebuggerBreakCommand");
+            });
+        }
+
+        [Fact]
+        public async Task StepOverHiddenSequencePoint()
+        {
+            var insp = new Inspector();
+
+            var scripts = SubscribeToScripts(insp);
+
+            await Ready();
+            await insp.Ready(async (cli, token) =>
+            {
                 var bp = await SetBreakpointInMethod("debugger-test.dll", "HiddenSequencePointTest", "StepOverHiddenSP2", 0);
 
                 var pause_location = await EvaluateAndCheck(

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -1994,7 +1994,6 @@ namespace DebuggerTests
             await insp.Ready(async (cli, token) =>
             {
                 ctx = new DebugTestContext(cli, insp, token, scripts);
-
                 await EvaluateAndCheck(
                     "window.setTimeout(function() { invoke_static_method_async('[debugger-test] UserBreak:BreakOnDebuggerBreakCommand'); }, 1);",
                     "dotnet://debugger-test.dll/debugger-test2.cs", 56, 4,
@@ -2006,12 +2005,14 @@ namespace DebuggerTests
         public async Task StepOverHiddenSequencePoint()
         {
             var insp = new Inspector();
-
+            //Collect events
             var scripts = SubscribeToScripts(insp);
 
             await Ready();
             await insp.Ready(async (cli, token) =>
             {
+                ctx = new DebugTestContext(cli, insp, token, scripts);
+
                 var bp = await SetBreakpointInMethod("debugger-test.dll", "HiddenSequencePointTest", "StepOverHiddenSP2", 0);
 
                 var pause_location = await EvaluateAndCheck(

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test2.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test2.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-
+using System.Diagnostics;
 public class Misc
 { //Only append content to this class as the test suite depends on line info
     public static int CreateObject(int foo, int bar)
@@ -47,5 +47,12 @@ public class Fancy
         ushort usMax = ushort.MaxValue;
 
         var d = usMin + usMax;
+    }
+}
+
+public class UserBreak {
+    public static void BreakOnDebuggerBreakCommand()
+    {
+        Debugger.Break();
     }
 }


### PR DESCRIPTION
backport of #44305 to release/5.0

/cc @thaystg 

## Customer Impact
Addresses VS Feedback ticket where using System.Diagnostics.Debugger.Break would cause a runtime assertion rather than a breakpoint. The trivial fix connects the existing functionality to the correct debugger endpoint.

Fixes https://github.com/dotnet/runtime/issues/44210

## Testing
Verified manually and includes a debugger test for basic functionality.

## Risk
Very low.  Connects existing code.