### PR TITLE
Fix debugger late attach, suspend=n.

### DIFF
--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -749,18 +749,18 @@ parse_address (char *address, char **host, int *port)
 static void
 print_usage (void)
 {
-	g_printerr ("Usage: mono --debugger-agent=[<option>=<value>,...] ...\n");
-	g_printerr ("Available options:\n");
-	g_printerr ("  transport=<transport>\t\tTransport to use for connecting to the debugger (mandatory, possible values: 'dt_socket')\n");
-	g_printerr ("  address=<hostname>:<port>\tAddress to connect to (mandatory)\n");
-	g_printerr ("  loglevel=<n>\t\t\tLog level (defaults to 0)\n");
-	g_printerr ("  logfile=<file>\t\tFile to log to (defaults to stdout)\n");
-	g_printerr ("  suspend=y/n\t\t\tWhether to suspend after startup.\n");
-	g_printerr ("  timeout=<n>\t\t\tTimeout for connecting in milliseconds.\n");
-	g_printerr ("  server=y/n\t\t\tWhether to listen for a client connection.\n");
-	g_printerr ("  keepalive=<n>\t\t\tSend keepalive events every n milliseconds.\n");
-	g_printerr ("  setpgid=y/n\t\t\tWhether to call setpid(0, 0) after startup.\n");
-	g_printerr ("  help\t\t\t\tPrint this help.\n");
+	PRINT_ERROR_MSG ("Usage: mono --debugger-agent=[<option>=<value>,...] ...\n");
+	PRINT_ERROR_MSG ("Available options:\n");
+	PRINT_ERROR_MSG ("  transport=<transport>\t\tTransport to use for connecting to the debugger (mandatory, possible values: 'dt_socket')\n");
+	PRINT_ERROR_MSG ("  address=<hostname>:<port>\tAddress to connect to (mandatory)\n");
+	PRINT_ERROR_MSG ("  loglevel=<n>\t\t\tLog level (defaults to 0)\n");
+	PRINT_ERROR_MSG ("  logfile=<file>\t\tFile to log to (defaults to stdout)\n");
+	PRINT_ERROR_MSG ("  suspend=y/n\t\t\tWhether to suspend after startup.\n");
+	PRINT_ERROR_MSG ("  timeout=<n>\t\t\tTimeout for connecting in milliseconds.\n");
+	PRINT_ERROR_MSG ("  server=y/n\t\t\tWhether to listen for a client connection.\n");
+	PRINT_ERROR_MSG ("  keepalive=<n>\t\t\tSend keepalive events every n milliseconds.\n");
+	PRINT_ERROR_MSG ("  setpgid=y/n\t\t\tWhether to call setpid(0, 0) after startup.\n");
+	PRINT_ERROR_MSG ("  help\t\t\t\tPrint this help.\n");
 }
 
 static gboolean
@@ -771,7 +771,7 @@ parse_flag (const char *option, char *flag)
 	else if (!strcmp (flag, "n"))
 		return FALSE;
 	else {
-		g_printerr ("debugger-agent: The valid values for the '%s' option are 'y' and 'n'.\n", option);
+		PRINT_ERROR_MSG ("debugger-agent: The valid values for the '%s' option are 'y' and 'n'.\n", option);
 		exit (1);
 		return FALSE;
 	}
@@ -786,7 +786,7 @@ debugger_agent_parse_options (char *options)
 	char *extra;
 
 #ifndef MONO_ARCH_SOFT_DEBUG_SUPPORTED
-	g_printerr ("--debugger-agent is not supported on this platform.\n");
+	PRINT_ERROR_MSG ("--debugger-agent is not supported on this platform.\n");
 	exit (1);
 #endif
 
@@ -857,19 +857,19 @@ debugger_agent_parse_options (char *options)
 	//agent_config.log_level = 0;
 
 	if (agent_config.transport == NULL) {
-		g_printerr ("debugger-agent: The 'transport' option is mandatory.\n");
+		PRINT_ERROR_MSG ("debugger-agent: The 'transport' option is mandatory.\n");
 		exit (1);
 	}
 
 	if (agent_config.address == NULL && !agent_config.server) {
-		g_printerr ("debugger-agent: The 'address' option is mandatory.\n");
+		PRINT_ERROR_MSG ("debugger-agent: The 'address' option is mandatory.\n");
 		exit (1);
 	}
 
 	// FIXME:
 	if (!strcmp (agent_config.transport, "dt_socket")) {
 		if (agent_config.address && parse_address (agent_config.address, &host, &port)) {
-			g_printerr ("debugger-agent: The format of the 'address' options is '<host>:<port>'\n");
+			PRINT_ERROR_MSG ("debugger-agent: The format of the 'address' options is '<host>:<port>'\n");
 			exit (1);
 		}
 	}
@@ -988,7 +988,7 @@ debugger_agent_init (void)
 	if (agent_config.log_file) {
 		log_file = fopen (agent_config.log_file, "w+");
 		if (!log_file) {
-			g_printerr ("Unable to create log file '%s': %s.\n", agent_config.log_file, strerror (errno));
+			PRINT_ERROR_MSG ("Unable to create log file '%s': %s.\n", agent_config.log_file, strerror (errno));
 			exit (1);
 		}
 	} else {
@@ -1049,7 +1049,7 @@ finish_agent_init (gboolean on_startup)
 #ifdef G_OS_WIN32
 		// Nothing. FIXME? g_spawn_async_with_pipes is easy enough to provide for Windows if needed.
 #elif !HAVE_G_SPAWN
-		g_printerr ("g_spawn_async_with_pipes not supported on this platform\n");
+		PRINT_ERROR_MSG ("g_spawn_async_with_pipes not supported on this platform\n");
 		exit (1);
 #else
 		char *argv [ ] = {
@@ -1060,7 +1060,7 @@ finish_agent_init (gboolean on_startup)
 		};
 		int res = g_spawn_async_with_pipes (NULL, argv, NULL, (GSpawnFlags)0, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 		if (!res) {
-			g_printerr ("Failed to execute '%s'.\n", agent_config.launch);
+			PRINT_ERROR_MSG ("Failed to execute '%s'.\n", agent_config.launch);
 			exit (1);
 		}
 #endif
@@ -1174,9 +1174,9 @@ socket_transport_accept (int socket_fd)
 	MONO_EXIT_GC_SAFE;
 
 	if (conn_fd == -1) {
-		g_printerr ("debugger-agent: Unable to listen on %d\n", socket_fd);
+		PRINT_ERROR_MSG ("debugger-agent: Unable to listen on %d\n", socket_fd);
 	} else {
-		DEBUG_PRINTF (1, "Accepted connection from client, connection fd=%d.\n", conn_fd);
+		PRINT_DEBUG_MSG (1, "Accepted connection from client, connection fd=%d.\n", conn_fd);
 	}
 	
 	return conn_fd;
@@ -1242,7 +1242,7 @@ socket_transport_connect (const char *address)
 				break;
 		}
 		if (s != 0) {
-			g_printerr ("debugger-agent: Unable to resolve %s:%d: %d\n", host, port, s); // FIXME add portable error conversion functions
+			PRINT_ERROR_MSG ("debugger-agent: Unable to resolve %s:%d: %d\n", host, port, s); // FIXME add portable error conversion functions
 			exit (1);
 		}
 	}
@@ -1256,14 +1256,14 @@ socket_transport_connect (const char *address)
 			/* No address, generate one */
 			sfd = socket (AF_INET, SOCK_STREAM, 0);
 			if (sfd == -1) {
-				g_printerr ("debugger-agent: Unable to create a socket: %s\n", strerror (get_last_sock_error ()));
+				PRINT_ERROR_MSG ("debugger-agent: Unable to create a socket: %s\n", strerror (get_last_sock_error ()));
 				exit (1);
 			}
 
 			/* This will bind the socket to a random port */
 			res = listen (sfd, 16);
 			if (res == -1) {
-				g_printerr ("debugger-agent: Unable to setup listening socket: %s\n", strerror (get_last_sock_error ()));
+				PRINT_ERROR_MSG ("debugger-agent: Unable to setup listening socket: %s\n", strerror (get_last_sock_error ()));
 				exit (1);
 			}
 			listen_fd = sfd;
@@ -1278,7 +1278,7 @@ socket_transport_connect (const char *address)
 
 			/* Emit the address to stdout */
 			/* FIXME: Should print another interface, not localhost */
-			printf ("%s:%d\n", host, port);
+			PRINT_MSG ("%s:%d\n", host, port);
 		} else {
 			/* Listen on the provided address */
 			for (rp = result->entries; rp != NULL; rp = rp->next) {
@@ -1313,7 +1313,7 @@ socket_transport_connect (const char *address)
 		if (agent_config.defer)
 			return;
 
-		DEBUG_PRINTF (1, "Listening on %s:%d (timeout=%d ms)...\n", host, port, agent_config.timeout);
+		PRINT_DEBUG_MSG (1, "Listening on %s:%d (timeout=%d ms)...\n", host, port, agent_config.timeout);
 
 		if (agent_config.timeout) {
 			fd_set readfds;
@@ -1329,7 +1329,7 @@ socket_transport_connect (const char *address)
 			MONO_EXIT_GC_SAFE;
 
 			if (res == 0) {
-				g_printerr ("debugger-agent: Timed out waiting to connect.\n");
+				PRINT_ERROR_MSG ("debugger-agent: Timed out waiting to connect.\n");
 				exit (1);
 			}
 		}
@@ -1338,7 +1338,7 @@ socket_transport_connect (const char *address)
 		if (conn_fd == -1)
 			exit (1);
 
-		DEBUG_PRINTF (1, "Accepted connection from client, socket fd=%d.\n", conn_fd);
+		PRINT_DEBUG_MSG (1, "Accepted connection from client, socket fd=%d.\n", conn_fd);
 	} else {
 		/* Connect to the specified address */
 		/* FIXME: Respect the timeout */
@@ -1370,7 +1370,7 @@ socket_transport_connect (const char *address)
 		}
 
 		if (rp == 0) {
-			g_printerr ("debugger-agent: Unable to connect to %s:%d\n", host, port);
+			PRINT_ERROR_MSG ("debugger-agent: Unable to connect to %s:%d\n", host, port);
 			exit (1);
 		}
 
@@ -1439,7 +1439,7 @@ socket_fd_transport_connect (const char *address)
 
 	res = sscanf (address, "%d", &conn_fd);
 	if (res != 1) {
-		g_printerr ("debugger-agent: socket-fd transport address is invalid: '%s'\n", address);
+		PRINT_ERROR_MSG ("debugger-agent: socket-fd transport address is invalid: '%s'\n", address);
 		exit (1);
 	}
 
@@ -1509,10 +1509,10 @@ transport_init (void)
 			break;
 	}
 	if (i == ntransports) {
-		g_printerr ("debugger-agent: The supported values for the 'transport' option are: ");
+		PRINT_ERROR_MSG ("debugger-agent: The supported values for the 'transport' option are: ");
 		for (i = 0; i < ntransports; ++i)
-			g_printerr ("%s'%s'", i > 0 ? ", " : "", transports [i].name);
-		g_printerr ("\n");
+			PRINT_ERROR_MSG ("%s'%s'", i > 0 ? ", " : "", transports [i].name);
+		PRINT_ERROR_MSG ("\n");
 		exit (1);
 	}
 	transport = &transports [i];
@@ -1575,7 +1575,7 @@ transport_handshake (void)
 	/* Read answer */
 	res = transport_recv (buf, strlen (handshake_msg));
 	if ((res != strlen (handshake_msg)) || (memcmp (buf, handshake_msg, strlen (handshake_msg)) != 0)) {
-		g_printerr ("debugger-agent: DWP handshake failed.\n");
+		PRINT_ERROR_MSG ("debugger-agent: DWP handshake failed.\n");
 		return FALSE;
 	}
 
@@ -1914,7 +1914,7 @@ send_buffered_reply_packets (void)
 	send_reply_packets (nreply_packets, reply_packets);
 	for (i = 0; i < nreply_packets; ++i)
 		buffer_free (reply_packets [i].data);
