### PR TITLE
Fix the EH-write thru scenario

### DIFF
--- a/src/coreclr/src/jit/block.cpp
+++ b/src/coreclr/src/jit/block.cpp
@@ -1495,6 +1495,11 @@ bool BasicBlock::hasEHBoundaryOut()
         returnVal = true;
     }
 
+    if (bbJumpKind == BBJ_THROW)
+    {
+        returnVal = true;
+    }
+
 #if FEATURE_EH_FUNCLETS
     if (bbJumpKind == BBJ_EHCATCHRET)
     {

--- a/src/coreclr/src/jit/block.cpp
+++ b/src/coreclr/src/jit/block.cpp
@@ -1495,11 +1495,6 @@ bool BasicBlock::hasEHBoundaryOut()
         returnVal = true;
     }
 
-    if (bbJumpKind == BBJ_THROW)
-    {
-        returnVal = hasTryIndex() || hasHndIndex();
-    }
-
 #if FEATURE_EH_FUNCLETS
     if (bbJumpKind == BBJ_EHCATCHRET)
     {

--- a/src/coreclr/src/jit/block.cpp
+++ b/src/coreclr/src/jit/block.cpp
@@ -1497,7 +1497,7 @@ bool BasicBlock::hasEHBoundaryOut()
 
     if (bbJumpKind == BBJ_THROW)
     {
-        returnVal = true;
+        returnVal = hasTryIndex() || hasHndIndex();
     }
 
 #if FEATURE_EH_FUNCLETS

--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -11007,6 +11007,8 @@ void LinearScan::verifyFinalAllocation()
                 }
                 if (currentRefPosition->spillAfter || currentRefPosition->lastUse)
                 {
+                    assert(!currentRefPosition->spillAfter || currentRefPosition->IsActualRef());
+
                     interval->physReg     = REG_NA;
                     interval->assignedReg = nullptr;
 

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -2259,7 +2259,7 @@ void LinearScan::buildIntervals()
                 while (iter.NextElem(&varIndex))
                 {
                     Interval* interval = getIntervalForLocalVar(varIndex);
-                    if (interval->recentRefPosition != nullptr)
+                    if (interval->recentRefPosition != nullptr && interval->recentRefPosition->IsActualRef())
                     {
                         JITDUMP("  Marking RP #%d of V%02u as spillAfter\n", interval->recentRefPosition->rpNum,
                                 interval->varNum);

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -2239,11 +2239,8 @@ void LinearScan::buildIntervals()
                 currentLoc = 1;
             }
 
-            // Handle special cases for live-in.
-            // If this block hasEHBoundaryIn, then we will mark the recentRefPosition of each EH Var preemptively as
-            // spillAfter, since we don't want them to remain in registers.
-            // Otherwise, determine if we need any DummyDefs.
-            // We need DummyDefs for cases where "predBlock" isn't really a predecessor.
+            // For blocks that don't have EHBoundaryIn, we need DummyDefs for cases where "predBlock" isn't
+            // really a predecessor.
             // Note that it's possible to have uses of unitialized variables, in which case even the first
             // block may require DummyDefs, which we are not currently adding - this means that these variables
             // will always be considered to be in memory on entry (and reloaded when the use is encountered).
@@ -2251,23 +2248,7 @@ void LinearScan::buildIntervals()
             // variables (which may actually be initialized along the dynamically executed paths, but not
             // on all static paths), we wind up with excessive liveranges for some of these variables.
 
-            if (blockInfo[block->bbNum].hasEHBoundaryIn)
-            {
-                VARSET_TP       liveInEHVars(VarSetOps::Intersection(compiler, currentLiveVars, exceptVars));
-                VarSetOps::Iter iter(compiler, liveInEHVars);
-                unsigned        varIndex = 0;
-                while (iter.NextElem(&varIndex))
-                {
-                    Interval* interval = getIntervalForLocalVar(varIndex);
-                    if (interval->recentRefPosition != nullptr && interval->recentRefPosition->IsActualRef())
-                    {
-                        JITDUMP("  Marking RP #%d of V%02u as spillAfter\n", interval->recentRefPosition->rpNum,
-                                interval->varNum);
-                        interval->recentRefPosition->spillAfter = true;
-                    }
-                }
-            }
-            else
+            if (!blockInfo[block->bbNum].hasEHBoundaryIn)
             {
                 // Any lclVars live-in on a non-EH boundary edge are resolution candidates.
                 VarSetOps::UnionD(compiler, resolutionCandidateVars, currentLiveVars);


### PR DESCRIPTION
Fix the scenario for EH-Writethru case that was broken with my https://github.com/dotnet/runtime/pull/44977 change. Below diffs compare the master (before my changes in https://github.com/dotnet/runtime/pull/44977) vs. PR. 

Code size diffs: 

```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 51297868
Total bytes of diff: 51312150
Total bytes of delta: 14282 (0.03% of base)
    diff is a regression.

Top file regressions (bytes):
        2561 : System.Private.CoreLib.dasm (0.05% of base)
        1453 : System.Linq.Parallel.dasm (0.09% of base)
        1443 : System.Linq.dasm (0.16% of base)
        1219 : System.Collections.Immutable.dasm (0.11% of base)
         884 : FSharp.Core.dasm (0.03% of base)
         719 : System.Collections.dasm (0.16% of base)
         568 : Microsoft.CodeAnalysis.dasm (0.03% of base)
         532 : Newtonsoft.Json.dasm (0.06% of base)
         522 : System.Numerics.Tensors.dasm (0.16% of base)
         498 : System.Threading.Tasks.Dataflow.dasm (0.06% of base)
         473 : CommandLine.dasm (0.11% of base)
         340 : System.Threading.Channels.dasm (0.19% of base)
         319 : System.Private.Xml.dasm (0.01% of base)
         250 : System.Data.Common.dasm (0.02% of base)
         223 : System.Collections.Concurrent.dasm (0.07% of base)
         219 : System.Linq.Expressions.dasm (0.03% of base)
         201 : System.ComponentModel.Composition.dasm (0.06% of base)
         175 : Microsoft.Diagnostics.FastSerialization.dasm (0.18% of base)
         169 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (0.01% of base)
         140 : System.Net.Http.dasm (0.02% of base)

Top file improvements (bytes):
        -109 : System.Security.Cryptography.Primitives.dasm (-0.31% of base)
         -75 : System.Security.Cryptography.Pkcs.dasm (-0.02% of base)
         -72 : System.Net.Connections.dasm (-0.23% of base)
         -47 : System.Security.Cryptography.Algorithms.dasm (-0.01% of base)
         -45 : System.Net.Primitives.dasm (-0.07% of base)
         -43 : System.IO.Pipelines.dasm (-0.06% of base)
         -14 : System.Net.WebClient.dasm (-0.03% of base)
         -13 : Microsoft.VisualBasic.Core.dasm (-0.00% of base)
         -11 : System.ServiceProcess.ServiceController.dasm (-0.04% of base)
         -10 : System.Security.Cryptography.Cng.dasm (-0.01% of base)
          -8 : System.Net.Quic.dasm (-0.01% of base)
          -8 : System.Transactions.Local.dasm (-0.01% of base)
          -6 : System.Net.Requests.dasm (-0.01% of base)
          -4 : xunit.runner.reporters.netcoreapp10.dasm (-0.01% of base)
          -3 : Microsoft.Extensions.Hosting.Abstractions.dasm (-0.04% of base)
          -2 : System.Data.Odbc.dasm (-0.00% of base)
          -2 : System.Net.Http.WinHttpHandler.dasm (-0.00% of base)
          -2 : System.Resources.Extensions.dasm (-0.01% of base)
          -1 : System.Text.Encoding.CodePages.dasm (-0.00% of base)
          -1 : System.Threading.dasm (-0.01% of base)

125 total files with Code Size differences (21 improved, 104 regressed), 143 unchanged.

Top method regressions (bytes):
         204 (11.14% of base) : CommandLine.dasm - <>c__DisplayClass0_2`1[__Canon][System.__Canon]:<Build>b__15():System.__Canon:this
         161 (14.22% of base) : System.Linq.Parallel.dasm - OrderedExceptQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
         143 (28.66% of base) : System.Linq.Parallel.dasm - ExceptQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
         143 (19.78% of base) : System.Linq.Parallel.dasm - OrderedIntersectQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
         128 (26.07% of base) : System.Linq.Parallel.dasm - IntersectQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
         112 (10.10% of base) : CommandLine.dasm - <>c__DisplayClass0_2`1[__Canon][System.__Canon]:<Build>b__23():System.__Canon:this
         109 (19.19% of base) : System.Linq.Parallel.dasm - OrderedDistinctQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
         106 (12.90% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.TypeNameDecoder`2[__Canon,__Canon][System.__Canon,System.__Canon]:GetTypeSymbol(AssemblyQualifiedTypeName,byref):System.__Canon:this
          97 ( 6.88% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[__Canon][System.__Canon]:GetLinqDataView():System.Data.LinqDataView:this
          95 (16.90% of base) : System.Linq.Parallel.dasm - ReverseQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
          95 (10.87% of base) : System.Numerics.Tensors.dasm - System.Numerics.Tensors.Tensor`1[__Canon][System.__Canon]:GetArrayString(bool):System.String:this
          89 (10.81% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,ResourceLocator][System.__Canon,System.Resources.ResourceLocator]:Resize(int,bool):this
          84 ( 2.05% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - StateMachineMethodToClassRewriter[__Canon][System.__Canon]:VisitTryStatement(Microsoft.CodeAnalysis.VisualBasic.BoundTryStatement):Microsoft.CodeAnalysis.VisualBasic.BoundNode:this
          83 ( 5.67% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:TryInsert(System.__Canon,System.__Canon,ubyte):bool:this
          80 (10.18% of base) : System.Linq.Parallel.dasm - System.Linq.Parallel.DefaultMergeHelper`2[__Canon,Int64][System.__Canon,System.Int64]:.ctor(System.Linq.Parallel.PartitionedStream`2[__Canon,Int64],bool,int,System.Threading.Tasks.TaskScheduler,System.Linq.Parallel.CancellationState,int):this
          79 (13.72% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[__Canon][System.__Canon]:SetOrAdd(int,System.__Canon,System.Collections.Generic.IEqualityComparer`1[__Canon],bool,byref,byref):System.Collections.Immutable.SortedInt32KeyNode`1[__Canon]:this
          79 ( 5.49% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,IntPtr][System.__Canon,System.IntPtr]:TryInsert(System.__Canon,long,ubyte):bool:this
          79 ( 5.44% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Int64][System.__Canon,System.Int64]:TryInsert(System.__Canon,long,ubyte):bool:this
          78 ( 5.76% of base) : System.Numerics.Tensors.dasm - System.Numerics.Tensors.CompressedSparseTensor`1[__Canon][System.__Canon]:RemoveAt(int,int):this
          78 ( 5.42% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Int32][System.__Canon,System.Int32]:TryInsert(System.__Canon,int,ubyte):bool:this

Top method improvements (bytes):
         -95 (-2.03% of base) : System.Linq.Expressions.dasm - System.Runtime.CompilerServices.CallSite`1[__Canon][System.__Canon]:CreateCustomUpdateDelegate(System.Reflection.MethodInfo):System.__Canon:this
         -76 (-2.67% of base) : System.IO.Pipelines.dasm - <ReadAsyncInternal>d__27:MoveNext():this
         -76 (-2.59% of base) : System.Net.Connections.dasm - <ReadAsync>d__20:MoveNext():this
         -65 (-1.42% of base) : System.Private.CoreLib.dasm - ReferenceTypeHelper`1[__Canon][System.__Canon]:GetPropertyGetter(System.Reflection.PropertyInfo):System.Func`2[PropertyValue,PropertyValue]:this
         -57 (-3.93% of base) : System.Security.Cryptography.Pkcs.dasm - System.Security.Cryptography.PasswordBasedEncryption:Decrypt(System.Security.Cryptography.SymmetricAlgorithm,System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.Span`1[Byte]):int
         -47 (-1.33% of base) : System.Net.Primitives.dasm - System.Net.CookieContainer:AgeCookies(System.String):bool:this
         -46 (-1.00% of base) : System.DirectoryServices.AccountManagement.dasm - System.DirectoryServices.AccountManagement.ADStoreCtx:GetGroupsMemberOf(System.DirectoryServices.AccountManagement.Principal):System.DirectoryServices.AccountManagement.ResultSet:this
         -46 (-1.58% of base) : System.Net.Http.dasm - <GetStringAsyncCore>d__41:MoveNext():this
         -46 (-0.94% of base) : System.Private.CoreLib.dasm - System.Diagnostics.Tracing.EventSource:CreateManifestAndDescriptors(System.Type,System.String,System.Diagnostics.Tracing.EventSource,int):System.Byte[]
         -40 (-1.09% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.ForestTrustRelationshipInformation:Save():this
         -34 (-4.77% of base) : FSharp.Core.dasm - Parallel@1229-3[__Canon][System.__Canon]:Invoke(int,Microsoft.FSharp.Control.FSharpAsync`1[__Canon]):Microsoft.FSharp.Core.Unit:this
         -30 (-0.66% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.CommonCompiler:RunCore(System.IO.TextWriter,Microsoft.CodeAnalysis.ErrorLogger,System.Threading.CancellationToken):int:this
         -23 (-1.53% of base) : System.Private.Xml.Linq.dasm - <LoadAsyncInternal>d__57:MoveNext():this
         -22 (-1.01% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.MethodCompiler:GenerateMethodBody(Microsoft.CodeAnalysis.CSharp.Emit.PEModuleBuilder,Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol,int,Microsoft.CodeAnalysis.CSharp.BoundStatement,System.Collections.Immutable.ImmutableArray`1[LambdaDebugInfo],System.Collections.Immutable.ImmutableArray`1[ClosureDebugInfo],Microsoft.CodeAnalysis.CSharp.StateMachineTypeSymbol,Microsoft.CodeAnalysis.CodeGen.VariableSlotAllocator,Microsoft.CodeAnalysis.DiagnosticBag,Microsoft.CodeAnalysis.CodeGen.DebugDocumentProvider,Microsoft.CodeAnalysis.CSharp.ImportChain,bool):Microsoft.CodeAnalysis.CodeGen.MethodBody
         -20 (-1.11% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PENamedTypeSymbol:EnsureNonTypeMemberNamesAreLoaded():this
         -20 (-1.07% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE.PENamedTypeSymbol:EnsureNonTypeMemberNamesAreLoaded():this
         -20 (-1.88% of base) : System.Private.Xml.dasm - <ReadContentAsAsync>d__185:MoveNext():this
         -19 (-1.70% of base) : System.Private.DataContractSerialization.dasm - System.Xml.XmlBaseReader:ReadBytes(System.Text.Encoding,int,int,System.Byte[],int,int,bool):int:this
         -18 (-2.28% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.TypeNameDecoder`2[__Canon,__Canon][System.__Canon,System.__Canon]:ResolveTypeArguments(Microsoft.CodeAnalysis.MetadataHelpers+AssemblyQualifiedTypeName[],byref):System.Collections.Immutable.ImmutableArray`1[KeyValuePair`2]:this
         -18 (-4.50% of base) : System.Private.Xml.dasm - System.Xml.XmlEncodedRawTextWriter:Close():this

Top method regressions (percentages):
         143 (28.66% of base) : System.Linq.Parallel.dasm - ExceptQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
         128 (26.07% of base) : System.Linq.Parallel.dasm - IntersectQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
          73 (20.68% of base) : Newtonsoft.Json.dasm - <Annotations>d__182`1[__Canon][System.__Canon]:MoveNext():bool:this
         143 (19.78% of base) : System.Linq.Parallel.dasm - OrderedIntersectQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
         109 (19.19% of base) : System.Linq.Parallel.dasm - OrderedDistinctQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
          21 (17.80% of base) : System.Collections.Immutable.dasm - Builder[__Canon][System.__Canon]:InsertRange(int,System.Collections.Generic.IEnumerable`1[__Canon]):this
          38 (17.51% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.List`1[__Canon][System.__Canon]:FindAll(System.Predicate`1[__Canon]):System.Collections.Generic.List`1[__Canon]:this
          60 (17.19% of base) : System.Linq.Parallel.dasm - OrderedPipeliningMergeEnumerator[__Canon,Int64][System.__Canon,System.Int64]:MoveNext():bool:this
          95 (16.90% of base) : System.Linq.Parallel.dasm - ReverseQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
          68 (16.39% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Boolean][System.__Canon,System.Boolean]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
          68 (16.39% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,IntPtr][System.__Canon,System.IntPtr]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
          68 (16.39% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Int32][System.__Canon,System.Int32]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
          68 (16.39% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,ResourceLocator][System.__Canon,System.Resources.ResourceLocator]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
          68 (16.39% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Int64][System.__Canon,System.Int64]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
          39 (15.79% of base) : System.Linq.Parallel.dasm - DistinctQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
          25 (15.15% of base) : System.Collections.Immutable.dasm - Builder[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.ImmutableHashSet`1[__Canon]):this
          35 (15.09% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.List`1[__Canon][System.__Canon]:RemoveAll(System.Predicate`1[__Canon]):int:this
          55 (14.99% of base) : System.Collections.Immutable.dasm - Builder[__Canon][System.__Canon]:set_KeyComparer(System.Collections.Generic.IEqualityComparer`1[__Canon]):this
          76 (14.93% of base) : System.Collections.Immutable.dasm - Builder[__Canon][System.__Canon]:IndexOf(System.__Canon,int,int,System.Collections.Generic.IEqualityComparer`1[__Canon]):int:this (2 methods)
         161 (14.22% of base) : System.Linq.Parallel.dasm - OrderedExceptQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this

Top method improvements (percentages):
         -13 (-8.67% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:CopyToPairs(System.Collections.Generic.KeyValuePair`2[System.__Canon,System.Int64][],int):this
         -11 (-6.01% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.TextKeyedCache`1[__Canon][System.__Canon]:AddSharedEntry(int,SharedEntryValue[__Canon]):this
          -7 (-5.83% of base) : System.ServiceProcess.ServiceController.dasm - System.ServiceProcess.ServiceBase:DeferredSessionChange(int,int):this
          -3 (-5.36% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:Union(System.Collections.Generic.IEnumerable`1[__Canon]):System.Collections.Immutable.ImmutableHashSet`1[__Canon]:this
          -3 (-5.36% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:AddRange(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):System.Collections.Immutable.ImmutableDictionary`2[__Canon,Int64]:this
          -3 (-5.08% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:AddRange(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64]:this
          -3 (-4.84% of base) : System.Collections.Immutable.dasm - Node[__Canon][System.__Canon]:FindIndex(System.Predicate`1[__Canon]):int:this
          -3 (-4.84% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:SetItems(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64]:this
         -34 (-4.77% of base) : FSharp.Core.dasm - Parallel@1229-3[__Canon][System.__Canon]:Invoke(int,Microsoft.FSharp.Control.FSharpAsync`1[__Canon]):Microsoft.FSharp.Core.Unit:this
         -13 (-4.64% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:SetEquals(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
         -12 (-4.63% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsProperSubsetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
         -12 (-4.63% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsProperSupersetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
         -12 (-4.63% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsSubsetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
         -12 (-4.63% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsSupersetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
         -12 (-4.63% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:Overlaps(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
          -3 (-4.62% of base) : System.Collections.Immutable.dasm - Node[__Canon][System.__Canon]:Contains(System.__Canon,System.Collections.Generic.IComparer`1[__Canon]):bool:this
         -18 (-4.50% of base) : System.Private.Xml.dasm - System.Xml.XmlEncodedRawTextWriter:Close():this
          -6 (-4.38% of base) : System.Net.Quic.dasm - System.Net.Quic.Implementations.MsQuic.Internal.ResettableCompletionSource`1[Vector`1][System.Numerics.Vector`1[System.Single]]:System.Threading.Tasks.Sources.IValueTaskSource.GetResult(short):this
          -4 (-4.35% of base) : System.Collections.Immutable.dasm - Node[__Canon][System.__Canon]:FindLastIndex(System.Predicate`1[__Canon]):int:this
          -6 (-4.14% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlSchemaException:CreateMessage(System.String,System.String[]):System.String

2817 total methods with Code Size differences (747 improved, 2070 regressed), 337810 unchanged.
```

Perfscore diffs:

```
Summary of Perf Score diffs:
(Lower is better)

Total PerfScoreUnits of base: 277538757.02999824
Total PerfScoreUnits of diff: 277662479.10999805
Total PerfScoreUnits of delta: 123722.08 (0.04% of base)
    diff is a regression.

Top file regressions (PerfScoreUnits):
    120733.29 : System.Linq.Parallel.dasm (4.86% of base)
     1681.25 : System.Linq.dasm (0.36% of base)
      855.33 : System.Private.CoreLib.dasm (0.03% of base)
      632.32 : System.Private.Xml.dasm (0.04% of base)
      505.60 : System.Collections.Concurrent.dasm (0.18% of base)
      502.31 : FSharp.Core.dasm (0.03% of base)
      472.19 : System.Collections.Immutable.dasm (0.12% of base)
      416.94 : System.Linq.Expressions.dasm (0.15% of base)
      413.35 : Microsoft.CodeAnalysis.dasm (0.02% of base)
      399.74 : System.Collections.dasm (0.26% of base)
      279.17 : Microsoft.CodeAnalysis.CSharp.dasm (0.01% of base)
      235.95 : System.Threading.Tasks.Parallel.dasm (0.29% of base)
      226.93 : System.Data.Common.dasm (0.00% of base)
      219.89 : Newtonsoft.Json.dasm (0.00% of base)
      214.16 : System.ComponentModel.Composition.dasm (0.16% of base)
      198.85 : System.Configuration.ConfigurationManager.dasm (0.11% of base)
      191.41 : System.Threading.Tasks.Dataflow.dasm (0.06% of base)
      184.52 : System.Private.Xml.Linq.dasm (0.26% of base)
      141.10 : System.Numerics.Tensors.dasm (0.11% of base)
      137.52 : CommandLine.dasm (0.12% of base)

Top file improvements (PerfScoreUnits):
    -6964.66 : System.DirectoryServices.dasm (-3.50% of base)
      -39.75 : Microsoft.CSharp.dasm (-0.03% of base)
      -36.90 : System.Security.Cryptography.Primitives.dasm (-0.22% of base)
      -20.10 : System.Net.Primitives.dasm (-0.05% of base)
      -14.38 : System.Security.Cryptography.Pkcs.dasm (-0.01% of base)
       -8.82 : System.Security.Cryptography.Algorithms.dasm (-0.01% of base)
       -8.53 : System.Net.Connections.dasm (-0.11% of base)
       -1.78 : System.Net.WebClient.dasm (-0.01% of base)
       -1.60 : System.ServiceProcess.ServiceController.dasm (-0.02% of base)
       -1.30 : System.Transactions.Local.dasm (-0.00% of base)
       -1.25 : System.Security.Cryptography.Cng.dasm (-0.00% of base)
       -1.09 : Microsoft.Extensions.Hosting.dasm (-0.01% of base)
       -0.67 : System.Net.Quic.dasm (-0.00% of base)
       -0.55 : Microsoft.Extensions.Hosting.Abstractions.dasm (-0.03% of base)
       -0.45 : System.Resources.Extensions.dasm (-0.00% of base)
       -0.35 : System.Text.Encoding.CodePages.dasm (-0.00% of base)
       -0.35 : xunit.performance.core.dasm (-0.01% of base)
       -0.15 : xunit.runner.reporters.netcoreapp10.dasm (-0.00% of base)

129 total files with Perf Score differences (18 improved, 111 regressed), 139 unchanged.

Top method regressions (PerfScoreUnits):
    84585.84 ( 7.58% of base) : System.Linq.Parallel.dasm - OrderedExceptQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
    31904.63 ( 9.60% of base) : System.Linq.Parallel.dasm - OrderedIntersectQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
     2768.98 (11.16% of base) : System.Linq.Parallel.dasm - OrderedDistinctQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
      402.53 ( 6.53% of base) : System.Linq.Parallel.dasm - ReverseQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
      257.20 ( 4.05% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[Double,Int64][System.Double,System.Int64]:TryAddInternal(double,System.Nullable`1[Int32],long,bool,bool,byref):bool:this
      257.10 ( 3.07% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[Vector`1,Int64][System.Numerics.Vector`1[System.Single],System.Int64]:TryAddInternal(System.Numerics.Vector`1[Single],System.Nullable`1[Int32],long,bool,bool,byref):bool:this
      237.93 (13.01% of base) : System.Linq.Parallel.dasm - ExceptQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
      228.18 ( 5.25% of base) : System.Private.Xml.dasm - System.Xml.Xsl.XPath.XPathParser`1[__Canon][System.__Canon]:ParseSubExpr(int):System.__Canon:this
      220.43 (12.16% of base) : System.Linq.Parallel.dasm - IntersectQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
      218.05 ( 4.40% of base) : System.Linq.Parallel.dasm - System.Linq.Parallel.SortHelper`2[__Canon,Int64][System.__Canon,System.Int64]:MergeSortCooperatively():this
       65.40 ( 3.19% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.ClsComplianceChecker:CheckForAttributeWithArrayArgumentInternal(System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.CSharpAttributeData, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):this
       65.25 ( 4.32% of base) : System.Numerics.Tensors.dasm - System.Numerics.Tensors.Tensor`1[__Canon][System.__Canon]:GetArrayString(bool):System.String:this
       64.70 ( 6.63% of base) : Microsoft.Extensions.Options.dasm - Microsoft.Extensions.Options.OptionsMonitor`1[__Canon][System.__Canon]:.ctor(Microsoft.Extensions.Options.IOptionsFactory`1[__Canon],System.Collections.Generic.IEnumerable`1[__Canon],Microsoft.Extensions.Options.IOptionsMonitorCache`1[__Canon]):this
       64.25 ( 3.68% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Compiler.VariableBinder:MergeScopes(System.Linq.Expressions.Expression):System.Collections.ObjectModel.ReadOnlyCollection`1[[System.Linq.Expressions.Expression, System.Linq.Expressions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]:this
       56.50 ( 3.30% of base) : System.Threading.Tasks.Parallel.dasm - <>c__DisplayClass44_0`2[Double,Int64][System.Double,System.Int64]:<PartitionerForEachWorker>b__1(byref,int,byref):this
       50.85 ( 5.26% of base) : System.Private.Xml.Linq.dasm - XHashtableState[__Canon][System.__Canon]:Resize():XHashtableState[__Canon]:this
       48.80 ( 0.43% of base) : xunit.execution.dotnet.dasm - <AfterTestCaseStartingAsync>d__9:MoveNext():this
       43.10 ( 0.13% of base) : Microsoft.Diagnostics.FastSerialization.dasm - System.Collections.Generic.SegmentedList`1[__Canon][System.__Canon]:QuickSort(int,int,System.Collections.Generic.IComparer`1[__Canon]):this
       39.05 ( 0.29% of base) : System.Net.HttpListener.dasm - <Process>d__19:MoveNext():this
       36.83 ( 8.46% of base) : CommandLine.dasm - <>c__DisplayClass0_2`1[__Canon][System.__Canon]:<Build>b__15():System.__Canon:this

Top method improvements (PerfScoreUnits):
    -7040.00 (-12.20% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.ForestTrustRelationshipInformation:Save():this
      -96.15 (-0.82% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[Key,__Canon][System.Text.RegularExpressions.RegexCache+Key,System.__Canon]:TryAddInternal(Key,System.Nullable`1[Int32],System.__Canon,bool,bool,byref):bool:this
      -47.90 (-3.26% of base) : Microsoft.CSharp.dasm - Microsoft.CSharp.RuntimeBinder.Semantics.ExpressionBinder:ChooseArrayIndexType(Microsoft.CSharp.RuntimeBinder.Semantics.Expr):Microsoft.CSharp.RuntimeBinder.Semantics.CType:this
      -39.55 (-4.41% of base) : System.Private.CoreLib.dasm - MemberInfoCache`1[__Canon][System.__Canon]:MergeWithGlobalList(System.__Canon[]):this
      -36.80 (-0.34% of base) : System.Net.Primitives.dasm - System.Net.CookieContainer:AgeCookies(System.String):bool:this
      -32.55 (-9.44% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:CopyToPairs(System.Collections.Generic.KeyValuePair`2[System.__Canon,System.Int64][],int):this
      -29.20 (-0.59% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:TryRemoveInternal(System.__Canon,byref,bool,long):bool:this
      -26.60 (-0.50% of base) : System.Private.CoreLib.dasm - System.Diagnostics.Tracing.EventSource:CreateManifestAndDescriptors(System.Type,System.String,System.Diagnostics.Tracing.EventSource,int):System.Byte[]
      -24.22 (-2.87% of base) : FSharp.Core.dasm - Parallel@1178-1[__Canon][System.__Canon]:Invoke(Microsoft.FSharp.Control.AsyncActivation`1[__Canon]):Microsoft.FSharp.Control.AsyncReturn:this
      -19.92 (-1.75% of base) : System.Linq.Expressions.dasm - System.Runtime.CompilerServices.CallSite`1[__Canon][System.__Canon]:CreateCustomUpdateDelegate(System.Reflection.MethodInfo):System.__Canon:this
      -17.71 (-2.54% of base) : System.Numerics.Tensors.dasm - System.Numerics.Tensors.CompressedSparseTensor`1[__Canon][System.__Canon]:Reshape(System.ReadOnlySpan`1[Int32]):System.Numerics.Tensors.Tensor`1[__Canon]:this
      -15.60 (-1.02% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[Vector`1,Int64][System.Numerics.Vector`1[System.Single],System.Int64]:TryUpdateInternal(System.Numerics.Vector`1[Single],System.Nullable`1[Int32],long,long):bool:this
      -14.20 (-3.36% of base) : System.Security.Cryptography.Pkcs.dasm - System.Security.Cryptography.PasswordBasedEncryption:Decrypt(System.Security.Cryptography.SymmetricAlgorithm,System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.Span`1[Byte]):int
      -10.80 (-6.14% of base) : System.Private.Xml.dasm - System.Xml.XmlEncodedRawTextWriter:Close():this
      -10.45 (-1.25% of base) : System.Net.Http.dasm - <GetStringAsyncCore>d__41:MoveNext():this
      -10.00 (-4.04% of base) : System.Private.Xml.dasm - System.Xml.Serialization.SoapReflectionImporter:ImportMembersMapping(System.Xml.Serialization.XmlReflectionMember[],System.String,bool,bool,bool,System.Xml.Serialization.RecursionLimiter):System.Xml.Serialization.MembersMapping:this
       -9.93 (-1.49% of base) : System.IO.Pipelines.dasm - <ReadAsyncInternal>d__27:MoveNext():this
       -9.93 (-1.47% of base) : System.Net.Connections.dasm - <ReadAsync>d__20:MoveNext():this
       -8.40 (-0.76% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[Int16,Int64][System.Int16,System.Int64]:TryUpdateInternal(short,System.Nullable`1[Int32],long,long):bool:this
       -8.40 (-0.77% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[Int32,Int64][System.Int32,System.Int64]:TryUpdateInternal(int,System.Nullable`1[Int32],long,long):bool:this

Top method regressions (percentages):
        5.85 (16.93% of base) : System.Collections.Immutable.dasm - Builder[__Canon][System.__Canon]:InsertRange(int,System.Collections.Generic.IEnumerable`1[__Canon]):this
       13.05 (13.83% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Boolean][System.__Canon,System.Boolean]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
       13.05 (13.83% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,IntPtr][System.__Canon,System.IntPtr]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
       13.05 (13.83% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Int32][System.__Canon,System.Int32]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
       13.05 (13.83% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,ResourceLocator][System.__Canon,System.Resources.ResourceLocator]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
       13.05 (13.83% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[__Canon,Int64][System.__Canon,System.Int64]:.ctor(int,System.Collections.Generic.IEqualityComparer`1[__Canon]):this
      237.93 (13.01% of base) : System.Linq.Parallel.dasm - ExceptQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
        6.75 (12.47% of base) : System.Collections.Immutable.dasm - Builder[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.ImmutableHashSet`1[__Canon]):this
       13.40 (12.25% of base) : System.Private.Xml.dasm - <GetActiveRecords>d__34[__Canon][System.__Canon]:MoveNext():bool:this
      220.43 (12.16% of base) : System.Linq.Parallel.dasm - IntersectQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
        9.75 (12.13% of base) : System.Collections.Immutable.dasm - Builder[__Canon,Int64][System.__Canon,System.Int64]:.ctor(System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64]):this
        2.45 (11.95% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:ContainsKey(System.__Canon):bool:this
        2.45 (11.95% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:ValueRef(System.__Canon):byref:this
        2.45 (11.95% of base) : System.Collections.Immutable.dasm - Builder[__Canon,Int64][System.__Canon,System.Int64]:ValueRef(System.__Canon):byref:this
        2.45 (11.64% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:TryGetValue(System.__Canon,byref):bool:this
        2.45 (11.64% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:TryGetKey(System.__Canon,byref):bool:this
       18.61 (11.56% of base) : Newtonsoft.Json.dasm - <Annotations>d__182`1[__Canon][System.__Canon]:MoveNext():bool:this
       11.70 (11.33% of base) : System.Collections.Immutable.dasm - Node[__Canon][System.__Canon]:.ctor(System.__Canon,Node[__Canon],Node[__Canon],bool):this (2 methods)
     2768.98 (11.16% of base) : System.Linq.Parallel.dasm - OrderedDistinctQueryOperatorEnumerator`1[__Canon,Int64][System.__Canon,System.Int64]:MoveNext(byref,byref):bool:this
        6.75 (10.84% of base) : System.Collections.Immutable.dasm - Builder[__Canon][System.__Canon]:.ctor(System.Collections.Immutable.ImmutableSortedSet`1[__Canon]):this

Top method improvements (percentages):
    -7040.00 (-12.20% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.ForestTrustRelationshipInformation:Save():this
      -32.55 (-9.44% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:CopyToPairs(System.Collections.Generic.KeyValuePair`2[System.__Canon,System.Int64][],int):this
       -1.30 (-8.90% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:Union(System.Collections.Generic.IEnumerable`1[__Canon]):System.Collections.Immutable.ImmutableHashSet`1[__Canon]:this
       -1.30 (-8.90% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:AddRange(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):System.Collections.Immutable.ImmutableDictionary`2[__Canon,Int64]:this
       -1.30 (-8.58% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:AddRange(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64]:this
       -1.30 (-8.41% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64][System.__Canon,System.Int64]:SetItems(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):System.Collections.Immutable.ImmutableSortedDictionary`2[__Canon,Int64]:this
       -1.30 (-7.45% of base) : System.Collections.Immutable.dasm - Node[__Canon][System.__Canon]:FindIndex(System.Predicate`1[__Canon]):int:this
       -1.30 (-7.34% of base) : System.Collections.Immutable.dasm - Node[__Canon,Int64][System.__Canon,System.Int64]:Remove(System.__Canon,System.Collections.Generic.IComparer`1[__Canon],byref):Node[__Canon,Int64]:this
       -1.30 (-7.03% of base) : System.Collections.Immutable.dasm - Node[__Canon][System.__Canon]:Contains(System.__Canon,System.Collections.Generic.IComparer`1[__Canon]):bool:this
      -10.80 (-6.14% of base) : System.Private.Xml.dasm - System.Xml.XmlEncodedRawTextWriter:Close():this
       -1.30 (-5.87% of base) : System.Collections.Immutable.dasm - Node[__Canon,Int64][System.__Canon,System.Int64]:ContainsKey(System.__Canon,System.Collections.Generic.IComparer`1[__Canon]):bool:this
       -1.30 (-5.83% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.SortedInt32KeyNode`1[__Canon][System.__Canon]:SetItem(int,System.__Canon,System.Collections.Generic.IEqualityComparer`1[__Canon],byref,byref):System.Collections.Immutable.SortedInt32KeyNode`1[__Canon]:this
       -3.61 (-5.82% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:SetEquals(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
       -1.28 (-5.49% of base) : System.Collections.Immutable.dasm - Node[__Canon][System.__Canon]:FindLastIndex(System.Predicate`1[__Canon]):int:this
       -3.64 (-5.45% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsProperSubsetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
       -3.64 (-5.45% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsProperSupersetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
       -3.64 (-5.45% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsSubsetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
       -3.64 (-5.45% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:IsSupersetOf(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
       -3.64 (-5.45% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableHashSet`1[__Canon][System.__Canon]:Overlaps(System.Collections.Generic.IEnumerable`1[__Canon]):bool:this
       -0.75 (-5.05% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.DictionaryEnumerator`2[__Canon,Int64][System.__Canon,System.Int64]:.ctor(System.Collections.Generic.IEnumerator`1[KeyValuePair`2]):this

2877 total methods with Perf Score differences (810 improved, 2067 regressed), 337750 unchanged.
```