### PR TITLE
Reduce SafeHandle allocation in CertEnumCertificatesInStore on Windows

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/SafeHandles.cs
@@ -62,6 +62,8 @@ namespace Internal.Cryptography.Pal.Native
             SetHandle(_parent.handle);
         }
 
+        internal new void SetHandle(IntPtr handle) => base.SetHandle(handle);
+
         protected override bool ReleaseHandle()
         {
             if (_parent != null)


### PR DESCRIPTION
And avoiding leaving the last invalid one for finalization.

Fixes https://github.com/dotnet/runtime/issues/44382
cc: @bartonjs 

|    Method |           Toolchain |     Mean |     Error | Ratio | Allocated |
|---------- |-------------------- |---------:|----------:|------:|----------:|
| Enumerate | \master\corerun.exe | 2.426 ms | 0.0408 ms |  1.00 |    3.9 KB |
| Enumerate |     \pr\corerun.exe | 2.391 ms | 0.0175 ms |  0.99 |    3.4 KB |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Security.Cryptography.X509Certificates;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    [Benchmark]
    public int Enumerate()
    {
        int count = 0;
        using var store = new X509Store(StoreLocation.CurrentUser);
        store.Open(OpenFlags.ReadOnly);
        foreach (var cert in store.Certificates)
        {
            count++;
            cert.Dispose();
        }
        return count;
    }
}
```

Contributes to #44598 