### PR TITLE
Breaking change: Throw when resolving on a disposed service provider

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         {
                             disposable.Dispose();
                         }
-                        _disposables = null;
                     }
                     ThrowHelper.ThrowObjectDisposedException();
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private List<object> _disposables;
 
         private bool _disposed;
-        private object _locker = new object();
+        private object _lock = new object();
 
         public ServiceProviderEngineScope(ServiceProviderEngine engine)
         {
@@ -49,13 +49,17 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 return service;
             }
 
-            lock (_locker)
+            lock (_lock)
             {
                 if (_disposed)
                 {
                     if (_disposables != null)
                     {
                         // cleanup disposable just in case still has items before throwing
+                        foreach (IDisposable disposable in _disposables)
+                        {
+                            disposable.Dispose();
+                        }
                         _disposables = null;
                     }
                     ThrowHelper.ThrowObjectDisposedException();
@@ -152,7 +156,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private List<object> BeginDispose()
         {
             List<object> toDispose;
-            lock (_locker)
+            lock (_lock)
             {
                 if (_disposed)
                 {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -53,13 +53,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 if (_disposed)
                 {
-                    if (_disposables != null)
+                    if (service is IDisposable disposable)
                     {
-                        // cleanup disposable just in case still has items before throwing
-                        foreach (IDisposable disposable in _disposables)
-                        {
-                            disposable.Dispose();
-                        }
+                        disposable.Dispose();
+                    }
+                    else
+                    {
+                        ((IAsyncDisposable)service).DisposeAsync().AsTask().Wait();
                     }
                     ThrowHelper.ThrowObjectDisposedException();
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     }
                     else
                     {
-                        ((IAsyncDisposable)service).DisposeAsync().AsTask().Wait();
+                        ((IAsyncDisposable)service).DisposeAsync().AsTask().GetAwaiter().GetResult();
                     }
                     ThrowHelper.ThrowObjectDisposedException();
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private List<object> _disposables;
 
         private bool _disposed;
-        private static object s_locker = new object();
+        private object _locker = new object();
 
         public ServiceProviderEngineScope(ServiceProviderEngine engine)
         {
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 return service;
             }
 
-            lock (s_locker)
+            lock (_locker)
             {
                 if (_disposed)
                 {
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private List<object> BeginDispose()
         {
             List<object> toDispose;
-            lock (s_locker)
+            lock (_locker)
             {
                 if (_disposed)
                 {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private List<object> _disposables;
 
         private bool _disposed;
-        private readonly object _lock = new object();
+        private readonly object _disposelock = new object();
 
         public ServiceProviderEngineScope(ServiceProviderEngine engine)
         {
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 return service;
             }
 
-            lock (_lock)
+            lock (_disposelock)
             {
                 if (_disposed)
                 {
@@ -64,6 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     }
                     ThrowHelper.ThrowObjectDisposedException();
                 }
+
                 if (_disposables == null)
                 {
                     _disposables = new List<object>();
@@ -156,7 +157,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private List<object> BeginDispose()
         {
             List<object> toDispose;
-            lock (_lock)
+            lock (_disposelock)
             {
                 if (_disposed)
                 {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     }
                     else
                     {
-                        ((IAsyncDisposable)service).DisposeAsync().AsTask().GetAwaiter().GetResult();
+                        Task.Run(() => ((IAsyncDisposable)service).DisposeAsync().AsTask().GetAwaiter().GetResult());
                     }
                     ThrowHelper.ThrowObjectDisposedException();
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -59,10 +59,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     }
                     else
                     {
-                        // this synchronous code path could cause a deadlock if we were to block on DisposeAsync
-                        // instead, a fire-and-forget call may cause race conditions while disposing borrowed resources.
-                        // since this is a rare error case, we just take the fire-and-forget approach here
-                        Task.Run(() => ((IAsyncDisposable)service).DisposeAsync().AsTask().GetAwaiter().GetResult());
+                        // sync over async, for the rare case that an object only implements IAsyncDisposable and may end up starving the thread pool.
+                        Task.Run(() => ((IAsyncDisposable)service).DisposeAsync().AsTask()).GetAwaiter().GetResult();
                     }
                     ThrowHelper.ThrowObjectDisposedException();
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -7,12 +7,18 @@
 
   <ItemGroup>
     <Compile Include="..\DI.Specification.Tests\**\*.cs" />
+    <Compile Include="$(CommonPath)..\tests\Extensions\SingleThreadedSynchronizationContext.cs"
+             Link="Shared\SingleThreadedSynchronizationContext.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\..\src\Microsoft.Extensions.DependencyInjection.csproj" SkipUseReferenceAssembly="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 scope2.ServiceProvider.GetRequiredService<Thing2>();
             });
 
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () => {await t1; await t2;});
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => { await t1; await t2; });
         }
 
         public class Thing2 : IDisposable

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Fact]
-        private void GetService_ThenDisposeOnDifferentThread_ServiceDisposed()
+        public void GetService_ThenDisposeOnDifferentThread_ServiceDisposed()
         {
             var services = new ServiceCollection();
             services.AddSingleton<Foo1>();
@@ -304,7 +304,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             });
         }
 
-        public class Foo1 : IDisposable
+        private class Foo1 : IDisposable
         {
             public Foo1()
             {
@@ -318,7 +318,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
-        public class Foo2 : IDisposable
+        private class Foo2 : IDisposable
         {
             public Foo2(IServiceProvider sp)
             {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 //forces Dispose ValueTask to be asynchronous and not be immediately completed
                 services.AddSingleton<DelayedAsyncDisposableService>();
             }
-            IServiceProvider sp = services.BuildServiceProvider();
+            ServiceProvider sp = services.BuildServiceProvider();
             var disposable = sp.GetRequiredService<Disposable>();
             var asyncDisposable = sp.GetRequiredService<AsyncDisposable>();
             DelayedAsyncDisposableService delayedAsyncDisposableService = null;
@@ -367,7 +367,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 delayedAsyncDisposableService = sp.GetRequiredService<DelayedAsyncDisposableService>();
             }
 
-            await (sp as IAsyncDisposable).DisposeAsync();
+            await sp.DisposeAsync();
             
             Assert.True(disposable.Disposed);
             Assert.True(asyncDisposable.DisposeAsyncCalled);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -268,18 +268,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Fact]
-        public async Task GetService_ThenDisposeOnDifferentThread_ServiceDisposed()
-        {
-            var services = new ServiceCollection();
-            services.AddSingleton<DisposableSleepInCtor>();
-            IServiceProvider sp = services.BuildServiceProvider();
-            var service = sp.GetRequiredService<DisposableSleepInCtor>();
-            await Task.Run(() => (sp as IDisposable).Dispose());
-            
-            Assert.True(service.IsDisposed);
-        }
-
-        [Fact]
         public void GetService_DisposeOnSameThread_Throws()
         {
             var services = new ServiceCollection();
@@ -313,20 +301,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }).Wait(TimeSpan.FromSeconds(10));
 
             Assert.True(success);
-        }
-
-        private class DisposableSleepInCtor : IDisposable
-        {
-            public DisposableSleepInCtor()
-            {
-                Thread.Sleep(5000);
-            }
-            public bool IsDisposed { get; private set; }
-
-            public void Dispose()
-            {
-                IsDisposed = true;
-            }
         }
 
         private class DisposeServiceProviderInCtor : IDisposable


### PR DESCRIPTION
- Resolving Services after ServiceProvider is Disposed should throw with ObjectDisposedException

@davidfowl, for testing I prepared a test similar to the repro code you provided earlier in [this comment](https://github.com/dotnet/runtime/issues/35986#issuecomment-670302230)

Similar to the use case you were illustrating there, this use case (before this PR change) would also result in a deadlock. Here we try to call Dispose while the singleton lock `ResolvedServices` is taken). As shown in this test now it would throw ObjectDisposedException instead.