### PR TITLE
[wasm][tests] Use correct output path when running with helix, so that the log

### DIFF
--- a/eng/testing/AndroidRunnerTemplate.sh
+++ b/eng/testing/AndroidRunnerTemplate.sh
@@ -16,7 +16,11 @@ while true; do
     fi
 done
 
-XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+if [ -z "$HELIX_WORKITEM_UPLOAD_ROOT" ]; then
+    XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+else
+    XHARNESS_OUT="$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output"
+fi
 
 if [ ! -z "$XHARNESS_CLI_PATH" ]; then
 	# When running in CI, we only have the .NET runtime available

--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -36,7 +36,12 @@ while true; do
 done
 
 XCODE_PATH="`xcode-select -p`/../.."
-export XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+
+if [ -z "$HELIX_WORKITEM_UPLOAD_ROOT" ]; then
+    export XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+else
+    export XHARNESS_OUT="$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output"
+fi
 
 dotnet xharness ios test  \
     --targets="$TARGET"   \

--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -4,7 +4,11 @@ EXECUTION_DIR=$(dirname $0)
 
 cd $EXECUTION_DIR
 
-XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+if [ -z "$HELIX_WORKITEM_UPLOAD_ROOT" ]; then
+	XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+else
+	XHARNESS_OUT="$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output"
+fi
 
 if [ ! -z "$XHARNESS_CLI_PATH" ]; then
 	# When running in CI, we only have the .NET runtime available


### PR DESCRIPTION
.. files get surfaced to azdo.

Thanks to @akoeplinger for the suggestion.