-	DEBUG_PRINTF (1, "[dbg] Sent %d buffered reply packets [at=%lx].\n", nreply_packets, (long)mono_100ns_ticks () / 10000);
+	PRINT_DEBUG_MSG (1, "[dbg] Sent %d buffered reply packets [at=%lx].\n", nreply_packets, (long)mono_100ns_ticks () / 10000);
 	nreply_packets = 0;
 }
 
@@ -2336,7 +2336,7 @@ decode_ptr_id (guint8 *buf, guint8 **endbuf, guint8 *limit, IdType type, MonoDom
 	dbg_unlock ();
 
 	if (res->domain == NULL || res->domain->state == MONO_APPDOMAIN_UNLOADED) {
-		DEBUG_PRINTF (1, "ERR_UNLOADED, id=%d, type=%d.\n", id, type);
+		PRINT_DEBUG_MSG (1, "ERR_UNLOADED, id=%d, type=%d.\n", id, type);
 		*err = ERR_UNLOADED;
 		return NULL;
 	}
@@ -2366,7 +2366,7 @@ decode_typeid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain,
 		char *s;
 
 		s = mono_type_full_name (m_class_get_byval_arg (klass));
-		DEBUG_PRINTF (2, "[dbg]   recv class [%s]\n", s);
+		PRINT_DEBUG_MSG (2, "[dbg]   recv class [%s]\n", s);
 		g_free (s);
 	}
 	return klass;
@@ -2394,7 +2394,7 @@ decode_methodid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domai
 		char *s;
 
 		s = mono_method_full_name (m, TRUE);
-		DEBUG_PRINTF (2, "[dbg]   recv method [%s]\n", s);
+		PRINT_DEBUG_MSG (2, "[dbg]   recv method [%s]\n", s);
 		g_free (s);
 	}
 	return m;
@@ -2427,9 +2427,9 @@ buffer_add_typeid (Buffer *buf, MonoDomain *domain, MonoClass *klass)
 
 		s = mono_type_full_name (m_class_get_byval_arg (klass));
 		if (is_debugger_thread ())
-			DEBUG_PRINTF (2, "[dbg]   send class [%s]\n", s);
+			PRINT_DEBUG_MSG (2, "[dbg]   send class [%s]\n", s);
 		else
-			DEBUG_PRINTF (2, "[%p]   send class [%s]\n", (gpointer) (gsize) mono_native_thread_id_get (), s);
+			PRINT_DEBUG_MSG (2, "[%p]   send class [%s]\n", (gpointer) (gsize) mono_native_thread_id_get (), s);
 		g_free (s);
 	}
 }
@@ -2443,9 +2443,9 @@ buffer_add_methodid (Buffer *buf, MonoDomain *domain, MonoMethod *method)
 
 		s = mono_method_full_name (method, 1);
 		if (is_debugger_thread ())
-			DEBUG_PRINTF (2, "[dbg]   send method [%s]\n", s);
+			PRINT_DEBUG_MSG (2, "[dbg]   send method [%s]\n", s);
 		else
-			DEBUG_PRINTF (2, "[%p]   send method [%s]\n", (gpointer) (gsize) mono_native_thread_id_get (), s);
+			PRINT_DEBUG_MSG (2, "[%p]   send method [%s]\n", (gpointer) (gsize) mono_native_thread_id_get (), s);
 		g_free (s);
 	}
 }
@@ -2457,7 +2457,7 @@ buffer_add_assemblyid (Buffer *buf, MonoDomain *domain, MonoAssembly *assembly)
 
 	id = buffer_add_ptr_id (buf, domain, ID_ASSEMBLY, assembly);
 	if (G_UNLIKELY (log_level >= 2) && assembly)
-		DEBUG_PRINTF (2, "[dbg]   send assembly [%s][%s][%d]\n", assembly->aname.name, domain->friendly_name, id);
+		PRINT_DEBUG_MSG (2, "[dbg]   send assembly [%s][%s][%d]\n", assembly->aname.name, domain->friendly_name, id);
 }
 
 static void
