### PR TITLE
Use OutputRid for host packs

### DIFF
--- a/src/installer/pkg/projects/Directory.Build.props
+++ b/src/installer/pkg/projects/Directory.Build.props
@@ -151,7 +151,7 @@
     <!-- During NuGet restore, grab assets for all applicable RIDs. -->
     <RuntimeIdentifiers Condition="'$(RestoreAllBuildRids)' == 'true'">@(RestoreBuildRID)</RuntimeIdentifiers>
     <!-- When resolving assets to pack, use the target runtime (if any). -->
-    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/installer/pkg/projects/host-packages.proj
+++ b/src/installer/pkg/projects/host-packages.proj
@@ -6,7 +6,7 @@
     <ProjectReference Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
     <ProjectReference Include="Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
     <ProjectReference Include="Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
-    <ProjectReference Include="@(ProjectReference)" AdditionalProperties="PackageTargetRuntime=$(PackageRID)" />
+    <ProjectReference Include="@(ProjectReference)" AdditionalProperties="PackageTargetRuntime=$(OutputRid)" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />

--- a/src/installer/pkg/projects/netcoreappRIDs.props
+++ b/src/installer/pkg/projects/netcoreappRIDs.props
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <PackageRID Condition="'$(PackageRID)' == ''">$(OutputRid)</PackageRID>
-  </PropertyGroup>
-
   <ItemGroup>
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="linux-musl-x64" />


### PR DESCRIPTION
cc @safern, we get the following output in linux-musl-arm64 container:

<details>
  <summary>expand</summary>

