### PR TITLE
Allow building iOS device builds without codesigning

### DIFF
--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -166,9 +166,19 @@ internal class Xcode
         {
             sdk = (Target == Utils.TargetOS.iOS) ? "iphoneos" : "appletvos";
             args.Append(" -arch arm64")
-                .Append(" -sdk " + sdk)
-                .Append(" -allowProvisioningUpdates")
-                .Append(" DEVELOPMENT_TEAM=").Append(devTeamProvisioning);
+                .Append(" -sdk " + sdk);
+
+            if (devTeamProvisioning == "-")
+            {
+                args.Append(" CODE_SIGN_IDENTITY=\"\"")
+                    .Append(" CODE_SIGNING_REQUIRED=NO")
+                    .Append(" CODE_SIGNING_ALLOWED=NO");
+            }
+            else
+            {
+                args.Append(" -allowProvisioningUpdates")
+                    .Append(" DEVELOPMENT_TEAM=").Append(devTeamProvisioning);
+            }
         }
         else
         {


### PR DESCRIPTION
This will be required for building on CI (where codesigning will happen separately) and can be enabled by passing `-` to the DevTeamProvisioning msbuild property.

/cc @premun 