### PR TITLE
Create full dumps on hang/crash for CoreCLR tests

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -207,7 +207,7 @@ namespace CoreclrTestLib
         {
             string coreRoot = Environment.GetEnvironmentVariable("CORE_ROOT");
             string createdumpPath = Path.Combine(coreRoot, "createdump");
-            string arguments = $"--name \"{path}\" {process.Id} --withheap";
+            string arguments = $"--name \"{path}\" {process.Id} --full";
             Process createdump = new Process();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Currently dumps collected in CI are heap dumps. The main problem with this is they don't contain the images and Visual Studio is currently unable to fully locate the information necessary