### PR TITLE
Change GC stack slot negative hex offsets to show as negative

### DIFF
--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -3666,8 +3666,8 @@ public:
         GcSlotId newSlotId = m_gcInfoEncoder->GetStackSlotId(spOffset, flags, spBase);
         if (m_doLogging)
         {
-            printf("Stack slot id for offset %d (0x%x) (%s) %s= %d.\n", spOffset, spOffset,
-                   JitGcStackSlotBaseNames[spBase], GcSlotFlagsNames[flags & 7], newSlotId);
+            printf("Stack slot id for offset %d (%s0x%x) (%s) %s= %d.\n", spOffset, spOffset < 0 ? "-" : "",
+                   abs(spOffset), JitGcStackSlotBaseNames[spBase], GcSlotFlagsNames[flags & 7], newSlotId);
         }
         return newSlotId;
     }


### PR DESCRIPTION
In the GC output, instead of:

```
Stack slot id for offset -104 (0xffffff98) (frame) = 5.
```

display:

```
Stack slot id for offset -104 (-0x68) (frame) = 5.
```

This makes it easier to search for or visually match the
`-0x68` against asm like:
```
mov      gword ptr [rbp-68H], rax
```