### PR TITLE
Run wasm console sample on Helix

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -256,8 +256,8 @@
 
     <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
       <!-- Create a work item for run-only WASM apps  -->
-      <_WorkItem Include="$(TestArchiveRoot)runonly/**/*.zip" />
-      <HelixWorkItem Include="@(_WorkItem -> '%(FileName)')" >
+      <_RunOnlyWorkItem Include="$(TestArchiveRoot)runonly/**/*.zip" />
+      <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
         <PayloadArchive>%(Identity)</PayloadArchive>
         <!-- No RunTests script generated for the sample project so we just use the direct command -->
         <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -256,8 +256,11 @@
 
     <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
       <!-- Create a work item for run-only WASM apps  -->
-      <HelixWorkItem Include="$(TestArchiveRoot)runonly/**/*.zip" >
-        <Command>$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>
+      <_WorkItem Include="$(TestArchiveRoot)runonly/**/*.zip" />
+      <HelixWorkItem Include="@(_WorkItem -> '%(FileName)')" >
+        <PayloadArchive>%(Identity)</PayloadArchive>
+        <!-- No RunTests script generated for the sample project so we just use the direct command -->
+        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>
       </HelixWorkItem>
     </ItemGroup>
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -254,6 +254,13 @@
       </HelixWorkItem>
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
+      <!-- Create a work item for run-only WASM apps  -->
+      <HelixWorkItem Include="$(TestArchiveRoot)runonly/**/*.zip" >
+        <Command>$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>
+      </HelixWorkItem>
+    </ItemGroup>
+
     <Message Condition="'$(Scenario)' != ''" Importance="High" Text="Done building Helix work items for scenario $(Scenario). Work item count: @(_WorkItem->Count())" />
     <Message Condition="'$(Scenario)' == '' and ('$(TargetOS)' == 'Android' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS')" Importance="High" Text="Done building Helix work items. Work item count: @(XHarnessAppBundleToTest->Count())" />
     <Message Condition="'$(Scenario)' == '' and '$(TargetOS)' != 'Android' and '$(TargetOS)' != 'iOS' and '$(TargetOS)' != 'tvOS'" Importance="High" Text="Done building Helix work items. Work item count: @(_WorkItem->Count())" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -175,6 +175,9 @@
     <ProjectReference Include="..\mono\netcore\sample\iOS\Program.csproj"
                       BuildInParallel="false"
                       Condition="'$(ArchiveTests)' == 'true' and ('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS')" />
+    <ProjectReference Include="..\mono\netcore\sample\wasm\console\WasmSample.csproj"
+                      BuildInParallel="false"
+                      Condition="'$(ArchiveTests)' == 'true' and '$(TargetOS)' == 'Browser'" />
   </ItemGroup>
 
   <Target Name="GenerateMergedCoverageReport"

--- a/src/mono/netcore/sample/wasm/console/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/console/WasmSample.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <TargetArchitecture>wasm</TargetArchitecture>
     <TargetOS>Browser</TargetOS>
     <MicrosoftNetCoreAppRuntimePackRidDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\$(Configuration)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackRidDir>
@@ -115,6 +115,23 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
+
+  <Target Name="CopySampleAppToHelixTestDir" 
+          Condition="'$(ArchiveTests)' == 'true'" 
+          AfterTargets="Build"
+          DependsOnTargets="Publish" >
+    <PropertyGroup>
+      <!-- Helix properties -->
+      <!-- AnyCPU as Platform-->
+      <OSPlatformConfig>$(TargetOS).AnyCPU.$(Configuration)</OSPlatformConfig>
+      <HelixArchiveRoot>$(ArtifactsDir)helix/</HelixArchiveRoot>
+      <HelixArchiveRunOnlyRoot>$(HelixArchiveRoot)runonly/</HelixArchiveRunOnlyRoot>
+      <HelixArchiveRunOnlyAppsDir>$(HelixArchiveRunOnlyRoot)$(OSPlatformConfig)/</HelixArchiveRunOnlyAppsDir>
+      <ZippedApp>$(OutputPath)/WasmConsoleSample.zip</ZippedApp>
+    </PropertyGroup>
+    <ZipDirectory SourceDirectory="$(AppDir)" DestinationFile="$(ZippedApp)" />
+    <Copy SourceFiles="$(ZippedApp)" DestinationFolder="$(HelixArchiveRunOnlyAppsDir)" />
+  </Target>
 
   <Import Project="$(MonoProjectRoot)\wasm\build\WasmApp.targets" />
 </Project>

--- a/src/mono/netcore/sample/wasm/console/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/console/WasmSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="WasmBuildApp">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>


### PR DESCRIPTION
- Included the WASM console sample project to the library test build. The sample can still be built/run locally using make file.
- Added zipping/copying the sample application to helix directory from where it can be consumed by CI.
- To run on Helix, tried to use a simple helix work item which wouldn't rely on generated RunTests.sh and just call the xharness command directly.  

Relates to https://github.com/dotnet/runtime/issues/43865