### PR TITLE
Permit key-reuse in PKCS12.

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ApplePkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ApplePkcs12Reader.cs
@@ -16,6 +16,9 @@ namespace Internal.Cryptography.Pal
     {
         internal ApplePkcs12Reader(ReadOnlySpan<byte> data)
         {
+            // MacOS does not permit ephemeral key imports, so key reuse can
+            // always be permitted.
+            PermitKeyReuse = true;
             ParsePkcs12(data);
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslPkcs12Reader.cs
@@ -26,11 +26,18 @@ namespace Internal.Cryptography.Pal
             throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
         }
 
-        public static bool TryRead(ReadOnlySpan<byte> data, [NotNullWhen(true)] out OpenSslPkcs12Reader? pkcs12Reader) =>
-            TryRead(data, out pkcs12Reader, out _, captureException: false);
+        public static bool TryRead(
+            ReadOnlySpan<byte> data,
+            bool permitKeyReuse,
+            [NotNullWhen(true)] out OpenSslPkcs12Reader? pkcs12Reader) =>
+                TryRead(data, permitKeyReuse, out pkcs12Reader, out _, captureException: false);
 
-        public static bool TryRead(ReadOnlySpan<byte> data, [NotNullWhen(true)] out OpenSslPkcs12Reader? pkcs12Reader, [NotNullWhen(false)] out Exception? openSslException) =>
-            TryRead(data, out pkcs12Reader, out openSslException!, captureException: true);
+        public static bool TryRead(
+            ReadOnlySpan<byte> data,
+            bool permitKeyReuse,
+            [NotNullWhen(true)] out OpenSslPkcs12Reader? pkcs12Reader,
+            [NotNullWhen(false)] out Exception? openSslException) =>
+                TryRead(data, permitKeyReuse, out pkcs12Reader, out openSslException!, captureException: true);
 
         protected override AsymmetricAlgorithm LoadKey(ReadOnlyMemory<byte> pkcs8)
         {
@@ -82,6 +89,7 @@ namespace Internal.Cryptography.Pal
 
         private static bool TryRead(
             ReadOnlySpan<byte> data,
+            bool permitKeyReuse,
             [NotNullWhen(true)] out OpenSslPkcs12Reader? pkcs12Reader,
             out Exception? openSslException,
             bool captureException)
@@ -90,7 +98,7 @@ namespace Internal.Cryptography.Pal
 
             try
             {
-                pkcs12Reader = new OpenSslPkcs12Reader(data);
+                pkcs12Reader = new OpenSslPkcs12Reader(data) { PermitKeyReuse = permitKeyReuse };
                 return true;
             }
             catch (CryptographicException e)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -50,11 +50,13 @@ namespace Internal.Cryptography.Pal
             ICertificatePal? cert;
             Exception? openSslException;
 
+            bool permitKeyReuse = !keyStorageFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet);
+
             if (TryReadX509Der(rawData, out cert) ||
                 TryReadX509Pem(rawData, out cert) ||
                 PkcsFormatReader.TryReadPkcs7Der(rawData, out cert) ||
                 PkcsFormatReader.TryReadPkcs7Pem(rawData, out cert) ||
-                PkcsFormatReader.TryReadPkcs12(rawData, password, out cert, out openSslException))
+                PkcsFormatReader.TryReadPkcs12(rawData, password, permitKeyReuse, out cert, out openSslException))
             {
                 if (cert == null)
                 {
@@ -84,9 +86,12 @@ namespace Internal.Cryptography.Pal
 
             if (pal == null)
             {
+                bool permitKeyReuse = !keyStorageFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet);
+
                 PkcsFormatReader.TryReadPkcs12(
                     File.ReadAllBytes(fileName),
                     password,
+                    permitKeyReuse,
                     out pal,
                     out Exception? exception);
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -86,7 +86,7 @@ namespace Internal.Cryptography.Pal
             {
                 OpenSslPkcs12Reader? pfx;
 
-                if (OpenSslPkcs12Reader.TryRead(rawData, out pfx))
+                if (OpenSslPkcs12Reader.TryRead(rawData, permitKeyReuse: true, out pfx))
                 {
                     pfx.Dispose();
                     return X509ContentType.Pkcs12;
@@ -153,7 +153,10 @@ namespace Internal.Cryptography.Pal
             {
                 OpenSslPkcs12Reader? pkcs12Reader;
 
-                if (OpenSslPkcs12Reader.TryRead(File.ReadAllBytes(fileName), out pkcs12Reader))
+                // We permit key-reuse only when attempting to determine the content type.
+                // If later during a real import key reuse should not be used, an exception
+                // is thrown then.
+                if (OpenSslPkcs12Reader.TryRead(File.ReadAllBytes(fileName), permitKeyReuse: true, out pkcs12Reader))
                 {
                     pkcs12Reader.Dispose();
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -253,24 +253,35 @@ namespace Internal.Cryptography.Pal
             return true;
         }
 
-        internal static bool TryReadPkcs12(ReadOnlySpan<byte> rawData, SafePasswordHandle password, [NotNullWhen(true)] out ICertificatePal? certPal, out Exception? openSslException)
+        internal static bool TryReadPkcs12(
+            ReadOnlySpan<byte> rawData,
+            SafePasswordHandle password,
+            bool permitKeyReuse,
+            [NotNullWhen(true)] out ICertificatePal? certPal,
+            out Exception? openSslException)
         {
             List<ICertificatePal>? ignored;
 
-            return TryReadPkcs12(rawData, password, true, out certPal!, out ignored, out openSslException);
+            return TryReadPkcs12(rawData, password, single: true, permitKeyReuse, out certPal!, out ignored, out openSslException);
         }
 
-        internal static bool TryReadPkcs12(ReadOnlySpan<byte> rawData, SafePasswordHandle password, [NotNullWhen(true)] out List<ICertificatePal>? certPals, out Exception? openSslException)
+        internal static bool TryReadPkcs12(
+            ReadOnlySpan<byte> rawData,
+            SafePasswordHandle password,
+            bool permitKeyReuse,
+            [NotNullWhen(true)] out List<ICertificatePal>? certPals,
+            out Exception? openSslException)
         {
             ICertificatePal? ignored;
 
-            return TryReadPkcs12(rawData, password, false, out ignored, out certPals!, out openSslException);
+            return TryReadPkcs12(rawData, password, single: false, permitKeyReuse, out ignored, out certPals!, out openSslException);
         }
 
         private static bool TryReadPkcs12(
             ReadOnlySpan<byte> rawData,
             SafePasswordHandle password,
             bool single,
+            bool permitKeyReuse,
             out ICertificatePal? readPal,
             out List<ICertificatePal>? readCerts,
             out Exception? openSslException)
@@ -278,7 +289,7 @@ namespace Internal.Cryptography.Pal
             // DER-PKCS12
             OpenSslPkcs12Reader? pfx;
 
-            if (!OpenSslPkcs12Reader.TryRead(rawData, out pfx, out openSslException))
+            if (!OpenSslPkcs12Reader.TryRead(rawData, permitKeyReuse, out pfx, out openSslException))
             {
                 readPal = null;
                 readCerts = null;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
@@ -157,12 +157,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PlatformSupportsEphemeralKeys))]
         [InlineData(false, false)]
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
-        public void OneCert_EncryptedEmptyPassword_OneKey_EncryptedNullPassword_NoMac(bool encryptKeySafe, bool associateKey)
+        public void OneCert_EncryptedEmptyPassword_OneKey_EncryptedNullPassword_NoMac_Ephemeral(bool encryptKeySafe, bool associateKey)
         {
             // This test shows that while a null or empty password will result in both
             // types being tested, the PFX contents have to be the same throughout.
@@ -189,14 +189,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 if (s_loaderFailsKeysEarly || associateKey || encryptKeySafe)
                 {
                     // NTE_FAIL, falling back to CRYPT_E_BAD_ENCODE if padding happened to work out.
-                    ReadUnreadablePfx(pfxBytes, null, altWin32Error: -2146885630);
-                    ReadUnreadablePfx(pfxBytes, string.Empty, altWin32Error: -2146885630);
+                    ReadUnreadablePfx(pfxBytes, null, altWin32Error: -2146885630, requiredFlags: X509KeyStorageFlags.EphemeralKeySet);
+                    ReadUnreadablePfx(pfxBytes, string.Empty, altWin32Error: -2146885630, requiredFlags: X509KeyStorageFlags.EphemeralKeySet);
                 }
                 else
                 {
                     using (var publicOnlyCert = new X509Certificate2(cert.RawData))
                     {
-                        ReadPfx(pfxBytes, string.Empty, publicOnlyCert);
+                        ReadPfx(pfxBytes, string.Empty, publicOnlyCert, requiredFlags: X509KeyStorageFlags.EphemeralKeySet);
                     }
                 }
             }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_Collection.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_Collection.cs
@@ -13,13 +13,30 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string correctPassword,
             X509Certificate2 expectedCert,
             Action<X509Certificate2> otherWork,
-            X509KeyStorageFlags? requiredFlags)
+            X509KeyStorageFlags? requiredFlags,
+            bool checkPrivateKey)
         {
-            ReadPfx(pfxBytes, correctPassword, expectedCert, null, otherWork, null, requiredFlags ?? s_importFlags);
+            ReadPfx(
+                pfxBytes,
+                correctPassword,
+                expectedCert,
+                null,
+                otherWork,
+                null,
+                requiredFlags ?? s_importFlags,
+                checkPrivateKey);
 
             if (requiredFlags is null)
             {
-                ReadPfx(pfxBytes, correctPassword, expectedCert, null, otherWork, null, s_exportableImportFlags);
+                ReadPfx(
+                    pfxBytes,
+                    correctPassword,
+                    expectedCert,
+                    null,
+                    otherWork,
+                    null,
+                    s_exportableImportFlags,
+                    checkPrivateKey);
             }
         }
 
@@ -30,7 +47,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X509Certificate2[] expectedOrder,
             Action<X509Certificate2> perCertOtherWork,
             Action<X509Certificate2Collection> collectionWork,
-            X509KeyStorageFlags? requiredFlags)
+            X509KeyStorageFlags? requiredFlags,
+            bool checkPrivateKey)
         {
             ReadPfx(
                 pfxBytes,
@@ -39,7 +57,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 expectedOrder,
                 perCertOtherWork,
                 collectionWork,
-                requiredFlags ?? s_importFlags);
+                requiredFlags ?? s_importFlags,
+                checkPrivateKey);
 
             if (requiredFlags is null)
             {
@@ -50,7 +69,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     expectedOrder,
                     perCertOtherWork,
                     collectionWork,
-                    s_exportableImportFlags);
+                    s_exportableImportFlags,
+                    checkPrivateKey);
             }
         }
 
