### PR TITLE
Optimize thread pool enqueue to handle job batches more efficiently.

### DIFF
--- a/src/mono/mono/sgen/sgen-gc.c
+++ b/src/mono/mono/sgen/sgen-gc.c
@@ -1657,7 +1657,7 @@ init_gray_queue (SgenGrayQueue *gc_thread_gray_queue)
 }
 
 static void
-enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjectOperations *ops, gboolean enqueue)
+enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjectOperations *ops, gboolean is_parallel)
 {
 	int i, split_count = sgen_workers_get_job_split_count (GENERATION_NURSERY);
 	size_t num_major_sections = sgen_major_collector.get_num_major_sections ();
@@ -1666,25 +1666,24 @@ enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjec
 	sj = (ScanJob*)sgen_thread_pool_job_alloc ("scan wbroots", job_scan_wbroots, sizeof (ScanJob));
 	sj->ops = ops;
 	sj->gc_thread_gray_queue = gc_thread_gray_queue;
-	sgen_workers_enqueue_job (GENERATION_NURSERY, &sj->job, enqueue);
+	sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &sj->job, is_parallel);
 
 	for (i = 0; i < split_count; i++) {
 		ParallelScanJob *psj;
-
 		psj = (ParallelScanJob*)sgen_thread_pool_job_alloc ("scan major remsets", job_scan_major_card_table, sizeof (ParallelScanJob));
 		psj->scan_job.ops = ops;
 		psj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 		psj->job_index = i;
 		psj->job_split_count = split_count;
 		psj->data = num_major_sections / split_count;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &psj->scan_job.job, enqueue);
+		sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &psj->scan_job.job, is_parallel);
 
 		psj = (ParallelScanJob*)sgen_thread_pool_job_alloc ("scan LOS remsets", job_scan_los_card_table, sizeof (ParallelScanJob));
 		psj->scan_job.ops = ops;
 		psj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 		psj->job_index = i;
 		psj->job_split_count = split_count;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &psj->scan_job.job, enqueue);
+		sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &psj->scan_job.job, is_parallel);
 	}
 }
 
@@ -1699,7 +1698,7 @@ sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean 
 	pjob->job_index = 0;
 	pjob->job_split_count = split_count;
 	pjob->callback = callback;
-	sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
+	sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &pjob->job, is_parallel);
 
 	for (i = 0; i < split_count; i++) {
 		pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate major block ranges", job_major_collector_iterate_block_ranges, sizeof (ParallelIterateBlockRangesJob));
@@ -1707,14 +1706,16 @@ sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean 
 		pjob->job_split_count = split_count;
 		pjob->data = num_major_sections / split_count;
 		pjob->callback = callback;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
+		sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &pjob->job, is_parallel);
 
 		pjob = (ParallelIterateBlockRangesJob*)sgen_thread_pool_job_alloc ("iterate LOS block ranges", job_los_iterate_live_block_ranges, sizeof (ParallelIterateBlockRangesJob));
 		pjob->job_index = i;
 		pjob->job_split_count = split_count;
 		pjob->callback = callback;
-		sgen_workers_enqueue_job (GENERATION_NURSERY, &pjob->job, is_parallel);
+		sgen_workers_enqueue_deferred_job (GENERATION_NURSERY, &pjob->job, is_parallel);
 	}
+
+	sgen_workers_flush_deferred_jobs (GENERATION_NURSERY, is_parallel);
 
 	if (is_parallel) {
 		sgen_workers_start_all_workers (GENERATION_NURSERY, NULL, NULL, NULL);
@@ -1723,7 +1724,7 @@ sgen_iterate_all_block_ranges (sgen_cardtable_block_callback callback, gboolean 
 }
 
 static void
-enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_start, char *heap_end, SgenObjectOperations *ops, gboolean enqueue)
+enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_start, char *heap_end, SgenObjectOperations *ops, gboolean is_parallel)
 {
 	ScanFromRegisteredRootsJob *scrrj;
 	ScanThreadDataJob *stdj;
@@ -1737,7 +1738,7 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 	scrrj->heap_start = heap_start;
 	scrrj->heap_end = heap_end;
 	scrrj->root_type = ROOT_TYPE_NORMAL;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &scrrj->scan_job.job, enqueue);
