### PR TITLE
Add Known* items to the local targeting pack resolution

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -21,7 +21,7 @@
                              Condition="'@(KnownFrameworkReference)' != '' and !@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
     <KnownAppHostPack Include="$(SharedFrameworkName)" 
                       AppHostPackNamePattern="$(SharedFrameworkName).Host.**RID**"
-                      AppHostPackVersion="$(MicrosoftNETCoreAppVersion)"
+                      AppHostPackVersion="$(ProductVersion)"
                       AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
                       TargetFramework="$(NetCoreAppCurrent)"
                       Condition="'@(KnownAppHostPack)' != '' and !@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -6,6 +6,33 @@
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
   </PropertyGroup>
 
+  <!-- Add Known* items if the SDK doesn't support the TargetFramework yet. -->
+  <ItemGroup Condition="'$(_UseLocalTargetingRuntimePack)' == 'true'">
+    <KnownFrameworkReference Include="$(SharedFrameworkName)"
+                             DefaultRuntimeFrameworkVersion="$(ProductVersion)"
+                             IsTrimmable="true"
+                             LatestRuntimeFrameworkVersion="$(ProductVersion)"
+                             RuntimeFrameworkName="$(SharedFrameworkName)"
+                             RuntimePackNamePatterns="$(SharedFrameworkName).Runtime.**RID**"
+                             RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;ios-arm64;ios-arm;ios-x64;ios-x86;tvos-arm64;tvos-x64;android-arm64;android-arm;android-x64;android-x86;browser-wasm"
+                             TargetFramework="$(NetCoreAppCurrent)"
+                             TargetingPackName="$(SharedFrameworkName).Ref"
+                             TargetingPackVersion="$(ProductVersion)"
+                             Condition="'@(KnownFrameworkReference)' != '' and !@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
+    <KnownAppHostPack Include="$(SharedFrameworkName)" 
+                      AppHostPackNamePattern="$(SharedFrameworkName).Host.**RID**"
+                      AppHostPackVersion="$(MicrosoftNETCoreAppVersion)"
+                      AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
+                      TargetFramework="$(NetCoreAppCurrent)"
+                      Condition="'@(KnownAppHostPack)' != '' and !@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
+    <KnownCrossgen2Pack Include="$(SharedFrameworkName).Crossgen2"
+                        TargetFramework="$(NetCoreAppCurrent)"
+                        Crossgen2PackNamePattern="$(SharedFrameworkName).Crossgen2.**RID**"
+                        Crossgen2PackVersion="$(ProductVersion)"
+                        Crossgen2RuntimeIdentifiers="linux-musl-x64;linux-x64;win-x64"
+                        Condition="'@(KnownCrossgen2Pack)' != '' and !@(KnownCrossgen2Pack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
+  </ItemGroup>
+
   <!-- .NETCoreApp 2.x DisableImplicitAssemblyReferences support. -->
   <Choose>
     <When Condition="'$(DisableImplicitAssemblyReferences)' == 'true' and


### PR DESCRIPTION
Add the required Known* items so that the ProcessFrameworkReferences
logic in the SDK knows about these and is able to create Resolved* items
that we later update to point to our local packs.

This is required when building with an SDK that doesn't support the
project's TargetFramework yet.