### PR TITLE
Fix Crossgen2 test concurrency on Windows

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -220,7 +220,7 @@ if defined RunCrossGen2 (
     if exist "IL-CG2" (
       REM We may have come in the middle of a concurrent CG2 compilation, wait for it to finish
       :ProbeCompilationFinished
-      if exist "%%compilationDoneFlagFile%%" goto :DoneCrossgen2OperationsNoRelease
+      if exist "!compilationDoneFlagFile!" goto :DoneCrossgen2OperationsNoRelease
       echo Waiting for concurrent Crossgen2 compilation^: !compilationDoneFlagFile!
       timeout /t 5 /nobreak
       goto :ProbeCompilationFinished


### PR DESCRIPTION
In my previous attempt at fixing the test concurrency w.r.t. to
multiple "RunOnly" tests exercising the same "BuildAndRun"
executable compiled with Crossgen2,

https://github.com/dotnet/runtime/pull/44492

I have apparently used the wrong escaping in the batch (cmd)
version of the script so that the fix doesn't work on Windows.
This change is fixing this deficiency.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib, @dotnet/runtime-infrastructure