@@ -61,7 +81,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X509Certificate2[] expectedOrder,
             Action<X509Certificate2> otherWork,
             Action<X509Certificate2Collection> collectionWork,
-            X509KeyStorageFlags flags)
+            X509KeyStorageFlags flags,
+            bool checkPrivateKey)
         {
             using (ImportedCollection imported = Cert.Import(pfxBytes, correctPassword, flags))
             {
@@ -75,7 +96,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 for (int i = 0; i < testOrder.Length; i++)
                 {
                     X509Certificate2 actual = coll[i];
-                    AssertCertEquals(testOrder[i], actual);
+                    AssertCertEquals(testOrder[i], actual, checkPrivateKey);
                     otherWork?.Invoke(actual);
                 }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
@@ -11,10 +11,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes,
             string correctPassword,
             X509Certificate2 expectedCert,
-            Action<X509Certificate2> otherWork)
+            Action<X509Certificate2> otherWork,
+            X509KeyStorageFlags? requiredFlags)
         {
-            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, s_importFlags);
-            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, s_exportableImportFlags);
+            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, null, requiredFlags ?? s_importFlags);
+
+            if (requiredFlags is null)
+            {
+                ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, null, s_exportableImportFlags);
+            }
         }
 
         protected override void ReadMultiPfx(
@@ -22,10 +27,26 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string correctPassword,
             X509Certificate2 expectedSingleCert,
             X509Certificate2[] expectedOrder,
-            Action<X509Certificate2> perCertOtherWork)
+            Action<X509Certificate2> perCertOtherWork,
+            Action<X509Certificate2Collection> collectionWork,
+            X509KeyStorageFlags? requiredFlags)
         {
-            ReadPfx(pfxBytes, correctPassword, expectedSingleCert, perCertOtherWork, s_importFlags);
-            ReadPfx(pfxBytes, correctPassword, expectedSingleCert, perCertOtherWork, s_exportableImportFlags);
+            ReadPfx(
+                pfxBytes,
+                correctPassword,
+                expectedSingleCert,
+                perCertOtherWork,
+                requiredFlags ?? s_importFlags);
+
+            if (requiredFlags is null)
+            {
+                ReadPfx(
+                    pfxBytes,
+                    correctPassword,
+                    expectedSingleCert,
+                    perCertOtherWork,
+                    s_exportableImportFlags);
+            }
         }
 
         private void ReadPfx(
@@ -33,6 +54,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string correctPassword,
             X509Certificate2 expectedCert,
             Action<X509Certificate2> otherWork,
+            Action<X509Certificate2Collection> collectionWork,
             X509KeyStorageFlags flags)
         {
             using (X509Certificate2 cert = new X509Certificate2(pfxBytes, correctPassword, flags))
@@ -63,10 +85,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes,
             string bestPassword,
             int win32Error,
-            int altWin32Error)
+            int altWin32Error,
+            X509KeyStorageFlags? requiredFlags)
         {
             CryptographicException ex = Assert.ThrowsAny<CryptographicException>(
-                () => new X509Certificate2(pfxBytes, bestPassword, s_importFlags));
+                () => new X509Certificate2(pfxBytes, bestPassword, requiredFlags ?? s_importFlags));
 
             if (OperatingSystem.IsWindows())
             {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
@@ -12,13 +12,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string correctPassword,
             X509Certificate2 expectedCert,
             Action<X509Certificate2> otherWork,
-            X509KeyStorageFlags? requiredFlags)
+            X509KeyStorageFlags? requiredFlags,
+            bool checkPrivateKey)
         {
-            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, null, requiredFlags ?? s_importFlags);
+            ReadPfx(
+                pfxBytes,
+                correctPassword,
+                expectedCert,
+                otherWork,
+                null,
+                requiredFlags ?? s_importFlags,
+                checkPrivateKey);
 
             if (requiredFlags is null)
             {
-                ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, null, s_exportableImportFlags);
+                ReadPfx(
+                    pfxBytes,
+                    correctPassword,
+                    expectedCert,
+                    otherWork,
+                    null,
+                    s_exportableImportFlags,
+                    checkPrivateKey);
             }
         }
 
