### PR TITLE
[runtime] Avoid checking for hardened runtime on ios, its not needed, and it causes alerts because of PROT_WRITE|PROT_EXEC.

### DIFF
--- a/src/mono/mono/utils/mono-mmap.c
+++ b/src/mono/mono/utils/mono-mmap.c
@@ -289,7 +289,7 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 		return NULL;
 #endif
 
-#if defined(__APPLE__) && defined(MAP_JIT)
+#if defined(__APPLE__) && defined(MAP_JIT) && defined(TARGET_OSX)
 	if (get_darwin_version () >= DARWIN_VERSION_MOJAVE) {
 		/* Check for hardened runtime */
 		static int is_hardened_runtime;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20622,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>