### PR TITLE
Reduce RuntimeType.MakeGenericType overheads

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -469,6 +469,17 @@ namespace System
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void Instantiate(QCallTypeHandle handle, IntPtr* pInst, int numGenericArgs, ObjectHandleOnStack type);
 
+        internal RuntimeType Instantiate(RuntimeType inst)
+        {
+            IntPtr ptr = inst.TypeHandle.Value;
+
+            RuntimeType? type = null;
+            RuntimeTypeHandle nativeHandle = GetNativeHandle();
+            Instantiate(new QCallTypeHandle(ref nativeHandle), &ptr, 1, ObjectHandleOnStack.Create(ref type));
+            GC.KeepAlive(inst);
+            return type!;
+        }
+
         internal RuntimeType Instantiate(Type[]? inst)
         {
             // defensive copy to be sure array is not mutated from the outside during processing


### PR DESCRIPTION
- Avoid an extra GetGenericArguments() call for all arities.
- Special-case a Type[] with just one type.  In looking at all calls to MakeGenericType when starting up a basic ASP.NET MVC app, 70% of the few hundred were for a single generic argument (the rest were for two).


|       Method |           Toolchain |     Mean | Ratio | Allocated |
|------------- |-------------------- |---------:|------:|----------:|
|   OneRefType | \master\corerun.exe | 255.3 ns |  1.00 |     128 B |
|   OneRefType |     \pr\corerun.exe | 156.6 ns |  0.61 |      32 B |
|              |                     |          |       |           |
| OneValueType | \master\corerun.exe | 247.8 ns |  1.00 |     128 B |
| OneValueType |     \pr\corerun.exe | 161.0 ns |  0.65 |      32 B |
|              |                     |          |       |           |
|   TwoRefType | \master\corerun.exe | 285.2 ns |  1.00 |     160 B |
|   TwoRefType |     \pr\corerun.exe | 199.8 ns |  0.70 |     120 B |
|              |                     |          |       |           |
| TwoValueType | \master\corerun.exe | 292.4 ns |  1.00 |     160 B |
| TwoValueType |     \pr\corerun.exe | 210.4 ns |  0.72 |     120 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System;
using System.Collections.Generic;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private Type[] _oneRef = new[] { typeof(string) };
    private Type[] _oneValue = new[] { typeof(int) };
    private Type[] _twoRef = new[] { typeof(string), typeof(string) };
    private Type[] _twoValue = new[] { typeof(int), typeof(int) };

    [Benchmark] public Type OneRefType() => typeof(List<>).MakeGenericType(_oneRef);
    [Benchmark] public Type OneValueType() => typeof(List<>).MakeGenericType(_oneValue);
    [Benchmark] public Type TwoRefType() => typeof(Dictionary<,>).MakeGenericType(_twoRef);
    [Benchmark] public Type TwoValueType() => typeof(Dictionary<,>).MakeGenericType(_twoValue);
}
```

Contributes to #44598 