### PR TITLE
JIT: don't compute edge weights when there's no profile data

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -13527,13 +13527,13 @@ void Compiler::fgComputeBlockAndEdgeWeights()
         JITDUMP(" -- no profile data, so using default called count\n");
     }
 
-    if (isOptimizing)
+    if (usingProfileWeights && isOptimizing)
     {
         fgComputeEdgeWeights();
     }
     else
     {
-        JITDUMP(" -- not optimizing, so not computing edge weights\n");
+        JITDUMP(" -- not optimizing or no profile data, so not computing edge weights\n");
     }
 }
 


### PR DESCRIPTION
We don't look edge the weights unless there's profile data, so only compute
edge weights if there is profile data.

Saves a tiny bit on TP (~0.2%).