### PR TITLE
Use Type.EmptyTypes consistently

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -377,7 +377,7 @@ namespace System
                 return indexParamTypes;
             }
 
-            return Array.Empty<Type>();
+            return Type.EmptyTypes;
         }
 
         private static void AddAttributesToList(List<Attribute> attributeList, Attribute[] attributes, Dictionary<Type, AttributeUsageAttribute> types)

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -268,7 +268,7 @@ namespace System.Reflection.Emit
             m_exceptions = null;
         }
 
-        internal override Type[] GetParameterTypes() => m_parameterTypes ??= Array.Empty<Type>();
+        internal override Type[] GetParameterTypes() => m_parameterTypes ??= Type.EmptyTypes;
 
         internal static Type? GetMethodBaseReturnType(MethodBase? method)
         {
@@ -306,7 +306,7 @@ namespace System.Reflection.Emit
 
         internal SignatureHelper GetMethodSignature()
         {
-            m_parameterTypes ??= Array.Empty<Type>();
+            m_parameterTypes ??= Type.EmptyTypes;
 
             m_signature = SignatureHelper.GetMethodSigHelper(m_module, m_callingConvention, m_inst != null ? m_inst.Length : 0,
                 m_returnType, m_returnTypeRequiredCustomModifiers, m_returnTypeOptionalCustomModifiers,
@@ -538,7 +538,7 @@ namespace System.Reflection.Emit
 
         public override bool IsGenericMethod => m_inst != null;
 
-        public override Type[] GetGenericArguments() => m_inst ?? Array.Empty<Type>();
+        public override Type[] GetGenericArguments() => m_inst ?? Type.EmptyTypes;
 
         public override MethodInfo MakeGenericMethod(params Type[] typeArguments)
         {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -39,7 +39,7 @@ namespace System.Reflection.Emit
             }
             else
             {
-                m_parameterTypes = Array.Empty<Type>();
+                m_parameterTypes = Type.EmptyTypes;
             }
 
             m_module = mod;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -846,7 +846,7 @@ namespace System.Reflection.Emit
 
             if (m_typeInterfaces == null)
             {
-                return Array.Empty<Type>();
+                return Type.EmptyTypes;
             }
 
             return m_typeInterfaces.ToArray();
@@ -1188,7 +1188,7 @@ namespace System.Reflection.Emit
             return TypeBuilderInstantiation.MakeGenericType(this, typeArguments);
         }
 
-        public override Type[] GetGenericArguments() => m_inst ?? Array.Empty<Type>();
+        public override Type[] GetGenericArguments() => m_inst ?? Type.EmptyTypes;
 
         // If a TypeBuilder is generic, it must be a generic type definition
         // All instantiated generic types are TypeBuilderInstantiation.

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/MdFieldInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/MdFieldInfo.cs
@@ -113,12 +113,12 @@ namespace System.Reflection
 
         public override Type[] GetRequiredCustomModifiers()
         {
-            return Array.Empty<Type>();
+            return Type.EmptyTypes;
         }
 
         public override Type[] GetOptionalCustomModifiers()
         {
-            return Array.Empty<Type>();
+            return Type.EmptyTypes;
         }
 
         #endregion

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -579,7 +579,7 @@ namespace System.Reflection
             RuntimeMethodHandle.GetMethodInstantiationInternal(this);
 
         public override Type[] GetGenericArguments() =>
-            RuntimeMethodHandle.GetMethodInstantiationPublic(this) ?? Array.Empty<Type>();
+            RuntimeMethodHandle.GetMethodInstantiationPublic(this) ?? Type.EmptyTypes;
 
         public override MethodInfo GetGenericMethodDefinition()
         {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3230,7 +3230,7 @@ namespace System
         public override Type[] GetGenericArguments()
         {
             Type[] types = GetRootElementType().GetTypeHandleInternal().GetInstantiationPublic();
-            return types ?? Array.Empty<Type>();
+            return types ?? Type.EmptyTypes;
         }
 
         public override Type MakeGenericType(Type[] instantiation)
@@ -3315,7 +3315,7 @@ namespace System
                 throw new InvalidOperationException(SR.Arg_NotGenericParameter);
 
             Type[] constraints = new RuntimeTypeHandle(this).GetConstraints();
-            return constraints ?? Array.Empty<Type>();
+            return constraints ?? Type.EmptyTypes;
         }
         #endregion
 

--- a/src/coreclr/src/tools/dotnet-pgo/Microsoft.Diagnostics.JitTrace/JitTraceRuntime.cs
+++ b/src/coreclr/src/tools/dotnet-pgo/Microsoft.Diagnostics.JitTrace/JitTraceRuntime.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Diagnostics.JitTrace
                     int signatureLen = int.Parse(methodStrComponents[2]);
                     string[] methodInstantiationArgComponents = SplitAndUnescape(methodStrComponents[3], innerCsvEscapeChar, innerCsvEscapeCharArray);
                     int genericMethodArgCount = int.Parse(methodInstantiationArgComponents[0]);
-                    Type[] methodArgs = genericMethodArgCount != 0 ? new Type[genericMethodArgCount] : Array.Empty<Type>();
+                    Type[] methodArgs = genericMethodArgCount != 0 ? new Type[genericMethodArgCount] : Type.EmptyTypes;
                     bool abortMethodDiscovery = false;
                     for (int iMethodArg = 0; iMethodArg < genericMethodArgCount; iMethodArg++)
                     {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         string ICSharpBinder.Name => "Invoke";
 
-        Type[] ICSharpInvokeOrInvokeMemberBinder.TypeArguments => Array.Empty<Type>();
+        Type[] ICSharpInvokeOrInvokeMemberBinder.TypeArguments => Type.EmptyTypes;
 
         CSharpCallFlags ICSharpInvokeOrInvokeMemberBinder.Flags => _flags;
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeConstructorBinder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
         public bool StaticCall => true;
 
-        public Type[] TypeArguments => Array.Empty<Type>();
+        public Type[] TypeArguments => Type.EmptyTypes;
 
         public string Name => ".ctor";
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinderExtensions.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                     }
 
                     // See if MetadataToken property is available.
-                    PropertyInfo property = memberInfo.GetProperty("MetadataToken", typeof(int), Array.Empty<Type>());
+                    PropertyInfo property = memberInfo.GetProperty("MetadataToken", typeof(int), Type.EmptyTypes);
 
                     if (property is not null && property.CanRead)
                     {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ActivatorUtilitiesTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ActivatorUtilitiesTests.cs
@@ -10,7 +10,7 @@ class Program
     {
         ServiceProvider provider = new ServiceCollection().BuildServiceProvider();
 
-        ObjectFactory factory = ActivatorUtilities.CreateFactory(typeof(ServiceA), Array.Empty<Type>());
+        ObjectFactory factory = ActivatorUtilities.CreateFactory(typeof(ServiceA), Type.EmptyTypes);
         ServiceA serviceA = factory(provider, null) as ServiceA;
         ServiceB serviceB = ActivatorUtilities.CreateInstance(provider, typeof(ServiceB)) as ServiceB;
         ServiceC serviceC = ActivatorUtilities.CreateInstance<ServiceC>(provider);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -285,7 +285,7 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    ConstructorInfo ci = reflect.UnderlyingSystemType.GetConstructor(Array.Empty<Type>());
+                    ConstructorInfo ci = reflect.UnderlyingSystemType.GetConstructor(Type.EmptyTypes);
                     if (ci != null)
                     {
                         attr = (Attribute)ci.Invoke(Array.Empty<object>());

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -81,7 +81,7 @@ namespace System.ComponentModel
                 }
 
                 const BindingFlags BindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.CreateInstance;
-                return itemType.GetConstructor(BindingFlags, null, Array.Empty<Type>(), null) != null;
+                return itemType.GetConstructor(BindingFlags, null, Type.EmptyTypes, null) != null;
             }
         }
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -298,7 +298,7 @@ namespace System.ComponentModel
                         if (_propInfo == null)
                         {
                             BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.GetProperty;
-                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
+                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, binder: null, PropertyType, Type.EmptyTypes, Array.Empty<ParameterModifier>());
                         }
                         if (_propInfo != null)
                         {
@@ -351,7 +351,7 @@ namespace System.ComponentModel
 
                     if (_receiverType == null)
                     {
-                        args = Array.Empty<Type>();
+                        args = Type.EmptyTypes;
                     }
                     else
                     {
@@ -382,7 +382,7 @@ namespace System.ComponentModel
                         for (Type t = ComponentType.BaseType; t != null && t != typeof(object); t = t.BaseType)
                         {
                             BindingFlags bindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-                            PropertyInfo p = t.GetProperty(name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), null);
+                            PropertyInfo p = t.GetProperty(name, bindingFlags, binder: null, PropertyType, Type.EmptyTypes, null);
                             if (p != null)
                             {
                                 _setMethod = p.GetSetMethod(nonPublic: false);
@@ -403,7 +403,7 @@ namespace System.ComponentModel
                         if (_propInfo == null)
                         {
                             BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.GetProperty;
-                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
+                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, binder: null, PropertyType, Type.EmptyTypes, Array.Empty<ParameterModifier>());
                         }
                         if (_propInfo != null)
                         {
@@ -435,7 +435,7 @@ namespace System.ComponentModel
 
                     if (_receiverType == null)
                     {
-                        args = Array.Empty<Type>();
+                        args = Type.EmptyTypes;
                     }
                     else
                     {
@@ -767,7 +767,7 @@ namespace System.ComponentModel
                     }
                     else
                     {
-                        memberInfo = currentReflectType.GetProperty(Name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
+                        memberInfo = currentReflectType.GetProperty(Name, bindingFlags, binder: null, PropertyType, Type.EmptyTypes, Array.Empty<ParameterModifier>());
                     }
 
                     // Get custom attributes for the member info.

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -247,7 +247,7 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    argTypes = Array.Empty<Type>();
+                    argTypes = Type.EmptyTypes;
                 }
 
                 obj = objectType.GetConstructor(argTypes)?.Invoke(args);

--- a/src/libraries/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilder.cs
+++ b/src/libraries/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilder.cs
@@ -13,7 +13,7 @@ namespace System.Composition.Convention
     /// </summary>
     public class PartConventionBuilder
     {
-        private readonly Type[] _emptyTypeArray = Array.Empty<Type>();
+        private readonly Type[] _emptyTypeArray = Type.EmptyTypes;
         private static List<Attribute> s_onImportsSatisfiedAttributeList;
         private static readonly List<Attribute> s_importingConstructorList = new List<Attribute>() { new ImportingConstructorAttribute() };
         private static readonly Type s_exportAttributeType = typeof(ExportAttribute);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -183,7 +183,7 @@ namespace System.Linq.Expressions.Compiler
             if (typeof(LambdaExpression).IsAssignableFrom(expr.Type))
             {
                 // if the invoke target is a lambda expression tree, first compile it into a delegate
-                expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Array.Empty<Type>())!);
+                expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Type.EmptyTypes)!);
             }
 
             EmitMethodCall(expr, expr.Type.GetInvokeMethod(), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2671,7 +2671,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (typeof(LambdaExpression).IsAssignableFrom(node.Expression.Type))
             {
-                MethodInfo compMethod = node.Expression.Type.GetMethod("Compile", Array.Empty<Type>())!;
+                MethodInfo compMethod = node.Expression.Type.GetMethod("Compile", Type.EmptyTypes)!;
                 CompileMethodCallExpression(
                     Expression.Call(
                         node.Expression,

--- a/src/libraries/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/DelegateType/DelegateCreationTests.cs
@@ -41,7 +41,7 @@ namespace System.Linq.Expressions.Tests
 
         public static IEnumerable<object[]> EmptyTypeArgs()
         {
-            yield return new object[] { Array.Empty<Type>() };
+            yield return new object[] { Type.EmptyTypes };
         }
 
         public static IEnumerable<object[]> ByRefTypeArgs()

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Tests
                 ModuleBuilder module = assembly.DefineDynamicModule("Name");
                 TypeBuilder type = module.DefineType("Type");
                 MethodBuilder throwingMethod = type.DefineMethod(
-                    "WillThrow", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Array.Empty<Type>());
+                    "WillThrow", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
                 ILGenerator ilGen = throwingMethod.GetILGenerator();
                 ilGen.Emit(OpCodes.Ldstr, "An Exceptional Exception!");
                 ilGen.Emit(OpCodes.Throw);
@@ -887,7 +887,7 @@ namespace System.Linq.Expressions.Tests
             */
 
             ConstantExpression builder = Expression.Constant(sb);
-            Type[] noTypes = Array.Empty<Type>();
+            Type[] noTypes = Type.EmptyTypes;
             TryExpression tryExp = Expression.TryCatch(
                 Expression.TryFinally(
                     Expression.Block(
@@ -911,7 +911,7 @@ namespace System.Linq.Expressions.Tests
         {
             StringBuilder sb = new StringBuilder();
             ConstantExpression builder = Expression.Constant(sb);
-            Type[] noTypes = Array.Empty<Type>();
+            Type[] noTypes = Type.EmptyTypes;
             TryExpression tryExp = Expression.TryCatch(
                 Expression.TryFault(
                     Expression.Block(

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
@@ -46,8 +46,8 @@ namespace System.Reflection
             return Array.Empty<object>();
         }
 
-        public virtual Type[] GetOptionalCustomModifiers() => Array.Empty<Type>();
-        public virtual Type[] GetRequiredCustomModifiers() => Array.Empty<Type>();
+        public virtual Type[] GetOptionalCustomModifiers() => Type.EmptyTypes;
+        public virtual Type[] GetRequiredCustomModifiers() => Type.EmptyTypes;
 
         public virtual int MetadataToken => MetadataToken_ParamDef;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/PropertyInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/PropertyInfo.cs
@@ -33,8 +33,8 @@ namespace System.Reflection
         public MethodInfo? GetSetMethod() => GetSetMethod(nonPublic: false);
         public abstract MethodInfo? GetSetMethod(bool nonPublic);
 
-        public virtual Type[] GetOptionalCustomModifiers() => Array.Empty<Type>();
-        public virtual Type[] GetRequiredCustomModifiers() => Array.Empty<Type>();
+        public virtual Type[] GetOptionalCustomModifiers() => Type.EmptyTypes;
+        public virtual Type[] GetRequiredCustomModifiers() => Type.EmptyTypes;
 
         [DebuggerHidden]
         [DebuggerStepThrough]

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureGenericParameterType.cs
@@ -30,8 +30,8 @@ namespace System.Reflection
         internal sealed override SignatureType? ElementType => null;
         public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);
         public sealed override Type GetGenericTypeDefinition() => throw new InvalidOperationException(SR.InvalidOperation_NotGenericType);
-        public sealed override Type[] GetGenericArguments() => Array.Empty<Type>();
-        public sealed override Type[] GenericTypeArguments => Array.Empty<Type>();
+        public sealed override Type[] GetGenericArguments() => Type.EmptyTypes;
+        public sealed override Type[] GenericTypeArguments => Type.EmptyTypes;
         public sealed override int GenericParameterPosition => _position;
         public abstract override string Name { get; }
         public sealed override string? Namespace => null;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureHasElementType.cs
@@ -31,8 +31,8 @@ namespace System.Reflection
         internal sealed override SignatureType? ElementType => _elementType;
         public abstract override int GetArrayRank();
         public sealed override Type GetGenericTypeDefinition() => throw new InvalidOperationException(SR.InvalidOperation_NotGenericType);
-        public sealed override Type[] GetGenericArguments() => Array.Empty<Type>();
-        public sealed override Type[] GenericTypeArguments => Array.Empty<Type>();
+        public sealed override Type[] GetGenericArguments() => Type.EmptyTypes;
+        public sealed override Type[] GenericTypeArguments => Type.EmptyTypes;
         public sealed override int GenericParameterPosition => throw new InvalidOperationException(SR.Arg_NotGenericParameter);
         public sealed override string Name => _elementType.Name + Suffix;
         public sealed override string? Namespace => _elementType.Namespace;

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -60,7 +60,7 @@ namespace System
         public virtual int GetArrayRank() => throw new NotSupportedException(SR.NotSupported_SubclassOverride);
 
         public virtual Type GetGenericTypeDefinition() => throw new NotSupportedException(SR.NotSupported_SubclassOverride);
-        public virtual Type[] GenericTypeArguments => (IsGenericType && !IsGenericTypeDefinition) ? GetGenericArguments() : Array.Empty<Type>();
+        public virtual Type[] GenericTypeArguments => (IsGenericType && !IsGenericTypeDefinition) ? GetGenericArguments() : Type.EmptyTypes;
         public virtual Type[] GetGenericArguments() => throw new NotSupportedException(SR.NotSupported_SubclassOverride);
 
         public virtual int GenericParameterPosition => throw new InvalidOperationException(SR.Arg_NotGenericParameter);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -388,7 +388,7 @@ namespace System.Runtime.Serialization
             else
             {
                 return (type.IsVisible &&
-                    type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>()) != null);
+                    type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Type.EmptyTypes) != null);
             }
         }
 
@@ -1425,7 +1425,7 @@ namespace System.Runtime.Serialization
                 if (type.IsValueType)
                     return null;
 
-                ConstructorInfo? ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>());
+                ConstructorInfo? ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Type.EmptyTypes);
                 if (ctor == null)
                     throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.NonAttributedSerializableTypesMustHaveDefaultConstructor, DataContract.GetClrTypeFullName(type))));
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
@@ -66,7 +66,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_objectToString == null)
                 {
-                    s_objectToString = typeof(object).GetMethod("ToString", Array.Empty<Type>());
+                    s_objectToString = typeof(object).GetMethod("ToString", Type.EmptyTypes);
                     Debug.Assert(s_objectToString != null);
                 }
                 return s_objectToString;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -883,7 +883,7 @@ namespace System.Runtime.Serialization
                     enumeratorType = GetEnumeratorMethod.ReturnType;
                 }
 
