### PR TITLE
[wasm] Extract run-v8.sh from WasmAppBuilder

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -150,6 +150,10 @@
              AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
 
   <Target Condition="'$(TargetOS)' == 'Browser'" Name="BundleTestWasmApp">
+    <PropertyGroup>
+      <AppDir>$(BundleDir)</AppDir>
+      <MainAssembly>WasmTestRunner.dll</MainAssembly>
+    </PropertyGroup>
     <ItemGroup>
       <WasmSatelliteAssemblies Include="$(PublishDir)*\*.resources.dll" />
       <WasmSatelliteAssemblies>
@@ -170,17 +174,17 @@
     </ItemGroup>
     <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
     <WasmAppBuilder
-      AppDir="$(BundleDir)"
+      AppDir="$(AppDir)"
       InvariantGlobalization="$(InvariantGlobalization)"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackRidDir)"
-      MainAssembly="$(PublishDir)WasmTestRunner.dll"
+      MainAssembly="$(PublishDir)$(MainAssembly)"
       MainJS="$(MonoProjectRoot)\wasm\runtime-test.js"
       Assemblies="@(Assemblies)"
       SatelliteAssemblies="@(WasmSatelliteAssemblies)"
       FilesToIncludeInFileSystem="@(WasmFilesToIncludeInFileSystem)" />
     <WriteLinesToFile
-      File="$(BundleDir)run-v8.sh"
-      Lines="v8 --expose_wasm runtime.js -- --run WasmTestRunner.dll $*"
+      File="$(AppDir)run-v8.sh"
+      Lines="v8 --expose_wasm runtime.js -- --run $(MainAssembly) $*"
       Overwrite="true"/>
   </Target>
 

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -178,6 +178,10 @@
       Assemblies="@(Assemblies)"
       SatelliteAssemblies="@(WasmSatelliteAssemblies)"
       FilesToIncludeInFileSystem="@(WasmFilesToIncludeInFileSystem)" />
+    <WriteLinesToFile
+      File="$(BundleDir)run-v8.sh"
+      Lines="v8 --expose_wasm runtime.js -- --run WasmTestRunner.dll $*"
+      Overwrite="true"/>
   </Target>
 
   <Target Name="AddTestRunnersToPublishedFiles"

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -183,6 +183,7 @@
       SatelliteAssemblies="@(WasmSatelliteAssemblies)"
       FilesToIncludeInFileSystem="@(WasmFilesToIncludeInFileSystem)" />
     <WriteLinesToFile
+      Condition="'$(Scenario)' != 'WasmTestOnBrowser'"
       File="$(AppDir)run-v8.sh"
       Lines="v8 --expose_wasm runtime.js -- --run $(MainAssembly) $*"
       Overwrite="true"/>

--- a/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <Target Name="RebuildWasmAppBuilder">
+    <PropertyGroup>
+      <MainAssembly>WasmSample.dll</MainAssembly>
+      <_JavaScriptDllPath>$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)\System.Private.Runtime.InteropServices.JavaScript.dll</_JavaScriptDllPath>
+    </PropertyGroup>
     <ItemGroup>
       <WasmAppBuildProject Include="$(RepoTasksDir)WasmAppBuilder\WasmAppBuilder.csproj" />
     </ItemGroup>
@@ -38,7 +42,7 @@
     </ItemGroup>
 
     <WasmLoadAssembliesAndReferences
-      Assemblies="bin\WasmSample.dll;$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)\System.Private.Runtime.InteropServices.JavaScript.dll"
+      Assemblies="bin\$(MainAssembly);$(_JavaScriptDllPath)"
       AssemblySearchPaths="@(AssemblySearchPaths)">
       <Output TaskParameter="ReferencedAssemblies" ItemName="ReferencedAssemblies" />
     </WasmLoadAssembliesAndReferences>
@@ -46,14 +50,14 @@
     <WasmAppBuilder
       AppDir="$(AppDir)"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
-      MainAssembly="bin\WasmSample.dll"
+      MainAssembly="bin\$(MainAssembly)"
       MainJS="runtime.js"
       Assemblies="@(ReferencedAssemblies)">
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </WasmAppBuilder>
     <WriteLinesToFile
       File="$(AppDir)/run-v8.sh"
-      Lines="v8 --expose_wasm runtime.js -- --run WasmSample.dll $*"
+      Lines="v8 --expose_wasm runtime.js -- --run $(MainAssembly) $*"
       Overwrite="true"/>
     <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
     <Copy SourceFiles="bin\index.html;bin\server.py" DestinationFolder="$(AppDir)" />

