### PR TITLE
JIT: consistently mark method table accesses as invariant

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1952,11 +1952,11 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
             return NO_ASSERTION_INDEX;
     }
 
-    // Look through CSEs so we see the actual trees providing values, if possible.
-    // This is important for exact type assertions.
+    // Look through any CSEs so we see the actual trees providing values, if possible.
+    // This is important for exact type assertions, which need to see the GT_IND.
     //
-    GenTree* op1 = relop->AsOp()->gtOp1->gtUnwrapCSE();
-    GenTree* op2 = relop->AsOp()->gtOp2->gtUnwrapCSE();
+    GenTree* op1 = relop->AsOp()->gtOp1->gtCommaAssignVal();
+    GenTree* op2 = relop->AsOp()->gtOp2->gtCommaAssignVal();
 
     // Check for op1 or op2 to be lcl var and if so, keep it in op1.
     if ((op1->gtOper != GT_LCL_VAR) && (op2->gtOper == GT_LCL_VAR))
@@ -2113,6 +2113,14 @@ AssertionIndex Compiler::optAssertionGenPhiDefn(GenTree* tree)
 void Compiler::optAssertionGen(GenTree* tree)
 {
     tree->ClearAssertion();
+
+    // If there are QMARKs in the IR, we won't generate assertions
+    // for conditionally executed code.
+    //
+    if (optLocalAssertionProp && ((tree->gtFlags & GTF_COLON_COND) != 0))
+    {
+        return;
+    }
 
 #ifdef DEBUG
     optAssertionPropCurrentTree = tree;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1931,9 +1931,6 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
 
     Compiler::optAssertionKind assertionKind = OAK_INVALID;
 
-    GenTree* op1 = relop->AsOp()->gtOp1;
-    GenTree* op2 = relop->AsOp()->gtOp2;
-
     AssertionInfo info = optCreateJTrueBoundsAssertion(tree);
     if (info.HasAssertion())
     {
@@ -1954,6 +1951,12 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
             // and not occupy assertion table slots. We'll add them when used.
             return NO_ASSERTION_INDEX;
     }
+
+    // Look through CSEs so we see the actual trees providing values, if possible.
+    // This is important for exact type assertions.
+    //
+    GenTree* op1 = relop->AsOp()->gtOp1->gtUnwrapCSE();
+    GenTree* op2 = relop->AsOp()->gtOp2->gtUnwrapCSE();
 
     // Check for op1 or op2 to be lcl var and if so, keep it in op1.
     if ((op1->gtOper != GT_LCL_VAR) && (op2->gtOper == GT_LCL_VAR))
@@ -2110,11 +2113,6 @@ AssertionIndex Compiler::optAssertionGenPhiDefn(GenTree* tree)
 void Compiler::optAssertionGen(GenTree* tree)
 {
     tree->ClearAssertion();
-
-    if (tree->gtFlags & GTF_COLON_COND)
-    {
-        return;
-    }
 
 #ifdef DEBUG
     optAssertionPropCurrentTree = tree;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2830,7 +2830,7 @@ public:
 
     GenTreeArrLen* gtNewArrLen(var_types typ, GenTree* arrayOp, int lenOffset, BasicBlock* block);
 
-    GenTree* gtNewIndir(var_types typ, GenTree* addr);
+    GenTreeIndir* gtNewIndir(var_types typ, GenTree* addr);
 
     GenTree* gtNewNullCheck(GenTree* addr, BasicBlock* basicBlock);
 
@@ -2878,6 +2878,8 @@ public:
     GenTreeAllocObj* gtNewAllocObjNode(CORINFO_RESOLVED_TOKEN* pResolvedToken, BOOL useParent);
 
     GenTree* gtNewRuntimeLookup(CORINFO_GENERIC_HANDLE hnd, CorInfoGenericHandleType hndTyp, GenTree* lookupTree);
+
+    GenTreeIndir* gtNewMethodTableLookup(GenTree* obj);
 
     //------------------------------------------------------------------------
     // Other GenTree functions

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1287,11 +1287,11 @@ inline GenTreeArrLen* Compiler::gtNewArrLen(var_types typ, GenTree* arrayOp, int
 // Return Value:
 //    New GT_IND node
 
-inline GenTree* Compiler::gtNewIndir(var_types typ, GenTree* addr)
+inline GenTreeIndir* Compiler::gtNewIndir(var_types typ, GenTree* addr)
 {
     GenTree* indir = gtNewOperNode(GT_IND, typ, addr);
     indir->SetIndirExceptionFlags(this);
-    return indir;
+    return indir->AsIndir();
 }
 
 //------------------------------------------------------------------------------
@@ -1460,6 +1460,13 @@ inline GenTreeCast* Compiler::gtNewCastNodeL(var_types typ, GenTree* op1, bool f
     GenTreeCast* res =
         new (this, LargeOpOpcode()) GenTreeCast(typ, op1, fromUnsigned, castType DEBUGARG(/*largeNode*/ true));
     return res;
+}
+
+inline GenTreeIndir* Compiler::gtNewMethodTableLookup(GenTree* object)
+{
+    GenTreeIndir* result = gtNewIndir(TYP_I_IMPL, object);
+    result->gtFlags |= GTF_IND_INVARIANT;
+    return result;
 }
 
 /*****************************************************************************/

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12876,8 +12876,7 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
             arg1 = op1->AsCall()->gtCallThisArg->GetNode();
         }
 
-        arg1 = gtNewOperNode(GT_IND, TYP_I_IMPL, arg1);
-        arg1->gtFlags |= GTF_EXCEPT;
+        arg1 = gtNewMethodTableLookup(arg1);
 
         GenTree* arg2;
 
@@ -12890,8 +12889,7 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
             arg2 = op2->AsCall()->gtCallThisArg->GetNode();
         }
 
-        arg2 = gtNewOperNode(GT_IND, TYP_I_IMPL, arg2);
-        arg2->gtFlags |= GTF_EXCEPT;
+        arg2 = gtNewMethodTableLookup(arg2);
 
         CorInfoInlineTypeCheck inliningKind =
             info.compCompHnd->canInlineTypeCheck(nullptr, CORINFO_INLINE_TYPECHECK_SOURCE_VTABLE);
@@ -12991,10 +12989,8 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
         }
     }
 