-                MethodInfo? getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
+                MethodInfo? getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes);
                 if (getCurrentMethod == null)
                 {
                     if (enumeratorType.IsInterface)
@@ -1145,7 +1145,7 @@ namespace System.Runtime.Serialization
             ConstructorInfo? defaultCtor = null;
             if (!type.IsValueType)
             {
-                defaultCtor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Array.Empty<Type>());
+                defaultCtor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes);
                 if (defaultCtor == null && constructorRequired)
                 {
                     // All collection types could be considered read-only collections except collection types that are marked [Serializable].
@@ -1364,7 +1364,7 @@ namespace System.Runtime.Serialization
 
             if (getEnumeratorMethod == null)
             {
-                getEnumeratorMethod = type.GetMethod(Globals.GetEnumeratorMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
+                getEnumeratorMethod = type.GetMethod(Globals.GetEnumeratorMethodName, BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes);
                 if (getEnumeratorMethod == null || !Globals.TypeOfIEnumerator.IsAssignableFrom(getEnumeratorMethod.ReturnType))
                 {
                     Type? ienumerableInterface = interfaceType.GetInterfaces().Where(t => t.FullName!.StartsWith("System.Collections.Generic.IEnumerable")).FirstOrDefault();

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1979,7 +1979,7 @@ namespace System.Runtime.Serialization
                             if (methodName.Length == 0)
                                 DataContract.ThrowInvalidDataContractException(SR.Format(SR.KnownTypeAttributeEmptyString, DataContract.GetClrTypeFullName(type)), type);
 
-                            MethodInfo? method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>());
+                            MethodInfo? method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public, Type.EmptyTypes);
                             if (method == null)
                                 DataContract.ThrowInvalidDataContractException(SR.Format(SR.KnownTypeAttributeUnknownMethod, methodName, DataContract.GetClrTypeFullName(type)), type);
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -162,7 +162,7 @@ namespace System.Runtime.Serialization
                     }
                     else
                     {
-                        _knownTypeCollection = new ReadOnlyCollection<Type>(Array.Empty<Type>());
+                        _knownTypeCollection = new ReadOnlyCollection<Type>(Type.EmptyTypes);
                     }
                 }
                 return _knownTypeCollection;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -92,7 +92,7 @@ namespace System.Runtime.Serialization.Json
                     }
                     else
                     {
-                        _knownTypeCollection = new ReadOnlyCollection<Type>(Array.Empty<Type>());
+                        _knownTypeCollection = new ReadOnlyCollection<Type>(Type.EmptyTypes);
                     }
                 }
                 return _knownTypeCollection;
