### PR TITLE
Enable StressLog for subprocess in EventPipe tests

### DIFF
--- a/src/tests/tracing/eventpipe/common/IpcUtils.cs
+++ b/src/tests/tracing/eventpipe/common/IpcUtils.cs
@@ -67,6 +67,9 @@ namespace Tracing.Tests.Common
 
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.Environment.Add("COMPlus_StressLog",   "1");    // Turn on stresslog for subprocess
+                process.StartInfo.Environment.Add("COMPlus_LogFacility", "1000"); // Diagnostics Server Log Facility
+                process.StartInfo.Environment.Add("COMPlus_LogLevel",    "10");   // Log everything
                 foreach ((string key, string value) in environment)
                     process.StartInfo.Environment.Add(key, value);
                 process.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;


### PR DESCRIPTION
Turning on StressLog for EventPipe tests in the hopes of getting more information on #44072.

I haven't been able to reproduce the issue locally and the dumps generated so far have been lacking in information pointing to a reason the test hangs.