### PR TITLE
Enable the AsnXml build target on non-Windows.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -198,3 +198,8 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd, bat}]
 end_of_line = crlf
+
+# ASN files are automatically generated with a BOM.
+[*Asn.xml.cs]
+charset = utf-8-bom
+generated_code = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -198,8 +198,3 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd, bat}]
 end_of_line = crlf
-
-# ASN files are automatically generated with a BOM.
-[*Asn.xml.cs]
-charset = utf-8-bom
-generated_code = true

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AlgorithmIdentifierAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AlgorithmIdentifierAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -8,10 +8,8 @@
     </None>
   </ItemGroup>
 
-  <!-- MSBuild for .NET Core doesn't support XslTransform at this time -->
   <Target Name="CompileAsn" BeforeTargets="CoreCompile"
-    Condition="'$(MSBuildRuntimeType)' != 'core'"
-    Inputs="@(AsnXml);$(MSBuildThisFileDirectory)asn.xslt"
+    Inputs="@(AsnXml)"
     Outputs="%(Identity).cs">
 
     <MakeDir Directories="$(IntermediateOutputPath)asnxml" />
@@ -21,23 +19,25 @@
       XmlInputPaths="@(AsnXml)"
       OutputPaths="@(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs')" />
 
-    <Exec Condition="'$(TargetOS)'=='windows'"
+    <Exec Condition="$([MSBuild]::IsOsPlatform('windows')) == 'true'"
       IgnoreExitCode="true"
       StandardOutputImportance="Low"
       Command="$(SystemRoot)\System32\fc.exe /a @(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs') @(AsnXml -> '%(Identity).cs')">
       <Output TaskParameter="ExitCode" ItemName="_AsnXmlDiffCode" />
     </Exec>
 
-    <!-- TODO: Call diff on Unix -->
-    <ItemGroup Condition="'$(TargetOS)'!='windows'">
-      <_AsnXmlDiffCode Include="1" />
-    </ItemGroup>
+    <Exec Condition="$([MSBuild]::IsOsPlatform('windows')) != 'true'"
+      IgnoreExitCode="true"
+      StandardOutputImportance="Low"
+      Command="/usr/bin/diff -q -a @(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs') @(AsnXml -> '%(Identity).cs')">
+      <Output TaskParameter="ExitCode" ItemName="_AsnXmlDiffCode" />
+    </Exec>
 
     <Copy
       Condition="'@(_AsnXmlDiffCode)' != '0'"
-      SourceFiles="@(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs')" 
+      SourceFiles="@(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs')"
       DestinationFiles="@(AsnXml -> '%(Identity).cs')" />
-    
-    <Warning Condition="'@(_AsnXmlDiffCode)' != '0'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
+
+    <Message Condition="'@(_AsnXmlDiffCode)' != '0'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" Importance="high" />
   </Target>
-</Project>  
+</Project>

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -9,7 +9,8 @@
   </ItemGroup>
 
   <Target Name="CompileAsn" BeforeTargets="CoreCompile"
-    Inputs="@(AsnXml)"
+    Condition=" '@(AsnXml)' != '' "
+    Inputs="@(AsnXml);$(MSBuildThisFileDirectory)asn.xslt"
     Outputs="%(Identity).cs">
 
     <MakeDir Directories="$(IntermediateOutputPath)asnxml" />

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -3,7 +3,6 @@
     <AsnXml />
     <_AsnXmlDiffCmd>%24%28command -v diff%29 -q -a</_AsnXmlDiffCmd>
     <_AsnXmlDiffCmd Condition="$([MSBuild]::IsOsPlatform('windows')) == 'true'">$(SystemRoot)\System32\fc.exe /a</_AsnXmlDiffCmd>
-    <_AsnIntermediatePath>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'asnxml'))</_AsnIntermediatePath>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)asn.xsd">
@@ -15,6 +14,10 @@
     Condition=" '@(AsnXml)' != '' "
     Inputs="@(AsnXml);$(MSBuildThisFileDirectory)asn.xslt"
     Outputs="%(Identity).cs">
+
+    <PropertyGroup>
+      <_AsnIntermediatePath>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'asnxml'))</_AsnIntermediatePath>
+    </PropertyGroup>
 
     <MakeDir Directories="$(_AsnIntermediatePath)" />
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -35,6 +35,6 @@
       SourceFiles="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')"
       DestinationFiles="@(AsnXml -> '%(Identity).cs')" />
 