@@ -547,7 +547,7 @@ namespace System.Runtime.Serialization.Json
                     }
                     else
                     {
-                        _knownTypeCollection = new ReadOnlyCollection<Type>(Array.Empty<Type>());
+                        _knownTypeCollection = new ReadOnlyCollection<Type>(Type.EmptyTypes);
                     }
                 }
                 return _knownTypeCollection;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -96,7 +96,7 @@ namespace System.Runtime.Serialization
 
         public static ConstructorInfo ExtensionDataObjectCtor => s_extensionDataObjectCtor ??
                                                                  (s_extensionDataObjectCtor =
-                                                                     typeof(ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, Array.Empty<Type>()))!;
+                                                                     typeof(ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, Type.EmptyTypes))!;
 
         public static PropertyInfo ExtensionDataProperty => s_extensionDataProperty ??
                                                             (s_extensionDataProperty = typeof(IExtensibleDataObject).GetProperty("ExtensionData")!);
@@ -180,7 +180,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_isStartElementMethod0 == null)
                 {
-                    s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Type.EmptyTypes);
                     Debug.Assert(s_isStartElementMethod0 != null);
                 }
                 return s_isStartElementMethod0;
@@ -383,7 +383,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_writeEndElementMethod == null)
                 {
-                    s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, Type.EmptyTypes);
                     Debug.Assert(s_writeEndElementMethod != null);
                 }
                 return s_writeEndElementMethod;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -573,11 +573,11 @@ namespace System.Runtime.Serialization.Json
                     {
                         case CollectionKind.GenericDictionary:
                             type = Globals.TypeOfDictionaryGeneric.MakeGenericType(itemType.GetGenericArguments());
-                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Array.Empty<Type>())!;
+                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes)!;
                             break;
                         case CollectionKind.Dictionary:
                             type = Globals.TypeOfHashtable;
-                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Array.Empty<Type>())!;
+                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes)!;
                             break;
                         case CollectionKind.Collection:
                         case CollectionKind.GenericCollection:

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -346,8 +346,8 @@ namespace System.Runtime.Serialization.Json
                     {
                         enumeratorType = collectionContract.GetEnumeratorMethod.ReturnType;
                     }
-                    MethodInfo? moveNextMethod = enumeratorType.GetMethod(Globals.MoveNextMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
-                    MethodInfo? getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
+                    MethodInfo? moveNextMethod = enumeratorType.GetMethod(Globals.MoveNextMethodName, BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes);
+                    MethodInfo? getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes);
                     if (moveNextMethod == null || getCurrentMethod == null)
                     {
                         if (enumeratorType.IsInterface)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionClassWriter.cs
@@ -66,7 +66,7 @@ namespace System.Runtime.Serialization
                     }
                     else
                     {
-                        MethodInfo getValue = memberType.GetMethod("get_Value", Array.Empty<Type>())!;
+                        MethodInfo getValue = memberType.GetMethod("get_Value", Type.EmptyTypes)!;
                         memberValue = getValue.Invoke(memberValue, Array.Empty<object>())!;
                         memberType = memberValue.GetType();
                     }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionReader.cs
@@ -441,7 +441,7 @@ namespace System.Runtime.Serialization
             else if (collectionContract.Kind == CollectionKind.GenericDictionary && collectionContract.UnderlyingType.IsInterface)
             {
                 Type type = Globals.TypeOfDictionaryGeneric.MakeGenericType(collectionContract.ItemType.GetGenericArguments());
-                ConstructorInfo ci = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>())!;
+                ConstructorInfo ci = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes)!;
                 object newGenericDict = ci.Invoke(Array.Empty<object>());
                 return newGenericDict;
             }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -241,7 +241,7 @@ namespace System.Runtime.Serialization
             if (type.IsValueType)
                 return null;
 
-            ConstructorInfo? ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Array.Empty<Type>());
+            ConstructorInfo? ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Type.EmptyTypes);
             if (ctor == null)
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.IXmlSerializableMustHaveDefaultConstructor, DataContract.GetClrTypeFullName(type))));
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatGeneratorStatics.cs
@@ -45,7 +45,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_writeEndElementMethod == null)
                 {
-                    s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    s_writeEndElementMethod = typeof(XmlWriterDelegator).GetMethod("WriteEndElement", Globals.ScanAllMembers, Type.EmptyTypes);
                     Debug.Assert(s_writeEndElementMethod != null);
                 }
                 return s_writeEndElementMethod;
@@ -147,7 +147,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_isStartElementMethod0 == null)
                 {
-                    s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Array.Empty<Type>());
+                    s_isStartElementMethod0 = typeof(XmlReaderDelegator).GetMethod("IsStartElement", Globals.ScanAllMembers, Type.EmptyTypes);
                     Debug.Assert(s_isStartElementMethod0 != null);
                 }
                 return s_isStartElementMethod0;
@@ -199,7 +199,7 @@ namespace System.Runtime.Serialization
         private static ConstructorInfo? s_extensionDataObjectCtor;
         internal static ConstructorInfo ExtensionDataObjectCtor => s_extensionDataObjectCtor ??
                                                                    (s_extensionDataObjectCtor =
-                                                                       typeof(ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, Array.Empty<Type>())!);
+                                                                       typeof(ExtensionDataObject).GetConstructor(Globals.ScanAllMembers, Type.EmptyTypes)!);
 
         private static ConstructorInfo? s_hashtableCtor;
         internal static ConstructorInfo HashtableCtor
@@ -208,7 +208,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_hashtableCtor == null)
                 {
-                    s_hashtableCtor = Globals.TypeOfHashtable.GetConstructor(Globals.ScanAllMembers, Array.Empty<Type>());
+                    s_hashtableCtor = Globals.TypeOfHashtable.GetConstructor(Globals.ScanAllMembers, Type.EmptyTypes);
                     Debug.Assert(s_hashtableCtor != null);
                 }
                 return s_hashtableCtor;
