### PR TITLE
[WIP] conditionally assign (exact)contextHandle

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -21193,8 +21193,8 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
     // https://github.com/dotnet/runtime/issues/38477
     // but hopefully the derived method conforms to
     // the base in most other ways.
-    *method        = derivedMethod;
-    *methodFlags   = derivedMethodAttribs;
+    *method      = derivedMethod;
+    *methodFlags = derivedMethodAttribs;
 
     if (((SIZE_T)(*contextHandle) & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_METHOD)
     {
@@ -21214,7 +21214,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
     }
 
     // Update context handle.
-    if ((exactContextHandle != nullptr) && (*exactContextHandle != nullptr))
+    if ((exactContextHandle != nullptr))
     {
         if (((SIZE_T)(*exactContextHandle) & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_METHOD)
         {

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -21195,12 +21195,43 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
     // the base in most other ways.
     *method        = derivedMethod;
     *methodFlags   = derivedMethodAttribs;
-    *contextHandle = MAKE_METHODCONTEXT(derivedMethod);
+
+    if (((SIZE_T)(*contextHandle) & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_METHOD)
+    {
+        *contextHandle = MAKE_METHODCONTEXT(derivedMethod);
+    }
+    else
+    {
+        assert(((SIZE_T)(*contextHandle) & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_CLASS);
+        if (isExact)
+        {
+            *contextHandle = MAKE_CLASSCONTEXT(objClass);
+        }
+        else
+        {
+            *contextHandle = MAKE_CLASSCONTEXT(derivedClass);
+        }
+    }
 
     // Update context handle.
     if ((exactContextHandle != nullptr) && (*exactContextHandle != nullptr))
     {
-        *exactContextHandle = MAKE_METHODCONTEXT(derivedMethod);
+        if (((SIZE_T)(*exactContextHandle) & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_METHOD)
+        {
+            *exactContextHandle = MAKE_METHODCONTEXT(derivedMethod);
+        }
+        else
+        {
+            assert(((SIZE_T)(*exactContextHandle) & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_CLASS);
+            if (isExact)
+            {
+                *exactContextHandle = MAKE_CLASSCONTEXT(objClass);
+            }
+            else
+            {
+                *exactContextHandle = MAKE_CLASSCONTEXT(derivedClass);
+            }
+        }
     }
 
 #ifdef FEATURE_READYTORUN_COMPILER


### PR DESCRIPTION
Fixes #38477 

I hacked this in a straightforward manner while I was working on #43668 but I was in doubt that such dumb fix is enough until I saw @AndyAyersMS 's [comment](https://github.com/dotnet/runtime/issues/38477#issuecomment-734003492)

~~I've ended with similar asm but with `System.Object:.ctor()` call not eliminated:~~ See *EDIT*

```asm
*************** After end code gen, before unwindEmit()
G_M24375_IG01:        ; func=00, offs=000000H, size=0004H, bbWeight=1    PerfScore 0.25, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG

IN0006: 000000 sub      rsp, 40

G_M24375_IG02:        ; offs=000004H, size=001CH, bbWeight=1    PerfScore 2.75, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref

IN0001: 000004 mov      rcx, 0x7FF88E89F850
IN0002: 00000E call     CORINFO_HELP_NEWSFAST
IN0003: 000013 mov      rcx, rax
IN0004: 000016 call     System.Object:.ctor():this
IN0005: 00001B mov      eax, 1

G_M24375_IG03:        ; offs=000020H, size=0005H, bbWeight=1    PerfScore 1.25, epilog, nogc, extend

IN0007: 000020 add      rsp, 40
IN0008: 000024 ret
```

```
    Inlines into 06000003 [via DefaultPolicy] Program:Main():int
        [1 IL=0000 TR=000005 06000002] [below ALWAYS_INLINE size] G`1[__Canon][System.__Canon]:.ctor():this
            [0 IL=0001 TR=000016 0600049E] [FAILED: noinline per VM] System.Object:.ctor():this
        [2 IL=0005 TR=000007 06000001] [aggressive inline attribute devirt] G`1[__Canon][System.__Canon]:M():bool:this
```

~~Given `FAILED: noinline per VM` I wonder if @AndyAyersMS was testing this on non-master branch.~~ However non-virtual `public bool M() => typeof(T) == typeof(string);` jits to 
```asm
*************** After end code gen, before unwindEmit()
G_M24375_IG01:        ; func=00, offs=000000H, size=0000H, bbWeight=1    PerfScore 0.00, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG
G_M24375_IG02:        ; offs=000000H, size=0005H, bbWeight=1    PerfScore 0.25, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref

IN0001: 000000 mov      eax, 100

G_M24375_IG03:        ; offs=000005H, size=0001H, bbWeight=1    PerfScore 1.00, epilog, nogc, extend

IN0002: 000005 ret
```

So there is definitely an opportunity for me to hack further.

I have issues with crafting jit diffs atm, will submit it soon.

*EDIT*:
Above asm was produced with debug build where `JIT_FLAG_DEBUG_CODE` prevents `System.Object:.ctor()` inlining.
With checked build I have asm similar to @AndyAyersMS 
```asm

*************** After end code gen, before unwindEmit()
G_M24375_IG01:        ; func=00, offs=000000H, size=0004H, bbWeight=1    PerfScore 0.25, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG

IN0002: 000000 sub      rsp, 40

G_M24375_IG02:        ; offs=000004H, size=0005H, bbWeight=1    PerfScore 0.25, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref

IN0001: 000004 mov      eax, 100

G_M24375_IG03:        ; offs=000009H, size=0005H, bbWeight=1    PerfScore 1.25, epilog, nogc, extend

IN0003: 000009 add      rsp, 40
IN0004: 00000D ret
```

```
Inlines into 06000003 [via DefaultPolicy] Program:Main():int
  [1 IL=0000 TR=000005 06000002] [below ALWAYS_INLINE size] G`1[__Canon][System.__Canon]:.ctor():this
    [2 IL=0001 TR=000030 0600049E] [below ALWAYS_INLINE size] System.Object:.ctor():this
  [3 IL=0007 TR=000010 06000001] [aggressive inline attribute devirt] G`1[__Canon][System.__Canon]:MVIRT():bool:this
```