### PR TITLE
[wasm] change filtering system timezones from zone.tab as a task parameter

### DIFF
--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -54,7 +54,7 @@
     AssemblyFile="$(WasmBuildTasksAssemblyPath)"/>
   <Target Name="CompileTimeZones">
     <PropertyGroup>
-      <FilterSystemTimeZones>true</FilterSystemTimeZones>
+      <FilterSystemTimeZones>false</FilterSystemTimeZones>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -12,6 +12,7 @@
     <MicrosoftNetCoreAppRuntimePackRidDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackDir)', 'runtimes', '$(PackageRID)'))</MicrosoftNetCoreAppRuntimePackRidDir>
     <MicrosoftNetCoreAppRuntimePackNativeDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackRidDir)', 'native'))</MicrosoftNetCoreAppRuntimePackNativeDir>
     <WasmEnableES6 Condition="'$(WasmEnableES6)' == ''">false</WasmEnableES6>
+    <FilterSystemTimeZones Condition="'$(FilterSystemTimeZones)' == ''">false</FilterSystemTimeZones>
   </PropertyGroup>
 
   <Target Name="CheckEnv">
@@ -53,10 +54,6 @@
   <UsingTask TaskName="CompileTimeZoneData"
     AssemblyFile="$(WasmBuildTasksAssemblyPath)"/>
   <Target Name="CompileTimeZones">
-    <PropertyGroup>
-      <FilterSystemTimeZones>false</FilterSystemTimeZones>
-    </PropertyGroup>
-
     <ItemGroup>
       <TimeZoneToCompile Include="africa" />
       <TimeZoneToCompile Include="antarctica" />

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -53,6 +53,10 @@
   <UsingTask TaskName="CompileTimeZoneData"
     AssemblyFile="$(WasmBuildTasksAssemblyPath)"/>
   <Target Name="CompileTimeZones">
+    <PropertyGroup>
+      <FilterSystemTimeZones>true</FilterSystemTimeZones>
+    </PropertyGroup>
+
     <ItemGroup>
       <TimeZoneToCompile Include="africa" />
       <TimeZoneToCompile Include="antarctica" />
@@ -64,10 +68,12 @@
       <TimeZoneToCompile Include="southamerica" />
       <TimeZoneToCompile Include="backward" />
     </ItemGroup>
+
     <CompileTimeZoneData
       TimeZones="@(TimeZoneToCompile)"
       InputDirectory="$([MSBuild]::NormalizePath('$(PkgSystem_Runtime_TimeZoneData)', 'contentFiles', 'any', 'any', 'data'))"
-      OutputDirectory="$(ArtifactsObjDir)wasm/timezones" />
+      OutputDirectory="$(ArtifactsObjDir)wasm/timezones" 
+      FilterSystemTimeZones="$(FilterSystemTimeZones)"/>
   </Target>
 
   <UsingTask TaskName="GenerateWasmBundle"

--- a/tools-local/tasks/mobile.tasks/WasmBuildTasks/CompileTimeZoneData.cs
+++ b/tools-local/tasks/mobile.tasks/WasmBuildTasks/CompileTimeZoneData.cs
@@ -86,7 +86,7 @@ public class CompileTimeZoneData : Task
         }
         CompileTimeZoneDataSource();
 
-        if (FilterSystemTimeZones!) {
+        if (FilterSystemTimeZones) {
             string[] filtered = new string[] { "America/Los_Angeles", "Australia/Sydney", "Europe/London", "Pacific/Tongatapu",
                                 "America/Sao_Paulo", "Australia/Perth", "Africa/Nairobi", "Europe/Berlin",
                                 "Europe/Moscow", "Africa/Tripoli", "America/Argentina/Catamarca", "Europe/Lisbon",

--- a/tools-local/tasks/mobile.tasks/WasmBuildTasks/CompileTimeZoneData.cs
+++ b/tools-local/tasks/mobile.tasks/WasmBuildTasks/CompileTimeZoneData.cs
@@ -26,6 +26,8 @@ public class CompileTimeZoneData : Task
     [Required]
     public string[]? TimeZones { get; set; }
 
+    public bool FilterSystemTimeZones { get; set; }
+
     private const string ZoneTabFileName = "zone1970.tab";
 
     private void CompileTimeZoneDataSource()
@@ -49,7 +51,8 @@ public class CompileTimeZoneData : Task
         //  for ex: `CST6CDT`, `MST`, etc.
         foreach (var entry in new DirectoryInfo (OutputDirectory!).EnumerateFiles())
         {
-            File.Delete(entry.FullName);
+            if (entry.Name != "zone.tab")
+                File.Delete(entry.FullName);
         }
     }
 
@@ -81,17 +84,21 @@ public class CompileTimeZoneData : Task
             Log.LogError($"Could not find required file {ZoneTabFile}");
             return false;
         }
-
         CompileTimeZoneDataSource();
 
-        string[] filtered = new string[] { "America/Los_Angeles", "Australia/Sydney", "Europe/London", "Pacific/Tongatapu",
+        if (FilterSystemTimeZones!) {
+            string[] filtered = new string[] { "America/Los_Angeles", "Australia/Sydney", "Europe/London", "Pacific/Tongatapu",
                                 "America/Sao_Paulo", "Australia/Perth", "Africa/Nairobi", "Europe/Berlin",
                                 "Europe/Moscow", "Africa/Tripoli", "America/Argentina/Catamarca", "Europe/Lisbon",
                                 "America/St_Johns"};
+            FilterZoneTab(filtered, ZoneTabFile);
+        }
+        else
+        {
+            File.Copy(ZoneTabFile, Path.Combine(OutputDirectory!, "zone.tab"), true);
+        }
 
         FilterTimeZoneData();
-        FilterZoneTab(filtered, ZoneTabFile);
-
         return !Log.HasLoggedErrors;
     }
 }


### PR DESCRIPTION
Partial fix for #44840

Default number of system timezones is now 349. There is no impact on `dotnet.timezones.blat` size. 