### PR TITLE
Initial checkin for regions

### DIFF
--- a/src/coreclr/src/gc/gc.h
+++ b/src/coreclr/src/gc/gc.h
@@ -16,6 +16,8 @@ Module Name:
 #include "gcinterface.h"
 #include "env/gcenv.os.h"
 
+#include "gchandletableimpl.h"
+
 #ifdef BUILD_AS_STANDALONE
 #include "gcenv.ee.standalone.inl"
 

--- a/src/coreclr/src/gc/gcconfig.h
+++ b/src/coreclr/src/gc/gcconfig.h
@@ -102,6 +102,7 @@ public:
     INT_CONFIG   (GCHeapHardLimit,        "GCHeapHardLimit",        "System.GC.HeapHardLimit",        0,                 "Specifies a hard limit for the GC heap")                                                 \
     INT_CONFIG   (GCHeapHardLimitPercent, "GCHeapHardLimitPercent", "System.GC.HeapHardLimitPercent", 0,                 "Specifies the GC heap usage as a percentage of the total memory")                        \
     INT_CONFIG   (GCTotalPhysicalMemory,  "GCTotalPhysicalMemory",  NULL,                             0,                 "Specifies what the GC should consider to be total physical memory")                      \
+    INT_CONFIG   (GCRegionsRange,         "GCRegionsRange",         NULL,                             0,                 "Specifies the range for the GC heap")                                                    \
     STRING_CONFIG(LogFile,                "GCLogFile",              NULL,                                                "Specifies the name of the GC log file")                                                  \
     STRING_CONFIG(ConfigLogFile,          "GCConfigLogFile",        NULL,                                                "Specifies the name of the GC config log file")                                           \
     INT_CONFIG   (BGCFLTuningEnabled,     "BGCFLTuningEnabled",     NULL,                             0,                 "Enables FL tuning")                                                                      \

--- a/src/coreclr/src/gc/gcee.cpp
+++ b/src/coreclr/src/gc/gcee.cpp
@@ -58,12 +58,15 @@ void GCHeap::UpdatePreGCCounters()
 
 void GCHeap::ReportGenerationBounds()
 {
-    g_theGCHeap->DiagDescrGenerations([](void*, int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
+    if (EVENT_ENABLED(GCGenerationRange))
     {
-        uint64_t range = static_cast<uint64_t>(rangeEnd - rangeStart);
-        uint64_t rangeReserved = static_cast<uint64_t>(rangeEndReserved - rangeStart);
-        FIRE_EVENT(GCGenerationRange, generation, rangeStart, range, rangeReserved);
-    }, nullptr);
+        g_theGCHeap->DiagDescrGenerations([](void*, int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
+        {
+            uint64_t range = static_cast<uint64_t>(rangeEnd - rangeStart);
+            uint64_t rangeReserved = static_cast<uint64_t>(rangeEndReserved - rangeStart);
+            FIRE_EVENT(GCGenerationRange, generation, rangeStart, range, rangeReserved);
+        }, nullptr);
+    }
 }
 
 void GCHeap::UpdatePostGCCounters()


### PR DESCRIPTION
I have not done a full functional test run - there are things I know don't work yet. But being
able to run some tests will allow multiple people to work on this in parallel. I've included the 
ones I ran below).

I added an env var for now to specify the range for regions (GCRegionsRange). We can have 
a default reserve range that's very large. This simplies a lot of things. Right now I'm only enabling 
the feature on 64-bit because I've only been testing on 64-bit. For 32-bit we would likely still 
need to have things like grow_brick_card_tables.

Each generation has at least one region; each region can only belong to one generation.

---
Main changes -

+ I'm using the current heap_segment to represent a region instead of doing a ton of renaming
  because each region also needs to keep track of the same allocated/committed/etc. So when
  USE_REGIONS is defined you could think region whenever you see segment. But gen/planned gen
  are now maintained by each region since we no long have a contiguous range for ephemeral gens.
