### PR TITLE
Optimise GetCustomAttribute(s)

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -98,5 +98,20 @@ namespace System.Reflection
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern uint GetAssemblyCount();
+
+        internal virtual Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            // Returns an Attribute of base class/inteface attributeType on the Assembly or null if none exists.
+            // throws an AmbiguousMatchException if there are more than one defined.
+            Attribute[] attrib = Attribute.GetCustomAttributes(this, attributeType, inherit);
+
+            if (attrib == null || attrib.Length == 0)
+                return null;
+
+            if (attrib.Length == 1)
+                return attrib[0];
+
+            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+        }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -990,7 +990,7 @@ namespace System.Reflection
                 type = (type.GetGenericTypeDefinition() as RuntimeType)!;
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType);
             PseudoCustomAttribute.GetCustomAttributes(type, caType, ref attributes);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
@@ -1001,7 +1001,7 @@ namespace System.Reflection
                 type = (type.BaseType as RuntimeType)!;
                 while (type != (RuntimeType)typeof(object) && type is not null)
                 {
-                    AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType, mustBeInheritable: true, attributes);
+                    AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType, mustBeInheritable: true, attributes.Count);
                     type = (type.BaseType as RuntimeType)!;
                 }
             }
@@ -1027,7 +1027,7 @@ namespace System.Reflection
                 type = (type.GetGenericTypeDefinition() as RuntimeType)!;
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType);
             PseudoCustomAttribute.GetCustomAttributes(type, caType, ref attributes);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
@@ -1038,7 +1038,7 @@ namespace System.Reflection
                 type = (type.BaseType as RuntimeType)!;
                 while (type != (RuntimeType)typeof(object) && type is not null)
                 {
-                    AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType, mustBeInheritable: true, attributes);
+                    AddCustomAttributes(ref attributes, type.GetRuntimeModule(), type.MetadataToken, caType, mustBeInheritable: true, attributes.Count);
                     type = (type.BaseType as RuntimeType)!;
                 }
             }
@@ -1055,7 +1055,7 @@ namespace System.Reflection
                 method = (method.GetGenericMethodDefinition() as RuntimeMethodInfo)!;
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType);
             PseudoCustomAttribute.GetCustomAttributes(method, caType, ref attributes);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
@@ -1066,7 +1066,7 @@ namespace System.Reflection
                 method = method.GetParentDefinition()!;
                 while (method is not null)
                 {
-                    AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType, mustBeInheritable: true, attributes);
+                    AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType, mustBeInheritable: true, attributes.Count);
                     method = method.GetParentDefinition()!;
                 }
             }
@@ -1089,7 +1089,7 @@ namespace System.Reflection
                 method = (method.GetGenericMethodDefinition() as RuntimeMethodInfo)!;
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType);
             PseudoCustomAttribute.GetCustomAttributes(method, caType, ref attributes);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
@@ -1100,7 +1100,7 @@ namespace System.Reflection
                 method = method.GetParentDefinition()!;
                 while (method is not null)
                 {
-                    AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType, mustBeInheritable: true, attributes);
+                    AddCustomAttributes(ref attributes, method.GetRuntimeModule(), method.MetadataToken, caType, mustBeInheritable: true, attributes.Count);
                     method = method.GetParentDefinition()!;
                 }
             }
@@ -1126,7 +1126,7 @@ namespace System.Reflection
             // No pseudo attributes for RuntimeConstructorInfo
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, ctor.GetRuntimeModule(), ctor.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, ctor.GetRuntimeModule(), ctor.MetadataToken, caType);
 
             return attributes.ToAttributeArray(caType);
         }
