### PR TITLE
FontConverter restore order of font properties

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/FontConverter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/FontConverter.cs
@@ -365,7 +365,11 @@ namespace System.Drawing
             object? value,
             Attribute[]? attributes)
         {
-            return value is Font ? TypeDescriptor.GetProperties(value, attributes) : base.GetProperties(context, value, attributes);
+            if (value is not Font)
+                return base.GetProperties(context, value, attributes);
+
+            PropertyDescriptorCollection props = TypeDescriptor.GetProperties(value, attributes);
+            return props.Sort(new string[] { nameof(Font.Name), nameof(Font.Size), nameof(Font.Unit) });
         }
 
         public override bool GetPropertiesSupported(ITypeDescriptorContext context) => true;

--- a/src/libraries/System.Drawing.Common/tests/System/Drawing/FontConverterTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/System/Drawing/FontConverterTests.cs
@@ -81,6 +81,38 @@ namespace System.ComponentModel.TypeConverterTests
             Assert.Null(font);
         }
 
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void GetFontPropsSorted()
+        {
+            // The order provided since .NET Framework
+            string[] expectedPropNames = new[]
+            {
+                nameof(Font.Name),
+                nameof(Font.Size),
+                nameof(Font.Unit),
+                nameof(Font.Bold),
+                nameof(Font.GdiCharSet),
+                nameof(Font.GdiVerticalFont),
+                nameof(Font.Italic),
+                nameof(Font.Strikeout),
+                nameof(Font.Underline),
+            };
+
+            FontConverter converter = new FontConverter();
+            Font font = new($"Courier New", 8.25f, FontStyle.Regular, GraphicsUnit.Point);
+
+            PropertyDescriptorCollection props = converter.GetProperties(font);
+            string[] propNames = new string[props.Count];
+
+            int index = 0;
+            foreach (PropertyDescriptor prop in props)
+            {
+                propNames[index++] = prop.DisplayName;
+            }
+
+            Assert.True(propNames.SequenceEqual(expectedPropNames));
+        }
+
         public static TheoryData<string, string, float, GraphicsUnit, FontStyle> TestConvertFormData()
         {
             var data = PlatformDetection.IsWindows ?


### PR DESCRIPTION
Fixes #45631

## Proposed changes:

.NET Framework implementation of `FontConverter` provided a different order of font properties, that can be observed by inspecting an instance of a font in a `PropertyGrid`.

![image](https://user-images.githubusercontent.com/4403806/59329728-f207f600-8d32-11e9-81f3-80cd6c2ae893.png)


Restore the original sort order.

The .NET Framework implementation has another sort argument "Weight", which however doesn't appear to be a property of `Font` type. It is possible this property has existed at some point, or the converter may have been expected to work for instances of `IFontDisp` object. Either way presence or absence of "Weight" doesn't appear to make any
difference, hence it has not been ported across.



## Testing strategy

- Added unit test
- Manual testing (by referencing .\artifacts\packages\Debug\Shipping\System.Drawing.Common.6.0.0-dev.nupkg)

## Screenshots 

* .NET Framework
    - en-AU culture
![image](https://user-images.githubusercontent.com/4403806/101580092-6d349000-3a2e-11eb-9b2e-3d7509de0955.png)
    - ru-RU culture
![image](https://user-images.githubusercontent.com/4403806/101579660-4d04d100-3a2e-11eb-90b7-2e4ff63a4a3a.png)

* .NET 5.0
    - en-AU culture
![image](https://user-images.githubusercontent.com/4403806/101581894-ed5af580-3a2e-11eb-8f96-9c59642904ae.png)


* With the fix
    - en-AU culture
![image](https://user-images.githubusercontent.com/4403806/101572862-44ab9680-3a2c-11eb-9c47-57d9412d95ca.png)
    - ru-RU culture
![image](https://user-images.githubusercontent.com/4403806/101573828-a409a680-3a2c-11eb-87ea-3cdd6d195de9.png)

