### PR TITLE
Skip Invariant initialization test for CultureData.Invariant

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -37,7 +37,7 @@ namespace System.Globalization
         private Tristate _isAsciiCasingSameAsInvariant = Tristate.NotInitialized;
 
         // Invariant text info
-        internal static readonly TextInfo Invariant = new TextInfo(CultureData.Invariant, readOnly: true, isInvariant: true);
+        internal static readonly TextInfo Invariant = new TextInfo(CultureData.Invariant, readOnly: true) { _isAsciiCasingSameAsInvariant = Tristate.True };
 
         internal TextInfo(CultureData cultureData)
         {
@@ -52,14 +52,9 @@ namespace System.Globalization
             }
         }
 
-        private TextInfo(CultureData cultureData, bool readOnly, bool isInvariant = false)
+        private TextInfo(CultureData cultureData, bool readOnly)
             : this(cultureData)
         {
-            if (isInvariant)
-            {
-                _isAsciiCasingSameAsInvariant = Tristate.True;
-            }
-
             SetReadOnlyState(readOnly);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -37,7 +37,7 @@ namespace System.Globalization
         private Tristate _isAsciiCasingSameAsInvariant = Tristate.NotInitialized;
 
         // Invariant text info
-        internal static readonly TextInfo Invariant = new TextInfo(CultureData.Invariant, readOnly: true);
+        internal static readonly TextInfo Invariant = new TextInfo(CultureData.Invariant, readOnly: true, isInvariant: true);
 
         internal TextInfo(CultureData cultureData)
         {
@@ -52,9 +52,14 @@ namespace System.Globalization
             }
         }
 
-        private TextInfo(CultureData cultureData, bool readOnly)
+        private TextInfo(CultureData cultureData, bool readOnly, bool isInvariant = false)
             : this(cultureData)
         {
+            if (isInvariant)
+            {
+                _isAsciiCasingSameAsInvariant = Tristate.True;
+            }
+
             SetReadOnlyState(readOnly);
         }
 


### PR DESCRIPTION
It currently goes through an expensive test `PopulateIsAsciiCasingSameAsInvariant` to check if Invariant is equivalent to Invariant which can be skipped; which shows up in startup (when running `ToUpperInvariant` for the first time to get the Guid to initialize an ASP.NET EventSource)

Before

![image](https://user-images.githubusercontent.com/1142958/99890379-6ba95080-2c56-11eb-9b15-59d05e7fc978.png)


![image](https://user-images.githubusercontent.com/1142958/99890266-5d0e6980-2c55-11eb-8262-65bfd67bc7e3.png)

After

![image](https://user-images.githubusercontent.com/1142958/99890389-9a272b80-2c56-11eb-8141-4eed53cbcee0.png)


![image](https://user-images.githubusercontent.com/1142958/99890279-70b9d000-2c55-11eb-8155-4205924bed89.png)


/cc @GrabYourPitchforks 

Contributes to #44598