-    <Message Condition="'@(_AsnXmlDiffCode)' != '0'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" Importance="high" />
+    <Warning Condition="'@(_AsnXmlDiffCode)' != '0'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
   </Target>
 </Project>

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AsnXml />
-    <_AsnXmlDiffCmd>/usr/bin/diff -q -a</_AsnXmlDiffCmd>
+    <_AsnXmlDiffCmd>%24%28command -v diff%29 -q -a</_AsnXmlDiffCmd>
     <_AsnXmlDiffCmd Condition="$([MSBuild]::IsOsPlatform('windows')) == 'true'">$(SystemRoot)\System32\fc.exe /a</_AsnXmlDiffCmd>
     <_AsnIntermediatePath>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'asnxml'))</_AsnIntermediatePath>
   </PropertyGroup>

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
     <AsnXml />
+    <_AsnXmlDiffCmd>/usr/bin/diff -q -a</_AsnXmlDiffCmd>
+    <_AsnXmlDiffCmd Condition="$([MSBuild]::IsOsPlatform('windows')) == 'true'">$(SystemRoot)\System32\fc.exe /a</_AsnXmlDiffCmd>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)asn.xsd">
@@ -20,17 +22,10 @@
       XmlInputPaths="@(AsnXml)"
       OutputPaths="@(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs')" />
 
-    <Exec Condition="$([MSBuild]::IsOsPlatform('windows')) == 'true'"
+    <Exec
       IgnoreExitCode="true"
       StandardOutputImportance="Low"
-      Command="$(SystemRoot)\System32\fc.exe /a @(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs') @(AsnXml -> '%(Identity).cs')">
-      <Output TaskParameter="ExitCode" ItemName="_AsnXmlDiffCode" />
-    </Exec>
-
-    <Exec Condition="$([MSBuild]::IsOsPlatform('windows')) != 'true'"
-      IgnoreExitCode="true"
-      StandardOutputImportance="Low"
-      Command="/usr/bin/diff -q -a @(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs') @(AsnXml -> '%(Identity).cs')">
+      Command="$(_AsnXmlDiffCmd) @(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs') @(AsnXml -> '%(Identity).cs')">
       <Output TaskParameter="ExitCode" ItemName="_AsnXmlDiffCode" />
     </Exec>
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -3,6 +3,7 @@
     <AsnXml />
     <_AsnXmlDiffCmd>/usr/bin/diff -q -a</_AsnXmlDiffCmd>
     <_AsnXmlDiffCmd Condition="$([MSBuild]::IsOsPlatform('windows')) == 'true'">$(SystemRoot)\System32\fc.exe /a</_AsnXmlDiffCmd>
+    <_AsnIntermediatePath>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'asnxml'))</_AsnIntermediatePath>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)asn.xsd">
@@ -15,23 +16,23 @@
     Inputs="@(AsnXml);$(MSBuildThisFileDirectory)asn.xslt"
     Outputs="%(Identity).cs">
 
-    <MakeDir Directories="$(IntermediateOutputPath)asnxml" />
+    <MakeDir Directories="$(_AsnIntermediatePath)" />
 
     <XslTransformation
       XslInputPath="$(MSBuildThisFileDirectory)asn.xslt"
       XmlInputPaths="@(AsnXml)"
-      OutputPaths="@(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs')" />
+      OutputPaths="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')" />
 
     <Exec
       IgnoreExitCode="true"
       StandardOutputImportance="Low"
-      Command="$(_AsnXmlDiffCmd) @(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs') @(AsnXml -> '%(Identity).cs')">
+      Command="$(_AsnXmlDiffCmd) @(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs') @(AsnXml -> '%(Identity).cs')">
       <Output TaskParameter="ExitCode" ItemName="_AsnXmlDiffCode" />
     </Exec>
 
     <Copy
       Condition="'@(_AsnXmlDiffCode)' != '0'"