@@ -264,7 +264,7 @@ namespace System.Runtime.Serialization
             {
                 if (s_resetCollectionMemberInfoMethod == null)
                 {
-                    s_resetCollectionMemberInfoMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ResetCollectionMemberInfo", Globals.ScanAllMembers, Array.Empty<Type>());
+                    s_resetCollectionMemberInfoMethod = typeof(XmlObjectSerializerReadContext).GetMethod("ResetCollectionMemberInfo", Globals.ScanAllMembers, Type.EmptyTypes);
                     Debug.Assert(s_resetCollectionMemberInfoMethod != null);
                 }
                 return s_resetCollectionMemberInfoMethod;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -596,7 +596,7 @@ namespace System.Runtime.Serialization
                     {
                         case CollectionKind.GenericDictionary:
                             type = Globals.TypeOfDictionaryGeneric.MakeGenericType(itemType.GetGenericArguments());
-                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>())!;
+                            constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes)!;
                             break;
                         case CollectionKind.Dictionary:
                             type = Globals.TypeOfHashtable;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -409,8 +409,8 @@ namespace System.Runtime.Serialization
                     {
                         enumeratorType = collectionContract.GetEnumeratorMethod.ReturnType;
                     }
-                    MethodInfo? moveNextMethod = enumeratorType.GetMethod(Globals.MoveNextMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
-                    MethodInfo? getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Array.Empty<Type>());
+                    MethodInfo? moveNextMethod = enumeratorType.GetMethod(Globals.MoveNextMethodName, BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes);
+                    MethodInfo? getCurrentMethod = enumeratorType.GetMethod(Globals.GetCurrentMethodName, BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes);
                     if (moveNextMethod == null || getCurrentMethod == null)
                     {
                         if (enumeratorType.IsInterface)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
@@ -309,7 +309,7 @@ namespace System.Xml.Serialization
                     MethodInfo ICollection_get_Count = typeof(ICollection).GetMethod(
                           "get_Count",
                           CodeGenerator.InstanceBindingFlags,
-                          Array.Empty<Type>()
+                          Type.EmptyTypes
                           )!;
                     Call(ICollection_get_Count);
                 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -234,7 +234,7 @@ namespace System.Xml.Serialization
                 }
             }
 
-            Type[] arguments = t.IsGenericType || t.ContainsGenericParameters ? t.GetGenericArguments() : Array.Empty<Type>();
+            Type[] arguments = t.IsGenericType || t.ContainsGenericParameters ? t.GetGenericArguments() : Type.EmptyTypes;
             GetCSharpName(t, arguments, 0, sb);
             for (int i = 0; i < rank; i++)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Models.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Models.cs
@@ -280,7 +280,7 @@ namespace System.Xml.Serialization
             _fieldType = fieldType;
             _fieldTypeDesc = fieldTypeDesc;
             _memberInfo = memberInfo;
-            _checkShouldPersistMethodInfo = memberInfo.DeclaringType!.GetMethod("ShouldSerialize" + memberInfo.Name, Array.Empty<Type>());
+            _checkShouldPersistMethodInfo = memberInfo.DeclaringType!.GetMethod("ShouldSerialize" + memberInfo.Name, Type.EmptyTypes);
             _checkShouldPersist = _checkShouldPersistMethodInfo != null;
 
             FieldInfo? specifiedField = memberInfo.DeclaringType.GetField(memberInfo.Name + "Specified");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SourceInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SourceInfo.cs
