### PR TITLE
Fix spelling of OverideEventProvider

### DIFF
--- a/src/coreclr/src/debug/ee/controller.cpp
+++ b/src/coreclr/src/debug/ee/controller.cpp
@@ -1332,7 +1332,7 @@ bool DebuggerController::ApplyPatch(DebuggerControllerPatch *patch)
     LOG((LF_CORDB, LL_INFO10000, "DC::ApplyPatch at addr 0x%p\n",
         patch->address));
 
-    // If we try to apply an already applied patch, we'll overide our saved opcode
+    // If we try to apply an already applied patch, we'll override our saved opcode
     // with the break opcode and end up getting a break in out patch bypass buffer.
     _ASSERTE(!patch->IsActivated() );
     _ASSERTE(patch->IsBound());

--- a/src/coreclr/src/vm/ceeload.h
+++ b/src/coreclr/src/vm/ceeload.h
@@ -3282,7 +3282,7 @@ public:
     void Destruct();
 #endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
-    // Overides functions to access sections
+    // Overrides functions to access sections
     virtual TADDR GetIL(RVA target);
     virtual PTR_VOID GetRvaField(RVA rva, BOOL fZapped);
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [InlineData(false, true, false, true)]
         public void GetHostFxrPath_GlobalInstallation(bool explicitLoad, bool useAssemblyPath, bool useRegisteredLocation, bool isValid)
         {
-            // Overide the registry key for self-registered global installs.
+            // Override the registry key for self-registered global installs.
             // If using the registered location, set the install location value to the valid/invalid root.
             // If not using the registered location, do not set the value. When the value does not exist,
             // the product falls back to the default install location.

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SectionInformation.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SectionInformation.cs
@@ -501,7 +501,7 @@ namespace System.Configuration
         // It may not be editable for the following reasons:
         //   - We are in Runtime mode, not Design time
         //   - The section is not attached to a _configRecord.
-        //   - We are locked (ie. allowOveride = false )
+        //   - We are locked (ie. AllowOverride = false )
         //   - We are a parent section (ie. Retrieved from GetParentSection)
         //
         internal void VerifyIsEditable()

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1481,12 +1481,12 @@ namespace System.Diagnostics.Tracing
 #endif
 #if FEATURE_MANAGED_ETW
                 // Register the provider with ETW
-                var etwProvider = new OverideEventProvider(this, EventProviderType.ETW);
+                var etwProvider = new OverrideEventProvider(this, EventProviderType.ETW);
                 etwProvider.Register(this);
 #endif
 #if FEATURE_PERFTRACING
                 // Register the provider with EventPipe
-                var eventPipeProvider = new OverideEventProvider(this, EventProviderType.EventPipe);
+                var eventPipeProvider = new OverrideEventProvider(this, EventProviderType.EventPipe);
                 lock (EventListener.EventListenersLock)
                 {
                     eventPipeProvider.Register(this);
@@ -2444,9 +2444,9 @@ namespace System.Diagnostics.Tracing
         /// <summary>
         /// This class lets us hook the 'OnEventCommand' from the eventSource.
         /// </summary>
-        private class OverideEventProvider : EventProvider
+        private class OverrideEventProvider : EventProvider
         {
-            public OverideEventProvider(EventSource eventSource, EventProviderType providerType)
+            public OverrideEventProvider(EventSource eventSource, EventProviderType providerType)
                 : base(providerType)
             {
                 this.m_eventSource = eventSource;
@@ -3774,12 +3774,12 @@ namespace System.Diagnostics.Tracing
         // Dispatching state
         internal volatile EventDispatcher? m_Dispatchers;    // Linked list of code:EventDispatchers we write the data to (we also do ETW specially)
 #if FEATURE_MANAGED_ETW
-        private volatile OverideEventProvider m_etwProvider = null!;   // This hooks up ETW commands to our 'OnEventCommand' callback
+        private volatile OverrideEventProvider m_etwProvider = null!;   // This hooks up ETW commands to our 'OnEventCommand' callback
 #endif
 #if FEATURE_PERFTRACING
         private object? m_createEventLock;
         private IntPtr m_writeEventStringEventHandle = IntPtr.Zero;
-        private volatile OverideEventProvider m_eventPipeProvider = null!;
+        private volatile OverrideEventProvider m_eventPipeProvider = null!;
 #endif
         private bool m_completelyInited;                // The EventSource constructor has returned without exception.
         private Exception? m_constructionException;      // If there was an exception construction, this is it

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -217,7 +217,7 @@ namespace System.Text.Json
             }
 
             // Priority 2: Attempt to get custom converter added at runtime.
-            // Currently there is not a way at runtime to overide the [JsonConverter] when applied to a property.
+            // Currently there is not a way at runtime to override the [JsonConverter] when applied to a property.
             foreach (JsonConverter item in Converters)
             {
                 if (item.CanConvert(typeToConvert))

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.Attribute.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.Attribute.cs
@@ -169,7 +169,7 @@ namespace System.Text.Json.Serialization.Tests
 
             ClassWithJsonConverterAttributeOverride point = JsonSerializer.Deserialize<ClassWithJsonConverterAttributeOverride>(json);
 
-            // The property attribute overides the type attribute.
+            // The property attribute overrides the type attribute.
             Assert.Equal(101, point.Point1.X);
             Assert.Equal(102, point.Point1.Y);
 
@@ -187,7 +187,7 @@ namespace System.Text.Json.Serialization.Tests
 
             ClassWithJsonConverterAttributeOverride point = JsonSerializer.Deserialize<ClassWithJsonConverterAttributeOverride>(json);
 
-            // The property attribute overides the runtime.
+            // The property attribute overrides the runtime.
             Assert.Equal(101, point.Point1.X);
             Assert.Equal(102, point.Point1.Y);
 

--- a/src/tests/Loader/classloader/generics/regressions/395780/testExplicitOverride2.il
+++ b/src/tests/Loader/classloader/generics/regressions/395780/testExplicitOverride2.il
@@ -3,7 +3,7 @@
 
 .assembly extern System.Console { }
 // this test is also regression test for VSW 395780. The difference is that
-// .overrride directive in this case is in the class scope, whereas in testExplicitOverride
+// .override directive in this case is in the class scope, whereas in testExplicitOverride
 // .override directive is in method scope.
 
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.41122.00

--- a/src/tests/Loader/classloader/generics/regressions/vsw395780/testExplicitOverride2.il
+++ b/src/tests/Loader/classloader/generics/regressions/vsw395780/testExplicitOverride2.il
@@ -3,7 +3,7 @@
 
 .assembly extern System.Console { }
 // this test is also regression test for VSW 395780. The difference is that
-// .overrride directive in this case is in the class scope, whereas in testExplicitOverride
+// .override directive in this case is in the class scope, whereas in testExplicitOverride
 // .override directive is in method scope.
 
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.41122.00


### PR DESCRIPTION
This bugs me every time I see it show up in a trace, so I'm fixing it :)

Also fixed the other occurrences of "overide" in the repo.