### PR TITLE
Drop Convert static constructor dependency from RuntimeType

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -194,23 +194,34 @@ namespace System
                     typeCode = TypeCode.Single; break;
                 case CorElementType.ELEMENT_TYPE_R8:
                     typeCode = TypeCode.Double; break;
+                case CorElementType.ELEMENT_TYPE_STRING:
+                    typeCode = TypeCode.String; break;
                 case CorElementType.ELEMENT_TYPE_VALUETYPE:
-                    if (this == Convert.ConvertTypes[(int)TypeCode.Decimal])
+                    if (ReferenceEquals(this, typeof(decimal)))
                         typeCode = TypeCode.Decimal;
-                    else if (this == Convert.ConvertTypes[(int)TypeCode.DateTime])
+                    else if (ReferenceEquals(this, typeof(DateTime)))
                         typeCode = TypeCode.DateTime;
                     else if (IsEnum)
-                        typeCode = GetTypeCode(Enum.GetUnderlyingType(this));
+                        typeCode = GetTypeCode(Enum.InternalGetUnderlyingType(this));
                     else
                         typeCode = TypeCode.Object;
                     break;
                 default:
-                    if (this == Convert.ConvertTypes[(int)TypeCode.DBNull])
-                        typeCode = TypeCode.DBNull;
-                    else if (this == Convert.ConvertTypes[(int)TypeCode.String])
+#if CORECLR
+                    // GetSignatureCorElementType returns E_T_CLASS for E_T_STRING
+                    if (ReferenceEquals(this, typeof(string)))
+                    {
                         typeCode = TypeCode.String;
-                    else
-                        typeCode = TypeCode.Object;
+                        break;
+                    }
+#endif
+                    if (ReferenceEquals(this, typeof(DBNull)))
+                    {
+                        typeCode = TypeCode.DBNull;
+                        break;
+                    }
+
+                    typeCode = TypeCode.Object;
                     break;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -194,8 +194,10 @@ namespace System
                     typeCode = TypeCode.Single; break;
                 case CorElementType.ELEMENT_TYPE_R8:
                     typeCode = TypeCode.Double; break;
+#if !CORECLR
                 case CorElementType.ELEMENT_TYPE_STRING:
                     typeCode = TypeCode.String; break;
+#endif
                 case CorElementType.ELEMENT_TYPE_VALUETYPE:
                     if (ReferenceEquals(this, typeof(decimal)))
                         typeCode = TypeCode.Decimal;

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -424,15 +424,14 @@ namespace System
 
         public static TypeCode GetTypeCode(Type? type)
         {
-            if (type == null)
-                return TypeCode.Empty;
-            return type.GetTypeCodeImpl();
+            return type?.GetTypeCodeImpl() ?? TypeCode.Empty;
         }
+
         protected virtual TypeCode GetTypeCodeImpl()
         {
             Type systemType = UnderlyingSystemType;
-            if (this != systemType && systemType != null)
-                return Type.GetTypeCode(systemType);
+            if (!ReferenceEquals(this, systemType) && systemType is not null)
+                return GetTypeCode(systemType);
 
             return TypeCode.Object;
         }


### PR DESCRIPTION
to make it trimmable. I also cleaned up GetTypeCode calls chain along the way.