@@ -1223,7 +1223,7 @@ namespace System.Reflection
             // No pseudo attributes for RuntimePropertyInfo
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, property.GetRuntimeModule(), property.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, property.GetRuntimeModule(), property.MetadataToken, caType);
 
             if (inherit)
             {
@@ -1247,7 +1247,7 @@ namespace System.Reflection
                 // We'll loop here rather than recurse so as not to need to recreate the paramTypes array more than once
                 while (baseProperty is not null)
                 {
-                    AddCustomAttributes(ref attributes, baseProperty.GetRuntimeModule(), baseProperty.MetadataToken, caType, mustBeInheritable: true, attributes);
+                    AddCustomAttributes(ref attributes, baseProperty.GetRuntimeModule(), baseProperty.MetadataToken, caType, mustBeInheritable: true, attributes.Count);
                     baseProperty = GetParentDefinition(baseProperty, paramTypes) as RuntimePropertyInfo;
                 }
             }
@@ -1322,7 +1322,7 @@ namespace System.Reflection
             // No pseudo attributes for RuntimeEventInfo
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, e.GetRuntimeModule(), e.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, e.GetRuntimeModule(), e.MetadataToken, caType);
 
             return attributes.ToAttributeArray(caType);
         }
@@ -1354,7 +1354,7 @@ namespace System.Reflection
             Debug.Assert(caType is not null);
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, field.GetRuntimeModule(), field.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, field.GetRuntimeModule(), field.MetadataToken, caType);
             PseudoCustomAttribute.GetCustomAttributes(field, caType, ref attributes);
 
             return attributes.ToAttributeArray(caType);
@@ -1459,7 +1459,7 @@ namespace System.Reflection
             Debug.Assert(caType is not null);
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, parameter.GetRuntimeModule()!, parameter.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, parameter.GetRuntimeModule()!, parameter.MetadataToken, caType);
             PseudoCustomAttribute.GetCustomAttributes(parameter, caType, ref attributes);
 
             if (inherit && parameter.Member.MemberType == MemberTypes.Method && parameter.Member.DeclaringType is not null)
@@ -1474,7 +1474,7 @@ namespace System.Reflection
                 RuntimeParameterInfo? parent = GetParentDefinition(parameter) as RuntimeParameterInfo;
                 while (parent is not null && parent.Member.DeclaringType is not null)
                 {
-                    AddCustomAttributes(ref attributes, parent.GetRuntimeModule()!, parent.MetadataToken, caType, mustBeInheritable: true, attributes);
+                    AddCustomAttributes(ref attributes, parent.GetRuntimeModule()!, parent.MetadataToken, caType, mustBeInheritable: true, attributes.Count);
 
                     parent = GetParentDefinition(parent) as RuntimeParameterInfo;
                 }
@@ -1503,7 +1503,7 @@ namespace System.Reflection
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
             int assemblyToken = RuntimeAssembly.GetToken(assembly.GetNativeHandle());
-            AddCustomAttributes(ref attributes, (assembly.ManifestModule as RuntimeModule)!, assemblyToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, (assembly.ManifestModule as RuntimeModule)!, assemblyToken, caType);
 
             return attributes.ToAttributeArray(caType);
         }
@@ -1526,7 +1526,7 @@ namespace System.Reflection
             // No pseudo attributes for RuntimeModule
 
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, module, module.MetadataToken, caType, mustBeInheritable: false, default);
+            AddCustomAttributes(ref attributes, module, module.MetadataToken, caType);
 
             return attributes.ToAttributeArray(caType);
         }
