### PR TITLE
Fix stack size allocation during interpreter entry.

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2005,7 +2005,7 @@ interp_entry (InterpEntryData *data)
 	frame.imethod = data->rmethod;
 	frame.stack = sp;
 
-	context->stack_pointer = (guchar*)(sp + sig->hasthis + sig->param_count);
+	context->stack_pointer = (guchar*)sp_args;
 
 	interp_exec_method (&frame, context, NULL);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44270.