### PR TITLE
Fix path to Unix folder for wasm

### DIFF
--- a/src/libraries/Native/build-native.cmd
+++ b/src/libraries/Native/build-native.cmd
@@ -97,7 +97,7 @@ goto :SetupDirs
 echo Commencing build of native components
 echo.
 
-if /i "%__BuildArch%" == "wasm" set __sourceDir=%~dp0..\Unix
+if /i "%__BuildArch%" == "wasm" set __sourceDir=%~dp0\Unix
 
 if [%__outConfig%] == [] set __outConfig=%__TargetOS%-%__BuildArch%-%CMAKE_BUILD_TYPE%
 


### PR DESCRIPTION
Looks like a typo or a problem in the repo move.  `..` should not be in this path.  See https://github.com/dotnet/runtimelab/pull/247#discussion_r530639798