### PR TITLE
Remove FEATURE_COMPILED_XSL define

### DIFF
--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -3393,9 +3393,6 @@
   <data name="DirectoryAccessDenied" xml:space="preserve">
     <value>Access to directory {0} is denied.  The process under which XmlSerializer is running does not have sufficient permission to access the directory.</value>
   </data>
-  <data name="Xslt_NotSupported" xml:space="preserve">
-    <value>Compilation of XSLT is not supported on this platform.</value>
-  </data>
   <data name="ErrLoadAssembly" xml:space="preserve">
     <value>File or assembly name '{0}', or one of its dependencies, was not found.</value>
   </data>

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <RootNamespace>System.Xml</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
@@ -2,25 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
-using System;
-using System.IO;
-using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Schema;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
-using System.Text;
 using System.Globalization;
 using System.Reflection;
-using System.Reflection.Emit;
-using System.Xml.Xsl.Qil;
-#if FEATURE_COMPILED_XSL
+using System.Xml.Schema;
+using System.Xml.XPath;
 using System.Xml.Xsl.IlGen;
-#endif
-using System.ComponentModel;
 using MS.Internal.Xml.XPath;
-using System.Runtime.Versioning;
 
 namespace System.Xml.Xsl.Runtime
 {
@@ -494,10 +485,9 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         internal object ChangeTypeXsltArgument(XmlQueryType xmlType, object value, Type destinationType)
         {
-#if FEATURE_COMPILED_XSL
             Debug.Assert(XmlILTypeHelper.GetStorageType(xmlType).IsAssignableFrom(value.GetType()),
                          "Values passed to ChangeTypeXsltArgument should be in ILGen's default Clr representation.");
-#endif
+
             Debug.Assert(destinationType == XsltConvert.ObjectType || !destinationType.IsAssignableFrom(value.GetType()),
                          "No need to call ChangeTypeXsltArgument since value is already assignable to destinationType " + destinationType);
 
@@ -695,9 +685,8 @@ namespace System.Xml.Xsl.Runtime
                     }
             }
 
-#if FEATURE_COMPILED_XSL
             Debug.Assert(XmlILTypeHelper.GetStorageType(xmlType).IsAssignableFrom(value.GetType()), "Xml type " + xmlType + " is not represented in ILGen as " + value.GetType().Name);
-#endif
+
             return value;
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
@@ -5,10 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
-#if FEATURE_COMPILED_XSL
 using System.Xml.Xsl.IlGen;
-#endif
 using System.Xml.Xsl.Qil;
 
 namespace System.Xml.Xsl.Runtime
@@ -35,7 +32,6 @@ namespace System.Xml.Xsl.Runtime
         private readonly string[] _globalNames;
         private readonly EarlyBoundInfo[] _earlyBound;
 
-#if FEATURE_COMPILED_XSL
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -70,7 +66,6 @@ namespace System.Xml.Xsl.Runtime
             _earlyBound = copy._earlyBound;
 #endif
         }
-#endif
 
         /// <summary>
         /// Deserialize XmlQueryStaticData object from a byte array.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Compiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Compiler.cs
@@ -6,16 +6,9 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Xml.XPath;
 using System.Xml.Xsl.Qil;
