### PR TITLE
revert ordering change to address PR feedback

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -145,6 +145,8 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 IsDisposed = true;
 
+                CacheEntryHelper.ExitScope(this, _previous);
+
                 // Don't commit or propagate options if the CacheEntry Value was never set.
                 // We assume an exception occurred causing the caller to not set the Value successfully,
                 // so don't use this entry.
@@ -158,7 +160,6 @@ namespace Microsoft.Extensions.Caching.Memory
                     }
                 }
 
-                CacheEntryHelper.ExitScope(this, _previous);
                 _previous = null; // we don't want to root unnecessary objects
             }
         }


### PR DESCRIPTION
In #45563 I've removed some allocations related to storing CacheEntry scopes but also changed the order of exiting the scope.

This PR reverts the ordering change based on feedback from @davidfowl 

So we are back to the "old order" but we still avoid a call to the expensive `CacheEntryHelper.Current` by taking advantage of having this value stored in `_previous` field.

https://github.com/dotnet/runtime/pull/45563#issuecomment-741748581