### PR TITLE
[Mono] Arrays shouldn't implement linked out generic classes

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2566,7 +2566,10 @@ generic_array_methods (MonoClass *klass)
 	}
 	/*g_print ("array generic methods: %d\n", count_generic);*/
 
-	generic_array_method_num = count_generic;
+	/* only count the methods we actually added, not the ones that we
+	 * skipped if they implement an interface method that was trimmed.
+	 */
+	generic_array_method_num = i;
 	g_list_free (list);
 	return generic_array_method_num;
 }

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -65,7 +65,7 @@ GENERATE_TRY_GET_CLASS_WITH_CACHE(icollection, "System.Collections.Generic", "IC
 static
 GENERATE_TRY_GET_CLASS_WITH_CACHE(ienumerable, "System.Collections.Generic", "IEnumerable`1");
 static
-GENERATE_TRY_GET_CLASS_WITH_CACHE(ireadonlycollection, "System.Collecitons.Generic", "IReadOnlyCollection`1");
+GENERATE_TRY_GET_CLASS_WITH_CACHE(ireadonlycollection, "System.Collections.Generic", "IReadOnlyCollection`1");
 
 /* This TLS variable points to a GSList of classes which have setup_fields () executing */
 static MonoNativeTlsKey setup_fields_tls_id;

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -797,11 +797,11 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_class_init_internal (mono_defaults.array_class);
 	mono_defaults.generic_nullable_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Nullable`1");
-	mono_defaults.generic_ilist_class = mono_class_load_from_name (
+	mono_defaults.generic_ilist_class = mono_class_try_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IList`1");
-	mono_defaults.generic_ireadonlylist_class = mono_class_load_from_name (
+	mono_defaults.generic_ireadonlylist_class = mono_class_try_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IReadOnlyList`1");
-	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
+	mono_defaults.generic_ienumerator_class = mono_class_try_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
 #ifdef ENABLE_NETCORE

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -4610,16 +4610,7 @@ method_nonpublic (MonoMethod* method, gboolean start_klass)
 {
 	switch (method->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) {
 		case METHOD_ATTRIBUTE_ASSEM:
-#ifdef ENABLE_NETCORE
-			/* FIXME: this is nto just netcore. it's any .NET >= 2.0
-			 *
-			 * The check for generic_ilist_class, below is a proxy for checking if we're
-			 * in pre-2.0 compat or not.  It will break if the IL Linker removed IList<T>.
-			 */
 			return TRUE;
-#else
-			return (start_klass || mono_defaults.generic_ilist_class);
-#endif
 		case METHOD_ATTRIBUTE_PRIVATE:
 			return start_klass;
 		case METHOD_ATTRIBUTE_PUBLIC:
@@ -5162,18 +5153,7 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHand
 		g_free (str);
 		mono_reflection_free_type_info (&info);
 		if (throwOnError) {
-			gboolean set_argument_exn = FALSE;
-#ifdef ENABLE_NETCORE
-			set_argument_exn = TRUE;
-#else
-			/* 1.0 and 2.0 throw different exceptions */
-			if (mono_defaults.generic_ilist_class)
-				set_argument_exn = TRUE;
-			else
-				mono_error_set_type_load_name (error, g_strdup (""), g_strdup (""), "Type names passed to Assembly.GetType() must not specify an assembly.");
-#endif
-			if (set_argument_exn)
-				mono_error_set_argument (error, NULL, "Type names passed to Assembly.GetType() must not specify an assembly.");
+			mono_error_set_argument (error, NULL, "Type names passed to Assembly.GetType() must not specify an assembly.");
 			goto fail;
 		}
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);

--- a/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -72,7 +72,7 @@
 
 		<!-- domain.c: mono_defaults.array_class -->
 		<type fullname="System.Array">
-			<!-- InternalArray__%s_%s is used in aot-compiler.c -->
+			<!-- InternalArray__%s_%s is used in aot-compiler.c and class-init.c -->
 			<method name="InternalArray__ICollection_get_Count" />
 			<method name="InternalArray__ICollection_get_IsReadOnly" />
 			<method name="InternalArray__IEnumerable_GetEnumerator" />
@@ -478,15 +478,6 @@
 
 		<!-- domain.c: mono_defaults.void_class -->
 		<type fullname="System.Void" preserve="nothing" />
-
-		<!-- class.c: generic_array_methods -->
-		<type fullname="System.Collections.Generic.ICollection`1" />
-		<type fullname="System.Collections.Generic.IEnumerable`1" />
-		<type fullname="System.Collections.Generic.IReadOnlyList`1" />
-		<type fullname="System.Collections.Generic.IReadOnlyCollection`1" />
-
-		<!-- domain.c: mono_defaults.generic_ilist_class -->
-		<type fullname="System.Collections.Generic.IList`1" />
 
 		<!-- aot-compiler.c: add_generic_instances and add_generic_class_with_depth -->
 		<type fullname="System.Collections.Generic.GenericEqualityComparer`1">


### PR DESCRIPTION
Don't implement the `IList<T>` and `IReadOnlyList<T>` for array types if those interfaces are linked out.
Also check for individual methods from the generic interfaces - if the methods aren't used and are linked out, drop them from the array initialization.

Also drop option for pre-.NET 2.0 behavior (in netcore and in mono net 4.x mode)

Related to #44859 