### PR TITLE
Added Nullable Anotation to XmlResolver Property of XmlDocument

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlDocument.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlDocument.cs
@@ -453,7 +453,7 @@ namespace System.Xml
             return _resolver;
         }
 
-        public virtual XmlResolver XmlResolver
+        public virtual XmlResolver? XmlResolver
         {
             set
             {

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -318,7 +318,7 @@ namespace System.Xml
         public bool PreserveWhitespace { get { throw null; } set { } }
         public override System.Xml.Schema.IXmlSchemaInfo SchemaInfo { get { throw null; } }
         public System.Xml.Schema.XmlSchemaSet Schemas { get { throw null; } set { } }
-        public virtual System.Xml.XmlResolver XmlResolver { set { } }
+        public virtual System.Xml.XmlResolver? XmlResolver { set { } }
         public event System.Xml.XmlNodeChangedEventHandler NodeChanged { add { } remove { } }
         public event System.Xml.XmlNodeChangedEventHandler NodeChanging { add { } remove { } }
         public event System.Xml.XmlNodeChangedEventHandler NodeInserted { add { } remove { } }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/45594

Change the nullable annotation of `XmlDocument.XmlResolver` as described in #45594 

As I understand the field `bSetResolved` tracks if the property was set to an explicit value including `null`. It does not check if the property has an value.

`bSetResolved` will be used on 3 locations (through an internal property). All those can handle `null`-values. So I think the change should not break something.

```c#
public virtual XmlResolver? XmlResolver
{
    set
    {
        _resolver = value;
        if (!bSetResolver) // <- this is ok and must not be changed to `_resolver is not null` since it does track if the property was explicitly set
            bSetResolver = true;
        XmlDocumentType? dtd = this.DocumentType;
        if (dtd != null)
        {
            dtd.DtdSchemaInfo = null;
        }
    }
}
```


Since the Property and the GetMethod now have the same nullability, should the getter of the property now used instead of the method?

EDIT (@krwq): added "Fixes" so that issue gets auto-closed on merge