@@ -1567,7 +1567,7 @@ namespace System.Reflection
                         out record.tkCtor.Value, out record.blob);
 
                     if (FilterCustomAttributeRecord(record.tkCtor, in scope,
-                        decoratedModule, decoratedMetadataToken, attributeFilterType, mustBeInheritable, in derivedAttributes,
+                        decoratedModule, decoratedMetadataToken, attributeFilterType, mustBeInheritable, in derivedAttributes, derivedAttributeCount: 0,
                         out _, out _, out _))
                     {
                         return true;
@@ -1598,7 +1598,7 @@ namespace System.Reflection
             RuntimeModule decoratedModule, int decoratedMetadataToken, RuntimeType? attributeFilterType)
         {
             RuntimeType.ListBuilder<Attribute> attributes = default;
-            AddCustomAttributes(ref attributes, decoratedModule, decoratedMetadataToken, attributeFilterType, false, default);
+            AddCustomAttributes(ref attributes, decoratedModule, decoratedMetadataToken, attributeFilterType);
 
             if (attributes.Count == 0)
                 return null;
@@ -1616,8 +1616,8 @@ namespace System.Reflection
         private static void AddCustomAttributes(
             ref RuntimeType.ListBuilder<Attribute> attributes,
             RuntimeModule decoratedModule, int decoratedMetadataToken,
-            RuntimeType? attributeFilterType, bool mustBeInheritable,
-            in RuntimeType.ListBuilder<Attribute> derivedAttributes)
+            RuntimeType? attributeFilterType, bool mustBeInheritable = false,
+            int derivedAttributeCount = 0)
         {
             if (attributeFilterType is null)
             {
@@ -1643,7 +1643,7 @@ namespace System.Reflection
 
                 if (!FilterCustomAttributeRecord(caRecord.tkCtor, in scope,
                                                  decoratedModule, decoratedMetadataToken, attributeFilterType!, mustBeInheritable,
-                                                 in derivedAttributes,
+                                                 in attributes, derivedAttributeCount,
                                                  out RuntimeType attributeType, out IRuntimeMethodInfo? ctorWithParameters, out bool isVarArg))
                 {
                     continue;
@@ -1766,6 +1766,7 @@ namespace System.Reflection
             RuntimeType attributeFilterType,
             bool mustBeInheritable,
             in RuntimeType.ListBuilder<Attribute> derivedAttributes,
+            int derivedAttributeCount,
             out RuntimeType attributeType,
             out IRuntimeMethodInfo? ctorWithParameters,
             out bool isVarArg)
@@ -1782,8 +1783,8 @@ namespace System.Reflection
 
             // Ensure if attribute type must be inheritable that it is inheritable
             // Ensure that to consider a duplicate attribute type AllowMultiple is true
-            if (mustBeInheritable || derivedAttributes.Count > 0)
-                if (!AttributeUsageCheck(attributeType, mustBeInheritable, in derivedAttributes))
+            if (mustBeInheritable || derivedAttributeCount > 0)
+                if (!AttributeUsageCheck(attributeType, mustBeInheritable, in derivedAttributes, derivedAttributeCount))
                     return false;
 
             // Windows Runtime attributes aren't real types - they exist to be read as metadata only, and as such
@@ -1863,7 +1864,7 @@ namespace System.Reflection
 
         #region Private Static Methods
         private static bool AttributeUsageCheck(
-            RuntimeType attributeType, bool mustBeInheritable, in RuntimeType.ListBuilder<Attribute> derivedAttributes)
+            RuntimeType attributeType, bool mustBeInheritable, in RuntimeType.ListBuilder<Attribute> derivedAttributes, int derivedAttributeCount)
         {
             AttributeUsageAttribute? attributeUsageAttribute = null;
 
@@ -1876,10 +1877,10 @@ namespace System.Reflection
             }
 
             // Legacy: AllowMultiple ignored for none inheritable attributes
-            if (derivedAttributes.Count == 0)
+            if (derivedAttributeCount == 0)
                 return true;
 
-            for (int i = 0; i < derivedAttributes.Count; i++)
+            for (int i = 0; i < derivedAttributeCount; i++)
             {
                 if (derivedAttributes[i].GetType() == attributeType)
                 {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Buffers;
+using System.Buffers.Binary;
 
 using Internal.Runtime.CompilerServices;
 
@@ -1679,7 +1680,7 @@ namespace System.Reflection
                         const int CustomAttributeVersion = 0x0001;
                         if ((data & 0xffff) != CustomAttributeVersion)
                         {
-                            ThrowIncorrectData();
+                            throw new CustomAttributeFormatException();
                         }
 
                         cNamedArgs = data >> 16;
@@ -1712,7 +1713,7 @@ namespace System.Reflection
                             // Did we get a valid property reference?
                             if (property is null)
                             {
-                                ThrowInvalidPropertyException(name);
+                                throw new CustomAttributeFormatException(SR.Format(SR.RFLCT_InvalidPropFail, name));
                             }
 
                             MethodInfo setMethod = property.GetSetMethod(true)!;
@@ -1738,30 +1739,18 @@ namespace System.Reflection
 
                     if (ex is not null)
                     {
-                        RethrowException(name, isProperty, ex);
+                        throw new CustomAttributeFormatException(
+                                        SR.Format(isProperty ? SR.RFLCT_InvalidPropFail : SR.RFLCT_InvalidFieldFail, name), ex);
                     }
                 }
 
                 if (blobStart != blobEnd)
                 {
-                    ThrowIncorrectData();
+                    throw new CustomAttributeFormatException();
                 }
 
                 attributes.Add(attribute);
             }
-
-            [DoesNotReturn]
-            [StackTraceHidden]
-            static void ThrowInvalidPropertyException(string name) => throw new CustomAttributeFormatException(SR.Format(SR.RFLCT_InvalidPropFail, name));
-
-            [DoesNotReturn]
-            [StackTraceHidden]
-            static void ThrowIncorrectData() => throw new CustomAttributeFormatException();
-
-            [DoesNotReturn]
-            [StackTraceHidden]
-            static void RethrowException(string name, bool isProperty, Exception e) => throw new CustomAttributeFormatException(
-                                        SR.Format(isProperty ? SR.RFLCT_InvalidPropFail : SR.RFLCT_InvalidFieldFail, name), e);
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -1,14 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Buffers;
-using System.Buffers.Binary;
 
 using Internal.Runtime.CompilerServices;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -173,14 +173,15 @@ namespace System.Reflection
 
     internal unsafe struct MetadataEnumResult
     {
+        public const int SmallSizeLength = 16;
         // Keep the definition in sync with vm\ManagedMdImport.hpp
         private int[] largeResult;
         private int length;
-        private fixed int smallResult[16];
+        private fixed int smallResult[SmallSizeLength];
 
-        public int Length => length;
+        public readonly int Length => length;
 
-        public int this[int index]
+        public readonly int this[int index]
         {
             get
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MemberInfo.Internal.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MemberInfo.Internal.cs
@@ -24,5 +24,18 @@ namespace System.Reflection
 
             return true;
         }
+
+        internal virtual Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            Attribute[]? attrib = GetCustomAttributes(attributeType, inherit) as Attribute[];
+
+            if (attrib == null || attrib.Length == 0)
+                return null;
+
+            if (attrib.Length == 1)
+                return attrib[0];
+
+            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+        }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -277,6 +277,19 @@ namespace System.Reflection
             return null;
         }
 
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType);
+        }
+
         // ISerializable implementation
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -266,7 +266,7 @@ namespace System.Reflection
 
         internal static void CheckCanCreateInstance(Type declaringType, bool isVarArg)
         {
-            if (declaringType == null)
+            if (declaringType is null)
                 throw new ArgumentNullException(nameof(declaringType));
 
             // ctor is declared on interface class
@@ -280,7 +280,7 @@ namespace System.Reflection
                     SR.Format(SR.Acc_CreateAbstEx, declaringType));
 
             // ctor is on a class that contains stack pointers
