### PR TITLE
More MemoryCache perf improvements

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -216,7 +216,11 @@ namespace Microsoft.Extensions.Caching.Memory
                 if (_valueHasBeenSet)
                 {
                     _notifyCacheEntryCommit(this);
-                    PropagateOptions(CacheEntryHelper.Current);
+
+                    if (CanPropagateOptions())
+                    {
+                        PropagateOptions(CacheEntryHelper.Current);
+                    }
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -239,12 +239,14 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private bool CheckForExpiredTime(in DateTimeOffset now)
         {
-            if (_absoluteExpiration == null && _absoluteExpiration == null)
+            if (!_absoluteExpiration.HasValue && !_absoluteExpiration.HasValue)
+            {
                 return false;
+            }
 
-            return SlowPath(now);
+            return FullCheck(now);
 
-            bool SlowPath(in DateTimeOffset offset)
+            bool FullCheck(in DateTimeOffset offset)
             {
                 if (_absoluteExpiration.HasValue && _absoluteExpiration.Value <= offset)
                 {
@@ -266,11 +268,13 @@ namespace Microsoft.Extensions.Caching.Memory
         private bool CheckForExpiredTokens()
         {
             if (_expirationTokens == null)
+            {
                 return false;
+            }
 
-            return SlowPath();
+            return CheckTokens();
 
-            bool SlowPath()
+            bool CheckTokens()
             {
                 for (int i = 0; i < _expirationTokens.Count; i++)
                 {
@@ -370,7 +374,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
-        internal bool CanPropagateOptions() => _expirationTokens != null || _absoluteExpiration != null;
+        internal bool CanPropagateOptions() => _expirationTokens != null || _absoluteExpiration.HasValue;
 
         internal void PropagateOptions(CacheEntry parent)
         {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -355,6 +355,8 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
+        internal bool CanPropagateOptions() => _expirationTokens != null || _absoluteExpiration != null;
+
         internal void PropagateOptions(CacheEntry parent)
         {
             if (parent == null)

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private bool CheckForExpiredTime(in DateTimeOffset now)
         {
-            if (!_absoluteExpiration.HasValue && !_absoluteExpiration.HasValue)
+            if (!_absoluteExpiration.HasValue && !_slidingExpiration.HasValue)
             {
                 return false;
             }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -250,9 +250,12 @@ namespace Microsoft.Extensions.Caching.Memory
                     entry.LastAccessed = utcNow;
                     result = entry.Value;
 
-                    // When this entry is retrieved in the scope of creating another entry,
-                    // that entry needs a copy of these expiration tokens.
-                    entry.PropagateOptions(CacheEntryHelper.Current);
+                    if (entry.CanPropagateOptions())
+                    {
+                        // When this entry is retrieved in the scope of creating another entry,
+                        // that entry needs a copy of these expiration tokens.
+                        entry.PropagateOptions(CacheEntryHelper.Current);
+                    }
 
                     StartScanForExpiredItemsIfNeeded(utcNow);
 


### PR DESCRIPTION
## don't acces expensive CacheEntryHelper.Current if options can't be propagated anyway

`CacheEntryHelper.Current` uses expensive `AsyncLocal`. Before accessing it, we can just check if the options can be propagated and don't use it at all if not.

![obraz](https://user-images.githubusercontent.com/6011991/100469090-f0bcbb80-30d5-11eb-9a21-7473b392b002.png)

+7.5% (+18k) RPS for TechEmpower benchmark!

| load                   |    before |     after |
| ---------------------- | --------- | --------- |
| CPU Usage (%)          |        19 |        21 |
| Cores usage (%)        |       528 |       574 |
| Working Set (MB)       |        48 |        48 |
| Build Time (ms)        |     4,500 |     4,541 |
| Start Time (ms)        |         0 |         0 |
| Published Size (KB)    |    76,401 |    76,401 |
| .NET Core SDK Version  | 3.1.404   | 3.1.404   |
| First Request (ms)     |        76 |        78 |
| Requests/sec           |   234,029 |   252,468 |
| Requests               | 3,533,646 | 3,812,090 |
| Mean latency (ms)      |      1.28 |      1.18 |
| Max latency (ms)       |     61.30 |     47.33 |
| Bad responses          |         0 |         0 |
| Socket errors          |         0 |         0 |
| Read throughput (MB/s) |    736.49 |    794.52 |
| Latency 50th (ms)      |      1.06 |      0.99 |
| Latency 75th (ms)      |      1.17 |      1.09 |
| Latency 90th (ms)      |      1.33 |      1.23 |
| Latency 99th (ms)      |     10.08 |      9.10 |

## inline the expiration check hot paths

![obraz](https://user-images.githubusercontent.com/6011991/100476067-f1108300-30e4-11eb-948e-9000f66b02c5.png)


| load                   |    before |     after |
| ---------------------- | --------- | --------- |
| CPU Usage (%)          |        21 |        21 |
| Cores usage (%)        |       574 |       580 |
| Working Set (MB)       |        48 |        48 |
| Build Time (ms)        |     4,541 |     4,923 |
| Start Time (ms)        |         0 |         0 |
| Published Size (KB)    |    76,401 |    76,401 |
| .NET Core SDK Version  | 3.1.404   | 3.1.404   |
| First Request (ms)     |        78 |        79 |
| Requests/sec           |   252,468 |   259,239 |
| Requests               | 3,812,090 | 3,914,333 |
| Mean latency (ms)      |      1.18 |      1.15 |
| Max latency (ms)       |     47.33 |     48.63 |
| Bad responses          |         0 |         0 |
| Socket errors          |         0 |         0 |
| Read throughput (MB/s) |    794.52 |    815.83 |
| Latency 50th (ms)      |      0.99 |      0.96 |
| Latency 75th (ms)      |      1.09 |      1.07 |
| Latency 90th (ms)      |      1.23 |      1.19 |
| Latency 99th (ms)      |      9.10 |      9.03 |
