### PR TITLE
Enable rolling builds for staging pipeline and fail the build if any failure

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -18,7 +18,7 @@ jobs:
     ${{ if eq(parameters.jobParameters.runtimeFlavor, 'mono') }}:
       runtimeFlavorDisplayName: 'Mono'
     
-    shouldContinueOnError: ${{ endsWith(variables['Build.DefinitionName'], 'staging') }}
+    shouldContinueOnError: ${{ and(endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest')) }}
 
     variables:
       # Disable component governance in our CI builds. These builds are not shipping nor

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -1,5 +1,27 @@
-# The staging pipeline only makes sense to run it on PRs.
-trigger: none
+# Setting batch to true, triggers one build at a time.
+# if there is a push while a build in progress, it will wait,
+# until the running build finishes, and produce a build with all the changes
+# that happened during the last build.
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - '*'
+    - docs/manpages/*
+    exclude:
+    - eng/Version.Details.xml
+    - .github/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 
 pr:
   branches:


### PR DESCRIPTION
In order to measure pass rate, we will need to have a rolling build with "failures" in it, as PR builds of this will always be green if there are test failures, so it will be harder to get data on that.

If someone breaks a test or something on their PR because this build was green, by having rolling builds that actually fail when running tests, we will know sooner rather than later and also it would be easier to track which change actually broke it.

This will actually help the v-team currently working on enabling a new test platform.