### PR TITLE
SuperPMI collection pipeline: fix location of JIT-EE version GUID

### DIFF
--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -1,9 +1,7 @@
 # This job definition automates the SuperPMI collection process.
 
 # Trigger this job if the JIT-EE GUID changes, which invalidates previous SuperPMI
-# collections. As a proxy for determining if the JIT-EE GUID has changed, we just
-# trigger if the file containing the GUID definition changes, which almost always
-# corresponds to the GUID itself changing.
+# collections.
 trigger:
   batch: true
   branches:
@@ -11,7 +9,7 @@ trigger:
     - master
   paths:
     include:
-    - src/coreclr/src/inc/corinfo.h
+    - src/coreclr/src/inc/jiteeversionguid.h
 
 pr: none
 


### PR DESCRIPTION
With #45044 it moved from corinfo.h to jiteeversionguid.h