### PR TITLE
Optimize Dictionary Copy of same capacity

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
@@ -53,6 +53,16 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
+        public void Dictionary_Generic_Constructor_IDictionary_Optimized(int count)
+        {
+            Dictionary<TKey, TValue> source = new Dictionary<TKey, TValue>(count);
+            AddToCollection(source, count);
+            Dictionary<TKey, TValue> copied = new Dictionary<TKey, TValue>(source);
+            Assert.Equal(source, copied);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_Constructor_IEqualityComparer(int count)
         {
             IEqualityComparer<TKey> comparer = GetKeyIEqualityComparer();


### PR DESCRIPTION
With #41944 dictionary copy is significantly faster when the same comparer is used. However there is still a loop over the source entries and using mod on the copied hash to find it's bucket to set the correct "next" buckets". When the source and new dictionary have the same capacity we can instead copy over the internal arrays and other internal state members. There are some downsides to this optimization so we should decide whether this optimization is worthwhile.

1. The new copy is coupled with all the internal state members, if new members are added they also need to be copied to avoid regressions.
2. The current copy adds items in order to the top of the "Entries" dictionary where the new version copies over the "fragmented" free slots. Adds to the copied dictionary may need to update the "freeCount" and "freeList" members and will make adds slightly more expensive. The benefits of the time saving in the copy should easily outweigh this.
3. When the source dictionary isn't full the array copy will technically copy all slots in the array instead of just the entries with items. Since the new dictionary is sized as the prime above the source dictionary count there shouldn't be more than 20% empty slots when this optimization applies.

In the below benchmark only the first method goes through the optimization and the second one goes through the old flow.

|                   Method | NetFX |     Mean |    Error |   StdDev |   Median | Ratio |   Gen 0 |  Gen 1 | Allocated |
|------------------------- |-------|---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|
|      CopyConstructorFull |    PR | 13.11 us | 0.741 us | 0.853 us | 12.82 us |  1.00 | 21.7179 | 4.3328 |   92.3 KB |
|      CopyConstructorFull |  Base | 27.87 us | 0.526 us | 0.585 us | 27.95 us |  2.13 | 21.6346 | 4.2614 |   92.3 KB |
|                          |       |          |          |          |          |       |         |        |           |
| CopyConstructorHalfEmpty |    PR | 15.86 us | 0.421 us | 0.468 us | 15.94 us |  1.00 | 10.2648 | 1.2755 |   43.8 KB |
| CopyConstructorHalfEmpty |  Base | 15.24 us | 0.289 us | 0.284 us | 15.31 us |  0.96 | 10.2886 | 1.2417 |   43.8 KB |

https://github.com/dotnet/performance/compare/master...johnthcall:DictionaryCopy?expand=1