### PR TITLE
Remove installing .NET Core SDK 2.1.808 in macos-sign-with-entitlements.yml

### DIFF
--- a/eng/pipelines/common/macos-sign-with-entitlements.yml
+++ b/eng/pipelines/common/macos-sign-with-entitlements.yml
@@ -2,12 +2,6 @@ parameters:
   filesToSign: []
 
 steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 2.1.808'
-    inputs:
-      packageType: sdk
-      version: 2.1.808
-
   - ${{ each file in parameters.filesToSign }}:
     - script: codesign -s - -f --entitlements ${{ file.entitlementsFile }} ${{ file.path }}/${{ file.name }}
       displayName: 'Add entitlements to ${{ file.name }}'


### PR DESCRIPTION
It's not needed by the ESRP signing task. Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=910935&view=results