### PR TITLE
Upgrade StyleCopAnalyzers to v1.2.0-beta.261

### DIFF
--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -316,6 +316,7 @@
     <Rule Id="SA1137" Action="None" />          <!-- Elements should have the same indentation -->
     <Rule Id="SA1139" Action="None" />          <!-- Use literal suffix notation instead of casting -->
     <Rule Id="SA1141" Action="Warning" />       <!-- Use tuple syntax -->
+    <Rule Id="SA1142" Action="None" />          <!-- Refer to tuple elements by name -->
     <Rule Id="SA1200" Action="None" />          <!-- Using directive should appear within a namespace declaration -->
     <Rule Id="SA1201" Action="None" />          <!-- Elements should appear in the correct order -->
     <Rule Id="SA1202" Action="None" />          <!-- Elements should be ordered by access -->

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -316,7 +316,7 @@
     <Rule Id="SA1137" Action="None" />          <!-- Elements should have the same indentation -->
     <Rule Id="SA1139" Action="None" />          <!-- Use literal suffix notation instead of casting -->
     <Rule Id="SA1141" Action="Warning" />       <!-- Use tuple syntax -->
-    <Rule Id="SA1142" Action="None" />          <!-- Refer to tuple elements by name -->
+    <Rule Id="SA1142" Action="Warning" />       <!-- Refer to tuple elements by name -->
     <Rule Id="SA1200" Action="None" />          <!-- Using directive should appear within a namespace declaration -->
     <Rule Id="SA1201" Action="None" />          <!-- Elements should appear in the correct order -->
     <Rule Id="SA1202" Action="None" />          <!-- Elements should be ordered by access -->

--- a/eng/CodeAnalysis.test.ruleset
+++ b/eng/CodeAnalysis.test.ruleset
@@ -315,6 +315,7 @@
     <Rule Id="SA1137" Action="None" />          <!-- Elements should have the same indentation -->
     <Rule Id="SA1139" Action="None" />          <!-- Use literal suffix notation instead of casting -->
     <Rule Id="SA1141" Action="None" />          <!-- Use tuple syntax -->
+    <Rule Id="SA1142" Action="None" />          <!-- Refer to tuple elements by name -->
     <Rule Id="SA1200" Action="None" />          <!-- Using directive should appear within a namespace declaration -->
     <Rule Id="SA1201" Action="None" />          <!-- Elements should appear in the correct order -->
     <Rule Id="SA1202" Action="None" />          <!-- Elements should be ordered by access -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <!-- CoreClr dependencies -->
     <MicrosoftNETCoreILAsmVersion>5.0.0-preview.8.20359.4</MicrosoftNETCoreILAsmVersion>
     <!-- Libraries dependencies -->
-    <StyleCopAnalyzersVersion>1.2.0-beta.205</StyleCopAnalyzersVersion>
+    <StyleCopAnalyzersVersion>1.2.0-beta.261</StyleCopAnalyzersVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsVersion>4.3.0</SystemCollectionsVersion>
     <SystemCollectionsConcurrentVersion>4.3.0</SystemCollectionsConcurrentVersion>


### PR DESCRIPTION
This release has some changes to support C# 9.0.

For example, SA1000 (which is currently enabled) was updated to support target-typed new expressions.

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/tag/1.2.0-beta.261