### PR TITLE
Do YieldProcessor normalization in preemptive GC mode

### DIFF
--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -370,7 +370,10 @@ DWORD WINAPI FinalizerThread::FinalizerThreadStart(void *args)
         {
             GetFinalizerThread()->SetBackground(TRUE);
 
-            EnsureYieldProcessorNormalizedInitialized();
+            {
+                GCX_PREEMP();
+                EnsureYieldProcessorNormalizedInitialized();
+            }
 
             while (!fQuitFinalizer)
             {

--- a/src/coreclr/vm/yieldprocessornormalized.cpp
+++ b/src/coreclr/vm/yieldprocessornormalized.cpp
@@ -14,7 +14,13 @@ void InitializeYieldProcessorNormalizedCrst()
 
 static void InitializeYieldProcessorNormalized()
 {
-    WRAPPER_NO_CONTRACT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_PREEMPTIVE;
+    }
+    CONTRACTL_END;
 
     CrstHolder lock(&s_initializeYieldProcessorNormalizedCrst);
 
@@ -92,7 +98,13 @@ static void InitializeYieldProcessorNormalized()
 
 void EnsureYieldProcessorNormalizedInitialized()
 {
-    WRAPPER_NO_CONTRACT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_PREEMPTIVE;
+    }
+    CONTRACTL_END;
 
     if (!s_isYieldProcessorNormalizedInitialized)
     {


### PR DESCRIPTION
- The YieldProcessor normalization takes ~10 ms. In the finalizer thread start function, `Thread::HasStarted()` puts the thread into cooperative GC mode. Switch to preemptive GC mode for the normalization.

Fixes https://github.com/dotnet/runtime/issues/42515