### PR TITLE
fallback to GetAddrInfoW if GetAddrInfoExW fails

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -553,7 +553,7 @@ namespace System.Net
                     {
                         return t;
                     }
-                    // If we failed with InvalidOperationException fall-throgh and use synchronous lookup on threadpool.
+                    // If we failed with InvalidOperationException fall-through and use synchronous lookup on threadpool.
                 }
 
                 asyncState = family == AddressFamily.Unspecified ? (object)hostName : new KeyValuePair<string, AddressFamily>(hostName, family);

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -539,7 +539,7 @@ namespace System.Net
 
                     Task t;
                     bool success;
-                    if (NameResolutionTelemetry.Log.IsEnabled() || true)
+                    if (NameResolutionTelemetry.Log.IsEnabled())
                     {
                         success = justAddresses
                             ? TryGetAddrInfoWithTelemetryAsync<IPAddress[]>(hostName, justAddresses, family, cancellationToken, out t)

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -592,14 +592,14 @@ namespace System.Net
 
             if (task != null)
             {
-                return InternalGetAddrInfoWithTelemetryAsync(task, hostName, stopwatch);
+                return CompleteAsync(task, hostName, stopwatch);
             }
 
             // If resolution even did not start don't bother with telemetry.
             // We will retry on thread-pool.
             return null;
 
-            static async Task<T> InternalGetAddrInfoWithTelemetryAsync(Task task, string hostName, ValueStopwatch stopwatch)
+            static async Task<T> CompleteAsync(Task task, string hostName, ValueStopwatch stopwatch)
             {
                 _  = NameResolutionTelemetry.Log.BeforeResolution(hostName);
                 T? result = null;

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -587,10 +587,11 @@ namespace System.Net
         private static bool TryGetAddrInfoWithTelemetryAsync<T>(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken, out Task t)
              where T : class
         {
+            ValueStopwatch stopwatch = ValueStopwatch.StartNew();
             if (NameResolutionPal.TryGetAddrInfoAsync(hostName, justAddresses, addressFamily, cancellationToken, out Task task))
             {
                 //return new Tuple<bool, Task>(true, (Task)InternalGetAddrInfoWithTelemetryAsync(task, hostName));
-                t  = InternalGetAddrInfoWithTelemetryAsync(task, hostName);
+                t  = InternalGetAddrInfoWithTelemetryAsync(task, hostName, stopwatch);
                 return true;
             }
 
@@ -600,9 +601,9 @@ namespace System.Net
             t = Task.CompletedTask;
             return false;
 
-            static async Task<T> InternalGetAddrInfoWithTelemetryAsync(Task task, string hostName)
+            static async Task<T> InternalGetAddrInfoWithTelemetryAsync(Task task, string hostName, ValueStopwatch stopwatch)
             {
-                ValueStopwatch stopwatch = NameResolutionTelemetry.Log.BeforeResolution(hostName);
+                _  = NameResolutionTelemetry.Log.BeforeResolution(hostName);
                 T? result = null;
                 try
                 {

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
@@ -16,7 +16,7 @@ namespace System.Net
     {
         public const bool SupportsGetAddrInfoAsync = false;
 
-        internal static Task GetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily family, CancellationToken cancellationToken) =>
+        internal static bool TryGetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily family, CancellationToken cancellationToken, out Task t) =>
             throw new NotSupportedException();
 
         private static SocketError GetSocketErrorForNativeError(int error)

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
@@ -16,7 +16,7 @@ namespace System.Net
     {
         public const bool SupportsGetAddrInfoAsync = false;
 
-        internal static bool TryGetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily family, CancellationToken cancellationToken, out Task t) =>
+        internal static Task? GetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily family, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         private static SocketError GetSocketErrorForNativeError(int error)

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -133,7 +133,7 @@ namespace System.Net
             return new string((sbyte*)buffer);
         }
 
-        public static unsafe bool TryGetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily family, CancellationToken cancellationToken, out Task task)
+        public static unsafe Task? GetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily family, CancellationToken cancellationToken)
         {
             Interop.Winsock.EnsureInitialized();
 
@@ -172,17 +172,14 @@ namespace System.Net
                 // synchronous failure here may signal issue when GetAddrInfoExW does not work from
                 // impersonated context.
                 GetAddrInfoExContext.FreeContext(context);
-                task = Task.CompletedTask;
-                return false;
+                return null;
             }
             else
             {
                 ProcessResult(errorCode, context);
             }
 
-
-            task = state.Task;
-            return true;
+            return state.Task;
         }
 
         [UnmanagedCallersOnly]

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -169,7 +169,7 @@ namespace System.Net
                 // WSATRY_AGAIN indicates possible problem with reachability according to docs.
                 // However, if servers are really unreachable, we would still get IOPenfing here
                 // and final result would be posted via overlapped IO.
-                // synchronouse failure here may signal issue when GetAddrInfoExW does not work from
+                // synchronous failure here may signal issue when GetAddrInfoExW does not work from
                 // impersonificated context.
                 return Task.FromException(new InvalidOperationException());
             }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -167,10 +167,10 @@ namespace System.Net
             else if (errorCode == SocketError.TryAgain)
             {
                 // WSATRY_AGAIN indicates possible problem with reachability according to docs.
-                // However, if servers are really unreachable, we would still get IOPenfing here
+                // However, if servers are really unreachable, we would still get IOPending here
                 // and final result would be posted via overlapped IO.
                 // synchronous failure here may signal issue when GetAddrInfoExW does not work from
-                // impersonificated context.
+                // impersonated context.
                 GetAddrInfoExContext.FreeContext(context);
                 task = Task.CompletedTask;
                 return false;

--- a/src/libraries/System.Net.NameResolution/tests/UnitTests/Fakes/FakeNameResolutionPal.cs
+++ b/src/libraries/System.Net.NameResolution/tests/UnitTests/Fakes/FakeNameResolutionPal.cs
@@ -38,7 +38,7 @@ namespace System.Net
             throw new NotImplementedException();
         }
 
-        internal static Task GetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken)
+        internal static bool TryGetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken, out Task t)
         {
             throw new NotImplementedException();
         }

--- a/src/libraries/System.Net.NameResolution/tests/UnitTests/Fakes/FakeNameResolutionPal.cs
+++ b/src/libraries/System.Net.NameResolution/tests/UnitTests/Fakes/FakeNameResolutionPal.cs
@@ -38,7 +38,7 @@ namespace System.Net
             throw new NotImplementedException();
         }
 
-        internal static bool TryGetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken, out Task t)
+        internal static Task GetAddrInfoAsync(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
While root cause why GetAddrInfoExW() is failing from impersonificated context is still investigated this change should make Async DNS working again on Windows when running from impersonificated context. 

We do not have infrastructure for automated authenticatiobn tests but I run the repro code manually on my Windows 10 and it works now eg. both explicit DNS lookup and HttpClient Async fetch works. 

fixes #29935