### PR TITLE
BackPorting some of the servicing fixes back into the master

### DIFF
--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -20,7 +20,7 @@
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">6.0.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
     <!-- major.minor.release version of the platforms package we're currently building
          Pre-release will be appended during build -->
     <PlatformPackageVersion>$(ProductVersion)</PlatformPackageVersion>

--- a/eng/pipelines/common/upload-intermediate-artifacts-step.yml
+++ b/eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -1,9 +1,11 @@
 parameters:
   name: ''
+  condition: always()
 
 steps:
 - task: CopyFiles@2
   displayName: Prepare job-specific intermediate artifacts subdirectory
+  condition: and(succeeded(), ${{ parameters.condition }})
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
     Contents: |
@@ -14,6 +16,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: Publish intermediate artifacts
+  condition: and(succeeded(), ${{ parameters.condition }})
   inputs:
     pathToPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'
     artifactName: IntermediateArtifacts

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -132,6 +132,7 @@ jobs:
             - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
               parameters:
                 name: Libraries_AllConfigurations
+                condition: eq(variables['_librariesBuildProducedPackages'], true)
 
         - ${{ if eq(parameters.runTests, true) }}:
           - template: /eng/pipelines/libraries/helix.yml

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -146,3 +146,5 @@ jobs:
               creator: dotnet-bot
               testRunNamePrefixSuffix: $(_testRunNamePrefixSuffix)
               extraHelixArguments: $(_extraHelixArguments)
+              ${{ if eq(parameters.framework, 'allConfigurations') }}:
+                condition: eq(variables['_librariesBuildProducedPackages'], true)

--- a/eng/restore/harvestPackages.targets
+++ b/eng/restore/harvestPackages.targets
@@ -1,16 +1,21 @@
 ﻿<Project InitialTargets="AddPackageDownload">
   <UsingTask TaskName="GetLastStablePackage" AssemblyFile="$(PackagingTaskAssembly)"/>
-  <Target Name="AddPackageDownload">
-    <ItemGroup>
-      <_AllPkgProjs Include="$(LibrariesProjectRoot)*\pkg\**\*.pkgproj" />
-    </ItemGroup>
-    <!-- Need separate ItemGroups so right metadata gets populated -->
-    <ItemGroup>
-      <_AllPkgProjsToPackageIdentity Include="@(_AllPkgProjs -> '%(Filename)')" />
-    </ItemGroup>
 
+  <Target Name="_GetBuildingPackageVersions">
+    <ItemGroup>
+      <_AllPkgProjs Include="$(LibrariesProjectRoot)*\pkg\**\*.pkgproj">
+        <UndefineProperties>MSBuildRestoreSessionId</UndefineProperties>
+      </_AllPkgProjs>
+    </ItemGroup>
+    
+    <MSBuild Projects="@(_AllPkgProjs)" Targets="GetPackageIdentityIfStable" Properties="$(ProjectProperties)">
+      <Output TaskParameter="TargetOutputs" ItemName="_AllPkgProjsWithVersion" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="AddPackageDownload" DependsOnTargets="_GetBuildingPackageVersions">    
     <GetLastStablePackage
-      LatestPackages="@(_AllPkgProjsToPackageIdentity)"
+      LatestPackages="@(_AllPkgProjsWithVersion)"
       PackageIndexes="$(PackageIndexFile)"
       DoNotAllowVersionsFromSameRelease="true">
       <Output TaskParameter="LastStablePackages" ItemName="_PackageDownload" />

--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -45,6 +45,7 @@
    <!-- Set the boolean below to true to generate packages with stabilized versions -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="($(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Transport'))) and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>  
   </PropertyGroup>
 
   <!-- Set the kind of PDB to Portable -->

--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -42,10 +42,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Central place to set the versions of all nuget packages produced in the repo -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">6.0.0</PackageVersion>
-
-    <!-- Set the boolean below to true to generate packages with stabilized versions -->
+   <!-- Set the boolean below to true to generate packages with stabilized versions -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
   </PropertyGroup>

--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -159,7 +159,8 @@
     <ZipDirectory
         SourceDirectory="$(TestProjectDir)%(SupportedPackage.Identity)"
         DestinationFile="$(TestArchiveTestsRoot)%(SupportedPackage.Identity).zip"
-        Overwrite="true" />
+        Overwrite="true"
+        Condition="'@(SupportedPackage)' != ''" />
 
     <MakeDir Directories="$(TestArchiveRuntimeRoot)" />
     <ZipDirectory

--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -23,12 +23,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Central place to set the versions of all nuget packages produced in the repo -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">6.0.0</PackageVersion>
-
     <!-- Set the boolean below to true to generate packages with stabilized versions -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="($(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Transport'))) and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- using the central package version
- fixing the case when no packages are produced 
- Harvesting fix being ported from 3.1 