### PR TITLE
Update portable thread pool event enablement checks

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -44,10 +43,7 @@ namespace System.Threading
                     {
                         Thread.Sleep(GateThreadDelayMs);
 
-                        if (ThreadPool.EnableWorkerTracking &&
-                            PortableThreadPoolEventSource.Log.IsEnabled(
-                                EventLevel.Verbose,
-                                PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+                        if (ThreadPool.EnableWorkerTracking && PortableThreadPoolEventSource.Log.IsEnabled())
                         {
                             PortableThreadPoolEventSource.Log.ThreadPoolWorkingThreadCount(
                                 (uint)threadPoolInstance.GetAndResetHighWatermarkCountOfThreadsProcessingUserCallbacks());

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.HillClimbing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.HillClimbing.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 
 namespace System.Threading
 {
@@ -170,7 +169,7 @@ namespace System.Threading
                 // Add the current thread count and throughput sample to our history
                 //
                 double throughput = numCompletions / sampleDurationSeconds;
-                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+                if (PortableThreadPoolEventSource.Log.IsEnabled())
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadAdjustmentSample(throughput);
                 }
@@ -344,7 +343,7 @@ namespace System.Threading
                 // Record these numbers for posterity
                 //
 
-                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Verbose, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+                if (PortableThreadPoolEventSource.Log.IsEnabled())
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadAdjustmentStats(sampleDurationSeconds, throughput, threadWaveComponent.Real, throughputWaveComponent.Real,
                         throughputErrorEstimate, _averageThroughputNoise, ratio.Real, confidence, _currentControlSetting, (ushort)newThreadWaveMagnitude);
@@ -405,7 +404,7 @@ namespace System.Threading
 
                 _logSize++;
 
-                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+                if (PortableThreadPoolEventSource.Log.IsEnabled())
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadAdjustmentAdjustment(
                         throughput,

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Threading
@@ -37,7 +36,7 @@ namespace System.Threading
         /// <param name="handle">A description of the requested registration.</param>
         internal void RegisterWaitHandle(RegisteredWaitHandle handle)
         {
-            if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Verbose, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+            if (PortableThreadPoolEventSource.Log.IsEnabled())
             {
                 PortableThreadPoolEventSource.Log.ThreadPoolIOEnqueue(handle);
             }
@@ -76,7 +75,7 @@ namespace System.Threading
 
         internal static void CompleteWait(RegisteredWaitHandle handle, bool timedOut)
         {
-            if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Verbose, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+            if (PortableThreadPoolEventSource.Log.IsEnabled())
             {
                 PortableThreadPoolEventSource.Log.ThreadPoolIODequeue(handle);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.Tracing;
-
 namespace System.Threading
 {
     internal partial class PortableThreadPool
@@ -22,7 +20,7 @@ namespace System.Threading
                     AppContextConfigHelper.GetInt32Config("System.Threading.ThreadPool.UnfairSemaphoreSpinLimit", 70, false),
                     onWait: () =>
                     {
-                        if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+                        if (PortableThreadPoolEventSource.Log.IsEnabled())
                         {
                             PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadWait(
                                 (uint)ThreadPoolInstance._separated.counts.VolatileRead().NumExistingThreads);
@@ -35,7 +33,7 @@ namespace System.Threading
 
                 PortableThreadPool threadPoolInstance = ThreadPoolInstance;
 
-                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+                if (PortableThreadPoolEventSource.Log.IsEnabled())
                 {
                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadStart(
                         (uint)threadPoolInstance._separated.counts.VolatileRead().NumExistingThreads);
@@ -107,7 +105,7 @@ namespace System.Threading
                             {
                                 HillClimbing.ThreadPoolHillClimber.ForceChange(newNumThreadsGoal, HillClimbing.StateOrTransition.ThreadTimedOut);
 
-                                if (PortableThreadPoolEventSource.Log.IsEnabled(EventLevel.Informational, PortableThreadPoolEventSource.Keywords.ThreadingKeyword))
+                                if (PortableThreadPoolEventSource.Log.IsEnabled())
                                 {
                                     PortableThreadPoolEventSource.Log.ThreadPoolWorkerThreadStop((uint)newNumExistingThreads);
                                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPoolEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPoolEventSource.cs
@@ -108,7 +108,10 @@ namespace System.Threading
             uint RetiredWorkerThreadCount = 0,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
-            WriteThreadEvent(50, ActiveWorkerThreadCount);
+            if (IsEnabled(EventLevel.Informational, Keywords.ThreadingKeyword))
+            {
+                WriteThreadEvent(50, ActiveWorkerThreadCount);
+            }
         }
 
         [Event(51, Level = EventLevel.Informational, Message = Messages.WorkerThread, Task = Tasks.ThreadPoolWorkerThread, Opcode = EventOpcode.Stop, Version = 0, Keywords = Keywords.ThreadingKeyword)]
@@ -117,16 +120,23 @@ namespace System.Threading
             uint RetiredWorkerThreadCount = 0,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
-            WriteThreadEvent(51, ActiveWorkerThreadCount);
+            if (IsEnabled(EventLevel.Informational, Keywords.ThreadingKeyword))
+            {
+                WriteThreadEvent(51, ActiveWorkerThreadCount);
+            }
         }
 
         [Event(57, Level = EventLevel.Informational, Message = Messages.WorkerThread, Task = Tasks.ThreadPoolWorkerThread, Opcode = Opcodes.Wait, Version = 0, Keywords = Keywords.ThreadingKeyword)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void ThreadPoolWorkerThreadWait(
             uint ActiveWorkerThreadCount,
             uint RetiredWorkerThreadCount = 0,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
-            WriteThreadEvent(57, ActiveWorkerThreadCount);
+            if (IsEnabled(EventLevel.Informational, Keywords.ThreadingKeyword))
+            {
+                WriteThreadEvent(57, ActiveWorkerThreadCount);
+            }
         }
 
         [Event(54, Level = EventLevel.Informational, Message = Messages.WorkerThreadAdjustmentSample, Task = Tasks.ThreadPoolWorkerThreadAdjustment, Opcode = Opcodes.Sample, Version = 0, Keywords = Keywords.ThreadingKeyword)]
@@ -134,6 +144,11 @@ namespace System.Threading
             double Throughput,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
+            if (!IsEnabled(EventLevel.Informational, Keywords.ThreadingKeyword))
+            {
+                return;
+            }
+
             EventData* data = stackalloc EventData[2];
             data[0].DataPointer = (IntPtr)(&Throughput);
             data[0].Size = sizeof(double);
@@ -151,6 +166,11 @@ namespace System.Threading
             ThreadAdjustmentReasonMap Reason,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
+            if (!IsEnabled(EventLevel.Informational, Keywords.ThreadingKeyword))
+            {
+                return;
+            }
+
             EventData* data = stackalloc EventData[4];
             data[0].DataPointer = (IntPtr)(&AverageThroughput);
             data[0].Size = sizeof(double);
@@ -181,6 +201,11 @@ namespace System.Threading
             ushort NewThreadWaveMagnitude,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
+            if (!IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
+            {
+                return;
+            }
+
             EventData* data = stackalloc EventData[11];
             data[0].DataPointer = (IntPtr)(&Duration);
             data[0].Size = sizeof(double);
@@ -247,8 +272,13 @@ namespace System.Threading
         // FrameworkEventSource's thread transfer send/receive events instead at callers.
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void ThreadPoolIOEnqueue(RegisteredWaitHandle registeredWaitHandle) =>
-            ThreadPoolIOEnqueue((IntPtr)registeredWaitHandle.GetHashCode(), IntPtr.Zero, registeredWaitHandle.Repeating);
+        public void ThreadPoolIOEnqueue(RegisteredWaitHandle registeredWaitHandle)
+        {
+            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
+            {
+                ThreadPoolIOEnqueue((IntPtr)registeredWaitHandle.GetHashCode(), IntPtr.Zero, registeredWaitHandle.Repeating);
+            }
+        }
 
         [Event(64, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IODequeue, Version = 0, Keywords = Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword)]
         private unsafe void ThreadPoolIODequeue(
@@ -273,12 +303,22 @@ namespace System.Threading
         // FrameworkEventSource's thread transfer send/receive events instead at callers.
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void ThreadPoolIODequeue(RegisteredWaitHandle registeredWaitHandle) =>
-            ThreadPoolIODequeue((IntPtr)registeredWaitHandle.GetHashCode(), IntPtr.Zero);
+        public void ThreadPoolIODequeue(RegisteredWaitHandle registeredWaitHandle)
+        {
+            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
+            {
+                ThreadPoolIODequeue((IntPtr)registeredWaitHandle.GetHashCode(), IntPtr.Zero);
+            }
+        }
 
         [Event(60, Level = EventLevel.Verbose, Message = Messages.WorkingThreadCount, Task = Tasks.ThreadPoolWorkingThreadCount, Opcode = EventOpcode.Start, Version = 0, Keywords = Keywords.ThreadingKeyword)]
         public unsafe void ThreadPoolWorkingThreadCount(uint Count, ushort ClrInstanceID = DefaultClrInstanceId)
         {
+            if (!IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
+            {
+                return;
+            }
+
             EventData* data = stackalloc EventData[2];
             data[0].DataPointer = (IntPtr)(&Count);
             data[0].Size = sizeof(uint);


### PR DESCRIPTION
- The original intent was to check only `IsEnabled()` on the caller side of the event method since it was seen that in very hot paths where events may be fired, more complicated checks involving keyword and verbosity increased the code size in the caller unnecessarily, making it slower. `IsEnabled()` (without keyword and verbosity checks) is a simple check that can be inlined and is less intrusive to the hot path callers. Instead, the callee (the public method in the event source) would check enablement based on keyword and verbosity, and in the really hot paths where it was necessary the callee was also attributed with `NoInlining`.
- From the comment regarding `IsEnabled` checks in https://github.com/dotnet/runtime/pull/38225#discussion_r444537044, I understood that the common paths in the eventing infra would do the necessary checks including keyword and verbosity checks before firing an event. That does not seem to be the case, hence https://github.com/dotnet/runtime/pull/45666.
- So I have reverted the part of https://github.com/dotnet/runtime/pull/38225/commits/e8043ffa05450b1983a1e751d0a1af80e43e1f31 relating to `IsEnabled` checks, which was in response to the comment above, and reverted https://github.com/dotnet/runtime/pull/45666 to restore the original intention