### PR TITLE
Don't emit type fixups for primitive types in Crossgen2

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1684,8 +1684,11 @@ namespace Internal.JitInterface
 
         private void classMustBeLoadedBeforeCodeIsRun(TypeDesc type)
         {
-            ISymbolNode node = _compilation.SymbolNodeFactory.CreateReadyToRunHelper(ReadyToRunHelperId.TypeHandle, type);
-            _methodCodeNode.Fixups.Add(node);
+            if (!type.IsPrimitive)
+            {
+                ISymbolNode node = _compilation.SymbolNodeFactory.CreateReadyToRunHelper(ReadyToRunHelperId.TypeHandle, type);
+                _methodCodeNode.Fixups.Add(node);
+            }
         }
 
         private static bool MethodSignatureIsUnstable(MethodSignature methodSig, out string unstableMessage)


### PR DESCRIPTION
We were emitting fixups for primitive types like bool, void, etc. These
are not necessary as all of these types are always loaded and so it was
just a waste of R2R file space.

This change blocks generating fixups for those.

Close #45509