-    GenTree* const objMT = gtNewOperNode(GT_IND, TYP_I_IMPL, objOp);
-
-    // Update various flags
-    objMT->gtFlags |= GTF_EXCEPT;
+    // Fetch the method table from the object
+    GenTree* const objMT = gtNewMethodTableLookup(objOp);
 
     // Compare the two method tables
     GenTree* const compare = gtCreateHandleCompare(oper, objMT, knownMT, typeCheckInliningResult);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1736,7 +1736,7 @@ public:
 
     inline GenTree* gtEffectiveVal(bool commaOnly = false);
 
-    inline GenTree* gtUnwrapCSE();
+    inline GenTree* gtCommaAssignVal();
 
     // Tunnel through any GT_RET_EXPRs
     inline GenTree* gtRetExprVal(unsigned __int64* pbbFlags = nullptr);
@@ -7157,15 +7157,15 @@ inline GenTree* GenTree::gtEffectiveVal(bool commaOnly /* = false */)
 }
 
 //-------------------------------------------------------------------------
-// gtUnwrapCSE - find value being CSE'd
+// gtCommaAssignVal - find value being assigned to a comma wrapped assigment
 //
 // Returns:
-//    tree representing value being CSE'd, if this tree represents a
-//    comma-wrapped CSE definition and use.
+//    tree representing value being assigned if this tree represents a
+//    comma-wrapped local definition and use.
 //
 //    original tree, of not.
 //
-inline GenTree* GenTree::gtUnwrapCSE()
+inline GenTree* GenTree::gtCommaAssignVal()
 {
     GenTree* result = this;
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1736,6 +1736,8 @@ public:
 
     inline GenTree* gtEffectiveVal(bool commaOnly = false);
 
+    inline GenTree* gtUnwrapCSE();
+
     // Tunnel through any GT_RET_EXPRs
     inline GenTree* gtRetExprVal(unsigned __int64* pbbFlags = nullptr);
 
@@ -7152,6 +7154,39 @@ inline GenTree* GenTree::gtEffectiveVal(bool commaOnly /* = false */)
             return effectiveVal;
         }
     }
+}
+
+//-------------------------------------------------------------------------
+// gtUnwrapCSE - find value being CSE'd
+//
+// Returns:
+//    tree representing value being CSE'd, if this tree represents a
+//    comma-wrapped CSE definition and use.
+//
+//    original tree, of not.
+//
+inline GenTree* GenTree::gtUnwrapCSE()
+{
+    GenTree* result = this;
+
+    if (OperIs(GT_COMMA))
+    {
+        GenTree* commaOp1 = AsOp()->gtOp1;
+        GenTree* commaOp2 = AsOp()->gtOp2;
+
+        if (commaOp2->OperIs(GT_LCL_VAR) && commaOp1->OperIs(GT_ASG))
+        {
+            GenTree* asgOp1 = commaOp1->AsOp()->gtOp1;
+            GenTree* asgOp2 = commaOp1->AsOp()->gtOp2;
+
+            if (asgOp1->OperIs(GT_LCL_VAR) && (asgOp1->AsLclVar()->GetLclNum() == commaOp2->AsLclVar()->GetLclNum()))
+            {
+                result = asgOp2;
+            }
+        }
+    }
+
+    return result;
 }
 
 //-------------------------------------------------------------------------

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2194,10 +2194,8 @@ GenTree* Compiler::getRuntimeContextTree(CORINFO_RUNTIME_LOOKUP_KIND kind)
         ctxTree = gtNewLclvNode(pRoot->info.compThisArg, TYP_REF);
         ctxTree->gtFlags |= GTF_VAR_CONTEXT;
 
