### PR TITLE
[release/5.0] Fix GC hole with STOREIND of LCL_VAR_ADDR/LCL_FLD_ADDR

### DIFF
--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -3113,7 +3113,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         }
 
         // Updating variable liveness after instruction was emitted
-        codeGen->genUpdateLife(varNode);
+        codeGen->genUpdateLife(mem);
         return;
     }
 


### PR DESCRIPTION
Backport of (part of) #45818 to release/5.0

Fixes: #45557

## Customer Impact

Reported by Roslyn. Bad GC info can lead to an unexplained crash that can't easily be found or worked around.

## Regression?

Yes, this is a regression from .NET Core 3.1

## Testing

Manual, new unit test, CLR outerloop, SuperPMI asm diffs.

## Risk

Low