### PR TITLE
Fix CoreRT frozen strings handling.

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -1625,7 +1625,11 @@ void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
                     assert(assertion->op2.u1.iconFlags != 0);
                     break;
                 case O1K_LCLVAR:
-                    assert((lvaTable[assertion->op1.lcl.lclNum].lvType != TYP_REF) || (assertion->op2.u1.iconVal == 0));
+                    if (!IsTargetAbi(CORINFO_CORERT_ABI)) // CoreRT allows non-zero const refs for frozen strings.
+                    {
+                        assert((lvaTable[assertion->op1.lcl.lclNum].lvType != TYP_REF) ||
+                               (assertion->op2.u1.iconVal == 0));
+                    }
                     break;
                 case O1K_VALUE_NUMBER:
                     assert((vnStore->TypeOfVN(assertion->op1.vn) != TYP_REF) || (assertion->op2.u1.iconVal == 0));

--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -1625,11 +1625,8 @@ void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
                     assert(assertion->op2.u1.iconFlags != 0);
                     break;
                 case O1K_LCLVAR:
-                    if (!IsTargetAbi(CORINFO_CORERT_ABI)) // CoreRT allows non-zero const refs for frozen strings.
-                    {
-                        assert((lvaTable[assertion->op1.lcl.lclNum].lvType != TYP_REF) ||
-                               (assertion->op2.u1.iconVal == 0));
-                    }
+                    assert((lvaTable[assertion->op1.lcl.lclNum].lvType != TYP_REF) ||
+                           (assertion->op2.u1.iconVal == 0) || doesMethodHaveFrozenString());
                     break;
                 case O1K_VALUE_NUMBER:
                     assert((vnStore->TypeOfVN(assertion->op1.vn) != TYP_REF) || (assertion->op2.u1.iconVal == 0));

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6697,6 +6697,7 @@ public:
 #define OMF_HAS_EXPRUNTIMELOOKUP 0x00000100 // Method contains a runtime lookup to an expandable dictionary.
 #define OMF_HAS_PATCHPOINT 0x00000200       // Method contains patchpoints
 #define OMF_NEEDS_GCPOLLS 0x00000400        // Method needs GC polls
