### PR TITLE
Fix continue on error conditions

### DIFF
--- a/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
@@ -18,7 +18,7 @@ steps:
     displayName: ${{ parameters.displayName }} (Windows)
     condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
     env: ${{ parameters.environment }}
-    continueOnError: ${{ parameters.shouldContinueOnError }}
+    continueOnError: ${{ eq(parameters.shouldContinueOnError, true) }}
 
 - ${{ if ne(parameters.osGroup, 'windows') }}:
   # TODO: Remove and consolidate this when we move to arcade via init-tools.sh.
@@ -34,4 +34,4 @@ steps:
     displayName: ${{ parameters.displayName }} (Unix)
     condition: and(succeeded(), ${{ and(ne(parameters.condition, false), ne(parameters.sendParams, '')) }})
     env: ${{ parameters.environment }}
-    continueOnError: ${{ parameters.shouldContinueOnError }}
+    continueOnError: ${{ eq(parameters.shouldContinueOnError, true) }}

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -378,13 +378,13 @@ jobs:
   - ${{ if ne(parameters.osGroup, 'OSX') }}:
     - script: $(BaseJobBuildCommand)
       displayName: Build
-      continueOnError: ${{ and(eq(variables.SkipTests, false), parameters.shouldContinueOnError) }}
+      continueOnError: ${{ and(eq(variables.SkipTests, false), eq(parameters.shouldContinueOnError, true)) }}
 
   # Build corehost, sign and add entitlements to MacOS binaries
   - ${{ if eq(parameters.osGroup, 'OSX') }}:
     - script: $(BaseJobBuildCommand) -subset host.native
       displayName: Build CoreHost
-      continueOnError: ${{ and(eq(variables.SkipTests, false), parameters.shouldContinueOnError) }}
+      continueOnError: ${{ and(eq(variables.SkipTests, false), eq(parameters.shouldContinueOnError, true)) }}
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
@@ -399,7 +399,7 @@ jobs:
 
     - script: $(BaseJobBuildCommand) -subset host.pkg+host.tools+packs
       displayName: Build and Package
-      continueOnError: ${{ and(eq(variables.SkipTests, false), parameters.shouldContinueOnError) }}
+      continueOnError: ${{ and(eq(variables.SkipTests, false), eq(parameters.shouldContinueOnError, true)) }}
 
   - ${{ if in(parameters.osGroup, 'OSX', 'iOS','tvOS') }}: 
     - script: |

--- a/eng/pipelines/libraries/helix.yml
+++ b/eng/pipelines/libraries/helix.yml
@@ -31,7 +31,7 @@ steps:
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix
     condition: and(succeeded(), ${{ parameters.condition }})
-    continueOnError: ${{ parameters.shouldContinueOnError }}
+    continueOnError: ${{ eq(parameters.shouldContinueOnError, true) }}
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
       HelixTargetQueues: ${{ join('+', parameters.helixQueues) }} # Pass queues to MSBuild as env var to avoid need of escaping them


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/45515
Installer builds are happening to be continuing on error, that means that PR builds are always green even if tests failed. This is fallout from adding the staging pipeline.

The reason why they are evaluating to true, is because the `parameter.shouldContinueOnError` is evaluating to a string (`'False'`) so in boolean conditions like `and` a string evaluates to true always. This is how the YAML evaluation looked like:

```
Evaluating: and(eq(variables['SkipTests'], False), parameters['shouldContinueOnError'])
Expanded: and(eq('False', False), 'False')
Result: True
```

I'm updating to use an `eq` to make sure it equals true. We can compare against a bool, since on `eq` expression the right parameter is casted to the left parameter type. 

cc: @dotnet/runtime-infrastructure 