### PR TITLE
Don't batch the SuperPMI collection job

### DIFF
--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -3,7 +3,7 @@
 # Trigger this job if the JIT-EE GUID changes, which invalidates previous SuperPMI
 # collections.
 trigger:
-  batch: true
+  batch: false
   branches:
     include:
     - master


### PR DESCRIPTION
The SuperPMI collection job gets triggered whenever the JIT-EE GUID changes.
We need a collection every time that happens. If, in the unlikely circumstance,
two GUID changes happen in quick succession, we don't want to skip
one due to batching, as that would leave us a window where there are
no collections corresponding to a range of commits.