-            else if (declaringType.GetRootElementType() == typeof(ArgIterator))
+            else if (ReferenceEquals(declaringType.GetRootElementType(), typeof(ArgIterator)))
                 throw new NotSupportedException();
 
             // ctor is vararg
@@ -295,7 +295,7 @@ namespace System.Reflection
             }
 
             // ctor is declared on System.Void
-            else if (declaringType == typeof(void))
+            else if (ReferenceEquals(declaringType, typeof(void)))
                 throw new MemberAccessException(SR.Access_Void);
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -183,6 +183,19 @@ namespace System.Reflection
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
         }
 
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType);
+        }
+
         public override bool IsDefined(Type attributeType, bool inherit)
         {
             if (attributeType == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
@@ -89,6 +89,19 @@ namespace System.Reflection
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
         }
 
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType, inherit);
+        }
+
         public override bool IsDefined(Type attributeType, bool inherit)
         {
             if (attributeType == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -74,6 +74,19 @@ namespace System.Reflection
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
         }
 
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType);
+        }
+
         public override bool IsDefined(Type attributeType, bool inherit)
         {
             if (attributeType == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -256,6 +256,19 @@ namespace System.Reflection
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType, inherit);
         }
 
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType, inherit);
+        }
+
         public override bool IsDefined(Type attributeType, bool inherit)
         {
             if (attributeType == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -388,6 +388,19 @@ namespace System.Reflection
             return RuntimeModule.nIsTransientInternal(new QCallModule(ref thisAsLocal));
         }
 
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType);
+        }
+
         internal MetadataImport MetadataImport => ModuleHandle.GetMetadataImport(this);
         #endregion
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -143,6 +143,25 @@ namespace System.Reflection
         {
             AttrsImpl = attributes;
         }
