### PR TITLE
Use assembly name formatting code for missing satellite assemblies

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -212,6 +212,9 @@ namespace System.Reflection
             {
                 if (this.Name == null)
                     return string.Empty;
+                if (this.Name == string.Empty)
+                    throw new System.IO.FileLoadException();
+
                 // Do not call GetPublicKeyToken() here - that latches the result into AssemblyName which isn't a side effect we want.
                 byte[]? pkt = _publicKeyToken ?? ComputePublicKeyToken();
                 return AssemblyNameFormatter.ComputeDisplayName(Name, Version, CultureName, pkt, Flags, ContentType);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameFormatter.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
+using System.Diagnostics;
 using System.Text;
 using System.Globalization;
 using System.Collections.Generic;
@@ -10,18 +10,13 @@ namespace System.Reflection
 {
     internal static class AssemblyNameFormatter
     {
-        public static string ComputeDisplayName(string? name, Version? version, string? cultureName, byte[]? pkt, AssemblyNameFlags flags, AssemblyContentType contentType)
+        public static string ComputeDisplayName(string name, Version? version, string? cultureName, byte[]? pkt, AssemblyNameFlags flags = 0, AssemblyContentType contentType = 0)
         {
             const int PUBLIC_KEY_TOKEN_LEN = 8;
-
-            if (name == string.Empty)
-                throw new FileLoadException();
+            Debug.Assert(name.Length != 0);
 
             StringBuilder sb = new StringBuilder();
-            if (name != null)
-            {
-                sb.AppendQuoted(name);
-            }
+            sb.AppendQuoted(name);
 
             if (version != null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -421,23 +421,12 @@ namespace System.Resources
         private void HandleSatelliteMissing()
         {
             Debug.Assert(_mediator.MainAssembly != null);
-            string satAssemName = _mediator.MainAssembly.GetName().Name + ".resources.dll";
-            if (_mediator.SatelliteContractVersion != null)
-            {
-                satAssemName += ", Version=" + _mediator.SatelliteContractVersion.ToString();
-            }
-
-            byte[]? token = _mediator.MainAssembly.GetName().GetPublicKeyToken();
-            if (token != null)
-            {
-                int iLen = token.Length;
-                StringBuilder publicKeyTok = new StringBuilder(iLen * 2);
-                for (int i = 0; i < iLen; i++)
-                {
-                    publicKeyTok.Append(token[i].ToString("x", CultureInfo.InvariantCulture));
-                }
-                satAssemName += ", PublicKeyToken=" + publicKeyTok;
-            }
+            AssemblyName mname = _mediator.MainAssembly.GetName();
+            string satAssemName = AssemblyNameFormatter.ComputeDisplayName(
+                mname.Name + ".resources.dll",
+                _mediator.SatelliteContractVersion,
+                null,
+                mname.GetPublicKeyToken());
 
             Debug.Assert(_mediator.NeutralResourcesCulture != null);
             string missingCultureName = _mediator.NeutralResourcesCulture.Name;


### PR DESCRIPTION
exception message