### PR TITLE
Remove ZipDownloadDisable for azdo artifacts download

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -30,11 +30,6 @@ jobs:
       - name: runCodesignValidationInjection
         value: false
 
-      # Workaround for azure devops flakiness when dowloading artifacts
-      # https://github.com/dotnet/runtime/issues/32805
-      - name: System.DisableZipDownload
-        value: true
-
       - name: buildConfigUpper
         ${{ if eq(parameters.jobParameters.buildConfig, 'debug') }}:
           value: 'Debug'


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/32805

Retries on ZipDownload for windows artifacts download was implemented a long time ago: https://github.com/microsoft/azure-pipelines-tasks/pull/12564/files

Let's revert this and see if this solves the issue as we're seeing this happen on Windows only and ZipDownload is only a thing for windows.

cc: @MattGal @markwilkie @jaredpar @ViktorHofer 