### PR TITLE
Make BinderEventListener not listen to TplEventSource

### DIFF
--- a/src/tests/Loader/binding/tracing/BinderEventListener.cs
+++ b/src/tests/Loader/binding/tracing/BinderEventListener.cs
@@ -158,7 +158,6 @@ namespace BinderTracingTests
 
     internal sealed class BinderEventListener : EventListener
     {
-        private const EventKeywords TasksFlowActivityIds = (EventKeywords)0x80;
         private const EventKeywords AssemblyLoaderKeyword = (EventKeywords)0x4;
 
         private readonly object eventsLock = new object();

--- a/src/tests/Loader/binding/tracing/BinderEventListener.cs
+++ b/src/tests/Loader/binding/tracing/BinderEventListener.cs
@@ -209,10 +209,6 @@ namespace BinderTracingTests
             {
                 EnableEvents(eventSource, EventLevel.Verbose, AssemblyLoaderKeyword);
             }
-            else if (eventSource.Name == "System.Threading.Tasks.TplEventSource")
-            {
-                EnableEvents(eventSource, EventLevel.Verbose, TasksFlowActivityIds);
-            }
         }
 
         protected override void OnEventWritten(EventWrittenEventArgs data)


### PR DESCRIPTION
Fix #37132. 
Fix #45088 

Note: there is an actual product issue here that is related to a deadlock that can occur from using EventListeners to listen to TplEventSource. I will file a separate issue to track the EventListener deadlock bug.

In the meantime, this changes BinderEventListener to not listen for TplEventSource which shouldn't be necessary for these tests (the EventListener doesn't check any payload from TplEventSource). 