### PR TITLE
[release/5.0] Fix ComWrappers interaction with the IReferenceTracker interface

### DIFF
--- a/src/coreclr/src/interop/inc/interoplib.h
+++ b/src/coreclr/src/interop/inc/interoplib.h
@@ -38,11 +38,8 @@ namespace InteropLib
         // Destroy the supplied wrapper
         void DestroyWrapperForObject(_In_ void* wrapper) noexcept;
 
-        // Check if a wrapper is active.
-        HRESULT IsActiveWrapper(_In_ IUnknown* wrapper) noexcept;
-
-        // Reactivate the supplied wrapper.
-        HRESULT ReactivateWrapper(_In_ IUnknown* wrapper, _In_ InteropLib::OBJECTHANDLE handle) noexcept;
+        // Check if a wrapper is considered a GC root.
+        HRESULT IsWrapperRooted(_In_ IUnknown* wrapper) noexcept;
 
         // Get the object for the supplied wrapper
         HRESULT GetObjectForWrapper(_In_ IUnknown* wrapper, _Outptr_result_maybenull_ OBJECTHANDLE* object) noexcept;
@@ -58,6 +55,9 @@ namespace InteropLib
             // See https://docs.microsoft.com/windows/win32/api/windows.ui.xaml.hosting.referencetracker/
             // for details.
             bool FromTrackerRuntime;
+
+            // The supplied external object is wrapping a managed object.
+            bool ManagedObjectWrapper;
         };
 
         // See CreateObjectFlags in ComWrappers.cs
@@ -66,13 +66,21 @@ namespace InteropLib
             CreateObjectFlags_None = 0,
             CreateObjectFlags_TrackerObject = 1,
             CreateObjectFlags_UniqueInstance = 2,
+            CreateObjectFlags_Aggregated = 4,
         };
+
+        // Get the true identity for the supplied IUnknown.
+        HRESULT GetIdentityForCreateWrapperForExternal(
+            _In_ IUnknown* external,
+            _In_ enum CreateObjectFlags flags,
+            _Outptr_ IUnknown** identity) noexcept;
 
         // Allocate a wrapper context for an external object.
         // The runtime supplies the external object, flags, and a memory
         // request in order to bring the object into the runtime.
         HRESULT CreateWrapperForExternal(
             _In_ IUnknown* external,
+            _In_opt_ IUnknown* inner,
             _In_ enum CreateObjectFlags flags,
             _In_ size_t contextSize,
             _Out_ ExternalWrapperResult* result) noexcept;

--- a/src/coreclr/src/interop/trackerobjectmanager.cpp
+++ b/src/coreclr/src/interop/trackerobjectmanager.cpp
@@ -296,7 +296,8 @@ HRESULT TrackerObjectManager::AfterWrapperCreated(_In_ IReferenceTracker* obj)
     // Send out AddRefFromTrackerSource callbacks to notify tracker runtime we've done AddRef()
     // for certain interfaces. We should do this *after* we made a AddRef() because we should never
     // be in a state where report refs > actual refs
-    RETURN_IF_FAILED(obj->AddRefFromTrackerSource());
+    RETURN_IF_FAILED(obj->AddRefFromTrackerSource()); // IUnknown
+    RETURN_IF_FAILED(obj->AddRefFromTrackerSource()); // IReferenceTracker
 
     return S_OK;
 }

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -309,10 +309,16 @@ bool GCToEEInterface::RefCountedHandleCallbacks(Object * pObject)
     //<REVISIT_TODO>@todo optimize the access to the ref-count
     ComCallWrapper* pWrap = ComCallWrapper::GetWrapperForObject((OBJECTREF)pObject);
 
-    return pWrap != NULL && pWrap->IsWrapperActive();
-#else
-    return false;
+    if (pWrap != NULL && pWrap->IsWrapperActive())
+        return true;
 #endif
+#ifdef FEATURE_COMWRAPPERS
+    bool isRooted = false;
+    if (ComWrappersNative::HasManagedObjectComWrapper((OBJECTREF)pObject, &isRooted))
+        return isRooted;
+#endif
+
+    return false;
 }
 
 void GCToEEInterface::GcBeforeBGCSweepWork()

