### PR TITLE
Fix dump of GC vars at call sites

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3247,9 +3247,8 @@ void emitter::emitDispGCRegDelta(const char* title, regMaskTP prevRegs, regMaskT
 // emitDispGCVarDelta: Print a delta for GC variables
 //
 // Notes:
-//    Uses the debug-only variables 'debugThisGCrefVars', 'debugPrevGCrefVars'
-//    and 'debugPrevRegPtrDsc' to print deltas from the last time this was
-//    called.
+//    Uses the debug-only variables 'debugThisGCrefVars' and 'debugPrevGCrefVars'.
+//    to print deltas from the last time this was called.
 //
 void emitter::emitDispGCVarDelta()
 {
@@ -3272,6 +3271,17 @@ void emitter::emitDispGCVarDelta()
         VarSetOps::Assign(emitComp, debugPrevGCrefVars, debugThisGCrefVars);
         printf("\n");
     }
+}
+
+//------------------------------------------------------------------------
+// emitDispRegPtrListDelta: Print a delta for regPtrDsc GC transitions
+//
+// Notes:
+//    Uses the debug-only variable 'debugPrevRegPtrDsc' to print deltas from the last time this was
+//    called.
+//
+void emitter::emitDispRegPtrListDelta()
+{
     // Dump any deltas in regPtrDsc's for outgoing args; these aren't captured in the other sets.
     if (debugPrevRegPtrDsc != codeGen->gcInfo.gcRegPtrLast)
     {
@@ -3308,6 +3318,7 @@ void emitter::emitDispGCVarDelta()
                     break;
                 default:
                     printf(" arg ??? %u", dsc->rpdPtrArg);
+                    break;
             }
             printf("\n");
         }
@@ -3325,6 +3336,7 @@ void emitter::emitDispGCInfoDelta()
     debugPrevGCrefRegs = emitThisGCrefRegs;
     debugPrevByrefRegs = emitThisByrefRegs;
     emitDispGCVarDelta();
+    emitDispRegPtrListDelta();
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1500,6 +1500,7 @@ protected:
     void emitDispGCDeltaTitle(const char* title);
     void emitDispGCRegDelta(const char* title, regMaskTP prevRegs, regMaskTP curRegs);
     void emitDispGCVarDelta();
+    void emitDispRegPtrListDelta();
     void emitDispGCInfoDelta();
 
     void emitDispIGflags(unsigned flags);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12781,7 +12781,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
         DONE_CALL:
 
-            /* We update the GC info before the call as the variables cannot be
+            /* We update the variable (not register) GC info before the call as the variables cannot be
                used by the call. Killing variables before the call helps with
                boundary conditions if the call is CORINFO_HELP_THROW - see bug 50029.
                If we ever track aliased variables (which could be used by the
@@ -12789,7 +12789,18 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
              */
             assert(FitsIn<unsigned char>(dst - *dp));
             callInstrSize = static_cast<unsigned char>(dst - *dp);
+
+            // Note the use of address `*dp`, the call instruction address, instead of `dst`, the post-call-instruction
+            // address.
             emitUpdateLiveGCvars(GCvars, *dp);
+
+#ifdef DEBUG
+            // Output any delta in GC variable info, corresponding to the before-call GC var updates done above.
+            if (EMIT_GC_VERBOSE || emitComp->opts.disasmWithGC)
+            {
+                emitDispGCVarDelta();
+            }
+#endif // DEBUG
 
             // If the method returns a GC ref, mark EAX appropriately
             if (id->idGCref() == GCT_GCREF)


### PR DESCRIPTION
GC vars are handled specially at call sites. In particular,
kills happen at the call site address, meaning before the
call. They JIT dump was displaying the kill after the call,
which is confusing, and different from all the other cases
of displaying GC refs. Fix this so the kills are properly
displayed before the call site.

Example diff:
```
call     System.Collections.Immutable.ImmutableArray:ToImmutableArray(System.Collections.Generic.IEnumerable`1[__Canon]):System.Collections.Immutable.ImmutableArray`1[__Canon]
    ; gcrRegs -[rdx r14]
    ; GC ptr vars -{V21}
    ; gcr arg pop 0

=>

    ; GC ptr vars -{V21}
call     System.Collections.Immutable.ImmutableArray:ToImmutableArray(System.Collections.Generic.IEnumerable`1[__Canon]):System.Collections.Immutable.ImmutableArray`1[__Canon]
    ; gcrRegs -[rdx r14]
    ; gcr arg pop 0

```