### PR TITLE
Reenable Mono Windows runtime build in runtime-official.yml

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -112,7 +112,7 @@ stages:
       - Browser_wasm
       # - Linux_musl_arm
       # - Linux_musl_arm64
-      # - windows_x64 enable once coreclr.dll has a version header: https://github.com/dotnet/runtime/issues/37503
+      - windows_x64
       # - windows_x86
       # - windows_arm
       # - windows_arm64


### PR DESCRIPTION
The binary now includes the proper version header.

Fixes https://github.com/dotnet/runtime/issues/37503

Test official build passed: https://dev.azure.com/dnceng/internal/_build/results?buildId=903046&view=results