### PR TITLE
Reduce CacheEntry size

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -45,9 +45,15 @@ namespace Microsoft.Extensions.Caching.Memory
         public TimeSpan? AbsoluteExpirationRelativeToNow
         {
             get => AbsoluteExpiration.HasValue ? AbsoluteExpiration.Value - _cache.GetUtcNow() : null;
-            set => AbsoluteExpiration = value > TimeSpan.Zero
-                ? (_cache.GetUtcNow() + value)
-                : throw new ArgumentOutOfRangeException(nameof(AbsoluteExpirationRelativeToNow), value, "The relative expiration value must be positive.");
+            set
+            {
+                if (value.HasValue)
+                {
+                    AbsoluteExpiration = value.Value > TimeSpan.Zero
+                        ? (_cache.GetUtcNow() + value)
+                        : throw new ArgumentOutOfRangeException(nameof(AbsoluteExpirationRelativeToNow), value, "The relative expiration value must be positive.");
+                }
+            }
         }
 
         /// <summary>
@@ -57,7 +63,7 @@ namespace Microsoft.Extensions.Caching.Memory
         public TimeSpan? SlidingExpiration
         {
             get => _slidingExpiration;
-            set => _slidingExpiration =  value > TimeSpan.Zero ? value : throw new ArgumentOutOfRangeException(nameof(SlidingExpiration), value, "The sliding expiration value must be positive.");
+            set => _slidingExpiration =  !value.HasValue || value > TimeSpan.Zero ? value : throw new ArgumentOutOfRangeException(nameof(SlidingExpiration), value, "The sliding expiration value must be positive.");
         }
 
         /// <summary>
@@ -82,7 +88,7 @@ namespace Microsoft.Extensions.Caching.Memory
         public long? Size
         {
             get => _size;
-            set => _size = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} must be non-negative.");
+            set => _size = !value.HasValue || value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} must be non-negative.");
         }
 
         public object Key { get; private set; }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Extensions.Caching.Memory
         private IList<IDisposable> _expirationTokenRegistrations;
         private IList<PostEvictionCallbackRegistration> _postEvictionCallbacks;
         private IList<IChangeToken> _expirationTokens;
+        private TimeSpan? _absoluteExpirationRelativeToNow;
         private TimeSpan? _slidingExpiration;
         private long? _size;
         private IDisposable _scope;
