### PR TITLE
Fix macos-arm64 corrupted adhoc signature

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -268,7 +268,7 @@ function(strip_symbols targetName outputFilename)
 
       string(TOLOWER "${CMAKE_BUILD_TYPE}" LOWERCASE_CMAKE_BUILD_TYPE)
       if (LOWERCASE_CMAKE_BUILD_TYPE STREQUAL release)
-        set(strip_command ${STRIP} -no_code_signature_warning -S ${strip_source_file})
+        set(strip_command ${STRIP} -no_code_signature_warning -S ${strip_source_file} && codesign -f -s - ${strip_source_file})
       else ()
         set(strip_command)
       endif ()


### PR DESCRIPTION
XCode linker adhoc signs binaries. Stripping the symbols
corrupts the signature.  Replace the adhoc signature
after stripping the symbols.