@@ -216,7 +216,7 @@ namespace System.Xml.Serialization
                 MethodInfo Nullable_get_Value = nullableType.GetMethod(
                     "get_Value",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ILG.Call(Nullable_get_Value);
                 if (targetType != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -1216,7 +1216,7 @@ namespace System.Xml.Serialization
 
         private static TypeFlags GetConstructorFlags(Type type, ref Exception? exception)
         {
-            ConstructorInfo? ctor = type.GetConstructor(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Array.Empty<Type>());
+            ConstructorInfo? ctor = type.GetConstructor(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes);
             if (ctor != null)
             {
                 TypeFlags flags = TypeFlags.HasDefaultConstructor;
@@ -1243,7 +1243,7 @@ namespace System.Xml.Serialization
         {
             if (typeof(IEnumerable).IsAssignableFrom(type))
             {
-                MethodInfo? enumerator = type.GetMethod("GetEnumerator", Array.Empty<Type>());
+                MethodInfo? enumerator = type.GetMethod("GetEnumerator", Type.EmptyTypes);
 
                 if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
                 {
@@ -1267,7 +1267,7 @@ namespace System.Xml.Serialization
                     {
                         // and finally private interface implementation
                         flags |= TypeFlags.UsePrivateImplementation;
-                        enumerator = type.GetMethod("System.Collections.IEnumerable.GetEnumerator", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Array.Empty<Type>());
+                        enumerator = type.GetMethod("System.Collections.IEnumerable.GetEnumerator", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes);
                     }
                 }
                 if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
@@ -165,7 +165,7 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(Hashtable),
                 "get_" + publicName,
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.PublicOverrideMethodAttributes | MethodAttributes.SpecialName);
             propertyBuilder.SetGetMethod(ilg.MethodBuilder!);
@@ -178,7 +178,7 @@ namespace System.Xml.Serialization
 
             ConstructorInfo Hashtable_ctor = typeof(Hashtable).GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             LocalBuilder _tmpLoc = ilg.DeclareLocal(typeof(Hashtable), "_tmp");
             ilg.New(Hashtable_ctor);
@@ -278,16 +278,16 @@ namespace System.Xml.Serialization
                 CodeIdentifier.GetCSharpName(baseSerializer),
                 TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializer),
-                Array.Empty<Type>());
+                Type.EmptyTypes);
 
             ConstructorInfo readerCtor = CreatedTypes[readerClass].GetConstructor(
                CodeGenerator.InstanceBindingFlags,
-               Array.Empty<Type>()
+               Type.EmptyTypes
                )!;
             ilg = new CodeGenerator(baseSerializerTypeBuilder);
             ilg.BeginMethod(typeof(XmlSerializationReader),
                 "CreateReader",
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             ilg.New(readerCtor);
@@ -295,11 +295,11 @@ namespace System.Xml.Serialization
 
             ConstructorInfo writerCtor = CreatedTypes[writerClass].GetConstructor(
                CodeGenerator.InstanceBindingFlags,
-               Array.Empty<Type>()
+               Type.EmptyTypes
                )!;
             ilg.BeginMethod(typeof(XmlSerializationWriter),
                 "CreateWriter",
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             ilg.New(writerCtor);
@@ -323,7 +323,7 @@ namespace System.Xml.Serialization
                 CodeIdentifier.GetCSharpName(serializerName),
                 TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
                 CreatedTypes[baseSerializer],
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 );
 
             ilg = new CodeGenerator(typedSerializerTypeBuilder);
@@ -395,7 +395,7 @@ namespace System.Xml.Serialization
                 MethodInfo readerType_readMethod = CreatedTypes[readerClass].GetMethod(
                     readMethod,
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg("reader");
                 ilg.Castclass(CreatedTypes[readerClass]);
@@ -423,7 +423,7 @@ namespace System.Xml.Serialization
             {
                 ConstructorInfo ctor = CreatedTypes[(string)serializers[key]].GetConstructor(
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg!.Ldloc(typeof(Hashtable), "_tmp");
                 ilg.Ldstr(GetCSharpString(key));
@@ -463,7 +463,7 @@ namespace System.Xml.Serialization
                     {
                         ConstructorInfo ctor = CreatedTypes[(string)serializers[xmlMappings[i].Key!]].GetConstructor(
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.New(ctor);
                         ilg.Stloc(ilg.ReturnLocal);
@@ -487,7 +487,7 @@ namespace System.Xml.Serialization
                 "XmlSerializerContract",
                 TypeAttributes.Public | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializerImplementation),
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 );
 
             ilg = new CodeGenerator(serializerContractTypeBuilder);
@@ -499,13 +499,13 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(XmlSerializationReader),
                 "get_Reader",
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.PublicOverrideMethodAttributes | MethodAttributes.SpecialName);
             propertyBuilder.SetGetMethod(ilg.MethodBuilder!);
             ConstructorInfo ctor = CreatedTypes[readerType].GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.New(ctor);
             ilg.EndMethod();
@@ -519,13 +519,13 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(XmlSerializationWriter),
                 "get_Writer",
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.PublicOverrideMethodAttributes | MethodAttributes.SpecialName);
             propertyBuilder.SetGetMethod(ilg.MethodBuilder!);
             ctor = CreatedTypes[writerType].GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.New(ctor);
             ilg.EndMethod();
@@ -539,13 +539,13 @@ namespace System.Xml.Serialization
             // Default ctor
             ConstructorInfo baseCtor = typeof(XmlSerializerImplementation).GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg = new CodeGenerator(serializerContractTypeBuilder);
             ilg.BeginMethod(
                 typeof(void),
                 ".ctor",
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.PublicMethodAttributes | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName
                 );

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -193,7 +193,7 @@ namespace System.Xml.Serialization
                 ClassName,
                 TypeAttributes | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializationReader),
-                Array.Empty<Type>());
+                Type.EmptyTypes);
             foreach (TypeScope scope in Scopes)
             {
                 foreach (TypeMapping mapping in scope.TypeMappings)
@@ -230,17 +230,17 @@ namespace System.Xml.Serialization
             GenerateInitCallbacksMethod();
 
             ilg = new CodeGenerator(this.typeBuilder);
-            ilg.BeginMethod(typeof(void), "InitIDs", Array.Empty<Type>(), Array.Empty<string>(),
+            ilg.BeginMethod(typeof(void), "InitIDs", Type.EmptyTypes, Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                  "get_Reader",
                  CodeGenerator.InstanceBindingFlags,
-                 Array.Empty<Type>()
+                 Type.EmptyTypes
                  )!;
             MethodInfo XmlReader_get_NameTable = typeof(XmlReader).GetMethod(
                 "get_NameTable",
                 CodeGenerator.InstanceBindingFlags,
-                 Array.Empty<Type>()
+                 Type.EmptyTypes
                 )!;
             MethodInfo XmlNameTable_Add = typeof(XmlNameTable).GetMethod(
                 "Add",
@@ -287,7 +287,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                  "get_Reader",
                  CodeGenerator.InstanceBindingFlags,
-                 Array.Empty<Type>()
+                 Type.EmptyTypes
                  )!;
             MethodInfo XmlReader_IsStartElement = typeof(XmlReader).GetMethod(
                  "IsStartElement",
@@ -345,7 +345,7 @@ namespace System.Xml.Serialization
         private void GenerateInitCallbacksMethod()
         {
             ilg = new CodeGenerator(this.typeBuilder);
-            ilg.BeginMethod(typeof(void), "InitCallbacks", Array.Empty<Type>(), Array.Empty<string>(),
+            ilg.BeginMethod(typeof(void), "InitCallbacks", Type.EmptyTypes, Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             ilg.EndMethod();
         }
@@ -394,7 +394,7 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(object[]),
                 methodName,
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.PublicMethodAttributes
                 );
@@ -403,12 +403,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                "MoveToContent",
                CodeGenerator.InstanceBindingFlags,
-               Array.Empty<Type>()
+               Type.EmptyTypes
                )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -523,7 +523,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_MoveToElement = typeof(XmlReader).GetMethod(
                     "MoveToElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -538,7 +538,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                     "get_IsEmptyElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -548,7 +548,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                         "Skip",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -563,7 +563,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                     "ReadStartElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -592,7 +592,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                     "ReadEndElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -637,7 +637,7 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(object),
                 methodName,
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 CodeGenerator.PublicMethodAttributes
                 );
@@ -652,12 +652,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                "MoveToContent",
                CodeGenerator.InstanceBindingFlags,
-               Array.Empty<Type>()
+               Type.EmptyTypes
                )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -705,12 +705,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_ReadXXXString = typeof(XmlReader).GetMethod(
                         source == "Reader.ReadElementString()" ? "ReadElementContentAsString" : "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -721,12 +721,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                           "get_Value",
                           CodeGenerator.InstanceBindingFlags,
-                          Array.Empty<Type>()
+                          Type.EmptyTypes
                           )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -755,12 +755,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_ReadXXXString = typeof(XmlReader).GetMethod(
                         source == "Reader.ReadElementString()" ? "ReadElementContentAsString" : "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -771,12 +771,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                           "get_Value",
                           CodeGenerator.InstanceBindingFlags,
-                          Array.Empty<Type>()
+                          Type.EmptyTypes
                           )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -820,12 +820,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_method = typeof(XmlReader).GetMethod(
                         source == "Reader.Value" ? "get_Value" : "ReadElementContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     if (mapping.TypeDesc.CollapseWhitespace)
                         ilg.Ldarg(0);
@@ -878,12 +878,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_ReadXXXString = typeof(XmlReader).GetMethod(
                         source == "Reader.ReadElementString()" ? "ReadElementContentAsString" : "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -894,12 +894,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                           "get_Value",
                           CodeGenerator.InstanceBindingFlags,
-                          Array.Empty<Type>()
+                          Type.EmptyTypes
                           )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -970,7 +970,7 @@ namespace System.Xml.Serialization
             ilg.BeginMethod(
                 typeof(Hashtable),
                 "get_" + propName,
-                Array.Empty<Type>(),
+                Type.EmptyTypes,
                 Array.Empty<string>(),
                 MethodAttributes.Assembly | MethodAttributes.HideBySig | MethodAttributes.SpecialName);
 
@@ -981,7 +981,7 @@ namespace System.Xml.Serialization
 
             ConstructorInfo Hashtable_ctor = typeof(Hashtable).GetConstructor(
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             LocalBuilder hLoc = ilg.DeclareLocal(typeof(Hashtable), "h");
             ilg.New(Hashtable_ctor);
@@ -1190,12 +1190,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                             "get_Reader",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                             "ReadStartElement",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationReader_get_Reader);
@@ -1220,7 +1220,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlReader_ReadString = typeof(XmlReader).GetMethod(
                             "ReadContentAsString",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldarg(0);
                         ilg.Ldarg(0);
@@ -1234,7 +1234,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                             "ReadEndElement",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -1300,7 +1300,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                 "ReadNull",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>())!;
+                Type.EmptyTypes)!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_ReadNull);
             ilg.If();
@@ -1358,12 +1358,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_GetXsiType = typeof(XmlSerializationReader).GetMethod(
                 "GetXsiType",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                  "ReadNull",
                  CodeGenerator.InstanceBindingFlags,
-                 Array.Empty<Type>()
+                 Type.EmptyTypes
                  )!;
             Label labelTrue = ilg.DefineLabel();
             Label labelEnd = ilg.DefineLabel();
@@ -1622,12 +1622,12 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                     "get_Reader",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 MethodInfo XmlReader_MoveToElement = typeof(XmlReader).GetMethod(
                     "MoveToElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1637,7 +1637,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                     "get_IsEmptyElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1646,7 +1646,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                     "Skip",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1660,7 +1660,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                     "ReadStartElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1676,7 +1676,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                     "MoveToContent",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_get_Reader);
@@ -1689,7 +1689,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                     "ReadEndElement",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -1710,12 +1710,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlQualifiedName_get_Name = typeof(XmlQualifiedName).GetMethod(
                 "get_Name",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlQualifiedName_get_Namespace = typeof(XmlQualifiedName).GetMethod(
                 "get_Namespace",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             Label labelEnd = ilg.DefineLabel();
             Label labelFalse = ilg.DefineLabel();
@@ -1753,17 +1753,17 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_" + source,
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_get_LocalName = typeof(XmlReader).GetMethod(
                 "get_LocalName",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_get_NamespaceURI = typeof(XmlReader).GetMethod(
                 "get_NamespaceURI",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
 
             Label labelFalse = ilg.DefineLabel();
@@ -1824,12 +1824,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_MoveToNextAttribute = typeof(XmlReader).GetMethod(
                 "MoveToNextAttribute",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.WhileBegin();
 
@@ -1888,17 +1888,17 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_Name = typeof(XmlReader).GetMethod(
                     "get_Name",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 MethodInfo XmlReader_get_LocalName = typeof(XmlReader).GetMethod(
                     "get_LocalName",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                     "get_Value",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Ldarg(0);
@@ -1914,7 +1914,7 @@ namespace System.Xml.Serialization
                 WriteSourceBegin(xmlnsMember.Source);
                 ConstructorInfo ctor = xmlnsMember.Mapping.TypeDesc!.Type!.GetConstructor(
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.New(ctor);
                 WriteSourceEnd(xmlnsMember.Source, xmlnsMember.Mapping.TypeDesc.Type!);
@@ -1930,7 +1930,7 @@ namespace System.Xml.Serialization
                 MethodInfo String_get_Length = typeof(string).GetMethod(
                     "get_Length",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ILGenLoad(xmlnsMember.ArraySource, xmlnsMember.Mapping.TypeDesc.Type);
                 ilg.Ldarg(0);
@@ -1963,7 +1963,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlReader_get_Name = typeof(XmlReader).GetMethod(
                     "get_Name",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 ilg.Ldarg(0);
                 ilg.Ldarg(0);
@@ -1979,7 +1979,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_get_Document = typeof(XmlSerializationReader).GetMethod(
                     "get_Document",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 MethodInfo XmlDocument_ReadNode = typeof(XmlDocument).GetMethod(
                     "ReadNode",
@@ -2094,12 +2094,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                         "get_Reader",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     MethodInfo XmlReader_get_Value = typeof(XmlReader).GetMethod(
                         "get_Value",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -2253,12 +2253,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_get_NodeType = typeof(XmlReader).GetMethod(
                  "get_NodeType",
                  CodeGenerator.InstanceBindingFlags,
-                 Array.Empty<Type>()
+                 Type.EmptyTypes
                  )!;
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             int XmlNodeType_Element = 1;
             ilg.Ldarg(0);
@@ -2285,12 +2285,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_get_NodeType = typeof(XmlReader).GetMethod(
                 "get_NodeType",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2342,17 +2342,17 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                             "get_Reader",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlReader_ReadString = typeof(XmlReader).GetMethod(
                             "ReadContentAsString",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlSerializationReader_get_Document = typeof(XmlSerializationReader).GetMethod(
                             "get_Document",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlDocument_CreateTextNode = typeof(XmlDocument).GetMethod(
                             "CreateTextNode",
@@ -2386,12 +2386,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                          "get_Reader",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     MethodInfo XmlReader_ReadString = typeof(XmlReader).GetMethod(
                         "ReadContentAsString",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -2526,7 +2526,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_get_IsReturnValue = typeof(XmlSerializationReader).GetMethod(
                             "get_IsReturnValue",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationReader_get_IsReturnValue);
@@ -2869,7 +2869,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                 "ReadNull",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_ReadNull);
@@ -2904,12 +2904,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                 "get_IsEmptyElement",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2925,7 +2925,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                 "Skip",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2935,7 +2935,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_ReadStartElement = typeof(XmlReader).GetMethod(
                 "ReadStartElement",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2947,7 +2947,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                 "MoveToContent",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -2958,7 +2958,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_ReadEndElement = typeof(XmlSerializationReader).GetMethod(
                 "ReadEndElement",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_ReadEndElement);
@@ -3015,7 +3015,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                          "ReadNull",
                          CodeGenerator.InstanceBindingFlags,
-                         Array.Empty<Type>()
+                         Type.EmptyTypes
                          )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_ReadNull);
@@ -3038,12 +3038,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                         "get_Reader",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                         "get_IsEmptyElement",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -3052,7 +3052,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                         "Skip",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -3069,12 +3069,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                        "get_Reader",
                        CodeGenerator.InstanceBindingFlags,
-                       Array.Empty<Type>()
+                       Type.EmptyTypes
                        )!;
                     MethodInfo XmlReader_get_IsEmptyElement = typeof(XmlReader).GetMethod(
                         "get_IsEmptyElement",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -3084,7 +3084,7 @@ namespace System.Xml.Serialization
                     MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                         "Skip",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
@@ -3112,7 +3112,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationReader_ReadElementQualifiedName = typeof(XmlSerializationReader).GetMethod(
                                "ReadElementQualifiedName",
                                CodeGenerator.InstanceBindingFlags,
-                               Array.Empty<Type>()
+                               Type.EmptyTypes
                                )!;
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationReader_ReadElementQualifiedName);
@@ -3153,12 +3153,12 @@ namespace System.Xml.Serialization
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                         "get_Reader",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     MethodInfo XmlReader_Skip = typeof(XmlReader).GetMethod(
                         "Skip",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     ilg.Ldloc(arrayName!);
                     ilg.Load(null);
@@ -3219,7 +3219,7 @@ namespace System.Xml.Serialization
                             MethodInfo XmlSerializationReader_GetXsiType = typeof(XmlSerializationReader).GetMethod(
                                 "GetXsiType",
                                 CodeGenerator.InstanceBindingFlags,
-                                Array.Empty<Type>()
+                                Type.EmptyTypes
                                 )!;
                             Label labelTrue = ilg.DefineLabel();
                             Label labelEnd = ilg.DefineLabel();
@@ -3372,12 +3372,12 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                 "get_Reader",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             MethodInfo XmlReader_MoveToContent = typeof(XmlReader).GetMethod(
                 "MoveToContent",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_get_Reader);
@@ -3397,12 +3397,12 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                     "get_Reader",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 MethodInfo XmlReader_get_NodeType = typeof(XmlReader).GetMethod(
                     "get_NodeType",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 Label labelFalse = ilg.DefineLabel();
                 Label labelEnd = ilg.DefineLabel();
@@ -3586,7 +3586,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationReader_CreateUnknownNodeException = typeof(XmlSerializationReader).GetMethod(
                        "CreateUnknownNodeException",
                        CodeGenerator.InstanceBindingFlags,
-                       Array.Empty<Type>()
+                       Type.EmptyTypes
                        )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationReader_CreateUnknownNodeException);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -29,7 +29,7 @@ namespace System.Xml.Serialization
                 ClassName,
                 TypeAttributes | TypeAttributes.BeforeFieldInit,
                 typeof(XmlSerializationWriter),
-                Array.Empty<Type>());
+                Type.EmptyTypes);
 
             foreach (TypeScope scope in Scopes)
             {
@@ -84,7 +84,7 @@ namespace System.Xml.Serialization
         private void GenerateInitCallbacksMethod()
         {
             ilg = new CodeGenerator(this.typeBuilder);
-            ilg.BeginMethod(typeof(void), "InitCallbacks", Array.Empty<Type>(), Array.Empty<string>(),
+            ilg.BeginMethod(typeof(void), "InitCallbacks", Type.EmptyTypes, Array.Empty<string>(),
                 CodeGenerator.ProtectedOverrideMethodAttributes);
             ilg.EndMethod();
         }
@@ -315,7 +315,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_WriteEndElement = typeof(XmlSerializationWriter).GetMethod(
                 "WriteEndElement",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_WriteEndElement);
@@ -363,7 +363,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_WriteStartDocument = typeof(XmlSerializationWriter).GetMethod(
                 "WriteStartDocument",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_WriteStartDocument);
@@ -371,7 +371,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_TopLevelElement = typeof(XmlSerializationWriter).GetMethod(
                 "TopLevelElement",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_TopLevelElement);
@@ -554,7 +554,7 @@ namespace System.Xml.Serialization
             MethodInfo XmlSerializationWriter_WriteStartDocument = typeof(XmlSerializationWriter).GetMethod(
                 "WriteStartDocument",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>()
+                Type.EmptyTypes
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationWriter_WriteStartDocument);
@@ -574,7 +574,7 @@ namespace System.Xml.Serialization
                 MethodInfo XmlSerializationWriter_TopLevelElement = typeof(XmlSerializationWriter).GetMethod(
                       "TopLevelElement",
                       CodeGenerator.InstanceBindingFlags,
-                      Array.Empty<Type>()
+                      Type.EmptyTypes
                       )!;
                 ilg.Ldarg(0);
                 ilg.Call(XmlSerializationWriter_TopLevelElement);
@@ -698,7 +698,7 @@ namespace System.Xml.Serialization
                     MethodInfo CultureInfo_get_InvariantCulture = typeof(CultureInfo).GetMethod(
                         "get_InvariantCulture",
                         CodeGenerator.StaticBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     MethodInfo Int64_ToString = typeof(long).GetMethod(
                         "ToString",
@@ -799,7 +799,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlWriter_WriteStartElement = typeof(XmlWriter).GetMethod(
                             "WriteStartElement",
@@ -842,7 +842,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlWriter_WriteEndElement = typeof(XmlWriter).GetMethod(
                             "WriteEndElement",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationWriter_get_Writer);
@@ -865,7 +865,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlWriter_WriteStartElement = typeof(XmlWriter).GetMethod(
                             "WriteStartElement",
@@ -892,7 +892,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlWriter_WriteEndElement = typeof(XmlWriter).GetMethod(
                             "WriteEndElement",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationWriter_get_Writer);
@@ -957,7 +957,7 @@ namespace System.Xml.Serialization
             MethodInfo Object_GetType = typeof(object).GetMethod(
                     "GetType",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
             ArgBuilder oArg = ilg.GetArg("o");
             ilg.LdargAddress(oArg);
@@ -1171,7 +1171,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlWriter_WriteStartAttribute = typeof(XmlWriter).GetMethod(
                             "WriteStartAttribute",
@@ -1190,7 +1190,7 @@ namespace System.Xml.Serialization
                         LocalBuilder sbLoc = ilg.DeclareOrGetLocal(typeof(StringBuilder), "sb");
                         ConstructorInfo StringBuilder_ctor = typeof(StringBuilder).GetConstructor(
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.New(StringBuilder_ctor);
                         ilg.Stloc(sbLoc);
@@ -1222,7 +1222,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlWriter_WriteString = typeof(XmlWriter).GetMethod(
                             "WriteString",
@@ -1286,12 +1286,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlWriter_WriteEndAttribute = typeof(XmlWriter).GetMethod(
                             "WriteEndAttribute",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldarg(0);
                         ilg.Call(XmlSerializationWriter_get_Writer);
@@ -1302,7 +1302,7 @@ namespace System.Xml.Serialization
                         MethodInfo StringBuilder_get_Length = typeof(StringBuilder).GetMethod(
                             "get_Length",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldloc("sb");
                         ilg.Call(StringBuilder_get_Length);
@@ -1322,7 +1322,7 @@ namespace System.Xml.Serialization
                         MethodInfo Object_ToString = typeof(object).GetMethod(
                             "ToString",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldloc("sb");
                         ilg.Call(Object_ToString);
@@ -1480,7 +1480,7 @@ namespace System.Xml.Serialization
                     getEnumeratorMethod = typeIEnumerable.GetMethod(
                         "GetEnumerator",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>())!;
+                        Type.EmptyTypes)!;
 
                     ilg.ConvertValue(arrayTypeDesc.Type!, typeIEnumerable);
                 }
@@ -1491,7 +1491,7 @@ namespace System.Xml.Serialization
                     getEnumeratorMethod = typeIEnumerable.GetMethod(
                         "GetEnumerator",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>())!;
+                        Type.EmptyTypes)!;
 
                     ilg.ConvertValue(arrayTypeDesc.Type!, typeIEnumerable);
                 }
@@ -1499,7 +1499,7 @@ namespace System.Xml.Serialization
                 {
                     getEnumeratorMethod = arrayTypeDesc.Type!.GetMethod(
                         "GetEnumerator",
-                        Array.Empty<Type>())!;
+                        Type.EmptyTypes)!;
                 }
                 ilg.Call(getEnumeratorMethod);
                 ilg.ConvertValue(getEnumeratorMethod.ReturnType, typeof(IEnumerator));
@@ -1518,7 +1518,7 @@ namespace System.Xml.Serialization
                 MethodInfo IEnumerator_MoveNext = typeof(IEnumerator).GetMethod(
                     "MoveNext",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>())!;
+                    Type.EmptyTypes)!;
                 ilg.Ldloc(eLoc);
                 ilg.Call(IEnumerator_MoveNext);
                 ilg.WhileEndCondition();
@@ -1699,12 +1699,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlNode_get_Name = typeof(XmlNode).GetMethod(
                             "get_Name",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlNode_get_NamespaceURI = typeof(XmlNode).GetMethod(
                             "get_NamespaceURI",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Ldloc(elemLoc);
                         ilg.Call(XmlNode_get_Name);
@@ -1769,12 +1769,12 @@ namespace System.Xml.Serialization
                         MethodInfo XmlNode_get_Name = typeof(XmlNode).GetMethod(
                             "get_Name",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         MethodInfo XmlNode_get_NamespaceURI = typeof(XmlNode).GetMethod(
                             "get_NamespaceURI",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         ilg.Call(XmlNode_get_Name);
                         ilg.Ldloc(elemLoc);
@@ -1870,7 +1870,7 @@ namespace System.Xml.Serialization
                         MethodInfo XmlSerializationWriter_get_Writer = typeof(XmlSerializationWriter).GetMethod(
                             "get_Writer",
                             CodeGenerator.InstanceBindingFlags,
-                            Array.Empty<Type>()
+                            Type.EmptyTypes
                             )!;
                         source.Load(source.Type);
                         ilg.Ldarg(0);
@@ -1894,7 +1894,7 @@ namespace System.Xml.Serialization
                     MethodInfo Nullable_get_HasValue = element.Mapping.TypeDesc.Type!.GetMethod(
                         "get_HasValue",
                         CodeGenerator.InstanceBindingFlags,
-                        Array.Empty<Type>()
+                        Type.EmptyTypes
                         )!;
                     source.LoadAddress(element.Mapping.TypeDesc.Type);
                     ilg.Call(Nullable_get_HasValue);
@@ -2087,7 +2087,7 @@ namespace System.Xml.Serialization
                 MethodInfo String_get_Length = typeof(string).GetMethod(
                     "get_Length",
                     CodeGenerator.InstanceBindingFlags,
-                    Array.Empty<Type>()
+                    Type.EmptyTypes
                     )!;
                 source.Load(typeof(string));
                 ilg.Call(String_get_Length);
@@ -2351,7 +2351,7 @@ namespace System.Xml.Serialization
             {
                 ConstructorInfo ctor = type.GetConstructor(
                        CodeGenerator.InstanceBindingFlags,
-                       Array.Empty<Type>()
+                       Type.EmptyTypes
                        )!;
                 if (ctor != null)
                     ilg.New(ctor);
@@ -2458,7 +2458,7 @@ namespace System.Xml.Serialization
             MethodInfo IEnumeratorMoveNext = typeof(IEnumerator).GetMethod(
                 "MoveNext",
                 CodeGenerator.InstanceBindingFlags,
-                Array.Empty<Type>())!;
+                Type.EmptyTypes)!;
             ilg.Ldloc(enumerator);
             ilg.Call(IEnumeratorMoveNext);
             ilg.WhileEndCondition();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -160,7 +160,7 @@ namespace System.Xml.Serialization
         {
         }
 
-        public XmlSerializer(Type type, XmlRootAttribute? root) : this(type, null, Array.Empty<Type>(), root, null, null)
+        public XmlSerializer(Type type, XmlRootAttribute? root) : this(type, null, Type.EmptyTypes, root, null, null)
         {
         }
 
@@ -168,7 +168,7 @@ namespace System.Xml.Serialization
         {
         }
 
-        public XmlSerializer(Type type, XmlAttributeOverrides? overrides) : this(type, overrides, Array.Empty<Type>(), null, null, null)
+        public XmlSerializer(Type type, XmlAttributeOverrides? overrides) : this(type, overrides, Type.EmptyTypes, null, null, null)
         {
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerFactory.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializerFactory.cs
@@ -24,7 +24,7 @@ namespace System.Xml.Serialization
 
         public XmlSerializer CreateSerializer(Type type, XmlRootAttribute? root)
         {
-            return CreateSerializer(type, null, Array.Empty<Type>(), root, null, null);
+            return CreateSerializer(type, null, Type.EmptyTypes, root, null, null);
         }
 
         public XmlSerializer CreateSerializer(Type type, Type[]? extraTypes)
@@ -34,7 +34,7 @@ namespace System.Xml.Serialization
 
         public XmlSerializer CreateSerializer(Type type, XmlAttributeOverrides? overrides)
         {
-            return CreateSerializer(type, overrides, Array.Empty<Type>(), null, null, null);
+            return CreateSerializer(type, overrides, Type.EmptyTypes, null, null, null);
         }
 
         public XmlSerializer CreateSerializer(XmlTypeMapping xmlTypeMapping)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/GenerateHelper.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/GenerateHelper.cs
@@ -145,7 +145,7 @@ namespace System.Xml.Xsl.IlGen
 
         private static ConstructorInfo GetConstructor(Type className)
         {
-            ConstructorInfo constrInfo = className.GetConstructor(Array.Empty<Type>())!;
+            ConstructorInfo constrInfo = className.GetConstructor(Type.EmptyTypes)!;
             Debug.Assert(constrInfo != null, "Constructor " + className + " cannot be null.");
             return constrInfo;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlIlGenerator.cs
@@ -124,13 +124,13 @@ namespace System.Xml.Xsl
 
             // Create metadata for the Execute function, which is the entry point to the query
             // public static void Execute(XmlQueryRuntime);
-            MethodInfo methExec = _module.DefineMethod("Execute", typeof(void), Array.Empty<Type>(), Array.Empty<string>(), XmlILMethodAttributes.NonUser);
+            MethodInfo methExec = _module.DefineMethod("Execute", typeof(void), Type.EmptyTypes, Array.Empty<string>(), XmlILMethodAttributes.NonUser);
 
             // Create metadata for the root expression
             // public void Root()
             Debug.Assert(_qil.Root != null);
             XmlILMethodAttributes methAttrs = (_qil.Root.SourceLine == null) ? XmlILMethodAttributes.NonUser : XmlILMethodAttributes.None;
-            MethodInfo methRoot = _module.DefineMethod("Root", typeof(void), Array.Empty<Type>(), Array.Empty<string>(), methAttrs);
+            MethodInfo methRoot = _module.DefineMethod("Root", typeof(void), Type.EmptyTypes, Array.Empty<string>(), methAttrs);
 
             // Declare all early bound function objects
             foreach (EarlyBoundInfo info in _qil.EarlyBoundTypes)
@@ -253,7 +253,7 @@ namespace System.Xml.Xsl
                 // public T GlobalValue()
                 typReturn = XmlILTypeHelper.GetStorageType(ndRef.XmlType!);
                 methAttrs = ndRef.SourceLine == null ? XmlILMethodAttributes.NonUser : XmlILMethodAttributes.None;
-                methInfo = _module!.DefineMethod(ndRef.DebugName!.ToString(), typReturn, Array.Empty<Type>(), Array.Empty<string>(), methAttrs);
+                methInfo = _module!.DefineMethod(ndRef.DebugName!.ToString(), typReturn, Type.EmptyTypes, Array.Empty<string>(), methAttrs);
 
                 // Annotate function with MethodBuilder
                 XmlILAnnotation.Write(ndRef).FunctionBinding = methInfo;

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -413,7 +413,7 @@ namespace DispatchProxyTests
             List<MethodInfo> invokedMethods = new List<MethodInfo>();
             object proxy =
                 typeof(DispatchProxy)
-                .GetRuntimeMethod("Create", Array.Empty<Type>()).MakeGenericMethod(ieventServiceTypeInfo.AsType(), typeof(TestDispatchProxy))
+                .GetRuntimeMethod("Create", Type.EmptyTypes).MakeGenericMethod(ieventServiceTypeInfo.AsType(), typeof(TestDispatchProxy))
                 .Invoke(null, null);
             ((TestDispatchProxy)proxy).CallOnInvoke = (method, args) =>
             {

--- a/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderGetGenericArguments.cs
+++ b/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderGetGenericArguments.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Emit.Tests
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.Abstract);
             MethodBuilder method = type.DefineMethod("Name", MethodAttributes.Public);
-            Assert.Equal(Array.Empty<Type>(), method.GetGenericArguments());
+            Assert.Equal(Type.EmptyTypes, method.GetGenericArguments());
         }
 
         [Fact]

--- a/src/libraries/System.Reflection.Extensions/tests/RuntimeReflectionExtensionTests.cs
+++ b/src/libraries/System.Reflection.Extensions/tests/RuntimeReflectionExtensionTests.cs
@@ -235,7 +235,7 @@ namespace System.Reflection.Tests
                 }
             }
 
-            Assert.Equal(typeof(TestType).GetMethod("Flush"), typeof(TestType).GetRuntimeMethod("Flush", Array.Empty<Type>()));
+            Assert.Equal(typeof(TestType).GetMethod("Flush"), typeof(TestType).GetRuntimeMethod("Flush", Type.EmptyTypes));
         }
 
         [Fact]

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Modules/RoResourceModule.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Modules/RoResourceModule.cs
@@ -46,7 +46,7 @@ namespace System.Reflection.TypeLoading
 
         public sealed override bool IsResource() => true;
 
-        public sealed override Type[] GetTypes() => Array.Empty<Type>();
+        public sealed override Type[] GetTypes() => Type.EmptyTypes;
         protected sealed override RoDefinitionType? GetTypeCoreNoCache(ReadOnlySpan<byte> ns, ReadOnlySpan<byte> name, out Exception? e)
         {
             e = new TypeLoadException(SR.Format(SR.TypeNotFound, ns.ToUtf16().AppendTypeName(name.ToUtf16()), Assembly));

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/TestUtils/NetStandardBridge.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/TestUtils/NetStandardBridge.cs
@@ -43,7 +43,7 @@ namespace System.Reflection.Tests
         //
         public static T CallUsingReflection<T>(this object _this, string name, Type[] parameterTypes = null, object[] arguments = null)
         {
-            parameterTypes = parameterTypes ?? Array.Empty<Type>();
+            parameterTypes = parameterTypes ?? Type.EmptyTypes;
             arguments = arguments ?? Array.Empty<object>();
             Type implementationType = _this.GetType();
             MethodInfo m = implementationType.GetMethod(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.ExactBinding, null, parameterTypes, null);

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeInvariants.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeInvariants.cs
@@ -603,7 +603,7 @@ namespace System.Reflection.Tests
             Assert.True(position >= 0);
             GenericParameterAttributes attributes = type.GenericParameterAttributes;
 
-            Assert.Equal<Type>(Array.Empty<Type>(), type.GetGenericArguments());
+            Assert.Equal<Type>(Type.EmptyTypes, type.GetGenericArguments());
 
             Assert.False(type.IsByRefLike());
 

--- a/src/libraries/System.Runtime/tests/System/Reflection/BindingFlagsDoNotWrap.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/BindingFlagsDoNotWrap.cs
@@ -20,14 +20,14 @@ namespace System.Reflection.Tests
         [Fact]
         public static void ConstructorInvoke()
         {
-            ConstructorInfo c = typeof(TestClass).GetConstructor(BindingFlags.Public|BindingFlags.Instance, null, Array.Empty<Type>(), null);
+            ConstructorInfo c = typeof(TestClass).GetConstructor(BindingFlags.Public|BindingFlags.Instance, null, Type.EmptyTypes, null);
             TestDoNotWrap<MyException2>((bf) => c.Invoke(bf, null, Array.Empty<object>(), null));
         }
 
         [Fact]
         public static void ConstructorInvokeTwoArgs()
         {
-            ConstructorInfo c = typeof(TestClass).GetConstructor(BindingFlags.Public | BindingFlags.Instance, Array.Empty<Type>());
+            ConstructorInfo c = typeof(TestClass).GetConstructor(BindingFlags.Public | BindingFlags.Instance, Type.EmptyTypes);
             TestDoNotWrap<MyException2>((bf) => c.Invoke(bf, null, Array.Empty<object>(), null));
         }
 
@@ -49,7 +49,7 @@ namespace System.Reflection.Tests
         [Fact]
         public static void ConstructorInvokeUsingMethodInfoInvoke()
         {
-            ConstructorInfo c = typeof(TestClass).GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, Array.Empty<Type>(), null);
+            ConstructorInfo c = typeof(TestClass).GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes, null);
             TestDoNotWrap<MyException2>((bf) => c.Invoke(new TestClass(0), bf, null, Array.Empty<object>(), null));
         }
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/XmlKeyHelper.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/XmlKeyHelper.cs
@@ -277,7 +277,7 @@ namespace System.Security.Cryptography
                         "Elements",
                         BindingFlags.Instance | BindingFlags.Public,
                         null,
-                        Array.Empty<Type>(),
+                        Type.EmptyTypes,
                         null)!;
                 private static readonly PropertyInfo s_elementNameProperty = s_docRootProperty.PropertyType.GetProperty("Name")!;
                 private static readonly PropertyInfo s_nameNameProperty = s_elementNameProperty.PropertyType.GetProperty("LocalName")!;

--- a/src/libraries/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/tests/CryptoConfigTests.cs
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.CryptoConfigTests
                 Assert.IsAssignableFrom(baseType, created);
 
                 using (HashAlgorithm equivalent =
-                    (HashAlgorithm)baseType.GetMethod("Create", Array.Empty<Type>()).Invoke(null, null))
+                    (HashAlgorithm)baseType.GetMethod("Create", Type.EmptyTypes).Invoke(null, null))
                 {
                     byte[] input = { 1, 2, 3, 4, 5 };
                     byte[] equivHash = equivalent.ComputeHash(input);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -352,7 +352,7 @@ namespace System.Reflection.Emit
             sbName.Append(' ');
             sbName.Append(Name);
             sbName.Append('(');
-            AppendParameters(ref sbName, parameters ?? Array.Empty<Type>(), CallingConvention);
+            AppendParameters(ref sbName, parameters ?? Type.EmptyTypes, CallingConvention);
             sbName.Append(')');
             return sbName.ToString();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1206,7 +1206,7 @@ namespace System
             Type[] types = GetGenericArgumentsInternal(false);
 
             if (types == null)
-                types = Array.Empty<Type>();
+                types = Type.EmptyTypes;
 
             return types;
         }
@@ -1858,7 +1858,7 @@ namespace System
             ListBuilder<ConstructorInfo> ctors = GetConstructorCandidates(
                 null,
                 BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly, CallingConventions.Any,
-                Array.Empty<Type>(), false);
+                Type.EmptyTypes, false);
 
             if (ctors.Count == 1)
                 cache.default_ctor = ctor = (RuntimeConstructorInfo)ctors[0];
@@ -2265,7 +2265,7 @@ namespace System
             var paramInfo = new Mono.RuntimeGenericParamInfoHandle(RuntimeTypeHandle.GetGenericParameterInfo(this));
             Type[] constraints = paramInfo.Constraints;
 
-            return constraints ?? Array.Empty<Type>();
+            return constraints ?? Type.EmptyTypes;
         }
 
         internal static object CreateInstanceForAnotherGenericParameter(Type genericType, RuntimeType genericArgument)

--- a/src/tests/JIT/Stress/ABI/Stubs.cs
+++ b/src/tests/JIT/Stress/ABI/Stubs.cs
@@ -168,7 +168,7 @@ namespace ABIStress
 
             ILGenerator g = cb.GetILGenerator();
             g.Emit(OpCodes.Ldarg, 0);
-            g.Emit(OpCodes.Call, typeof(object).GetConstructor(Array.Empty<Type>()));
+            g.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes));
             g.Emit(OpCodes.Ldarg, 0);
             g.Emit(OpCodes.Ldarg_1);
             g.Emit(OpCodes.Stfld, fieldInfoMagicValueField);


### PR DESCRIPTION
We currently have several hundred uses of `Array.Empty<Type>()` and several hundred uses of `Type.EmptyTypes`.  This just changes the repo to use the latter consistently.