### PR TITLE
Fix GNU linker detection on FreeBSD

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -654,7 +654,7 @@ else (CLR_CMAKE_HOST_WIN32)
         ERROR_QUIET
         OUTPUT_VARIABLE ldVersionOutput)
 
-    if("${ldVersionOutput}" MATCHES "GNU ld" OR "${ldVersionOutput}" MATCHES "GNU gold")
+    if("${ldVersionOutput}" MATCHES "GNU ld" OR "${ldVersionOutput}" MATCHES "GNU gold" OR "${ldVersionOutput}" MATCHES "GNU linkers")
         set(LD_GNU 1)
     elseif("${ldVersionOutput}" MATCHES "Solaris Link")
         set(LD_SOLARIS 1)


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/37753, we unified linker detection by version output string. At the time, only cross compilation of FreeBSD was validated, but on the OS, the output looks like:

```sh
$ clang -Wl,--version
LLD 10.0.1 (FreeBSD llvmorg-10.0.1-0-gef32c611aa2-1200012) (compatible with GNU linkers)
```

This PR fixes CoreCLR build on FreeBSD and build succeeds.

Fixes https://github.com/dotnet/runtime/issues/45663

cc @janvorli, @Thefrank