### PR TITLE
Add support for diffing GC ref map info to R2RDump; small bugfix

### DIFF
--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -250,7 +250,7 @@ namespace R2RDump
         {
             if (theThis.StackPop != GCRefMap.InvalidStackPop)
             {
-                writer.Write(@"POP(0x{StackPop:X}) ");
+                writer.Write($@"POP(0x{theThis.StackPop:X}) ");
             }
             for (int entryIndex = 0; entryIndex < theThis.Entries.Length; entryIndex++)
             {

--- a/src/coreclr/src/tools/r2rdump/R2RDiff.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDiff.cs
@@ -383,8 +383,8 @@ namespace R2RDump
 
         private static Dictionary<string, ReadyToRunImportSection.ImportSectionEntry> GetImports(ReadyToRunReader reader)
         {
-            Dictionary<string, ReadyToRunImportSection.ImportSectionEntry> result = new Dictionary<string, ReadyToRunImportSection.ImportSectionEntry>();
-            SignatureFormattingOptions signatureOptions = new SignatureFormattingOptions() { Naked = true };
+            var result = new Dictionary<string, ReadyToRunImportSection.ImportSectionEntry>();
+            var signatureOptions = new SignatureFormattingOptions() { Naked = true };
             foreach (ReadyToRunImportSection section in reader.ImportSections)
             {
                 foreach (ReadyToRunImportSection.ImportSectionEntry entry in section.Entries)

--- a/src/coreclr/src/tools/r2rdump/R2RDiff.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDiff.cs
@@ -57,6 +57,7 @@ namespace R2RDump
             DiffTitle();
             DiffPESections();
             DiffR2RSections();
+            DiffImportSections();
             DiffR2RMethods();
 
             DiffMethodsForModule(AllModules, AllModules);
@@ -142,6 +143,37 @@ namespace R2RDump
         private void DiffR2RSections()
         {
             ShowDiff(GetR2RSectionMap(_leftDumper.Reader), GetR2RSectionMap(_rightDumper.Reader), "R2R sections");
+        }
+
+        private void DiffImportSections()
+        {
+            Dictionary<string, ReadyToRunImportSection.ImportSectionEntry> leftImports = GetImports(_leftDumper.Reader);
+            Dictionary<string, ReadyToRunImportSection.ImportSectionEntry> rightImports = GetImports(_rightDumper.Reader);
+            HashSet<string> commonKeys = new HashSet<string>(leftImports.Keys);
+            commonKeys.IntersectWith(rightImports.Keys);
+
+            _writer.WriteLine("Import entries");
+            _writer.WriteLine("--------------");
+
+            foreach (string key in commonKeys.OrderBy(k => k))
+            {
+                ReadyToRunImportSection.ImportSectionEntry leftEntry = leftImports[key];
+                ReadyToRunImportSection.ImportSectionEntry rightEntry = rightImports[key];
+                StringWriter leftInfo = new StringWriter();
+                StringWriter rightInfo = new StringWriter();
+                leftEntry.GCRefMap?.WriteTo(leftInfo);
+                rightEntry.GCRefMap?.WriteTo(rightInfo);
+                string leftGCRefMap = leftInfo.ToString();
+                string rightGCRefMap = rightInfo.ToString();
+                if (leftGCRefMap != rightGCRefMap)
+                {
+                    _writer.WriteLine($@"Method:           {key}");
+                    _writer.WriteLine($@"Left GC ref map:  {leftGCRefMap}");
+                    _writer.WriteLine($@"Right GC ref map: {rightGCRefMap}");
+                }
+            }
+
+            _writer.WriteLine();
         }
 
         /// <summary>
@@ -347,6 +379,20 @@ namespace R2RDump
             {
                 dumper.DumpMethod(method);
             }
+        }
+
+        private static Dictionary<string, ReadyToRunImportSection.ImportSectionEntry> GetImports(ReadyToRunReader reader)
+        {
+            Dictionary<string, ReadyToRunImportSection.ImportSectionEntry> result = new Dictionary<string, ReadyToRunImportSection.ImportSectionEntry>();
+            SignatureFormattingOptions signatureOptions = new SignatureFormattingOptions() { Naked = true };
+            foreach (ReadyToRunImportSection section in reader.ImportSections)
+            {
+                foreach (ReadyToRunImportSection.ImportSectionEntry entry in section.Entries)
+                {
+                    result[entry.Signature.ToString(signatureOptions)] = entry;
+                }
+            }
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
/cc @dotnet/crossgen-contrib 

Using this new diffing tool I'm seeing a bunch of methods with GC ref map differences between CG1 and CG2 I suspect to be causing the SPC-CG2 issues; as next step I'm going to investigate the cause of the difference.

Thanks

Tomas

<pre>
Import entries
--------------
Method:           int System.Collections.Generic.IComparer`1&lt;bool>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x1) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;byte>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x1) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;double>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x4) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;float>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x2) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;int>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x1) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;long>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x4) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;sbyte>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x1) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;short>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x1) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;uint>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x1) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;ulong>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x4) R(04)
Method:           int System.Collections.Generic.IComparer`1&lt;ushort>.Compare(!0, !0) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x1) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;int,System.IO.BufferedStream+&lt;ReadFromUnderlyingStreamAsync>d__49>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;int,System.IO.Stream+&lt;&lt;ReadAsync>g__FinishReadAsync|44_0>d>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;int,System.IO.StreamReader+&lt;ReadAsyncInternal>d__64>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;int,System.IO.StreamReader+&lt;ReadBufferAsync>d__67>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;int,System.IO.TextReader+&lt;ReadBlockAsyncInternal>d__20>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;int,System.Text.TranscodingStream+&lt;&lt;ReadAsync>g__ReadAsyncCore|41_0>d>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;System.Threading.Tasks.VoidTaskResult,System.IO.BufferedStream+&lt;DisposeAsync>d__33>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;System.Threading.Tasks.VoidTaskResult,System.IO.BufferedStream+&lt;FlushWriteAsync>d__40>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;System.Threading.Tasks.VoidTaskResult,System.IO.BufferedStream+&lt;WriteToUnderlyingStreamAsync>d__60>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;System.Threading.Tasks.VoidTaskResult,System.IO.FileStream+&lt;DisposeAsyncCore>d__100>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;System.Threading.Tasks.VoidTaskResult,System.IO.StreamWriter+&lt;DisposeAsyncCore>d__33>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;System.Threading.Tasks.VoidTaskResult,System.Text.TranscodingStream+&lt;&lt;DisposeAsync>g__DisposeAsyncCore|30_0>d>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1+StateMachineBox`1&lt;System.Threading.Tasks.VoidTaskResult,System.Text.TranscodingStream+&lt;&lt;WriteAsync>g__WriteAsyncCore|50_0>d>.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext() (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04)
Method:           void System.Threading.Tasks.ITaskCompletionAction.Invoke(System.Threading.Tasks.Task) (VIRTUAL_ENTRY)
Left GC ref map:  
Right GC ref map: POP(0x0) R(04 00)
</pre>