### PR TITLE
r0InUse should be true for case of SoftFP

### DIFF
--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -1749,7 +1749,7 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper)
     else if (varTypeIsFloating(compiler->info.compRetType) ||
              compiler->IsHfa(compiler->info.compMethodInfo->args.retTypeClass))
     {
-        r0InUse = !compiler->info.compIsVarArgs && !compiler->opts.compUseSoftFP;
+        r0InUse = compiler->info.compIsVarArgs || compiler->opts.compUseSoftFP;
     }
     else
     {


### PR DESCRIPTION
As reported in #45370 there is an error in computing `r0InUse` value for arm32 <s>on Linux</s> in `CodeGen::genProfilingLeaveCallback()`.

@dotnet/jit-contrib PTAL