### PR TITLE
Fix work item exit code for helix tests

### DIFF
--- a/eng/testing/RunnerTemplate.cmd
+++ b/eng/testing/RunnerTemplate.cmd
@@ -62,7 +62,13 @@ pushd %EXECUTION_DIR%
 @echo off
 popd
 echo ----- end %DATE% %TIME% ----- exit code %ERRORLEVEL% ----------------------------------------------------------
-exit /b %ERRORLEVEL%
+:: The helix work item should not exit with non-zero if tests ran and produced results
+:: The special console runner for runtime returns 1 when tests fail
+if %ERRORLEVEL%==1 (
+  exit /b 0
+) else (
+  exit /b %ERRORLEVEL%
+)
 :: ========================= END Test Execution =================================
 
 :usage

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -199,7 +199,7 @@ popd >/dev/null
 # ======================== END Core File Inspection ==========================
 # The helix work item should not exit with non-zero if tests ran and produced results
 # The special console runner for runtime returns 1 when tests fail
-if [ "$test_exitcode" != "1" ]; then
+if [ "$test_exitcode" == "1" ]; then
   exit 0
 else
   exit $test_exitcode

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -197,4 +197,10 @@ if [[ "$(uname -s)" == "Linux" && $test_exitcode -ne 0 ]]; then
 fi
 popd >/dev/null
 # ======================== END Core File Inspection ==========================
-exit $test_exitcode
+# The helix work item should not exit with non-zero if tests ran and produced results
+# The special console runner for runtime returns 1 when tests fail
+if [ "$test_exitcode" != "1" ]; then
+  exit 0
+else
+  exit $test_exitcode
+fi


### PR DESCRIPTION
The helix work items are only supposed to return non-zero if they fail
to report tests for some reason.