### PR TITLE
Disabled Http2_PingKeepAlive

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1657,6 +1657,7 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Significant delay.")]
         [MemberData(nameof(KeepAliveTestDataSource))]
         [ConditionalTheory(nameof(SupportsAlpn))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/41929")]
         public async Task Http2_PingKeepAlive(TimeSpan keepAlivePingDelay, HttpKeepAlivePingPolicy keepAlivePingPolicy, bool expectRequestFail)
         {
             TimeSpan pingTimeout = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
The high numbers of failures seem to be temporary in the end. My assumption about product code change was probably false.
We might hold this PR back for a few more days to confirm this.

Numbers per day ([kusto](https://dataexplorer.azure.com/clusters/engsrvprod/databases/engineeringdata?query=H4sIAAAAAAAAA22LQQuCQBSE7/2KhxcV8tLdQ5fIQqgIOsrae+VLd1d23xZGPz4x8NRchpn55kxeTuRDJx4WH3g15AhKksYi5DlEW5F+VR3Y3PdE/brjJ0WgDMLvNDEbxV00nh+WDbRsMGdjyMHFurYQ0h6smUOBf8idrSdo9Gn3QWvl+E1wtcFIkkI9gFhUQsKakuRmnVZSzcUxUCBcQjyMysoyQ4zTNP0CCoiGV94AAAA=)):

Disabled test tracked in #41929

<details>

|Queued    | Count |
|----------|-------|
|2020-09-26|1|
|2020-09-27|2|
|2020-09-28|2|
|2020-09-29|7|
|2020-09-30|2|
|2020-10-01|1|
|2020-10-02|4|
|2020-10-03|4|
|2020-10-04|3|
|2020-10-05|8|
|2020-10-06|1|
|2020-10-07|5|
|2020-10-08|6|
|2020-10-09|2|
|2020-10-10|2|
|2020-10-11|2|
|2020-10-13|4|
|2020-10-14|6|
|2020-10-15|4|
|2020-10-16|3|
|2020-10-17|2|
|2020-10-18|2|
|2020-10-19|3|
|2020-10-20|4|
|2020-10-21|3|
|2020-10-22|1|
|2020-10-23|2|
|2020-10-26|2|
|2020-10-30|1|
|2020-10-31|4|
|2020-11-02|1|
|2020-11-04|12|
|2020-11-05|30|
|2020-11-06|15|
|2020-11-07|22|
|2020-11-08|11|
|2020-11-09|12|
|2020-11-10|23|
|2020-11-11|15|
|2020-11-12|29|
|2020-11-13|30|
|2020-11-14|16|
|2020-11-16|17|
|2020-11-17|11|
|2020-11-18|29|
|2020-11-19|37|
|2020-11-20|16|
|2020-11-21|7|
|2020-11-25|1|

</details>