-using System.Xml.Xsl.XPath;
-using System.Runtime.Versioning;
 
 namespace System.Xml.Xsl.Xslt
 {
-    using TypeFactory = XmlQueryTypeFactory;
-#if DEBUG && FEATURE_COMPILED_XSL
-    using XmlILTrace = System.Xml.Xsl.IlGen.XmlILTrace;
-#endif
-
     internal enum XslVersion
     {
         Version10 = 0,

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Scripts.cs
@@ -5,20 +5,7 @@
 //------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Configuration;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
-using System.Threading;
-#if FEATURE_COMPILED_XSL
-using System.Xml.Xsl.IlGen;
-#endif
 using System.Xml.Xsl.Runtime;
-using System.Runtime.Versioning;
 
 namespace System.Xml.Xsl.Xslt
 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -40,10 +40,8 @@ namespace System.Xml.Xsl
 
     public sealed class XslCompiledTransform
     {
-#if FEATURE_COMPILED_XSL
         // Version for GeneratedCodeAttribute
         private static readonly Version? s_version = typeof(XslCompiledTransform).Assembly.GetName().Version;
-#endif
 
         // Options of compilation
         private readonly bool _enableDebug;
@@ -53,10 +51,8 @@ namespace System.Xml.Xsl
         private XmlWriterSettings? _outputSettings;
         private QilExpression? _qil;
 
-#if FEATURE_COMPILED_XSL
         // Executable command for the compiled stylesheet
         private XmlILCommand? _command;
-#endif
 
         public XslCompiledTransform() { }
 
@@ -73,9 +69,7 @@ namespace System.Xml.Xsl
             _compilerErrorColl = null;
             _outputSettings = null;
             _qil = null;
-#if FEATURE_COMPILED_XSL
             _command = null;
-#endif
         }
 
         /// <summary>
@@ -192,13 +186,9 @@ namespace System.Xml.Xsl
 
         private void CompileQilToMsil(XsltSettings settings)
         {
-#if FEATURE_COMPILED_XSL
             _command = new XmlILGenerator().Generate(_qil!, /*typeBuilder:*/null)!;
             _outputSettings = _command.StaticData.DefaultWriterSettings;
             _qil = null;
-#else
-            throw new PlatformNotSupportedException(SR.Xslt_NotSupported);
-#endif
         }
 
         //------------------------------------------------
@@ -207,7 +197,6 @@ namespace System.Xml.Xsl
 
         public void Load(Type compiledStylesheet)
         {
-#if FEATURE_COMPILED_XSL
             Reset();
             if (compiledStylesheet == null)
                 throw new ArgumentNullException(nameof(compiledStylesheet));
@@ -247,14 +236,10 @@ namespace System.Xml.Xsl
             // Throw an exception if the command was not loaded
             if (_command == null)
                 throw new ArgumentException(SR.Format(SR.Xslt_NotCompiledStylesheet, compiledStylesheet.FullName), nameof(compiledStylesheet));
-#else
-            throw new PlatformNotSupportedException(SR.Xslt_NotSupported);
-#endif
         }
 
         public void Load(MethodInfo executeMethod, byte[] queryData, Type[]? earlyBoundTypes)
         {
-#if FEATURE_COMPILED_XSL
             Reset();
 
             if (executeMethod == null)
@@ -268,9 +253,6 @@ namespace System.Xml.Xsl
             Delegate delExec = (dm != null) ? dm.CreateDelegate(typeof(ExecuteDelegate)) : executeMethod.CreateDelegate(typeof(ExecuteDelegate));
             _command = new XmlILCommand((ExecuteDelegate)delExec, new XmlQueryStaticData(queryData, earlyBoundTypes));
             _outputSettings = _command.StaticData.DefaultWriterSettings;
-#else
-            throw new PlatformNotSupportedException(SR.Xslt_NotSupported);
-#endif
         }
 
         //------------------------------------------------
@@ -417,26 +399,18 @@ namespace System.Xml.Xsl
         // It's OK to suppress the SxS warning.
         public void Transform(XmlReader input, XsltArgumentList? arguments, XmlWriter results, XmlResolver? documentResolver)
         {
-#if FEATURE_COMPILED_XSL
             CheckArguments(input, results);
             CheckCommand();
             _command.Execute((object)input, documentResolver, arguments, results);
-#else
-            throw new PlatformNotSupportedException(SR.Xslt_NotSupported);
-#endif
         }
 
         // SxS: This method does not take any resource name and does not expose any resources to the caller.
         // It's OK to suppress the SxS warning.
         public void Transform(IXPathNavigable input, XsltArgumentList? arguments, XmlWriter results, XmlResolver? documentResolver)
         {
-#if FEATURE_COMPILED_XSL
             CheckArguments(input, results);
             CheckCommand();
             _command.Execute((object)input.CreateNavigator()!, documentResolver, arguments, results);
-#else
-            throw new PlatformNotSupportedException(SR.Xslt_NotSupported);
-#endif
         }
 
         //------------------------------------------------
@@ -464,14 +438,10 @@ namespace System.Xml.Xsl
         [MemberNotNull(nameof(_command))]
         private void CheckCommand()
         {
-#if FEATURE_COMPILED_XSL
             if (_command == null)
             {
                 throw new InvalidOperationException(SR.Xslt_NoStylesheetLoaded);
             }
-#else
-            throw new InvalidOperationException(SR.Xslt_NoStylesheetLoaded);
-#endif
         }
 
         private static XmlResolver CreateDefaultResolver()
@@ -503,12 +473,10 @@ namespace System.Xml.Xsl
             CompileQilToMsil(settings);
         }
 
-#if FEATURE_COMPILED_XSL
         private void Transform(string inputUri, XsltArgumentList? arguments, XmlWriter results, XmlResolver documentResolver)
         {
             _command!.Execute(inputUri, documentResolver, arguments, results);
         }
-#endif
     }
 #endif // ! HIDE_XSL
 }


### PR DESCRIPTION
This is always defined, so there is no need in this define. In the past, it was not defined for UAP builds.