+
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            if (MdToken.IsNullToken(m_tkParamDef))
+            {
+                if (!inherit || Member.MemberType != MemberTypes.Method)
+                    return null;
+            }
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType, inherit);
+        }
         #endregion
 
         #region Constructor
@@ -502,9 +521,12 @@ namespace System.Reflection
         public override object[] GetCustomAttributes(bool inherit)
         {
             if (MdToken.IsNullToken(m_tkParamDef))
-                return Array.Empty<object>();
+            {
+                if (!inherit || Member.MemberType != MemberTypes.Method)
+                    return Array.Empty<object>();
+            }
 
-            return CustomAttribute.GetCustomAttributes(this, (typeof(object) as RuntimeType)!);
+            return CustomAttribute.GetCustomAttributes(this, (typeof(object) as RuntimeType)!, inherit);
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
@@ -513,14 +535,17 @@ namespace System.Reflection
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (MdToken.IsNullToken(m_tkParamDef))
-                return Array.Empty<object>();
+            {
+                if (!inherit || Member.MemberType != MemberTypes.Method)
+                    return Array.Empty<object>();
+            }
 
             RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
             if (attributeRuntimeType == null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
-            return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
+            return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType, inherit);
         }
 
         public override bool IsDefined(Type attributeType, bool inherit)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -134,7 +134,7 @@ namespace System.Reflection
         #region ICustomAttributeProvider
         public override object[] GetCustomAttributes(bool inherit)
         {
-            return CustomAttribute.GetCustomAttributes(this, (typeof(object) as RuntimeType)!);
+            return CustomAttribute.GetCustomAttributes(this, (typeof(object) as RuntimeType)!, inherit);
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
@@ -147,7 +147,20 @@ namespace System.Reflection
             if (attributeRuntimeType == null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
-            return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
+            return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType, inherit);
+        }
+
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType, inherit);
         }
 
         public override bool IsDefined(Type attributeType, bool inherit)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -69,25 +69,12 @@ namespace System
                 _capacity = capacity;
             }
 
