### PR TITLE
P/Invoke function returning SafeSocketHandle throws MissingMethodException

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
@@ -1,6 +1,6 @@
 <linker>
   <assembly fullname="System.IO.MemoryMappedFiles">
-    <type fullname="Microsoft.Win32.SafeHandles">
+    <type fullname="Microsoft.Win32.SafeHandles.SafeMemoryMappedFileHandle">
       <!-- don't trim the default constructor, since it is necessary for p/invokes made by external code -->
       <method name=".ctor" />
     </type>

--- a/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
@@ -1,6 +1,6 @@
 <linker>
   <assembly fullname="System.IO.MemoryMappedFiles">
-    <type fullname="Microsoft.Win32.SafeHandles.SafeMemoryMappedFileHandle">
+    <type fullname="Microsoft.Win32.SafeHandles.SafeMemoryMappedViewHandle">
       <!-- don't trim the default constructor, since it is necessary for p/invokes made by external code -->
       <method name=".ctor" />
     </type>

--- a/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="System.IO.MemoryMappedFiles">
+    <type fullname="Microsoft.Win32.SafeHandles">
+      <!-- don't trim the default constructor, since it is necessary for p/invokes made by external code -->
+      <method name=".ctor" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/SafeMemoryMappedViewHandleTests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/SafeMemoryMappedViewHandleTests.cs
@@ -44,7 +44,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Tests that external code can use SafeMemoryMappedViewHandle as the result of a P/Invoke on Unix.
         /// </summary>
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
         public void SafeMemoryMappedViewHandle_CanUseInPInvoke_Unix()
         {
             const int MAP_PRIVATE = 0x02;

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/SafeMemoryMappedViewHandleTests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/SafeMemoryMappedViewHandleTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace System.IO.MemoryMappedFiles.Tests
+{
+    /// <summary>
+    /// Tests for SafeMemoryMappedViewHandle
+    /// </summary>
+    public class SafeMemoryMappedViewHandleTests : MemoryMappedFilesTestBase
+    {
+        /// <summary>
+        /// Tests that external code can use SafeMemoryMappedViewHandle as the result of a P/Invoke on Windows.
+        /// </summary>
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void SafeMemoryMappedViewHandle_CanUseInPInvoke_Windows()
+        {
+            const int BUF_SIZE = 256;
+
+            Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = default;
+            using SafeMemoryMappedFileHandle fileHandle = Interop.Kernel32.CreateFileMapping(
+                new IntPtr(-1),
+                ref secAttrs,
+                Interop.Kernel32.PageOptions.PAGE_EXECUTE_READWRITE,
+                0,
+                BUF_SIZE,
+                CreateUniqueMapName());
+
+            using SafeMemoryMappedViewHandle handle = Interop.Kernel32.MapViewOfFile(
+                fileHandle,
+                Interop.Kernel32.FileMapOptions.FILE_MAP_READ,
+                0,
+                0,
+                (UIntPtr)BUF_SIZE);
+
+            Assert.NotNull(handle);
+        }
+
+        /// <summary>
+        /// Tests that external code can use SafeMemoryMappedViewHandle as the result of a P/Invoke on Unix.
+        /// </summary>
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void SafeMemoryMappedViewHandle_CanUseInPInvoke_Unix()
+        {
+            const int MAP_PRIVATE = 0x02;
+            const int MAP_ANONYMOUS = 0x10;
+
+            const int PROT_READ = 0x1;
+            const int PROT_WRITE = 0x2;
+
+            // The handle returned may be invalid, but this is testing that the
+            // SafeHandle object can successfully be created in a P/Invoke
+            using SafeMemoryMappedViewHandle handle = mmap(
+                IntPtr.Zero,
+                1,
+                PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS,
+                -1,
+                0);
+
+            Assert.NotNull(handle);
+        }
+
+        [DllImport("libc")]
+        private static unsafe extern SafeMemoryMappedViewHandle mmap(IntPtr addr, nint lengthint, int prot, int flags, int fd, nuint offset);
+    }
+}

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="MemoryMappedFilesTestsBase.Unix.cs" Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'" />
     <Compile Include="MemoryMappedFilesTestsBase.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs" Link="Common\System\IO\TempFile.cs" />
+    <Compile Include="SafeMemoryMappedViewHandleTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="$(CommonTestPath)Tests\System\IO\StreamConformanceTests.cs" Link="Common\System\IO\StreamConformanceTests.cs" />
@@ -24,5 +25,11 @@
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="ProductionCode\Common\System\Net\ArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.BOOL.cs" Link="ProductionCode\Common\Interop\Windows\Interop.BOOL.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="ProductionCode\Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateFileMapping.cs" Link="ProductionCode\Common\Interop\Windows\Kernel32\Interop.CreateFileMapping.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MapViewOfFile.cs" Link="ProductionCode\Common\Interop\Windows\Kernel32\Interop.MapViewOfFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MemOptions.cs" Link="ProductionCode\Common\Interop\Windows\Kernel32\Interop.MemOptions.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs" Link="ProductionCode\Common\Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/src/ILLink/ILLinkTrim_LibraryBuild.xml
+++ b/src/libraries/System.Net.Sockets/src/ILLink/ILLinkTrim_LibraryBuild.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="System.Net.Sockets">
+    <type fullname="System.Net.Sockets.SafeSocketHandle">
+      <!-- don't trim the default constructor, since it is necessary for p/invokes made by external code -->
+      <method name=".ctor" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SafeHandleTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SafeHandleTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Net.Sockets.Tests
@@ -15,5 +16,27 @@ namespace System.Net.Sockets.Tests
                 Assert.False(s.SafeHandle.IsInvalid);
             }
         }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.AnyUnix)]
+        public void SafeSocketHandle_CanUseInPInvoke()
+        {
+            const int AF_INET = 2;
+            const int SOCK_STREAM = 1;
+
+            using SafeSocketHandle handle = Socket(AF_INET, SOCK_STREAM, 0);
+            Assert.NotNull(handle);
+        }
+
+        private static SafeSocketHandle Socket(int af, int type, int protocol) =>
+            OperatingSystem.IsWindows() ?
+                SocketWindows(af, type, protocol) :
+                SocketUnix(af, type, protocol);
+
+        [DllImport("ws2_32.dll", EntryPoint = "socket")]
+        private static extern SafeSocketHandle SocketWindows(int af, int type, int protocol);
+
+        [DllImport("libc", EntryPoint = "socket")]
+        private static extern SafeSocketHandle SocketUnix(int af, int type, int protocol);
     }
 }


### PR DESCRIPTION
The ILLinker is trimming the private default constructors of SafeHandle classes if they are not used by the library. Adding an XML descriptor file to preserve the private constructors of these SafeHandles so they can be used in P/Invokes in external code.

Fix #45633