### PR TITLE
Use minimum supported PAGE_SIZE as stack probe step

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -7419,10 +7419,13 @@ public:
 
     GenTree* eeGetPInvokeCookie(CORINFO_SIG_INFO* szMetaSig);
 
-    // Returns the page size for the target machine as reported by the EE.
+    // The following value is used by the JIT to determine when
+    // to emit a stack probing instruction sequence or a call to the stack probe helper while:
+    //   1. allocating a frame in a method prolog;
+    //   2. allocating a local heap in a method body (i.e. localloc).
     target_size_t eeGetPageSize()
     {
-        return (target_size_t)eeGetEEInfo()->osPageSize;
+        return 0x1000;
     }
 
     // Returns the frame size at which we will generate a loop to probe the stack.


### PR DESCRIPTION
JIT should not use the target page size for making decisions when to emit a call to a stack probe helper or inline stack probing instruction sequence. Such assumption would be wrong in AOT scenarios when crossgen compiles R2R code on a build machine with larger page size than a target machine that will be used for running this code. In theory, JIT can make such decisions in non-AOT scenarios, but the added complexity would not be justified.  

@dotnet/jit-contrib 
