### PR TITLE
Enable Supported attributes from sdk for non browser build, fix related warnings

### DIFF
--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -22,8 +22,8 @@
     </AssemblyMetadata>
   </ItemGroup>
 
-  <!-- Adds SupportedOSPlatform attribute for Windows Specific libraries and Windows targets -->
-  <ItemGroup Condition="('$(IsWindowsSpecific)' == 'true' or '$(TargetsWindows)' == 'true') and '$(IsTestProject)' != 'true'">
+  <!-- Adds SupportedOSPlatform attribute for Windows Specific libraries -->
+  <ItemGroup Condition="'$(IsWindowsSpecific)' == 'true' and '$(IsTestProject)' != 'true'">
     <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform">
         <_Parameter1>windows</_Parameter1>
     </AssemblyAttribute>
@@ -156,12 +156,10 @@
 
   </Target>
 
-  <!-- Removes specified assembly level attributes. https://github.com/dotnet/runtime/issues/44257-->
-  <Target Name="RemoveSupportedPlatformAssemblyLevelAttribute"
-          AfterTargets="GetAssemblyAttributes">
+  <!-- Removes assembly level attributes for Browser. -->
+  <Target Name="RemoveSupportedPlatformAssemblyAttributeForBrowser" AfterTargets="GetAssemblyAttributes" Condition="'$(TargetFrameworkSuffix)' == 'Browser'">
     <ItemGroup>
       <AssemblyAttribute Remove="System.Runtime.Versioning.SupportedOSPlatformAttribute" />
-      <AssemblyAttribute Remove="System.Runtime.Versioning.TargetPlatformAttribute" />
     </ItemGroup>
   </Target>
 

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -157,9 +157,10 @@
   </Target>
 
   <!-- Removes assembly level attributes for Browser. -->
-  <Target Name="RemoveSupportedPlatformAssemblyAttributeForBrowser" AfterTargets="GetAssemblyAttributes" Condition="'$(TargetFrameworkSuffix)' == 'Browser'">
+  <Target Name="RemoveSupportedPlatformAssemblyAttributeForBrowser" AfterTargets="GetAssemblyAttributes" Condition="'$(TargetFrameworkSuffix)' == 'Browser' or '$(IsTestProject)' == 'true'">
     <ItemGroup>
       <AssemblyAttribute Remove="System.Runtime.Versioning.SupportedOSPlatformAttribute" />
+	  <AssemblyAttribute Remove="System.Runtime.Versioning.TargetPlatformAttribute" />
     </ItemGroup>
   </Target>
 

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -160,7 +160,7 @@
   <Target Name="RemoveSupportedPlatformAssemblyAttributeForBrowser" AfterTargets="GetAssemblyAttributes" Condition="'$(TargetFrameworkSuffix)' == 'Browser' or '$(IsTestProject)' == 'true'">
     <ItemGroup>
       <AssemblyAttribute Remove="System.Runtime.Versioning.SupportedOSPlatformAttribute" />
-	  <AssemblyAttribute Remove="System.Runtime.Versioning.TargetPlatformAttribute" />
+      <AssemblyAttribute Remove="System.Runtime.Versioning.TargetPlatformAttribute" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
+++ b/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <!-- 
     Microsoft ResX Schema 
     
@@ -487,5 +488,8 @@
   </data>
   <data name="DirectoryServicesProtocols_PlatformNotSupported" xml:space="preserve">
     <value>System.DirectoryServices.Protocols is not supported on this platform.</value>
+  </data>
+  <data name="QuotaControlNotSupported" xml:space="preserve">
+    <value>System.DirectoryServices.Protocols.QuotaControl is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\DirectoryServices\Protocols\common\BerConverter.Windows.cs" />
+    <Compile Include="System\DirectoryServices\Protocols\common\QuotaControl.Windows.cs" />
     <Compile Include="System\DirectoryServices\Protocols\Interop\LdapPal.Windows.cs" />
     <Compile Include="System\DirectoryServices\Protocols\Interop\BerPal.Windows.cs" />
     <Compile Include="System\DirectoryServices\Protocols\ldap\LdapConnection.Windows.cs" />
@@ -58,6 +59,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\DirectoryServices\Protocols\common\BerConverter.Linux.cs" />
+    <Compile Include="System\DirectoryServices\Protocols\common\QuotaControl.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\Interop\LdapPal.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\Interop\BerPal.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\ldap\LdapConnection.Linux.cs" />

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
@@ -1022,7 +1022,7 @@ namespace System.DirectoryServices.Protocols
     }
 
     [SupportedOSPlatform("windows")]
-    public class QuotaControl : DirectoryControl
+    public partial class QuotaControl : DirectoryControl
     {
         private byte[] _sid;
 
@@ -1031,23 +1031,6 @@ namespace System.DirectoryServices.Protocols
         public QuotaControl(SecurityIdentifier querySid) : this()
         {
             QuerySid = querySid;
-        }
-
-        public SecurityIdentifier QuerySid
-        {
-            get => _sid == null ? null : new SecurityIdentifier(_sid, 0);
-            set
-            {
-                if (value == null)
-                {
-                    _sid = null;
-                }
-                else
-                {
-                    _sid = new byte[value.BinaryLength];
-                    value.GetBinaryForm(_sid, 0);
-                }
-            }
         }
 
         public override byte[] GetValue()

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/QuotaControl.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/QuotaControl.Linux.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Principal;
+
+namespace System.DirectoryServices.Protocols
+{
+    public partial class QuotaControl : DirectoryControl
+    {
+        public SecurityIdentifier QuerySid
+        {
+            get => _sid == null ? null : throw new System.PlatformNotSupportedException(SR.QuotaControlNotSupported);
+            set
+            {
+                if (value == null)
+                {
+                    _sid = null;
+                }
+                else
+                {
+                    throw new System.PlatformNotSupportedException(SR.QuotaControlNotSupported);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/QuotaControl.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/QuotaControl.Windows.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Principal;
+
+namespace System.DirectoryServices.Protocols
+{
+    public partial class QuotaControl : DirectoryControl
+    {
+        public SecurityIdentifier QuerySid
+        {
+            get => _sid == null ? null : new SecurityIdentifier(_sid, 0);
+            set
+            {
+                if (value == null)
+                {
+                    _sid = null;
+                }
+                else
+                {
+                    _sid = new byte[value.BinaryLength];
+                    value.GetBinaryForm(_sid, 0);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to #44231 and #44257
Enabling Supported attributes from sdk for non browser builds, fix related warnings. We will enable it for browser later with different PR after separating `Unsupported on browser` files from browser build.

