### PR TITLE
Fix MicrosoftNetCoreAppRefPackRefDir calculation

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -36,7 +36,8 @@
           Condition="'$(DisableImplicitAssemblyReferences)' == 'true' and
                      '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                      $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">
-    <PropertyGroup>
+    <!-- Point MicrosoftNetCoreAppRefPackRefDir to the acquired targeting pack to use it later for AssemblySearchPaths resolution. -->
+    <PropertyGroup Condition="'$(_UseLocalTargetingRuntimePack)' != 'true'">
       <_NetCoreAppTargetFrameworkIdentifier Condition="$([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))">netcoreapp</_NetCoreAppTargetFrameworkIdentifier>
       <_NetCoreAppTargetFrameworkIdentifier Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))">net</_NetCoreAppTargetFrameworkIdentifier>
       <MicrosoftNetCoreAppRefPackRefDir>%(ResolvedFrameworkReference.TargetingPackPath)\ref\$(_NetCoreAppTargetFrameworkIdentifier)$(TargetFrameworkVersion.TrimStart('v'))\</MicrosoftNetCoreAppRefPackRefDir>


### PR DESCRIPTION
MicrosoftNetCoreAppRefPackRefDir was redefined on NetCoreAppCurrent and relied on the ResolvedFrameworkReference item which isn't available when an SDK is used that doesn't support the current TFM yet.  Redefining MicrosoftNetCoreAppRefPackRefDir on NetCoreAppCurrent isn't necessary and will stop the wrong calculation of the property.