### PR TITLE
[release/5.0] Backport #45529: Disable Windows x64 Mono test leg

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -794,7 +794,7 @@ jobs:
     runtimeFlavor: mono
     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     platforms:
-    - Windows_NT_x64
+    # - Windows_NT_x64
     - OSX_x64
     - Linux_arm64
     - Linux_x64


### PR DESCRIPTION
This is tracked by #45524. A VS update broke all reflection usages on Windows x64 mono. @akoeplinger 