### PR TITLE
Fix for Issue 44762

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -19095,7 +19095,7 @@ bool GenTreeHWIntrinsic::OperIsMemoryStore() const
     return false;
 }
 
-// Returns true for the HW Intrinsic instructions that have MemoryLoad semantics, false otherwise
+// Returns true for the HW Intrinsic instructions that have MemoryLoad or MemoryStore semantics, false otherwise
 bool GenTreeHWIntrinsic::OperIsMemoryLoadOrStore() const
 {
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64)

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -300,6 +300,19 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             fgCurMemoryDef |= memoryKindSet(GcHeap, ByrefExposed);
             break;
 
+#ifdef FEATURE_SIMD
+        case GT_SIMD:
+        {
+            GenTreeSIMD* simdNode = tree->AsSIMD();
+            if (simdNode->OperIsMemoryLoad())
+            {
+                // This instruction loads from memory and we need to record this information
+                fgCurMemoryUse |= memoryKindSet(GcHeap, ByrefExposed);
+            }
+            break;
+        }
+#endif // FEATURE_SIMD
+
 #ifdef FEATURE_HW_INTRINSICS
         case GT_HWINTRINSIC:
         {
@@ -319,7 +332,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             }
             break;
         }
-#endif
+#endif // FEATURE_HW_INTRINSICS
 
         // For now, all calls read/write GcHeap/ByrefExposed, writes in their entirety.  Might tighten this case later.
         case GT_CALL:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8444,6 +8444,8 @@ void Compiler::fgValueNumberSimd(GenTree* tree)
     assert(tree->OperGet() == GT_SIMD);
     GenTreeSIMD* simdNode = tree->AsSIMD();
     assert(simdNode != nullptr);
+
+    VNFunc       simdFunc = GetVNFuncForNode(tree);
     ValueNumPair excSetPair;
     ValueNumPair normalPair;
 
@@ -8451,7 +8453,7 @@ void Compiler::fgValueNumberSimd(GenTree* tree)
     if (tree->AsOp()->gtOp1 == nullptr)
     {
         excSetPair = ValueNumStore::VNPForEmptyExcSet();
-        normalPair = vnStore->VNPairForFunc(tree->TypeGet(), GetVNFuncForNode(tree));
+        normalPair = vnStore->VNPairForFunc(tree->TypeGet(), simdFunc);
     }
     else if (tree->AsOp()->gtOp1->OperIs(GT_LIST))
     {
@@ -8471,9 +8473,18 @@ void Compiler::fgValueNumberSimd(GenTree* tree)
         ValueNumPair op1Xvnp;
         vnStore->VNPUnpackExc(tree->AsOp()->gtOp1->gtVNPair, &op1vnp, &op1Xvnp);
 
-        if (simdNode->gtSIMDIntrinsicID == SIMDIntrinsicInitArray)
+        ValueNum addrVN       = ValueNumStore::NoVN;
+        bool     isMemoryLoad = simdNode->OperIsMemoryLoad();
+
+        if (isMemoryLoad)
         {
+            // Currently the only SIMD operation with MemoryLoad sematics is SIMDIntrinsicInitArray
+            // and it has to be handled specially since it has an optional op2
+            //
+            assert(simdNode->gtSIMDIntrinsicID == SIMDIntrinsicInitArray);
+
             // rationalize rewrites this as an explicit load with op1 as the base address
+            assert(tree->OperIsImplicitIndir());
 
             ValueNumPair op2vnp;
             if (tree->AsOp()->gtOp2 == nullptr)
@@ -8491,17 +8502,19 @@ void Compiler::fgValueNumberSimd(GenTree* tree)
                 excSetPair = vnStore->VNPExcSetUnion(op1Xvnp, op2Xvnp);
             }
 
-            ValueNum addrVN =
-                vnStore->VNForFunc(TYP_BYREF, GetVNFuncForNode(tree), op1vnp.GetLiberal(), op2vnp.GetLiberal());
+            assert(vnStore->VNFuncArity(simdFunc) == 2);
+            addrVN = vnStore->VNForFunc(TYP_BYREF, simdFunc, op1vnp.GetLiberal(), op2vnp.GetLiberal());
+
 #ifdef DEBUG
             if (verbose)
             {
-                printf("Treating GT_SIMD InitArray as a ByrefExposed load , addrVN is ");
+                printf("Treating GT_SIMD %s as a ByrefExposed load , addrVN is ",
+                       simdIntrinsicNames[simdNode->gtSIMDIntrinsicID]);
                 vnPrint(addrVN, 0);
             }
 #endif // DEBUG
 
-            // The address points into the heap, so it is an ByrefExposed load.
+            // The address could point anywhere, so it is an ByrefExposed load.
             //
             ValueNum loadVN = fgValueNumberByrefExposedLoad(tree->TypeGet(), addrVN);
             tree->gtVNPair.SetLiberal(loadVN);
@@ -8529,8 +8542,6 @@ void Compiler::fgValueNumberSimd(GenTree* tree)
             }
 #endif
         }
