### PR TITLE
Update DacTableGen.csproj to escape a path in a command-line

### DIFF
--- a/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
+++ b/src/coreclr/ToolBox/SOS/DacTableGen/DacTableGen.csproj
@@ -14,7 +14,7 @@
 
   <Target Name="ResolveDIALibToCopy" BeforeTargets="AssignTargetPaths">
     <PropertyGroup>
-      <VSWherePath>$([MSBuild]::NormalizePath('$(Pkgvswhere)','tools','vswhere.exe'))</VSWherePath>
+      <VSWherePath>"$([MSBuild]::NormalizePath('$(Pkgvswhere)','tools','vswhere.exe'))"</VSWherePath>
     </PropertyGroup>
     <Exec
       Command="$(VSWherePath) -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath"


### PR DESCRIPTION
This fixed a build error for me. My user profile path contains a space.