### PR TITLE
Use C# 7.3 pattern-based fixed statement

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -592,7 +592,7 @@ namespace System
                 {
                     uint result = Interop.Errors.ERROR_SUCCESS;
 
-                    fixed (char* c = &builder.GetPinnableReference())
+                    fixed (char* c = builder)
                     {
                         result = Interop.Kernel32.GetConsoleTitleW(c, (uint)builder.Capacity);
                     }


### PR DESCRIPTION
Replace all instances of `fixed (var a = &b.GetPinnableReference())` with `fixed (var a = b)`, using pattern-matching instead of the explicit method call to `GetPinnableReference`.