### PR TITLE
Upgrade StyleCopAnalyzers to v1.2.0-beta.312

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <!-- CoreClr dependencies -->
     <MicrosoftNETCoreILAsmVersion>5.0.0-preview.8.20359.4</MicrosoftNETCoreILAsmVersion>
     <!-- Libraries dependencies -->
-    <StyleCopAnalyzersVersion>1.2.0-beta.304</StyleCopAnalyzersVersion>
+    <StyleCopAnalyzersVersion>1.2.0-beta.312</StyleCopAnalyzersVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsVersion>4.3.0</SystemCollectionsVersion>
     <SystemCollectionsConcurrentVersion>4.3.0</SystemCollectionsConcurrentVersion>


### PR DESCRIPTION
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/tag/1.2.0-beta.312

Follow-up to #45644.