### PR TITLE
Disable Long Running JSON tests on Checked CoreCLR

### DIFF
--- a/src/libraries/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonDocumentTests.cs
@@ -470,9 +470,9 @@ namespace System.Text.Json.Tests
                     new WrappedMemoryStream(canRead: true, canWrite: false, canSeek: false, data)));
         }
 
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(BadBOMCases))]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public static Task ParseJson_UnseekableStream_Async_BadBOM(string json)
         {
             byte[] data = Encoding.UTF8.GetBytes(json);

--- a/src/libraries/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonDocumentTests.cs
@@ -470,6 +470,7 @@ namespace System.Text.Json.Tests
                     new WrappedMemoryStream(canRead: true, canWrite: false, canSeek: false, data)));
         }
 
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(BadBOMCases))]
         public static Task ParseJson_UnseekableStream_Async_BadBOM(string json)

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Cache.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Cache.cs
@@ -124,8 +124,8 @@ namespace System.Text.Json.Serialization.Tests
         // this options is not the default options instance the tests will not use previously cached metadata.
         private JsonSerializerOptions s_options = new JsonSerializerOptions();
 
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public async Task MultipleTypes()
         {
             void Serialize<T>(object[] args)

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Cache.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Cache.cs
@@ -124,6 +124,7 @@ namespace System.Text.Json.Serialization.Tests
         // this options is not the default options instance the tests will not use previously cached metadata.
         private JsonSerializerOptions s_options = new JsonSerializerOptions();
 
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
         public async Task MultipleTypes()
         {

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
@@ -10,6 +10,7 @@ namespace System.Text.Json.Serialization.Tests
 {
     public abstract partial class ConstructorTests
     {
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
         public async Task ReadSimpleObjectAsync()
         {

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
@@ -10,8 +10,8 @@ namespace System.Text.Json.Serialization.Tests
 {
     public abstract partial class ConstructorTests
     {
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public async Task ReadSimpleObjectAsync()
         {
             async Task RunTestAsync<T>(byte[] testData)

--- a/src/libraries/System.Text.Json/tests/Serialization/ContinuationTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ContinuationTests.cs
@@ -178,10 +178,10 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestData), /* enumeratePayloadTweaks: */ false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42677", platforms: TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public static void ShouldWorkAtAnyPosition_Sequence(
             string json,
             int bufferSize,

--- a/src/libraries/System.Text.Json/tests/Serialization/ContinuationTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ContinuationTests.cs
@@ -178,6 +178,7 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestData), /* enumeratePayloadTweaks: */ false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42677", platforms: TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]

--- a/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
@@ -599,6 +599,7 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/39674", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         public static void DictionariesRoundTrip()

--- a/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
@@ -599,9 +599,9 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/39674", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public static void DictionariesRoundTrip()
         {
             RunAllDictionariessRoundTripTest(JsonNumberTestData.ULongs);

--- a/src/libraries/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
@@ -48,6 +48,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("null", value);
         }
 
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
         public static async Task RoundTripAsync()
         {

--- a/src/libraries/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
@@ -48,8 +48,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("null", value);
         }
 
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Fact]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public static async Task RoundTripAsync()
         {
             byte[] buffer;

--- a/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -1809,6 +1809,7 @@ namespace System.Text.Json.Tests
             }
         }
 
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [InlineData("{]")]
         [InlineData("[}")]

--- a/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -1809,7 +1809,6 @@ namespace System.Text.Json.Tests
             }
         }
 
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [InlineData("{]")]
         [InlineData("[}")]
@@ -1840,6 +1839,7 @@ namespace System.Text.Json.Tests
         [InlineData("{\"Property1\": {\"Property1.1\": 42} // comment\n,5}")]
         [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\n // comment\n5}")]
         [InlineData("{// comment\n5}")]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public static void ReadInvalidJsonStringsWithComments(string jsonString)
         {
             byte[] input = Encoding.UTF8.GetBytes(jsonString);

--- a/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -3115,12 +3115,12 @@ namespace System.Text.Json.Tests
         }
 
         // https://github.com/dotnet/runtime/issues/30746
-        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
         public void Writing3MBBase64Bytes(bool formatted, bool skipValidation)
         {
             byte[] value = new byte[3 * 1024 * 1024];

--- a/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -3115,6 +3115,7 @@ namespace System.Text.Json.Tests
         }
 
         // https://github.com/dotnet/runtime/issues/30746
+        [SkipOnCoreClr("Long running test on Checked mode", RuntimeConfiguration.Checked)]
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]


### PR DESCRIPTION
Relates to: https://github.com/dotnet/runtime/issues/45464

