### PR TITLE
Explicitly check for arrays in Marshal.SizeOf impl.

### DIFF
--- a/src/coreclr/src/vm/marshalnative.cpp
+++ b/src/coreclr/src/vm/marshalnative.cpp
@@ -277,7 +277,7 @@ FCIMPL2(UINT32, MarshalNative::SizeOfClass, ReflectClassBaseObject* refClassUNSA
     // refClass is validated to be non-NULL RuntimeType by callers
     TypeHandle th = refClass->GetType();
 
-    if (throwIfNotMarshalable && !th.IsBlittable())
+    if (throwIfNotMarshalable && (!th.IsBlittable() || th.IsArray()))
     {
         GCX_PREEMP();
         // Determine if the type is marshalable
@@ -1350,7 +1350,7 @@ void QCALLTYPE MarshalNative::GetTypeFromCLSID(REFCLSID clsid, PCWSTR wszServer,
 
     BEGIN_QCALL;
 
-    // Ensure COM is started up.	
+    // Ensure COM is started up.
     EnsureComStarted();
 
     GCX_COOP();

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
@@ -78,6 +78,7 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeBuilder, "t" };
 
             yield return new object[] { typeof(TestStructWithFxdLPSTRSAFld), null };
+            yield return new object[] { typeof(int[]), null };
         }
 
         [Theory]


### PR DESCRIPTION
With the refactoring to lazily generate type interop data, we missed a corner case where we could sometimes end up trying to get the native size of an array. A debug runtime asserts, but a release runtime just ran through and crashed.

Explicitly check for arrays in `MarshalNative::SizeOfClass` since arrays of blittable types return true from `IsBlittable`.

Fixes #44508 