### PR TITLE
optimize DateTimeOffset.UtcNow by removing redundant verification

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -54,14 +54,14 @@ namespace System
 
         // Constructors
 
-        private DateTimeOffset(DateTime validDateTime, short validOffsetMinutes)
+        private DateTimeOffset(short validOffsetMinutes, DateTime validDateTime)
         {
             _dateTime = validDateTime;
             _offsetMinutes = validOffsetMinutes;
         }
 
         // Constructs a DateTimeOffset from a tick count and offset
-        public DateTimeOffset(long ticks, TimeSpan offset) : this(ValidateDate(new DateTime(ticks), offset), ValidateOffset(offset))
+        public DateTimeOffset(long ticks, TimeSpan offset) : this(ValidateOffset(offset), ValidateDate(new DateTime(ticks), offset))
         {
         }
 
@@ -181,7 +181,7 @@ namespace System
             get
             {
                 DateTime utcNow = DateTime.UtcNow;
-                var result = new DateTimeOffset(utcNow, validOffsetMinutes: 0);
+                var result = new DateTimeOffset(0, utcNow);
 
                 Debug.Assert(new DateTimeOffset(utcNow) == result); // ensure lack of verification does not break anything
 

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -180,8 +180,8 @@ namespace System
         {
             get
             {
-                var utcNow = DateTime.UtcNow;
-                var result = new DateTimeOffset(validDateTime: utcNow, validOffsetMinutes: 0);
+                DateTime utcNow = DateTime.UtcNow;
+                var result = new DateTimeOffset(utcNow, validOffsetMinutes: 0);
 
                 Debug.Assert(new DateTimeOffset(utcNow) == result); // ensure lack of verification does not break anything
 

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -54,13 +54,15 @@ namespace System
 
         // Constructors
 
-        // Constructs a DateTimeOffset from a tick count and offset
-        public DateTimeOffset(long ticks, TimeSpan offset)
+        private DateTimeOffset(DateTime validDateTime, short validOffsetMinutes)
         {
-            _offsetMinutes = ValidateOffset(offset);
-            // Let the DateTime constructor do the range checks
-            DateTime dateTime = new DateTime(ticks);
-            _dateTime = ValidateDate(dateTime, offset);
+            _dateTime = validDateTime;
+            _offsetMinutes = validOffsetMinutes;
+        }
+
+        // Constructs a DateTimeOffset from a tick count and offset
+        public DateTimeOffset(long ticks, TimeSpan offset) : this(ValidateDate(new DateTime(ticks), offset), ValidateOffset(offset))
+        {
         }
 
         // Constructs a DateTimeOffset from a DateTime. For Local and Unspecified kinds,
@@ -174,7 +176,18 @@ namespace System
         // resolution of the returned value depends on the system timer.
         public static DateTimeOffset Now => ToLocalTime(DateTime.UtcNow, true);
 
-        public static DateTimeOffset UtcNow => new DateTimeOffset(DateTime.UtcNow);
+        public static DateTimeOffset UtcNow
+        {
+            get
+            {
+                var utcNow = DateTime.UtcNow;
+                var result = new DateTimeOffset(validDateTime: utcNow, validOffsetMinutes: 0);
+
+                Debug.Assert(new DateTimeOffset(utcNow) == result); // ensure lack of verification does not break anything
+
+                return result;
+            }
+        }
 
         public DateTime DateTime => ClockDateTime;
 


### PR DESCRIPTION
cuts 10% of the time on Windows and contributes to the Caching TE benchmark

```cs
[Benchmark]
public DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
```

```ini
BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.18363.1198 (1909/November2019Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=5.0.100-rc.2.20479.15
  [Host]     : .NET 5.0.0 (5.0.20.47505), X64 RyuJIT
  Job-MJJALX : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT
  Job-NASKJQ : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT
```

|    Method |           Toolchain |     Mean | Ratio |
|---------- |-------------------- |---------:|------:|
| GetUtcNow |  \after\CoreRun.exe | 68.91 ns |  0.90 |
| GetUtcNow | \before\CoreRun.exe | 76.34 ns |  1.00 |

the Caching benchmark shows +4.5% RPS improvement on Windows:

| load                   |    before |     after |
| ---------------------- | --------- | --------- |
| CPU Usage (%)          |        34 |        35 |
| Cores usage (%)        |       957 |       978 |
| Working Set (MB)       |        48 |        48 |
| Build Time (ms)        |     7,922 |     4,230 |
| Start Time (ms)        |         0 |         0 |
| Published Size (KB)    |    76,401 |    76,401 |
| First Request (ms)     |        85 |        83 |
| Requests/sec           |   286,622 |   299,359 |
| Requests               | 4,327,835 | 4,520,311 |
| Mean latency (ms)      |      2.17 |      1.63 |
| Max latency (ms)       |    218.08 |    250.79 |
| Bad responses          |         0 |         0 |
| Socket errors          |         0 |         0 |
| Read throughput (MB/s) |    901.12 |    942.08 |
| Latency 50th (ms)      |      0.88 |      0.84 |
| Latency 75th (ms)      |      0.93 |      0.88 |
| Latency 90th (ms)      |      0.98 |      0.93 |
| Latency 99th (ms)      |     52.50 |     32.75 |