### PR TITLE
Improve PUTARG_STK generation for Arm/Arm64.

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -919,7 +919,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 // The dst size can be rounded up to PUTARG_STK size.
                 // The src size can be rounded up if it reads a local variable slot because the local
                 // variable stack allocation size is rounded up to be a multiple of the TARGET_POINTER_SIZE.
-                // The exception  is arm64 apple arguments because they can be packed without padding.
+                // The exception  is arm64 apple arguments because they can be passed without padding.
                 if (varNode != nullptr)
                 {
 #if defined(OSX_ARM64_ABI)

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -918,7 +918,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 // We can generate a smaller code if store size is a multiple of TARGET_POINTER_SIZE.
                 // The dst size can be rounded up to PUTARG_STK size.
                 // The src size can be rounded up if it reads a local variable slot because the local
-                // variable stack allocation size is rounded up to be a multiple of the slot size.
+                // variable stack allocation size is rounded up to be a multiple of the TARGET_POINTER_SIZE.
                 // The exception  is arm64 apple arguments because they can be packed without padding.
                 if (varNode != nullptr)
                 {

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -795,7 +795,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         }
         else // We must have a GT_OBJ or a GT_LCL_VAR
         {
-            noway_assert((source->OperGet() == GT_LCL_VAR) || (source->OperGet() == GT_OBJ));
+            noway_assert(source->OperIs(GT_LCL_VAR, GT_OBJ));
 
             var_types targetType = source->TypeGet();
             noway_assert(varTypeIsStruct(targetType));
@@ -891,26 +891,9 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 // it provides (size and GC layout) even if the node wraps a lclvar. Due
                 // to struct reinterpretation (e.g. Unsafe.As<X, Y>) it is possible that
                 // the OBJ node has a different type than the lclvar.
-                layout = source->AsObj()->GetLayout();
-
+                layout     = source->AsObj()->GetLayout();
                 structSize = layout->GetSize();
-
-                // The codegen code below doesn't have proper support for struct sizes
-                // that are not multiple of the slot size. Call arg morphing handles this
-                // case by copying non-local values to temporary local variables.
-                // More generally, we can always round up the struct size when the OBJ node
-                // wraps a local variable because the local variable stack allocation size
-                // is also rounded up to be a multiple of the slot size.
-                if (varNode != nullptr)
-                {
-                    structSize = roundUp(structSize, TARGET_POINTER_SIZE);
-                }
-                else
-                {
-                    assert((structSize % TARGET_POINTER_SIZE) == 0);
-                }
-
-                isHfa = compiler->IsHfa(layout->GetClassHandle());
+                isHfa      = compiler->IsHfa(layout->GetClassHandle());
             }
 
             // If we have an HFA we can't have any GC pointers,
@@ -927,6 +910,31 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 
             noway_assert(structSize <= MAX_PASS_MULTIREG_BYTES);
 #endif // TARGET_ARM64
+
+            unsigned roundedDstSize = treeNode->GetStackByteSize();
+            if (roundedDstSize != structSize)
+            {
+                unsigned roundedSrcSize = structSize;
+                // We can generate a smaller code if store size is a multiple of TARGET_POINTER_SIZE.
+                // The dst size can be rounded up to PUTARG_STK size.
+                // The src size can be rounded up if it reads a local variable slot because the local
+                // variable stack allocation size is rounded up to be a multiple of the slot size.
+                // The exception  is arm64 apple arguments because they can be packed without padding.
+                if (varNode != nullptr)
+                {
+#if defined(OSX_ARM64_ABI)
+                    const LclVarDsc* varDsc = compiler->lvaGetDesc(varNode);
+                    if (!varDsc->lvIsParam || !isHfa || (varDsc->GetHfaType() != TYP_FLOAT))
+#endif // OSX_ARM64_ABI
+                    {
+                        roundedSrcSize = roundUp(structSize, TARGET_POINTER_SIZE);
+                    }
+                }
+                if (roundedDstSize == roundedSrcSize)
+                {
+                    structSize = roundedDstSize;
+                }
+            }
 
             int      remainingSize = structSize;
             unsigned structOffset  = 0;
@@ -1010,70 +1018,58 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 
             while (remainingSize > 0)
             {
+                var_types type;
+
                 if (remainingSize >= TARGET_POINTER_SIZE)
                 {
-                    var_types nextType = layout->GetGCPtrType(nextIndex);
-                    emitAttr  nextAttr = emitTypeSize(nextType);
-                    remainingSize -= TARGET_POINTER_SIZE;
-
-                    if (varNode != nullptr)
-                    {
-                        // Load from our varNumImp source
-                        emit->emitIns_R_S(ins_Load(nextType), nextAttr, loReg, varNode->GetLclNum(), structOffset);
-                    }
-                    else
-                    {
-                        assert(loReg != addrReg);
-
-                        // Load from our address expression source
-                        emit->emitIns_R_R_I(ins_Load(nextType), nextAttr, loReg, addrReg, structOffset);
-                    }
-                    // Emit a store instruction to store the register into the outgoing argument area
-                    emit->emitIns_S_R(ins_Store(nextType), nextAttr, loReg, varNumOut, argOffsetOut);
-                    argOffsetOut += EA_SIZE_IN_BYTES(nextAttr);
-                    assert(argOffsetOut <= argOffsetMax); // We can't write beyound the outgoing area area
-
-                    structOffset += TARGET_POINTER_SIZE;
-                    nextIndex++;
+                    type = layout->GetGCPtrType(nextIndex);
                 }
                 else // (remainingSize < TARGET_POINTER_SIZE)
                 {
-                    int loadSize  = remainingSize;
-                    remainingSize = 0;
-
-                    // We should never have to do a non-pointer sized load when we have a LclVar source
-                    assert(varNode == nullptr);
-
                     // the left over size is smaller than a pointer and thus can never be a GC type
                     assert(!layout->IsGCPtr(nextIndex));
 
-                    var_types loadType = TYP_UINT;
-                    if (loadSize == 1)
+                    if (remainingSize == 1)
                     {
-                        loadType = TYP_UBYTE;
+                        type = TYP_UBYTE;
                     }
-                    else if (loadSize == 2)
+                    else if (remainingSize == 2)
                     {
-                        loadType = TYP_USHORT;
+                        type = TYP_USHORT;
                     }
                     else
                     {
-                        // Need to handle additional loadSize cases here
-                        noway_assert(loadSize == 4);
+                        assert(remainingSize == 4);
+                        type = TYP_UINT;
                     }
-
-                    instruction loadIns  = ins_Load(loadType);
-                    emitAttr    loadAttr = emitAttr(loadSize);
-
-                    assert(loReg != addrReg);
-
-                    emit->emitIns_R_R_I(loadIns, loadAttr, loReg, addrReg, structOffset);
-
-                    // Emit a store instruction to store the register into the outgoing argument area
-                    emit->emitIns_S_R(ins_Store(loadType), loadAttr, loReg, varNumOut, argOffsetOut);
-                    argOffsetOut += EA_SIZE_IN_BYTES(loadAttr);
-                    assert(argOffsetOut <= argOffsetMax); // We can't write beyound the outgoing area area
                 }
+                const emitAttr attr     = emitTypeSize(type);
+                const unsigned moveSize = genTypeSize(type);
+                assert(EA_SIZE_IN_BYTES(attr) == moveSize);
+
+                remainingSize -= moveSize;
+
+                instruction loadIns = ins_Load(type);
+                if (varNode != nullptr)
+                {
+                    // Load from our varNumImp source
+                    emit->emitIns_R_S(loadIns, attr, loReg, varNode->GetLclNum(), structOffset);
+                }
+                else
+                {
+                    assert(loReg != addrReg);
+                    // Load from our address expression source
+                    emit->emitIns_R_R_I(loadIns, attr, loReg, addrReg, structOffset);
+                }
+
+                // Emit a store instruction to store the register into the outgoing argument area
+                instruction storeIns = ins_Store(type);
+                emit->emitIns_S_R(storeIns, attr, loReg, varNumOut, argOffsetOut);
+                argOffsetOut += moveSize;
+                assert(argOffsetOut <= argOffsetMax); // We can't write beyound the outgoing area area
+
+                structOffset += moveSize;
+                nextIndex++;
             }
         }
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3959,12 +3959,15 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                            ((copyBlkClass != NO_CLASS_HANDLE) && varTypeIsEnregisterable(structBaseType)));
                 }
 
