### PR TITLE
Change AssemblyName formatting not to require static table of KVPs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
@@ -99,24 +99,32 @@ namespace System.Reflection
 
             for (int i = 0; i < s.Length; i++)
             {
-                bool addedEscape = false;
-                foreach (KeyValuePair<char, string> kv in EscapeSequences)
+                switch (s[i])
                 {
-                    string escapeReplacement = kv.Value;
-                    if (!(s[i] == escapeReplacement[0]))
-                        continue;
-                    if ((s.Length - i) < escapeReplacement.Length)
-                        continue;
-                    if (s.AsSpan(i, escapeReplacement.Length).SequenceEqual(escapeReplacement))
-                    {
+                    case '\\':
+                    case ',':
+                    case '=':
+                    case '\'':
+                    case '"':
                         sb.Append('\\');
-                        sb.Append(kv.Key);
-                        addedEscape = true;
-                    }
+                        break;
+                    case '\t':
+                        sb.Append('\\').Append('t');
+                        continue;
+                    case '\n':
+                        sb.Append('\\').Append('n');
+                        continue;
+#if TARGET_WINDOWS
+                    case '\r':
+                        if (++i < s.Length - 1 && s[i] == '\n')
+                            goto case '\n';
+
+                        --i;
+                        break;
+#endif
                 }
 
-                if (!addedEscape)
-                    sb.Append(s[i]);
+                sb.Append(s[i]);
             }
 
             if (needsQuoting)
@@ -135,16 +143,5 @@ namespace System.Reflection
 
             return new Version(major, minor, build, revision);
         }
-
-        public static KeyValuePair<char, string>[] EscapeSequences =
-        {
-            new KeyValuePair<char, string>('\\', "\\"),
-            new KeyValuePair<char, string>(',', ","),
-            new KeyValuePair<char, string>('=', "="),
-            new KeyValuePair<char, string>('\'', "'"),
-            new KeyValuePair<char, string>('\"', "\""),
-            new KeyValuePair<char, string>('n', Environment.NewLineConst),
-            new KeyValuePair<char, string>('t', "\t"),
-        };
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
@@ -109,18 +109,22 @@ namespace System.Reflection
                         sb.Append('\\');
                         break;
                     case '\t':
-                        sb.Append('\\').Append('t');
-                        continue;
-                    case '\n':
-                        sb.Append('\\').Append('n');
+                        sb.Append("\\t");
                         continue;
 #if TARGET_WINDOWS
                     case '\r':
-                        if (++i < s.Length - 1 && s[i] == '\n')
-                            goto case '\n';
+                        if (++i < s.Length && s[i] == '\n')
+                        {
+                            sb.Append("\\n");
+                            continue;
+                        }
 
                         --i;
                         break;
+#else
+                    case '\n':
+                        sb.Append("\\n");
+                        continue;
 #endif
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
@@ -111,21 +111,12 @@ namespace System.Reflection
                     case '\t':
                         sb.Append("\\t");
                         continue;
-#if TARGET_WINDOWS
                     case '\r':
-                        if (++i < s.Length && s[i] == '\n')
-                        {
-                            sb.Append("\\n");
-                            continue;
-                        }
-
-                        --i;
-                        break;
-#else
+                        sb.Append("\\r");
+                        continue;
                     case '\n':
                         sb.Append("\\n");
                         continue;
-#endif
                 }
 
                 sb.Append(s[i]);

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -34,6 +34,22 @@ namespace System.Reflection.Tests
             yield return new object[] { "\uD83D\uDC3B\uD83D\uDC3B\uD83D\uDC3B\uD83D\uDC3B\uD83D\uDC3B", "\uD83D\uDC3B\uD83D\uDC3B\uD83D\uDC3B\uD83D\uDC3B\uD83D\uDC3B" };
         }
 
+        public static IEnumerable<object[]> Names_TestDataQuoted()
+        {
+            yield return new object[] { " name ", "\" name \"" };
+            yield return new object[] { "na,me", "na\\,me" };
+            yield return new object[] { "na=me", "na\\=me" };
+            yield return new object[] { "na\'me", "\"na\\'me\"" };
+            yield return new object[] { "na\"me", "\"na\\\"me\"" };
+            yield return new object[] { "na\tme", "na\\tme" };
+            yield return new object[] { "na\0me", "na\0me" };
+            yield return new object[] { "na\bme", "na\bme" };
+            if (PlatformDetection.IsWindows)
+                yield return new object[] { "name\r\n", "\"name\\n\"" };
+            else
+                yield return new object[] { "name\n", "\"name\\n\"" };
+        }
+
         [Fact]
         public void Ctor_Empty()
         {
@@ -44,6 +60,8 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Names_TestData))]
+        [InlineData(" name ", "name")]
+        [InlineData("\tname\t", "name")]
         public void Ctor_String(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName(name);
@@ -59,6 +77,10 @@ namespace System.Reflection.Tests
         [InlineData("/a", typeof(FileLoadException))]
         [InlineData("           ", typeof(FileLoadException))]
         [InlineData("  \t \r \n ", typeof(FileLoadException))]
+        [InlineData("na,me", typeof(FileLoadException))]
+        [InlineData("na=me", typeof(FileLoadException))]
+        [InlineData("na\'me", typeof(FileLoadException))]
+        [InlineData("na\"me", typeof(FileLoadException))]
         public void Ctor_String_Invalid(string assemblyName, Type exceptionType)
         {
             Assert.Throws(exceptionType, () => new AssemblyName(assemblyName));
@@ -354,11 +376,32 @@ namespace System.Reflection.Tests
         [MemberData(nameof(Names_TestData))]
         [InlineData(null, null)]
         [InlineData("", "")]
+        [InlineData(" name ", " name ")]
+        [InlineData("\tname\t", "\tname\t")]
         public void Name_Set(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName("MyAssemblyName");
             assemblyName.Name = name;
             Assert.Equal(expectedName, assemblyName.Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(Names_TestData))]
+        [MemberData(nameof(Names_TestDataQuoted))]
+        [InlineData(null, "")]
+        public void Name_Set_FullName(string name, string expectedName)
+        {
+            AssemblyName assemblyName = new AssemblyName("MyAssemblyName");
+            assemblyName.Name = name;
+            Assert.Equal(expectedName, assemblyName.FullName);
+        }
+
+        [Fact]
+        public void Name_Set_FullName_Invalid()
+        {
+            AssemblyName assemblyName = new AssemblyName("MyAssemblyName");
+            assemblyName.Name = "";
+            Assert.Throws<FileLoadException>(() => assemblyName.FullName);
         }
 
         [Fact]

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -45,10 +45,8 @@ namespace System.Reflection.Tests
             yield return new object[] { "na\tme", "na\\tme" };
             yield return new object[] { "na\0me", "na\0me" };
             yield return new object[] { "na\bme", "na\bme" };
-            if (PlatformDetection.IsWindows)
-                yield return new object[] { "name\r\n", "\"name\\n\"" };
-            else
-                yield return new object[] { "name\n", "\"name\\n\"" };
+            yield return new object[] { "name\r", "\"name\\r\"" };
+            yield return new object[] { "name\n", "\"name\\n\"" };
         }
 
         [Fact]


### PR DESCRIPTION
to do loop with span operations to replace single characters

Expanded test coverage to actually cover this odd behaviour