### PR TITLE
Code cleanup

### DIFF
--- a/src/coreclr/gc/gcee.cpp
+++ b/src/coreclr/gc/gcee.cpp
@@ -77,7 +77,7 @@ void GCHeap::UpdatePostGCCounters()
     // The following is for instrumentation.
     //
     // Calculate the common ones for ETW and perf counters.
-#if defined(FEATURE_EVENT_TRACE)
+#ifdef FEATURE_EVENT_TRACE
 #ifdef MULTIPLE_HEAPS
     //take the first heap....
     gc_heap* hp1 = gc_heap::g_heaps[0];
@@ -153,9 +153,7 @@ void GCHeap::UpdatePostGCCounters()
         }
 #endif //MULTIPLE_HEAPS
     }
-#endif //FEATURE_EVENT_TRACE
 
-#ifdef FEATURE_EVENT_TRACE
     ReportGenerationBounds();
 
     FIRE_EVENT(GCEnd_V1, static_cast<uint32_t>(pSettings->gc_index), condemned_gen);
@@ -460,12 +458,12 @@ segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
     heap_segment_plan_allocated(seg) = 0;
     seg->flags = heap_segment_flags_readonly;
 
-#if defined (MULTIPLE_HEAPS) && !defined (ISOLATED_HEAPS)
+#ifdef MULTIPLE_HEAPS
     gc_heap* heap = gc_heap::g_heaps[0];
     heap_segment_heap(seg) = heap;
 #else
     gc_heap* heap = pGenGCHeap;
-#endif //MULTIPLE_HEAPS && !ISOLATED_HEAPS
+#endif //MULTIPLE_HEAPS
 
     if (heap->insert_ro_segment(seg) == FALSE)
     {
@@ -483,11 +481,11 @@ segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
 void GCHeap::UnregisterFrozenSegment(segment_handle seg)
 {
 #ifdef FEATURE_BASICFREEZE
-#if defined (MULTIPLE_HEAPS) && !defined (ISOLATED_HEAPS)
+#ifdef MULTIPLE_HEAPS
     gc_heap* heap = gc_heap::g_heaps[0];
 #else
     gc_heap* heap = pGenGCHeap;
-#endif //MULTIPLE_HEAPS && !ISOLATED_HEAPS
+#endif //MULTIPLE_HEAPS
 
     heap->remove_ro_segment(reinterpret_cast<heap_segment*>(seg));
 #else


### PR DESCRIPTION
Changed a bunch of dprintf levels, eg from 3 to 1 when they are for FATAL_GC_ERROR 'cause you'd always want them; from 1 to 2 in seg_mapping table functions 'cause there could be tons of these when there are many heaps.

Fixed a perf bug in commit_new_mark_array introduced by the refactor change (#1688). This doesn't cause functional problems - we are just calling the same commit_mark_array_with_check on new_heap_segment multiple times.

Got rid of keep_card_live - all it needs is just to increase the cross gen pointer count.

Got rid of useful empty lines/comments/a few vars.

Renamed a few vars to the actual meaning.

Renamed should_commit_mark_array to is_bgc_in_progress and modified a few places to call it instead of duplicated code.

Moved the decision of condemning 1 when bgc is in progress to joined_generation_to_condemn (should logically belong there anyway) which fixes the problem that GCToEEInterface::DiagGCStart was getting the wrong condemned gen in this case.

Make PARALLEL_MARK_LIST_SORT always defined and got rid of code when it's not.

Proper checks for FEATURE_LOH_COMPACTION in a few places.

Changed some really long lines (please try to keep lines under 110 chars in general).