### PR TITLE
Fix break in send-to-helix-inner.yml

### DIFF
--- a/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
@@ -12,7 +12,7 @@ steps:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.cmd.
   - powershell: $(Build.SourcesDirectory)\eng\common\build.ps1 -ci ${{ parameters.restoreParams }}
     displayName: Restore blob feed tasks (Windows)
-    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
+    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.restoreParams, '')) }})
 
   - powershell: $(Build.SourcesDirectory)\eng\common\msbuild.ps1 -ci ${{ parameters.sendParams }}
     displayName: ${{ parameters.displayName }} (Windows)
@@ -24,7 +24,7 @@ steps:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.sh.
   - script: $(Build.SourcesDirectory)/eng/common/build.sh --ci ${{ parameters.restoreParams }}
     displayName: Restore blob feed tasks (Unix)
-    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
+    condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.restoreParams, '')) }})
     ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       env:
         # Arcade uses this SDK instead of trying to restore one.


### PR DESCRIPTION
In: https://github.com/dotnet/runtime/pull/45432 I messed up the condition because of copy pasting to get the yml right after the PR was approved to fix the build and broke the perf runs. 

cc: @DrewScoggins @trylek 