### PR TITLE
[release/5.0] Set default value for value-type ctor params properly (#43831)

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfoOfT.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Text.Json
@@ -25,10 +26,19 @@ namespace System.Text.Json
                 matchingProperty,
                 options);
 
+            Debug.Assert(parameterInfo.ParameterType == matchingProperty.DeclaredPropertyType);
+
             if (parameterInfo.HasDefaultValue)
             {
-                DefaultValue = parameterInfo.DefaultValue;
-                TypedDefaultValue = (T)parameterInfo.DefaultValue!;
+                if (parameterInfo.DefaultValue == null && !matchingProperty.PropertyTypeCanBeNull)
+                {
+                    DefaultValue = TypedDefaultValue;
+                }
+                else
+                {
+                    DefaultValue = parameterInfo.DefaultValue;
+                    TypedDefaultValue = (T)parameterInfo.DefaultValue!;
+                }
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -396,5 +396,8 @@ namespace System.Text.Json
         public bool IsIgnored { get; private set; }
 
         public JsonNumberHandling? NumberHandling { get; private set; }
+
+        //  Whether the property type can be null.
+        public bool PropertyTypeCanBeNull { get; protected set; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -100,6 +100,9 @@ namespace System.Text.Json
             }
 
             _converterIsExternalAndPolymorphic = !converter.IsInternalConverter && DeclaredPropertyType != converter.TypeToConvert;
+            PropertyTypeCanBeNull = !DeclaredPropertyType.IsValueType ||
+                (DeclaredPropertyType.IsGenericType && DeclaredPropertyType.GetGenericTypeDefinition() == typeof(Nullable<>));
+
             GetPolicies(ignoreCondition, parentTypeNumberHandling, defaultValueIsNull: Converter.CanBeNull);
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1134,5 +1134,57 @@ namespace System.Text.Json.Serialization.Tests
             AgePoco obj = JsonSerializer.Deserialize<AgePoco>(@"{""age"":1}");
             Assert.Equal(1, obj.age);
         }
+
+        [Theory]
+        [InlineData(typeof(TypeWithGuid))]
+        [InlineData(typeof(TypeWithNullableGuid))]
+        public void DefaultForValueTypeCtorParam(Type type)
+        {
+            string json = @"{""MyGuid"":""edc421bf-782a-4a95-ad67-3d73b5d7db6f""}";
+            object obj = JsonSerializer.Deserialize(json, type);
+            Assert.Equal(json, JsonSerializer.Serialize(obj));
+
+            json = @"{}";
+            obj = JsonSerializer.Deserialize(json, type);
+
+            var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault };
+            Assert.Equal(json, JsonSerializer.Serialize(obj, options));
+        }
+
+        private class TypeWithGuid
+        {
+            public Guid MyGuid { get; }
+
+            public TypeWithGuid(Guid myGuid = default) => MyGuid = myGuid;
+        }
+
+        private struct TypeWithNullableGuid
+        {
+            public Guid? MyGuid { get; }
+
+            [JsonConstructor]
+            public TypeWithNullableGuid(Guid? myGuid = default) => MyGuid = myGuid;
+        }
+
+        [Fact]
+        public void DefaultForReferenceTypeCtorParam()
+        {
+            string json = @"{""MyUri"":""http://hello""}";
+            object obj = JsonSerializer.Deserialize(json, typeof(TypeWithUri));
+            Assert.Equal(json, JsonSerializer.Serialize(obj));
+
+            json = @"{}";
+            obj = JsonSerializer.Deserialize(json, typeof(TypeWithUri));
+
+            var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault };
+            Assert.Equal(json, JsonSerializer.Serialize(obj, options));
+        }
+
+        private class TypeWithUri
+        {
+            public Uri MyUri { get; }
+
+            public TypeWithUri(Uri myUri = default) => MyUri = myUri;
+        }
     }
 }


### PR DESCRIPTION
Ports https://github.com/dotnet/runtime/pull/43831 to 5.0
Fixes https://github.com/dotnet/runtime/issues/43757 in 5.0

# Description

Fixes bug where a `NullReferenceException` is thrown when (de)serializing a type whose constructor has `default` is set as optional argument default for a value-typed ctor parameter. For example, this type:

```cs
public record PositionalRecord(Guid st = default);
```

# Customer Impact

Avoids a `NullReferenceException` in a potentially common scenario.

# Regression

Not a regression since the deserialization-with-paramterized-ctor feature is new in 5.0.

# Testing

Unit tests have been added to verify the expected behavior.

# Risk

Little to none. This is a very small and scoped change to address this issue only.