### PR TITLE
Fix debugger attach+read on Linux 32 bit

### DIFF
--- a/src/coreclr/pal/src/debug/debug.cpp
+++ b/src/coreclr/pal/src/debug/debug.cpp
@@ -19,10 +19,6 @@ Revision History:
 
 --*/
 
-#ifndef HOST_64BIT
-#undef _LARGEFILE64_SOURCE
-#undef _FILE_OFFSET_BITS
-#endif
 
 #include "pal/dbgmsg.h"
 SET_DEFAULT_DEBUG_CHANNEL(DEBUG); // some headers have code with asserts, so do this first


### PR DESCRIPTION
The debug PAL was undefining of macros that cause 32 bit POSIX syscalls to use 64 bit offsets. The offsets are defined in a signed manner, which means that any address over the 2GB range that we use will result in an incoherent call to `pread` and similar APIs. This has been the case for years, but it only affected ARM32 systems as they are currently our only Unix 32 bit target. Customers started reporting issues where the debugger wouldn't attach. This happened as we changed the debugger startup path to use symbol exports in CoreCLR for our single file story, meaning that the DAC no longer used a compile time header but an export read that caused to read on the >2GB region of the process when run in a device with enough memory available.