-#ifndef UNIX_AMD64_ABI
+#if !defined(UNIX_AMD64_ABI) && !defined(TARGET_ARMARCH)
+                // TODO-CQ-XARCH: there is no need for a temp copy if we improve our code generation in
+                // `genPutStructArgStk` for xarch like we did it for Arm/Arm64.
+
                 // We still have a struct unless we converted the GT_OBJ into a GT_IND above...
                 if (isHfaArg && passUsingFloatRegs)
                 {
                 }
-                else if ((!isHfaArg || !passUsingFloatRegs) && (structBaseType == TYP_STRUCT))
+                else if (structBaseType == TYP_STRUCT)
                 {
                     // If the valuetype size is not a multiple of TARGET_POINTER_SIZE,
                     // we must copyblk to a temp before doing the obj to avoid


### PR DESCRIPTION
Allow non-pointer-size put args for structs on arm/arm64.
It was an old CQ issue but now it is an Arm64 apple requirement.

It gives us a small code size improvement (arm64 fx crossgen/pmi):
```
Total bytes of delta: -752 (-0.00% of base)
    diff is an improvement.
5 total files with Code Size differences (5 improved, 0 regressed), 261 unchanged.
25 total methods with Code Size differences (25 improved, 0 regressed), 257960 unchanged.
```

Contributes to https://github.com/dotnet/runtime/issues/45780