+#define OMF_HAS_FROZEN_STRING 0x00000800    // Method has a frozen string (REF constant int), currently only on CoreRT.
 
     bool doesMethodHaveFatPointer()
     {
@@ -6715,7 +6716,17 @@ public:
 
     void addFatPointerCandidate(GenTreeCall* call);
 
-    bool doesMethodHaveGuardedDevirtualization()
+    bool doesMethodHaveFrozenString() const
+    {
+        return (optMethodFlags & OMF_HAS_FROZEN_STRING) != 0;
+    }
+
+    void setMethodHasFrozenString()
+    {
+        optMethodFlags |= OMF_HAS_FROZEN_STRING;
+    }
+
+    bool doesMethodHaveGuardedDevirtualization() const
     {
         return (optMethodFlags & OMF_HAS_GUARDEDDEVIRT) != 0;
     }

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -3871,7 +3871,7 @@ inline GenTree* Compiler::impCheckForNullPointer(GenTree* obj)
         // We can see non-zero byrefs for RVA statics or for frozen strings.
         if (obj->AsIntCon()->gtIconVal != 0)
         {
-            assert((obj->gtType == TYP_BYREF) || doesMethodHaveFrozenString());
+            assert((obj->gtType == TYP_BYREF) || (doesMethodHaveFrozenString() && obj->IsIconHandle(GTF_ICON_STR_HDL)));
             return obj;
         }
 

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -3868,15 +3868,10 @@ inline GenTree* Compiler::impCheckForNullPointer(GenTree* obj)
     {
         assert(obj->gtType == TYP_REF || obj->gtType == TYP_BYREF);
 
-        // We can see non-zero byrefs for RVA statics (all ABIs) or for frozen strings (CoreRT only).
+        // We can see non-zero byrefs for RVA statics or for frozen strings.
         if (obj->AsIntCon()->gtIconVal != 0)
         {
-#ifdef DEBUG
-            if (!IsTargetAbi(CORINFO_CORERT_ABI))
-            {
-                assert(obj->gtType == TYP_BYREF);
-            }
-#endif // DEBUG
+            assert((obj->gtType == TYP_BYREF) || doesMethodHaveFrozenString());
             return obj;
         }
 

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -3871,7 +3871,18 @@ inline GenTree* Compiler::impCheckForNullPointer(GenTree* obj)
         // We can see non-zero byrefs for RVA statics or for frozen strings.
         if (obj->AsIntCon()->gtIconVal != 0)
         {
-            assert((obj->gtType == TYP_BYREF) || (doesMethodHaveFrozenString() && obj->IsIconHandle(GTF_ICON_STR_HDL)));
+#ifdef DEBUG
+            if (!obj->TypeIs(TYP_BYREF))
+            {
+                assert(obj->TypeIs(TYP_REF));
+                assert(obj->IsIconHandle(GTF_ICON_STR_HDL));
+                if (!doesMethodHaveFrozenString())
+                {
+                    assert(compIsForInlining());
+                    assert(impInlineInfo->InlinerCompiler->doesMethodHaveFrozenString());
+                }
+            }
+#endif // DEBUG
             return obj;
         }
 

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -3868,10 +3868,15 @@ inline GenTree* Compiler::impCheckForNullPointer(GenTree* obj)
     {
         assert(obj->gtType == TYP_REF || obj->gtType == TYP_BYREF);
 
-        // We can see non-zero byrefs for RVA statics.
+        // We can see non-zero byrefs for RVA statics (all ABIs) or for frozen strings (CoreRT only).
         if (obj->AsIntCon()->gtIconVal != 0)
         {
-            assert(obj->gtType == TYP_BYREF);
+#ifdef DEBUG
+            if (!IsTargetAbi(CORINFO_CORERT_ABI))
+            {
+                assert(obj->gtType == TYP_BYREF);
+            }
+#endif // DEBUG
             return obj;
         }
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -6070,12 +6070,6 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
     switch (iat)
     {
         case IAT_VALUE:
-            // For CoreRT only - Constant object can be a frozen string.
-            if (!IsTargetAbi(CORINFO_CORERT_ABI))
-            {
-                // Non CoreRT - This case is illegal, creating a TYP_REF from an INT_CNS
-                noway_assert(!"unreachable IAT_VALUE case in gtNewStringLiteralNode");
-            }
             setMethodHasFrozenString();
             tree         = gtNewIconEmbHndNode(pValue, nullptr, GTF_ICON_STR_HDL, nullptr);
             tree->gtType = TYP_REF;

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -6076,7 +6076,7 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
                 // Non CoreRT - This case is illegal, creating a TYP_REF from an INT_CNS
                 noway_assert(!"unreachable IAT_VALUE case in gtNewStringLiteralNode");
             }
-
+            setMethodHasFrozenString();
             tree         = gtNewIconEmbHndNode(pValue, nullptr, GTF_ICON_STR_HDL, nullptr);
             tree->gtType = TYP_REF;
 #ifdef DEBUG

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -21416,7 +21416,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
             return true;
         }
         // Non-0 const refs can only occur with frozen objects
-        assert(doesMethodHaveFrozenString());
+        assert(doesMethodHaveFrozenString() && value->IsIconHandle(GTF_ICON_STR_HDL));
     }
 
     // Try and get a class handle for the array

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -21416,7 +21416,9 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
             return true;
         }
         // Non-0 const refs can only occur with frozen objects
