### PR TITLE
SocketsHttpHandler: do not use DualMode sockets in default connection logic

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -7,6 +7,8 @@ using System.Net.Quic;
 using System.Net.Quic.Implementations;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +17,124 @@ namespace System.Net.Http
 {
     internal static class ConnectHelper
     {
+        public static ValueTask<Stream> ConnectAsync(string host, int port, bool async, CancellationToken cancellationToken)
+        {
+            return async ? ConnectAsync(host, port, cancellationToken) : new ValueTask<Stream>(Connect(host, port, cancellationToken));
+        }
+
+        private static async ValueTask<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+        {
+            // Rather than creating a new Socket and calling ConnectAsync on it, we use the static
+            // Socket.ConnectAsync with a SocketAsyncEventArgs, as we can then use Socket.CancelConnectAsync
+            // to cancel it if needed.
+            var saea = new ConnectEventArgs();
+            try
+            {
+                saea.Initialize(cancellationToken);
+
+                // Configure which server to which to connect.
+                saea.RemoteEndPoint = new DnsEndPoint(host, port);
+
+                // Initiate the connection.
+                if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, saea))
+                {
+                    // Connect completing asynchronously. Enable it to be canceled and wait for it.
+                    using (cancellationToken.UnsafeRegister(static s => Socket.CancelConnectAsync((SocketAsyncEventArgs)s!), saea))
+                    {
+                        await saea.Builder.Task.ConfigureAwait(false);
+                    }
+                }
+                else if (saea.SocketError != SocketError.Success)
+                {
+                    // Connect completed synchronously but unsuccessfully.
+                    throw new SocketException((int)saea.SocketError);
+                }
+
+                Debug.Assert(saea.SocketError == SocketError.Success, $"Expected Success, got {saea.SocketError}.");
+                Debug.Assert(saea.ConnectSocket != null, "Expected non-null socket");
+
+                // Configure the socket and return a stream for it.
+                Socket socket = saea.ConnectSocket;
+                socket.NoDelay = true;
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception error) when (!(error is OperationCanceledException))
+            {
+                throw CreateWrappedException(error, host, port, cancellationToken);
+            }
+            finally
+            {
+                saea.Dispose();
+            }
+        }
+
+        private static Stream Connect(string host, int port, CancellationToken cancellationToken)
+        {
+            // For synchronous connections, we can just create a socket and make the connection.
+            cancellationToken.ThrowIfCancellationRequested();
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            try
+            {
+                socket.NoDelay = true;
+                using (cancellationToken.UnsafeRegister(static s => ((Socket)s!).Dispose(), socket))
+                {
+                    socket.Connect(new DnsEndPoint(host, port));
+                }
+
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception e)
+            {
+                socket.Dispose();
+                throw CreateWrappedException(e, host, port, cancellationToken);
+            }
+        }
+
+        /// <summary>SocketAsyncEventArgs that carries with it additional state for a Task builder and a CancellationToken.</summary>
+        private sealed class ConnectEventArgs : SocketAsyncEventArgs
+        {
+            internal ConnectEventArgs() :
+                // The OnCompleted callback serves just to complete a task that's awaited in ConnectAsync,
+                // so we don't need to also flow ExecutionContext again into the OnCompleted callback.
+                base(unsafeSuppressExecutionContextFlow: true)
+            {
+            }
+
+            public AsyncTaskMethodBuilder Builder { get; private set; }
+            public CancellationToken CancellationToken { get; private set; }
+
+            public void Initialize(CancellationToken cancellationToken)
+            {
+                CancellationToken = cancellationToken;
+                AsyncTaskMethodBuilder b = default;
+                _ = b.Task; // force initialization
+                Builder = b;
+            }
+
+            protected override void OnCompleted(SocketAsyncEventArgs _)
+            {
+                switch (SocketError)
+                {
+                    case SocketError.Success:
+                        Builder.SetResult();
+                        break;
+
+                    case SocketError.OperationAborted:
+                    case SocketError.ConnectionAborted:
+                        if (CancellationToken.IsCancellationRequested)
+                        {
+                            Builder.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(CancellationHelper.CreateOperationCanceledException(null, CancellationToken)));
+                            break;
+                        }
+                        goto default;
+
+                    default:
+                        Builder.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(new SocketException((int)SocketError)));
+                        break;
+                }
+            }
+        }
+
         /// <summary>
         /// Helper type used by HttpClientHandler when wrapping SocketsHttpHandler to map its
         /// certificate validation callback to the one used by SslStream.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -24,9 +24,10 @@ namespace System.Net.Http
 
         private static async ValueTask<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
         {
-            // Rather than creating a new Socket and calling ConnectAsync on it, we use the static
-            // Socket.ConnectAsync with a SocketAsyncEventArgs, as we can then use Socket.CancelConnectAsync
-            // to cancel it if needed.
+            // We use the static Socket.ConnectAsync with a SocketAsyncEventArgs, because this approach is:
+            // 1. Cancellable
+            // 2. Does not create Dual-stack sockets, which are unavailable in certain environments,
+            //    see https://github.com/dotnet/runtime/issues/44686.
             var saea = new ConnectEventArgs();
             try
             {


### PR DESCRIPTION
In some environments IPV6 (thus dual-stack) sockets do not work despite `Socket.SupportsIPv6` returning true.

I'm reverting the default branch of `HttpConnectionPool.ConnectToTcpHostAsync` to use the logic in 628d99b624f338b0eaca031adc50952b4c2d509d (before #39524) to fix #44686.

The only thing I changed in the old code is comments.

@scalablecory @geoffkizer PTAL.