### PR TITLE
Make PortableThreadPool to check events correctly before firing them

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.HillClimbing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.HillClimbing.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 
 namespace System.Threading
 {
@@ -169,7 +170,7 @@ namespace System.Threading
                 // Add the current thread count and throughput sample to our history
                 //
                 double throughput = numCompletions / sampleDurationSeconds;
-                if (PortableThreadPoolEventSource.Log.IsEnabled())
+                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadAdjustmentSample(throughput);
                 }
@@ -343,7 +344,7 @@ namespace System.Threading
                 // Record these numbers for posterity
                 //
 
-                if (PortableThreadPoolEventSource.Log.IsEnabled())
+                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Verbose, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadAdjustmentStats(sampleDurationSeconds, throughput, threadWaveComponent.Real, throughputWaveComponent.Real,
                         throughputErrorEstimate, _averageThroughputNoise, ratio.Real, confidence, _currentControlSetting, (ushort)newThreadWaveMagnitude);
@@ -404,7 +405,7 @@ namespace System.Threading
 
                 _logSize++;
 
-                if (PortableThreadPoolEventSource.Log.IsEnabled())
+                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadAdjustmentAdjustment(
                         throughput,

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Threading
@@ -36,7 +37,7 @@ namespace System.Threading
         /// <param name="handle">A description of the requested registration.</param>
         internal void RegisterWaitHandle(RegisteredWaitHandle handle)
         {
-            if (PortableThreadPoolEventSource.Log.IsEnabled())
+            if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Verbose, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
             {
                 PortableThreadPoolEventSource.Log.ThreadPoolIOEnqueue(handle);
             }
@@ -75,7 +76,7 @@ namespace System.Threading
 
         internal static void CompleteWait(RegisteredWaitHandle handle, bool timedOut)
         {
-            if (PortableThreadPoolEventSource.Log.IsEnabled())
+            if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Verbose, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
             {
                 PortableThreadPoolEventSource.Log.ThreadPoolIODequeue(handle);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Tracing;
+
 namespace System.Threading
 {
     internal partial class PortableThreadPool
@@ -20,7 +22,7 @@ namespace System.Threading
                     AppContextConfigHelper.GetInt32Config("System.Threading.ThreadPool.UnfairSemaphoreSpinLimit", 70, false),
                     onWait: () =>
                     {
-                        if (PortableThreadPoolEventSource.Log.IsEnabled())
+                        if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
                         {
                             PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadWait(
                                 (uint)ThreadPoolInstance._separated.counts.VolatileRead().NumExistingThreads);
@@ -33,7 +35,7 @@ namespace System.Threading
 
                 PortableThreadPool threadPoolInstance = ThreadPoolInstance;
 
-                if (PortableThreadPoolEventSource.Log.IsEnabled())
+                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadStart(
                         (uint)threadPoolInstance._separated.counts.VolatileRead().NumExistingThreads);
@@ -105,7 +107,7 @@ namespace System.Threading
                             {
                                 HillClimbing.ThreadPoolHillClimber.ForceChange(newNumThreadsGoal, HillClimbing.StateOrTransition.ThreadTimedOut);
 
-                                if (PortableThreadPoolEventSource.Log.IsEnabled())
+                                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
                                 {
                                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadStop((uint)newNumExistingThreads);
                                 }


### PR DESCRIPTION
PortableThreadPool is firing several verbose events without checking whether they are enabled properly. Specifically they need to be checked with the proper `EventLevel` and `EventKeywords` but they were only being checked via the default `IsEnabled()` method which will return true whenever any event under NativeRuntimeEventSource is enabled. 
 
This should also fix #45660. 

