### PR TITLE
Fix for R2RDumpTests nullref in composite mode

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -424,12 +424,16 @@ namespace ILCompiler.Reflection.ReadyToRun
         internal void EnsureMethods()
         {
             EnsureHeader();
-            if (_readyToRunAssemblies[0]._methods != null)
+            if (_instanceMethods != null)
             {
                 return;
             }
 
             _instanceMethods = new List<InstanceMethod>();
+            foreach (ReadyToRunAssembly assembly in _readyToRunAssemblies)
+            {
+                assembly._methods = new List<ReadyToRunMethod>();
+            }
 
             if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.RuntimeFunctions, out ReadyToRunSection runtimeFunctionSection))
             {
@@ -706,7 +710,6 @@ namespace ILCompiler.Reflection.ReadyToRun
         private void ParseMethodDefEntrypointsSection(ReadyToRunSection section, IAssemblyMetadata componentReader, bool[] isEntryPoint)
         {
             int assemblyIndex = GetAssemblyIndex(section);
-            _readyToRunAssemblies[assemblyIndex]._methods = new List<ReadyToRunMethod>();
             int methodDefEntryPointsOffset = GetOffset(section.RelativeVirtualAddress);
             NativeArray methodEntryPoints = new NativeArray(Image, (uint)methodDefEntryPointsOffset);
             uint nMethodEntryPoints = methodEntryPoints.GetCount();


### PR DESCRIPTION
My original conjecture that the R2RDumpTests nullref crash in CG2
composite pipeline had the same cause as the libraries test
failures spotted over the weekend seems wrong. The R2RDumpTests
crash is a plain initialization issue:

In composite mode, native code for the entire framework gets
emitted into the special composite native image (CoreCLR test
scripting uses the name framework-r2r.dll for this image); the
individual component assemblies including SPC only act as holders
for the MSIL and forwarders to the native image.

For this reason, running R2RDumpTests to dump SPC in composite mode
yielded a library with zero native methods; thus we never entered
the conditional clause in EnsureMethods and _methods remained null.
I have reformulated the code by centralizing initialization of
both _instanceMethods and _methods in EnsureMethods.

Thanks

Tomas

/cc @dotnet/crossgen-contrib