-        // Vtable pointer of this object
-        ctxTree = gtNewOperNode(GT_IND, TYP_I_IMPL, ctxTree);
-        ctxTree->gtFlags |= GTF_EXCEPT; // Null-pointer exception
-        ctxTree->gtFlags |= GTF_IND_INVARIANT;
+        // context is the method table pointer of the this object
+        ctxTree = gtNewMethodTableLookup(ctxTree);
     }
     else
     {
@@ -10956,8 +10954,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
         op2Var                                                  = fgInsertCommaFormTemp(&op2);
         lvaTable[op2Var->AsLclVarCommon()->GetLclNum()].lvIsCSE = true;
     }
-    temp = gtNewOperNode(GT_IND, TYP_I_IMPL, temp);
-    temp->gtFlags |= GTF_EXCEPT;
+    temp   = gtNewMethodTableLookup(temp);
     condMT = gtNewOperNode(GT_NE, TYP_INT, temp, op2);
 
     GenTree* condNull;
@@ -15832,7 +15829,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     GenTree* cloneOperand;
                     op1 = impCloneExpr(op1, &cloneOperand, NO_CLASS_HANDLE, (unsigned)CHECK_SPILL_ALL,
                                        nullptr DEBUGARG("inline UNBOX clone1"));
-                    op1 = gtNewOperNode(GT_IND, TYP_I_IMPL, op1);
+                    op1 = gtNewMethodTableLookup(op1);
 
                     GenTree* condBox = gtNewOperNode(GT_EQ, TYP_INT, op1, op2);
 

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -606,8 +606,7 @@ private:
                 origCall->gtCallThisArg = compiler->gtNewCallArgs(compiler->gtNewLclvNode(thisTempNum, TYP_REF));
             }
 
-            GenTree* methodTable = compiler->gtNewIndir(TYP_I_IMPL, thisTree);
-            methodTable->gtFlags |= GTF_IND_INVARIANT;
+            GenTree* methodTable = compiler->gtNewMethodTableLookup(thisTree);
 
             // Find target method table
             GuardedDevirtualizationCandidateInfo* guardedInfo       = origCall->gtGuardedDevirtualizationCandidateInfo;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17140,8 +17140,7 @@ GenTree* Compiler::fgInitThisClass()
                 GenTree* vtTree = gtNewLclvNode(info.compThisArg, TYP_REF);
                 vtTree->gtFlags |= GTF_VAR_CONTEXT;
                 // Vtable pointer of this object
-                vtTree = gtNewOperNode(GT_IND, TYP_I_IMPL, vtTree);
-                vtTree->gtFlags |= GTF_EXCEPT; // Null-pointer exception
+                vtTree             = gtNewMethodTableLookup(vtTree);
                 GenTree* methodHnd = gtNewIconEmbMethHndNode(info.compMethodHnd);
 
                 return gtNewHelperCallNode(CORINFO_HELP_INITINSTCLASS, TYP_VOID, gtNewCallArgs(vtTree, methodHnd));

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -1455,16 +1455,6 @@ void Compiler::optValnumCSE_Availablity()
 
                     if (isDef)
                     {
-                        // @ToDo - Remove this block as it no longer applies
-                        if (tree->gtFlags & GTF_COLON_COND)
-                        {
-                            // We can't create CSE definitions inside QMARK-COLON trees
-                            tree->gtCSEnum = NO_CSE;
-
-                            JITDUMP(" NO_CSE - This CSE def occurs in a GTF_COLON_COND!\n");
-                            continue;
-                        }
-
                         // This is a CSE def
 
                         // Is defExcSetCurrent still set to the uninit marker value of VNForNull() ?


### PR DESCRIPTION
Introduce a new utility method to create the IR for method table access,
marking the resulting indir as invariant. This allows method table access
CSEs (which will be increasingly common with the advent of PGO-enabled
Guarded Devirtualization).

Add a workaround to assertion prop for method table to be able to see
through a CSE'd method table access.

Remove optimizer inhibitions related to colon cond, as there are no qmark
nodes around by this point.