### PR TITLE
Make managed `enum_flag_HasTypeEquivalence` match value in methodtable.h

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -291,18 +291,13 @@ namespace System.Runtime.CompilerServices
                 mt = mt->ParentMethodTable;
             }
 
-            if (RuntimeHelpers.GetMethodTable(obj)->HasTypeEquivalence)
-            {
-                goto slowPath;
-            }
+            // this helper is not supposed to be used with type-equivalent "to" type.
+            Debug.Assert(!((MethodTable*)toTypeHnd)->HasTypeEquivalence);
 
             obj = null;
 
         done:
             return obj;
-
-        slowPath:
-            return IsInstance_Helper(toTypeHnd, obj);
         }
 
         [DebuggerHidden]

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -408,7 +408,7 @@ namespace System.Runtime.CompilerServices
         // WFLAGS_HIGH_ENUM
         private const uint enum_flag_ContainsPointers = 0x01000000;
         private const uint enum_flag_HasComponentSize = 0x80000000;
-        private const uint enum_flag_HasTypeEquivalence = 0x00004000;
+        private const uint enum_flag_HasTypeEquivalence = 0x02000000;
         // Types that require non-trivial interface cast have this bit set in the category
         private const uint enum_flag_NonTrivialInterfaceCast = 0x00080000 // enum_flag_Category_Array
                                                              | 0x40000000 // enum_flag_ComObject


### PR DESCRIPTION
By its use `enum_flag_HasTypeEquivalence` needs to match the native counterpart in methodtable.h

Currently it matches the value in typedesc.h , which happens to be different from the one in methodtable.h.
