### PR TITLE
Add Microsoft StrongNameKey back to System.Composition*

### DIFF
--- a/src/libraries/System.Composition/Directory.Build.props
+++ b/src/libraries/System.Composition/Directory.Build.props
@@ -1,3 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
+   <PropertyGroup>	
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>	
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/corefx/commit/9a4ed0d00bc642b015974684c32b00650426429f#diff-739e1ffbaee417f430131875c0471f5ab63a11561f06de857adcd32f4eddce15L5 and was reported via https://github.com/dotnet/runtime/issues/45638.