--- a/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
@@ -51,6 +51,10 @@
       Assemblies="@(ReferencedAssemblies)">
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </WasmAppBuilder>
+    <WriteLinesToFile
+      File="$(AppDir)/run-v8.sh"
+      Lines="v8 --expose_wasm runtime.js -- --run WasmSample.dll $*"
+      Overwrite="true"/>
     <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
     <Copy SourceFiles="bin\index.html;bin\server.py" DestinationFolder="$(AppDir)" />
   </Target>

--- a/src/mono/netcore/sample/wasm/console/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/console/WasmSample.csproj
@@ -113,6 +113,10 @@
       MainAssembly="$(PublishDir)\WasmSample.dll"
       MainJS="$(MonoProjectRoot)wasm\runtime-test.js"
       Assemblies="@(BundleAssemblies)"/>
+    <WriteLinesToFile
+      File="$(AppDir)run-v8.sh"
+      Lines="v8 --expose_wasm runtime.js -- --run WasmSample.dll $*"
+      Overwrite="true"/>
     <Exec Command="chmod a+x $(AppDir)run-v8.sh" />
 
     <!-- Run mono-cil-strip on the assemblies -->

--- a/src/mono/netcore/sample/wasm/console/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/console/WasmSample.csproj
@@ -61,6 +61,10 @@
   <Target Name="BuildApp" AfterTargets="CopyFilesToPublishDirectory" DependsOnTargets="RebuildWasmAppBuilder;Build">
     <RemoveDir Directories="$(AppDir)" />
 
+    <PropertyGroup>
+      <MainAssembly>WasmSample.dll</MainAssembly>
+    </PropertyGroup>
+
     <ItemGroup>
       <BundleAssemblies Condition="'$(RunAOTCompilation)' != 'true'" Include="$(MSBuildThisFileDirectory)$(PublishDir)\*.dll" />
       <AotInputAssemblies Condition="'$(RunAOTCompilation)' == 'true'" Include="$(MSBuildThisFileDirectory)$(PublishDir)\*.dll">
@@ -110,12 +114,12 @@
     <WasmAppBuilder
       AppDir="$(AppDir)"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
-      MainAssembly="$(PublishDir)\WasmSample.dll"
+      MainAssembly="$(PublishDir)\$(MainAssembly)"
       MainJS="$(MonoProjectRoot)wasm\runtime-test.js"
       Assemblies="@(BundleAssemblies)"/>
     <WriteLinesToFile
       File="$(AppDir)run-v8.sh"
-      Lines="v8 --expose_wasm runtime.js -- --run WasmSample.dll $*"
+      Lines="v8 --expose_wasm runtime.js -- --run $(MainAssembly) $*"
       Overwrite="true"/>
     <Exec Command="chmod a+x $(AppDir)run-v8.sh" />
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -40,7 +40,7 @@
   <Target Name="BuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">
     <PropertyGroup>
       <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\Release\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
-      <MainAssembly>$(OutDir)debugger-test.dll</MainAssembly>
+      <MainAssembly>debugger-test.dll</MainAssembly>
       <_JavaScriptDllPath>$(ArtifactsBinDir)\System.Private.Runtime.InteropServices.JavaScript\$(NetCoreAppCurrent)-Browser-$(RuntimeConfiguration)\System.Private.Runtime.InteropServices.JavaScript.dll</_JavaScriptDllPath>
     </PropertyGroup>
     <ItemGroup>
@@ -51,7 +51,7 @@
     </ItemGroup>
 
     <WasmLoadAssembliesAndReferences
-      Assemblies="$(MainAssembly);$(_JavaScriptDllPath)"
+      Assemblies="$(OutDir)$(MainAssembly);$(_JavaScriptDllPath)"
       AssemblySearchPaths="@(AssemblySearchPaths)">
       <Output TaskParameter="ReferencedAssemblies" ItemName="ReferencedAssemblies" />
     </WasmLoadAssembliesAndReferences>
@@ -59,7 +59,7 @@
     <WasmAppBuilder
       AppDir="$(AppDir)"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
-      MainAssembly="$(OutDir)debugger-test.dll"
+      MainAssembly="$(OutDir)$(MainAssembly)"
       MainJS="$(MonoProjectRoot)wasm\runtime-test.js"
       DebugLevel="1"
       Assemblies="@(ReferencedAssemblies)">
