### PR TITLE
FileSystemGlobbing: Allow rootDir paths ending with separator to match files correctly

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -119,13 +119,11 @@ namespace Microsoft.Extensions.FileSystemGlobbing
 
         private bool IsRootDirectory(string rootDir, string filePath)
         {
-            if (!filePath.StartsWith(rootDir, StringComparison.Ordinal) ||
-                filePath.IndexOf(Path.DirectorySeparatorChar, rootDir.Length) != rootDir.Length)
-            {
-                return false;
-            }
+            int rootDirLength = rootDir.Length;
 
-            return true;
+            return filePath.StartsWith(rootDir, StringComparison.Ordinal) &&
+                (rootDir[rootDirLength - 1] == Path.DirectorySeparatorChar ||
+                filePath.IndexOf(Path.DirectorySeparatorChar, rootDirLength) == rootDirLength);
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -855,13 +855,13 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
                 directoryInfo = new InMemoryDirectoryInfo(@"C:\", files);
                 fileSystemInfos = directoryInfo.EnumerateFileSystemInfos();
 
-                Assert.NotEmpty(fileSystemInfos);
+                Assert.Equal(1, fileSystemInfos.Count());
             }
 
             directoryInfo = new InMemoryDirectoryInfo("/", files);
             fileSystemInfos = directoryInfo.EnumerateFileSystemInfos();
 
-            Assert.NotEmpty(fileSystemInfos);
+            Assert.Equal(1, fileSystemInfos.Count());
         }
     }
 }


### PR DESCRIPTION
`InMemoryDirectoryInfo.IsRootDirectory` method was failing to evaluate correctly when the rootDir argument was ending with a separator e.g: `C:\` or `/`. This PR changes the condition to correctly support the aforementioned cases. 

Fixes https://github.com/dotnet/runtime/issues/36415, https://github.com/dotnet/runtime/issues/44767