### PR TITLE
Make all pipelines triggerable via '/azp run name'.

### DIFF
--- a/eng/pipelines/coreclr/clrinterpreter.yml
+++ b/eng/pipelines/coreclr/clrinterpreter.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 19 * * 6,0"
   displayName: Sat and Sun at 11:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/gc-longrunning.yml
+++ b/eng/pipelines/coreclr/gc-longrunning.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 11 * * 2,4"
   displayName: Every Tuesday and Thursday at 3:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/gc-simulator.yml
+++ b/eng/pipelines/coreclr/gc-simulator.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 11 * * *"
   displayName: Mon through Sun at 3:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/gcstress-extra.yml
+++ b/eng/pipelines/coreclr/gcstress-extra.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 21 * * 6,0"
   displayName: Sat and Sun at 1:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 13 * * 6,0"
   displayName: Sat and Sun at 5:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/jitrollingbuild.yml
+++ b/eng/pipelines/coreclr/jitrollingbuild.yml
@@ -7,8 +7,6 @@ trigger:
     include:
     - src/coreclr/jit/*
 
-pr: none
-
 jobs:
 #
 # Checkout repository

--- a/eng/pipelines/coreclr/jitstress-isas-arm.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-arm.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 19 * * 6"
   displayName: Sat at 11:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/jitstress-isas-x86.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-x86.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "30 19 * * 6"
   displayName: Sat at 11:30 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 4 * * 1,3,5"
   displayName: Mon, Wed, Fri at 8:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 17 * * 6,0"
   displayName: Sat and Sun at 9:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/jitstressregs-x86.yml
+++ b/eng/pipelines/coreclr/jitstressregs-x86.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 19 * * 0"
   displayName: Sun at 11:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstressregs.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 10 * * 6,0"
   displayName: Sat and Sun at 2:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/libraries-gcstress-extra.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress-extra.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 # This pipeline currently has too many failures to be enabled by schedule.
 # schedules:
 # - cron: "0 10 * * 0"

--- a/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 # This pipeline currently has too many failures to be enabled by schedule.
 # schedules:
 # - cron: "0 10 * * 6"

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 7 * * 0,2,4,6"
   displayName: Sun, Tue, Thu, Sat at 11:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 9 * * 6"
   displayName: Sat at 1:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/libraries-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstressregs.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 9 * * 0"
   displayName: Sun at 1:00 AM (UTC-8:00)

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -18,8 +18,6 @@ trigger:
     - README.md
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
-  
-pr: none
 
 jobs:
 #

--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -1,7 +1,5 @@
 trigger: none
 
-pr: none
-
 schedules:
 - cron: "0 6 * * *"
   displayName: Daily at 10:00 PM (UTC-8:00)

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -11,8 +11,6 @@ trigger:
     include:
     - src/coreclr/inc/jiteeversionguid.h
 
-pr: none
-
 schedules:
 - cron: "0 17 * * 0"
   displayName: Sun at 9:00 AM (UTC-8:00)

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -20,8 +20,6 @@ trigger:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
 
-pr: none
-
 variables:
 - template: /eng/pipelines/common/variables.yml
 # TODO: (Consolidation) Switch away from old signing/validation variables from former Core-Setup. https://github.com/dotnet/runtime/issues/1027


### PR DESCRIPTION
Extend https://github.com/dotnet/runtime/pull/42933.

The old `/azp run` issue is not actual anymore because it shows:
```
You have several pipelines (over 10) configured to build pull requests in this repository. Specify which pipelines you would like to run by using /azp run [pipelines] command. You can specify multiple pipelines using a comma separated list.
```