-
-        VNFunc simdFunc = GetVNFuncForNode(tree);
 
         if (tree->AsOp()->gtOp2 == nullptr)
         {
@@ -8585,9 +8596,37 @@ void Compiler::fgValueNumberHWIntrinsic(GenTree* tree)
         fgMutateGcHeap(tree DEBUGARG("HWIntrinsic - MemoryStore"));
     }
 
-    int    lookupNumArgs    = HWIntrinsicInfo::lookupNumArgs(hwIntrinsicNode->gtHWIntrinsicId);
-    bool   encodeResultType = vnEncodesResultTypeForHWIntrinsic(hwIntrinsicNode->gtHWIntrinsicId);
-    VNFunc func             = GetVNFuncForNode(tree);
+    VNFunc func         = GetVNFuncForNode(tree);
+    bool   isMemoryLoad = hwIntrinsicNode->OperIsMemoryLoad();
+
+    // If we have a MemoryLoad operation we will use the fgValueNumberByrefExposedLoad
+    // method to assign a value number that depends upon fgCurMemoryVN[ByrefExposed] ValueNumber
+    //
+    if (isMemoryLoad)
+    {
+        ValueNumPair op1vnp;
+        ValueNumPair op1Xvnp;
+        vnStore->VNPUnpackExc(tree->AsOp()->gtOp1->gtVNPair, &op1vnp, &op1Xvnp);
+
+        // The addrVN incorporates both op1's ValueNumber and the func operation
+        // The func is used because operations such as LoadLow and LoadHigh perform
+        // different operations, thus need to compute different ValueNumbers
+        // We don't need to encode the result type as it will be encoded by the opcode in 'func'
+        //
+        ValueNum addrVN = vnStore->VNForFunc(TYP_BYREF, func, op1vnp.GetLiberal());
+
+        // The address could point anywhere, so it is an ByrefExposed load.
+        //
+        ValueNum loadVN = fgValueNumberByrefExposedLoad(tree->TypeGet(), addrVN);
+        tree->gtVNPair.SetLiberal(loadVN);
+        tree->gtVNPair.SetConservative(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
+        tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, op1Xvnp);
+        fgValueNumberAddExceptionSetForIndirection(tree, tree->AsOp()->gtOp1);
+        return;
+    }
+
+    int  lookupNumArgs    = HWIntrinsicInfo::lookupNumArgs(hwIntrinsicNode->gtHWIntrinsicId);
+    bool encodeResultType = vnEncodesResultTypeForHWIntrinsic(hwIntrinsicNode->gtHWIntrinsicId);
 
     ValueNumPair excSetPair = ValueNumStore::VNPForEmptyExcSet();
     ValueNumPair normalPair;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+
