### PR TITLE
WinHttpHandler: apply [SupportedOSPlatform("windows10.0.19041")] on TcpKeepAlive properties

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -44,8 +44,11 @@ namespace System.Net.Http
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool>? ServerCertificateValidationCallback { get { throw null; } set { } }
         public System.Net.ICredentials? ServerCredentials { get { throw null; } set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.2004")]
         public bool TcpKeepAliveEnabled { get { throw null; } set { } }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.2004")]
         public System.TimeSpan TcpKeepAliveTime { get { throw null; } set { } }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.2004")]
         public System.TimeSpan TcpKeepAliveInterval { get { throw null; } set { } }
         public System.Net.Http.WindowsProxyUsePolicy WindowsProxyUsePolicy { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }

--- a/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -44,11 +44,11 @@ namespace System.Net.Http
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool>? ServerCertificateValidationCallback { get { throw null; } set { } }
         public System.Net.ICredentials? ServerCredentials { get { throw null; } set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
-        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.2004")]
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
         public bool TcpKeepAliveEnabled { get { throw null; } set { } }
-        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.2004")]
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
         public System.TimeSpan TcpKeepAliveTime { get { throw null; } set { } }
-        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.2004")]
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
         public System.TimeSpan TcpKeepAliveInterval { get { throw null; } set { } }
         public System.Net.Http.WindowsProxyUsePolicy WindowsProxyUsePolicy { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -418,9 +419,11 @@ namespace System.Net.Http
         /// Gets or sets a value indicating whether TCP keep-alive is enabled.
         /// </summary>
         /// <remarks>
+        /// Only supported on Windows 10 version 2004 or newer.
         /// If enabled, the values of <see cref="TcpKeepAliveInterval" /> and <see cref="TcpKeepAliveTime"/> will be forwarded
         /// to set WINHTTP_OPTION_TCP_KEEPALIVE, enabling and configuring TCP keep-alive for the backing TCP socket.
         /// </remarks>
+        [SupportedOSPlatform("windows10.0.2004")]
         public bool TcpKeepAliveEnabled
         {
             get
@@ -438,9 +441,11 @@ namespace System.Net.Http
         /// Gets or sets the TCP keep-alive timeout.
         /// </summary>
         /// <remarks>
+        /// Only supported on Windows 10 version 2004 or newer.
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 2 hours.
         /// </remarks>
+        [SupportedOSPlatform("windows10.0.2004")]
         public TimeSpan TcpKeepAliveTime
         {
             get
@@ -459,9 +464,11 @@ namespace System.Net.Http
         /// Gets or sets the TCP keep-alive interval.
         /// </summary>
         /// <remarks>
+        /// Only supported on Windows 10 version 2004 or newer.
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 1 second.
         /// </remarks>
+        [SupportedOSPlatform("windows10.0.2004")]
         public TimeSpan TcpKeepAliveInterval
         {
             get

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -423,7 +423,7 @@ namespace System.Net.Http
         /// If enabled, the values of <see cref="TcpKeepAliveInterval" /> and <see cref="TcpKeepAliveTime"/> will be forwarded
         /// to set WINHTTP_OPTION_TCP_KEEPALIVE, enabling and configuring TCP keep-alive for the backing TCP socket.
         /// </remarks>
-        [SupportedOSPlatform("windows10.0.2004")]
+        [SupportedOSPlatform("windows10.0.19041")]
         public bool TcpKeepAliveEnabled
         {
             get
@@ -445,7 +445,7 @@ namespace System.Net.Http
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 2 hours.
         /// </remarks>
-        [SupportedOSPlatform("windows10.0.2004")]
+        [SupportedOSPlatform("windows10.0.19041")]
         public TimeSpan TcpKeepAliveTime
         {
             get
@@ -468,7 +468,7 @@ namespace System.Net.Http
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 1 second.
         /// </remarks>
-        [SupportedOSPlatform("windows10.0.2004")]
+        [SupportedOSPlatform("windows10.0.19041")]
         public TimeSpan TcpKeepAliveInterval
         {
             get


### PR DESCRIPTION
`WINHTTP_OPTION_TCP_KEEPALIVE` is only available since the May 2020 Update, so it's reasonable to mark the corresponding managed API-s with `[SupportedOSPlatform("windows10.0.2004")]`.

As discussed, I'm applying the internal variant of `SupportedOSPlatformAttribute` in all build targets for simplicity.  Note that with this solution the attribute does not contribute to the public API as it was originally suggested in the proposal #44025.

This change finishes and resolves #44025.

/cc @scalablecory @ericstj 