```sh
  [ 98%] Building CXX object cli/apphost/static/CMakeFiles/singlefilehost.dir/__/__/__/corehost.cpp.o
  [ 99%] Linking CXX shared library libhostpolicy.so
  Stripping symbols from $<TARGET_FILE:hostpolicy> into file $<TARGET_FILE:hostpolicy>.dbg
  [ 99%] Linking CXX shared library libhostfxr.so
  [ 99%] Built target hostpolicy
  Stripping symbols from $<TARGET_FILE:hostfxr> into file $<TARGET_FILE:hostfxr>.dbg
  [ 99%] Built target hostfxr
  [100%] Linking CXX executable singlefilehost
  Stripping symbols from $<TARGET_FILE:singlefilehost> into file $<TARGET_FILE:singlefilehost>.dbg
  [100%] Built target singlefilehost
  Install the project...
  -- Install configuration: "RELEASE"
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/singlefilehost.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/singlefilehost
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/apphost.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/apphost
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/dotnet.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/dotnet
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/coreclr_delegates.h
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/hostfxr.h
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/nethost.h
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/libnethost.so.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/libnethost.so
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/libnethost.a
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/test_fx_ver
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/libhostfxr.so.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/libhostfxr.so
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/libhostpolicy.so.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost/libhostpolicy.so
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/libmockcoreclr.so.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/libmockcoreclr.so
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/libmockhostfxr_2_2.so.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/libmockhostfxr_2_2.so
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/libmockhostpolicy.so.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/libmockhostpolicy.so
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/nativehost.dbg
  -- Installing: /runtime/artifacts/bin/linux-musl-arm64.Release/corehost_test/nativehost
  Microsoft.NETCore.DotNetHost -> /runtime/artifacts/packages/Release/Shipping/runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost.6.0.0-dev.nupkg
  Microsoft.NETCore.DotNetHostPolicy -> /runtime/artifacts/packages/Release/Shipping/runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy.6.0.0-dev.nupkg
  Microsoft.NETCore.DotNetHostResolver -> /runtime/artifacts/packages/Release/Shipping/runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver.6.0.0-dev.nupkg
  Microsoft.NETCore.DotNetHost -> /runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.DotNetHost.6.0.0-dev.nupkg
  Microsoft.NETCore.DotNetHostPolicy -> /runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.DotNetHostPolicy.6.0.0-dev.nupkg
  Microsoft.NETCore.DotNetHostResolver -> /runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.DotNetHostResolver.6.0.0-dev.nupkg
  Microsoft.NETCore.DotNetAppHost -> /runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.DotNetAppHost.6.0.0-dev.nupkg
  Microsoft.NETCore.DotNetAppHost -> /runtime/artifacts/packages/Release/Shipping/runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost.6.0.0-dev.nupkg
  Microsoft.NETCore.App.Ref -> 
  Successfully created package '/runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.App.Ref.6.0.0-dev.nupkg'.
  Successfully created package '/runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.App.Ref.6.0.0-dev.symbols.nupkg'.
  Microsoft.NETCore.App.Runtime -> 
  Successfully created package '/runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.App.Runtime.linux-musl-arm64.6.0.0-dev.nupkg'.
  Successfully created package '/runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.App.Runtime.linux-musl-arm64.6.0.0-dev.symbols.nupkg'.
  Microsoft.NETCore.App.Host -> 
  Successfully created package '/runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.App.Host.linux-musl-arm64.6.0.0-dev.nupkg'.
  Successfully created package '/runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.App.Host.linux-musl-arm64.6.0.0-dev.symbols.nupkg'.
  Microsoft.NETCore.App.Crossgen2 -> 
  dotnet-host -> 
  dotnet-hostfxr -> 
  dotnet-runtime-deps-centos.7 -> 
  dotnet-runtime-deps-debian -> 
  dotnet-runtime-deps-fedora.27 -> 
  dotnet-runtime-deps-opensuse.42 -> 
  dotnet-runtime-deps-oraclelinux.7 -> 
  dotnet-runtime-deps-rhel.7 -> 
  dotnet-runtime-deps-sles.12 -> 
  Microsoft.NETCore.App.Bundle -> 
  Microsoft.NET.HostModel -> /runtime/artifacts/bin/Microsoft.NET.HostModel/Release/netstandard2.0/Microsoft.NET.HostModel.dll
  Successfully created package '/runtime/artifacts/packages/Release/NonShipping/Microsoft.NET.HostModel.6.0.0-dev.nupkg'.
  Successfully created package '/runtime/artifacts/packages/Release/NonShipping/Microsoft.NET.HostModel.6.0.0-dev.symbols.nupkg'.
  TestUtils -> /runtime/artifacts/bin/TestUtils/Release/net6.0/TestUtils.dll
  Microsoft.NET.HostModel.ComHost.Tests -> /runtime/artifacts/bin/Microsoft.NET.HostModel.ComHost.Tests/Release/net6.0/Microsoft.NET.HostModel.ComHost.Tests.dll
  Microsoft.DotNet.CoreSetup.Packaging.Tests -> /runtime/artifacts/bin/Microsoft.DotNet.CoreSetup.Packaging.Tests/Release/net6.0/Microsoft.DotNet.CoreSetup.Packaging.Tests.dll
  BundleHelper -> /runtime/artifacts/bin/BundleHelper/Release/net6.0/BundleHelper.dll
  Microsoft.NET.HostModel.AppHost.Tests -> /runtime/artifacts/bin/Microsoft.NET.HostModel.AppHost.Tests/Release/net6.0/Microsoft.NET.HostModel.AppHost.Tests.dll
  HostActivation.Tests -> /runtime/artifacts/bin/HostActivation.Tests/Release/net6.0/HostActivation.Tests.dll
  AppHost.Bundle.Tests -> /runtime/artifacts/bin/AppHost.Bundle.Tests/Release/net6.0/AppHost.Bundle.Tests.dll
  Microsoft.NET.HostModel.Bundle.Tests -> /runtime/artifacts/bin/Microsoft.NET.HostModel.Bundle.Tests/Release/net6.0/Microsoft.NET.HostModel.Bundle.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:01:15.85
```

</details>