-      SourceFiles="@(AsnXml -> '$(IntermediateOutputPath)asnxml\%(filename).cs')"
+      SourceFiles="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')"
       DestinationFiles="@(AsnXml -> '%(Identity).cs')" />
 
     <Message Condition="'@(_AsnXmlDiffCode)' != '0'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" Importance="high" />

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/CurveAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/CurveAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DigestInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DigestInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DirectoryStringAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DirectoryStringAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DssParms.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DssParms.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECDomainParameters.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECDomainParameters.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECPrivateKey.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECPrivateKey.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/EdiPartyNameAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/EdiPartyNameAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/EncryptedPrivateKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/EncryptedPrivateKeyInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/FieldID.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/FieldID.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/GeneralNameAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/GeneralNameAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/OaepParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/OaepParamsAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out OaepParamsAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out OaepParamsAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/OtherNameAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/OtherNameAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBEParameter.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBEParameter.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBES2Params.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBES2Params.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2Params.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2Params.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2SaltChoice.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2SaltChoice.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/CertBagAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/CertBagAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SafeBagAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SafeBagAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedContentInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedContentInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedDataAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedDataAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPrivateKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPrivateKeyAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPublicKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPublicKeyAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/SpecifiedECDomain.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/SpecifiedECDomain.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/CadesIssuerSerial.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/CadesIssuerSerial.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out CadesIssuerSerial decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out CadesIssuerSerial decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/CertificateChoiceAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/CertificateChoiceAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, encoded, out CertificateChoiceAsn decoded);
+                DecodeCore(ref reader, encoded, out CertificateChoiceAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EncapsulatedContentInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EncapsulatedContentInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out EncapsulatedContentInfoAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out EncapsulatedContentInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EnvelopedDataAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EnvelopedDataAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -70,7 +70,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out EnvelopedDataAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out EnvelopedDataAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertId.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertId.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out EssCertId decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out EssCertId decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertIdV2.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertIdV2.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out EssCertIdV2 decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out EssCertIdV2 decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/IssuerAndSerialNumberAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/IssuerAndSerialNumberAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out IssuerAndSerialNumberAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out IssuerAndSerialNumberAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientIdentifierAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientIdentifierAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, encoded, out KeyAgreeRecipientIdentifierAsn decoded);
+                DecodeCore(ref reader, encoded, out KeyAgreeRecipientIdentifierAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out KeyAgreeRecipientInfoAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out KeyAgreeRecipientInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyTransRecipientInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyTransRecipientInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out KeyTransRecipientInfoAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out KeyTransRecipientInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/MessageImprint.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/MessageImprint.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out MessageImprint decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out MessageImprint decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorIdentifierOrKeyAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorIdentifierOrKeyAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -78,7 +78,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, encoded, out OriginatorIdentifierOrKeyAsn decoded);
+                DecodeCore(ref reader, encoded, out OriginatorIdentifierOrKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -71,7 +71,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out OriginatorInfoAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out OriginatorInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorPublicKeyAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorPublicKeyAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out OriginatorPublicKeyAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out OriginatorPublicKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OtherKeyAttributeAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OtherKeyAttributeAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -58,7 +58,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out OtherKeyAttributeAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out OtherKeyAttributeAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PkiStatusInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PkiStatusInfo.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out PkiStatusInfo decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out PkiStatusInfo decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyInformation.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyInformation.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out PolicyInformation decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out PolicyInformation decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyQualifierInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyQualifierInfo.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out PolicyQualifierInfo decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out PolicyQualifierInfo decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientEncryptedKeyAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientEncryptedKeyAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out RecipientEncryptedKeyAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out RecipientEncryptedKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientIdentifierAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientIdentifierAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, encoded, out RecipientIdentifierAsn decoded);
+                DecodeCore(ref reader, encoded, out RecipientIdentifierAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, encoded, out RecipientInfoAsn decoded);
+                DecodeCore(ref reader, encoded, out RecipientInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientKeyIdentifier.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientKeyIdentifier.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out RecipientKeyIdentifier decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out RecipientKeyIdentifier decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161Accuracy.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161Accuracy.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out Rfc3161Accuracy decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out Rfc3161Accuracy decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -102,7 +102,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out Rfc3161TimeStampReq decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out Rfc3161TimeStampReq decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampResp.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampResp.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out Rfc3161TimeStampResp decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out Rfc3161TimeStampResp decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -117,7 +117,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out Rfc3161TstInfo decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out Rfc3161TstInfo decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SecretBagAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SecretBagAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out SecretBagAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out SecretBagAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedAttributesSet.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedAttributesSet.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.Pkcs
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, encoded, out SignedAttributesSet decoded);
+                DecodeCore(ref reader, encoded, out SignedAttributesSet decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedDataAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedDataAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -93,7 +93,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out SignedDataAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out SignedDataAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignerIdentifierAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignerIdentifierAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, encoded, out SignerIdentifierAsn decoded);
+                DecodeCore(ref reader, encoded, out SignerIdentifierAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignerInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignerInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -83,7 +83,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out SignerInfoAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out SignerInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out SigningCertificateAsn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out SigningCertificateAsn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateV2Asn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateV2Asn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             {
                 AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
 
-                Decode(ref reader, expectedTag, encoded, out SigningCertificateV2Asn decoded);
+                DecodeCore(ref reader, expectedTag, encoded, out SigningCertificateV2Asn decoded);
                 reader.ThrowIfNotEmpty();
                 return decoded;
             }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/AccessDescriptionAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/AccessDescriptionAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificatePolicyMappingAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificatePolicyMappingAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateTemplateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateTemplateAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointNameAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointNameAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyConstraintsAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyConstraintsAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyInformationAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyInformationAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/ValidityAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/ValidityAsn.xml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable SA1028 // ignore whitespace warnings for generated code


### PR DESCRIPTION
This enables the `AsnXml` target to run on all platforms.