+namespace IntrinsicsMisoptimizationTest {
+    class Program {
+        unsafe static void WriteArray (float* ptr, int count)
+        {
+            Console.Write ("[");
+            for (int i = 0; i < count; i++)
+            {
+                if (i > 0)
+                    Console.Write (", ");
+
+                Console.Write (ptr [i]);
+            }
+            Console.WriteLine ("]");
+        }
+
+        unsafe static bool TestXmm_NoCSE()
+        {
+            const int VecLen = 4;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector128 (mem);
+
+                    memSpan.Fill (75);
+                    x2 = Avx.LoadVector128 (mem);
+
+                    x3 = Avx.Add (x1, x2);
+
+                    Avx.Store (mem, x3);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3;
+
+                    memSpan.Fill (25);
+                    x1 = AdvSimd.LoadVector128 (mem);
+
+                    memSpan.Fill (75);
+                    x2 = AdvSimd.LoadVector128 (mem);
+
+                    x3 = AdvSimd.Add (x1, x2);
+
+                    AdvSimd.Store (mem, x3);
+                    WriteArray (mem, VecLen);
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("XMM_NoCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        unsafe static bool TestXmm_CanCSE()
+        {
+            const int VecLen = 4;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3, x4;
+                    Vector128<float> x5, x6, x7;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector128 (mem);
+                    x2 = Avx.LoadVector128 (mem);
+                    x3 = Avx.LoadVector128 (mem);
+                    x4 = Avx.LoadVector128 (mem);
+
+                    x5 = Avx.Add (x1, x2);
+                    x6 = Avx.Add (x3, x4);
+                    x7 = Avx.Add (x5, x6);
+
+                    Avx.Store (mem, x7);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3, x4;
+                    Vector128<float> x5, x6, x7;
+
+                    memSpan.Fill (25);
+                    x1 = AdvSimd.LoadVector128 (mem);
+                    x2 = AdvSimd.LoadVector128 (mem);
+                    x3 = AdvSimd.LoadVector128 (mem);
+                    x4 = AdvSimd.LoadVector128 (mem);
+
+                    x5 = AdvSimd.Add (x1, x2);
+                    x6 = AdvSimd.Add (x3, x4);
+                    x7 = AdvSimd.Add (x5, x6);
+
+                    AdvSimd.Store (mem, x7);
+                    WriteArray (mem, VecLen);
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("XMM_CanCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        unsafe static bool TestYmm_NoCSE()
+        {
+            const int VecLen = 8;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector256<float> x1, x2, x3;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector256 (mem);
+
+                    memSpan.Fill (75);
+                    x2 = Avx.LoadVector256 (mem);
+                    
+                    x3 = Avx.Add (x1, x2);
+
+                    Avx.Store (mem, x3);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Console.WriteLine("Vector256 not supported");
+                    return true;
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("YMM_NoCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        unsafe static bool TestYmm_CanCSE()
+        {
+            const int VecLen = 8;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector256<float> x1, x2, x3, x4;
+                    Vector256<float> x5, x6, x7;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector256 (mem);
+                    x2 = Avx.LoadVector256 (mem);
+                    x3 = Avx.LoadVector256 (mem);
+                    x4 = Avx.LoadVector256 (mem);
+
+                    x5 = Avx.Add (x1, x2);
+                    x6 = Avx.Add (x3, x4);
+                    x7 = Avx.Add (x5, x6);
+
+                    Avx.Store (mem, x7);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Console.WriteLine("Vector256 not supported");
+                    return true;
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("YMM_CanCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        static int Main (string [] args)
+        {
+            bool result = true;
+            result &= TestXmm_NoCSE();
+            result &= TestYmm_NoCSE();
+            result &= TestXmm_CanCSE();
+            result &= TestYmm_CanCSE();
+
+            if (result == true)
+            {
+                return 100;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
  Treat both SIMD and HWIntrinsic Memory Loads as Byref Exposed Loads that depend upon the global byref memory state.
  In liveness added byref use for SIMD Memory Loads
  Corrected the comment for GenTreeHWIntrinsic::OperIsMemoryLoadOrStore()
  Added test case Runtime_44762.cs