@@ -2620,7 +2620,7 @@ thread_interrupt (DebuggerTlsData *tls, MonoThreadInfo *info, MonoJitInfo *ji)
 
 	if (ji && !ji->is_trampoline) {
 		/* Running managed code, will be suspended by the single step code */
-		DEBUG_PRINTF (1, "[%p] Received interrupt while at %s(%p), continuing.\n", (gpointer)(gsize)tid, jinfo_get_method (ji)->name, ip);
+		PRINT_DEBUG_MSG (1, "[%p] Received interrupt while at %s(%p), continuing.\n", (gpointer)(gsize)tid, jinfo_get_method (ji)->name, ip);
 	} else {
 		/* 
 		 * Running native code, will be suspended when it returns to/enters 
@@ -2634,7 +2634,7 @@ thread_interrupt (DebuggerTlsData *tls, MonoThreadInfo *info, MonoJitInfo *ji)
 			// FIXME: printf is not signal safe, but this is only used during
 			// debugger debugging
 			if (ip)
-				DEBUG_PRINTF (1, "[%p] Received interrupt while at %p, treating as suspended.\n", (gpointer)(gsize)tid, ip);
+				PRINT_DEBUG_MSG (1, "[%p] Received interrupt while at %p, treating as suspended.\n", (gpointer)(gsize)tid, ip);
 			//save_thread_context (&ctx);
 
 			if (!tls->thread)
@@ -2746,7 +2746,7 @@ notify_thread (gpointer key, gpointer value, gpointer user_data)
 	if (mono_thread_internal_is_current (thread) || tls->terminated)
 		return;
 
-	DEBUG_PRINTF (1, "[%p] Interrupting %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)(gsize)tid);
+	PRINT_DEBUG_MSG (1, "[%p] Interrupting %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)(gsize)tid);
 
 	/* This is _not_ equivalent to mono_thread_internal_abort () */
 	InterruptData interrupt_data = { 0 };
@@ -2754,7 +2754,7 @@ notify_thread (gpointer key, gpointer value, gpointer user_data)
 
 	mono_thread_info_safe_suspend_and_run ((MonoNativeThreadId)(gsize)thread->tid, FALSE, debugger_interrupt_critical, &interrupt_data);
 	if (!interrupt_data.valid_info) {
-		DEBUG_PRINTF (1, "[%p] mono_thread_info_suspend_sync () failed for %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)tid);
+		PRINT_DEBUG_MSG (1, "[%p] mono_thread_info_suspend_sync () failed for %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)tid);
 		/* 
 		 * Attached thread which died without detaching.
 		 */
@@ -2785,7 +2785,7 @@ process_suspend (DebuggerTlsData *tls, MonoContext *ctx)
 	if (suspend_count - tls->resume_count > 0)
 		tls->suspending = TRUE;
 
-	DEBUG_PRINTF (1, "[%p] Received single step event for suspending.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+	PRINT_DEBUG_MSG (1, "[%p] Received single step event for suspending.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 
 	if (suspend_count - tls->resume_count == 0) {
 		/* 
@@ -2793,7 +2793,7 @@ process_suspend (DebuggerTlsData *tls, MonoContext *ctx)
 		 * suspending is still active.
 		 * FIXME: This slows down single threaded invokes.
 		 */
-		DEBUG_PRINTF (1, "[%p] Ignored during single threaded invoke.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+		PRINT_DEBUG_MSG (1, "[%p] Ignored during single threaded invoke.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 		return;
 	}
 
@@ -2851,7 +2851,7 @@ suspend_vm (void)
 
 	suspend_count ++;
 
-	DEBUG_PRINTF (1, "[%p] Suspending vm...\n", (gpointer) (gsize) mono_native_thread_id_get ());
+	PRINT_DEBUG_MSG (1, "[%p] Suspending vm...\n", (gpointer) (gsize) mono_native_thread_id_get ());
 
 	if (suspend_count == 1) {
 		// FIXME: Is it safe to call this inside the lock ?
@@ -2893,7 +2893,7 @@ resume_vm (void)
 	g_assert (suspend_count > 0);
 	suspend_count --;
 
-	DEBUG_PRINTF (1, "[%p] Resuming vm, suspend count=%d...\n", (gpointer) (gsize) mono_native_thread_id_get (), suspend_count);
+	PRINT_DEBUG_MSG (1, "[%p] Resuming vm, suspend count=%d...\n", (gpointer) (gsize) mono_native_thread_id_get (), suspend_count);
 
 	if (suspend_count == 0) {
 		// FIXME: Is it safe to call this inside the lock ?
@@ -2938,7 +2938,7 @@ resume_thread (MonoInternalThread *thread)
 
 	g_assert (suspend_count > 0);
 
-	DEBUG_PRINTF (1, "[sdb] Resuming thread %p...\n", (gpointer)(gssize)thread->tid);
+	PRINT_DEBUG_MSG (1, "[sdb] Resuming thread %p...\n", (gpointer)(gssize)thread->tid);
 
 	tls->resume_count += suspend_count;
 	tls->resume_count_internal += tls->suspend_count;
@@ -3026,7 +3026,7 @@ suspend_current (void)
 		}
 
 		mono_debugger_log_suspend (tls);
-		DEBUG_PRINTF (1, "[%p] Suspended.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+		PRINT_DEBUG_MSG (1, "[%p] Suspended.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 
 		while (suspend_count - tls->resume_count > 0) {
 			mono_coop_cond_wait (&suspend_cond, &suspend_mutex);
@@ -3038,7 +3038,7 @@ suspend_current (void)
 		mono_coop_mutex_unlock (&suspend_mutex);
 
 		mono_debugger_log_resume (tls);
-		DEBUG_PRINTF (1, "[%p] Resumed.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+		PRINT_DEBUG_MSG (1, "[%p] Resumed.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 
 		if (tls->pending_invoke) {
 			/* Save the original context */
@@ -3100,7 +3100,7 @@ wait_for_suspend (void)
 	while (TRUE) {
 		nwait = count_threads_to_wait_for ();
 		if (nwait) {
-			DEBUG_PRINTF (1, "Waiting for %d(%d) threads to suspend...\n", nwait, nthreads);
+			PRINT_DEBUG_MSG (1, "Waiting for %d(%d) threads to suspend...\n", nwait, nthreads);
 			err = mono_coop_sem_wait (&suspend_sem, MONO_SEM_FLAGS_NONE);
 			g_assert (err == 0);
 			waited = TRUE;
@@ -3110,7 +3110,7 @@ wait_for_suspend (void)
 	}
 
 	if (waited)
-		DEBUG_PRINTF (1, "%d threads suspended.\n", nthreads);
+		PRINT_DEBUG_MSG (1, "%d threads suspended.\n", nthreads);
 }
 
 /*
@@ -3130,7 +3130,7 @@ no_seq_points_found (MonoMethod *method, int offset)
 	/*
 	 * This can happen in full-aot mode with assemblies AOTed without the 'soft-debug' option to save space.
 	 */
-	printf ("Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
+	PRINT_MSG ("Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
 }
 
 static int
@@ -3196,7 +3196,7 @@ process_frame (StackFrameInfo *info, MonoContext *ctx, gpointer user_data)
 		info->il_offset = calc_il_offset (info->domain, method, info->native_offset, ud->frames == NULL);
 	}
 
-	DEBUG_PRINTF (1, "\tFrame: %s:[il=0x%x, native=0x%x] %d\n", mono_method_full_name (method, TRUE), info->il_offset, info->native_offset, info->managed);
+	PRINT_DEBUG_MSG (1, "\tFrame: %s:[il=0x%x, native=0x%x] %d\n", mono_method_full_name (method, TRUE), info->il_offset, info->native_offset, info->managed);
 
 	if (method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
 		if (!CHECK_PROTOCOL_VERSION (2, 17)) {
@@ -3347,7 +3347,7 @@ compute_frame_info (MonoInternalThread *thread, DebuggerTlsData *tls, gboolean f
 	if (tls->frames && tls->frames_up_to_date && !force_update)
 		return;
 
-	DEBUG_PRINTF (1, "Frames for %p(tid=%lx):\n", thread, (glong)thread->tid);
+	PRINT_DEBUG_MSG (1, "Frames for %p(tid=%lx):\n", thread, (glong)thread->tid);
 
 	if (CHECK_PROTOCOL_VERSION (2, 52)) {
 		if (tls->restore_state.valid && MONO_CONTEXT_GET_IP (&tls->context.ctx) != MONO_CONTEXT_GET_IP (&tls->restore_state.ctx)) {
@@ -3378,7 +3378,7 @@ compute_frame_info (MonoInternalThread *thread, DebuggerTlsData *tls, gboolean f
 		 */
 		if (tls->context.valid) {
 			mono_walk_stack_with_state (process_filter_frame, &tls->context, opts, &user_data);
-			DEBUG_PRINTF (1, "\tFrame: <call filter>\n");
+			PRINT_DEBUG_MSG (1, "\tFrame: <call filter>\n");
 		}
 		/*
 		 * After that, we resume unwinding from the location where the exception has been thrown.
@@ -3853,28 +3853,28 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 	int nevents;
 
 	if (!agent_inited) {
-		DEBUG_PRINTF (2, "Debugger agent not initialized yet: dropping %s\n", event_to_string (event));
+		PRINT_DEBUG_MSG (2, "Debugger agent not initialized yet: dropping %s\n", event_to_string (event));
 		return;
 	}
 
 	if (!vm_start_event_sent && event != EVENT_KIND_VM_START) {
 		// FIXME: We miss those events
-		DEBUG_PRINTF (2, "VM start event not sent yet: dropping %s\n", event_to_string (event));
+		PRINT_DEBUG_MSG (2, "VM start event not sent yet: dropping %s\n", event_to_string (event));
 		return;
 	}
 
 	if (vm_death_event_sent) {
-		DEBUG_PRINTF (2, "VM death event has been sent: dropping %s\n", event_to_string (event));
+		PRINT_DEBUG_MSG (2, "VM death event has been sent: dropping %s\n", event_to_string (event));
 		return;
 	}
 
 	if (mono_runtime_is_shutting_down () && event != EVENT_KIND_VM_DEATH) {
-		DEBUG_PRINTF (2, "Mono runtime is shutting down: dropping %s\n", event_to_string (event));
+		PRINT_DEBUG_MSG (2, "Mono runtime is shutting down: dropping %s\n", event_to_string (event));
 		return;
 	}
 
 	if (disconnected) {
-		DEBUG_PRINTF (2, "Debugger client is not connected: dropping %s\n", event_to_string (event));
+		PRINT_DEBUG_MSG (2, "Debugger client is not connected: dropping %s\n", event_to_string (event));
 		return;
 	}
 
@@ -4056,7 +4056,7 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 	events = NULL;
 
 	if (!send_success) {
-		DEBUG_PRINTF (2, "Sending command %s failed.\n", event_to_string (event));
+		PRINT_DEBUG_MSG (2, "Sending command %s failed.\n", event_to_string (event));
 		return;
 	}
 	
@@ -4064,7 +4064,7 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 		vm_start_event_sent = TRUE;
 	}
 
-	DEBUG_PRINTF (1, "[%p] Sent %d events %s(%d), suspend=%d.\n", (gpointer) (gsize) mono_native_thread_id_get (), nevents, event_to_string (event), ecount, suspend_policy);
+	PRINT_DEBUG_MSG (1, "[%p] Sent %d events %s(%d), suspend=%d.\n", (gpointer) (gsize) mono_native_thread_id_get (), nevents, event_to_string (event), ecount, suspend_policy);
 
 	switch (suspend_policy) {
 	case SUSPEND_POLICY_NONE:
@@ -4139,14 +4139,14 @@ thread_startup (MonoProfiler *prof, uintptr_t tid)
 			 * For some reason, thread_startup () might be called for the same thread
 			 * multiple times (attach ?).
 			 */
-			DEBUG_PRINTF (1, "[%p] thread_start () called multiple times for %p, ignored.\n", GUINT_TO_POINTER (tid), GUINT_TO_POINTER (tid));
+			PRINT_DEBUG_MSG (1, "[%p] thread_start () called multiple times for %p, ignored.\n", GUINT_TO_POINTER (tid), GUINT_TO_POINTER (tid));
 			return;
 		} else {
 			/*
 			 * thread_end () might not be called for some threads, and the tid could
 			 * get reused.
 			 */
-			DEBUG_PRINTF (1, "[%p] Removing stale data for tid %p.\n", GUINT_TO_POINTER (tid), GUINT_TO_POINTER (tid));
+			PRINT_DEBUG_MSG (1, "[%p] Removing stale data for tid %p.\n", GUINT_TO_POINTER (tid), GUINT_TO_POINTER (tid));
 			mono_loader_lock ();
 			mono_g_hash_table_remove (thread_to_tls, old_thread);
 			mono_g_hash_table_remove (tid_to_thread, GUINT_TO_POINTER (tid));
@@ -4165,7 +4165,7 @@ thread_startup (MonoProfiler *prof, uintptr_t tid)
 	tls->thread_id = (intptr_t) thread->tid;
 	mono_native_tls_set_value (debugger_tls_id, tls);
 
-	DEBUG_PRINTF (1, "[%p] Thread started, obj=%p, tls=%p.\n", (gpointer)tid, thread, tls);
+	PRINT_DEBUG_MSG (1, "[%p] Thread started, obj=%p, tls=%p.\n", (gpointer)tid, thread, tls);
 
 	mono_loader_lock ();
 	mono_g_hash_table_insert_internal (thread_to_tls, thread, tls);
@@ -4205,7 +4205,7 @@ thread_end (MonoProfiler *prof, uintptr_t tid)
 
 	/* We might be called for threads started before we registered the start callback */
 	if (thread) {
-		DEBUG_PRINTF (1, "[%p] Thread terminated, obj=%p, tls=%p (domain=%p).\n", (gpointer)tid, thread, tls, (gpointer)mono_domain_get ());
+		PRINT_DEBUG_MSG (1, "[%p] Thread terminated, obj=%p, tls=%p (domain=%p).\n", (gpointer)tid, thread, tls, (gpointer)mono_domain_get ());
 
 		if (mono_thread_internal_is_current (thread) &&
 		    (!mono_native_tls_get_value (debugger_tls_id) ||
@@ -4500,7 +4500,7 @@ ensure_jit (DbgEngineStackFrame* the_frame)
 
 			/* This could happen for aot images with no jit debug info */
 			s = mono_method_full_name (frame->api_method, TRUE);
-			DEBUG_PRINTF(1, "[dbg] No debug information found for '%s'.\n", s);
+			PRINT_DEBUG_MSG(1, "[dbg] No debug information found for '%s'.\n", s);
 			g_free (s);
 			return FALSE;
 		}
@@ -4656,7 +4656,7 @@ resume_from_signal_handler (void *sigctx, void *func)
 	// FIXME: This might not work on an altstack ?
 	tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
 	if (!tls)
-		g_printerr ("Thread %p is not attached to the JIT.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+		PRINT_ERROR_MSG ("Thread %p is not attached to the JIT.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 	g_assert (tls);
 
 	// FIXME: MonoContext usually doesn't include the fp registers, so these are 
@@ -4896,7 +4896,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args)
 	mono_loader_unlock ();
 	g_assert (tls);
 	if (!tls->context.valid) {
-		DEBUG_PRINTF (1, "Received a single step request on a thread with no managed frames.\n");
+		PRINT_DEBUG_MSG (1, "Received a single step request on a thread with no managed frames.\n");
 		return ERR_INVALID_ARGUMENT;
 	}
 
@@ -4918,7 +4918,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args)
 		 */
 		frame = tls->catch_frame;
 		if (frame.type != FRAME_TYPE_MANAGED && frame.type != FRAME_TYPE_INTERP) {
-			DEBUG_PRINTF (1, "Current frame is not managed nor interpreter.\n");
+			PRINT_DEBUG_MSG (1, "Current frame is not managed nor interpreter.\n");
 			return ERR_INVALID_ARGUMENT;
 		}
 
@@ -4930,7 +4930,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args)
 		if (!found_sp)
 			no_seq_points_found (frame.method, frame.native_offset);
 		if (!found_sp) {
-			DEBUG_PRINTF (1, "Could not find next sequence point.\n");
+			PRINT_DEBUG_MSG (1, "Could not find next sequence point.\n");
 			return ERR_INVALID_ARGUMENT;
 		}
 
@@ -4978,7 +4978,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args)
 				if (!found_sp)
 					no_seq_points_found (frame->de.method, frame->de.native_offset);
 				if (!found_sp) {
-					DEBUG_PRINTF (1, "Could not find next sequence point.\n");
+					PRINT_DEBUG_MSG (1, "Could not find next sequence point.\n");
 					return ERR_INVALID_ARGUMENT;
 				}
 				method = frame->de.method;
@@ -5376,7 +5376,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 	if (t->byref) {
 		if (!(*(void**)addr)) {
 			/* This can happen with compiler generated locals */
-			//printf ("%s\n", mono_type_full_name (t));
+			//PRINT_MSG ("%s\n", mono_type_full_name (t));
 			buffer_add_byte (buf, VALUE_TYPE_ID_NULL);
 			return;
 		}
@@ -5605,7 +5605,7 @@ decode_vtype (MonoType *t, MonoDomain *domain, gpointer void_addr, gpointer void
 	if (t && klass != mono_class_from_mono_type_internal (t)) {
 		char *name = mono_type_full_name (t);
 		char *name2 = mono_type_full_name (m_class_get_byval_arg (klass));
-		DEBUG_PRINTF (1, "[%p] Expected value of type %s, got %s.\n", (gpointer) (gsize) mono_native_thread_id_get (), name, name2);
+		PRINT_DEBUG_MSG (1, "[%p] Expected value of type %s, got %s.\n", (gpointer) (gsize) mono_native_thread_id_get (), name, name2);
 		g_free (name);
 		g_free (name2);
 		return ERR_INVALID_ARGUMENT;
@@ -5694,7 +5694,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 		!(t->type == MONO_TYPE_GENERICINST && type == MONO_TYPE_VALUETYPE) &&
 		!(t->type == MONO_TYPE_VALUETYPE && type == MONO_TYPE_OBJECT)) {
 		char *name = mono_type_full_name (t);
-		DEBUG_PRINTF (1, "[%p] Expected value of type %s, got 0x%0x.\n", (gpointer) (gsize) mono_native_thread_id_get (), name, type);
+		PRINT_DEBUG_MSG (1, "[%p] Expected value of type %s, got 0x%0x.\n", (gpointer) (gsize) mono_native_thread_id_get (), name, type);
 		g_free (name);
 		return ERR_INVALID_ARGUMENT;
 	}
@@ -5773,7 +5773,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 			if (!obj)
 				return ERR_INVALID_ARGUMENT;
 			if (obj->vtable->klass != mono_class_from_mono_type_internal (t)) {
-				DEBUG_PRINTF (1, "Expected type '%s', got object '%s'\n", mono_type_full_name (t), m_class_get_name (obj->vtable->klass));
+				PRINT_DEBUG_MSG (1, "Expected type '%s', got object '%s'\n", mono_type_full_name (t), m_class_get_name (obj->vtable->klass));
 				return ERR_INVALID_ARGUMENT;
 			}
 			memcpy (addr, mono_object_unbox_internal (obj), mono_class_value_size (obj->vtable->klass, NULL));
@@ -5798,7 +5798,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 				if (obj) {
 					if (!obj_is_of_type (obj, t)) {
 						if (check_field_datatype) { //if it's not executing a invoke method check the datatypes.
-							DEBUG_PRINTF (1, "Expected type '%s', got '%s'\n", mono_type_full_name (t), m_class_get_name (obj->vtable->klass));
+							PRINT_DEBUG_MSG (1, "Expected type '%s', got '%s'\n", mono_type_full_name (t), m_class_get_name (obj->vtable->klass));
 							return ERR_INVALID_ARGUMENT;
 						}
 					}
@@ -5847,7 +5847,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 				g_free (vtype_buf);
 			} else {
 				char *name = mono_type_full_name (t);
-				DEBUG_PRINTF (1, "[%p] Expected value of type %s, got 0x%0x.\n", (gpointer) (gsize) mono_native_thread_id_get (), name, type);
+				PRINT_DEBUG_MSG (1, "[%p] Expected value of type %s, got 0x%0x.\n", (gpointer) (gsize) mono_native_thread_id_get (), name, type);
 				g_free (name);
 				return ERR_INVALID_ARGUMENT;
 			}
@@ -5940,7 +5940,7 @@ add_var (Buffer *buf, MonoDebugMethodJitInfo *jit, MonoType *t, MonoDebugVarInfo
 		addr = (guint8 *)mono_arch_context_get_int_reg (ctx, reg);
 		addr += (gint32)var->offset;
 
-		//printf ("[R%d+%d] = %p\n", reg, var->offset, addr);
+		//PRINT_MSG ("[R%d+%d] = %p\n", reg, var->offset, addr);
 
 		buffer_add_value_full (buf, t, addr, domain, as_vtype, NULL, 1);
 		break;
@@ -6060,11 +6060,11 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 		/* Set value on the stack or in the return ctx */
 		if (reg_locations [reg]) {
 			/* Saved on the stack */
-			DEBUG_PRINTF (1, "[dbg] Setting stack location %p for reg %x to %p.\n", reg_locations [reg], reg, (gpointer)v);
+			PRINT_DEBUG_MSG (1, "[dbg] Setting stack location %p for reg %x to %p.\n", reg_locations [reg], reg, (gpointer)v);
 			*(reg_locations [reg]) = v;
 		} else {
 			/* Not saved yet */
-			DEBUG_PRINTF (1, "[dbg] Setting context location for reg %x to %p.\n", reg, (gpointer)v);
+			PRINT_DEBUG_MSG (1, "[dbg] Setting context location for reg %x to %p.\n", reg, (gpointer)v);
 			mono_arch_context_set_int_reg (restore_ctx, reg, v);
 		}			
 
@@ -6080,7 +6080,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 		addr = (guint8 *)mono_arch_context_get_int_reg (ctx, reg);
 		addr += (gint32)var->offset;
 
-		//printf ("[R%d+%d] = %p\n", reg, var->offset, addr);
+		//PRINT_MSG ("[R%d+%d] = %p\n", reg, var->offset, addr);
 
 		if (t->byref) {
 			addr = *(guint8**)addr;
@@ -6335,7 +6335,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		 * Invoke this method directly, currently only Environment.Exit () is supported.
 		 */
 		this_arg = NULL;
-		DEBUG_PRINTF (1, "[%p] Invoking method '%s' on receiver '%s'.\n", (gpointer) (gsize) mono_native_thread_id_get (), mono_method_full_name (invoke->method, TRUE), this_arg ? m_class_get_name (this_arg->vtable->klass) : "<null>");
+		PRINT_DEBUG_MSG (1, "[%p] Invoking method '%s' on receiver '%s'.\n", (gpointer) (gsize) mono_native_thread_id_get (), mono_method_full_name (invoke->method, TRUE), this_arg ? m_class_get_name (this_arg->vtable->klass) : "<null>");
 
 		mono_runtime_try_invoke (invoke->method, NULL, invoke->args, &exc, error);
 		mono_error_assert_ok (error);
@@ -6353,13 +6353,13 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		this_buf = (guint8 *)g_alloca (sizeof (MonoObject*));
 
 	if (m->is_generic) {
-		DEBUG_PRINTF (1, "[%p] Error: Attempting to invoke uninflated generic method %s.\n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (m, TRUE));
+		PRINT_DEBUG_MSG (1, "[%p] Error: Attempting to invoke uninflated generic method %s.\n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (m, TRUE));
 		return ERR_INVALID_ARGUMENT;
 	} else if (m_class_is_valuetype (m->klass) && (m->flags & METHOD_ATTRIBUTE_STATIC)) {
 		/* Should be null */
 		int type = decode_byte (p, &p, end);
 		if (type != VALUE_TYPE_ID_NULL) {
-			DEBUG_PRINTF (1, "[%p] Error: Static vtype method invoked with this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+			PRINT_DEBUG_MSG (1, "[%p] Error: Static vtype method invoked with this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 			return ERR_INVALID_ARGUMENT;
 		}
 		memset (this_buf, 0, mono_class_instance_size (m->klass));
@@ -6389,7 +6389,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 
 	if (MONO_CLASS_IS_INTERFACE_INTERNAL (m->klass)) {
 		if (!this_arg) {
-			DEBUG_PRINTF (1, "[%p] Error: Interface method invoked without this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+			PRINT_DEBUG_MSG (1, "[%p] Error: Interface method invoked without this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 			return ERR_INVALID_ARGUMENT;
 		}
 		m = mono_object_get_virtual_method_internal (this_arg, m);
@@ -6400,7 +6400,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		}
 	} else if ((m->flags & METHOD_ATTRIBUTE_VIRTUAL) && !m_class_is_valuetype (m->klass) && invoke->flags & INVOKE_FLAG_VIRTUAL) {
 		if (!this_arg) {
-			DEBUG_PRINTF (1, "[%p] Error: invoke with INVOKE_FLAG_VIRTUAL flag set without this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+			PRINT_DEBUG_MSG (1, "[%p] Error: invoke with INVOKE_FLAG_VIRTUAL flag set without this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 			return ERR_INVALID_ARGUMENT;
 		}
 		m = mono_object_get_virtual_method_internal (this_arg, m);
@@ -6410,7 +6410,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		}
 	}
 
-	DEBUG_PRINTF (1, "[%p] Invoking method '%s' on receiver '%s'.\n", (gpointer) (gsize) mono_native_thread_id_get (), mono_method_full_name (m, TRUE), this_arg ? m_class_get_name (this_arg->vtable->klass) : "<null>");
+	PRINT_DEBUG_MSG (1, "[%p] Invoking method '%s' on receiver '%s'.\n", (gpointer) (gsize) mono_native_thread_id_get (), mono_method_full_name (m, TRUE), this_arg ? m_class_get_name (this_arg->vtable->klass) : "<null>");
 
 	if (this_arg && this_arg->vtable->domain != domain)
 		NOT_IMPLEMENTED;
@@ -6500,7 +6500,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		mono_error_cleanup (error); /* FIXME report error */
 	}
 	mono_stopwatch_stop (&watch);
-	DEBUG_PRINTF (1, "[%p] Invoke result: %p, exc: %s, time: %ld ms.\n", (gpointer) (gsize) mono_native_thread_id_get (), res, exc ? m_class_get_name (exc->vtable->klass) : NULL, (long)mono_stopwatch_elapsed_ms (&watch));
+	PRINT_DEBUG_MSG (1, "[%p] Invoke result: %p, exc: %s, time: %ld ms.\n", (gpointer) (gsize) mono_native_thread_id_get (), res, exc ? m_class_get_name (exc->vtable->klass) : NULL, (long)mono_stopwatch_elapsed_ms (&watch));
 	if (exc) {
 		buffer_add_byte (buf, 0);
 		buffer_add_value (buf, mono_get_object_type (), &exc, domain);
@@ -6661,7 +6661,7 @@ invoke_method (void)
 		tls->resume_count -= invoke->suspend_count;
 	}
 
-	DEBUG_PRINTF (1, "[%p] Invoke finished (%d), resume_count = %d.\n", (gpointer) (gsize) mono_native_thread_id_get (), err, tls->resume_count);
+	PRINT_DEBUG_MSG (1, "[%p] Invoke finished (%d), resume_count = %d.\n", (gpointer) (gsize) mono_native_thread_id_get (), err, tls->resume_count);
 
 	/*
 	 * Take the loader lock to avoid race conditions with CMD_VM_ABORT_INVOKE:
@@ -6880,7 +6880,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		major_version = decode_int (p, &p, end);
 		minor_version = decode_int (p, &p, end);
 		protocol_version_set = TRUE;
-		DEBUG_PRINTF (1, "[dbg] Protocol version %d.%d, client protocol version %d.%d.\n", MAJOR_VERSION, MINOR_VERSION, major_version, minor_version);
+		PRINT_DEBUG_MSG (1, "[dbg] Protocol version %d.%d, client protocol version %d.%d.\n", MAJOR_VERSION, MINOR_VERSION, major_version, minor_version);
 		break;
 	}
 	case CMD_VM_ALL_THREADS: {
@@ -6902,8 +6902,13 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		wait_for_suspend ();
 		break;
 	case CMD_VM_RESUME:
-		if (suspend_count == 0)
-			return ERR_NOT_SUSPENDED;
+		if (suspend_count == 0) {
+			if (agent_config.defer && !agent_config.suspend)
+				// Workaround for issue in debugger-libs when running in defer attach mode.
+				break;
+			else
+				return ERR_NOT_SUSPENDED;
+		}
 		resume_vm ();
 		clear_suspended_objs ();
 		break;
@@ -6990,13 +6995,13 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 
 			/* Suspend all managed threads since the runtime is going away */
 #ifndef ENABLE_NETCORE
-			DEBUG_PRINTF (1, "Suspending all threads...\n");
+			PRINT_DEBUG_MSG (1, "Suspending all threads...\n");
 			mono_thread_suspend_all_other_threads ();
 #endif
-			DEBUG_PRINTF (1, "Shutting down the runtime...\n");
+			PRINT_DEBUG_MSG (1, "Shutting down the runtime...\n");
 			mono_runtime_quit_internal ();
 			transport_close2 ();
-			DEBUG_PRINTF (1, "Exiting...\n");
+			PRINT_DEBUG_MSG (1, "Exiting...\n");
 
 			exit (exit_code);
 		}
@@ -7079,7 +7084,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		g_assert (tls);
 
 		if (tls->abort_requested) {
-			DEBUG_PRINTF (1, "Abort already requested.\n");
+			PRINT_DEBUG_MSG (1, "Abort already requested.\n");
 			mono_loader_unlock ();
 			break;
 		}
@@ -7290,11 +7295,11 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				if (CHECK_PROTOCOL_VERSION (2, 54)) {
 					req->modifiers [i].not_filtered_feature = decode_byte (p, &p, end);
 					req->modifiers [i].everything_else  = decode_byte (p, &p, end);
-					DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY 2 filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : (req->modifiers [i].everything_else ? "everything else" : "all"), req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
+					PRINT_DEBUG_MSG (1, "[dbg] \tEXCEPTION_ONLY 2 filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : (req->modifiers [i].everything_else ? "everything else" : "all"), req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
 				} else {
 					req->modifiers [i].not_filtered_feature = FALSE;
 					req->modifiers [i].everything_else = FALSE;
-					DEBUG_PRINTF (1, "[dbg] \tEXCEPTION_ONLY filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : "all", req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
+					PRINT_DEBUG_MSG (1, "[dbg] \tEXCEPTION_ONLY filter (%s%s%s%s).\n", exc_class ? m_class_get_name (exc_class) : "all", req->modifiers [i].caught ? ", caught" : "", req->modifiers [i].uncaught ? ", uncaught" : "", req->modifiers [i].subclasses ? ", include-subclasses" : "");
 				}
 				
 			} else if (mod == MOD_KIND_ASSEMBLY_ONLY) {
@@ -7350,7 +7355,7 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			req->info = mono_de_set_breakpoint (method, location, req, error);
 			if (!is_ok (error)) {
 				g_free (req);
-				DEBUG_PRINTF (1, "[dbg] Failed to set breakpoint: %s\n", mono_error_get_message (error));
+				PRINT_DEBUG_MSG (1, "[dbg] Failed to set breakpoint: %s\n", mono_error_get_message (error));
 				mono_error_cleanup (error);
 				return ERR_NO_SEQ_POINT_AT_IL_OFFSET;
 			}
@@ -7527,7 +7532,7 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 		o = mono_string_new_checked (domain, s, error);
 		if (!is_ok (error)) {
-			DEBUG_PRINTF (1, "[dbg] Failed to allocate String object '%s': %s\n", s, mono_error_get_message (error));
+			PRINT_DEBUG_MSG (1, "[dbg] Failed to allocate String object '%s': %s\n", s, mono_error_get_message (error));
 			mono_error_cleanup (error);
 			return ERR_INVALID_OBJECT;
 		}
@@ -7894,7 +7899,7 @@ buffer_add_cattrs (Buffer *buf, MonoDomain *domain, MonoImage *image, MonoClass 
 
 			mono_reflection_create_custom_attr_data_args (image, attr->ctor, attr->data, attr->data_size, typed_args_h, named_args_h, &arginfo, error);
 			if (!is_ok (error)) {
-				DEBUG_PRINTF (2, "[dbg] mono_reflection_create_custom_attr_data_args () failed with: '%s'\n", mono_error_get_message (error));
+				PRINT_DEBUG_MSG (2, "[dbg] mono_reflection_create_custom_attr_data_args () failed with: '%s'\n", mono_error_get_message (error));
 				mono_error_cleanup (error);
 				CLEAR_ICALL_FRAME;
 				return ERR_LOADER_ERROR;
@@ -8560,7 +8565,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 			buffer_add_string (buf, source_file);
 		}
 		buffer_add_int (buf, n_il_offsets);
-		DEBUG_PRINTF (10, "Line number table for method %s:\n", mono_method_full_name (method,  TRUE));
+		PRINT_DEBUG_MSG (10, "Line number table for method %s:\n", mono_method_full_name (method,  TRUE));
 		for (i = 0; i < n_il_offsets; ++i) {
 			MonoSymSeqPoint *sp = &sym_seq_points [i];
 			const char *srcfile = "";
@@ -8569,7 +8574,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 				MonoDebugSourceInfo *sinfo = (MonoDebugSourceInfo *)g_ptr_array_index (source_file_list, source_files [i]);
 				srcfile = sinfo->source_file;
 			}
-			DEBUG_PRINTF (10, "IL%x -> %s:%d %d %d %d\n", sp->il_offset, srcfile, sp->line, sp->column, sp->end_line, sp->end_column);
+			PRINT_DEBUG_MSG (10, "IL%x -> %s:%d %d %d %d\n", sp->il_offset, srcfile, sp->line, sp->column, sp->end_line, sp->end_column);
 			buffer_add_int (buf, sp->il_offset);
 			buffer_add_int (buf, sp->line);
 			if (CHECK_PROTOCOL_VERSION (2, 13))
@@ -9093,7 +9098,7 @@ thread_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 		// FIXME: Check that the ip change is safe
 
-		DEBUG_PRINTF (1, "[dbg] Setting IP to %s:0x%0x(0x%0x)\n", tls->frames [0]->actual_method->name, (int)sp.il_offset, (int)sp.native_offset);
+		PRINT_DEBUG_MSG (1, "[dbg] Setting IP to %s:0x%0x(0x%0x)\n", tls->frames [0]->actual_method->name, (int)sp.il_offset, (int)sp.native_offset);
 
 		if (tls->frames [0]->de.ji->is_interp) {
 			MonoJitTlsData *jit_data = thread->thread_info->jit_data;
@@ -9197,7 +9202,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (pos < 0) {
 				pos = - pos - 1;
 
-				DEBUG_PRINTF (4, "[dbg]   send arg %d.\n", pos);
+				PRINT_DEBUG_MSG (4, "[dbg]   send arg %d.\n", pos);
 
 				if (frame->de.ji->is_interp) {
 					guint8 *addr;
@@ -9220,7 +9225,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 					mono_debug_free_locals (locals);
 				}
 
-				DEBUG_PRINTF (4, "[dbg]   send local %d.\n", pos);
+				PRINT_DEBUG_MSG (4, "[dbg]   send local %d.\n", pos);
 
 				if (frame->de.ji->is_interp) {
 					guint8 *addr;
@@ -10012,16 +10017,16 @@ wait_for_attach (void)
 {
 #ifndef DISABLE_SOCKET_TRANSPORT
 	if (listen_fd == -1) {
-		DEBUG_PRINTF (1, "[dbg] Invalid listening socket\n");
+		PRINT_DEBUG_MSG (1, "[dbg] Invalid listening socket\n");
 		return FALSE;
 	}
 
 	/* Block and wait for client connection */
 	conn_fd = socket_transport_accept (listen_fd);
 
-	DEBUG_PRINTF (1, "Accepted connection on %d\n", conn_fd);
+	PRINT_DEBUG_MSG (1, "Accepted connection on %d\n", conn_fd);
 	if (conn_fd == -1) {
-		DEBUG_PRINTF (1, "[dbg] Bad client connection\n");
+		PRINT_DEBUG_MSG (1, "[dbg] Bad client connection\n");
 		return FALSE;
 	}
 #else
@@ -10031,7 +10036,7 @@ wait_for_attach (void)
 	/* Handshake */
 	disconnected = !transport_handshake ();
 	if (disconnected) {
-		DEBUG_PRINTF (1, "Transport handshake failed!\n");
+		PRINT_DEBUG_MSG (1, "Transport handshake failed!\n");
 		return FALSE;
 	}
 	
@@ -10056,7 +10061,7 @@ debugger_thread (void *arg)
 	gboolean no_reply;
 	gboolean attach_failed = FALSE;
 
-	DEBUG_PRINTF (1, "[dbg] Agent thread started, pid=%p\n", (gpointer) (gsize) mono_native_thread_id_get ());
+	PRINT_DEBUG_MSG (1, "[dbg] Agent thread started, pid=%p\n", (gpointer) (gsize) mono_native_thread_id_get ());
 
 	gboolean log_each_step = g_hasenv ("MONO_DEBUGGER_LOG_AFTER_COMMAND");
 
@@ -10070,7 +10075,7 @@ debugger_thread (void *arg)
 
 	if (agent_config.defer) {
 		if (!wait_for_attach ()) {
-			DEBUG_PRINTF (1, "[dbg] Can't attach, aborting debugger thread.\n");
+			PRINT_DEBUG_MSG (1, "[dbg] Can't attach, aborting debugger thread.\n");
 			attach_failed = TRUE; // Don't abort process when we can't listen
 		} else {
 			mono_set_is_debugger_attached (TRUE);
@@ -10086,7 +10091,7 @@ debugger_thread (void *arg)
 
 		/* This will break if the socket is closed during shutdown too */
 		if (res != HEADER_LENGTH) {
-			DEBUG_PRINTF (1, "[dbg] transport_recv () returned %d, expected %d.\n", res, HEADER_LENGTH);
+			PRINT_DEBUG_MSG (1, "[dbg] transport_recv () returned %d, expected %d.\n", res, HEADER_LENGTH);
 			command_set = (CommandSet)0;
 			command = 0;
 			dispose_vm ();
@@ -10113,7 +10118,7 @@ debugger_thread (void *arg)
 		}
 
 		if (log_level) {
-			DEBUG_PRINTF (1, "[dbg] Command %s(%s) [%d][at=%lx].\n", command_set_to_string (command_set), cmd_str, id, (long)mono_100ns_ticks () / 10000);
+			PRINT_DEBUG_MSG (1, "[dbg] Command %s(%s) [%d][at=%lx].\n", command_set_to_string (command_set), cmd_str, id, (long)mono_100ns_ticks () / 10000);
 		}
 
 		data = (guint8 *)g_malloc (len - HEADER_LENGTH);
@@ -10121,7 +10126,7 @@ debugger_thread (void *arg)
 		{
 			res = transport_recv (data, len - HEADER_LENGTH);
 			if (res != len - HEADER_LENGTH) {
-				DEBUG_PRINTF (1, "[dbg] transport_recv () returned %d, expected %d.\n", res, len - HEADER_LENGTH);
+				PRINT_DEBUG_MSG (1, "[dbg] transport_recv () returned %d, expected %d.\n", res, len - HEADER_LENGTH);
 				break;
 			}
 		}
@@ -10194,7 +10199,7 @@ debugger_thread (void *arg)
 				buffer_reply_packet (id, err, &buf);
 			} else {
 				send_reply_packet (id, err, &buf);
-				//DEBUG_PRINTF (1, "[dbg] Sent reply to %d [at=%lx].\n", id, (long)mono_100ns_ticks () / 10000);
+				//PRINT_DEBUG_MSG (1, "[dbg] Sent reply to %d [at=%lx].\n", id, (long)mono_100ns_ticks () / 10000);
 			}
 		}
 
@@ -10211,7 +10216,7 @@ debugger_thread (void *arg)
 		if (log_each_step) {
 			char *debugger_log = mono_debugger_state_str ();
 			if (debugger_log) {
-				fprintf (stderr, "Debugger state: %s\n", debugger_log);
+				PRINT_ERROR_MSG ("Debugger state: %s\n", debugger_log);
 				g_free (debugger_log);
 			}
 		}
@@ -10227,10 +10232,10 @@ debugger_thread (void *arg)
 	mono_coop_cond_signal (&debugger_thread_exited_cond);
 	mono_coop_mutex_unlock (&debugger_thread_exited_mutex);
 
-	DEBUG_PRINTF (1, "[dbg] Debugger thread exited.\n");
+	PRINT_DEBUG_MSG (1, "[dbg] Debugger thread exited.\n");
 	
 	if (!attach_failed && command_set == CMD_SET_VM && command == CMD_VM_DISPOSE && !(vm_death_event_sent || mono_runtime_is_shutting_down ())) {
-		DEBUG_PRINTF (2, "[dbg] Detached - restarting clean debugger thread.\n");
+		PRINT_DEBUG_MSG (2, "[dbg] Detached - restarting clean debugger thread.\n");
 		ERROR_DECL (error);
 		start_debugger_thread (error);
 		mono_error_cleanup (error);

--- a/src/mono/mono/mini/debugger-engine.c
+++ b/src/mono/mono/mini/debugger-engine.c
@@ -174,7 +174,7 @@ insert_breakpoint (MonoSeqPointInfo *seq_points, MonoDomain *domain, MonoJitInfo
 
 		mono_seq_point_iterator_init (&it, seq_points);
 		while (mono_seq_point_iterator_next (&it))
-			DEBUG_PRINTF (1, "%d\n", it.seq_point.il_offset);
+			PRINT_DEBUG_MSG (1, "%d\n", it.seq_point.il_offset);
 
 		if (error) {
 			mono_error_set_error (error, MONO_ERROR_GENERIC, "%s", s);
@@ -207,7 +207,7 @@ insert_breakpoint (MonoSeqPointInfo *seq_points, MonoDomain *domain, MonoJitInfo
 	dbg_unlock ();
 
 	if (it.seq_point.native_offset == SEQ_POINT_NATIVE_OFFSET_DEAD_CODE) {
-		DEBUG_PRINTF (1, "[dbg] Attempting to insert seq point at dead IL offset %d, ignoring.\n", (int)bp->il_offset);
+		PRINT_DEBUG_MSG (1, "[dbg] Attempting to insert seq point at dead IL offset %d, ignoring.\n", (int)bp->il_offset);
 	} else if (count == 0) {
 		if (ji->is_interp) {
 			mini_get_interp_callbacks ()->set_breakpoint (ji, inst->ip);
@@ -220,7 +220,7 @@ insert_breakpoint (MonoSeqPointInfo *seq_points, MonoDomain *domain, MonoJitInfo
 		}
 	}
 
-	DEBUG_PRINTF (1, "[dbg] Inserted breakpoint at %s:[il=0x%x,native=0x%x] [%p](%d).\n", mono_method_full_name (jinfo_get_method (ji), TRUE), (int)it.seq_point.il_offset, (int)it.seq_point.native_offset, inst->ip, count);
+	PRINT_DEBUG_MSG (1, "[dbg] Inserted breakpoint at %s:[il=0x%x,native=0x%x] [%p](%d).\n", mono_method_full_name (jinfo_get_method (ji), TRUE), (int)it.seq_point.il_offset, (int)it.seq_point.native_offset, inst->ip, count);
 }
 
 static void
@@ -247,7 +247,7 @@ remove_breakpoint (BreakpointInstance *inst)
 			NOT_IMPLEMENTED;
 #endif
 		}
-		DEBUG_PRINTF (1, "[dbg] Clear breakpoint at %s [%p].\n", mono_method_full_name (jinfo_get_method (ji), TRUE), ip);
+		PRINT_DEBUG_MSG (1, "[dbg] Clear breakpoint at %s [%p].\n", mono_method_full_name (jinfo_get_method (ji), TRUE), ip);
 	}
 }
 
@@ -433,7 +433,7 @@ mono_de_set_breakpoint (MonoMethod *method, long il_offset, EventRequest *req, M
 	bp->req = req;
 	bp->children = g_ptr_array_new ();
 
-	DEBUG_PRINTF (1, "[dbg] Setting %sbreakpoint at %s:0x%x.\n", (req->event_kind == EVENT_KIND_STEP) ? "single step " : "", method ? mono_method_full_name (method, TRUE) : "<all>", (int)il_offset);
+	PRINT_DEBUG_MSG  (1, "[dbg] Setting %sbreakpoint at %s:0x%x.\n", (req->event_kind == EVENT_KIND_STEP) ? "single step " : "", method ? mono_method_full_name (method, TRUE) : "<all>", (int)il_offset);
 
 	methods = g_ptr_array_new ();
 	method_domains = g_ptr_array_new ();
@@ -677,7 +677,7 @@ no_seq_points_found (MonoMethod *method, int offset)
 	/*
 	 * This can happen in full-aot mode with assemblies AOTed without the 'soft-debug' option to save space.
 	 */
-	printf ("Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
+	PRINT_MSG ("Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
 }
 
 static const char*
@@ -725,7 +725,7 @@ ss_stop (SingleStepReq *ss_req)
 static void
 ss_destroy (SingleStepReq *req)
 {
-	DEBUG_PRINTF (1, "[dbg] ss_destroy.\n");
+	PRINT_DEBUG_MSG (1, "[dbg] ss_destroy.\n");
 
 	ss_stop (req);
 
@@ -824,7 +824,7 @@ mono_de_process_single_step (void *tls, gboolean from_signal)
 	g_assert (ji && !ji->is_trampoline);
 
 	if (log_level > 0) {
-		DEBUG_PRINTF (1, "[%p] Single step event (depth=%s) at %s (%p)[0x%x], sp %p, last sp %p\n", (gpointer) (gsize) mono_native_thread_id_get (), ss_depth_to_string (ss_req->depth), mono_method_full_name (jinfo_get_method (ji), TRUE), MONO_CONTEXT_GET_IP (ctx), (int)((guint8*)MONO_CONTEXT_GET_IP (ctx) - (guint8*)ji->code_start), MONO_CONTEXT_GET_SP (ctx), ss_req->last_sp);
+		PRINT_DEBUG_MSG (1, "[%p] Single step event (depth=%s) at %s (%p)[0x%x], sp %p, last sp %p\n", (gpointer) (gsize) mono_native_thread_id_get (), ss_depth_to_string (ss_req->depth), mono_method_full_name (jinfo_get_method (ji), TRUE), MONO_CONTEXT_GET_IP (ctx), (int)((guint8*)MONO_CONTEXT_GET_IP (ctx) - (guint8*)ji->code_start), MONO_CONTEXT_GET_SP (ctx), ss_req->last_sp);
 	}
 
 	method = jinfo_get_method (ji);
@@ -943,11 +943,11 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		}
 
 		if (!method_in_stack) {
-			g_printerr ("[%p] The instruction pointer of the currently executing method(%s) is not on the recorded stack. This is likely due to a runtime bug. The %d frames are as follow: \n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (method, TRUE), nframes);
-			/*DEBUG_PRINTF (1, "[%p] The instruction pointer of the currently executing method(%s) is not on the recorded stack. This is likely due to a runtime bug. The %d frames are as follow: \n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (method, TRUE), tls->frame_count);*/
+			PRINT_ERROR_MSG ("[%p] The instruction pointer of the currently executing method(%s) is not on the recorded stack. This is likely due to a runtime bug. The %d frames are as follow: \n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (method, TRUE), nframes);
+			/*PRINT_DEBUG_MSG (1, "[%p] The instruction pointer of the currently executing method(%s) is not on the recorded stack. This is likely due to a runtime bug. The %d frames are as follow: \n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (method, TRUE), tls->frame_count);*/
 
 			for (int i=0; i < nframes; i++)
-				g_printerr ("\t [%p] Frame (%d / %d): %s\n", (gpointer)(gsize)mono_native_thread_id_get (), i, nframes, mono_method_full_name (frames [i]->method, TRUE));
+				PRINT_ERROR_MSG ("\t [%p] Frame (%d / %d): %s\n", (gpointer)(gsize)mono_native_thread_id_get (), i, nframes, mono_method_full_name (frames [i]->method, TRUE));
 		}
 
 		rt_callbacks.ss_discard_frame_context (tls);
@@ -957,7 +957,7 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 	}
 
 	if (req->async_stepout_method == method) {
-		DEBUG_PRINTF (1, "[%p] Breakpoint hit during async step-out at %s hit, continuing stepping out.\n", (gpointer)(gsize)mono_native_thread_id_get (), method->name);
+		PRINT_DEBUG_MSG (1, "[%p] Breakpoint hit during async step-out at %s hit, continuing stepping out.\n", (gpointer)(gsize)mono_native_thread_id_get (), method->name);
 		return FALSE;
 	}
 
@@ -965,7 +965,7 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		/*
 		 * These seq points are inserted by the JIT after calls, step over needs to skip them.
 		 */
-		DEBUG_PRINTF (1, "[%p] Seq point at nonempty stack %x while stepping over, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), sp->il_offset);
+		PRINT_DEBUG_MSG (1, "[%p] Seq point at nonempty stack %x while stepping over, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), sp->il_offset);
 		return FALSE;
 	}
 
@@ -979,7 +979,7 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		int target_frames = req->nframes + (is_step_out ? -1 : 0);
 		if (req->nframes > 0 && nframes > 0 && nframes > target_frames) {
 			/* Hit the breakpoint in a recursive call, don't halt */
-			DEBUG_PRINTF (1, "[%p] Breakpoint at lower frame while stepping %s, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), is_step_out ? "out" : "over");
+			PRINT_DEBUG_MSG (1, "[%p] Breakpoint at lower frame while stepping %s, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), is_step_out ? "out" : "over");
 			return FALSE;
 		}
 	}
@@ -988,7 +988,7 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		int nframes;
 		rt_callbacks.ss_calculate_framecount (tls, ctx, FALSE, NULL, &nframes);
 		if (req->start_method == method && req->nframes && nframes == req->nframes) { //Check also frame count(could be recursion)
-			DEBUG_PRINTF (1, "[%p] Seq point at nonempty stack %x while stepping in, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), sp->il_offset);
+			PRINT_DEBUG_MSG (1, "[%p] Seq point at nonempty stack %x while stepping in, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), sp->il_offset);
 			return FALSE;
 		}
 	}
@@ -1014,14 +1014,14 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		loc = mono_debug_method_lookup_location (minfo, sp->il_offset);
 
 	if (!loc) {
-		DEBUG_PRINTF (1, "[%p] No line number info for il offset %x, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), sp->il_offset);
+		PRINT_DEBUG_MSG (1, "[%p] No line number info for il offset %x, continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), sp->il_offset);
 		req->last_method = method;
 		hit = FALSE;
 	} else if (loc && method == req->last_method && loc->row == req->last_line) {
 		int nframes;
 		rt_callbacks.ss_calculate_framecount (tls, ctx, FALSE, NULL, &nframes);
 		if (nframes == req->nframes) { // If the frame has changed we're clearly not on the same source line.
-			DEBUG_PRINTF (1, "[%p] Same source line (%d), continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), loc->row);
+			PRINT_DEBUG_MSG (1, "[%p] Same source line (%d), continuing single stepping.\n", (gpointer) (gsize) mono_native_thread_id_get (), loc->row);
 			hit = FALSE;
 		}
 	}
@@ -1086,7 +1086,7 @@ mono_de_process_breakpoint (void *void_tls, gboolean from_signal)
 
 	g_assert (found_sp);
 
-	DEBUG_PRINTF (1, "[%p] Breakpoint hit, method=%s, ip=%p, [il=0x%x,native=0x%x].\n", (gpointer) (gsize) mono_native_thread_id_get (), method->name, ip, sp.il_offset, native_offset);
+	PRINT_DEBUG_MSG (1, "[%p] Breakpoint hit, method=%s, ip=%p, [il=0x%x,native=0x%x].\n", (gpointer) (gsize) mono_native_thread_id_get (), method->name, ip, sp.il_offset, native_offset);
 
 	mono_debugger_log_bp_hit (tls, method, sp.il_offset);
 
@@ -1245,7 +1245,7 @@ ss_bp_add_one (SingleStepReq *ss_req, int *ss_req_bp_count, GHashTable **ss_req_
 			g_hash_table_insert (*ss_req_bp_cache, bp, bp);
 		(*ss_req_bp_count)++;
 	} else {
-		DEBUG_PRINTF (1, "[dbg] Candidate breakpoint at %s:[il=0x%x] is a duplicate for this step request, will not add.\n", mono_method_full_name (method, TRUE), (int)il_offset);
+		PRINT_DEBUG_MSG (1, "[dbg] Candidate breakpoint at %s:[il=0x%x] is a duplicate for this step request, will not add.\n", mono_method_full_name (method, TRUE), (int)il_offset);
 	}
 }
 
@@ -1466,7 +1466,7 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 			ss_req->nframes = nframes;
 
 		if ((ss_req->depth == STEP_DEPTH_OVER) && (!sp && !parent_sp)) {
-			DEBUG_PRINTF (1, "[dbg] No parent frame for step over, transition to step into.\n");
+			PRINT_DEBUG_MSG (1, "[dbg] No parent frame for step over, transition to step into.\n");
 			/*
 			 * This is needed since if we leave managed code, and later return to it, step over
 			 * is not going to stop.
@@ -1488,11 +1488,11 @@ mono_de_ss_start (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 	}
 
 	if (enable_global) {
-		DEBUG_PRINTF (1, "[dbg] Turning on global single stepping.\n");
+		PRINT_DEBUG_MSG (1, "[dbg] Turning on global single stepping.\n");
 		ss_req->global = TRUE;
 		mono_de_start_single_stepping ();
 	} else if (!ss_req->bps) {
-		DEBUG_PRINTF (1, "[dbg] Turning on global single stepping.\n");
+		PRINT_DEBUG_MSG (1, "[dbg] Turning on global single stepping.\n");
 		ss_req->global = TRUE;
 		mono_de_start_single_stepping ();
 	} else {
@@ -1524,12 +1524,12 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 		err = rt_callbacks.handle_multiple_ss_requests ();
 
 		if (err == DE_ERR_NOT_IMPLEMENTED) {
-			DEBUG_PRINTF (0, "Received a single step request while the previous one was still active.\n");		
+			PRINT_DEBUG_MSG (0, "Received a single step request while the previous one was still active.\n");		
 			return DE_ERR_NOT_IMPLEMENTED;
 		}
 	}
 
-	DEBUG_PRINTF (1, "[dbg] Starting single step of thread %p (depth=%s).\n", thread, ss_depth_to_string (depth));
+	PRINT_DEBUG_MSG (1, "[dbg] Starting single step of thread %p (depth=%s).\n", thread, ss_depth_to_string (depth));
 
 	SingleStepReq *ss_req = g_new0 (SingleStepReq, 1);
 	ss_req->req = req;
@@ -1666,7 +1666,7 @@ get_object_id_for_debugger_method (MonoClass* async_builder_class)
 		//if we don't find method get_ObjectIdForDebugger we try to find the property Task to continue async debug.
 		MonoProperty *prop = mono_class_get_property_from_name_internal (async_builder_class, "Task");
 		if (!prop) {
-			DEBUG_PRINTF (1, "Impossible to debug async methods.\n");
+			PRINT_DEBUG_MSG (1, "Impossible to debug async methods.\n");
 			return NULL;
 		}
 		return prop->get;

--- a/src/mono/mono/mini/debugger-engine.h
+++ b/src/mono/mono/mini/debugger-engine.h
@@ -326,14 +326,27 @@ MonoMethod* get_notify_debugger_of_wait_completion_method (void);
 MonoMethod* get_object_id_for_debugger_method (MonoClass* async_builder_class);
 
 #ifdef HOST_ANDROID
-#define DEBUG_PRINTF(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { g_print (__VA_ARGS__); } } while (0)
+#define PRINT_DEBUG_MSG(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { g_print (__VA_ARGS__); } } while (0)
 #define DEBUG(level,s) do { if (G_UNLIKELY ((level) <= log_level)) { s; } } while (0)
 #elif HOST_WASM
 void wasm_debugger_log(int level, const gchar *format, ...);
-#define DEBUG_PRINTF(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { wasm_debugger_log (level, __VA_ARGS__); } } while (0)
+#define PRINT_DEBUG_MSG(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { wasm_debugger_log (level, __VA_ARGS__); } } while (0)
+#define DEBUG(level,s) do { if (G_UNLIKELY ((level) <= log_level)) { s; } } while (0)
+#elif defined(HOST_WIN32) && !HAVE_API_SUPPORT_WIN32_CONSOLE
+void win32_debugger_log(FILE *stream, const gchar *format, ...);
+#define PRINT_DEBUG_MSG(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { win32_debugger_log (log_file, __VA_ARGS__); } } while (0)
 #define DEBUG(level,s) do { if (G_UNLIKELY ((level) <= log_level)) { s; } } while (0)
 #else
+#define PRINT_DEBUG_MSG(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { fprintf (log_file, __VA_ARGS__); fflush (log_file); } } while (0)
 #define DEBUG(level,s) do { if (G_UNLIKELY ((level) <= log_level)) { s; fflush (log_file); } } while (0)
-#define DEBUG_PRINTF(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { fprintf (log_file, __VA_ARGS__); fflush (log_file); } } while (0)
 #endif
+#endif
+
+#if defined(HOST_WIN32) && !HAVE_API_SUPPORT_WIN32_CONSOLE
+void win32_debugger_log(FILE *stream, const gchar *format, ...);
+#define PRINT_ERROR_MSG(...) win32_debugger_log (log_file, __VA_ARGS__)
+#define PRINT_MSG(...) win32_debugger_log (log_file, __VA_ARGS__)
+#else
+#define PRINT_ERROR_MSG(...) g_printerr (__VA_ARGS__)
+#define PRINT_MSG(...) g_print (__VA_ARGS__)
 #endif

--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -172,10 +172,10 @@ collect_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 	if (!method)
 		return FALSE;
 
-	DEBUG_PRINTF (2, "collect_frames: Reporting method %s native_offset %d, wrapper_type: %d\n", method->name, info->native_offset, method->wrapper_type);
+	PRINT_DEBUG_MSG (2, "collect_frames: Reporting method %s native_offset %d, wrapper_type: %d\n", method->name, info->native_offset, method->wrapper_type);
 
 	if (!mono_find_prev_seq_point_for_native_offset (mono_get_root_domain (), method, info->native_offset, NULL, &sp))
-		DEBUG_PRINTF (2, "collect_frames: Failed to lookup sequence point. method: %s, native_offset: %d \n", method->name, info->native_offset);
+		PRINT_DEBUG_MSG (2, "collect_frames: Failed to lookup sequence point. method: %s, native_offset: %d \n", method->name, info->native_offset);
 
  
 	StackFrame *frame = g_new0 (StackFrame, 1);
@@ -327,7 +327,7 @@ typedef struct {
 static void*
 create_breakpoint_events (GPtrArray *ss_reqs, GPtrArray *bp_reqs, MonoJitInfo *ji, EventKind kind)
 {
-	DEBUG_PRINTF (1, "ss_reqs %d bp_reqs %d\n", ss_reqs->len, bp_reqs->len);
+	PRINT_DEBUG_MSG (1, "ss_reqs %d bp_reqs %d\n", ss_reqs->len, bp_reqs->len);
 	if ((ss_reqs && ss_reqs->len) || (bp_reqs && bp_reqs->len)) {
 		BpEvents *evts = g_new0 (BpEvents, 1); //just a non-null value to make sure we can raise it on process_breakpoint_events
 		evts->is_ss = (ss_reqs && ss_reqs->len);
@@ -354,7 +354,7 @@ no_seq_points_found (MonoMethod *method, int offset)
 	/*
 	 * This can happen in full-aot mode with assemblies AOTed without the 'soft-debug' option to save space.
 	 */
-	DEBUG_PRINTF (1, "Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
+	PRINT_DEBUG_MSG (1, "Unable to find seq points for method '%s', offset 0x%x.\n", mono_method_full_name (method, TRUE), offset);
 }
 
 #define DBG_NOT_SUSPENDED 1
@@ -362,7 +362,7 @@ no_seq_points_found (MonoMethod *method, int offset)
 static int
 ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 {
-	DEBUG_PRINTF (1, "ss_create_init_args\n");
+	PRINT_DEBUG_MSG (1, "ss_create_init_args\n");
 	int dummy = 0;
 	ss_req->start_sp = ss_req->last_sp = &dummy;
 	compute_frames ();
@@ -370,7 +370,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 
 	// This shouldn't happen - maybe should assert here ?
 	if (frames->len == 0) {
-		DEBUG_PRINTF (1, "SINGLE STEPPING FOUND NO FRAMES");
+		PRINT_DEBUG_MSG (1, "SINGLE STEPPING FOUND NO FRAMES");
 		return DBG_NOT_SUSPENDED;
 	}
 
@@ -450,7 +450,7 @@ mono_wasm_debugger_init (void)
 MONO_API void
 mono_wasm_enable_debugging (int debug_level)
 {
-	DEBUG_PRINTF (1, "DEBUGGING ENABLED\n");
+	PRINT_DEBUG_MSG (1, "DEBUGGING ENABLED\n");
 	debugger_enabled = TRUE;
 	log_level = debug_level;
 }
@@ -459,7 +459,7 @@ EMSCRIPTEN_KEEPALIVE int
 mono_wasm_pause_on_exceptions (int state)
 {
 	pause_on_exc = state;
-	DEBUG_PRINTF (1, "setting pause on exception: %d\n", pause_on_exc);
+	PRINT_DEBUG_MSG (1, "setting pause on exception: %d\n", pause_on_exc);
 	return 1;
 }
 
@@ -468,7 +468,7 @@ mono_wasm_setup_single_step (int kind)
 {
 	int nmodifiers = 1;
 
-	DEBUG_PRINTF (2, ">>>> mono_wasm_setup_single_step %d\n", kind);
+	PRINT_DEBUG_MSG (2, ">>>> mono_wasm_setup_single_step %d\n", kind);
 	EventRequest *req = (EventRequest *)g_malloc0 (sizeof (EventRequest) + (nmodifiers * sizeof (Modifier)));
 	req->id = ++event_request_id;
 	req->event_kind = EVENT_KIND_STEP;
@@ -499,9 +499,9 @@ mono_wasm_setup_single_step (int kind)
 
 	DbgEngineErrorCode err = mono_de_ss_create (THREAD_TO_INTERNAL (mono_thread_current ()), size, depth, filter, req);
 	if (err != DE_ERR_NONE) {
-		DEBUG_PRINTF (1, "[dbg] Failed to setup single step request");
+		PRINT_DEBUG_MSG (1, "[dbg] Failed to setup single step request");
 	}
-	DEBUG_PRINTF (1, "[dbg] single step is in place, now what?\n");
+	PRINT_DEBUG_MSG (1, "[dbg] single step is in place, now what?\n");
 	SingleStepReq *ss_req = req->info;
 	int isBPOnNativeCode = 0;
 	if (ss_req && ss_req->bps) {
@@ -521,7 +521,7 @@ mono_wasm_setup_single_step (int kind)
 static void
 assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly)
 {
-	DEBUG_PRINTF (2, "assembly_loaded callback called for %s\n", assembly->aname.name);
+	PRINT_DEBUG_MSG (2, "assembly_loaded callback called for %s\n", assembly->aname.name);
 	MonoImage *assembly_image = assembly->image;
 	MonoImage *pdb_image = NULL;
 
@@ -551,7 +551,7 @@ static void
 handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch_ctx, StackFrameInfo *catch_frame)
 {
 	ERROR_DECL (error);
-	DEBUG_PRINTF (1, "handle exception - %d - %p - %p - %p\n", pause_on_exc, exc, throw_ctx, catch_ctx);
+	PRINT_DEBUG_MSG (1, "handle exception - %d - %p - %p - %p\n", pause_on_exc, exc, throw_ctx, catch_ctx);
 
 	if (pause_on_exc == EXCEPTION_MODE_NONE)
 		return;
@@ -565,18 +565,18 @@ handle_exception (MonoException *exc, MonoContext *throw_ctx, MonoContext *catch
 		error_message = "Failed to get exception message.";
 
 	const char *class_name = mono_class_full_name (mono_object_class (exc));
-	DEBUG_PRINTF (2, "handle exception - calling mono_wasm_fire_exc(): %d - message - %s, class_name: %s\n", obj_id,  error_message, class_name);
+	PRINT_DEBUG_MSG (2, "handle exception - calling mono_wasm_fire_exc(): %d - message - %s, class_name: %s\n", obj_id,  error_message, class_name);
 
 	mono_wasm_fire_exception (obj_id, error_message, class_name, !catch_ctx);
 
-	DEBUG_PRINTF (2, "handle exception - done\n");
+	PRINT_DEBUG_MSG (2, "handle exception - done\n");
 }
 
 
 EMSCRIPTEN_KEEPALIVE void
 mono_wasm_clear_all_breakpoints (void)
 {
-	DEBUG_PRINTF (1, "CLEAR BREAKPOINTS\n");
+	PRINT_DEBUG_MSG (1, "CLEAR BREAKPOINTS\n");
 	mono_de_clear_all_breakpoints ();
 }
 
@@ -585,7 +585,7 @@ mono_wasm_set_breakpoint (const char *assembly_name, int method_token, int il_of
 {
 	int i;
 	ERROR_DECL (error);
-	DEBUG_PRINTF (1, "SET BREAKPOINT: assembly %s method %x offset %x\n", assembly_name, method_token, il_offset);
+	PRINT_DEBUG_MSG (1, "SET BREAKPOINT: assembly %s method %x offset %x\n", assembly_name, method_token, il_offset);
 
 
 	//we get 'foo.dll' but mono_assembly_load expects 'foo' so we strip the last dot
@@ -605,7 +605,7 @@ mono_wasm_set_breakpoint (const char *assembly_name, int method_token, int il_of
 	MonoAssembly *assembly = mono_assembly_request_byname (aname, &byname_req, &status);
 	g_free (lookup_name);
 	if (!assembly) {
-		DEBUG_PRINTF (1, "Could not resolve assembly %s\n", assembly_name);
+		PRINT_DEBUG_MSG (1, "Could not resolve assembly %s\n", assembly_name);
 		return -1;
 	}
 
@@ -614,7 +614,7 @@ mono_wasm_set_breakpoint (const char *assembly_name, int method_token, int il_of
 	MonoMethod *method = mono_get_method_checked (assembly->image, MONO_TOKEN_METHOD_DEF | method_token, NULL, NULL, error);
 	if (!method) {
 		//FIXME don't swallow the error
-		DEBUG_PRINTF (1, "Could not find method due to %s\n", mono_error_get_message (error));
+		PRINT_DEBUG_MSG (1, "Could not find method due to %s\n", mono_error_get_message (error));
 		mono_error_cleanup (error);
 		return -1;
 	}
@@ -631,12 +631,12 @@ mono_wasm_set_breakpoint (const char *assembly_name, int method_token, int il_of
 	MonoBreakpoint *bp = mono_de_set_breakpoint (method, il_offset, req, error);
 
 	if (!bp) {
-		DEBUG_PRINTF (1, "Could not set breakpoint to %s\n", mono_error_get_message (error));
+		PRINT_DEBUG_MSG (1, "Could not set breakpoint to %s\n", mono_error_get_message (error));
 		mono_error_cleanup (error);
 		return 0;
 	}
 
-	DEBUG_PRINTF (1, "NEW BP %p has id %d\n", req, req->id);
+	PRINT_DEBUG_MSG (1, "NEW BP %p has id %d\n", req, req->id);
 	return req->id;
 }
 
@@ -673,7 +673,7 @@ mono_wasm_user_break (void)
 EMSCRIPTEN_KEEPALIVE int
 mono_wasm_current_bp_id (void)
 {
-	DEBUG_PRINTF (2, "COMPUTING breakpoint ID\n");
+	PRINT_DEBUG_MSG (2, "COMPUTING breakpoint ID\n");
 	//FIXME handle compiled case
 
 	/* Interpreter */
@@ -697,24 +697,24 @@ mono_wasm_current_bp_id (void)
 	SeqPoint sp;
 	gboolean found_sp = mono_find_prev_seq_point_for_native_offset (mono_domain_get (), method, native_offset, &info, &sp);
 	if (!found_sp)
-		DEBUG_PRINTF (1, "Could not find SP\n");
+		PRINT_DEBUG_MSG (1, "Could not find SP\n");
 
 
 	GPtrArray *bp_reqs = g_ptr_array_new ();
 	mono_de_collect_breakpoints_by_sp (&sp, ji, NULL, bp_reqs);
 
 	if (bp_reqs->len == 0) {
-		DEBUG_PRINTF (1, "BP NOT FOUND for method %s JI %p il_offset %d\n", method->name, ji, sp.il_offset);
+		PRINT_DEBUG_MSG (1, "BP NOT FOUND for method %s JI %p il_offset %d\n", method->name, ji, sp.il_offset);
 		return -1;
 	}
 
 	if (bp_reqs->len > 1)
-		DEBUG_PRINTF (1, "Multiple breakpoints (%d) at the same location, returning the first one.", bp_reqs->len);
+		PRINT_DEBUG_MSG (1, "Multiple breakpoints (%d) at the same location, returning the first one.", bp_reqs->len);
 
 	EventRequest *evt = (EventRequest *)g_ptr_array_index (bp_reqs, 0);
 	g_ptr_array_free (bp_reqs, TRUE);
 
-	DEBUG_PRINTF (1, "Found BP %p with id %d\n", evt, evt->id);
+	PRINT_DEBUG_MSG (1, "Found BP %p with id %d\n", evt, evt->id);
 	return evt->id;
 }
 
@@ -723,13 +723,13 @@ get_object_from_id (int objectId)
 {
 	ObjRef *ref = (ObjRef *)g_hash_table_lookup (objrefs, GINT_TO_POINTER (objectId));
 	if (!ref) {
-		DEBUG_PRINTF (2, "get_object_from_id !ref: %d\n", objectId);
+		PRINT_DEBUG_MSG (2, "get_object_from_id !ref: %d\n", objectId);
 		return NULL;
 	}
 
 	MonoObject *obj = mono_gchandle_get_target_internal (ref->handle);
 	if (!obj)
-		DEBUG_PRINTF (2, "get_object_from_id !obj: %d\n", objectId);
+		PRINT_DEBUG_MSG (2, "get_object_from_id !obj: %d\n", objectId);
 
 	return obj;
 }
@@ -756,10 +756,10 @@ list_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 	if (!method || method->wrapper_type != MONO_WRAPPER_NONE)
 		return FALSE;
 
-	DEBUG_PRINTF (2, "list_frames: Reporting method %s native_offset %d, wrapper_type: %d\n", method->name, info->native_offset, method->wrapper_type);
+	PRINT_DEBUG_MSG (2, "list_frames: Reporting method %s native_offset %d, wrapper_type: %d\n", method->name, info->native_offset, method->wrapper_type);
 
 	if (!mono_find_prev_seq_point_for_native_offset (mono_get_root_domain (), method, info->native_offset, NULL, &sp))
-		DEBUG_PRINTF (2, "list_frames: Failed to lookup sequence point. method: %s, native_offset: %d\n", method->name, info->native_offset);
+		PRINT_DEBUG_MSG (2, "list_frames: Failed to lookup sequence point. method: %s, native_offset: %d\n", method->name, info->native_offset);
 
 	method_full_name = mono_method_full_name (method, FALSE);
 	while (method->is_inflated)
@@ -768,7 +768,7 @@ list_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 	char *assembly_name = g_strdup (m_class_get_image (method->klass)->module_name);
 	inplace_tolower (assembly_name);
 
-	DEBUG_PRINTF (2, "adding off %d token %d assembly name %s\n", sp.il_offset, mono_metadata_token_index (method->token), assembly_name);
+	PRINT_DEBUG_MSG (2, "adding off %d token %d assembly name %s\n", sp.il_offset, mono_metadata_token_index (method->token), assembly_name);
 	mono_wasm_add_frame (sp.il_offset, mono_metadata_token_index (method->token), *frame_id_p, assembly_name, method_full_name);
 
 	g_free (assembly_name);
@@ -809,7 +809,7 @@ invoke_to_string (const char *class_name, MonoClass *klass, gpointer addr)
 
 		MonoString *mstr = (MonoString*) mono_runtime_try_invoke (method, addr , NULL, &exc, error);
 		if (exc || !is_ok (error)) {
-			DEBUG_PRINTF (1, "Failed to invoke ToString for %s\n", class_name);
+			PRINT_DEBUG_MSG (1, "Failed to invoke ToString for %s\n", class_name);
 			return NULL;
 		}
 
@@ -1328,7 +1328,7 @@ describe_delegate_properties (MonoObject *obj)
 static gboolean
 describe_object_properties (guint64 objectId, gboolean isAsyncLocalThis, int gpflags)
 {
-	DEBUG_PRINTF (2, "describe_object_properties %llu, gpflags: %d\n", objectId, gpflags);
+	PRINT_DEBUG_MSG (2, "describe_object_properties %llu, gpflags: %d\n", objectId, gpflags);
 
 	MonoObject *obj = get_object_from_id (objectId);
 	if (!obj)
@@ -1348,7 +1348,7 @@ static gboolean
 invoke_getter (void *obj_or_value, MonoClass *klass, const char *name)
 {
 	if (!obj_or_value || !klass || !name) {
-		DEBUG_PRINTF (2, "invoke_getter: none of the arguments can be null");
+		PRINT_DEBUG_MSG (2, "invoke_getter: none of the arguments can be null");
 		return FALSE;
 	}
 
@@ -1386,7 +1386,7 @@ describe_array_values (guint64 objectId, int startIdx, int count, int gpflags)
 	MonoClass *klass = mono_object_class (arr);
 	MonoTypeEnum type = m_class_get_byval_arg (klass)->type;
 	if (type != MONO_TYPE_SZARRAY && type != MONO_TYPE_ARRAY) {
-		DEBUG_PRINTF (1, "describe_array_values: object is not an array. type: 0x%x\n", type);
+		PRINT_DEBUG_MSG (1, "describe_array_values: object is not an array. type: 0x%x\n", type);
 		return FALSE;
 	}
 
@@ -1397,12 +1397,12 @@ describe_array_values (guint64 objectId, int startIdx, int count, int gpflags)
 	}
 
 	if (startIdx < 0 || (len > 0 && startIdx >= len)) {
-		DEBUG_PRINTF (1, "describe_array_values: invalid startIdx (%d) for array of length %d\n", startIdx, len);
+		PRINT_DEBUG_MSG (1, "describe_array_values: invalid startIdx (%d) for array of length %d\n", startIdx, len);
 		return FALSE;
 	}
 
 	if (count > 0 && (startIdx + count) > len) {
-		DEBUG_PRINTF (1, "describe_array_values: invalid count (%d) for startIdx: %d, and array of length %d\n", count, startIdx, len);
+		PRINT_DEBUG_MSG (1, "describe_array_values: invalid count (%d) for startIdx: %d, and array of length %d\n", count, startIdx, len);
 		return FALSE;
 	}
 
@@ -1466,7 +1466,7 @@ describe_variable (InterpFrame *frame, MonoMethod *method, MonoMethodHeader *hea
 		pos = -pos - 1;
 
 		if (pos >= sig->param_count) {
-			DEBUG_PRINTF(1, "BUG: describe_variable, trying to access param indexed %d, but the method (%s) has only %d params\n", pos, method->name, sig->param_count);
+			PRINT_DEBUG_MSG(1, "BUG: describe_variable, trying to access param indexed %d, but the method (%s) has only %d params\n", pos, method->name, sig->param_count);
 			return FALSE;
 		}
 
@@ -1474,7 +1474,7 @@ describe_variable (InterpFrame *frame, MonoMethod *method, MonoMethodHeader *hea
 		addr = mini_get_interp_callbacks ()->frame_get_arg (frame, pos);
 	} else {
 		if (pos >= header->num_locals) {
-			DEBUG_PRINTF(1, "BUG: describe_variable, trying to access local indexed %d, but the method (%s) has only %d locals\n", pos, method->name, header->num_locals);
+			PRINT_DEBUG_MSG(1, "BUG: describe_variable, trying to access local indexed %d, but the method (%s) has only %d locals\n", pos, method->name, header->num_locals);
 			return FALSE;
 		}
 
@@ -1482,7 +1482,7 @@ describe_variable (InterpFrame *frame, MonoMethod *method, MonoMethodHeader *hea
 		addr = mini_get_interp_callbacks ()->frame_get_local (frame, pos);
 	}
 
-	DEBUG_PRINTF (2, "adding val %p type [%p] %s\n", addr, type, mono_type_full_name (type));
+	PRINT_DEBUG_MSG (2, "adding val %p type [%p] %s\n", addr, type, mono_type_full_name (type));
 
 	return describe_value(type, addr, gpflags);
 }
@@ -1531,7 +1531,7 @@ mono_wasm_get_deref_ptr_value (void *value_addr, MonoClass *klass)
 {
 	MonoType *type = m_class_get_byval_arg (klass);
 	if (type->type != MONO_TYPE_PTR && type->type != MONO_TYPE_FNPTR) {
-		DEBUG_PRINTF (2, "BUG: mono_wasm_get_deref_ptr_value: Expected to get a ptr type, but got 0x%x\n", type->type);
+		PRINT_DEBUG_MSG (2, "BUG: mono_wasm_get_deref_ptr_value: Expected to get a ptr type, but got 0x%x\n", type->type);
 		return FALSE;
 	}
 
@@ -1561,7 +1561,7 @@ mono_wasm_get_local_vars (int scope, int* pos, int len)
 EMSCRIPTEN_KEEPALIVE gboolean
 mono_wasm_get_object_properties (int object_id, int gpflags)
 {
-	DEBUG_PRINTF (2, "getting properties of object %d, gpflags: %d\n", object_id, gpflags);
+	PRINT_DEBUG_MSG (2, "getting properties of object %d, gpflags: %d\n", object_id, gpflags);
 
 	return describe_object_properties (object_id, FALSE, gpflags);
 }
@@ -1569,7 +1569,7 @@ mono_wasm_get_object_properties (int object_id, int gpflags)
 EMSCRIPTEN_KEEPALIVE gboolean
 mono_wasm_get_array_values (int object_id, int start_idx, int count, int gpflags)
 {
-	DEBUG_PRINTF (2, "getting array values %d, startIdx: %d, count: %d, gpflags: 0x%x\n", object_id, start_idx, count, gpflags);
+	PRINT_DEBUG_MSG (2, "getting array values %d, startIdx: %d, count: %d, gpflags: 0x%x\n", object_id, start_idx, count, gpflags);
 
 	return describe_array_values (object_id, start_idx, count, gpflags);
 }
@@ -1587,12 +1587,12 @@ mono_wasm_invoke_getter_on_object (int object_id, const char* name)
 EMSCRIPTEN_KEEPALIVE gboolean
 mono_wasm_invoke_getter_on_value (void *value, MonoClass *klass, const char *name)
 {
-	DEBUG_PRINTF (2, "mono_wasm_invoke_getter_on_value: v: %p klass: %p, name: %s\n", value, klass, name);
+	PRINT_DEBUG_MSG (2, "mono_wasm_invoke_getter_on_value: v: %p klass: %p, name: %s\n", value, klass, name);
 	if (!klass || !value)
 		return FALSE;
 
 	if (!m_class_is_valuetype (klass)) {
-		DEBUG_PRINTF (2, "mono_wasm_invoke_getter_on_value: klass is not a valuetype. name: %s\n", mono_class_full_name (klass));
+		PRINT_DEBUG_MSG (2, "mono_wasm_invoke_getter_on_value: klass is not a valuetype. name: %s\n", mono_class_full_name (klass));
 		return FALSE;
 	}
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20644,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Runtime workaround fix for incorrect VM resume when suspend policy none is in use. Real fix is in debugger-libs, mono/debugger-libs#264 but until that lands in VS installer (and tooling has been upgraded to VS2019) this workaround will prevent the error to be propagated back to client and VM will make sure the correct suspend state is maintained.

Fix also makes sure logging done within debugger engine/agent is not directly send to stdout/stderr on platforms where there is no console (or alternative console).

This is done to prevent scenarios where stdout/stderr has been redirected to for example the debug client, but logging into the same streams as part of debugger agent implementation will trigger new messages to redirect, flooding the message queue and suspending/resuming the VM for each message. This PR makes sure it is possible to get all logging done in debugger agent/engine (not just debug logging) into an alternative log implementation on platforms needing it.