### PR TITLE
Remove autotools dependencies from the build requirements

### DIFF
--- a/docs/workflow/requirements/freebsd-requirements.md
+++ b/docs/workflow/requirements/freebsd-requirements.md
@@ -49,9 +49,6 @@ Building dotnet/runtime depends on several tools to be installed.
 Install the following packages:
 
 - cmake
-- autoconf
-- automake
-- libtool
 - icu
 - libunwind
 - lttng-ust
@@ -62,7 +59,7 @@ Install the following packages:
 The lines to install all the packages above using package manager.
 
 ```sh
-sudo pkg install --yes libunwind icu libinotify lttng-ust krb5 cmake autoconf automake openssl ninja
+sudo pkg install --yes libunwind icu libinotify lttng-ust krb5 cmake openssl ninja
 ```
 
 Additionally, working dotnet cli with SDK is needed. On other platforms this would be downloaded automatically during build but it is not currently available for FreeBSD.

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -32,9 +32,6 @@ Install the following packages for the toolchain:
 - cmake
 - llvm-9
 - clang-9
-- autoconf
-- automake
-- libtool
 - build-essential
 - python
 - curl
@@ -52,15 +49,9 @@ Install the following packages for the toolchain:
 - zlib1g-dev
 - ninja-build (optional, enables building native code with ninja instead of make)
 
-The following dependencies are needed if Mono Runtime is enabled (default behavior):
-
-- autoconf
-- automake
-- libtool
-
 ```
-sudo apt-get install -y cmake llvm-9 clang-9 autoconf automake \
-libtool build-essential python curl git lldb-6.0 liblldb-6.0-dev \
+sudo apt-get install -y cmake llvm-9 clang-9 \
+build-essential python curl git lldb-6.0 liblldb-6.0-dev \
 libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev \
 libssl-dev libnuma-dev libkrb5-dev zlib1g-dev ninja-build
 ```

--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -21,10 +21,7 @@ Building dotnet/runtime depends on several tools to be installed. You can downlo
 Install the following packages:
 
 - cmake 3.15.5 or newer
-- autoconf
-- automake
 - icu4c
-- libtool
 - openssl 1.1
 - pkg-config
 - python3

--- a/eng/Brewfile
+++ b/eng/Brewfile
@@ -1,8 +1,5 @@
-brew "autoconf"
-brew "automake"
 brew "cmake"
 brew "icu4c"
-brew "libtool"
 brew "openssl@1.1"
 brew "pkg-config"
 brew "python3"

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -24,7 +24,7 @@ if [ "$1" = "Linux" ]; then
     if [ "$?" != "0" ]; then
        exit 1;
     fi
-    sudo apt install cmake llvm-3.9 clang-3.9 lldb-3.9 liblldb-3.9-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev libkrb5-dev libnuma-dev autoconf automake libtool build-essential
+    sudo apt install cmake llvm-3.9 clang-3.9 lldb-3.9 liblldb-3.9-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev libkrb5-dev libnuma-dev build-essential
     if [ "$?" != "0" ]; then
         exit 1;
     fi

--- a/src/mono/cmake/README.md
+++ b/src/mono/cmake/README.md
@@ -1,9 +1,0 @@
-# Introduction
-
-* This is an alternative CMAKE based build system for mono.
-* The autoconf build system is still the official one.
-* Only a subset of platforms/configurations etc. are supported.
-
-# Usage
-
-```cmake -DENABLE_NETCORE=1 -G Ninja .```


### PR DESCRIPTION
Now that Mono has switched to CMake we no longer need the autoconf, automake and libtool build dependencies.