--- a/src/coreclr/src/vm/interoplibinterface.h
+++ b/src/coreclr/src/vm/interoplibinterface.h
@@ -44,6 +44,7 @@ public: // COM activation
 
 public: // Unwrapping support
     static IUnknown* GetIdentityForObject(_In_ OBJECTREF* objectPROTECTED, _In_ REFIID riid, _Out_ INT64* wrapperId);
+    static bool HasManagedObjectComWrapper(_In_ OBJECTREF object, _Out_ bool* isActive);
 };
 
 class GlobalComWrappersForMarshalling

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -18,31 +18,34 @@ namespace ComWrappersTests
         {
             protected unsafe override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
             {
-                Assert.IsTrue(obj is Test);
-
                 IntPtr fpQueryInteface = default;
                 IntPtr fpAddRef = default;
                 IntPtr fpRelease = default;
                 ComWrappers.GetIUnknownImpl(out fpQueryInteface, out fpAddRef, out fpRelease);
 
-                var vtbl = new ITestVtbl()
+                ComInterfaceEntry* entryRaw = null;
+                count = 0;
+                if (obj is Test)
                 {
-                    IUnknownImpl = new IUnknownVtbl()
+                    var vtbl = new ITestVtbl()
                     {
-                        QueryInterface = fpQueryInteface,
-                        AddRef = fpAddRef,
-                        Release = fpRelease
-                    },
-                    SetValue = Marshal.GetFunctionPointerForDelegate(ITestVtbl.pSetValue)
-                };
-                var vtblRaw = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ITestVtbl));
-                Marshal.StructureToPtr(vtbl, vtblRaw, false);
+                        IUnknownImpl = new IUnknownVtbl()
+                        {
+                            QueryInterface = fpQueryInteface,
+                            AddRef = fpAddRef,
+                            Release = fpRelease
+                        },
+                        SetValue = Marshal.GetFunctionPointerForDelegate(ITestVtbl.pSetValue)
+                    };
+                    var vtblRaw = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ITestVtbl));
+                    Marshal.StructureToPtr(vtbl, vtblRaw, false);
 
-                var entryRaw = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ComInterfaceEntry));
-                entryRaw->IID = typeof(ITest).GUID;
-                entryRaw->Vtable = vtblRaw;
+                    entryRaw = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ComInterfaceEntry));
+                    entryRaw->IID = typeof(ITest).GUID;
+                    entryRaw->Vtable = vtblRaw;
+                    count = 1;
+                }
 
-                count = 1;
                 return entryRaw;
             }
 
@@ -73,6 +76,19 @@ namespace ComWrappersTests
                 Assert.AreNotEqual(fpAddRef, IntPtr.Zero);
                 Assert.AreNotEqual(fpRelease, IntPtr.Zero);
             }
+        }
+
+        static void ForceGC()
+        {
+            // Trigger the GC multiple times and then
+            // wait for all finalizers since that is where
+            // most of the cleanup occurs.
+            GC.Collect();
+            GC.Collect();
+            GC.Collect();
+            GC.Collect();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
         }
 
         static void ValidateComInterfaceCreation()
@@ -375,11 +391,7 @@ namespace ComWrappersTests
 
             Assert.IsTrue(testWrapperIds.Count <= Test.InstanceCount);
 
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
+            ForceGC();
 
             Assert.IsTrue(testWrapperIds.Count <= Test.InstanceCount);
 
