### PR TITLE
RyuJIT: Remove redundant memory barrier for XAdd and XChg on arm

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2947,8 +2947,6 @@ void CodeGen::genCodeForCmpXchg(GenTreeCmpXchg* treeNode)
             noway_assert(dataReg != targetReg);
         }
         GetEmitter()->emitIns_R_R_R(INS_casal, dataSize, targetReg, dataReg, addrReg);
-
-        instGen_MemoryBarrier();
     }
     else
     {

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2814,20 +2814,11 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
                 GetEmitter()->emitIns_R_R_R(INS_swpal, dataSize, dataReg, targetReg, addrReg);
                 break;
             case GT_XADD:
-                if ((targetReg == REG_NA) || (targetReg == REG_ZR))
-                {
-                    GetEmitter()->emitIns_R_R(INS_staddl, dataSize, dataReg, addrReg);
-                }
-                else
-                {
-                    GetEmitter()->emitIns_R_R_R(INS_ldaddal, dataSize, dataReg, targetReg, addrReg);
-                }
+                GetEmitter()->emitIns_R_R_R(INS_ldaddal, dataSize, dataReg, (targetReg == REG_NA) ? REG_ZR : targetReg, addrReg);
                 break;
             default:
                 assert(!"Unexpected treeNode->gtOper");
         }
-
-        instGen_MemoryBarrier();
     }
     else
     {

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2814,7 +2814,8 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
                 GetEmitter()->emitIns_R_R_R(INS_swpal, dataSize, dataReg, targetReg, addrReg);
                 break;
             case GT_XADD:
-                GetEmitter()->emitIns_R_R_R(INS_ldaddal, dataSize, dataReg, (targetReg == REG_NA) ? REG_ZR : targetReg, addrReg);
+                GetEmitter()->emitIns_R_R_R(INS_ldaddal, dataSize, dataReg, (targetReg == REG_NA) ? REG_ZR : targetReg,
+                                            addrReg);
                 break;
             default:
                 assert(!"Unexpected treeNode->gtOper");


### PR DESCRIPTION
As far as I understand that memory barrier is not needed when we already emit [LDADDAL](https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/LDADDA--LDADDAL--LDADD--LDADDL--LDADDAL--LDADD--LDADDL?lang=en) and [SWPAL](https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/SWPA--SWPAL--SWP--SWPL--SWPAL--SWP--SWPL?lang=en) with "acquire and release" semantics.

**UPD**: same for [CASAL](https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/CASA--CASAL--CAS--CASL--CASAL--CAS--CASL?lang=en) (emitted for `Interlocked.CompareExchange`)

For this reason I also replaced `staddl` with `ldaddal` for the case when we don't need the return value of `Interlocked.Add`.
Just like LLVM does: https://godbolt.org/z/a9GcT8

Here are the diff examples:
```csharp
static int XAdd_ret(ref int x, int y) => Interlocked.Add(ref x, y);
```
```diff
G_M16300_IG01:
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp
G_M16300_IG02:
        B8E10000          ldaddal w1, w0, [x0]
-       D5033BBF          dmb     ish
        0B010000          add     w0, w0, w1
G_M16300_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr
```

<br/>
<br/>

```csharp
static void XChg_noret(ref int x, int y) => Interlocked.Exchange(ref x, y);
```
```diff
G_M24897_IG01: 
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp
G_M24897_IG02: 
        B8E18000          swpal   w1, w0, [x0]
-       D5033BBF          dmb     ish
G_M24897_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr
```

/cc @dotnet/jit-contrib 