### PR TITLE
Disable C11 compat in libunwind

### DIFF
--- a/src/coreclr/pal/src/libunwind/CMakeLists.txt
+++ b/src/coreclr/pal/src/libunwind/CMakeLists.txt
@@ -2,6 +2,10 @@
 # It overwrites the one found in upstream
 project(unwind)
 
+# Disable C11 compat
+unset(CMAKE_C_STANDARD)
+unset(CMAKE_C_STANDARD_REQUIRED)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # define variables for the configure_file below


### PR DESCRIPTION
It looks like C11 and C++latest are incompatible in libunwind (possibly due to VS update). It doesn't appear that we need both flags and it's not clear what C11 compat would mean in this instance. This change removes it and just leaves C++latest.

Fixes #45763