### PR TITLE
COM Host - Invalid compute of default value string length

### DIFF
--- a/src/installer/corehost/cli/comhost/comhost.cpp
+++ b/src/installer/corehost/cli/comhost/comhost.cpp
@@ -269,7 +269,7 @@ namespace
             0,
             REG_SZ,
             reinterpret_cast<const BYTE*>(entry.type.c_str()),
-            static_cast<DWORD>(sizeof(entry.type.size() + 1) * sizeof(entry.type[0])));
+            static_cast<DWORD>((entry.type.size() + 1) * sizeof(entry.type[0])));
         if (res != ERROR_SUCCESS)
             return __HRESULT_FROM_WIN32(res);
 
@@ -346,7 +346,7 @@ namespace
             0,
             REG_SZ,
             reinterpret_cast<const BYTE*>(defServerName),
-            static_cast<DWORD>(sizeof(defServerName) * sizeof(defServerName[0])));
+            static_cast<DWORD>(sizeof(defServerName)));
         if (res != ERROR_SUCCESS)
             return __HRESULT_FROM_WIN32(res);
 


### PR DESCRIPTION
Incorrectly compute the length of the default string value for a registry key. This doesn't impact the actual COM registration but does impact tooling that consumes COM registration.

Fixes #45721 

/cc @jkoritzinsky @vitek-karas 