-            public T this[int index]
+            public readonly T this[int index]
             {
-                readonly get
+                get
                 {
                     Debug.Assert(index < Count);
                     return (_items != null) ? _items[index] : _item;
-                }
-
-                set
-                {
-                    Debug.Assert(index < Count);
-                    if (_items != null)
-                    {
-                        _items[index] = value;
-                    }
-                    else
-                    {
-                        _item = value;
-                    }
                 }
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -71,10 +71,23 @@ namespace System
 
             public T this[int index]
             {
-                get
+                readonly get
                 {
                     Debug.Assert(index < Count);
                     return (_items != null) ? _items[index] : _item;
+                }
+
+                set
+                {
+                    Debug.Assert(index < Count);
+                    if (_items != null)
+                    {
+                        _items[index] = value;
+                    }
+                    else
+                    {
+                        _item = value;
+                    }
                 }
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -104,7 +104,7 @@ namespace System
                 Array.Copy(_items!, 0, array, index, _count);
             }
 
-            public int Count => _count;
+            public readonly int Count => _count;
 
             public void Add(T item)
             {
@@ -1868,6 +1868,32 @@ namespace System
 
             GC.KeepAlive(methodInstantiation);
             return retval;
+        }
+
+        internal override Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException(nameof(attributeType));
+
+            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
+
+            return CustomAttribute.GetCustomAttribute(this, attributeRuntimeType, inherit);
+        }
+
+        internal override AttributeUsageAttribute GetAttributeUsageAttribute()
+        {
+            if (!this.IsSubclassOf(typeof(Attribute)))
+                throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass);
+
+            RuntimeType? attributeRuntimeType = typeof(AttributeUsageAttribute).UnderlyingSystemType as RuntimeType;
+
+            if (attributeRuntimeType == null)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(Attribute));
+
+            return CustomAttribute.GetAttributeUsage(this);
         }
 
         internal object? GenericCache

--- a/src/coreclr/System.Private.CoreLib/src/System/Type.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Type.CoreCLR.cs
@@ -105,5 +105,21 @@ namespace System
         // Exists to faciliate code sharing between CoreCLR and CoreRT.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsRuntimeImplemented() => this is RuntimeType;
+
+        internal virtual AttributeUsageAttribute GetAttributeUsageAttribute()
+        {
+            if (!this.IsSubclassOf(typeof(Attribute)))
+                throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass);
+
+            Attribute[]? attrib = GetCustomAttributes(typeof(AttributeUsageAttribute), false) as Attribute[];
+
+            if (attrib == null || attrib.Length == 0)
+                return AttributeUsageAttribute.Default;
+
+            if (attrib.Length == 1)
+                return (AttributeUsageAttribute)attrib[0];
+
+            throw new FormatException(SR.Format(SR.Format_AttributeUsage, this));
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Module.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Module.cs
@@ -189,5 +189,20 @@ namespace System.Reflection
 
             return cls.Name.Equals(str, comparison);
         }
