### PR TITLE
use pack on csproj to build the packages

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/pkg/Microsoft.Extensions.HostFactoryResolver.Sources.pkgproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/pkg/Microsoft.Extensions.HostFactoryResolver.Sources.pkgproj
@@ -5,7 +5,7 @@
     <IsSourcePackage>true</IsSourcePackage>
   </PropertyGroup>
   <ItemGroup>
-    <SourcePackageFiles Include="..\src\*.*" PackagePath="contentFiles/cs/netstandard1.0/%(FileName)%(Extension)"  />
+    <SourcePackageFiles Include="..\src\*.cs" PackagePath="contentFiles/cs/netstandard1.0/%(FileName)%(Extension)"  />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <!-- Avoid trying to binplace non existent documentation file.-->
+    <EnableBinPlacing>false</EnableBinPlacing>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets">
+  <!-- These are wrapper project files for packaging.-->
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <!-- Avoid trying to binplace non existent documentation file.-->

--- a/src/libraries/System.Composition/src/System.Composition.csproj
+++ b/src/libraries/System.Composition/src/System.Composition.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets">
+  <!-- These are wrapper project files for packaging.-->
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/src/libraries/System.Composition/src/System.Composition.csproj
+++ b/src/libraries/System.Composition/src/System.Composition.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -1,4 +1,4 @@
-<Project>
+<Project  DefaultTargets="Pack">
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.props" />
 
   <PropertyGroup>
@@ -16,8 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.csproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.ilproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.*sproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
   </ItemGroup>
 
@@ -85,8 +84,5 @@
   </Target>
 
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />
-
-  <!-- Build is a no-op and should just invoke Pack. -->
-  <Target Name="Build" DependsOnTargets="Pack" />
 
 </Project>

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.*proj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" Exclude="$(MSBuildThisFileDirectory)*\src\**\*.shproj"/>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\*.*proj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" Exclude="$(MSBuildThisFileDirectory)*\src\**\*.shproj"/>
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
   </ItemGroup>
 

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -16,7 +16,8 @@
 
   <ItemGroup>
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" />
-    <PkgProjectsPath Include="$(MSBuildThisFileDirectory)*\pkg\**\*.pkgproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.csproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.ilproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
   </ItemGroup>
 
@@ -85,18 +86,7 @@
 
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />
 
-  <PropertyGroup>
-    <PackDependsOn>$(PackDependsOn);GetCsprojWithPkg</PackDependsOn>
-  </PropertyGroup>
-
   <!-- Build is a no-op and should just invoke Pack. -->
   <Target Name="Build" DependsOnTargets="Pack" />
-
-  <Target Name="GetCsprojWithPkg">
-    <ItemGroup>
-      <ProjectReference Include="%(PkgProjectsPath.Identity)\..\..\src\*.csproj"/>
-      <ProjectReference Include="%(PkgProjectsPath.Identity)\..\..\src\*.ilproj"/>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -1,5 +1,4 @@
-<Project  DefaultTargets="Pack">
-  <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.props" />
+<Project Sdk="Microsoft.Build.Traversal" DefaultTargets="Pack">
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
@@ -16,7 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.*sproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.*proj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'"/>
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
   </ItemGroup>
 
@@ -82,7 +81,5 @@
 
     <Message Condition="'@(_PackageReports)' != '' and Exists('$(ArtifactsDir)packages')" Importance="High" Text="##vso[task.setvariable variable=_librariesBuildProducedPackages]true" />
   </Target>
-
-  <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />
 
 </Project>

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.*proj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'"/>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\**\*.*proj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" Exclude="$(MSBuildThisFileDirectory)*\src\**\*.shproj"/>
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
   </ItemGroup>
 

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\**\*.pkgproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
+    <PkgProjectsPath Include="$(MSBuildThisFileDirectory)*\pkg\**\*.pkgproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
   </ItemGroup>
 
@@ -85,6 +85,18 @@
 
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.targets" />
 
-  <!-- Pack is a no-op and should just invoke build. -->
-  <Target Name="Pack" DependsOnTargets="Build" />
+  <PropertyGroup>
+    <PackDependsOn>$(PackDependsOn);GetCsprojWithPkg</PackDependsOn>
+  </PropertyGroup>
+
+  <!-- Build is a no-op and should just invoke Pack. -->
+  <Target Name="Build" DependsOnTargets="Pack" />
+
+  <Target Name="GetCsprojWithPkg">
+    <ItemGroup>
+      <ProjectReference Include="%(PkgProjectsPath.Identity)\..\..\src\*.csproj"/>
+      <ProjectReference Include="%(PkgProjectsPath.Identity)\..\..\src\*.ilproj"/>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/libraries/pkg/dir.traversal.targets
+++ b/src/libraries/pkg/dir.traversal.targets
@@ -25,6 +25,9 @@
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
 
+  <!-- Pack is a no-op and should just invoke build. -->
+  <Target Name="Pack" DependsOnTargets="Build" />
+
   <PropertyGroup>
     <TraversalBuildDependsOn>BuildAllProjects;$(TraversalBuildDependsOn);</TraversalBuildDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
Currently we build the packages by running the build task on all the pkgprojs.
This change helps us to build packages by running the pack task on the src csprojs. 
The purpose of doing this is to be able to onboard the new packaging system (running pack task on csprojs to build the packages) for individual packages rather than for all the packages
