### PR TITLE
Update ServiceModel version on compat pack

### DIFF
--- a/src/libraries/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/src/libraries/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <PropertyGroup>
-    <ServiceModelVersion>4.7.0</ServiceModelVersion>
+    <ServiceModelVersion>4.8.0</ServiceModelVersion>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>
   </PropertyGroup>


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/43837

Validated that the package depends on the new version and that it restores an publishes fine on multiple tfms.

![image](https://user-images.githubusercontent.com/22899328/101823209-4bdfac80-3adf-11eb-9aca-b8844084e21a.png)