@@ -391,11 +403,69 @@ namespace ComWrappersTests
 
             testWrapperIds.Clear();
 
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
+            ForceGC();
+        }
+
+        unsafe class Derived : ITrackerObjectWrapper
+        {
+            public Derived(ComWrappers cw, bool aggregateRefTracker)
+                : base(cw, aggregateRefTracker)
+            { }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static WeakReference<Derived> AllocateAndUseBaseType(ComWrappers cw, bool aggregateRefTracker)
+            {
+                var derived = new Derived(cw, aggregateRefTracker);
+
+                // Use the base type
+                IntPtr testWrapper = cw.GetOrCreateComInterfaceForObject(new Test(), CreateComInterfaceFlags.TrackerSupport);
+                int id = derived.AddObjectRef(testWrapper);
+
+                // Tell the tracker runtime to release its hold on the base instance.
+                MockReferenceTrackerRuntime.ReleaseAllTrackerObjects();
+
+                // Validate the GC is tracking the entire Derived type.
+                ForceGC();
+
+                derived.DropObjectRef(id);
+
+                return new WeakReference<Derived>(derived);
+            }
+        }
+
+        static void ValidateAggregationWithComObject()
+        {
+            Console.WriteLine($"Running {nameof(ValidateAggregationWithComObject)}...");
+
+            using var allocTracker = MockReferenceTrackerRuntime.CountTrackerObjectAllocations();
+            var cw = new TestComWrappers();
+            WeakReference<Derived> weakRef = Derived.AllocateAndUseBaseType(cw, aggregateRefTracker: false);
+
+            ForceGC();
+
+            // Validate all instances were cleaned up
+            Assert.IsFalse(weakRef.TryGetTarget(out _));
+            Assert.AreEqual(0, allocTracker.GetCount());
+        }
+
+        static void ValidateAggregationWithReferenceTrackerObject()
+        {
+            Console.WriteLine($"Running {nameof(ValidateAggregationWithReferenceTrackerObject)}...");
+
+            using var allocTracker = MockReferenceTrackerRuntime.CountTrackerObjectAllocations();
+            var cw = new TestComWrappers();
+            WeakReference<Derived> weakRef = Derived.AllocateAndUseBaseType(cw, aggregateRefTracker: true);
+
+            ForceGC();
+
+            // Validate all instances were cleaned up.
+            Assert.IsFalse(weakRef.TryGetTarget(out _));
+
+            // Reference counter cleanup requires additional GCs since the Finalizer is used
+            // to clean up the Reference Tracker runtime references.
+            ForceGC();
+
+            Assert.AreEqual(0, allocTracker.GetCount());
         }
 
         static int Main(string[] doNotUse)
@@ -410,6 +480,8 @@ namespace ComWrappersTests
                 ValidateIUnknownImpls();
                 ValidateBadComWrapperImpl();
                 ValidateRuntimeTrackerScenario();