+	sgen_workers_enqueue_deferred_job (sgen_current_collection_generation, &scrrj->scan_job.job, is_parallel);
 
 	if (sgen_current_collection_generation == GENERATION_OLD) {
 		/* During minors we scan the cardtable for these roots instead */
@@ -1747,7 +1748,7 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 		scrrj->heap_start = heap_start;
 		scrrj->heap_end = heap_end;
 		scrrj->root_type = ROOT_TYPE_WBARRIER;
-		sgen_workers_enqueue_job (sgen_current_collection_generation, &scrrj->scan_job.job, enqueue);
+		sgen_workers_enqueue_deferred_job (sgen_current_collection_generation, &scrrj->scan_job.job, is_parallel);
 	}
 
 	/* Threads */
@@ -1757,7 +1758,7 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 	stdj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	stdj->heap_start = heap_start;
 	stdj->heap_end = heap_end;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &stdj->scan_job.job, enqueue);
+	sgen_workers_enqueue_deferred_job (sgen_current_collection_generation, &stdj->scan_job.job, is_parallel);
 
 	/* Scan the list of objects ready for finalization. */
 
@@ -1765,13 +1766,13 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 	sfej->scan_job.ops = ops;
 	sfej->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	sfej->queue = &fin_ready_queue;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &sfej->scan_job.job, enqueue);
+	sgen_workers_enqueue_deferred_job (sgen_current_collection_generation, &sfej->scan_job.job, is_parallel);
 
 	sfej = (ScanFinalizerEntriesJob*)sgen_thread_pool_job_alloc ("scan critical finalizer entries", job_scan_finalizer_entries, sizeof (ScanFinalizerEntriesJob));
 	sfej->scan_job.ops = ops;
 	sfej->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	sfej->queue = &critical_fin_queue;
-	sgen_workers_enqueue_job (sgen_current_collection_generation, &sfej->scan_job.job, enqueue);
+	sgen_workers_enqueue_deferred_job (sgen_current_collection_generation, &sfej->scan_job.job, is_parallel);
 }
 
 /*
@@ -1900,6 +1901,8 @@ collect_nursery (const char *reason, gboolean is_overflow)
 	time_minor_scan_pinned += TV_ELAPSED (btv, atv);
 
 	enqueue_scan_from_roots_jobs (&gc_thread_gray_queue, sgen_nursery_section->data, sgen_nursery_section->end_data, is_parallel ? NULL : object_ops_nopar, is_parallel);
+
+	sgen_workers_flush_deferred_jobs (GENERATION_NURSERY, is_parallel);
 
 	if (is_parallel) {
 		gray_queue_redirect (&gc_thread_gray_queue);

--- a/src/mono/mono/sgen/sgen-thread-pool.c
+++ b/src/mono/mono/sgen/sgen-thread-pool.c
@@ -261,6 +261,11 @@ sgen_thread_pool_create_context (int num_threads, SgenThreadPoolThreadInitFunc i
 
 	sgen_pointer_queue_init (&pool_contexts [contexts_num].job_queue, 0);
 
+	// Job batches normally split into num_threads * 4 jobs. Make room for up to four job batches in the deferred queue (should reduce flushes during minor collections).
+	pool_contexts [context_id].deferred_jobs_len = (num_threads * 4 * 4) + 1;
+	pool_contexts [context_id].deferred_jobs = (void **)sgen_alloc_internal_dynamic (sizeof (void *) * pool_contexts [context_id].deferred_jobs_len, INTERNAL_MEM_THREAD_POOL_JOB, TRUE);
+	pool_contexts [context_id].deferred_jobs_count = 0;
+
 	contexts_num++;
 
 	return context_id;
@@ -339,6 +344,45 @@ sgen_thread_pool_job_enqueue (int context_id, SgenThreadPoolJob *job)
 	mono_os_cond_broadcast (&work_cond);
 
 	mono_os_mutex_unlock (&lock);
+}
+
+/*
+ * LOCKING: Assumes the GC lock is held  (or it will race with sgen_thread_pool_flush_deferred_jobs)
+ */
+void
+sgen_thread_pool_job_enqueue_deferred (int context_id, SgenThreadPoolJob *job)
+{
+	// Fast path assumes the GC lock is held.
+	pool_contexts [context_id].deferred_jobs [pool_contexts [context_id].deferred_jobs_count++] = job;
+	if (pool_contexts [context_id].deferred_jobs_count >= pool_contexts [context_id].deferred_jobs_len) {
+		// Slow path, flush jobs into queue, but don't signal workers.
+		sgen_thread_pool_flush_deferred_jobs (context_id, FALSE);
+	}
+}
+
+/*
+ * LOCKING: Assumes the GC lock is held (or it will race with sgen_thread_pool_job_enqueue_deferred).
+ */
+void
+sgen_thread_pool_flush_deferred_jobs (int context_id, gboolean signal)
+{
+	if (!signal && !sgen_thread_pool_have_deferred_jobs (context_id))
+		return;
+
+	mono_os_mutex_lock (&lock);
+	for (int i = 0; i < pool_contexts [context_id].deferred_jobs_count; i++) {
+		sgen_pointer_queue_add (&pool_contexts[context_id].job_queue, pool_contexts [context_id].deferred_jobs [i]);
+		pool_contexts [context_id].deferred_jobs [i] = NULL;
+	}
+	pool_contexts [context_id].deferred_jobs_count = 0;
+	if (signal)
+		mono_os_cond_broadcast (&work_cond);
+	mono_os_mutex_unlock (&lock);
+}
+
+gboolean sgen_thread_pool_have_deferred_jobs (int context_id)
+{
+	return pool_contexts [context_id].deferred_jobs_count != 0;
 }
 
 void
