### PR TITLE
Redirect default install location in test to avoid using machine-wide install

### DIFF
--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -78,7 +78,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     SharedState.FrameworkReferenceApp,
                     new TestSettings()
                         .WithRuntimeConfigCustomizer(runtimeConfig)
-                        .WithEnvironment(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, SharedState.DotNetGlobalHive.BinPath),
+                        .WithEnvironment(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, SharedState.DotNetGlobalHive.BinPath)
+                        .WithEnvironment( // Redirect the default install location to an invalid location so that a machine-wide install is not used
+                            Constants.TestOnlyEnvironmentVariables.DefaultInstallPath,
+                            System.IO.Path.Combine(SharedState.DotNetMainHive.BinPath, "invalid")),
                     // Must enable multi-level lookup otherwise multiple hives are not enabled
                     multiLevelLookup: true);
             }


### PR DESCRIPTION
Test for framework resolution with multiple hives enables multi-level lookup. Explicitly set the default install path to an invalid location so that any actual machine-wide install won't be used in the test.