### PR TITLE
Fix conditions to include suceeded on send to helix inner

### DIFF
--- a/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
@@ -12,11 +12,11 @@ steps:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.cmd.
   - powershell: $(Build.SourcesDirectory)\eng\common\build.ps1 -ci ${{ parameters.restoreParams }}
     displayName: Restore blob feed tasks (Windows)
-    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
+    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
 
   - powershell: $(Build.SourcesDirectory)\eng\common\msbuild.ps1 -ci ${{ parameters.sendParams }}
     displayName: ${{ parameters.displayName }} (Windows)
-    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
+    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
     env: ${{ parameters.environment }}
     continueOnError: ${{ parameters.shouldContinueOnError }}
 
@@ -24,7 +24,7 @@ steps:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.sh.
   - script: $(Build.SourcesDirectory)/eng/common/build.sh --ci ${{ parameters.restoreParams }}
     displayName: Restore blob feed tasks (Unix)
-    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
+    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
     ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       env:
         # Arcade uses this SDK instead of trying to restore one.
@@ -32,6 +32,6 @@ steps:
 
   - script: $(Build.SourcesDirectory)/eng/common/msbuild.sh --ci ${{ parameters.sendParams }}
     displayName: ${{ parameters.displayName }} (Unix)
-    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
+    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
     env: ${{ parameters.environment }}
     continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
@@ -12,11 +12,11 @@ steps:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.cmd.
   - powershell: $(Build.SourcesDirectory)\eng\common\build.ps1 -ci ${{ parameters.restoreParams }}
     displayName: Restore blob feed tasks (Windows)
-    condition: ${{ and(ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
+    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
 
   - powershell: $(Build.SourcesDirectory)\eng\common\msbuild.ps1 -ci ${{ parameters.sendParams }}
     displayName: ${{ parameters.displayName }} (Windows)
-    condition: ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
+    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
     env: ${{ parameters.environment }}
     continueOnError: ${{ parameters.shouldContinueOnError }}
 
@@ -24,7 +24,7 @@ steps:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.sh.
   - script: $(Build.SourcesDirectory)/eng/common/build.sh --ci ${{ parameters.restoreParams }}
     displayName: Restore blob feed tasks (Unix)
-    condition: ${{ and(ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
+    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.restoreParams, '')) }}
     ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       env:
         # Arcade uses this SDK instead of trying to restore one.
@@ -32,6 +32,6 @@ steps:
 
   - script: $(Build.SourcesDirectory)/eng/common/msbuild.sh --ci ${{ parameters.sendParams }}
     displayName: ${{ parameters.displayName }} (Unix)
-    condition: ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
+    condition: ${{ and(succeeded(), ne(parameters.condition, false), ne(parameters.sendParams, '')) }}
     env: ${{ parameters.environment }}
     continueOnError: ${{ parameters.shouldContinueOnError }}


### PR DESCRIPTION
Since this doesn't include suceeded, this step runs regardless of previous steps result if the condition is true. This leads to harder diagnosis of why send to helix failed or miss leading on what the actual build failure was. i.e: https://dev.azure.com/dnceng/public/_build/results?buildId=901142&view=logs&j=545e4d1e-a16d-5a06-75f8-2e440306c0fa&t=844a804f-fe4a-5f11-cab4-78484b8cc7ab

That build, failed to download artifacts, but at a first sight it seems like send to helix failed, and so reading the logs might be miss leading.

cc: @dotnet/runtime-infrastructure 