### PR TITLE
Add workaround to remove runtime pack from download to use local runtime pack

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -93,7 +93,9 @@
           AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <PackageDownload Remove="@(PackageDownload)"
-                       Condition="$([System.String]::Copy('%(Identity)').StartsWith('$(SharedFrameworkName).Runtime'))" />
+                       Condition="'$(UsePackageDownload)' == 'true' and $([System.String]::Copy('%(Identity)').StartsWith('$(SharedFrameworkName).Runtime'))" />
+      <PackageReference Remove="@(PackageReference)"
+                        Condition="'$(UsePackageDownload)' != 'true' and $([System.String]::Copy('%(Identity)').StartsWith('$(SharedFrameworkName).Runtime'))" />
     </ItemGroup>
   </Target>
 

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -89,11 +89,11 @@
 
   <!-- SDK tries to download runtime packs when RuntimeIdentifier is set, remove them from PackageDownload item. -->
   <Target Name="RemoveRuntimePackFromDownloadItem"
-          Condition="'$(_UseLocalTargetingRuntimePack)' == 'true' and '$(RuntimeIdentifier)' != ''"
+          Condition="'$(_UseLocalTargetingRuntimePack)' == 'true'"
           AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <PackageDownload Remove="@(PackageDownload)"
-                       Condition="$([System.String]::Copy('%(Identity)').StartsWith('Microsoft.NETCore.App.Runtime'))" />
+                       Condition="$([System.String]::Copy('%(Identity)').StartsWith('$(SharedFrameworkName).Runtime'))" />
     </ItemGroup>
   </Target>
 

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -87,6 +87,16 @@
     </PropertyGroup>
   </Target>
 
+  <!-- SDK tries to download runtime packs when RuntimeIdentifier is set, remove them from PackageDownload item. -->
+  <Target Name="RemoveRuntimePackFromDownloadItem"
+          Condition="'$(_UseLocalTargetingRuntimePack)' == 'true' and '$(RuntimeIdentifier)' != ''"
+          AfterTargets="ProcessFrameworkReferences">
+    <ItemGroup>
+      <PackageDownload Remove="@(PackageDownload)"
+                       Condition="$([System.String]::Copy('%(Identity)').StartsWith('Microsoft.NETCore.App.Runtime'))" />
+    </ItemGroup>
+  </Target>
+
   <!-- Use local targeting pack for NetCoreAppCurrent. -->
   <Target Name="UpdateTargetingAndRuntimePack"
           Condition="'$(_UseLocalTargetingRuntimePack)' == 'true'"


### PR DESCRIPTION
This unblocks: https://github.com/dotnet/runtime/pull/45781 because it is removing the `KnownFramework` item that points to `5.0-rc1*` and the mobile tests because they set a `RuntimeIdentifier` the SDK tries to download a the runtime pack (even when we set `EnableTargetingPackDownload=false`). When removing the `KnownFramework` item that we define in `Directory.Build.targets` we end up using a `6.0.0` that of course doesn't exist on nuget yet: https://github.com/dotnet/runtime/blob/bc1ff0875008acade68e03154ab66f4d0c7c0b62/eng/targetingpacks.targets#L12-L22

```cmd
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Runtime.browser-wasm with version (= 6.0.0)
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102:   - Found 437 version(s) in dotnet5 [ Nearest version: 6.0.0-alpha.1.20420.3 ]
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102:   - Found 396 version(s) in dotnet6 [ Nearest version: 6.0.0-alpha.1.20610.6 ]
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102:   - Found 8 version(s) in nuget.org [ Nearest version: 5.0.1 ]
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102:   - Found 0 version(s) in dotnet-eng
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102:   - Found 0 version(s) in dotnet-tools
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102:   - Found 0 version(s) in dotnet5-transport
/Users/santifdezm/repos/runtime/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj : error NU1102:   - Found 0 version(s) in dotnet6-transport
```

I will go ahead and open an issue on the SDK as there should be a better way to disable downloading the runtime pack to use a locally built one.

