### PR TITLE
Use Windows.10.Amd64.X86 to run superpmi

### DIFF
--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -23,12 +23,12 @@
 # 4.  Lastly, it sets the pipeline variables.
 
 # Below are the helix queues it sets depending on the OS/architecture:
-# | Arch  | windows       | Linux                                                                                                                                |
-# |-------|------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-# | x86   | Windows.10.Amd64 | -                                                                                                                                    |
-# | x64   | Windows.10.Amd64 | Ubuntu.1804.Amd64                                                                                                                    |
-# | arm   | -                | (Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440 |
-# | arm64 | Windows.10.Arm64 | (Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855 |
+# | Arch  | windows                           | Linux                                                                                                                                |
+# |-------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+# | x86   | Windows.10.Amd64.CoreAppCompat.Pr | -                                                                                                                                    |
+# | x64   | Windows.10.Amd64.CoreAppCompat.Pr | Ubuntu.1804.Amd64                                                                                                                    |
+# | arm   | -                                 | (Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440 |
+# | arm64 | Windows.10.Arm64                  | (Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855 |
 ################################################################################
 ################################################################################
 
@@ -345,7 +345,7 @@ def main(main_args):
     creator = ""
     ci = True
     if is_windows:
-        helix_queue = "Windows.10.Arm64" if arch == "arm64" else "Windows.10.Amd64"
+        helix_queue = "Windows.10.Arm64" if arch == "arm64" else "Windows.10.Amd64.CoreAppCompat.Pr"
     else:
         if arch == "arm":
             helix_queue = "(Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440"

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -23,12 +23,12 @@
 # 4.  Lastly, it sets the pipeline variables.
 
 # Below are the helix queues it sets depending on the OS/architecture:
-# | Arch  | windows                           | Linux                                                                                                                                |
-# |-------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-# | x86   | Windows.10.Amd64.CoreAppCompat.Pr | -                                                                                                                                    |
-# | x64   | Windows.10.Amd64.CoreAppCompat.Pr | Ubuntu.1804.Amd64                                                                                                                    |
-# | arm   | -                                 | (Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440 |
-# | arm64 | Windows.10.Arm64                  | (Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855 |
+# | Arch  | windows              | Linux                                                                                                                                |
+# |-------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+# | x86   | Windows.10.Amd64.X86 |                                                                                                                                      |
+# | x64   | Windows.10.Amd64.X86 | Ubuntu.1804.Amd64                                                                                                                    |
+# | arm   | -                    | (Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440 |
+# | arm64 | Windows.10.Arm64     | (Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855 |
 ################################################################################
 ################################################################################
 
@@ -345,7 +345,7 @@ def main(main_args):
     creator = ""
     ci = True
     if is_windows:
-        helix_queue = "Windows.10.Arm64" if arch == "arm64" else "Windows.10.Amd64.CoreAppCompat.Pr"
+        helix_queue = "Windows.10.Arm64" if arch == "arm64" else "Windows.10.Amd64.X86"
     else:
         if arch == "arm":
             helix_queue = "(Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440"


### PR DESCRIPTION
Superpmi job takes around 4+ hours to complete. This PR changes the helix queue used to run this job.
The PR will be merged once the changes https://github.com/dotnet/core-eng/issues/11577 will be merged and rolled out.