### PR TITLE
Linux: don't use deprecated sysctl

### DIFF
--- a/src/coreclr/gc/unix/configure.cmake
+++ b/src/coreclr/gc/unix/configure.cmake
@@ -91,7 +91,12 @@ check_library_exists(${PTHREAD_LIBRARY} pthread_setaffinity_np "" HAVE_PTHREAD_S
 check_cxx_symbol_exists(_SC_PHYS_PAGES unistd.h HAVE__SC_PHYS_PAGES)
 check_cxx_symbol_exists(_SC_AVPHYS_PAGES unistd.h HAVE__SC_AVPHYS_PAGES)
 check_cxx_symbol_exists(swapctl sys/swap.h HAVE_SWAPCTL)
-check_function_exists(sysctl HAVE_SYSCTL)
+if(CLR_CMAKE_TARGET_LINUX)
+  # sysctl is deprecated on Linux
+  set(HAVE_SYSCTL 0)
+else()
+  check_function_exists(sysctl HAVE_SYSCTL)
+endif()
 check_function_exists(sysinfo HAVE_SYSINFO)
 check_function_exists(sysconf HAVE_SYSCONF)
 check_struct_has_member ("struct sysinfo" mem_unit "sys/sysinfo.h" HAVE_SYSINFO_WITH_MEM_UNIT)

--- a/src/coreclr/pal/src/config.h.in
+++ b/src/coreclr/pal/src/config.h.in
@@ -17,7 +17,6 @@
 #cmakedefine01 HAVE_SYS_LWP_H
 #cmakedefine01 HAVE_LWP_H
 #cmakedefine01 HAVE_RUNETYPE_H
-#cmakedefine01 HAVE_SYS_SYSCTL_H
 #cmakedefine01 HAVE_GNU_LIBNAMES_H
 #cmakedefine01 HAVE_PRCTL_H
 #cmakedefine01 HAVE_NUMA_H

--- a/src/coreclr/pal/src/configure.cmake
+++ b/src/coreclr/pal/src/configure.cmake
@@ -74,7 +74,6 @@ int main(int argc, char **argv) {
 
 set(CMAKE_REQUIRED_LIBRARIES)
 
-check_include_files(sys/sysctl.h HAVE_SYS_SYSCTL_H)
 check_function_exists(sysctlbyname HAVE_SYSCTLBYNAME)
 check_include_files(gnu/lib-names.h HAVE_GNU_LIBNAMES_H)
 
@@ -110,7 +109,12 @@ set(CMAKE_REQUIRED_LIBRARIES)
 check_function_exists(fsync HAVE_FSYNC)
 check_function_exists(futimes HAVE_FUTIMES)
 check_function_exists(utimes HAVE_UTIMES)
-check_function_exists(sysctl HAVE_SYSCTL)
+if(CLR_CMAKE_TARGET_LINUX)
+  # sysctl is deprecated on Linux
+  set(HAVE_SYSCTL 0)
+else()
+  check_function_exists(sysctl HAVE_SYSCTL)
+endif()
 check_function_exists(sysinfo HAVE_SYSINFO)
 check_function_exists(sysconf HAVE_SYSCONF)
 check_function_exists(gmtime_r HAVE_GMTIME_R)

--- a/src/installer/corehost/cli/hostmisc/pal.h
+++ b/src/installer/corehost/cli/hostmisc/pal.h
@@ -185,10 +185,6 @@ namespace pal
     #define __stdcall  /* nothing */
     #if !defined(TARGET_FREEBSD)
         #define __fastcall /* nothing */
-    #else
-        #include <sys/types.h>
-        #include <sys/sysctl.h>
-        #include <sys/param.h>
     #endif
     #define STDMETHODCALLTYPE __stdcall
 

--- a/src/installer/corehost/cli/hostmisc/pal.unix.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.unix.cpp
@@ -27,6 +27,10 @@
 #include <sys/sysctl.h>
 #elif defined(__sun)
 #include <sys/utsname.h>
+#elif defined(TARGET_FREEBSD)
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
 #endif
 
 #if !HAVE_DIRENT_D_TYPE

--- a/src/libraries/Native/Unix/System.Native/pal_sysctl.c
+++ b/src/libraries/Native/Unix/System.Native/pal_sysctl.c
@@ -23,7 +23,7 @@ int32_t SystemNative_Sysctl(int* name, unsigned int namelen, void* value, size_t
     void* newp = NULL;
     size_t newlen = 0;
 
-#if defined(__linux__) || defined(TARGET_WASM)
+#if defined(TARGET_WASM)
     return sysctl(name, (int)(namelen), value, len, newp, newlen);
 #else
     return sysctl(name, namelen, value, len, newp, newlen);

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -805,9 +805,14 @@ check_type_size(
      BUILTIN_TYPES_ONLY)
 set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
 
-check_include_files(
-    "sys/types.h;sys/sysctl.h"
-    HAVE_SYS_SYSCTL_H)
+if (CLR_CMAKE_TARGET_LINUX)
+    # sysctl is deprecated on Linux
+    set(HAVE_SYS_SYSCTL_H 0)
+else ()
+    check_include_files(
+        "sys/types.h;sys/sysctl.h"
+        HAVE_SYS_SYSCTL_H)
+endif()
 
 check_include_files(
     "sys/ioctl.h"


### PR DESCRIPTION
sysctl is removed in Linux 5.5.
This changes ensures we're not using it on Linux.

cc @janvorli @wfurt