+
+        internal virtual Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            // Returns an Attribute of base class/inteface attributeType on the Module or null if none exists.
+            // throws an AmbiguousMatchException if there are more than one defined.
+            Attribute[] attrib = Attribute.GetCustomAttributes(this, attributeType, inherit);
+
+            if (attrib == null || attrib.Length == 0)
+                return null;
+
+            if (attrib.Length == 1)
+                return attrib[0];
+
+            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Module.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Module.cs
@@ -192,7 +192,7 @@ namespace System.Reflection
 
         internal virtual Attribute? GetCustomAttribute(Type attributeType, bool inherit)
         {
-            // Returns an Attribute of base class/inteface attributeType on the Module or null if none exists.
+            // Returns an Attribute of base class/interface attributeType on the Module or null if none exists.
             // throws an AmbiguousMatchException if there are more than one defined.
             Attribute[] attrib = Attribute.GetCustomAttributes(this, attributeType, inherit);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
@@ -37,6 +37,21 @@ namespace System.Reflection
         public virtual IEnumerable<CustomAttributeData> CustomAttributes => GetCustomAttributesData();
         public virtual IList<CustomAttributeData> GetCustomAttributesData() { throw NotImplemented.ByDesign; }
 
+        internal virtual Attribute? GetCustomAttribute(Type attributeType, bool inherit)
+        {
+            // Returns an Attribute of base class/inteface attributeType on the ParameterInfo or null if none exists.
+            // throws an AmbiguousMatchException if there are more than one defined.
+            Attribute[] attrib = Attribute.GetCustomAttributes(this, attributeType, inherit);
+
+            if (attrib == null || attrib.Length == 0)
+                return null;
+
+            if (attrib.Length == 1)
+                return attrib[0];
+
+            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+        }
+
         public virtual object[] GetCustomAttributes(bool inherit) => Array.Empty<object>();
         public virtual object[] GetCustomAttributes(Type attributeType, bool inherit)
         {


### PR DESCRIPTION
For `GetCustomAttribute`  brings allocations down to 25% and down to 3% for  #44713 (to just the requested attribute); with a performance improvement of 25% and 56% for #44713

For `PropertyInfo`, `Type`, `ConstructorInfo`, `MethodInfo`, `FieldInfo`, `EventInfo`


|          Method |               Toolchain | Inherit | CustomAttributeVariant |       Mean | Allocated | Ratio |
|---------------- |------------------------ |-------- |----------------------- |-----------:|----------:|------:|
|    PropertyInfo | 	\master\corerun.exe |    True |     GetCustomAttribute | 1,000.4 ns |     664 B |  1.00 |
|    PropertyInfo |         \pr\corerun.exe |    True |     GetCustomAttribute |   431.2 ns |      24 B |  0.43 |
|    PropertyInfo |                     now |    True |     GetCustomAttribute |   368.5 ns |      24 B |  0.37 |
|                 | 	                    |         |                        |            |           |       |
|            Type | 	\master\corerun.exe |    True |     GetCustomAttribute |   714.6 ns |     104 B |  1.00 |
|            Type |         \pr\corerun.exe |    True |     GetCustomAttribute |   515.3 ns |      24 B |  0.72 |
|            Type |                     now |    True |     GetCustomAttribute |   450.5 ns |      24 B |  0.63 |
|                 | 	                    |         |                        |            |           |       |
| ConstructorInfo | 	\master\corerun.exe |    True |     GetCustomAttribute |   576.3 ns |     104 B |  1.00 |
| ConstructorInfo |         \pr\corerun.exe |    True |     GetCustomAttribute |   419.7 ns |      24 B |  0.73 |
| ConstructorInfo |                     now |    True |     GetCustomAttribute |   350.0 ns |      24 B |  0.61 |
|                 | 	                    |         |                        |            |           |       |
|      MethodInfo | 	\master\corerun.exe |    True |     GetCustomAttribute |   611.6 ns |     104 B |  1.00 |
|      MethodInfo |         \pr\corerun.exe |    True |     GetCustomAttribute |   462.9 ns |      24 B |  0.76 |
|      MethodInfo |                     now |    True |     GetCustomAttribute |   392.2 ns |      24 B |  0.64 |
|                 | 	                    |         |                        |            |           |       |
|       FieldInfo | 	\master\corerun.exe |    True |     GetCustomAttribute |   618.4 ns |     104 B |  1.00 |
|       FieldInfo |         \pr\corerun.exe |    True |     GetCustomAttribute |   436.7 ns |      24 B |  0.71 |
|       FieldInfo |                     now |    True |     GetCustomAttribute |   380.7 ns |      24 B |  0.61 |
|                 | 	                    |         |                        |            |           |       |
|       EventInfo | 	\master\corerun.exe |    True |     GetCustomAttribute | 1,034.5 ns |     664 B |  1.00 |
|       EventInfo |         \pr\corerun.exe |    True |     GetCustomAttribute |   471.0 ns |      24 B |  0.46 |
|       EventInfo |                     now |    True |     GetCustomAttribute |   408.2 ns |      24 B |  0.39 |

For `GetCustomAttributes` and `GetCustomAttributes(Type)` it halves allocations to just array + attribute

Resolves  #44713 