### PR TITLE
Add logging to open ssl uninstall

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -34,7 +34,11 @@ elif [ "$1" = "OSX" ] || [ "$1" = "tvOS" ] || [ "$1" = "iOS" ]; then
     if [ "$3" = "azDO" ]; then
         # workaround for old osx images on hosted agents
         # piped in case we get an agent without these values installed
-        brew uninstall openssl@1.0.2t 2>&1 | true
+        if ! brew uninstall openssl@1.0.2t 2>&1 >/dev/null | false; then
+            echo "didn't uninstall openssl@1.0.2t"
+        else
+            echo "succesfully uninstalled openssl@1.0.2t"
+        fi
     fi
 
     brew update --preinstall

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -34,7 +34,7 @@ elif [ "$1" = "OSX" ] || [ "$1" = "tvOS" ] || [ "$1" = "iOS" ]; then
     if [ "$3" = "azDO" ]; then
         # workaround for old osx images on hosted agents
         # piped in case we get an agent without these values installed
-        if ! brew uninstall openssl@1.0.2t 2>&1 >/dev/null | false; then
+        if ! brew_output="$(brew uninstall openssl@1.0.2t 2>&1 >/dev/null)"; then
             echo "didn't uninstall openssl@1.0.2t"
         else
             echo "succesfully uninstalled openssl@1.0.2t"


### PR DESCRIPTION
Add more logging to the openssl uninstall step in case we hit the openssl issue again to make investigation easier to know what's going on with this step.