+                ValidateAggregationWithComObject();
+                ValidateAggregationWithReferenceTrackerObject();
             }
             catch (Exception e)
             {

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -4,6 +4,7 @@
 namespace ComWrappersTests.Common
 {
     using System;
+    using System.Threading;
     using System.Runtime.InteropServices;
 
     //
@@ -84,10 +85,64 @@ namespace ComWrappersTests.Common
     //
     // Native interface defintion with managed wrapper for tracker object
     //
-    struct MockReferenceTrackerRuntime
+    sealed class MockReferenceTrackerRuntime
     {
+        private static readonly ReaderWriterLockSlim AllocLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+
+        public static IntPtr CreateTrackerObject()
+        {
+            return CreateTrackerObject(IntPtr.Zero, out IntPtr _);
+        }
+
+        public static IntPtr CreateTrackerObject(IntPtr outer, out IntPtr inner)
+        {
+            AllocLock.EnterReadLock();
+            try
+            {
+                return CreateTrackerObject_Unsafe(outer, out inner);
+            }
+            finally
+            {
+                AllocLock.ExitReadLock();
+            }
+        }
+
         [DllImport(nameof(MockReferenceTrackerRuntime))]
-        extern public static IntPtr CreateTrackerObject();
+        extern private static IntPtr CreateTrackerObject_Unsafe(IntPtr outer, out IntPtr inner);
+
+        public class AllocationCountResult : IDisposable
+        {
+            private bool isDisposed = false;
+            private ReaderWriterLockSlim allocLock;
+            public AllocationCountResult(ReaderWriterLockSlim allocLock)
+            {
+                this.allocLock = allocLock;
+                this.allocLock.EnterWriteLock();
+                StartTrackerObjectAllocationCount_Unsafe();
+            }
+
+            public int GetCount() => StopTrackerObjectAllocationCount_Unsafe();
+
+            void IDisposable.Dispose()
+            {
+                if (this.isDisposed)
+                    return;
+
+                this.allocLock.ExitWriteLock();
+                this.isDisposed = true;
+            }
+        }
+
+        public static AllocationCountResult CountTrackerObjectAllocations()
+        {
+            return new AllocationCountResult(AllocLock);
+        }
+
+        [DllImport(nameof(MockReferenceTrackerRuntime))]
+        extern private static void StartTrackerObjectAllocationCount_Unsafe();
+
+        [DllImport(nameof(MockReferenceTrackerRuntime))]
+        extern private static int StopTrackerObjectAllocationCount_Unsafe();
 
         [DllImport(nameof(MockReferenceTrackerRuntime))]
         extern public static void ReleaseAllTrackerObjects();
@@ -108,7 +163,7 @@ namespace ComWrappersTests.Common
         public IntPtr Vtbl;
     }
 
-    public class ITrackerObjectWrapper : ITrackerObject
+    public class ITrackerObjectWrapper : ITrackerObject, ICustomQueryInterface
     {
         private struct ITrackerObjectWrapperVtbl
         {
@@ -124,28 +179,40 @@ namespace ComWrappersTests.Common
         private delegate int _AddObjectRef(IntPtr This, IntPtr obj, out int id);
         private delegate int _DropObjectRef(IntPtr This, int id);
 
-        private readonly IntPtr instance;
+        private ComWrappersHelper.ClassNative classNative;
+
         private readonly ITrackerObjectWrapperVtbl vtable;
 
-        public ITrackerObjectWrapper(IntPtr instance)
+        public ITrackerObjectWrapper(IntPtr instancePtr)
         {
-            var inst = Marshal.PtrToStructure<VtblPtr>(instance);
+            var inst = Marshal.PtrToStructure<VtblPtr>(instancePtr);
             this.vtable = Marshal.PtrToStructure<ITrackerObjectWrapperVtbl>(inst.Vtbl);
-            this.instance = instance;
+            this.classNative.Instance = instancePtr;
+            this.classNative.Release = ComWrappersHelper.ReleaseFlags.Instance;
+        }
+
+        protected unsafe ITrackerObjectWrapper(ComWrappers cw, bool aggregateRefTracker)
+        {
+            ComWrappersHelper.Init<ITrackerObjectWrapper>(ref this.classNative, this, aggregateRefTracker, cw, &CreateInstance);
+
+            var inst = Marshal.PtrToStructure<VtblPtr>(this.classNative.Instance);
+            this.vtable = Marshal.PtrToStructure<ITrackerObjectWrapperVtbl>(inst.Vtbl);
+
+            static IntPtr CreateInstance(IntPtr outer, out IntPtr inner)
+            {
+                return MockReferenceTrackerRuntime.CreateTrackerObject(outer, out inner);
+            }
         }
 
         ~ITrackerObjectWrapper()
         {
-            if (this.instance != IntPtr.Zero)
-            {
-                this.vtable.Release(this.instance);
-            }
+            ComWrappersHelper.Cleanup(ref this.classNative);
         }
 
         public int AddObjectRef(IntPtr obj)
         {
             int id;
-            int hr = this.vtable.AddObjectRef(this.instance, obj, out id);
+            int hr = this.vtable.AddObjectRef(this.classNative.Instance, obj, out id);
             if (hr != 0)
             {
                 throw new COMException($"{nameof(AddObjectRef)}", hr);
@@ -156,10 +223,253 @@ namespace ComWrappersTests.Common
 
         public void DropObjectRef(int id)
         {
-            int hr = this.vtable.DropObjectRef(this.instance, id);
+            int hr = this.vtable.DropObjectRef(this.classNative.Instance, id);
             if (hr != 0)
             {
                 throw new COMException($"{nameof(DropObjectRef)}", hr);
+            }
+        }
+
+        CustomQueryInterfaceResult ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
+        {
+            if (this.classNative.Inner == IntPtr.Zero)
+            {
+                ppv = IntPtr.Zero;
+                return CustomQueryInterfaceResult.NotHandled;
+            }
+
+            const int S_OK = 0;
+            const int E_NOINTERFACE = unchecked((int)0x80004002);
+
+            int hr = Marshal.QueryInterface(this.classNative.Inner, ref iid, out ppv);
+            if (hr == S_OK)
+            {
+                return CustomQueryInterfaceResult.Handled;
+            }
+
+            return hr == E_NOINTERFACE
+                ? CustomQueryInterfaceResult.NotHandled
+                : CustomQueryInterfaceResult.Failed;
+        }
+    }
+
+    class ComWrappersHelper
+    {
+        private static Guid IID_IReferenceTracker = new Guid("11d3b13a-180e-4789-a8be-7712882893e6");
+
+        [Flags]
+        public enum ReleaseFlags
+        {
+            None = 0,
+            Instance = 1,
+            Inner = 2,
+            ReferenceTracker = 4
+        }
+
+        public struct ClassNative
+        {
+            public ReleaseFlags Release;
+            public IntPtr Instance;
+            public IntPtr Inner;
+            public IntPtr ReferenceTracker;
+        }
+
+        public unsafe static void Init<T>(
+            ref ClassNative classNative,
+            object thisInstance,
+            bool aggregateRefTracker,
+            ComWrappers cw,
+            delegate*<IntPtr, out IntPtr, IntPtr> CreateInstance)
+        {
+            bool isAggregation = typeof(T) != thisInstance.GetType();
+
+            {
+                IntPtr outer = default;
+                if (isAggregation)
+                {
+                    // Create a managed object wrapper (i.e. CCW) to act as the outer.
+                    // Passing the CreateComInterfaceFlags.TrackerSupport can be done if
+                    // IReferenceTracker support is possible.
+                    //
+                    // The outer is now owned in this context.
+                    outer = cw.GetOrCreateComInterfaceForObject(thisInstance, CreateComInterfaceFlags.TrackerSupport);
+                }
+
+                // Create an instance of the COM/WinRT type.
+                // This is typically accomplished through a call to CoCreateInstance() or RoActivateInstance().
+                //
+                // Ownership of the outer has been transferred to the new instance.
+                // Some APIs do return a non-null inner even with a null outer. This
+                // means ownership may now be owned in this context in either aggregation state.
+                classNative.Instance = CreateInstance(outer, out classNative.Inner);
+            }
+
+            // TEST: Indicate if we should attempt aggregation with ReferenceTracker.
+            if (aggregateRefTracker)
+            {
+                // Determine if the instance supports IReferenceTracker (e.g. WinUI).
+                // Acquiring this interface is useful for:
+                //   1) Providing an indication of what value to pass during RCW creation.
+                //   2) Informing the Reference Tracker runtime during non-aggregation
+                //      scenarios about new references.
+                //
+                // If aggregation, query the inner since that will have the implementation
+                // otherwise the new instance will be used. Since the inner was composed
+                // it should answer immediately without going through the outer. Either way
+                // the reference count will go to the new instance.
+                IntPtr queryForTracker = isAggregation ? classNative.Inner : classNative.Instance;
+                int hr = Marshal.QueryInterface(queryForTracker, ref IID_IReferenceTracker, out classNative.ReferenceTracker);
+                if (hr != 0)
+                {
+                    classNative.ReferenceTracker = default;
+                }
+            }
+
+            {
+                // Determine flags needed for native object wrapper (i.e. RCW) creation.
+                var createObjectFlags = CreateObjectFlags.None;
+                IntPtr instanceToWrap = classNative.Instance;
+
+                // Update flags if the native instance is being used in an aggregation scenario.
+                if (isAggregation)
+                {
+                    // Indicate the scenario is aggregation
+                    createObjectFlags |= (CreateObjectFlags)4;
+
+                    // The instance supports IReferenceTracker.
+                    if (classNative.ReferenceTracker != default(IntPtr))
+                    {
+                        createObjectFlags |= CreateObjectFlags.TrackerObject;
+
+                        // IReferenceTracker is not needed in aggregation scenarios.
+                        // It is not needed because all QueryInterface() calls on an
+                        // object are followed by an immediately release of the returned
+                        // pointer - see below for details.
+                        Marshal.Release(classNative.ReferenceTracker);
+
+                        // .NET 5 limitation
+                        //
+                        // For aggregated scenarios involving IReferenceTracker
+                        // the API handles object cleanup. In .NET 5 the API
+                        // didn't expose an option to handle this so we pass the inner
+                        // in order to handle its lifetime.
+                        //
+                        // The API doesn't handle inner lifetime in any other scenario
+                        // in the .NET 5 timeframe.
+                        instanceToWrap = classNative.Inner;
+                    }
+                }
+
+                // Create a native object wrapper (i.e. RCW).
+                //
+                // Note this function will call QueryInterface() on the supplied instance,
+                // therefore it is important that the enclosing CCW forwards to its inner
+                // if aggregation is involved. This is typically accomplished through an
+                // implementation of ICustomQueryInterface.
+                cw.GetOrRegisterObjectForComInstance(instanceToWrap, createObjectFlags, thisInstance);
+            }
+
+            if (isAggregation)
+            {
+                // We release the instance here, but continue to use it since
+                // ownership was transferred to the API and it will guarantee
+                // the appropriate lifetime.
+                Marshal.Release(classNative.Instance);
+            }
+            else
+            {
+                // In non-aggregation scenarios where an inner exists and
+                // reference tracker is involved, we release the inner.
+                //
+                // .NET 5 limitation - see logic above.
+                if (classNative.Inner != default(IntPtr) && classNative.ReferenceTracker != default(IntPtr))
+                {
+                    Marshal.Release(classNative.Inner);
+                }
+            }
+
+            // The following describes the valid local values to consider and details
+            // on their usage during the object's lifetime.
+            classNative.Release = ReleaseFlags.None;
+            if (isAggregation)
+            {
+                // Aggregation scenarios should avoid calling AddRef() on the
+                // newInstance value. This is due to the semantics of COM Aggregation
+                // and the fact that calling an AddRef() on the instance will increment
+                // the CCW which in turn will ensure it cannot be cleaned up. Calling
+                // AddRef() on the instance when passed to unmanagec code is correct
+                // since unmanaged code is required to call Release() at some point.
+                if (classNative.ReferenceTracker == default(IntPtr))
+                {
+                    // COM scenario
+                    // The pointer to dispatch on for the instance.
+                    // ** Never release.
+                    classNative.Release |= ReleaseFlags.None; // Instance
+
+                    // A pointer to the inner that should be queried for
+                    //    additional interfaces. Immediately after a QueryInterface()
+                    //    a Release() should be called on the returned pointer but the
+                    //    pointer can be retained and used.
+                    // ** Release in this class's Finalizer.
+                    classNative.Release |= ReleaseFlags.Inner; // Inner
+                }
+                else
+                {
+                    // WinUI scenario
+                    // The pointer to dispatch on for the instance.
+                    // ** Never release.
+                    classNative.Release |= ReleaseFlags.None; // Instance
+
+                    // A pointer to the inner that should be queried for
+                    //    additional interfaces. Immediately after a QueryInterface()
+                    //    a Release() should be called on the returned pointer but the
+                    //    pointer can be retained and used.
+                    // ** Never release.
+                    classNative.Release |= ReleaseFlags.None; // Inner
+
+                    // No longer needed.
+                    // ** Never release.
+                    classNative.Release |= ReleaseFlags.None; // ReferenceTracker
+                }
+            }
+            else
+            {
+                if (classNative.ReferenceTracker == default(IntPtr))
+                {
+                    // COM scenario
+                    // The pointer to dispatch on for the instance.
+                    // ** Release in this class's Finalizer.
+                    classNative.Release |= ReleaseFlags.Instance; // Instance
+                }
+                else
+                {
+                    // WinUI scenario
+                    // The pointer to dispatch on for the instance.
+                    // ** Release in this class's Finalizer.
+                    classNative.Release |= ReleaseFlags.Instance; // Instance
+
+                    // This instance should be used to tell the
+                    //    Reference Tracker runtime whenever an AddRef()/Release()
+                    //    is performed on newInstance.
+                    // ** Release in this class's Finalizer.
+                    classNative.Release |= ReleaseFlags.ReferenceTracker; // ReferenceTracker
+                }
+            }
+        }
+
+        public static void Cleanup(ref ClassNative classNative)
+        {
+            if (classNative.Release.HasFlag(ReleaseFlags.Inner))
+            {
+                Marshal.Release(classNative.Inner);
+            }
+            if (classNative.Release.HasFlag(ReleaseFlags.Instance))
+            {
+                Marshal.Release(classNative.Instance);
+            }
+            if (classNative.Release.HasFlag(ReleaseFlags.ReferenceTracker))
+            {
+                Marshal.Release(classNative.ReferenceTracker);
             }
         }
     }

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
@@ -15,15 +15,15 @@ namespace ComWrappersTests.GlobalInstance
     {
         struct MarshalInterface
         {
-            [DllImport(nameof(MockReferenceTrackerRuntime), EntryPoint=nameof(MockReferenceTrackerRuntime.CreateTrackerObject))]
+            [DllImport(nameof(MockReferenceTrackerRuntime), EntryPoint="CreateTrackerObject_SkipTrackerRuntime")]
             [return: MarshalAs(UnmanagedType.IUnknown)]
             extern public static object CreateTrackerObjectAsIUnknown();
 
-            [DllImport(nameof(MockReferenceTrackerRuntime), EntryPoint=nameof(MockReferenceTrackerRuntime.CreateTrackerObject))]
+            [DllImport(nameof(MockReferenceTrackerRuntime), EntryPoint="CreateTrackerObject_SkipTrackerRuntime")]
             [return: MarshalAs(UnmanagedType.Interface)]
             extern public static FakeWrapper CreateTrackerObjectAsInterface();
 
-            [DllImport(nameof(MockReferenceTrackerRuntime), EntryPoint = nameof(MockReferenceTrackerRuntime.CreateTrackerObject))]
+            [DllImport(nameof(MockReferenceTrackerRuntime), EntryPoint="CreateTrackerObject_SkipTrackerRuntime")]
             [return: MarshalAs(UnmanagedType.Interface)]
             extern public static Test CreateTrackerObjectWrongType();
 


### PR DESCRIPTION
Issues: https://github.com/microsoft/CsWinRT/issues/413, https://github.com/microsoft/microsoft-ui-xaml/issues/3719

# Description

A fundamental flaw was discovered during consumption of the `ComWrappers` API (introduced .NET 5) in [WinUI 3.0](https://github.com/microsoft/microsoft-ui-xaml) scenarios. This was related to COM Aggregation and how [C#/WinRT](https://github.com/microsoft/cswinrt) generated interop code.

The work here corrects this issue and provides additional testing.

# Customer Impact

Scenarios involving WinRT support provided by C#/WinRT with aggregation of WinRT types will leak memory with no recourse. This impacts consumption of the WinUI stack.

# Regression

This API is new in .NET 5.0. However the API is used to address the removal of WinRT built-in support - https://github.com/dotnet/runtime/issues/37672.

# Testing

Additional E2E testing has been added in this PR. The scenario was also manually validated on a local build against the official XAML/Jupiter runtime using hand crafted interop code. A private build of coreclr was then shared with the C#/WinRT team for validation.

# Risk

Minimal risk. The code paths in question are not used outside of the `ComWrappers` API scenario - only known consumer is C#/WinRT and WinUI. The risk for these two consumers are as follows:

1. This fix is incomplete.
2. This fix results in a crash in a WinUI scenario.

Risk (1) means leaks may still exist but they are no worse off than the current code. There has been verified improvement, but it is possible additional leaks exist. Risk (2) is slightly more concerning but is mitigable if this PR results in early collection or use after free scenarios. The C#/WinRT code generation tool can introduce a quirk to explicitly leak the object instead of attempting to participate in collection.

Neither of these are expected but they represent reduced risk from the CoreCLR perspective.

/cc @scottj1s @davidwrighton @jeffschwMSFT @MikeHillberg @elinor-fung @jkoritzinsky 