### PR TITLE
Use correct CoreLib configuration for shared framework linker trimming

### DIFF
--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -31,9 +31,19 @@
     </PropertyGroup>
 
     <!-- Retrieve CoreLib's path as it isn't binplaced alongside the libraries. -->
-    <MSBuild Projects="$(CoreLibProject)"
-             Properties="Configuration=$(RuntimeConfiguration)"
-             RemoveProperties="Platform;TargetFramework"
+    <ItemGroup>
+      <CoreLibProjectWithRuntimeConfig Include="$(CoreLibProject)">
+        <!-- Don't flow TargetFramework and Platform to use same inputs and outputs as the CoreLib's build as part of the runtime. -->
+        <UndefineProperties>$(UndefineProperties);TargetFramework;Platform</UndefineProperties>
+        <!-- If conflicting, manually set the Configuration property of the CoreLib project so that it aligns with the specified RuntimeConfiguration in the libraries' build. -->
+        <Properties Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
+                               '$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</Properties>
+        <Properties Condition="'$(RuntimeFlavor)' == 'Mono' and
+                               '$(Configuration)' != '$(MonoConfiguration)'">Configuration=$(MonoConfiguration)</Properties>
+      </CoreLibProjectWithRuntimeConfig>
+    </ItemGroup>
+
+    <MSBuild Projects="@(CoreLibProjectWithRuntimeConfig)"
              Targets="GetTargetPath">
       <Output TaskParameter="TargetOutputs" PropertyName="SystemPrivateCoreLibPath" />
     </MSBuild>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -30,12 +30,12 @@
       <ILLinkArgs>$(ILLinkArgs) --nowarn $(LinkerNoWarn)</ILLinkArgs>
     </PropertyGroup>
 
-    <!-- Retrieve CoreLib's path as it isn't binplaced alongside the libraries. -->
+    <!-- Retrieve CoreLib's path as it isn't binplaced alongside the libraries - https://github.com/dotnet/runtime/issues/43095. -->
     <ItemGroup>
       <CoreLibProjectWithRuntimeConfig Include="$(CoreLibProject)">
         <!-- Don't flow TargetFramework and Platform to use same inputs and outputs as the CoreLib's build as part of the runtime. -->
         <UndefineProperties>$(UndefineProperties);TargetFramework;Platform</UndefineProperties>
-        <!-- If conflicting, manually set the Configuration property of the CoreLib project so that it aligns with the specified RuntimeConfiguration in the libraries' build. -->
+        <!-- If conflicting, manually set the Configuration property of the CoreLib project so that it aligns with the specified runtime configuration in the libraries' build. -->
         <Properties Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
                                '$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</Properties>
         <Properties Condition="'$(RuntimeFlavor)' == 'Mono' and

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -31,11 +31,12 @@
     </PropertyGroup>
 
     <!-- Retrieve CoreLib's path as it isn't binplaced alongside the libraries. -->
-    <PropertyGroup>
-      <SystemPrivateCoreLibDllFileName>System.Private.CoreLib.dll</SystemPrivateCoreLibDllFileName>
-      <SystemPrivateCoreLibDir>$(CoreCLRArtifactsPath)IL\</SystemPrivateCoreLibDir>
-      <SystemPrivateCoreLibPath>$(SystemPrivateCoreLibDir)$(SystemPrivateCoreLibDllFileName)</SystemPrivateCoreLibPath>
-    </PropertyGroup>
+    <MSBuild Projects="$(CoreLibProject)"
+             Properties="Configuration=$(RuntimeConfiguration)"
+             RemoveProperties="Platform;TargetFramework"
+             Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs" PropertyName="SystemPrivateCoreLibPath" />
+    </MSBuild>
 
     <PropertyGroup>
       <_AssemblyPaths>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir);$(SystemPrivateCoreLibPath)</_AssemblyPaths>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -30,11 +30,13 @@
       <ILLinkArgs>$(ILLinkArgs) --nowarn $(LinkerNoWarn)</ILLinkArgs>
     </PropertyGroup>
 
-     <!-- Retrieve CoreLib's targetpath via GetTargetPath as it isn't binplaced yet. -->
-    <MSBuild Projects="$(CoreLibProject)"
-             Targets="GetTargetPath">
-      <Output TaskParameter="TargetOutputs" PropertyName="SystemPrivateCoreLibPath" />
-    </MSBuild>
+    <!-- Retrieve CoreLib's path as it isn't binplaced alongside the libraries. -->
+    <PropertyGroup>
+      <SystemPrivateCoreLibDllFileName>System.Private.CoreLib.dll</SystemPrivateCoreLibDllFileName>
+      <SystemPrivateCoreLibDir>$(CoreCLRArtifactsPath)</SystemPrivateCoreLibDir>
+      <SystemPrivateCoreLibDir Condition="'$(RuntimeFlavor)' != 'mono'">$(SystemPrivateCoreLibDir)IL\</SystemPrivateCoreLibDir>
+      <SystemPrivateCoreLibPath>$(SystemPrivateCoreLibDir)$(SystemPrivateCoreLibDllFileName)</SystemPrivateCoreLibPath>
+    </PropertyGroup>
 
     <PropertyGroup>
       <_AssemblyPaths>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir);$(SystemPrivateCoreLibPath)</_AssemblyPaths>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -33,8 +33,7 @@
     <!-- Retrieve CoreLib's path as it isn't binplaced alongside the libraries. -->
     <PropertyGroup>
       <SystemPrivateCoreLibDllFileName>System.Private.CoreLib.dll</SystemPrivateCoreLibDllFileName>
-      <SystemPrivateCoreLibDir>$(CoreCLRArtifactsPath)</SystemPrivateCoreLibDir>
-      <SystemPrivateCoreLibDir Condition="'$(RuntimeFlavor)' != 'mono'">$(SystemPrivateCoreLibDir)IL\</SystemPrivateCoreLibDir>
+      <SystemPrivateCoreLibDir>$(CoreCLRArtifactsPath)IL\</SystemPrivateCoreLibDir>
       <SystemPrivateCoreLibPath>$(SystemPrivateCoreLibDir)$(SystemPrivateCoreLibDllFileName)</SystemPrivateCoreLibPath>
     </PropertyGroup>
 


### PR DESCRIPTION
From https://github.com/dotnet/runtime/pull/45821#issuecomment-741858345:

`GetTargetPath` is returning the path to CoreLib based on the libraries configuration (`-lc`), rather than the runtime configuration (`-rc`). This means that when we do a build such as `build -s clr+libs -rc Release`, we are passing `Debug` libraries and `Debug` CoreLib, rather than `Debug` libraries and `Release` CoreLib to the linker which is not expected.