### PR TITLE
WIP: Explore using Aho-Corasick for specific patterns in Regex

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexAhoCorasick.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.MappingTable.cs" />
     <Compile Include="System\Text\SegmentStringBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -31,8 +31,10 @@ namespace System.Text.RegularExpressions
 
         internal WeakReference<RegexReplacement?>? _replref;  // cached parsed replacement pattern
         private volatile RegexRunner? _runner;                // cached runner
-        private RegexCode? _code;                             // if interpreted, this is the code for RegexInterpreter
+        internal RegexCode? _code;                             // if interpreted, this is the code for RegexInterpreter
         private bool _refsInitialized;
+
+        internal RegexAhoCorasick? aho;
 
         protected Regex()
         {
@@ -110,6 +112,16 @@ namespace System.Text.RegularExpressions
             capnames = tree.CapNames;
             capslist = tree.CapsList;
             _code = RegexWriter.Write(tree);
+            if (!this.RightToLeft && _code.ahoCorasickWords != null)
+            {
+                aho = new RegexAhoCorasick();
+                for (int i = 0; i < _code.ahoCorasickWords.Count; i++)
+                {
+                    aho.AddString(_code.ahoCorasickWords[i], i);
+                }
+
+                aho.Initialize();
+            }
             caps = _code.Caps;
             capsize = _code.CapSize;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAhoCorasick.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAhoCorasick.cs
@@ -1,13 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// The RegexAhoCorasick object runs the Aho-Corasick algorithm to find multiple string matches in the pattern efficiently.
+// The RegexAhoCorasick object once ready, runs the Aho-Corasick algorithm to find multiple string matches in the pattern efficiently.
 
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 
 namespace System.Text.RegularExpressions
 {
@@ -61,14 +57,13 @@ namespace System.Text.RegularExpressions
             size++;
         }
 
-        public void AddString(string s, int wordID)
+        public void AddString(string word, int wordID)
         {
             int currentVertex = root;
-            for (int i = 0; i < s.Length; ++i) // Iterating over the string's characters
+            for (int i = 0; i < word.Length; ++i)
             {
-                char c = s[i];
+                char c = word[i];
 
-                // Checking if a vertex with this edge exists in the trie:
                 if (!trie[currentVertex].Children.ContainsKey(c))
                 {
                     trie.Add(new TrieNode());
@@ -84,10 +79,10 @@ namespace System.Text.RegularExpressions
             // Mark the end of the word and store its ID
             trie[currentVertex].Leaf = true;
             trie[currentVertex].WordID = wordID;
-            wordsLength.Add(s.Length);
+            wordsLength.Add(word.Length);
         }
 
-        public void PrepareAho()
+        public void Initialize()
         {
             Queue<int> vertexQueue = new Queue<int>();
             vertexQueue.Enqueue(root);
@@ -105,14 +100,14 @@ namespace System.Text.RegularExpressions
 
         public void CalculateSuffixAndDictionaryLinks(int vertex)
         {
-            // Processing root (empty string)
             if (vertex == root)
             {
                 trie[vertex].SuffixLink = root;
                 trie[vertex].DictionaryLink = root;
                 return;
             }
-            // Processing children of the root (one character substrings)
+
+            // one character substrings
             if (trie[vertex].Parent == root)
             {
                 trie[vertex].SuffixLink = root;
@@ -120,39 +115,31 @@ namespace System.Text.RegularExpressions
                 else trie[vertex].DictionaryLink = trie[trie[vertex].SuffixLink].DictionaryLink;
                 return;
             }
-            // Cases above are degenerate cases as for prefix function calculation; the
-            // value is always 0 and links to the root vertex.
 
             // To calculate the suffix link for the current vertex, we need the suffix
-            // link for the parent of the vertex and the character that moved us to the
+            // link for the parent and the character that moved us to the
             // current vertex.
             int curBetterVertex = trie[trie[vertex].Parent].SuffixLink;
             char chVertex = trie[vertex].ParentCharacter;
-            // From this vertex and its substring we will start to look for the maximum
-            // prefix for the current vertex and its substring.
-
             while (true)
             {
-                // If there is an edge with the needed char, we update our suffix link
+                // If there is an edge with the needed char, update the suffix link
                 // and leave the cycle
                 if (trie[curBetterVertex].Children.ContainsKey(chVertex))
                 {
                     trie[vertex].SuffixLink = (int)trie[curBetterVertex].Children[chVertex];
                     break;
                 }
-                // Otherwise, we are jumping by suffix links until we reach the root
-                // (equivalent of k == 0 in prefix function calculation) or we find a
-                // better prefix for the current substring.
+                // Jump by suffix links until we reach the root or find a better prefix for the current substring.
                 if (curBetterVertex == root)
                 {
                     trie[vertex].SuffixLink = root;
                     break;
                 }
-                curBetterVertex = trie[curBetterVertex].SuffixLink; // Go back by sufflink
+                // Go up by suffixlink
+                curBetterVertex = trie[curBetterVertex].SuffixLink;
             }
-            // When we complete the calculation of the suffix link for the current
-            // vertex, we should update the link to the end of the maximum length word
-            // that can be produced from the current substring.
+
             if (trie[vertex].Leaf)
             {
                 trie[vertex].DictionaryLink = vertex;
@@ -163,30 +150,20 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        public int ProcessString(string text)
+        public IEnumerable<(int indexOfMatch, int lengthOfMatch)> ProcessString(string text)
         {
-            // Current state value
             int currentState = root;
-
-            // Targeted result value
             int result = 0;
 
             for (int j = 0; j < text.Length; j++)
             {
-                // Calculating new state in the trie
                 while (true)
                 {
-                    // If we have the edge, then use it
                     if (trie[currentState].Children.ContainsKey(text[j]))
                     {
                         currentState = (int)trie[currentState].Children[text[j]];
                         break;
                     }
-                    // Otherwise, jump by suffix links and try to find the edge with
-                    // this char
-
-                    // If there aren't any possible edges we will eventually ascend to
-                    // the root, and at this point we stop checking.
                     if (currentState == root)
                     {
                         break;
@@ -200,25 +177,21 @@ namespace System.Text.RegularExpressions
                 // Trying to find all possible words from this prefix
                 while (true)
                 {
-                    // Checking all words that we can get from the current prefix
                     checkState = trie[checkState].DictionaryLink;
 
-                    // If we are in the root vertex, there are no more matches
                     if (checkState == root) break;
 
-                    // If the algorithm arrived at this row, it means we have found a
-                    // pattern match. And we can make additional calculations like find
-                    // the index of the found match in the text. Or check that the found
-                    // pattern is a separate word and not just, e.g., a substring.
+                    // Found a match
                     result++;
                     int indexOfMatch = j + 1 - wordsLength[trie[checkState].WordID];
+                    yield return (indexOfMatch, wordsLength[trie[checkState].WordID]);
 
-                    // Trying to find all matched patterns of smaller length
+                    // Try to find all matched patterns of smaller length
                     checkState = trie[checkState].SuffixLink;
                 }
             }
 
-            return result;
+            yield return (-1, -1);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAhoCorasick.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAhoCorasick.cs
@@ -1,0 +1,224 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// The RegexAhoCorasick object runs the Aho-Corasick algorithm to find multiple string matches in the pattern efficiently.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace System.Text.RegularExpressions
+{
+    internal class TrieNode
+    {
+        public TrieNode()
+        {
+            Children = new Dictionary<char, int>();
+            Leaf = false;
+            Parent = -1;
+            SuffixLink = -1;
+            WordID = -1;
+            DictionaryLink = -1;
+        }
+
+        public Dictionary<char, int> Children;
+
+        public bool Leaf;
+
+        public int Parent;
+
+        public char ParentCharacter;
+
+        public int SuffixLink;
+
+        public int DictionaryLink;
+
+        public int WordID;
+    }
+
+    internal class RegexAhoCorasick
+    {
+        private List<TrieNode> trie;
+        private List<int> wordsLength;
+        private int size;
+#pragma warning disable CS0649
+        private readonly int root;
+#pragma warning restore CS0649
+
+        public RegexAhoCorasick()
+        {
+            trie = new List<TrieNode>();
+            wordsLength = new List<int>();
+            root = 0;
+            Init();
+        }
+
+        private void Init()
+        {
+            trie.Add(new TrieNode());
+            size++;
+        }
+
+        public void AddString(string s, int wordID)
+        {
+            int currentVertex = root;
+            for (int i = 0; i < s.Length; ++i) // Iterating over the string's characters
+            {
+                char c = s[i];
+
+                // Checking if a vertex with this edge exists in the trie:
+                if (!trie[currentVertex].Children.ContainsKey(c))
+                {
+                    trie.Add(new TrieNode());
+
+                    trie[size].SuffixLink = -1; // If not - add vertex
+                    trie[size].Parent = currentVertex;
+                    trie[size].ParentCharacter = c;
+                    trie[currentVertex].Children[c] = size;
+                    size++;
+                }
+                currentVertex = (int)trie[currentVertex].Children[c]; // Move to the new vertex in the trie
+            }
+            // Mark the end of the word and store its ID
+            trie[currentVertex].Leaf = true;
+            trie[currentVertex].WordID = wordID;
+            wordsLength.Add(s.Length);
+        }
+
+        public void PrepareAho()
+        {
+            Queue<int> vertexQueue = new Queue<int>();
+            vertexQueue.Enqueue(root);
+            while (vertexQueue.Count > 0)
+            {
+                int currentVertex = vertexQueue.Dequeue();
+                CalculateSuffixAndDictionaryLinks(currentVertex);
+
+                foreach (char key in trie[currentVertex].Children.Keys)
+                {
+                    vertexQueue.Enqueue((int)trie[currentVertex].Children[key]);
+                }
+            }
+        }
+
+        public void CalculateSuffixAndDictionaryLinks(int vertex)
+        {
+            // Processing root (empty string)
+            if (vertex == root)
+            {
+                trie[vertex].SuffixLink = root;
+                trie[vertex].DictionaryLink = root;
+                return;
+            }
+            // Processing children of the root (one character substrings)
+            if (trie[vertex].Parent == root)
+            {
+                trie[vertex].SuffixLink = root;
+                if (trie[vertex].Leaf) trie[vertex].DictionaryLink = vertex;
+                else trie[vertex].DictionaryLink = trie[trie[vertex].SuffixLink].DictionaryLink;
+                return;
+            }
+            // Cases above are degenerate cases as for prefix function calculation; the
+            // value is always 0 and links to the root vertex.
+
+            // To calculate the suffix link for the current vertex, we need the suffix
+            // link for the parent of the vertex and the character that moved us to the
+            // current vertex.
+            int curBetterVertex = trie[trie[vertex].Parent].SuffixLink;
+            char chVertex = trie[vertex].ParentCharacter;
+            // From this vertex and its substring we will start to look for the maximum
+            // prefix for the current vertex and its substring.
+
+            while (true)
+            {
+                // If there is an edge with the needed char, we update our suffix link
+                // and leave the cycle
+                if (trie[curBetterVertex].Children.ContainsKey(chVertex))
+                {
+                    trie[vertex].SuffixLink = (int)trie[curBetterVertex].Children[chVertex];
+                    break;
+                }
+                // Otherwise, we are jumping by suffix links until we reach the root
+                // (equivalent of k == 0 in prefix function calculation) or we find a
+                // better prefix for the current substring.
+                if (curBetterVertex == root)
+                {
+                    trie[vertex].SuffixLink = root;
+                    break;
+                }
+                curBetterVertex = trie[curBetterVertex].SuffixLink; // Go back by sufflink
+            }
+            // When we complete the calculation of the suffix link for the current
+            // vertex, we should update the link to the end of the maximum length word
+            // that can be produced from the current substring.
+            if (trie[vertex].Leaf)
+            {
+                trie[vertex].DictionaryLink = vertex;
+            }
+            else
+            {
+                trie[vertex].DictionaryLink = trie[trie[vertex].SuffixLink].DictionaryLink;
+            }
+        }
+
+        public int ProcessString(string text)
+        {
+            // Current state value
+            int currentState = root;
+
+            // Targeted result value
+            int result = 0;
+
+            for (int j = 0; j < text.Length; j++)
+            {
+                // Calculating new state in the trie
+                while (true)
+                {
+                    // If we have the edge, then use it
+                    if (trie[currentState].Children.ContainsKey(text[j]))
+                    {
+                        currentState = (int)trie[currentState].Children[text[j]];
+                        break;
+                    }
+                    // Otherwise, jump by suffix links and try to find the edge with
+                    // this char
+
+                    // If there aren't any possible edges we will eventually ascend to
+                    // the root, and at this point we stop checking.
+                    if (currentState == root)
+                    {
+                        break;
+                    }
+
+                    currentState = trie[currentState].SuffixLink;
+                }
+
+                int checkState = currentState;
+
+                // Trying to find all possible words from this prefix
+                while (true)
+                {
+                    // Checking all words that we can get from the current prefix
+                    checkState = trie[checkState].DictionaryLink;
+
+                    // If we are in the root vertex, there are no more matches
+                    if (checkState == root) break;
+
+                    // If the algorithm arrived at this row, it means we have found a
+                    // pattern match. And we can make additional calculations like find
+                    // the index of the found match in the text. Or check that the found
+                    // pattern is a separate word and not just, e.g., a substring.
+                    result++;
+                    int indexOfMatch = j + 1 - wordsLength[trie[checkState].WordID];
+
+                    // Trying to find all matched patterns of smaller length
+                    checkState = trie[checkState].SuffixLink;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -684,6 +684,7 @@ namespace System.Text.RegularExpressions
             return false;
         }
 
+        // Possible place that can be optimized with an IndexSet. Or the return can be modified to use RegexCharClass
         /// <summary>Gets all of the characters in the specified set, storing them into the provided span.</summary>
         /// <param name="set">The character class.</param>
         /// <param name="chars">The span into which the chars should be stored.</param>
@@ -1064,6 +1065,7 @@ namespace System.Text.RegularExpressions
             return CharInCategory(ch, set, start, setLength, categoryLength);
         }
 
+        // TODO: This is essentially a linear scan. An IndexSet may help here
         private static bool CharInCategory(char ch, string set, int start, int setLength, int categoryLength)
         {
             UnicodeCategory chcategory = char.GetUnicodeCategory(ch);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -14,6 +14,7 @@
 // Strings and sets are indices into a string table.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -21,6 +22,7 @@ namespace System.Text.RegularExpressions
 {
     internal sealed class RegexCode
     {
+        public List<string>? ahoCorasickWords;
         // The following primitive operations come directly from the parser
 
                                                   // lef/back operands        description

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -238,15 +238,20 @@ namespace System.Text.RegularExpressions
                 pos = runtextpos;
             }
 
+            // Vectorize?
             if (!_caseInsensitive)
             {
-                while (c != 0)
+                if (!str.AsSpan().SequenceEqual(runtext.AsSpan(pos - c, c)))
                 {
-                    if (str[--c] != runtext![--pos])
-                    {
-                        return false;
-                    }
+                    return false;
                 }
+                //while (c != 0)
+                //{
+                //    if (str[--c] != runtext![--pos])
+                //    {
+                //        return false;
+                //    }
+                //}
             }
             else
             {
@@ -262,7 +267,11 @@ namespace System.Text.RegularExpressions
 
             if (!_rightToLeft)
             {
-                pos += str.Length;
+                //pos += str.Length;
+            }
+            if (_rightToLeft)
+            {
+                pos -= str.Length;
             }
 
             runtextpos = pos;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -114,10 +114,16 @@ namespace System.Text.RegularExpressions
         public RegexOptions Options;
         public RegexNode? Next;
 
+        internal int cumulativeNumberOfChildren;
+
         public RegexNode(int type, RegexOptions options)
         {
             Type = type;
             Options = options;
+            if (Type == RegexNode.Concatenate)
+            {
+                cumulativeNumberOfChildren = 1;
+            }
         }
 
         public RegexNode(int type, RegexOptions options, char ch)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -136,6 +136,32 @@ namespace System.Text.RegularExpressions
             runtextbeg = textbeg;
             runtextend = textend;
 
+            if (!regex.RightToLeft && regex.aho != null)
+            {
+                bool initialized1 = false;
+                foreach ((int indexOfMatch, int lengthOfMatch) result in regex.aho.ProcessString(runtext))
+                {
+                    if (!initialized1)
+                    {
+                        InitializeForGo();
+                        initialized1 = true;
+                    }
+                    Match match = runmatch!;
+                    if (result.indexOfMatch != -1)
+                    {
+                        runmatch!.AddMatch(0, result.indexOfMatch, result.lengthOfMatch);
+                        runmatch!.Tidy(result.indexOfMatch + result.lengthOfMatch);
+                        return match;
+                    }
+                    else
+                    {
+                        runtext = null; // drop reference to text to avoid keeping it alive in a cache
+                        if (runmatch != null) runmatch.Text = null!;
+                        return Match.Empty;
+                    }
+                }
+            }
+
             // Main loop: FindFirstChar/Go + bump until the ending position.
             bool initialized = false;
             while (true)

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1139,5 +1139,14 @@ namespace System.Text.RegularExpressions.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("inner", () => System.Text.RegularExpressions.Match.Synchronized(null));
         }
+
+        [Fact]
+        public void Explore()
+        {
+            var regex = new Regex("abc");
+            var match = regex.Match("abcd");
+            var match1 = regex.Match("ababcd");
+            Console.WriteLine("BH");
+        }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1143,8 +1143,11 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void Explore()
         {
-            var regex = new Regex("abc");
-            var match = regex.Match("abcd");
+            var regex2 = new Regex("abc(efg|hij)xyz");
+            //var regex1 = new Regex("((abc|def)mno|(xyz|abc)ghi)rst");
+            var regex = new Regex("(efg|xyz|hij)abcd");
+            //var matches = regex.Matches("hijabcd");
+            var match = regex.Match("hijabcd");
             var match1 = regex.Match("ababcd");
             Console.WriteLine("BH");
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1143,12 +1143,10 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void Explore()
         {
-            var regex2 = new Regex("abc(efg|hij)xyz");
-            //var regex1 = new Regex("((abc|def)mno|(xyz|abc)ghi)rst");
+            //var regex2 = new Regex("abc(efg|hij)xyz");
+            //var regex1 = new Regex("((abc|def)mno|(xyz|abc)ghi)rst"); // AC word list still has a bug
             var regex = new Regex("(efg|xyz|hij)abcd");
-            //var matches = regex.Matches("hijabcd");
-            var match = regex.Match("hijabcd");
-            var match1 = regex.Match("ababcd");
+            var match = regex.Match("hhhhhhhhhhhhijabcd");
             Console.WriteLine("BH");
         }
     }


### PR DESCRIPTION
This is draft PR, strictly for prototyping and exploring using Aho-Corasick (AC) for specific patterns in Regex and to gather initial feedback.
cc @danmosemsft @jeffhandley @eerhardt @stephentoub 
Prelim perf results:
```
Benchmark:
        _ahoCorasickMultipleWords = new Regex("(efg|xyz|hij)abcd");

        [Benchmark] public void AhoCorasickMultipleWords() => _ahoCorasickMultipleWords.IsMatch(@"hhhhhhhhhhhhijabcd");

```
```
D:\repos\performance\src\tools\ResultsComparer>dotnet run --base "D:\repos\before_aho" --diff "D:\repos\after_aho" --threshold 0.001%
summary:
better: 3, geomean: 3.047
total diff: 3

No Slower results for the provided threshold = 0.001% and noise filter = 0.3ns.

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Text.RegularExpressions.Tests.Perf_Regex_Common.AhoCorasickMultipleWords( |      3.09 |          1800.19 |           583.00 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Common.AhoCorasickMultipleWords( |      3.07 |          1775.07 |           578.28 |         |
| System.Text.RegularExpressions.Tests.Perf_Regex_Common.AhoCorasickMultipleWords( |      2.99 |          1762.12 |           590.22 |         |

```

Over the past couple weeks, I spent some time prototyping AC in Regex. As https://github.com/dotnet/runtime/issues/1349 points out, we should expect to see perf gains when alternations are present in a Regex. 

Current code and Prototype:
We have a `FindFirstChar` and `Go` loop to find matches in a given input. `FindFirstChar` looks for the first matching character in the input. Once we find a matching character, `Go` runs a loop to see if the following characters match a word in the Regex. This logic is however not efficient for multiple words. For ex: If we have the pattern `(efg|xyz|hij)abcd`, `FindFirstChar` looks for either `e, x, h`. Then `Go` checks for `efgabcd, xyzabcd and hijabcd` in that order. So, for the input `hhhhhhhhhhhhijabcd` (12 `h` followed by abcd), at each `h`, `Go` performs 3 checks => 11 * 3 = 33 checks before the 12th `h` is matched and `hijabcd` is found. In contrast, the AC algorithm scans linearly, so we perform only 11 checks before the 12th `h` is matched and we find `hijabcd`. This is where the speed up comes from!

Note: The benchmarks lie in the sense that the setup phase of AC is not accounted for. The allocations to prepare `_ahoCorasickWords` are not measured in the benchmark. Also, the pattern and text used are the specifically chosen to see the speedup, but they are valid nonetheless :) 