@@ -67,7 +67,7 @@
     </WasmAppBuilder>
     <WriteLinesToFile
       File="$(AppDir)/run-v8.sh"
-      Lines="v8 --expose_wasm runtime.js -- --run debugger-test.dll $*"
+      Lines="v8 --expose_wasm runtime.js -- --run $(MainAssembly) $*"
       Overwrite="true"/>
 
     <Copy SourceFiles="@(ExtraFileForPublish)" DestinationFolder="$(AppDir)" />

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -65,6 +65,10 @@
       Assemblies="@(ReferencedAssemblies)">
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </WasmAppBuilder>
+    <WriteLinesToFile
+      File="$(AppDir)/run-v8.sh"
+      Lines="v8 --expose_wasm runtime.js -- --run debugger-test.dll $*"
+      Overwrite="true"/>
 
     <Copy SourceFiles="@(ExtraFileForPublish)" DestinationFolder="$(AppDir)" />
   </Target>

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -236,13 +236,6 @@ public class WasmAppBuilder : Task
         }
         _fileWrites.Add(monoConfigPath);
 
-        string runv8Path = Path.Join(AppDir, "run-v8.sh");
-        using (var sw = File.CreateText(runv8Path))
-        {
-            sw.WriteLine("v8 --expose_wasm runtime.js -- --run " + Path.GetFileName(MainAssembly) + " $*");
-        }
-        _fileWrites.Add(runv8Path);
-
         return true;
     }
 

--- a/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
+++ b/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
@@ -44,6 +44,10 @@
       MainJS="$(CORE_ROOT)\runtime-test\runtime-test.js"
       Assemblies="@(ReferencedAssemblies)" />
 
+    <WriteLinesToFile
+      File="$(AppDir)/run-v8.sh"
+      Lines="v8 --expose_wasm runtime.js -- --run $(TestAssembly) $*"
+      Overwrite="true"/>
     <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
   </Target>
 </Project>

--- a/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
+++ b/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
@@ -17,9 +17,11 @@
       AssemblyFile="$(CORE_ROOT)/WasmAppBuilder/WasmAppBuilder.dll"/>
 
   <Target Name="BuildApp">
+    <PropertyGroup>
+      <MainAssembly>$(TestAssembly)</MainAssembly>
+      <_JavaScriptDllPath>$(CORE_ROOT)\System.Private.Runtime.InteropServices.JavaScript.dll</_JavaScriptDllPath>
+    </PropertyGroup>
     <ItemGroup>
-      <MainAssembly Include="$(TestAssembly)" />
-      <ExtraAssemblies Include="$(CORE_ROOT)\System.Private.Runtime.InteropServices.JavaScript.dll" />
       <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)\native"/>
       <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)"/>
       <AssemblySearchPaths Include="$(CORE_ROOT)/TargetingPack" />
@@ -31,7 +33,7 @@
     <Message Importance="High" Text="ArtifactsBinDir: $(ArtifactsBinDir)" />
 
     <WasmLoadAssembliesAndReferences
-      Assemblies="@(MainAssembly);@(ExtraAssemblies)"
+      Assemblies="$(MainAssembly);$(_JavaScriptDllPath)"
       AssemblySearchPaths="@(AssemblySearchPaths)"
       SkipMissingAssemblies="true">
       <Output TaskParameter="ReferencedAssemblies" ItemName="ReferencedAssemblies" />
@@ -40,13 +42,13 @@
     <WasmAppBuilder
       AppDir="$(AppDir)"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
-      MainAssembly="$(TestAssembly)"
+      MainAssembly="$(MainAssembly)"
       MainJS="$(CORE_ROOT)\runtime-test\runtime-test.js"
       Assemblies="@(ReferencedAssemblies)" />
 
     <WriteLinesToFile
       File="$(AppDir)/run-v8.sh"
-      Lines="v8 --expose_wasm runtime.js -- --run $(TestAssembly) $*"
+      Lines="v8 --expose_wasm runtime.js -- --run $(MainAssembly) $*"
       Overwrite="true"/>
     <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
   </Target>


### PR DESCRIPTION
This PR looks to extract a step from the WasmAppBuilder that generates a `run-v8.sh` script because it does not partake in building the application. Instead, it is used primarily for local runs.

The changes made are:
1. Create the `run-v8.sh` script outside of the `WasmAppBuilder`
2. Remove the `run-v8.sh` creation from `WasmAppBuilder`
3. Cleaning up paths and creating properties to softcode parts of the script generation.

https://github.com/dotnet/runtime/pull/44751#discussion_r539451093