### PR TITLE
Environment variable & AppCtx switch to force-disable IPV6

### DIFF
--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -7,12 +7,8 @@ using System.Runtime.InteropServices;
 
 namespace System.Net
 {
-    internal static class SocketProtocolSupportPal
+    internal static partial class SocketProtocolSupportPal
     {
-        public static bool OSSupportsIPv6 { get; } = IsSupported(AddressFamily.InterNetworkV6);
-        public static bool OSSupportsIPv4 { get; } = IsSupported(AddressFamily.InterNetwork);
-        public static bool OSSupportsUnixDomainSockets { get; } = IsSupported(AddressFamily.Unix);
-
         private static unsafe bool IsSupported(AddressFamily af)
         {
             IntPtr invalid = (IntPtr)(-1);

--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Windows.cs
@@ -9,12 +9,8 @@ using SocketType = System.Net.Internals.SocketType;
 
 namespace System.Net
 {
-    internal static class SocketProtocolSupportPal
+    internal static partial class SocketProtocolSupportPal
     {
-        public static bool OSSupportsIPv6 { get; } = IsSupported(AddressFamily.InterNetworkV6);
-        public static bool OSSupportsIPv4 { get; } = IsSupported(AddressFamily.InterNetwork);
-        public static bool OSSupportsUnixDomainSockets { get; } = IsSupported(AddressFamily.Unix);
-
         private static bool IsSupported(AddressFamily af)
         {
             Interop.Winsock.EnsureInitialized();

--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Sockets;
+
+namespace System.Net
+{
+    internal static partial class SocketProtocolSupportPal
+    {
+        public static bool OSSupportsIPv6 { get; } = !IsIPV6Disabled && IsSupported(AddressFamily.InterNetworkV6);
+        public static bool OSSupportsIPv4 { get; } = IsSupported(AddressFamily.InterNetwork);
+        public static bool OSSupportsUnixDomainSockets { get; } = IsSupported(AddressFamily.Unix);
+
+        private static bool IsIPV6Disabled
+        {
+            get
+            {
+                const string DisableIpv6AppContextSettingName = "System.Net.Sockets.DisableIPv6";
+                const string DisableIpv6EnvironmentVariableName = "DOTNET_SYSTEM_NET_SOCKETS_DISABLEIPV6";
+
+                if (AppContext.TryGetSwitch(DisableIpv6AppContextSettingName, out bool disableIpV6))
+                {
+                    return disableIpV6;
+                }
+
+                string? envVar = Environment.GetEnvironmentVariable(DisableIpv6EnvironmentVariableName);
+                return envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1"));
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
@@ -72,6 +72,8 @@
              Link="Common\System\Net\RangeValidationHelpers.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketAddress.cs"
              Link="Common\System\Net\SocketAddress.cs" />
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.cs"
+             Link="Common\System\Net\SocketProtocolSupportPal.cs" />
     <Compile Include="$(CommonPath)System\Net\TcpValidationHelpers.cs"
              Link="Common\System\Net\TcpValidationHelpers.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"
@@ -109,7 +111,7 @@
     <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs"
              Link="Common\System\Net\SocketAddressPal.Windows.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Windows.cs"
-             Link="Common\System\Net\SocketProtocolSupportPal.Windows" />
+             Link="Common\System\Net\SocketProtocolSupportPal.Windows.cs" />
     <!-- Interop -->
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
              Link="Common\Interop\Windows\Interop.Libraries.cs" />
@@ -208,7 +210,7 @@
     <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs"
              Link="Common\System\Net\SocketAddressPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Unix.cs"
-             Link="Common\System\Net\SocketProtocolSupportPal.Unix" />
+             Link="Common\System\Net\SocketProtocolSupportPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs"
              Link="Common\System\Net\Sockets\SocketErrorPal.Unix" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Errors.cs"


### PR DESCRIPTION
This is an alternative fix for #44686.

In some Azure App Service and AWS environments IPV6 (thus dual-stack) is broken, but there's no way to notice it before an actual connection attempt is made.

Since we don't know at the moment what further checks we may perform to detect IPv6 in a reliable manner, I'm proposing to expose a switch for users and/or infra people to explicitly disable IPV6 in .NET Sockets and all layers depending on them.

This way we can avoid hacky workarounds in HttpClient while still addressing the issue quickly, and at the same time provide a workaround for all users of the `Socket(SocketType, ProtocolType)` constructor not just HttpClient.