### PR TITLE
Fix PlaintextStreamFilter for sync requests

### DIFF
--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -591,12 +591,6 @@
   <data name="net_http_requested_version_server_refused" xml:space="preserve">
     <value>Requesting HTTP version {0} with version policy {1} while server offers only version fallback.</value>
   </data>
-  <data name="net_http_sync_operations_not_allowed_with_connect_callback" xml:space="preserve">
-    <value>Synchronous operation is not supported when a ConnectCallback is specified on the SocketsHttpHandler instance.</value>
-  </data>
-  <data name="net_http_sync_operations_not_allowed_with_plaintext_filter" xml:space="preserve">
-    <value>Synchronous operation is not supported when a PlaintextStreamFilter is specified on the SocketsHttpHandler instance.</value>
-  </data>
   <data name="net_http_exception_during_plaintext_filter" xml:space="preserve">
     <value>An exception occurred while invoking the PlaintextStreamFilter.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -37,13 +37,8 @@ namespace System.Net.Http
 
         // SendAsyncCore returns already completed ValueTask for when async: false is passed.
         // Internally, it calls the synchronous Send method of the base class.
-        protected internal override HttpResponseMessage Send(HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            ValueTask<HttpResponseMessage> sendTask = SendAsyncCore(request, async: false, cancellationToken);
-            Debug.Assert(sendTask.IsCompleted);
-            return sendTask.GetAwaiter().GetResult();
-        }
+        protected internal override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            SendAsyncCore(request, async: false, cancellationToken).AsTask().GetAwaiter().GetResult();
 
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
             SendAsyncCore(request, async: true, cancellationToken).AsTask();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1835,6 +1835,7 @@ namespace System.Net.Http
 
         public sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
+            Debug.Assert(async);
             if (NetEventSource.Log.IsEnabled()) Trace($"{request}");
 
             try

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -158,6 +158,8 @@ namespace System.Net.Http
 
         public override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
+            Debug.Assert(async);
+
             // Wait for an available stream (based on QUIC MAX_STREAMS) if there isn't one available yet.
 
             TaskCompletionSourceWithCancellation<bool>? waitForAvailableStreamTcs = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpMessageHandlerStage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpMessageHandlerStage.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,9 +11,10 @@ namespace System.Net.Http
         protected internal sealed override HttpResponseMessage Send(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            ValueTask<HttpResponseMessage> sendTask = SendAsync(request, async:false, cancellationToken);
-            Debug.Assert(sendTask.IsCompleted);
-            return sendTask.GetAwaiter().GetResult();
+            ValueTask<HttpResponseMessage> sendTask = SendAsync(request, async: false, cancellationToken);
+            return sendTask.IsCompleted ?
+                sendTask.Result :
+                sendTask.AsTask().GetAwaiter().GetResult();
         }
 
         protected internal sealed override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -513,11 +513,6 @@ namespace System.Net.Http
             CheckDisposed();
             HttpMessageHandlerStage handler = _handler ?? SetupHandlerChain();
 
-            if (_settings._plaintextStreamFilter is not null)
-            {
-                throw new NotSupportedException(SR.net_http_sync_operations_not_allowed_with_plaintext_filter);
-            }
-
             Exception? error = ValidateAndNormalizeRequest(request);
             if (error != null)
             {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2372,6 +2372,7 @@ namespace System.Net.Http.Functional.Tests
                         else
                         {
                             await s.ConnectAsync(context.DnsEndPoint, token);
+                            await Task.Delay(1);
                         }
                         return new NetworkStream(s, ownsSocket: true);
                     };
@@ -2626,24 +2627,22 @@ namespace System.Net.Http.Functional.Tests
     {
         public SocketsHttpHandlerTest_PlaintextStreamFilter(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
-        public void PlaintextStreamFilter_SyncRequest_Fails()
-        {
-            using SocketsHttpHandler handler = new SocketsHttpHandler
-            {
-                PlaintextStreamFilter = (context, token) => default,
-            };
-
-            using HttpClient client = CreateHttpClient(handler);
-
-            Assert.ThrowsAny<NotSupportedException>(() => client.Send(new HttpRequestMessage(HttpMethod.Get, "http://bing.com")));
-        }
+        public static IEnumerable<object> PlaintextStreamFilter_ContextHasCorrectProperties_Success_MemberData() =>
+            from useSsl in new[] { false, true }
+            from syncRequest in new[] { false, true }
+            from syncCallback in new[] { false, true }
+            select new object[] { useSsl, syncRequest, syncCallback };
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task PlaintextStreamFilter_ContextHasCorrectProperties_Success(bool useSsl)
+        [MemberData(nameof(PlaintextStreamFilter_ContextHasCorrectProperties_Success_MemberData))]
+        public async Task PlaintextStreamFilter_ContextHasCorrectProperties_Success(bool useSsl, bool syncRequest, bool syncCallback)
         {
+            if (syncRequest && UseVersion > HttpVersion.Version11)
+            {
+                // Sync requests are only supported on 1.x
+                return;
+            }
+
             GenericLoopbackOptions options = new GenericLoopbackOptions() { UseSsl = useSsl };
             await LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
@@ -2655,17 +2654,24 @@ namespace System.Net.Http.Functional.Tests
                     using HttpClientHandler handler = CreateHttpClientHandler();
                     handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
                     var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
-                    socketsHandler.PlaintextStreamFilter = (context, token) =>
+                    socketsHandler.PlaintextStreamFilter = async (context, token) =>
                     {
                         Assert.Equal(UseVersion, context.NegotiatedHttpVersion);
                         Assert.Equal(requestMessage, context.InitialRequestMessage);
 
-                        return ValueTask.FromResult(context.PlaintextStream);
+                        if (!syncCallback)
+                        {
+                            await Task.Delay(1);
+                        }
+
+                        return context.PlaintextStream;
                     };
 
                     using HttpClient client = CreateHttpClient(handler);
 
-                    HttpResponseMessage response = await client.SendAsync(requestMessage);
+                    HttpResponseMessage response = await (syncRequest ?
+                        Task.Run(() => client.Send(requestMessage)) :
+                        client.SendAsync(requestMessage));
                     Assert.Equal("foo", await response.Content.ReadAsStringAsync());
                 },
                 async server =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2372,7 +2372,7 @@ namespace System.Net.Http.Functional.Tests
                         else
                         {
                             await s.ConnectAsync(context.DnsEndPoint, token);
-                            await Task.Delay(1);
+                            await Task.Delay(1); // to increase the chances of the whole operation completing asynchronously, without consuming too much additional time
                         }
                         return new NetworkStream(s, ownsSocket: true);
                     };
@@ -2661,7 +2661,7 @@ namespace System.Net.Http.Functional.Tests
 
                         if (!syncCallback)
                         {
-                            await Task.Delay(1);
+                            await Task.Delay(1); // to increase the chances of the whole operation completing asynchronously, without consuming too much additional time
                         }
 
                         return context.PlaintextStream;


### PR DESCRIPTION
As with ConnectCallback, make it usable for sync requests. Also:
- Consolidate blocking to the sync entry point where possible.
- Remove unnecessary async arguments
- Fix XxAsync naming on several methods

Follow-up to https://github.com/dotnet/runtime/pull/45300
cc: @geoffkizer, @ManickaP 