### PR TITLE
Fix some PAL tests that compare sleep/wait times from one thread to sleep/wait times on another thread

### DIFF
--- a/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
@@ -37,6 +37,7 @@ VOID PALAPI APCFunc_SleepEx_test2(ULONG_PTR dwParam);
 DWORD PALAPI SleeperProc_SleepEx_test2(LPVOID lpParameter);
 
 DWORD ThreadSleepDelta;
+static volatile bool s_preWaitTimestampRecorded = 0;
 
 PALTEST(threading_SleepEx_test2_paltest_sleepex_test2, "threading/SleepEx/test2/paltest_sleepex_test2")
 {
@@ -118,6 +119,13 @@ void RunTest_SleepEx_test2(BOOL AlertThread)
             "GetLastError returned %d\n", GetLastError());
     }
 
+    // Wait for the pre-wait timestamp to be recorded on the other thread before sleeping, since the sleep duration here will be
+    // compared against the sleep/wait duration on the other thread
+    while (!s_preWaitTimestampRecorded)
+    {
+        Sleep(0);
+    }
+
     if (SleepEx(InterruptTime, FALSE) != 0)
     {
         Fail("The creating thread did not sleep!\n");
@@ -160,6 +168,7 @@ DWORD PALAPI SleeperProc_SleepEx_test2(LPVOID lpParameter)
     }
 
     OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
+    s_preWaitTimestampRecorded = true;
 
     ret = SleepEx(ChildThreadSleepTime, Alertable);
     

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
@@ -26,8 +26,7 @@ DWORD PALAPI WaiterProc_WFSOExMutexTest(LPVOID lpParameter);
 
 DWORD ThreadWaitDelta_WFSOExMutexTest;
 HANDLE hMutex_WFSOExMutexTest;
-
-
+static volatile bool s_preWaitTimestampRecorded = 0;
 
 PALTEST(threading_WaitForSingleObject_WFSOExMutexTest_paltest_waitforsingleobject_wfsoexmutextest, "threading/WaitForSingleObject/WFSOExMutexTest/paltest_waitforsingleobject_wfsoexmutextest")
 {
@@ -136,9 +135,14 @@ void RunTest_WFSOExMutexTest(BOOL AlertThread)
             "GetLastError returned %d\n", GetLastError());
     }
 
+    // Wait for the pre-wait timestamp to be recorded on the other thread before sleeping, since the sleep duration here will be
+    // compared against the sleep/wait duration on the other thread
+    while (!s_preWaitTimestampRecorded)
+    {
+        Sleep(0);
+    }
 
-	
-	Sleep(InterruptTime);
+    Sleep(InterruptTime);
 
     ret = QueueUserAPC(APCFunc_WFSOExMutexTest, hThread, 0);
     
@@ -186,6 +190,7 @@ DWORD PALAPI WaiterProc_WFSOExMutexTest(LPVOID lpParameter)
     }
 
     OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
+    s_preWaitTimestampRecorded = true;
 
     ret = WaitForSingleObjectEx(	hMutex_WFSOExMutexTest, 
 								ChildThreadWaitTime, 

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
@@ -26,6 +26,7 @@ DWORD PALAPI WaiterProc_WFSOExThreadTest(LPVOID lpParameter);
 void WorkerThread_WFSOExThreadTest(void);
 
 int ThreadWaitDelta_WFSOExThreadTest;
+static volatile bool s_preWaitTimestampRecorded = 0;
 
 PALTEST(threading_WaitForSingleObject_WFSOExThreadTest_paltest_waitforsingleobject_wfsoexthreadtest, "threading/WaitForSingleObject/WFSOExThreadTest/paltest_waitforsingleobject_wfsoexthreadtest")
 {
@@ -92,6 +93,13 @@ void RunTest_WFSOExThreadTest(BOOL AlertThread)
     {
         Fail("ERROR: Was not able to create the thread to test!\n"
             "GetLastError returned %d\n", GetLastError());
+    }
+
+    // Wait for the pre-wait timestamp to be recorded on the other thread before sleeping, since the sleep duration here will be
+    // compared against the sleep/wait duration on the other thread
+    while (!s_preWaitTimestampRecorded)
+    {
+        Sleep(0);
     }
 
     Sleep(InterruptTime);
@@ -161,6 +169,7 @@ satisfying any threads that were waiting on the object.
     }
 
     OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
+    s_preWaitTimestampRecorded = true;
 
     ret = WaitForSingleObjectEx(	hWaitThread, 
 								ChildThreadWaitTime, 


### PR DESCRIPTION
- This affects some tests where the main thread T0 creates another thread T1, T0 sleeps for some time while T1 sleeps/waits, then after waking up T0 interrupts T1's sleep/wait with an APC, and compares the expected interrupt delay with T1's sleep/wait duration as recognized by T1 after the interrupt
- In the failures T0 is likely starting to sleep for the interrupt delay before T1 has recorded the pre-sleep/wait timestamp, so the interrupt occurs sooner than intended and the expectation later fails
- Fix T0 to wait for T1 to record the pre-wait timestamp before sleeping for the interrupt delay

Hopefully fixes https://github.com/dotnet/runtime/issues/42669