### PR TITLE
Add default case in RLimitResources switch

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_process.c
+++ b/src/libraries/Native/Unix/System.Native/pal_process.c
@@ -562,6 +562,10 @@ static int32_t ConvertRLimitResourcesPalToPlatform(RLimitResources value)
 #endif
         case PAL_RLIMIT_NOFILE:
             return RLIMIT_NOFILE;
+#if !defined(RLIMIT_RSS) || !(defined(RLIMIT_MEMLOCK) || defined(RLIMIT_VMEM)) || !defined(RLIMIT_NPROC)
+        default:
+            break;
+#endif
     }
 
     assert_msg(false, "Unknown RLIMIT value", (int)value);

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -7,6 +7,11 @@ include(CheckStructHasMember)
 include(CheckSymbolExists)
 include(CheckTypeSize)
 
+# CMP0075 Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
+if(POLICY CMP0075)
+    cmake_policy(SET CMP0075 NEW)
+endif()
+
 if (CLR_CMAKE_TARGET_ANDROID)
     set(PAL_UNIX_NAME \"ANDROID\")
 elseif (CLR_CMAKE_TARGET_BROWSER)


### PR DESCRIPTION
1.  Add default case in RLimitResources switch. It was breaking illumos CLR subset build (since native libraries are statically compiling with CLR too, and apparently different compiler flags are set in each partition)
    * ```sh
      /runtime/src/libraries/Native/Unix/System.Native/pal_process.c:534:5: error: enumeration value 'PAL_RLIMIT_RSS' not handled in switch [-Werror=switch]
             switch (value)
             ^~~~~~
        /runtime/src/libraries/Native/Unix/System.Native/pal_process.c:534:5: error: enumeration value 'PAL_RLIMIT_NPROC' not handled in switch [-Werror=switch]
        /runtime/src/libraries/Native/Unix/System.Native/pal_process.c: At top level:
        ```
2. Fix an old cmake warning in libraries native, which is now showing up in CLR partition as well.
    * e.g. from previous runtime pipeline logs (Linux x64):
      ```sh
      -- Performing Test IPV6MR_INTERFACE_UNSIGNED
      -- Performing Test IPV6MR_INTERFACE_UNSIGNED - Success
      CMake Warning (dev) at /usr/local/share/cmake-3.15/Modules/CheckIncludeFiles.cmake:120 (message):
        Policy CMP0075 is not set: Include file check macros honor
        CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
        details.  Use the cmake_policy command to set the policy and suppress this
        warning.

        CMAKE_REQUIRED_LIBRARIES is set to:

          rt

        For compatibility with CMake 3.11 and below this check is ignoring it.
      Call Stack (most recent call first):
        /__w/1/s/src/libraries/Native/Unix/configure.cmake:625 (check_include_files)
        /__w/1/s/src/libraries/Native/Unix/CMakeLists.txt:215 (include)
      This warning is for project developers.  Use -Wno-dev to suppress it.
      ```

cc @janvorli, @VSadov