### PR TITLE
[release/5.0] Fix AssemblyInformationalAttribute version in coreclr corelib

### DIFF
--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -41,14 +41,6 @@
     <PackagesBinDir>$(BinDir).nuget\</PackagesBinDir>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Set the boolean below to true to generate packages with stabilized versions -->
-    <IsShipping>false</IsShipping>
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
-    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
-    <StableVersion Condition="($(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Transport'))) and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>
-  </PropertyGroup>
-
   <!-- Set up common target properties that we use to conditionally include sources -->
   <PropertyGroup>
     <TargetsFreeBSD Condition="'$(TargetOS)' == 'FreeBSD'">true</TargetsFreeBSD>

--- a/src/coreclr/src/.nuget/packaging.props
+++ b/src/coreclr/src/.nuget/packaging.props
@@ -25,6 +25,14 @@
     <VersionTxtFile Condition="'$(VersionTxtFile)' == ''">$(ArtifactsObjDir)version.txt</VersionTxtFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Set the boolean below to true to generate packages with stabilized versions -->
+    <IsShipping>false</IsShipping>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="$(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Transport'))" />
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.pkgproj'">
     <!-- Add required legal files to packages -->
     <File Condition="Exists('$(PackageLicenseFile)')"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/45812

I will port this back to master to have it in the same place. 

The reason why this was happening is because we added `IsShipping=false` and that causes the `InformationalVersion` to include the `VersionSuffix`. This was intended to avoid shipping stable packages from coreclr for every servicing release which we wanted to avoid, however this was done on the wrong place as it affected `System.Private.CoreLib`. 

Moving it to `packaging.props` as those properties should only affect packages.

## Customer Impact
`System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription` API returns wrong version which contains non-stable version suffix.

In summary RuntimeInformation.FrameworkDescription gives:

2.1: .NET Core 4.6.29321.03 
3.1: .NET Core 3.1.10
5.0.0: .NET 5.0.0
5.0.1: .NET 5.0.1-servicing.20575.16

## Testing
Manual testing. Validated that the attribute contains the right version when producing a stable release. (Note, part after + is stripped in the code)
![image](https://user-images.githubusercontent.com/22899328/101712396-45ebbc00-3a4a-11eb-9922-0247b2d4a0c7.png)

Made sure that package versions are not affected

## Risk
Low

## Regression
Yes from 5.0.0, introduced when disabling stable packages for coreclr for 5.0.1