### PR TITLE
Set GenerateErrorForMissingTargetingPacks to false

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -4,6 +4,7 @@
                             $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
     <_UseLocalTargetingRuntimePack>true</_UseLocalTargetingRuntimePack>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
   </PropertyGroup>
 
   <!-- .NETCoreApp 2.x DisableImplicitAssemblyReferences support. -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/45755

Based on the discussion in https://github.com/dotnet/runtime/pull/45781, we want to set this property so that the SDK doesn't error when consuming a locally built targeting pack later.