### PR TITLE
Share SingleFileTest publishing between test classes

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
@@ -13,8 +13,7 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    [Collection(nameof(SingleFileSharedCollection))]
-    public class NetCoreApp3CompatModeTests : BundleTestBase
+    public class NetCoreApp3CompatModeTests : BundleTestBase, IClassFixture<SingleFileSharedState>
     {
         private SingleFileSharedState sharedTestState;
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
@@ -13,11 +13,12 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class NetCoreApp3CompatModeTests : BundleTestBase, IClassFixture<NetCoreApp3CompatModeTests.SharedTestState>
+    [Collection(nameof(SingleFileSharedCollection))]
+    public class NetCoreApp3CompatModeTests : BundleTestBase
     {
-        private SharedTestState sharedTestState;
+        private SingleFileSharedState sharedTestState;
 
-        public NetCoreApp3CompatModeTests(SharedTestState fixture)
+        public NetCoreApp3CompatModeTests(SingleFileSharedState fixture)
         {
             sharedTestState = fixture;
         }
@@ -25,7 +26,7 @@ namespace AppHost.Bundle.Tests
         [Fact]
         public void Bundle_Is_Extracted()
         {
-            var fixture = sharedTestState.SingleFileTestFixture.Copy();
+            var fixture = sharedTestState.TestFixture.Copy();
             UseSingleFileSelfContainedHost(fixture);
             Bundler bundler = BundleHelper.BundleApp(fixture, out string singleFile, BundleOptions.BundleAllContent);
             var extractionBaseDir = BundleHelper.GetExtractionRootDir(fixture);
@@ -51,21 +52,6 @@ namespace AppHost.Bundle.Tests
                 .Except(bundleFiles)
                 .ToArray();
             extractionDir.Should().HaveFiles(publishedFiles);
-        }
-
-        public class SharedTestState : SharedTestStateBase, IDisposable
-        {
-            public TestProjectFixture SingleFileTestFixture { get; set; }
-
-            public SharedTestState()
-            {
-                SingleFileTestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests");
-            }
-
-            public void Dispose()
-            {
-                SingleFileTestFixture.Dispose();
-            }
         }
     }
 }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -8,8 +8,7 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    [Collection(nameof(SingleFileSharedCollection))]
-    public class SingleFileApiTests : BundleTestBase
+    public class SingleFileApiTests : BundleTestBase, IClassFixture<SingleFileSharedState>
     {
         private SingleFileSharedState sharedTestState;
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -8,11 +8,12 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class SingleFileApiTests : BundleTestBase, IClassFixture<SingleFileApiTests.SharedTestState>
+    [Collection(nameof(SingleFileSharedCollection))]
+    public class SingleFileApiTests : BundleTestBase
     {
-        private SharedTestState sharedTestState;
+        private SingleFileSharedState sharedTestState;
 
-        public SingleFileApiTests(SharedTestState fixture)
+        public SingleFileApiTests(SingleFileSharedState fixture)
         {
             sharedTestState = fixture;
         }
@@ -119,24 +120,6 @@ namespace AppHost.Bundle.Tests
                 .Should().Pass()
                 .And.HaveStdOutContaining(extractionDir)
                 .And.HaveStdOutContaining(bundleDir);
-        }
-
-        public class SharedTestState : SharedTestStateBase, IDisposable
-        {
-            public TestProjectFixture TestFixture { get; set; }
-
-            public SharedTestState()
-            {
-                // We include mockcoreclr in our project to test native binaries extraction.
-                string mockCoreClrPath = Path.Combine(RepoDirectories.Artifacts, "corehost_test",
-                    RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr"));
-                TestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests", $"/p:AddFile={mockCoreClrPath}");
-            }
-
-            public void Dispose()
-            {
-                TestFixture.Dispose();
-            }
         }
     }
 }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.CoreSetup.Test;
+using Xunit;
+using static AppHost.Bundle.Tests.BundleTestBase;
+
+namespace AppHost.Bundle.Tests
+{
+    public class SingleFileSharedState : SharedTestStateBase, IDisposable
+    {
+        public TestProjectFixture TestFixture { get; set; }
+
+        public SingleFileSharedState()
+        {
+            // We include mockcoreclr in our project to test native binaries extraction.
+            string mockCoreClrPath = Path.Combine(RepoDirectories.Artifacts, "corehost_test",
+                RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr"));
+            TestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests", $"/p:AddFile={mockCoreClrPath}");
+        }
+
+        public void Dispose()
+        {
+            TestFixture.Dispose();
+        }
+    }
+
+    [CollectionDefinition(nameof(SingleFileSharedCollection))]
+    public class SingleFileSharedCollection : ICollectionFixture<SingleFileSharedState>
+    {
+
+    }
+}

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
@@ -26,10 +26,4 @@ namespace AppHost.Bundle.Tests
             TestFixture.Dispose();
         }
     }
-
-    [CollectionDefinition(nameof(SingleFileSharedCollection))]
-    public class SingleFileSharedCollection : ICollectionFixture<SingleFileSharedState>
-    {
-
-    }
 }

--- a/src/installer/tests/TestUtils/TestArtifact.cs
+++ b/src/installer/tests/TestUtils/TestArtifact.cs
@@ -67,7 +67,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     Debug.Assert(!Directory.Exists(Location));
                     var lockPath = Directory.GetParent(Location) + ".lock";
                     File.Delete(lockPath);
-                } catch {}
+                } catch (Exception e)
+                {
+                    Console.WriteLine("delete failed" + e);
+                }
             }
 
             foreach (TestArtifact copy in _copies)


### PR DESCRIPTION
Tests in the AppHost.Bundle.Tests assembly seem to randomly fail due to a race condition
with the file system. They try to create separate '0','1','2'... subdirectories to isolate
the published files for each test, but I think what's happening is that files may be
marked for deletion, but then not deleted until a later write. For instance, files in
'2' may be marked for deletion and some may fail a File.Exists check, which leads to
'2' being recreated, at which point deletion may occur, which will cause the current test
to fail due to a concurrent write operation.

This change tries to simplify the system by sharing the test state across all the classes
in the assembly, instead of per-class, and then cleaning up only when all of them are
finished executing.

Fixes #43316