### PR TITLE
Slight cleanup of host test RepoDirectoriesProvider helper

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DotnetTestXunit.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetTestXunit.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             using (var portableTestAppFixture = new TestProjectFixture("PortableTestApp", RepoDirectories))
             {
                 portableTestAppFixture
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 ActivateDotnetTestXunitOnTestProject(RepoDirectories, portableTestAppFixture);
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             using (var standaloneTestAppFixture = new TestProjectFixture("StandaloneTestApp", RepoDirectories))
             {
                 standaloneTestAppFixture
-                    .EnsureRestoredForRid(standaloneTestAppFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(standaloneTestAppFixture.CurrentRid)
                     .BuildProject(runtime: standaloneTestAppFixture.CurrentRid);
 
                 ActivateDotnetTestXunitOnTestProject(RepoDirectories, standaloneTestAppFixture);

--- a/src/installer/tests/HostActivation.Tests/HostVersionCompatibility.cs
+++ b/src/installer/tests/HostActivation.Tests/HostVersionCompatibility.cs
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 var fixtureLatest = new TestProjectFixture("StandaloneApp", RepoDirectories);
                 fixtureLatest
-                    .EnsureRestoredForRid(fixtureLatest.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(fixtureLatest.CurrentRid)
                     .PublishProject(runtime: fixtureLatest.CurrentRid);
 
                 FixtureLatest = fixtureLatest;
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 if (IsRidSupported())
                 {
                     publishFixture
-                        .EnsureRestoredForRid(publishFixture.CurrentRid, repoDirectories.CorehostPackages)
+                        .EnsureRestoredForRid(publishFixture.CurrentRid)
                         .PublishProject(runtime: publishFixture.CurrentRid);
                 }
 

--- a/src/installer/tests/HostActivation.Tests/LightupAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/LightupAppActivation.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             var repoDirectories = new RepoDirectoriesProvider(builtDotnet: _currentWorkingDir);
             GlobalLightupClientFixture = new TestProjectFixture("LightupClient", repoDirectories)
-                .EnsureRestored(sharedTestState.RepoDirectories.CorehostPackages)
+                .EnsureRestored()
                 .BuildProject();
 
             string greatestVersionSharedFxPath = sharedTestState.LightupLibFixture_Built.BuiltDotnet.GreatestVersionSharedFxPath;
@@ -558,15 +558,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 RepoDirectories = new RepoDirectoriesProvider();
 
                 LightupLibFixture_Built = new TestProjectFixture("LightupLib", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 LightupLibFixture_Published = new TestProjectFixture("LightupLib", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 LightupClientFixture = new TestProjectFixture("LightupClient", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
             }
 

--- a/src/installer/tests/HostActivation.Tests/MultilevelSharedFxLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSharedFxLookup.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             // Restore and build SharedFxLookupPortableApp from exe dir
             SharedFxLookupPortableAppFixture = new TestProjectFixture("SharedFxLookupPortableApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
+                .EnsureRestored()
                 .BuildProject();
             var fixture = SharedFxLookupPortableAppFixture;
 

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -269,15 +269,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 RepoDirectories = new RepoDirectoriesProvider();
 
                 HostApiInvokerAppFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 PortableAppFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 PortableAppWithExceptionFixture = new TestProjectFixture("PortableAppWithException", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
@@ -72,11 +72,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
 
                 PortableAppFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 PortableAppWithExceptionFixture = new TestProjectFixture("PortableAppWithException", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
             }
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 }
 
                 ComLibraryFixture = new TestProjectFixture("ComLibrary", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 // Create a .clsidmap from the assembly
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     ComLibraryFixture.TestProject.BuiltApp.Location,
                     $"{ ComLibraryFixture.TestProject.AssemblyName }.comhost.dll");
                 ComHost.Create(
-                    Path.Combine(RepoDirectories.CorehostPackages, "comhost.dll"),
+                    Path.Combine(RepoDirectories.HostArtifacts, "comhost.dll"),
                     ComHostPath,
                     clsidMapPath);
             }

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
@@ -231,13 +231,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
 
                 ApplicationFixture = new TestProjectFixture("AppWithCustomEntryPoints", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject(selfContained: false);
                 ComponentWithNoDependenciesFixture = new TestProjectFixture("ComponentWithNoDependencies", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 SelfContainedApplicationFixture = new TestProjectFixture("AppWithCustomEntryPoints", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject(selfContained: true);
                 ComponentTypeName = $"Component.Component, {ComponentWithNoDependenciesFixture.TestProject.AssemblyName}";
                 FunctionPointerTypeName = $"AppWithCustomEntryPoints.Program, {ApplicationFixture.TestProject.AssemblyName}";

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
@@ -248,13 +248,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
 
                 ApplicationFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 ComponentWithNoDependenciesFixture = new TestProjectFixture("ComponentWithNoDependencies", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 SelfContainedApplicationFixture = new TestProjectFixture("StandaloneApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject(selfContained: true);
                 ComponentTypeName = $"Component.Component, {ComponentWithNoDependenciesFixture.TestProject.AssemblyName}";
             }

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -263,7 +263,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             // This is to make sure that we're using the unmodified product binary. If some previous test
             // enabled test-only product behavior on the binary and didn't correctly cleanup, this test would fail.
             File.Copy(
-                Path.Combine(sharedState.RepoDirectories.CorehostPackages, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("nethost")),
+                Path.Combine(sharedState.RepoDirectories.HostArtifacts, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("nethost")),
                 sharedState.NethostPath,
                 overwrite: true);
 
@@ -302,7 +302,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 string productDir = Path.Combine(BaseDirectory, "product");
                 Directory.CreateDirectory(productDir);
                 ProductHostFxrPath = Path.Combine(productDir, HostFxrName);
-                File.Copy(Path.Combine(RepoDirectories.CorehostPackages, HostFxrName), ProductHostFxrPath);
+                File.Copy(Path.Combine(RepoDirectories.HostArtifacts, HostFxrName), ProductHostFxrPath);
             }
 
             private string CreateHostFxr(string destinationDirectory)

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             string nethostName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("nethost");
             NethostPath = Path.Combine(Path.GetDirectoryName(NativeHostPath), nethostName);
             File.Copy(
-                Path.Combine(RepoDirectories.CorehostPackages, nethostName),
+                Path.Combine(RepoDirectories.HostArtifacts, nethostName),
                 NethostPath);
         }
 

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -708,11 +708,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 BuiltDotNet = new DotNetCli(RepoDirectories.BuiltDotnet);
 
                 PortableAppFixture_Built = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 PortableAppFixture_Published = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 MockApp = new TestApp(SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "portableAppActivation")), "App");

--- a/src/installer/tests/HostActivation.Tests/ResourceLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/ResourceLookup.cs
@@ -74,11 +74,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 RepoDirectories = new RepoDirectoriesProvider();
 
                 ResourceLookupFixture_Built = new TestProjectFixture("ResourceLookup", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 ResourceLookupFixture_Published = new TestProjectFixture("ResourceLookup", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
             }
 

--- a/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
+++ b/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 RepoDirectories = new RepoDirectoriesProvider(builtDotnet: copiedDotnet);
 
                 RuntimePropertiesFixture = new TestProjectFixture("RuntimeProperties", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 RuntimeConfig.FromFile(RuntimePropertiesFixture.TestProject.RuntimeConfigJson)

--- a/src/installer/tests/HostActivation.Tests/SharedFxLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SharedFxLookup.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             // Restore and build SharedFxLookupPortableApp from exe dir
             SharedFxLookupPortableAppFixture = new TestProjectFixture("SharedFxLookupPortableApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
+                .EnsureRestored()
                 .BuildProject();
             var fixture = SharedFxLookupPortableAppFixture;
 

--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -311,12 +311,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 var buildFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
                 buildFixture
-                    .EnsureRestoredForRid(buildFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(buildFixture.CurrentRid)
                     .BuildProject(runtime: buildFixture.CurrentRid);
 
                 var publishFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
                 publishFixture
-                    .EnsureRestoredForRid(publishFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(publishFixture.CurrentRid)
                     .PublishProject(runtime: publishFixture.CurrentRid);
 
                 ReplaceTestProjectOutputHostInTestProjectFixture(buildFixture);

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -703,60 +703,60 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Entry point projects
                 PortableAppFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 PortableAppWithExceptionFixture = new TestProjectFixture("PortableAppWithException", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 // Entry point with missing reference assembly
                 PortableAppWithMissingRefFixture = new TestProjectFixture("PortableAppWithMissingRef", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 // Correct startup hooks
                 StartupHookFixture = new TestProjectFixture("StartupHook", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 StartupHookWithOverloadFixture = new TestProjectFixture("StartupHookWithOverload", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 // Missing startup hook type (no StartupHook type defined)
                 StartupHookWithoutStartupHookTypeFixture = new TestProjectFixture("StartupHookWithoutStartupHookType", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 // Missing startup hook method (no Initialize method defined)
                 StartupHookWithoutInitializeMethodFixture = new TestProjectFixture("StartupHookWithoutInitializeMethod", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 // Invalid startup hook assembly
                 StartupHookStartupHookInvalidAssemblyFixture = new TestProjectFixture("StartupHookFake", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 // Invalid startup hooks (incorrect signatures)
                 StartupHookWithNonPublicMethodFixture = new TestProjectFixture("StartupHookWithNonPublicMethod", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 StartupHookWithInstanceMethodFixture = new TestProjectFixture("StartupHookWithInstanceMethod", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 StartupHookWithParameterFixture = new TestProjectFixture("StartupHookWithParameter", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 StartupHookWithReturnTypeFixture = new TestProjectFixture("StartupHookWithReturnType", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 StartupHookWithMultipleIncorrectSignaturesFixture = new TestProjectFixture("StartupHookWithMultipleIncorrectSignatures", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
                 // Valid startup hooks with incorrect behavior
                 StartupHookWithDependencyFixture = new TestProjectFixture("StartupHookWithDependency", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
 
                 // Startup hook with an assembly resolver
                 StartupHookWithAssemblyResolver = new TestProjectFixture("StartupHookWithAssemblyResolver", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
             }
 

--- a/src/installer/tests/HostActivation.Tests/Tracing.cs
+++ b/src/installer/tests/HostActivation.Tests/Tracing.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Entry point projects
                 PortableAppFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
             }
 

--- a/src/installer/tests/HostActivation.Tests/WindowsSpecificBehavior.cs
+++ b/src/installer/tests/HostActivation.Tests/WindowsSpecificBehavior.cs
@@ -89,11 +89,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 RepoDirectories = new RepoDirectoriesProvider();
 
                 PortableAppWithLongPathFixture = new TestProjectFixture("PortableAppWithLongPath", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 TestWindowsOsShimsAppFixture = new TestProjectFixture("TestWindowsOsShimsApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject();
             }
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
@@ -63,7 +63,7 @@ namespace AppHost.Bundle.Tests
             {
                 var testFixture = new TestProjectFixture(projectName, RepoDirectories);
                 testFixture
-                    .EnsureRestoredForRid(testFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(testFixture.CurrentRid)
                     .PublishProject(runtime: testFixture.CurrentRid,
                                     outputDirectory: BundleHelper.GetPublishPath(testFixture),
                                     extraArgs: extraArgs);

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -92,7 +92,7 @@ namespace AppHost.Bundle.Tests
                 TestFrameworkDependentFixture = new TestProjectFixture("AppWithSubDirs", RepoDirectories);
                 BundleHelper.AddLongNameContentToAppWithSubDirs(TestFrameworkDependentFixture);
                 TestFrameworkDependentFixture
-                    .EnsureRestoredForRid(TestFrameworkDependentFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(TestFrameworkDependentFixture.CurrentRid)
                     .PublishProject(runtime: TestFrameworkDependentFixture.CurrentRid,
                                     selfContained: false,
                                     outputDirectory: BundleHelper.GetPublishPath(TestFrameworkDependentFixture));
@@ -100,7 +100,7 @@ namespace AppHost.Bundle.Tests
                 TestSelfContainedFixture = new TestProjectFixture("AppWithSubDirs", RepoDirectories);
                 BundleHelper.AddLongNameContentToAppWithSubDirs(TestSelfContainedFixture);
                 TestSelfContainedFixture
-                    .EnsureRestoredForRid(TestSelfContainedFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(TestSelfContainedFixture.CurrentRid)
                     .PublishProject(runtime: TestSelfContainedFixture.CurrentRid,
                                     outputDirectory: BundleHelper.GetPublishPath(TestSelfContainedFixture));
 
@@ -108,7 +108,7 @@ namespace AppHost.Bundle.Tests
                 BundleHelper.AddLongNameContentToAppWithSubDirs(TestAppWithEmptyFileFixture);
                 BundleHelper.AddEmptyContentToApp(TestAppWithEmptyFileFixture);
                 TestAppWithEmptyFileFixture
-                    .EnsureRestoredForRid(TestAppWithEmptyFileFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(TestAppWithEmptyFileFixture.CurrentRid)
                     .PublishProject(runtime: TestAppWithEmptyFileFixture.CurrentRid,
                                     outputDirectory: BundleHelper.GetPublishPath(TestAppWithEmptyFileFixture));
             }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/HammerServiceTest.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/HammerServiceTest.cs
@@ -80,7 +80,7 @@ namespace AppHost.Bundle.Tests
 
                 ServiceFixture = new TestProjectFixture("ServicedLocation", RepoDirectories, assemblyName: "Location");
                 ServiceFixture
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .PublishProject(outputDirectory: BundleHelper.GetPublishPath(ServiceFixture));
 
             }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
@@ -88,7 +88,7 @@ namespace Microsoft.NET.HostModel.Tests
                 TestFixture = new TestProjectFixture("AppWithSubDirs", RepoDirectories);
                 BundleHelper.AddLongNameContentToAppWithSubDirs(TestFixture);
                 TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(TestFixture.CurrentRid)
                     .PublishProject(runtime: TestFixture.CurrentRid,
                                     outputDirectory: BundleHelper.GetPublishPath(TestFixture));
             }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.NET.HostModel.Tests
 
                 TestFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
                 TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .EnsureRestoredForRid(TestFixture.CurrentRid)
                     .PublishProject(runtime: TestFixture.CurrentRid,
                                     outputDirectory: BundleHelper.GetPublishPath(TestFixture));
             }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/ClsidMapTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/ClsidMapTests.cs
@@ -154,15 +154,15 @@ namespace Microsoft.NET.HostModel.ComHost.Tests
                 RepoDirectories = new RepoDirectoriesProvider();
 
                 ComLibraryFixture = new TestProjectFixture("ComLibrary", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 ComLibraryMissingGuidFixture = new TestProjectFixture("ComLibraryMissingGuid", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
 
                 ComLibraryConflictingGuidFixture = new TestProjectFixture("ComLibraryConflictingGuid", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .EnsureRestored()
                     .BuildProject();
             }
 

--- a/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
@@ -17,28 +17,21 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public string Configuration { get; }
         public string RepoRoot { get; }
         public string BaseArtifactsFolder { get; }
-        public string BaseBinFolder { get; }
-        public string BaseObjFolder { get; }
         public string Artifacts { get; }
         public string HostArtifacts { get; }
         public string BuiltDotnet { get; }
         public string NugetPackages { get; }
-        public string CorehostPackages { get; }
         public string DotnetSDK { get; }
 
         private string _testContextVariableFilePath { get; }
         private ImmutableDictionary<string, string> _testContextVariables { get; }
 
         public RepoDirectoriesProvider(
-            string repoRoot = null,
-            string artifacts = null,
             string builtDotnet = null,
-            string nugetPackages = null,
-            string corehostPackages = null,
-            string dotnetSdk = null,
             string microsoftNETCoreAppVersion = null)
         {
-            RepoRoot = repoRoot ?? GetRepoRootDirectory();
+            RepoRoot = GetRepoRootDirectory();
+            BaseArtifactsFolder = Path.Combine(RepoRoot, "artifacts");
 
             _testContextVariableFilePath = Path.Combine(
                 Directory.GetCurrentDirectory(),
@@ -50,10 +43,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     line => line.Substring(line.IndexOf('=') + 1),
                     StringComparer.OrdinalIgnoreCase);
 
-            BaseArtifactsFolder = artifacts ?? Path.Combine(RepoRoot, "artifacts");
-            BaseBinFolder = artifacts ?? Path.Combine(BaseArtifactsFolder, "bin");
-            BaseObjFolder = artifacts ?? Path.Combine(BaseArtifactsFolder, "obj");
-
             TargetRID = GetTestContextVariable("TEST_TARGETRID");
             BuildRID = GetTestContextVariable("BUILDRID");
             BuildArchitecture = GetTestContextVariable("BUILD_ARCHITECTURE");
@@ -61,23 +50,19 @@ namespace Microsoft.DotNet.CoreSetup.Test
             TestAssetsFolder = GetTestContextVariable("TEST_ASSETS");
 
             Configuration = GetTestContextVariable("BUILD_CONFIGURATION");
+
             string osPlatformConfig = $"{BuildRID}.{Configuration}";
+            Artifacts = Path.Combine(BaseArtifactsFolder, "bin", osPlatformConfig);
+            HostArtifacts = Path.Combine(Artifacts, "corehost");
 
-            DotnetSDK = dotnetSdk ?? GetTestContextVariable("DOTNET_SDK_PATH");
-
+            DotnetSDK = GetTestContextVariable("DOTNET_SDK_PATH");
             if (!Directory.Exists(DotnetSDK))
             {
                 throw new InvalidOperationException("ERROR: Test SDK folder not found.");
             }
 
-            Artifacts = Path.Combine(BaseBinFolder, osPlatformConfig);
-            HostArtifacts = artifacts ?? Path.Combine(Artifacts, "corehost");
+            NugetPackages = GetTestContextVariable("NUGET_PACKAGES") ?? Path.Combine(RepoRoot, ".packages");
 
-            NugetPackages = nugetPackages ??
-                GetTestContextVariable("NUGET_PACKAGES") ??
-                Path.Combine(RepoRoot, ".packages");
-
-            CorehostPackages = corehostPackages ?? Path.Combine(Artifacts, "corehost");
             BuiltDotnet = builtDotnet ?? Path.Combine(GetTestContextVariable("TEST_ARTIFACTS"), "sharedFrameworkPublish");
         }
 

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -119,9 +119,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 throw new Exception($"Unable to find built host and sharedfx, please ensure the build has been run: {repoDirectoriesProvider.BuiltDotnet}");
             }
 
-            if ( ! Directory.Exists(repoDirectoriesProvider.CorehostPackages))
+            if ( ! Directory.Exists(repoDirectoriesProvider.HostArtifacts))
             {
-                throw new Exception($"Unable to find host packages directory, please ensure the build has been run: {repoDirectoriesProvider.CorehostPackages}");
+                throw new Exception($"Unable to find host artifacts directory, please ensure the build has been run: {repoDirectoriesProvider.HostArtifacts}");
             }
         }
 


### PR DESCRIPTION
- `CorehostPackages` property was just pointing to the host artifacts directory and does not contain packages (test assets are restored before running the tests using a config now) - since the switch to Arcade, I think.
- Remove unused customization in `RepoDirectoriesProvider` constructor