### PR TITLE
[release/5.0] Use minimum supported PAGE_SIZE as stack probe step

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -7264,10 +7264,13 @@ public:
 
     GenTree* eeGetPInvokeCookie(CORINFO_SIG_INFO* szMetaSig);
 
-    // Returns the page size for the target machine as reported by the EE.
+    // The following value is used by the JIT to determine when
+    // to emit a stack probing instruction sequence or a call to the stack probe helper while:
+    //   1. allocating a frame in a method prolog;
+    //   2. allocating a local heap in a method body (i.e. localloc).
     target_size_t eeGetPageSize()
     {
-        return (target_size_t)eeGetEEInfo()->osPageSize;
+        return 0x1000;
     }
 
     // Returns the frame size at which we will generate a loop to probe the stack.


### PR DESCRIPTION
Backport of #45225 to release/5.0

## Customer Impact

Apple Silicon with Rosetta 2 emulation uses a 16K memory page.  This configuration sends the runtime into untested and unstable stack probing configuration which causes crashes in Rosetta 2 emulation. We need this fixed to support Apple Silicon.

## Regression

No.  Apple Silicon is a new scenario which we are backporting to .NET 5

## Testing

- Applied change to 5.0 tip.  Ran full set of priority 1 tests on Apple Silicon under Rosetta 2 emulation. All symptoms of stack issues were resolved.

## Risk

This is a low risk change.  It changes stack probing to use a constant 4k page size.  This is the industry standard minimum page size used across all supported CPU architectures. The use of a constant reduces complexity and simplifies testing. Fixes issues with mismatched AOT and runtime page sizes.

@dotnet/jit-contrib
cc @sdmaclea 