### PR TITLE
Re-use ImportThunks in Crossgen2

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -174,13 +174,13 @@ namespace ILCompiler.DependencyAnalysis.X64
             Builder.EmitByte(0xC3);
         }
 
-        public void EmitXOR(Register regDst, Register regSrc)
+        public void EmitZeroReg(Register reg)
         {
             // High 32 bits get cleared automatically when using 32bit registers
-            AddrMode rexAddrMode = new AddrMode(regSrc, null, 0, 0, AddrModeSize.Int32);
-            EmitRexPrefix(regDst, ref rexAddrMode);
+            AddrMode rexAddrMode = new AddrMode(reg, null, 0, 0, AddrModeSize.Int32);
+            EmitRexPrefix(reg, ref rexAddrMode);
             Builder.EmitByte(0x33);
-            Builder.EmitByte((byte)(0xC0 | (((int)regDst & 0x07) << 3) | ((int)regSrc & 0x07)));
+            Builder.EmitByte((byte)(0xC0 | (((int)reg & 0x07) << 3) | ((int)reg & 0x07)));
         }
 
         private bool InSignedByteRange(int i)

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -174,6 +174,15 @@ namespace ILCompiler.DependencyAnalysis.X64
             Builder.EmitByte(0xC3);
         }
 
+        public void EmitXOR(Register regDst, Register regSrc)
+        {
+            // High 32 bits get cleared automatically when using 32bit registers
+            AddrMode rexAddrMode = new AddrMode(regSrc, null, 0, 0, AddrModeSize.Int32);
+            EmitRexPrefix(regDst, ref rexAddrMode);
+            Builder.EmitByte(0x33);
+            Builder.EmitByte((byte)(0xC0 | (((int)regDst & 0x07) << 3) | ((int)regSrc & 0x07)));
+        }
+
         private bool InSignedByteRange(int i)
         {
             return i == (int)(sbyte)i;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             _helper = helper;
             _useVirtualCall = useVirtualCall;
-            _delayLoadHelper = new ImportThunk(helper, factory, this, useVirtualCall);
+            _delayLoadHelper = factory.ImportThunk(helper, importSectionNode, useVirtualCall);
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM/ImportThunk.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                     if (!relocsOnly)
                     {
-                        int index = _instanceCell.Table.IndexFromBeginningOfArray;
+                        int index = _containingImportSection.IndexFromBeginningOfArray;
                         // mov r4, #index
                         instructionEncoder.EmitMOV(Register.R4, index);
                         // push r4
@@ -44,7 +44,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     }
 
                     // mov r4, [module]
-                    instructionEncoder.EmitMOV(Register.R4, _moduleImport);
+                    instructionEncoder.EmitMOV(Register.R4, factory.ModuleImport);
                     // ldr r4, [r4]
                     instructionEncoder.EmitLDR(Register.R4, Register.R4);
                     // push r4
@@ -60,7 +60,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 case Kind.Lazy:
                     // mov r1, [module]
-                    instructionEncoder.EmitMOV(Register.R1, _moduleImport);
+                    instructionEncoder.EmitMOV(Register.R1, factory.ModuleImport);
                     // ldr r1, [r1]
                     instructionEncoder.EmitLDR(Register.R1, Register.R1);
                     // mov r12, [helper]

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM64/ImportThunk.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     if (!relocsOnly)
                     {
                         // movz x9, #index
-                        int index = _instanceCell.Table.IndexFromBeginningOfArray;
+                        int index = _containingImportSection.IndexFromBeginningOfArray;
                         instructionEncoder.EmitMOV(Register.X9, checked((ushort)index));
                     }
 
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Emit relocation for the Module* load above
             if (_thunkKind != Kind.Eager)
-                instructionEncoder.Builder.EmitReloc(_moduleImport, RelocType.IMAGE_REL_BASED_DIR64);
+                instructionEncoder.Builder.EmitReloc(factory.ModuleImport, RelocType.IMAGE_REL_BASED_DIR64);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_X64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_X64/ImportThunk.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 case Kind.DelayLoadHelper:
                     // xor eax, eax
-                    instructionEncoder.EmitXOR(Register.RAX, Register.RAX);
+                    instructionEncoder.EmitZeroReg(Register.RAX);
 
                     if (!relocsOnly)
                     {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_X64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_X64/ImportThunk.cs
@@ -23,19 +23,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     break;
 
                 case Kind.DelayLoadHelper:
-                    // lea rax, [pCell] - this is the simple case which allows for only one lazy resolution
-                    // of the indirection cell; the final method pointer stored in the indirection cell
-                    // no longer receives the location of the cell so it cannot modify it repeatedly.
-                    instructionEncoder.EmitLEAQ(Register.RAX, _instanceCell);
+                    // xor eax, eax
+                    instructionEncoder.EmitXOR(Register.RAX, Register.RAX);
 
                     if (!relocsOnly)
                     {
                         // push table index
-                        instructionEncoder.EmitPUSH((sbyte)_instanceCell.Table.IndexFromBeginningOfArray);
+                        instructionEncoder.EmitPUSH((sbyte)_containingImportSection.IndexFromBeginningOfArray);
                     }
 
                     // push [module]
-                    instructionEncoder.EmitPUSH(_moduleImport);
+                    instructionEncoder.EmitPUSH(factory.ModuleImport);
 
                     break;
 
@@ -48,16 +46,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     if (!relocsOnly)
                     {
                         // push table index
-                        instructionEncoder.EmitPUSH((sbyte)_instanceCell.Table.IndexFromBeginningOfArray);
+                        instructionEncoder.EmitPUSH((sbyte)_containingImportSection.IndexFromBeginningOfArray);
                     }
 
                     // push [module]
-                    instructionEncoder.EmitPUSH(_moduleImport);
+                    instructionEncoder.EmitPUSH(factory.ModuleImport);
 
                     break;
 
                 case Kind.Lazy:
-                    instructionEncoder.EmitMOV(factory.Target.OperatingSystem == TargetOS.Windows ? Register.RDX : Register.RSI, _moduleImport);
+                    instructionEncoder.EmitMOV(factory.Target.OperatingSystem == TargetOS.Windows ? Register.RDX : Register.RSI, factory.ModuleImport);
 
                     break;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_X86/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_X86/ImportThunk.cs
@@ -29,17 +29,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     if (!relocsOnly)
                     {
                         // push table index
-                        instructionEncoder.EmitPUSH((sbyte)_instanceCell.Table.IndexFromBeginningOfArray);
+                        instructionEncoder.EmitPUSH((sbyte)_containingImportSection.IndexFromBeginningOfArray);
                     }
 
                     // push [module]
-                    instructionEncoder.EmitPUSH(_moduleImport);
+                    instructionEncoder.EmitPUSH(factory.ModuleImport);
 
                     break;
 
                 case Kind.Lazy:
                     // mov edx, [module]
-                    instructionEncoder.EmitMOV(Register.EDX, _moduleImport);
+                    instructionEncoder.EmitMOV(Register.EDX, factory.ModuleImport);
                     break;
             }
             instructionEncoder.EmitJMP(_helperCell);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -418,7 +418,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public ISymbolNode InterfaceDispatchCell(MethodWithToken method, MethodDesc callingMethod)
         {
-            MethodAndCallSite cellKey = new MethodAndCallSite(method, /*callingMethod*/ null);
+            MethodAndCallSite cellKey = new MethodAndCallSite(method, null);
             return _interfaceDispatchCells.GetOrAdd(cellKey);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -418,7 +418,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public ISymbolNode InterfaceDispatchCell(MethodWithToken method, MethodDesc callingMethod)
         {
-            MethodAndCallSite cellKey = new MethodAndCallSite(method, callingMethod);
+            MethodAndCallSite cellKey = new MethodAndCallSite(method, /*callingMethod*/ null);
             return _interfaceDispatchCells.GetOrAdd(cellKey);
         }
 


### PR DESCRIPTION
Reduce the number of thunks generated to be in line with Crossgen1. Each unique method that is called currently gets its own thunk used for that specific import section entry. Change the thunk calling pattern to match Crossgen1, allowing a small handful of thunks to be re-used for all method / virtual method calls.

* Create ImportThunks using the `NodeFactory` instead of allocating directly to allow sharing between different imports.

* On x64, switch method call helper thunk to use following assembly:
```
xor eax, eax
push index
push [module]
jmp [helperCell]
```

* Previously we emitted this assembly for the thunks:
```
lea eax, [instanceCell]
push index
push [module]
jmp [helperCell]
```

* The runtime doesn't need the import cell for the call passing in - it finds it by disassembling the address from `call [helper]`.

* Each thunk encodes the containing import section index; duplication of thunks is thus allowed per import section.

* Share virtual method call fixup cells between all invocations of a given virtual method. Currently, each unique method calling a given virtual method gets a fixup. That can have a runtime performance gain but comes at the expense of binary size. Match Crossgen1 behavior and use a single fixup cell per virtual method.