### PR TITLE
Delete unnecessary GetNativeHandle methods on reflection types

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -1521,7 +1521,7 @@ namespace System.Reflection
         {
             byte* pBlobStart = (byte*)blobStart;
             _GetPropertyOrFieldData(
-                module.GetNativeHandle(), &pBlobStart, (byte*)blobEnd, out name, out isProperty, out type, out value);
+                module, &pBlobStart, (byte*)blobEnd, out name, out isProperty, out type, out value);
             blobStart = (IntPtr)pBlobStart;
         }
 
@@ -1845,7 +1845,7 @@ namespace System.Reflection
 
         private static MarshalAsAttribute? GetMarshalAsCustomAttribute(int token, RuntimeModule scope)
         {
-            ConstArray nativeType = ModuleHandle.GetMetadataImport(scope.GetNativeHandle()).GetFieldMarshal(token);
+            ConstArray nativeType = ModuleHandle.GetMetadataImport(scope).GetFieldMarshal(token);
 
             if (nativeType.Length == 0)
                 return null;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -153,8 +153,6 @@ namespace System.Reflection.Emit
 
         internal InternalAssemblyBuilder InternalAssembly => _internalAssemblyBuilder;
 
-        internal RuntimeAssembly GetNativeHandle() => InternalAssembly.GetNativeHandle();
-
         #endregion
 
         #region Constructor
@@ -212,7 +210,7 @@ namespace System.Reflection.Emit
         [MemberNotNull(nameof(_manifestModuleBuilder))]
         private void InitManifestModule()
         {
-            InternalModuleBuilder modBuilder = (InternalModuleBuilder)GetInMemoryAssemblyModule(GetNativeHandle());
+            InternalModuleBuilder modBuilder = (InternalModuleBuilder)GetInMemoryAssemblyModule(InternalAssembly);
 
             // Note that this ModuleBuilder cannot be used for RefEmit yet
             // because it hasn't been initialized.

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -332,9 +332,7 @@ namespace System.Reflection.Emit
         // _internalModuleBuilder is null iff this is a "internal" ModuleBuilder
         internal InternalModuleBuilder InternalModule => _internalModuleBuilder;
 
-        protected override ModuleHandle GetModuleHandleImpl() => new ModuleHandle(GetNativeHandle());
-
-        internal RuntimeModule GetNativeHandle() => InternalModule.GetNativeHandle();
+        protected override ModuleHandle GetModuleHandleImpl() => new ModuleHandle(InternalModule);
 
         private static RuntimeModule GetRuntimeModuleFromModule(Module? m)
         {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -31,7 +31,7 @@ namespace System.Reflection
 
         internal RuntimeType[] GetDefinedTypes()
         {
-            return GetTypes(GetNativeHandle());
+            return GetTypes(this);
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -121,7 +121,7 @@ namespace System.Reflection
                     methodArgs = ConvertToTypeHandleArray(genericMethodArguments);
                 }
 
-                ModuleHandle moduleHandle = new ModuleHandle(GetNativeHandle());
+                ModuleHandle moduleHandle = new ModuleHandle(this);
                 IRuntimeMethodInfo methodHandle = moduleHandle.ResolveMethodHandle(tk, typeArgs, methodArgs).GetMethodInfo();
 
                 Type declaringType = RuntimeMethodHandle.GetDeclaringType(methodHandle);
@@ -218,7 +218,7 @@ namespace System.Reflection
 
                 if (declaringType.IsGenericType || declaringType.IsArray)
                 {
-                    int tkDeclaringType = ModuleHandle.GetMetadataImport(GetNativeHandle()).GetParentToken(metadataToken);
+                    int tkDeclaringType = ModuleHandle.GetMetadataImport(this).GetParentToken(metadataToken);
                     declaringType = (RuntimeType)ResolveType(tkDeclaringType, genericTypeArguments, genericMethodArguments);
                 }
 
@@ -334,10 +334,10 @@ namespace System.Reflection
 
         public override void GetPEKind(out PortableExecutableKinds peKind, out ImageFileMachine machine)
         {
-            ModuleHandle.GetPEKind(GetNativeHandle(), out peKind, out machine);
+            ModuleHandle.GetPEKind(this, out peKind, out machine);
         }
 
-        public override int MDStreamVersion => ModuleHandle.GetMDStreamVersion(GetNativeHandle());
+        public override int MDStreamVersion => ModuleHandle.GetMDStreamVersion(this);
         #endregion
 
         #region Data Members
@@ -461,7 +461,7 @@ namespace System.Reflection
       [RequiresUnreferencedCode("Types might be removed")]
         public override Type[] GetTypes()
         {
-            return GetTypes(GetNativeHandle());
+            return GetTypes(this);
         }
 
         #endregion
@@ -477,11 +477,11 @@ namespace System.Reflection
             }
         }
 
-        public override int MetadataToken => ModuleHandle.GetToken(GetNativeHandle());
+        public override int MetadataToken => ModuleHandle.GetToken(this);
 
         public override bool IsResource()
         {
-            return IsResource(GetNativeHandle());
+            return IsResource(this);
         }
 
         [RequiresUnreferencedCode("Fields might be removed")]
@@ -550,11 +550,6 @@ namespace System.Reflection
         protected override ModuleHandle GetModuleHandleImpl()
         {
             return new ModuleHandle(this);
-        }
-
-        internal RuntimeModule GetNativeHandle()
-        {
-            return this;
         }
 
         internal IntPtr GetUnderlyingNativeHandle()

--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1371,7 +1371,7 @@ namespace System
             }
             catch (Exception)
             {
-                if (!ModuleHandle.GetMetadataImport(module.GetNativeHandle()).IsValidToken(methodToken))
+                if (!ModuleHandle.GetMetadataImport(module).IsValidToken(methodToken))
                     throw new ArgumentOutOfRangeException(nameof(methodToken),
                         SR.Format(SR.Argument_InvalidToken, methodToken, new ModuleHandle(module)));
                 throw;
@@ -1423,7 +1423,7 @@ namespace System
                 }
                 catch (Exception)
                 {
-                    if (!GetMetadataImport(module.GetNativeHandle()).IsValidToken(fieldToken))
+                    if (!GetMetadataImport(module).IsValidToken(fieldToken))
                         throw new ArgumentOutOfRangeException(nameof(fieldToken),
                             SR.Format(SR.Argument_InvalidToken, fieldToken, new ModuleHandle(module)));
                     throw;
@@ -1473,14 +1473,14 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern int GetMDStreamVersion(RuntimeModule module);
 
-        public int MDStreamVersion => GetMDStreamVersion(GetRuntimeModule().GetNativeHandle());
+        public int MDStreamVersion => GetMDStreamVersion(GetRuntimeModule());
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern IntPtr _GetMetadataImport(RuntimeModule module);
 
         internal static MetadataImport GetMetadataImport(RuntimeModule module)
         {
-            return new MetadataImport(_GetMetadataImport(module.GetNativeHandle()), module);
+            return new MetadataImport(_GetMetadataImport(module), module);
         }
         #endregion
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/QCallHandles.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/QCallHandles.cs
@@ -62,7 +62,7 @@ namespace System.Runtime.CompilerServices
         internal QCallModule(ref System.Reflection.Emit.ModuleBuilder module)
         {
             _ptr = Unsafe.AsPointer(ref module);
-            _module = module.GetNativeHandle().GetUnderlyingNativeHandle();
+            _module = module.InternalModule.GetUnderlyingNativeHandle();
         }
     }
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
@@ -851,7 +851,7 @@ namespace System.Reflection.Emit
             return false;
         }
 
-        internal ModuleBuilder GetNativeHandle() => this;
+        internal ModuleBuilder InternalModule => this;
 
         internal IntPtr GetUnderlyingNativeHandle() { return _impl; }
 


### PR DESCRIPTION
They just return "this" for the most part