### PR TITLE
Removed thread-safety from SequenceReader

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Internal.Runtime.CompilerServices;
 
 namespace System.Buffers
@@ -101,7 +100,7 @@ namespace System.Buffers
                 if (_length < 0)
                 {
                     // Cast-away readonly to initialize lazy field
-                    Volatile.Write(ref Unsafe.AsRef(_length), Sequence.Length);
+                    Unsafe.AsRef(_length) = Sequence.Length;
                 }
                 return _length;
             }


### PR DESCRIPTION
As it's a ref-struct and thus stack-only there's no need to have any guarantees for thread-safety and atomicity.
Cf. https://github.com/dotnet/runtime/issues/45379#issuecomment-736021061

Fixes https://github.com/dotnet/runtime/issues/45379