### PR TITLE
Use FORCE_AOT define in the MonoAOTCompiler Task

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -321,7 +321,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                 writer.WriteLine("#include <mono/jit/jit.h>");
                 writer.WriteLine("#include <TargetConditionals.h>");
                 writer.WriteLine("");
-                writer.WriteLine("#if TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || USE_AOT_FOR_SIMULATOR)");
+                writer.WriteLine("#if TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || FORCE_AOT)");
 
                 foreach (var symbol in symbols)
                 {


### PR DESCRIPTION
Fixes mono_aot_register_module not being found when AOT'ing.