-        assert(doesMethodHaveFrozenString() && value->IsIconHandle(GTF_ICON_STR_HDL));
+        assert(value->IsIconHandle(GTF_ICON_STR_HDL));
+        assert(doesMethodHaveFrozenString() ||
+               (compIsForInlining() && impInlineInfo->InlinerCompiler->doesMethodHaveFrozenString()));
     }
 
     // Try and get a class handle for the array

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -21409,9 +21409,23 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     // Check for assignment of NULL.
     if (value->OperIs(GT_CNS_INT))
     {
-        JITDUMP("\nstelem of null: skipping covariant store check\n");
-        assert((value->gtType == TYP_REF) && (value->AsIntCon()->gtIconVal == 0));
-        return true;
+        assert(value->gtType == TYP_REF);
+        bool skipCheck = false;
+        if (!IsTargetAbi(CORINFO_CORERT_ABI))
+        {
+            // Non CoreRt ABI can have only 0 const refs.
+            assert(value->AsIntCon()->gtIconVal == 0);
+            skipCheck = true;
+        }
+        else if (value->AsIntCon()->gtIconVal == 0)
+        {
+            skipCheck = true;
+        }
+        if (skipCheck)
+        {
+            JITDUMP("\nstelem of null: skipping covariant store check\n");
+            return true;
+        }
     }
 
     // Try and get a class handle for the array

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -21410,22 +21410,13 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     if (value->OperIs(GT_CNS_INT))
     {
         assert(value->gtType == TYP_REF);
-        bool skipCheck = false;
-        if (!IsTargetAbi(CORINFO_CORERT_ABI))
-        {
-            // Non CoreRt ABI can have only 0 const refs.
-            assert(value->AsIntCon()->gtIconVal == 0);
-            skipCheck = true;
-        }
-        else if (value->AsIntCon()->gtIconVal == 0)
-        {
-            skipCheck = true;
-        }
-        if (skipCheck)
+        if (value->AsIntCon()->gtIconVal == 0)
         {
             JITDUMP("\nstelem of null: skipping covariant store check\n");
             return true;
         }
+        // Non-0 const refs can only occur with frozen objects
+        assert(doesMethodHaveFrozenString());
     }
 
     // Try and get a class handle for the array

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -6453,7 +6453,7 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
             }
             else
             {
-                assert(tree->gtFlags == GTF_ICON_STR_HDL); // Constant object can be only frozen string.
+                assert(tree->IsIconHandle(GTF_ICON_STR_HDL)); // Constant object can be only frozen string.
                 tree->gtVNPair.SetBoth(
                     vnStore->VNForHandle(ssize_t(tree->AsIntConCommon()->IconValue()), tree->GetIconHandleFlag()));
             }


### PR DESCRIPTION
Fix asserts about const non-zero refs that are possible on CoreRT, in the past they were always hidden with `GT_NOP` but it was creating other issues.

It should fix failures seen in https://github.com/dotnet/runtimelab/pull/374#issuecomment-731611598 introduced by https://github.com/dotnet/runtime/pull/44398.

With the changes the tests results are:
```
src\tests\run.cmd runnativeaottests Checked
Total tests run    : 2578
Total passing tests: 2565
Total failed tests : 13
Total skipped tests: 0
```
the 13 failing tests are failing without the change as well, so they are probably preexisting, PTAL @jkotas :
```
JIT\Directed\tailcall\mutual_recursion\mutual_recursion.cmd [FAIL]	Line 271:       JIT\Methodical\tailcall_v4\hijacking\hijacking.cmd [FAIL]
JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd [FAIL]
JIT\Regression\JitBlue\devdiv_902271\DevDiv_902271\DevDiv_902271.cmd [FAIL]
JIT\Regression\JitBlue\GitHub_27924\GitHub_27924\GitHub_27924.cmd [FAIL]
JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b353858\b353858\b353858.cmd [FAIL]
JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71120\b71120\b71120.cmd [FAIL]
JIT\Stress\ABI\pinvokes_d\pinvokes_d.cmd [FAIL]
JIT\Stress\ABI\tailcalls_d\tailcalls_d.cmd [FAIL]
JIT\Stress\ABI\stubs_do\stubs_do.cmd [FAIL]
JIT\Stress\ABI\pinvokes_do\pinvokes_do.cmd [FAIL]
JIT\Stress\ABI\tailcalls_do\tailcalls_do.cmd [FAIL]
Loader\classloader\MethodImpl\CovariantReturns\UnitTest\OverrideMoreDerivedReturn\OverrideMoreDerivedReturn.cmd [FAIL]
```
before the fix there were 90 failures including this 13.

PTAL @dotnet/jit-contrib 