### PR TITLE
Create cancellation token registration wrapper only when it's needed

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
@@ -35,12 +35,6 @@ namespace System.Threading
         private readonly CancellationTokenSource? _source;
         // !! warning. If more fields are added, the assumptions in CreateLinkedToken may no longer be valid
 
-        private static readonly Action<object?> s_actionToActionObjShunt = obj =>
-        {
-            Debug.Assert(obj is Action, $"Expected {typeof(Action)}, got {obj}");
-            ((Action)obj)();
-        };
-
         /// <summary>
         /// Returns an empty CancellationToken value.
         /// </summary>
@@ -136,12 +130,7 @@ namespace System.Threading
         /// <returns>The <see cref="System.Threading.CancellationTokenRegistration"/> instance that can
         /// be used to unregister the callback.</returns>
         /// <exception cref="System.ArgumentNullException"><paramref name="callback"/> is null.</exception>
-        public CancellationTokenRegistration Register(Action callback) =>
-            Register(
-                s_actionToActionObjShunt,
-                callback ?? throw new ArgumentNullException(nameof(callback)),
-                useSynchronizationContext: false,
-                useExecutionContext: true);
+        public CancellationTokenRegistration Register(Action callback) => Register(callback, useSynchronizationContext: false);
 
         /// <summary>
         /// Registers a delegate that will be called when this
@@ -167,7 +156,7 @@ namespace System.Threading
         /// <exception cref="System.ArgumentNullException"><paramref name="callback"/> is null.</exception>
         public CancellationTokenRegistration Register(Action callback, bool useSynchronizationContext) =>
             Register(
-                s_actionToActionObjShunt,
+                new Action<object?>(static obj => ((Action)obj!)()),
                 callback ?? throw new ArgumentNullException(nameof(callback)),
                 useSynchronizationContext,
                 useExecutionContext: true);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
@@ -156,7 +156,7 @@ namespace System.Threading
         /// <exception cref="System.ArgumentNullException"><paramref name="callback"/> is null.</exception>
         public CancellationTokenRegistration Register(Action callback, bool useSynchronizationContext) =>
             Register(
-                new Action<object?>(static obj => ((Action)obj!)()),
+                (Action<object?>)(static obj => ((Action)obj!)()),
                 callback ?? throw new ArgumentNullException(nameof(callback)),
                 useSynchronizationContext,
                 useExecutionContext: true);


### PR DESCRIPTION
instead of doing it eagerly in static ctor