### PR TITLE
Update `Environment.ProcessorCount` on Windows to take into account the processor affinity mask

### DIFF
--- a/src/coreclr/classlibnative/bcltype/system.cpp
+++ b/src/coreclr/classlibnative/bcltype/system.cpp
@@ -335,28 +335,18 @@ INT32 QCALLTYPE SystemNative::GetProcessorCount()
 #ifndef TARGET_UNIX
     CPUGroupInfo::EnsureInitialized();
 
-    if(CPUGroupInfo::CanEnableThreadUseAllCpuGroups())
+    if (CPUGroupInfo::CanEnableThreadUseAllCpuGroups())
     {
         processorCount = CPUGroupInfo::GetNumActiveProcessors();
     }
+    else
 #endif // !TARGET_UNIX
-    // Processor count will be 0 if CPU groups are disabled/not supported
-    if(processorCount == 0)
     {
-        SYSTEM_INFO systemInfo;
-        ZeroMemory(&systemInfo, sizeof(systemInfo));
-
-        GetSystemInfo(&systemInfo);
-
-        processorCount = systemInfo.dwNumberOfProcessors;
+        // This similar to GetSystemInfo() + dwNumberOfProcessors except:
+        // - GetCurrentProcessCpuCount() tries to take into account the processor affinity mask where applicable
+        // - GetCurrentProcessCpuCount() on Unixes tries to take into account cgroups CPU quota limits where applicable
+        processorCount = GetCurrentProcessCpuCount();
     }
-
-#ifdef TARGET_UNIX
-    uint32_t cpuLimit;
-
-    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < (uint32_t)processorCount)
-        processorCount = cpuLimit;
-#endif
 
     END_QCALL;
 

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -1278,7 +1278,6 @@ private:
     static BOOL m_threadAssignCpuGroups;
     static WORD m_initialGroup;
     static CPU_Group_Info *m_CPUGroupInfoArray;
-    static bool s_hadSingleProcessorAtStartup;
 
     static BOOL InitCPUGroupInfoArray();
     static BOOL InitCPUGroupInfoRange();
@@ -1309,13 +1308,6 @@ public:
     static void ClearCPUGroupAffinity(GROUP_AFFINITY *gf);
     static BOOL GetCPUGroupRange(WORD group_number, WORD* group_begin, WORD* group_size);
 #endif
-
-public:
-    static bool HadSingleProcessorAtStartup()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return s_hadSingleProcessorAtStartup;
-    }
 };
 
 DWORD_PTR GetCurrentProcessCpuMask();

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -856,7 +856,6 @@ BYTE * ClrVirtualAllocWithinRange(const BYTE *pMinAddr,
 /*static*/ WORD CPUGroupInfo::m_initialGroup = 0;
 /*static*/ CPU_Group_Info *CPUGroupInfo::m_CPUGroupInfoArray = NULL;
 /*static*/ LONG CPUGroupInfo::m_initialization = 0;
-/*static*/ bool CPUGroupInfo::s_hadSingleProcessorAtStartup = false;
 
 #if !defined(FEATURE_REDHAWK) && (defined(TARGET_AMD64) || defined(TARGET_ARM64))
 // Calculate greatest common divisor
@@ -1014,18 +1013,6 @@ DWORD LCM(DWORD u, DWORD v)
     m_threadUseAllCpuGroups = threadUseAllCpuGroups && hasMultipleGroups;
     m_threadAssignCpuGroups = threadAssignCpuGroups && hasMultipleGroups;
 #endif // TARGET_AMD64 || TARGET_ARM64
-
-    // Determine if the process is affinitized to a single processor (or if the system has a single processor)
-    DWORD_PTR processAffinityMask, systemAffinityMask;
-    if (GetProcessAffinityMask(GetCurrentProcess(), &processAffinityMask, &systemAffinityMask))
-    {
-        processAffinityMask &= systemAffinityMask;
-        if (processAffinityMask != 0 && // only one CPU group is involved
-            (processAffinityMask & (processAffinityMask - 1)) == 0) // only one bit is set
-        {
-            s_hadSingleProcessorAtStartup = true;
-        }
-    }
 }
 
 /*static*/ BOOL CPUGroupInfo::IsInitialized()

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -901,12 +901,18 @@ fTrackDynamicMethodDebugInfo = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_
 
         tieredCompilation_CallCountingDelayMs = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCountingDelayMs);
 
+        bool hasSingleProcessor;
 #ifndef TARGET_UNIX
-        bool hadSingleProcessorAtStartup = CPUGroupInfo::HadSingleProcessorAtStartup();
-#else // !TARGET_UNIX
-        bool hadSingleProcessorAtStartup = g_SystemInfo.dwNumberOfProcessors == 1;
-#endif // !TARGET_UNIX
-        if (hadSingleProcessorAtStartup)
+        if (CPUGroupInfo::CanEnableThreadUseAllCpuGroups())
+        {
+            hasSingleProcessor = CPUGroupInfo::GetNumActiveProcessors() == 1;
+        }
+        else
+#endif
+        {
+            hasSingleProcessor = GetCurrentProcessCpuCount() == 1;
+        }
+        if (hasSingleProcessor)
         {
             DWORD delayMultiplier = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_DelaySingleProcMultiplier);
             if (delayMultiplier > 1)


### PR DESCRIPTION
- Similarly to cases on Unixes where sched_getaffinity is available
- If `GCCpuGroup` and `Thread_UseAllCpuGroups` are both enabled, I'm not sure if the `CPUGroupInfo` count of active processors takes affinity into account as the docs are not clear, for now I'm not modifying that path until I can verify it
- Otherwise, a process that is started with a specific processor affinity mask still shows full CPU count and perf is much worse in CPU-affinitized cases compared to the native thread pool
- This is one of the differences in the portable managed thread pool implementation, which relies on `Environment.ProcessorCount`, as opposed to the native thread pool, which uses the affinity mask
- After this change, in affinitized cases on Windows, perf-wise where this difference matters, the behavior perf-wise is closer to that on Linux and closer to what is currently expected:
  - The portable thread pool uses the same worker thread count as the native thread pool
  - `Environment.ProcessorCount` returns the number of processors the process is affinitized to, which may be less than it would have returned before, similarly to Linux

Breaking change issue: https://github.com/dotnet/runtime/issues/47427