### PR TITLE
[release/5.0] Explicitly check for arrays in Marshal.SizeOf impl.

### DIFF
--- a/src/coreclr/src/vm/marshalnative.cpp
+++ b/src/coreclr/src/vm/marshalnative.cpp
@@ -334,7 +334,7 @@ FCIMPL2(UINT32, MarshalNative::SizeOfClass, ReflectClassBaseObject* refClassUNSA
     // refClass is validated to be non-NULL RuntimeType by callers
     TypeHandle th = refClass->GetType();
 
-    if (throwIfNotMarshalable && !th.IsBlittable())
+    if (throwIfNotMarshalable && (!th.IsBlittable() || th.IsArray()))
     {
         GCX_PREEMP();
         // Determine if the type is marshalable

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
@@ -78,6 +78,7 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeBuilder, "t" };
 
             yield return new object[] { typeof(TestStructWithFxdLPSTRSAFld), null };
+            yield return new object[] { typeof(int[]), null };
         }
 
         [Theory]


### PR DESCRIPTION
Fixes Issue #44508 

Master PR #45227 

# Description

In .NET 5.0, calling Marshal.SizeOf with an array type crashes. This PR fixes Marshal.SizeOf to throw in this error case instead of crashing the runtime.

# Customer Impact

Customers will see a process crash instead of being able to gracefully handle the exception.

# Regression

This was a regression in .NET 5.0

# Testing

Unit tests have been added to confirm the behavior matches the expected behavior.

# Risk

Minimal risk. This returns the behavior to match the previous behavior.