### PR TITLE
Fix EventPipeSession::WriteEventSuspend 

### DIFF
--- a/src/coreclr/vm/eventpipebuffermanager.cpp
+++ b/src/coreclr/vm/eventpipebuffermanager.cpp
@@ -986,7 +986,7 @@ void EventPipeBufferManager::SuspendWriteEvent(uint32_t sessionIndex)
 
             // By the time we get here, most threads should have already been marked as done but it is
             // still possible (while pretty unlikely) for some threads to race with EventPipeSession::SuspendWriteEvent
-            // if they were already in the WriteEvent() call and got preemptied before setting themselves as
+            // if they were already in the WriteEvent() call and got preempted before setting themselves as
             // write in progress. Apart from these threads, the check below should be a single cmp op. For threads
             // who do end up in that state, we block for at most one check (pSession != nullptr).
             YIELD_WHILE(pThread->GetSessionWriteInProgress() == sessionIndex);

--- a/src/coreclr/vm/eventpipebuffermanager.cpp
+++ b/src/coreclr/vm/eventpipebuffermanager.cpp
@@ -983,13 +983,6 @@ void EventPipeBufferManager::SuspendWriteEvent(uint32_t sessionIndex)
             EventPipeThread *pThread = pElem->GetValue()->GetThread();
             threadList.Push(pThread);
             pElem = m_pThreadSessionStateList->GetNext(pElem);
-
-            // By the time we get here, most threads should have already been marked as done but it is
-            // still possible (while pretty unlikely) for some threads to race with EventPipeSession::SuspendWriteEvent
-            // if they were already in the WriteEvent() call and got preempted before setting themselves as
-            // write in progress. Apart from these threads, the check below should be a single cmp op. For threads
-            // who do end up in that state, we block for at most one check (pSession != nullptr).
-            YIELD_WHILE(pThread->GetSessionWriteInProgress() == sessionIndex);
         }
     }
 

--- a/src/coreclr/vm/eventpipebuffermanager.cpp
+++ b/src/coreclr/vm/eventpipebuffermanager.cpp
@@ -988,7 +988,7 @@ void EventPipeBufferManager::SuspendWriteEvent(uint32_t sessionIndex)
             // still possible (while pretty unlikely) for some threads to race with EventPipeSession::SuspendWriteEvent
             // if they were already in the WriteEvent() call and got preemptied before setting themselves as
             // write in progress. Apart from these threads, the check below should be a single cmp op. For threads
-            // who do end up writing, we block for that duration.
+            // who do end up in that state, we block for at most one check (pSession != nullptr).
             YIELD_WHILE(pThread->GetSessionWriteInProgress() == sessionIndex);
         }
     }


### PR DESCRIPTION
Found from a test failure: #44447 

It is possible for pThread to get a SessionWriteInProgress if it was created between EventPipeSession::SuspendWriteEvent and EventPipeBufferManager::SuspendWriteEvent because in EventPipe::WriteEventInternal we still call SessionWriteInProgress before checking if the session is enabled.

That thread will then get new EventPipeThread whose state does not indicate that the session is disabled, which means this thread will think it's still under writing.

The fix is to just remove this ASSERTE since this is not a valid assertion under this circumstance. 

Note this won't result in a segfault in release build either, since pSession is null by the time the preempted thread returns to write an event after setting the SessionWriteInProgress. 
