### PR TITLE
WinHttpHandler: fix double -> uint conversions for ARM64

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -963,8 +963,8 @@ namespace System.Net.Http
                 // call of the response body data. WINHTTP_OPTION_RECEIVE_TIMEOUT sets a timeout on each
                 // lower layer winsock read.
                 // Timeout.InfiniteTimeSpan will be converted to uint.MaxValue milliseconds (~ 50 days).
-                // The result a of double->uint cast is unspecified and may differ on ARM, returning 0 instead of uint.MaxValue.
-                // To handle Timeout.InfiniteTimespan correctly, we need to cast to Int32 first.
+                // The result a of double->uint cast is unspecified for -1 and may differ on ARM, returning 0 instead of uint.MaxValue.
+                // To handle Timeout.InfiniteTimespan correctly, we need to cast to int first.
                 uint optionData = (uint)(int)_receiveDataTimeout.TotalMilliseconds;
                 SetWinHttpOption(state.RequestHandle, Interop.WinHttp.WINHTTP_OPTION_RECEIVE_TIMEOUT, ref optionData);
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -962,7 +962,10 @@ namespace System.Net.Http
                 // Since the headers have been read, set the "receive" timeout to be based on each read
                 // call of the response body data. WINHTTP_OPTION_RECEIVE_TIMEOUT sets a timeout on each
                 // lower layer winsock read.
-                uint optionData = unchecked((uint)_receiveDataTimeout.TotalMilliseconds);
+                // Timeout.InfiniteTimeSpan will be converted to uint.MaxValue milliseconds (~ 50 days).
+                // The result a of double->uint cast is unspecified and may differ on ARM.
+                // To handle Timeout.InfiniteTimespan correctly, we need to cast to Int32 first.
+                uint optionData = unchecked((uint)(int)_receiveDataTimeout.TotalMilliseconds);
                 SetWinHttpOption(state.RequestHandle, Interop.WinHttp.WINHTTP_OPTION_RECEIVE_TIMEOUT, ref optionData);
 
                 HttpResponseMessage responseMessage =
@@ -1007,8 +1010,10 @@ namespace System.Net.Http
                     onoff = 1,
 
                     // Timeout.InfiniteTimeSpan will be converted to uint.MaxValue milliseconds (~ 50 days)
-                    keepaliveinterval = (uint)_tcpKeepAliveInterval.TotalMilliseconds,
-                    keepalivetime = (uint)_tcpKeepAliveTime.TotalMilliseconds
+                    // The result a of double->uint cast is unspecified and may differ on ARM.
+                    // To handle Timeout.InfiniteTimespan correctly, we need to cast to Int32 first.
+                    keepaliveinterval = unchecked((uint)(int)_tcpKeepAliveInterval.TotalMilliseconds),
+                    keepalivetime = unchecked((uint)(int)_tcpKeepAliveTime.TotalMilliseconds)
                 };
 
                 SetWinHttpOption(

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -963,9 +963,9 @@ namespace System.Net.Http
                 // call of the response body data. WINHTTP_OPTION_RECEIVE_TIMEOUT sets a timeout on each
                 // lower layer winsock read.
                 // Timeout.InfiniteTimeSpan will be converted to uint.MaxValue milliseconds (~ 50 days).
-                // The result a of double->uint cast is unspecified and may differ on ARM.
+                // The result a of double->uint cast is unspecified and may differ on ARM, returning 0 instead of uint.MaxValue.
                 // To handle Timeout.InfiniteTimespan correctly, we need to cast to Int32 first.
-                uint optionData = unchecked((uint)(int)_receiveDataTimeout.TotalMilliseconds);
+                uint optionData = (uint)(int)_receiveDataTimeout.TotalMilliseconds;
                 SetWinHttpOption(state.RequestHandle, Interop.WinHttp.WINHTTP_OPTION_RECEIVE_TIMEOUT, ref optionData);
 
                 HttpResponseMessage responseMessage =
@@ -1010,10 +1010,10 @@ namespace System.Net.Http
                     onoff = 1,
 
                     // Timeout.InfiniteTimeSpan will be converted to uint.MaxValue milliseconds (~ 50 days)
-                    // The result a of double->uint cast is unspecified and may differ on ARM.
+                    // The result a of double->uint cast is unspecified and may differ on ARM, returning 0 instead of uint.MaxValue.
                     // To handle Timeout.InfiniteTimespan correctly, we need to cast to Int32 first.
-                    keepaliveinterval = unchecked((uint)(int)_tcpKeepAliveInterval.TotalMilliseconds),
-                    keepalivetime = unchecked((uint)(int)_tcpKeepAliveTime.TotalMilliseconds)
+                    keepaliveinterval = (uint)(int)_tcpKeepAliveInterval.TotalMilliseconds,
+                    keepalivetime = (uint)(int)_tcpKeepAliveTime.TotalMilliseconds
                 };
 
                 SetWinHttpOption(

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1010,8 +1010,8 @@ namespace System.Net.Http
                     onoff = 1,
 
                     // Timeout.InfiniteTimeSpan will be converted to uint.MaxValue milliseconds (~ 50 days)
-                    // The result a of double->uint cast is unspecified and may differ on ARM, returning 0 instead of uint.MaxValue.
-                    // To handle Timeout.InfiniteTimespan correctly, we need to cast to Int32 first.
+                    // The result a of double->uint cast is unspecified for -1 and may differ on ARM, returning 0 instead of uint.MaxValue.
+                    // To handle Timeout.InfiniteTimespan correctly, we need to cast to int first.
                     keepaliveinterval = (uint)(int)_tcpKeepAliveInterval.TotalMilliseconds,
                     keepalivetime = (uint)(int)_tcpKeepAliveTime.TotalMilliseconds
                 };

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/APICallHistory.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/APICallHistory.cs
@@ -66,7 +66,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
 
         public static int? WinHttpOptionSendTimeout { get; set; }
 