@@ -441,6 +485,21 @@ sgen_thread_pool_job_free (SgenThreadPoolJob *job)
 void
 sgen_thread_pool_job_enqueue (int context_id, SgenThreadPoolJob *job)
 {
+}
+
+void
+sgen_thread_pool_job_enqueue_deferred (int context_id, SgenThreadPoolJob *job)
+{
+}
+
+void
+sgen_thread_pool_flush_deferred_jobs (int context_id, gboolean signal)
+{
+}
+
+gboolean sgen_thread_pool_have_deferred_jobs (int context_id)
+{
+	return FALSE;
 }
 
 void

--- a/src/mono/mono/sgen/sgen-thread-pool.h
+++ b/src/mono/mono/sgen/sgen-thread-pool.h
@@ -37,6 +37,13 @@ struct _SgenThreadPoolContext {
 	/* Only accessed with the lock held. */
 	SgenPointerQueue job_queue;
 
+	/*
+	 * LOCKING: Assumes the GC lock is held.
+	 */
+	void **deferred_jobs;
+	int deferred_jobs_len;
+	int deferred_jobs_count;
+
 	SgenThreadPoolThreadInitFunc thread_init_func;
 	SgenThreadPoolIdleJobFunc idle_job_func;
 	SgenThreadPoolContinueIdleJobFunc continue_idle_job_func;
@@ -57,6 +64,19 @@ SgenThreadPoolJob* sgen_thread_pool_job_alloc (const char *name, SgenThreadPoolJ
 void sgen_thread_pool_job_free (SgenThreadPoolJob *job);
 
 void sgen_thread_pool_job_enqueue (int context_id, SgenThreadPoolJob *job);
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+void sgen_thread_pool_job_enqueue_deferred (int context_id, SgenThreadPoolJob *job);
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+void sgen_thread_pool_flush_deferred_jobs (int context_id, gboolean signal);
+
+gboolean sgen_thread_pool_have_deferred_jobs (int context_id);
+
 /* This must only be called after the job has been enqueued. */
 void sgen_thread_pool_job_wait (int context_id, SgenThreadPoolJob *job);
 

--- a/src/mono/mono/sgen/sgen-workers.c
+++ b/src/mono/mono/sgen/sgen-workers.c
@@ -189,6 +189,32 @@ sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enque
 	sgen_thread_pool_job_enqueue (worker_contexts [generation].thread_pool_context, job);
 }
 
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+
+void
+sgen_workers_enqueue_deferred_job (int generation, SgenThreadPoolJob *job, gboolean enqueue)
+{
+	if (!enqueue) {
+		job->func (NULL, job);
+		sgen_thread_pool_job_free (job);
+		return;
+	}
+
+	sgen_thread_pool_job_enqueue_deferred (worker_contexts [generation].thread_pool_context, job);
+}
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+
+void
+sgen_workers_flush_deferred_jobs (int generation, gboolean signal)
+{
+	sgen_thread_pool_flush_deferred_jobs (generation, signal);
+}
+
 static gboolean
 workers_get_work (WorkerData *data)
 {
@@ -471,6 +497,7 @@ sgen_workers_start_all_workers (int generation, SgenObjectOperations *object_ops
 	WorkerContext *context = &worker_contexts [generation];
 	int i;
 	SGEN_ASSERT (0, !context->started, "Why are we starting to work without finishing previous cycle");
+	SGEN_ASSERT (0, !sgen_thread_pool_have_deferred_jobs (generation), "All deferred jobs should have been flushed");
 
 	context->idle_func_object_ops_par = object_ops_par;
 	context->idle_func_object_ops_nopar = object_ops_nopar;
@@ -626,6 +653,16 @@ sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enque
 		sgen_thread_pool_job_free (job);
 		return;
 	}
+}
+
+void
+sgen_workers_enqueue_deferred_job (int generation, SgenThreadPoolJob *job, gboolean enqueue)
+{
+	sgen_workers_enqueue_job (generation, job, enqueue);
+}
+
+void sgen_workers_flush_deferred_jobs (int generation, gboolean signal)
+{
 }
 
 gboolean

--- a/src/mono/mono/sgen/sgen-workers.h
+++ b/src/mono/mono/sgen/sgen-workers.h
@@ -83,7 +83,19 @@ void sgen_workers_start_all_workers (int generation, SgenObjectOperations *objec
 #else
 #define sgen_workers_start_all_workers(...)
 #endif
+
 void sgen_workers_enqueue_job (int generation, SgenThreadPoolJob *job, gboolean enqueue);
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+void sgen_workers_enqueue_deferred_job (int generation, SgenThreadPoolJob *job, gboolean enqueue);
+
+/*
+ * LOCKING: Assumes the GC lock is held.
+ */
+void sgen_workers_flush_deferred_jobs (int generation, gboolean signal);
+
 void sgen_workers_join (int generation);
 gboolean sgen_workers_have_idle_work (int generation);
 gboolean sgen_workers_all_done (void);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20634,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When running parallel minor GC the scan of major and LOS is split up in several jobs based on number of available cores * 4 * 2. On an 8 core machine that will generate 32 major heap and 32 LOS scanning jobs. Current implementation queued each individual job into the thread pool but since the threads where not allowed to work on the items at this point, doing it
this way creates a lot of signalled threads + contention over shared mutex for each queued job.

Commit optimize this pattern adding the ability to add a batch of allocated jobs into the thread pool at the same time, signalling all threads when all, jobs have been added to the queue reducing the number of mutex acquire/release and waking all thread pool threads from 65 (including scan wbroots) down to 1.

This is an upstream of a change running in downstream repro for a little over a year giving a good performance boost for those platforms. As part of upstreaming I also did some performance benchmark around performance of this PR on desktop 8 core Windows PC. Test was primarily stressing the job dispatch as part of minor GC using a major heap of ~2.5 GB and a LOB heap of ~1 GB, doing around 1500 minor GC measures points per configuration (over stable GC state). The following is a summary of minor GC pause times comparing default, default with minor=simple-par and minor=simple-par + this PR:


  | Default | Simple-par | Simple-par + enqueue   optimization | Improvement | Improvement default Simple-par
-- | -- | -- | -- | -- | --
Stdev (µs) | 1143 | 1047 | 952 |   |  
Avg (µs) | 2585 | 2206 | 1629 | 36,98% | 26,17%
  |   |   |   |   |  
TrimMean 10% (µs) | 2548 | 2146 | 1576 | 38,17% | 26,58%
TrimMean 25% (µs) | 2535 | 2106 | 1548 | 38,94% | 26,50%
First   quartile – 25th percentile (µs) | 1598 | 1295 | 965 | 39,63% | 25,54%
First   quartile – 50th percentile (µs) | 2449 | 2062 | 1515 | 38,16% | 26,55%
First   quartile – 75th percentile (µs) | 3588 | 2892 | 2116 | 41,04% | 26,84%

So to summarize, above indicates minor GC pause times improved with ~38% when running with the enqueue optimizations implemented in this PR on a desktop 8 core machine on a 2.5 GB major heap and 1 GB LOB heap. Results can off course vary depending on hardware, workload and platform, but benchmark above at least gives a good indication that batching jobs and reduce number of unnecessary kernel calls and pressure on scheduler have measurable positive improvements on minor GC pause times.
