### PR TITLE
Suppress ILLink warnings in Reflection

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -1472,7 +1472,7 @@ namespace System.Reflection
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Module.ResolveType is marked as RequiresUnreferencedCode because it relies on tokens" +
                             "which are not guaranteed to be stable across trimming. So if somebody hardcodes a token it could break." +
-                            "The usage here is not like that as all these tokes come from existing metadata loaded from some IL" +
+                            "The usage here is not like that as all these tokens come from existing metadata loaded from some IL" +
                             "and so trimming has no effect (the tokens are read AFTER trimming occured).")]
         internal static AttributeUsageAttribute GetAttributeUsage(RuntimeType decoratedAttribute)
         {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -291,9 +291,9 @@ namespace System.Reflection
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "property setters and fiels which are accessed by any attribute instantiation which is present in the code linker has analyzed." +
-                            "As such enumerating all fields and properties may return different results fater trimming" +
-                            "but all those which are needed to actually have data should be there.")]
+            Justification = "Property setters and fields which are accessed by any attribute instantiation which is present in the code linker has analyzed." +
+                            "As such enumerating all fields and properties may return different results after trimming" +
+                            "but all those which are needed to actually have data will be there.")]
         private CustomAttributeData(RuntimeModule scope, MetadataToken caCtorToken, in ConstArray blob)
         {
             m_scope = scope;
@@ -416,9 +416,21 @@ namespace System.Reflection
             CustomAttributeNamedArgument[] namedArgs = Array.Empty<CustomAttributeNamedArgument>();
             m_namedArgs = Array.AsReadOnly(namedArgs);
         }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "The pca object had to be created by the single ctor on the Type. So the ctor couldn't have been trimmed.")]
         private void Init(object pca)
         {
-            m_ctor = pca.GetType().GetConstructors(BindingFlags.Public | BindingFlags.Instance)[0];
+            Type type = pca.GetType();
+
+#if DEBUG
+            // Ensure there is only a single constructor for 'pca', so it is safe to suppress IL2075
+            ConstructorInfo[] allCtors = type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            Debug.Assert(allCtors.Length == 1);
+            Debug.Assert(allCtors[0].GetParameters().Length == 0);
+#endif
+
+            m_ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)[0];
             m_typedCtorArgs = Array.AsReadOnly(Array.Empty<CustomAttributeTypedArgument>());
             m_namedArgs = Array.AsReadOnly(Array.Empty<CustomAttributeNamedArgument>());
         }
@@ -1183,9 +1195,9 @@ namespace System.Reflection
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2065:UnrecognizedReflectionPattern",
-            Justification = "Linker guarantees presence of all the constructor parameters, property setters and fiels which are accessed by any " +
+            Justification = "Linker guarantees presence of all the constructor parameters, property setters and fields which are accessed by any " +
                             "attribute instantiation which is present in the code linker has analyzed." +
-                            "As such the reflection usage in this method should never fail as those methods/fields should always be present.")]
+                            "As such the reflection usage in this method will never fail as those methods/fields will be present.")]
         private static void AddCustomAttributes(
             ref RuntimeType.ListBuilder<object> attributes,
             RuntimeModule decoratedModule, int decoratedMetadataToken,
@@ -1322,8 +1334,8 @@ namespace System.Reflection
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Module.ResolveMethod and Module.ResolveType are marked as RequiresUnreferencedCode because they rely on tokens" +
-                            "which are not guaranteed to be stable across trimming. So if somebody harcodes a token it could break." +
-                            "The usage here is not like that as all these tokes come from existing metadata loaded from some IL" +
+                            "which are not guaranteed to be stable across trimming. So if somebody hardcodes a token it could break." +
+                            "The usage here is not like that as all these tokens come from existing metadata loaded from some IL" +
                             "and so trimming has no effect (the tokens are read AFTER trimming occured).")]
         private static bool FilterCustomAttributeRecord(
             MetadataToken caCtorToken,
@@ -1459,7 +1471,7 @@ namespace System.Reflection
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Module.ResolveType is marked as RequiresUnreferencedCode because it relies on tokens" +
-                            "which are not guaranteed to be stable across trimming. So if somebody harcodes a token it could break." +
+                            "which are not guaranteed to be stable across trimming. So if somebody hardcodes a token it could break." +
                             "The usage here is not like that as all these tokes come from existing metadata loaded from some IL" +
                             "and so trimming has no effect (the tokens are read AFTER trimming occured).")]
         internal static AttributeUsageAttribute GetAttributeUsage(RuntimeType decoratedAttribute)

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -275,6 +275,8 @@ namespace System.Reflection
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2059:RunClassConstructor",
+            Justification = "This ConstructorInfo instance represents the static constructor itself, so if this object was created, the static constructor exists.")]
         public override object? Invoke(
             object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
@@ -177,12 +177,6 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2059</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Reflection.RuntimeConstructorInfo.Invoke(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
       <property name="Target">T:System.Resources.ResourceReader</property>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
@@ -41,18 +41,6 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Reflection.CustomAttribute.FilterCustomAttributeRecord(System.Reflection.MetadataToken,System.Reflection.MetadataImport@,System.Reflection.RuntimeModule,System.Reflection.MetadataToken,System.RuntimeType,System.Boolean,System.RuntimeType.ListBuilder{System.Object}@,System.RuntimeType@,System.IRuntimeMethodInfo@,System.Boolean@)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Reflection.CustomAttribute.GetAttributeUsage(System.RuntimeType)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Reflection.Emit.ModuleBuilder.GetGenericMethodBaseDefinition(System.Reflection.MethodBase)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -189,12 +177,6 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2065</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Reflection.CustomAttribute.AddCustomAttributes(System.RuntimeType.ListBuilder{System.Object}@,System.Reflection.RuntimeModule,System.Int32,System.RuntimeType,System.Boolean,System.RuntimeType.ListBuilder{System.Object})</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2067</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.__ComObject.CreateEventProvider(System.RuntimeType)</property>
@@ -294,18 +276,6 @@
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Diagnostics.Tracing.ManifestBuilder.CreateManifestString</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Reflection.CustomAttributeData.#ctor(System.Reflection.RuntimeModule,System.Reflection.MetadataToken,System.Reflection.ConstArray@)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Reflection.CustomAttributeData.Init(System.Object)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>


### PR DESCRIPTION
* Suppress RunClassConstructor ILLinker warning in RuntimeConstructorInfo 
* Suppress ILLink warning in CustomAttributeData.Init
* Update ILLink.Suppressions.xml file

Contributes to #45623