-        public static int? WinHttpOptionReceiveTimeout { get; set; }
+        public static uint? WinHttpOptionReceiveTimeout { get; set; }
 
         public static List<IntPtr> WinHttpOptionClientCertContext { get { return winHttpOptionClientCertContextList; } }
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -507,6 +507,10 @@ internal static partial class Interop
             {
                 APICallHistory.WinHttpOptionRedirectPolicy = optionData;
             }
+            else if (option == Interop.WinHttp.WINHTTP_OPTION_RECEIVE_TIMEOUT)
+            {
+                APICallHistory.WinHttpOptionReceiveTimeout = optionData;
+            }
 
             return true;
         }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -464,6 +464,16 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
+        public void ReceiveDataTimeout_SetValidValue_ForwardsCorrectNativeOptionToWinHttp()
+        {
+            var handler = new WinHttpHandler();
+
+            SendRequestHelper.Send(handler, () => handler.ReceiveDataTimeout = TimeSpan.FromSeconds(13));
+
+            Assert.Equal(13_000u, APICallHistory.WinHttpOptionReceiveTimeout.Value);
+        }
+
+        [Fact]
         public void ReceiveDataTimeout_SetNegativeValue_ThrowsArgumentOutOfRangeException()
         {
             var handler = new WinHttpHandler();
@@ -490,11 +500,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
-        public void ReceiveDataTimeout_SetInfiniteValue_NoExceptionThrown()
+        public void ReceiveDataTimeout_SetInfiniteTimeSpan_TranslatesToUInt32MaxValue()
         {
             var handler = new WinHttpHandler();
 
-            handler.ReceiveDataTimeout = Timeout.InfiniteTimeSpan;
+            SendRequestHelper.Send(handler, () => handler.ReceiveDataTimeout = Timeout.InfiniteTimeSpan);
+
+            Assert.Equal(uint.MaxValue, APICallHistory.WinHttpOptionReceiveTimeout.Value);
         }
 
         [Fact]


### PR DESCRIPTION
According to the [Explicit numeric conversions section](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/conversions#explicit-numeric-conversions) of the C# specification, the unchecked case of a `double` -> `uint` cast goes as following:

> - If the value of the operand is `NaN` or infinite, the result of the conversion is an unspecified value of the destination type.
> - Otherwise, the source operand is rounded towards zero to the nearest integral value. If this integral value is within the range of the destination type then this value is the result of the conversion.
> - Otherwise, the result of the conversion is **an unspecified value of the destination type**.

Looks like we do not handle the `Timeout.InfiniteTimeSpan.TotalMilliseconds == -1.0` case correctly for `ReceiveDataTimeout` and `TcpKeepAlive*` , the latter resulting in [test failures on ARM64 machines](https://dev.azure.com/dnceng/public/_build/results?buildId=900283&view=ms.vss-test-web.build-test-results-tab&runId=28759380&resultId=131878&paneView=debug).

Fixes #45249

**Note:**
The failing `Libraries Test Run release coreclr windows arm64 Release` job does not get executed on PR-s, only on `refs/heads/master`, which means there is no way for me to validate the change before merging it. (Unless someone can suggest a way to access an ARM64  windows machine.)

/cc @EgorBo @tannergooding if interested.