+ Added a simple region allocator that finds free blocks for region alloc requests and coalesce
  adjacent free blocks.
+ Places that need to check for ephemeral generations are changed to check for gen_num/plan_gen_num
  accordingly, eg, gc_mark, mark_through_cards, relocate_address.
+ plan phase is changed quite a bit to accommodate regions, eg, we set each region's plan as
  we've planned them; we need to go through eph regions for allocating survivors, instead of
  detecting crossing gen0/1 boundary by the survivors position relative to their gen start, we
  plan the next generation (if necessary) when we run out of regions of the current generation
  we are going through. This actually avoids some of the complexity with segments.
+ sweep phase is heavily changed since we don't have a gen limit to detect eph gen boundaries
  anymore.
+ Rewrote the code that threads segments together for regions after compact/sweep is done.
+ Changed the SOH allocator to acquire new regions when needed, still maintain ephemeral_heap_segment
  but now it's used to indicate the region we are currently allocating in.
+ Got rid of the following that doesn't apply to regions -
  ephemeral_low/ephemeral_high
  demotion_low/demotion_high
  Some of these were replaced for regions; others haven't been (like ephemeral_low/ephemeral_high)
  which will be done in separate work items.
+ Added some internal stress mechanisms like selectively pinning some objects and creating ro segs
  in GC.
+ I have not changed the write barrier code so for WKS GC cards will be set unconditionally like in
  SVR GC.
+ Changed verify_heap to verify regions.
+ Perf changes, eg, to determine compaction.
+ Some changes for BGC; it's still incomplete but I've changed places where it needs to avoid reading
  into the ephemeral regions for concurrent like BGC revisit/overflow. Overflow can be optimized to
  be per region (this optimization applies to segs as well but more gains with regions).

---
Some key implementation differences between regions and segments -

+ We no longer have the expand heap code paths which simplies things by a lot.
+ We no longer have a generation start object - each generation has a list of regions that belong to
  that generation. Any empty region can be removed off of this list. This is different from when we
  had a generation start which meant the first segment would never be empty and we don't reuse it for new
  eph seg.
+ With segments in plan phase we may not have allocated gen1/0 start while going through survivors since
  there may not be survivors in gen1/0... with regions it's different because each time I finish a generation
  I will call process_last_np to allocate the new gen. It's more consistent.
+ consing_gen in plan phase really doesn't need to be a generation. With segments it would change that
  generation's alloc seg and we'd switch to gen1 when we need to plan ephemeral generations. But this is
  unnecessary because all we need is the alloc_ptr/limit pair + alloc seg (or alloc region for regions).
  I've made some progress simplying this so this never changes (always the condemned gen) and always
  represents the alloc_ptr/limit/region. We can totally get rid of consing_gen and only maintain those
  3 things.

---

Other things worth mentioning -

+ I intentionally left quite a bit of logging for the new code. Some can be removed when the code
  is more baked.
+ I have some "REGIONS TODO"s in the code that are things needed to changed about this PR. Of course
  there are many optimizations that will be done - seperated PRs will be submitted for those.

---

This is the env I used for testing -

complus_gcConcurrent=0
complus_GCLogEnabled=1
complus_GCLogFile=c:\temp\gclog
complus_GCLogFileSize=100
complus_GCName=clrgc.dll
complus_GCRegionsRange=20000000
complus_heapverify=1
complus_StressLog=0

command line I used for GCPerfSim -

-tc 2 -tagb 16 -tlgb 0.05 -lohar 0 -sohsi 10 -lohsi 0 -pohsi 0 -sohpi 0 -lohpi 0 -pohpi 0 -sohfi 0 -lohfi 0 -pohfi 0 -allocType reference -testKind time -printEveryNthIter 300000

-tc 2 -tagb 32 -tlgb 0.05 -lohar 100 -sohsi 10 -lohsi 100 -pohsi 0 -sohpi 0 -lohpi 0 -pohpi 0 -sohfi 0 -lohfi 0 -pohfi 0 -allocType reference -testKind time -printEveryNthIter 300000