### PR TITLE
Upgrade pip before installing azure-storage-blob

### DIFF
--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -105,8 +105,8 @@ jobs:
         displayName: Build CoreCLR JIT
 
     # Ensure the Python azure-storage-blob package is installed before doing the upload.
-    - script: $(PipScript) install --user azure.storage.blob==12.5.0 --force-reinstall
-      displayName: Install azure-storage-blob Python package
+    - script: $(PipScript) install --user --upgrade pip && $(PipScript) install --user azure.storage.blob==12.5.0 --force-reinstall
+      displayName: Upgrade Pip to latest and install azure-storage-blob Python package
 
     - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/jitrollingbuild.py upload -build_type $(buildConfig) -arch $(archType) -host_os $(osGroup) -git_hash $(Build.SourceVersion)
       displayName: Upload JIT to Azure Storage


### PR DESCRIPTION
A breaking change in PEP517 for installing the dependencies of azure-storage-blob  means older PIPs cannot install this.  It's good hygiene (and quick) to always update PIP