### PR TITLE
Remove dependency on PerfCounter.dll

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -19,7 +19,7 @@ internal static partial class Interop
         internal const string Odbc32 = "odbc32.dll";
         internal const string Ole32 = "ole32.dll";
         internal const string OleAut32 = "oleaut32.dll";
-        internal const string PerfCounter = "perfcounter.dll";
+        internal const string Pdh = "pdh.dll";
         internal const string Secur32 = "secur32.dll";
         internal const string Shell32 = "shell32.dll";
         internal const string SspiCli = "sspicli.dll";

--- a/src/libraries/Common/src/Interop/Windows/Pdh/Interop.PdhFormatFromRawValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Pdh/Interop.PdhFormatFromRawValue.cs
@@ -5,10 +5,10 @@ using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
-    internal partial class PerfCounter
+    internal partial class Pdh
     {
-        [DllImport(Libraries.PerfCounter, CharSet = CharSet.Unicode)]
-        public static extern int FormatFromRawValue(
+        [DllImport(Libraries.Pdh, CharSet = CharSet.Unicode)]
+        public static extern int PdhFormatFromRawValue(
             uint dwCounterType,
             uint dwFormat,
             ref long pTimeBase,

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -110,8 +110,8 @@
              Link="Common\Interop\Windows\Kernel32\Interop.VirtualQuery.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs" />
-    <Compile Include="$(CommonPath)Interop\Windows\PerfCounter\Interop.FormatFromRawValue.cs"
-             Link="Common\Interop\Windows\PerfCounter\Interop.FormatFromRawValue.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Pdh\Interop.PdhFormatFromRawValue.cs"
+             Link="Common\Interop\Windows\Pdh\Interop.PdhFormatFromRawValue.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\PerfCounter\Interop.PerformanceData.cs"
              Link="Common\Interop\Windows\PerfCounter\Interop.PerformanceData.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs"

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSampleCalculator.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSampleCalculator.cs
@@ -13,8 +13,6 @@ namespace System.Diagnostics
     /// </summary>
     public static class CounterSampleCalculator
     {
-        private static volatile bool s_perfCounterDllLoaded;
-
         /// <summary>
         ///    Converts 100NS elapsed time to fractional seconds
         /// </summary>
@@ -89,11 +87,9 @@ namespace System.Diagnostics
 
             FillInValues(oldSample, newSample, ref oldPdhValue, ref newPdhValue);
 
-            LoadPerfCounterDll();
-
             Interop.Kernel32.PerformanceCounterOptions.PDH_FMT_COUNTERVALUE pdhFormattedValue = default;
             long timeBase = newSample.SystemFrequency;
-            int result = Interop.PerfCounter.FormatFromRawValue((uint)newCounterType, Interop.Kernel32.PerformanceCounterOptions.PDH_FMT_DOUBLE | Interop.Kernel32.PerformanceCounterOptions.PDH_FMT_NOSCALE | Interop.Kernel32.PerformanceCounterOptions.PDH_FMT_NOCAP100,
+            int result = Interop.Pdh.PdhFormatFromRawValue((uint)newCounterType, Interop.Kernel32.PerformanceCounterOptions.PDH_FMT_DOUBLE | Interop.Kernel32.PerformanceCounterOptions.PDH_FMT_NOSCALE | Interop.Kernel32.PerformanceCounterOptions.PDH_FMT_NOCAP100,
                                                           ref timeBase, ref newPdhValue, ref oldPdhValue, ref pdhFormattedValue);
 
             if (result != Interop.Errors.ERROR_SUCCESS)
@@ -226,22 +222,6 @@ namespace System.Diagnostics
                     oldPdhValue.SecondValue = 0;
                     break;
             }
-        }
-
-        private static void LoadPerfCounterDll()
-        {
-            if (s_perfCounterDllLoaded)
-                return;
-
-            string installPath = NetFrameworkUtils.GetLatestBuildDllDirectory(".");
-
-            string perfcounterPath = Path.Combine(installPath, "perfcounter.dll");
-            if (Interop.Kernel32.LoadLibrary(perfcounterPath) == IntPtr.Zero)
-            {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
-            s_perfCounterDllLoaded = true;
         }
     }
 }

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterCreationDataCollectionTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterCreationDataCollectionTests.cs
@@ -10,14 +10,14 @@ namespace System.Diagnostics.Tests
 {
     public static class CounterCreationDataCollectionTests
     {
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_CreateCounterCreationDataCollection_Empty()
         {
             CounterCreationDataCollection ccdc = new CounterCreationDataCollection();
             Assert.Equal(0, ccdc.Count);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_CreateCounterCreationDataCollection_CCDC()
         {
             CounterCreationData[] ccds = { new CounterCreationData("Simple1", "Simple Help", PerformanceCounterType.RawBase), new CounterCreationData("Simple2", "Simple Help", PerformanceCounterType.RawBase) };
@@ -27,7 +27,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(2, ccdc2.Count);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_CreateCounterCreationDataCollection_Array()
         {
             CounterCreationData[] ccds = { new CounterCreationData("Simple1", "Simple Help", PerformanceCounterType.RawBase), new CounterCreationData("Simple2", "Simple Help", PerformanceCounterType.RawBase) };
@@ -37,7 +37,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(0, ccdc.IndexOf(ccds[0]));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_CreateCounterCreationDataCollection_Invalid()
         {
             CounterCreationData[] ccds = null;
@@ -46,7 +46,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentNullException>(() => new CounterCreationDataCollection(ccdc));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_SetIndex2()
         {
             CounterCreationData[] ccds = { new CounterCreationData("Simple1", "Simple Help", PerformanceCounterType.RawBase), new CounterCreationData("Simple2", "Simple Help", PerformanceCounterType.RawBase) };
@@ -59,7 +59,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(ccd, ccdc[1]);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_Remove()
         {
             CounterCreationData[] ccds = { new CounterCreationData("Simple1", "Simple Help", PerformanceCounterType.RawBase), new CounterCreationData("Simple2", "Simple Help", PerformanceCounterType.RawBase) };
@@ -69,7 +69,7 @@ namespace System.Diagnostics.Tests
             Assert.False(ccdc.Contains(ccds[0]));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_Insert()
         {
             CounterCreationData[] ccds = { new CounterCreationData("Simple1", "Simple Help", PerformanceCounterType.RawBase), new CounterCreationData("Simple2", "Simple Help", PerformanceCounterType.RawBase) };
@@ -82,7 +82,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(1, ccdc.IndexOf(ccd));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationDataCollection_CopyTo()
         {
             CounterCreationData[] ccds = { new CounterCreationData("Simple1", "Simple Help", PerformanceCounterType.RawBase), new CounterCreationData("Simple2", "Simple Help", PerformanceCounterType.RawBase) };

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterCreationDataTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterCreationDataTests.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics.Tests
 {
     public static class CounterCreationDataTests
     {
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationData_CreateCounterCreationData_SimpleSimpleHelpRawBase()
         {
             CounterCreationData ccd = new CounterCreationData("Simple", "Simple Help", PerformanceCounterType.RawBase);
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(PerformanceCounterType.RawBase, ccd.CounterType);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterCreationData_SetCounterType_Invalud()
         {
             CounterCreationData ccd = new CounterCreationData("Simple", "Simple Help", PerformanceCounterType.RawBase);

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.Tests
 {
     public static class CounterSampleCalculatorTests
     {
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void CounterSampleCalculator_ElapsedTime()
         {
             var name = nameof(CounterSampleCalculator_ElapsedTime) + "_Counter";

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleTests.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.Tests
 {
     public static class CounterSampleTests
     {
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterSample_Constructor_EmptyCounterSample()
         {
             CounterSample counterSample = new CounterSample();
@@ -24,7 +24,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(0, counterSample.TimeStamp100nSec);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterSample_Constructor_CounterSample()
         {
             long timeStamp = DateTime.Now.ToFileTime();
@@ -39,8 +39,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(timeStamp, counterSample.TimeStamp100nSec);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34409", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [Fact]
         public static void CounterSample_Calculate_CalculateCounterSample()
         {
             CounterSample counterSample = new CounterSample(5, 0, 0, 0, 0, 0, PerformanceCounterType.NumberOfItems32);
@@ -48,8 +47,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(5, CounterSample.Calculate(counterSample));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34409", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [Fact]
         public static void CounterSample_Calculate_CalculateCounterSampleCounterSample()
         {
             CounterSample counterSample1 = new CounterSample(5, 0, 0, 1, 0, 0, PerformanceCounterType.CounterDelta32);
@@ -58,7 +56,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(10, CounterSample.Calculate(counterSample1, counterSample2));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterSample_Equal()
         {
             CounterSample counterSample1 = new CounterSample(5, 0, 0, 1, 0, 0, PerformanceCounterType.CounterDelta32);
@@ -67,7 +65,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(counterSample1, counterSample2);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterSample_opInequality()
         {
             CounterSample counterSample1 = new CounterSample(5, 0, 0, 1, 0, 0, PerformanceCounterType.CounterDelta32);
@@ -76,7 +74,7 @@ namespace System.Diagnostics.Tests
             Assert.True(counterSample1 != counterSample2);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterSample_opEquality()
         {
             CounterSample counterSample1 = new CounterSample(5, 0, 0, 1, 0, 0, PerformanceCounterType.CounterDelta32);
@@ -85,7 +83,7 @@ namespace System.Diagnostics.Tests
             Assert.True(counterSample1 == counterSample2);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void CounterSample_GetHashCode()
         {
             CounterSample counterSample1 = new CounterSample(5, 0, 0, 1, 0, 0, PerformanceCounterType.CounterDelta32);

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.IO;
 using System.Threading;
 using Xunit;
 
@@ -12,7 +13,9 @@ namespace System.Diagnostics.Tests
     internal class Helpers
     {
         public static bool IsElevatedAndCanWriteToPerfCounters { get => AdminHelpers.IsProcessElevated() && CanWriteToPerfCounters; }
+        public static bool IsElevatedAndCanWriteAndReadNetPerfCounters { get => AdminHelpers.IsProcessElevated() && CanWriteToPerfCounters && CanReadNetPerfCounters; }
         public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer; }
+        public static bool CanReadNetPerfCounters { get => File.Exists(Environment.SystemDirectory + Path.DirectorySeparatorChar + "netfxperf.dll"); }
 
         public static string CreateCategory(string name, PerformanceCounterCategoryType categoryType)
         {

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics.Tests
     internal class Helpers
     {
         public static bool IsElevatedAndCanWriteToPerfCounters { get => AdminHelpers.IsProcessElevated() && CanWriteToPerfCounters; }
-        public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer && PlatformDetection.IsNotArmNorArm64Process; }
+        public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer; }
 
         public static string CreateCategory(string name, PerformanceCounterCategoryType categoryType)
         {

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/InstanceDataTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/InstanceDataTests.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.Tests
 {
     public static class InstanceDataTests
     {
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceData_CreateInstanceData_FromCounterSample()
         {
             long timestamp = DateTime.Now.ToFileTime();
@@ -22,7 +22,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(1, id.RawValue);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollection_GetItem_ExistingCounter()
         {
             InstanceDataCollection idc = GetInstanceDataCollection();
@@ -41,7 +41,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollection_NullTest()
         {
             InstanceDataCollection idc = GetInstanceDataCollection();
@@ -50,7 +50,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentNullException>(() => idc.Contains(null));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollection_GetKeys()
         {
             InstanceDataCollection idc = GetInstanceDataCollection();
@@ -61,7 +61,7 @@ namespace System.Diagnostics.Tests
             Assert.True(keys.Length > 0);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollection_GetValues()
         {
             InstanceDataCollection idc = GetInstanceDataCollection();
@@ -72,7 +72,7 @@ namespace System.Diagnostics.Tests
             Assert.True(values.Length > 0);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollectionCollection_GetItem_Invalid()
         {
             InstanceDataCollectionCollection idcc = GetInstanceDataCollectionCollection();
@@ -80,7 +80,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentNullException>(() => idcc[null]);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollectionCollection_GetKeys()
         {
             InstanceDataCollectionCollection idcc = GetInstanceDataCollectionCollection();
@@ -88,7 +88,7 @@ namespace System.Diagnostics.Tests
             Assert.True(idcc.Keys.Count > 0);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollectionCollection_GetValues()
         {
             InstanceDataCollectionCollection idcc = GetInstanceDataCollectionCollection();
@@ -96,7 +96,7 @@ namespace System.Diagnostics.Tests
             Assert.True(idcc.Values.Count > 0);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollectionCollection_Contains_Valid()
         {
             InstanceDataCollectionCollection idcc = GetInstanceDataCollectionCollection();
@@ -104,7 +104,7 @@ namespace System.Diagnostics.Tests
             Assert.False(idcc.Contains("Not a real instance"));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollectionCollection_Contains_inValid()
         {
             InstanceDataCollectionCollection idcc = GetInstanceDataCollectionCollection();
@@ -112,7 +112,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentNullException>(() => idcc.Contains(null));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void InstanceDataCollectionCollection_CopyTo()
         {
             InstanceDataCollectionCollection idcc = GetInstanceDataCollectionCollection();

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
@@ -10,14 +10,14 @@ namespace System.Diagnostics.Tests
 {
     public static class PerformanceCounterCategoryTests
     {
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_CreatePerformanceCounterCategory_DefaultConstructor()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
             Assert.Equal(".", pcc.MachineName);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_CreatePerformanceCounterCategory_NullTests()
         {
             Assert.Throws<ArgumentNullException>(() => new PerformanceCounterCategory(null, "."));
@@ -25,7 +25,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => new PerformanceCounterCategory("category", string.Empty));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_SetCategoryName_Valid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -33,7 +33,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("Processor", pcc.CategoryName);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_SetCategoryName_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -42,7 +42,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => pcc.CategoryName = string.Empty);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_SetMachineName_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -50,7 +50,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => pcc.MachineName = string.Empty);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_SetMachineName_ValidCategoryNameNull()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -59,7 +59,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("machineName", pcc.MachineName);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_SetMachineName_ValidCategoryNameNotNull()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -69,7 +69,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("machineName", pcc.MachineName);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_GetCounterHelp_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -77,7 +77,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => pcc.CategoryHelp);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounterCategory_CategoryType_MultiInstance()
         {
             var name = nameof(PerformanceCounterCategory_CategoryType_MultiInstance) + "_Counter";
@@ -90,7 +90,7 @@ namespace System.Diagnostics.Tests
             PerformanceCounterCategory.Delete(category);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounterCategory_CategoryType_SingleInstance()
         {
             var name = nameof(PerformanceCounterCategory_CategoryType_SingleInstance) + "_Counter";
@@ -152,7 +152,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => PerformanceCounterCategory.Create("Category name", maxCounter, PerformanceCounterCategoryType.SingleInstance, "Counter name", "counter help"));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_GetCategories()
         {
             PerformanceCounterCategory[] categories = PerformanceCounterCategory.GetCategories();
@@ -160,13 +160,13 @@ namespace System.Diagnostics.Tests
             Assert.True(categories.Length > 0);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_GetCategories_StaticInvalid()
         {
             Assert.Throws<ArgumentException>(() => PerformanceCounterCategory.GetCategories(string.Empty));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_CounterExists_InterruptsPerSec()
         {
             PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory("Processor"));
@@ -174,7 +174,7 @@ namespace System.Diagnostics.Tests
             Assert.True(pcc.CounterExists("Interrupts/sec"));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_CounterExists_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -183,13 +183,13 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => pcc.CounterExists("Interrupts/sec"));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_CounterExists_StaticInterruptsPerSec()
         {
             Assert.True(PerformanceCounterCategory.CounterExists("Interrupts/sec", "Processor"));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_CounterExists_StaticInvalid()
         {
             Assert.Throws<ArgumentNullException>(() => PerformanceCounterCategory.CounterExists(null, "Processor"));
@@ -198,7 +198,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => PerformanceCounterCategory.CounterExists("Interrupts/sec", "Processor", string.Empty));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_DeleteCategory_Invalid()
         {
             Assert.Throws<InvalidOperationException>(() => PerformanceCounterCategory.Delete("Processor"));
@@ -215,7 +215,7 @@ namespace System.Diagnostics.Tests
             Assert.False(PerformanceCounterCategory.Exists(category));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_Exists_Invalid()
         {
             Assert.Throws<ArgumentNullException>(() => PerformanceCounterCategory.Exists(null, "."));
@@ -223,7 +223,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => PerformanceCounterCategory.Exists("Processor", string.Empty));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounterCategory_GetCounters()
         {
             var name = nameof(PerformanceCounterCategory_GetCounters) + "_Counter";
@@ -236,7 +236,7 @@ namespace System.Diagnostics.Tests
             PerformanceCounterCategory.Delete(category);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_GetCounters_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -249,7 +249,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => pcc.GetCounters("Not An Instance"));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_GetInstanceNames_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -257,7 +257,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => pcc.GetInstanceNames());
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_InstanceExists_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();
@@ -266,7 +266,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => pcc.InstanceExists(""));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_InstanceExists_Static()
         {
             PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory("Processor"));
@@ -280,7 +280,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_InstanceExists_StaticInvalid()
         {
             Assert.Throws<ArgumentNullException>(() => PerformanceCounterCategory.InstanceExists(null, "Processor", "."));
@@ -289,7 +289,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => PerformanceCounterCategory.InstanceExists("", "Processor", string.Empty));
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_ReadCategory()
         {
             PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory("Processor"));
@@ -299,7 +299,7 @@ namespace System.Diagnostics.Tests
             Assert.NotNull(idColCol);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounterCategory_ReadCategory_Invalid()
         {
             PerformanceCounterCategory pcc = new PerformanceCounterCategory();

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.Tests
 {
     public static class PerformanceCounterTests
     {
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_CreateCounter_EmptyCounter()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter())
@@ -36,7 +36,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_CreateCounter_ProcessorCounter()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
@@ -66,7 +66,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_CreateCounter_SetReadOnly()
         {
             var name = nameof(PerformanceCounter_CreateCounter_SetReadOnly) + "_Counter";
@@ -83,7 +83,7 @@ namespace System.Diagnostics.Tests
             Helpers.DeleteCategory(name);
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_SetProperties_Null()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter())
@@ -94,7 +94,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_SetRawValue_ReadOnly()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter())
@@ -103,7 +103,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_GetRawValue_EmptyCategoryName()
         {
             var name = nameof(PerformanceCounter_GetRawValue_EmptyCategoryName) + "_Counter";
@@ -116,7 +116,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_GetRawValue_EmptyCounterName()
         {
             var name = nameof(PerformanceCounter_GetRawValue_EmptyCounterName) + "_Counter";
@@ -129,7 +129,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_GetRawValue_CounterDoesNotExist()
         {
             var name = nameof(PerformanceCounter_GetRawValue_CounterDoesNotExist) + "_Counter";
@@ -144,7 +144,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/29753")]
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_NextValue_ProcessorCounter()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
@@ -156,7 +156,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_BeginInit_ProcessorCounter()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
@@ -167,7 +167,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [Fact]
         public static void PerformanceCounter_BeginInitEndInit_ProcessorCounter()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "0", "."))
@@ -179,7 +179,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_Decrement()
         {
             var name = nameof(PerformanceCounter_Decrement) + "_Counter";
@@ -193,7 +193,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_Increment()
         {
             var name = nameof(PerformanceCounter_Increment) + "_Counter";
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_IncrementBy_IncrementBy2()
         {
             var name = nameof(PerformanceCounter_IncrementBy_IncrementBy2) + "_Counter";
@@ -221,7 +221,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/24176")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
         public static void PerformanceCounter_IncrementBy_IncrementByReadOnly()
         {
@@ -233,7 +232,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_Increment_IncrementReadOnly()
         {
             var name = nameof(PerformanceCounter_Increment_IncrementReadOnly) + "_Counter";
@@ -270,7 +269,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_NextSample_MultiInstance()
         {
             var name = nameof(PerformanceCounter_NextSample_MultiInstance) + "_Counter";

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
@@ -47,7 +47,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_CreateCounter_MultiInstanceReadOnly()
         {
             var name = nameof(PerformanceCounter_CreateCounter_MultiInstanceReadOnly) + "_Counter";
@@ -221,7 +221,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_IncrementBy_IncrementByReadOnly()
         {
             var name = nameof(PerformanceCounter_IncrementBy_IncrementByReadOnly) + "_Counter";
@@ -243,7 +243,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounter_Decrement_DecrementReadOnly()
         {
             var name = nameof(PerformanceCounter_Decrement_DecrementReadOnly) + "_Counter";

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceDataTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceDataTests.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics.Tests
         }
 
         // We run the test only if the stress mode is enabled and the process is elvated.
-        private static bool IsRunnableEnvironnement => Helpers.IsElevatedAndCanWriteToPerfCounters && TestEnvironment.IsStressModeEnabled && RemoteExecutor.IsSupported;
+        private static bool IsRunnableEnvironnement => Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters && TestEnvironment.IsStressModeEnabled && RemoteExecutor.IsSupported;
 
         /// <summary>
         /// This test was taken from System.Diagnostics.PerformanceData documentation https://msdn.microsoft.com/en-us/library/system.diagnostics.performancedata(v=vs.110).aspx


### PR DESCRIPTION
This dependency was unnecessary and only for calling through to pdh.dll.

PerfCounter.dll is still needed for the consumption side of performance
counters, but removing from the dependency from the .NET can help enable
some scenarios like reading non-.NET counters.