@@ -29,14 +44,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X509Certificate2[] expectedOrder,
             Action<X509Certificate2> perCertOtherWork,
             Action<X509Certificate2Collection> collectionWork,
-            X509KeyStorageFlags? requiredFlags)
+            X509KeyStorageFlags? requiredFlags,
+            bool checkPrivateKey)
         {
             ReadPfx(
                 pfxBytes,
                 correctPassword,
                 expectedSingleCert,
                 perCertOtherWork,
-                requiredFlags ?? s_importFlags);
+                requiredFlags ?? s_importFlags,
+                checkPrivateKey);
 
             if (requiredFlags is null)
             {
@@ -45,7 +62,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     correctPassword,
                     expectedSingleCert,
                     perCertOtherWork,
-                    s_exportableImportFlags);
+                    s_exportableImportFlags,
+                    checkPrivateKey);
             }
         }
 
@@ -55,11 +73,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X509Certificate2 expectedCert,
             Action<X509Certificate2> otherWork,
             Action<X509Certificate2Collection> collectionWork,
-            X509KeyStorageFlags flags)
+            X509KeyStorageFlags flags,
+            bool checkPrivateKey)
         {
             using (X509Certificate2 cert = new X509Certificate2(pfxBytes, correctPassword, flags))
             {
-                AssertCertEquals(expectedCert, cert);
+                AssertCertEquals(expectedCert, cert, checkPrivateKey);
                 otherWork?.Invoke(cert);
             }
         }


### PR DESCRIPTION
In .NET 5 when switching to the managed PKCS12 decoding in Unix, a more-restrictive behavior was introduced where two certificates could not reference the same key, to match Windows' behavior. However, the result was more restrictive than what Windows permitted. Windows permits the key to be reused if the imported PFX is not imported with ephemeral keys (persisted). The Unix check however did not permit this at all.

This change attempts to align the Unix import more closely with Windows. If the import is non-ephemeral, the key-reuse is permitted.

Fixes #44535 