@@ -44,21 +45,19 @@ namespace Microsoft.Extensions.Caching.Memory
         /// </summary>
         public TimeSpan? AbsoluteExpirationRelativeToNow
         {
-            get => AbsoluteExpiration.HasValue ? AbsoluteExpiration.Value - _cache.GetUtcNow() : null;
+            get => _absoluteExpirationRelativeToNow;
             set
             {
-                if (value.HasValue)
-                {
-                    if (value <= TimeSpan.Zero)
-                    {
-                        throw new ArgumentOutOfRangeException(
-                            nameof(AbsoluteExpirationRelativeToNow),
-                            value,
-                            "The relative expiration value must be positive.");
-                    }
 
-                    AbsoluteExpiration = _cache.GetUtcNow() + value;
+                if (value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(AbsoluteExpirationRelativeToNow),
+                        value,
+                        "The relative expiration value must be positive.");
                 }
+
+                _absoluteExpirationRelativeToNow = value;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Extensions.Caching.Memory
             get => _absoluteExpirationRelativeToNow;
             set
             {
+                // this method does not set AbsoluteExpiration as it would require calling Clock.UtcNow twice:
+                // once here and once in MemoryCache.SetEntry
 
                 if (value <= TimeSpan.Zero)
                 {
@@ -264,6 +266,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private void DetachTokens()
         {
+            // _expirationTokenRegistrations is not checked for null, because AttachTokens might initialize it under lock
             lock (_lock)
             {
                 IList<IDisposable> registrations = _expirationTokenRegistrations;
@@ -313,6 +316,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
+        // this simple check very often allows us to avoid expensive call to PropagateOptions(CacheEntryHelper.Current)
         internal bool CanPropagateOptions() => _expirationTokens != null || AbsoluteExpiration.HasValue;
 
         internal void PropagateOptions(CacheEntry parent)

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -90,11 +90,7 @@ namespace Microsoft.Extensions.Caching.Memory
         public object Value
         {
             get => _value;
-            set
-            {
-                _value = value;
-                IsValueSet = true;
-            }
+            set { _value = value; IsValueSet = true; }
         }
 
         internal DateTimeOffset LastAccessed { get; set; }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Extensions.Caching.Memory
         private IList<IDisposable> _expirationTokenRegistrations;
         private IList<PostEvictionCallbackRegistration> _postEvictionCallbacks;
         private IList<IChangeToken> _expirationTokens;
-        private TimeSpan? _absoluteExpirationRelativeToNow;
         private TimeSpan? _slidingExpiration;
         private long? _size;
         private IDisposable _scope;
@@ -45,8 +44,10 @@ namespace Microsoft.Extensions.Caching.Memory
         /// </summary>
         public TimeSpan? AbsoluteExpirationRelativeToNow
         {
-            get => _absoluteExpirationRelativeToNow;
-            set => _absoluteExpirationRelativeToNow = value > TimeSpan.Zero ? value : throw new ArgumentOutOfRangeException(nameof(AbsoluteExpirationRelativeToNow), value, "The relative expiration value must be positive.");
+            get => AbsoluteExpiration.HasValue ? AbsoluteExpiration.Value - _cache.GetUtcNow() : null;
+            set => AbsoluteExpiration = value > TimeSpan.Zero
+                ? (_cache.GetUtcNow() + value)
+                : throw new ArgumentOutOfRangeException(nameof(AbsoluteExpirationRelativeToNow), value, "The relative expiration value must be positive.");
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -14,21 +14,21 @@ namespace Microsoft.Extensions.Caching.Memory
     internal class CacheEntry : ICacheEntry
     {
         private static readonly Action<object> ExpirationCallback = ExpirationTokensExpired;
+
+        private readonly object _lock = new object();
         private readonly Action<CacheEntry> _notifyCacheOfExpiration;
         private readonly Action<CacheEntry> _notifyCacheEntryCommit;
-        private IList<IDisposable> _expirationTokenRegistrations;
-        private IList<PostEvictionCallbackRegistration> _postEvictionCallbacks;
         private readonly ILogger _logger;
 
-        internal IList<IChangeToken> _expirationTokens;
-        internal TimeSpan? _absoluteExpirationRelativeToNow;
+        private IList<IDisposable> _expirationTokenRegistrations;
+        private IList<PostEvictionCallbackRegistration> _postEvictionCallbacks;
+        private IList<IChangeToken> _expirationTokens;
+        private TimeSpan? _absoluteExpirationRelativeToNow;
         private TimeSpan? _slidingExpiration;
         private long? _size;
         private IDisposable _scope;
         private object _value;
         private State _state;
-
-        internal readonly object _lock = new object();
 
         internal CacheEntry(
             object key,

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Extensions.Caching.Memory
         private readonly ILogger _logger;
 
         internal IList<IChangeToken> _expirationTokens;
-        internal DateTimeOffset? _absoluteExpiration;
         internal TimeSpan? _absoluteExpirationRelativeToNow;
         private TimeSpan? _slidingExpiration;
         private long? _size;
@@ -68,17 +67,7 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <summary>
         /// Gets or sets an absolute expiration date for the cache entry.
         /// </summary>
-        public DateTimeOffset? AbsoluteExpiration
-        {
-            get
-            {
-                return _absoluteExpiration;
-            }
-            set
-            {
-                _absoluteExpiration = value;
-            }
-        }
+        public DateTimeOffset? AbsoluteExpiration { get; set; }
 
         /// <summary>
         /// Gets or sets an absolute expiration time, relative to now.
@@ -247,7 +236,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private bool CheckForExpiredTime(in DateTimeOffset now)
         {
-            if (!_absoluteExpiration.HasValue && !_slidingExpiration.HasValue)
+            if (!AbsoluteExpiration.HasValue && !_slidingExpiration.HasValue)
             {
                 return false;
             }
@@ -256,7 +245,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             bool FullCheck(in DateTimeOffset offset)
             {
-                if (_absoluteExpiration.HasValue && _absoluteExpiration.Value <= offset)
+                if (AbsoluteExpiration.HasValue && AbsoluteExpiration.Value <= offset)
                 {
                     SetExpired(EvictionReason.Expired);
                     return true;
@@ -382,7 +371,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
-        internal bool CanPropagateOptions() => _expirationTokens != null || _absoluteExpiration.HasValue;
+        internal bool CanPropagateOptions() => _expirationTokens != null || AbsoluteExpiration.HasValue;
 
         internal void PropagateOptions(CacheEntry parent)
         {
@@ -407,11 +396,11 @@ namespace Microsoft.Extensions.Caching.Memory
                 }
             }
 
-            if (_absoluteExpiration.HasValue)
+            if (AbsoluteExpiration.HasValue)
             {
-                if (!parent._absoluteExpiration.HasValue || _absoluteExpiration < parent._absoluteExpiration)
+                if (!parent.AbsoluteExpiration.HasValue || AbsoluteExpiration < parent.AbsoluteExpiration)
                 {
-                    parent._absoluteExpiration = _absoluteExpiration;
+                    parent.AbsoluteExpiration = AbsoluteExpiration;
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -242,16 +242,19 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private void DetachTokens()
         {
-            lock (_lock)
+            if (_expirationTokenRegistrations != null)
             {
-                IList<IDisposable> registrations = _expirationTokenRegistrations;
-                if (registrations != null)
+                lock (_lock)
                 {
-                    _expirationTokenRegistrations = null;
-                    for (int i = 0; i < registrations.Count; i++)
+                    IList<IDisposable> registrations = _expirationTokenRegistrations;
+                    if (registrations != null)
                     {
-                        IDisposable registration = registrations[i];
-                        registration.Dispose();
+                        _expirationTokenRegistrations = null;
+                        for (int i = 0; i < registrations.Count; i++)
+                        {
+                            IDisposable registration = registrations[i];
+                            registration.Dispose();
+                        }
                     }
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -43,8 +42,18 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <param name="loggerFactory">The factory used to create loggers.</param>
         public MemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory loggerFactory)
         {
-            _options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
-            _logger = loggerFactory?.CreateLogger<MemoryCache>() ?? throw new ArgumentNullException(nameof(loggerFactory));
+            if (optionsAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(optionsAccessor));
+            }
+
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _options = optionsAccessor.Value;
+            _logger = loggerFactory.CreateLogger<MemoryCache>();
 
             _entries = new ConcurrentDictionary<object, CacheEntry>();
             _lastExpirationScan = _options.Clock?.UtcNow ?? DateTimeOffset.UtcNow;

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -124,9 +124,9 @@ namespace Microsoft.Extensions.Caching.Memory
             DateTimeOffset utcNow = _options.Clock.UtcNow;
 
             DateTimeOffset? absoluteExpiration = null;
-            if (entry._absoluteExpirationRelativeToNow.HasValue)
+            if (entry.AbsoluteExpirationRelativeToNow.HasValue)
             {
-                absoluteExpiration = utcNow + entry._absoluteExpirationRelativeToNow;
+                absoluteExpiration = utcNow + entry.AbsoluteExpirationRelativeToNow;
             }
             else if (entry.AbsoluteExpiration.HasValue)
             {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -128,9 +128,9 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 absoluteExpiration = utcNow + entry._absoluteExpirationRelativeToNow;
             }
-            else if (entry._absoluteExpiration.HasValue)
+            else if (entry.AbsoluteExpiration.HasValue)
             {
-                absoluteExpiration = entry._absoluteExpiration;
+                absoluteExpiration = entry.AbsoluteExpiration;
             }
 
             // Applying the option's absolute expiration only if it's not already smaller.
@@ -138,9 +138,9 @@ namespace Microsoft.Extensions.Caching.Memory
             // it was set by cascading it to its parent.
             if (absoluteExpiration.HasValue)
             {
-                if (!entry._absoluteExpiration.HasValue || absoluteExpiration.Value < entry._absoluteExpiration.Value)
+                if (!entry.AbsoluteExpiration.HasValue || absoluteExpiration.Value < entry.AbsoluteExpiration.Value)
                 {
-                    entry._absoluteExpiration = absoluteExpiration;
+                    entry.AbsoluteExpiration = absoluteExpiration;
                 }
             }
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -43,18 +43,8 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <param name="loggerFactory">The factory used to create loggers.</param>
         public MemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory loggerFactory)
         {
-            if (optionsAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(optionsAccessor));
-            }
-
-            if (loggerFactory == null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
-
-            _options = optionsAccessor.Value;
-            _logger = loggerFactory.CreateLogger<MemoryCache>();
+            _options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
+            _logger = loggerFactory?.CreateLogger<MemoryCache>() ?? throw new ArgumentNullException(nameof(loggerFactory));
 
             _entries = new ConcurrentDictionary<object, CacheEntry>();
             _lastExpirationScan = _options.Clock?.UtcNow ?? DateTimeOffset.UtcNow;
@@ -63,18 +53,12 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <summary>
         /// Cleans up the background collection events.
         /// </summary>
-        ~MemoryCache()
-        {
-            Dispose(false);
-        }
+        ~MemoryCache() => Dispose(false);
 
         /// <summary>
         /// Gets the count of the current entries for diagnostic purposes.
         /// </summary>
-        public int Count
-        {
-            get { return _entries.Count; }
-        }
+        public int Count => _entries.Count;
 
         // internal for testing
         internal long Size { get => Interlocked.Read(ref _cacheSize); }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheEntryScopeExpirationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheEntryScopeExpirationTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 cache.Set(key, obj, new MemoryCacheEntryOptions().AddExpirationToken(expirationToken));
             }
 
-            Assert.Single(((CacheEntry)entry)._expirationTokens);
+            Assert.Single(((CacheEntry)entry).ExpirationTokens);
             Assert.Null(((CacheEntry)entry).AbsoluteExpiration);
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 cache.Set(key, obj, new MemoryCacheEntryOptions().SetAbsoluteExpiration(time));
             }
 
-            Assert.Null(((CacheEntry)entry)._expirationTokens);
+            Assert.Empty(((CacheEntry)entry).ExpirationTokens);
             Assert.NotNull(((CacheEntry)entry).AbsoluteExpiration);
             Assert.Equal(time, ((CacheEntry)entry).AbsoluteExpiration);
         }
@@ -331,7 +331,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             Assert.Null(CacheEntryHelper.Current);
 
-            Assert.Single(((CacheEntry)entry)._expirationTokens);
+            Assert.Single(((CacheEntry)entry).ExpirationTokens);
             Assert.Null(((CacheEntry)entry).AbsoluteExpiration);
         }
 
@@ -365,9 +365,9 @@ namespace Microsoft.Extensions.Caching.Memory
 
             Assert.Null(CacheEntryHelper.Current);
 
-            Assert.Single(((CacheEntry)entry1)._expirationTokens);
+            Assert.Single(((CacheEntry)entry1).ExpirationTokens);
             Assert.Null(((CacheEntry)entry1).AbsoluteExpiration);
-            Assert.Single(((CacheEntry)entry)._expirationTokens);
+            Assert.Single(((CacheEntry)entry).ExpirationTokens);
             Assert.Null(((CacheEntry)entry).AbsoluteExpiration);
         }
 
@@ -402,11 +402,11 @@ namespace Microsoft.Extensions.Caching.Memory
                 }
             }
 
-            Assert.Equal(2, ((CacheEntry)entry1)._expirationTokens.Count());
+            Assert.Equal(2, ((CacheEntry)entry1).ExpirationTokens.Count());
             Assert.NotNull(((CacheEntry)entry1).AbsoluteExpiration);
             Assert.Equal(clock.UtcNow + TimeSpan.FromSeconds(10), ((CacheEntry)entry1).AbsoluteExpiration);
 
-            Assert.Single(((CacheEntry)entry2)._expirationTokens);
+            Assert.Single(((CacheEntry)entry2).ExpirationTokens);
             Assert.NotNull(((CacheEntry)entry2).AbsoluteExpiration);
             Assert.Equal(clock.UtcNow + TimeSpan.FromSeconds(15), ((CacheEntry)entry2).AbsoluteExpiration);
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheEntryScopeExpirationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CacheEntryScopeExpirationTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Assert.Single(((CacheEntry)entry)._expirationTokens);
-            Assert.Null(((CacheEntry)entry)._absoluteExpiration);
+            Assert.Null(((CacheEntry)entry).AbsoluteExpiration);
         }
 
         [Fact]
@@ -63,8 +63,8 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Assert.Null(((CacheEntry)entry)._expirationTokens);
-            Assert.NotNull(((CacheEntry)entry)._absoluteExpiration);
-            Assert.Equal(time, ((CacheEntry)entry)._absoluteExpiration);
+            Assert.NotNull(((CacheEntry)entry).AbsoluteExpiration);
+            Assert.Equal(time, ((CacheEntry)entry).AbsoluteExpiration);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ namespace Microsoft.Extensions.Caching.Memory
             Assert.Null(CacheEntryHelper.Current);
 
             Assert.Single(((CacheEntry)entry)._expirationTokens);
-            Assert.Null(((CacheEntry)entry)._absoluteExpiration);
+            Assert.Null(((CacheEntry)entry).AbsoluteExpiration);
         }
 
         [Fact]
@@ -366,9 +366,9 @@ namespace Microsoft.Extensions.Caching.Memory
             Assert.Null(CacheEntryHelper.Current);
 
             Assert.Single(((CacheEntry)entry1)._expirationTokens);
-            Assert.Null(((CacheEntry)entry1)._absoluteExpiration);
+            Assert.Null(((CacheEntry)entry1).AbsoluteExpiration);
             Assert.Single(((CacheEntry)entry)._expirationTokens);
-            Assert.Null(((CacheEntry)entry)._absoluteExpiration);
+            Assert.Null(((CacheEntry)entry).AbsoluteExpiration);
         }
 
         [Fact]
@@ -403,12 +403,12 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Assert.Equal(2, ((CacheEntry)entry1)._expirationTokens.Count());
-            Assert.NotNull(((CacheEntry)entry1)._absoluteExpiration);
-            Assert.Equal(clock.UtcNow + TimeSpan.FromSeconds(10), ((CacheEntry)entry1)._absoluteExpiration);
+            Assert.NotNull(((CacheEntry)entry1).AbsoluteExpiration);
+            Assert.Equal(clock.UtcNow + TimeSpan.FromSeconds(10), ((CacheEntry)entry1).AbsoluteExpiration);
 
             Assert.Single(((CacheEntry)entry2)._expirationTokens);
-            Assert.NotNull(((CacheEntry)entry2)._absoluteExpiration);
-            Assert.Equal(clock.UtcNow + TimeSpan.FromSeconds(15), ((CacheEntry)entry2)._absoluteExpiration);
+            Assert.NotNull(((CacheEntry)entry2).AbsoluteExpiration);
+            Assert.Equal(clock.UtcNow + TimeSpan.FromSeconds(15), ((CacheEntry)entry2).AbsoluteExpiration);
         }
 
         [Fact]


### PR DESCRIPTION
I've one more big improvement for the MemoryCache, but it's a little bit controversial so I decided to separate it from reducing the CacheEntry size (this PR).

Changes:

- Remove `_notifyCacheOfExpiration`, `_notifyCacheEntryCommit` and `_logger` from CacheEntry, replace it with a reference to `MemoryCache` and instead of invoking delegates, invoke internal methods. 
- Replace 3 boolean fields (`_isDisposed`, `_isExpired` and `_valueHasBeenSet`) with a single `[Flag]` field. I did this mostly because I plan to introduce another boolean flag soon.