### PR TITLE
Delete non-supported handling of Windows-specific PDBs in ilasm

### DIFF
--- a/src/coreclr/ilasm/assembler.cpp
+++ b/src/coreclr/ilasm/assembler.cpp
@@ -1417,7 +1417,6 @@ void Assembler::EmitOpcode(Instr* instr)
                 pLPC->LineEnd = instr->linenum_end;
                 pLPC->ColumnEnd = instr->column_end;
                 pLPC->PC = m_CurPC;
-                pLPC->pWriter = instr->pWriter;
 
                 pLPC->pOwnerDocument = instr->pOwnerDocument;
                 if (0xfeefee == instr->linenum &&
@@ -2390,51 +2389,11 @@ void Assembler::SetSourceFileName(__in __nullterminated char* szName)
             }
             if(m_fGeneratePDB)
             {
-                if (IsPortablePdb())
+                if (FAILED(m_pPortablePdbWriter->DefineDocument(szName, &m_guidLang)))
                 {
-                    if (FAILED(m_pPortablePdbWriter->DefineDocument(szName, &m_guidLang)))
-                    {
-                        report->error("Failed to define a document: '%s'", szName);
-                    }
-                    delete[] szName;
+                    report->error("Failed to define a document: '%s'", szName);
                 }
-                else
-                {
-                    DocWriter* pDW;
-                    unsigned i = 0;
-                    while ((pDW = m_DocWriterList.PEEK(i++)) != NULL)
-                    {
-                        if (!strcmp(szName, pDW->Name)) break;
-                    }
-                    if (pDW)
-                    {
-                        m_pSymDocument = pDW->pWriter;
-                        delete[] szName;
-                    }
-                    else if (m_pSymWriter)
-                    {
-                        HRESULT hr;
-                        WszMultiByteToWideChar(g_uCodePage, 0, szName, -1, wzUniBuf, dwUniBuf);
-                        if (FAILED(hr = m_pSymWriter->DefineDocument(wzUniBuf, &m_guidLang,
-                            &m_guidLangVendor, &m_guidDoc, &m_pSymDocument)))
-                        {
-                            m_pSymDocument = NULL;
-                            report->error("Failed to define a document writer");
-                        }
-                        if ((pDW = new DocWriter()) != NULL)
-                        {
-                            pDW->Name = szName;
-                            pDW->pWriter = m_pSymDocument;
-                            m_DocWriterList.PUSH(pDW);
-                        }
-                        else
-                        {
-                            report->error("Out of memory");
-                            delete[] szName;
-                        }
-                    }
-                    else delete[] szName;
-                }
+                delete[] szName;
             }
             else delete [] szName;
         }
@@ -2471,20 +2430,14 @@ HRESULT Assembler::SavePdbFile()
     HRESULT hr = S_OK;
     mdMethodDef entryPoint;
 
-    if (m_pdbFormat == PORTABLE)
-    {
-        if (FAILED(hr = (m_pPortablePdbWriter == NULL ? E_FAIL : S_OK))) goto exit;
-        if (FAILED(hr = (m_pPortablePdbWriter->GetEmitter() == NULL ? E_FAIL : S_OK))) goto exit;
-        if (FAILED(hr = m_pCeeFileGen->GetEntryPoint(m_pCeeFile, &entryPoint))) goto exit;
-        if (FAILED(hr = m_pPortablePdbWriter->BuildPdbStream(m_pEmitter, entryPoint))) goto exit;
-        if (FAILED(hr = m_pPortablePdbWriter->GetEmitter()->Save(m_wzPdbFileName, NULL))) goto exit;
-    }
+    if (FAILED(hr = (m_pPortablePdbWriter == NULL ? E_FAIL : S_OK))) goto exit;
+    if (FAILED(hr = (m_pPortablePdbWriter->GetEmitter() == NULL ? E_FAIL : S_OK))) goto exit;
+    if (FAILED(hr = m_pCeeFileGen->GetEntryPoint(m_pCeeFile, &entryPoint))) goto exit;
+    if (FAILED(hr = m_pPortablePdbWriter->BuildPdbStream(m_pEmitter, entryPoint))) goto exit;
+    if (FAILED(hr = m_pPortablePdbWriter->GetEmitter()->Save(m_wzPdbFileName, NULL))) goto exit;
+
 exit:
     return hr;
-}
-BOOL Assembler::IsPortablePdb()
-{
-    return (m_pdbFormat == PORTABLE) && (m_pPortablePdbWriter != NULL);
 }
 
 // This method is called after we have parsed the generic type parameters for either

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -279,7 +279,7 @@ Instr* SetupInstr(unsigned short opcode)
     if((pVal = PASM->GetInstr()))
     {
         pVal->opcode = opcode;
-        if((pVal->pWriter = PASM->m_pSymDocument)!=NULL || PASM->IsPortablePdb())
+        if(PASM->m_fGeneratePDB)
         {
             if(PENV->bExternSource)
             {
@@ -297,10 +297,10 @@ Instr* SetupInstr(unsigned short opcode)
                 // Portable PDB rule:
                 // - If Start Line is equal to End Line then End Column is greater than Start Column.
                 // To fulfill this condition the column_end is set to 2 instead of 0
-                pVal->column_end = PASM->IsPortablePdb() ? 2 : 0;
+                pVal->column_end = 2;
                 pVal->pc = PASM->m_CurPC;
             }
-            pVal->pOwnerDocument = PASM->IsPortablePdb() ? PASM->m_pPortablePdbWriter->GetCurrentDocument() : NULL;
+            pVal->pOwnerDocument = PASM->m_pPortablePdbWriter->GetCurrentDocument();
         }
     }
     return pVal;

--- a/src/coreclr/ilasm/method.hpp
+++ b/src/coreclr/ilasm/method.hpp
@@ -23,7 +23,6 @@ struct LinePC
     ULONG   LineEnd;
     ULONG   ColumnEnd;
     ULONG   PC;
-    ISymUnmanagedDocumentWriter* pWriter;
     Document* pOwnerDocument;
     BOOL    IsHidden;
 };

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -52,7 +52,7 @@ HRESULT Assembler::InitMetaData()
     if(FAILED(hr = m_pEmitter->QueryInterface(IID_IMetaDataImport2, (void**)&m_pImporter)))
         goto exit;
 
-    if (m_pdbFormat == PdbFormat::PORTABLE)
+    if (m_fGeneratePDB)
     {
         m_pPortablePdbWriter = new PortablePdbWriter();
         if (FAILED(hr = m_pPortablePdbWriter->Init(m_pDisp))) goto exit;
@@ -209,7 +209,7 @@ HRESULT Assembler::CreateDebugDirectory()
     ULONG deOffset;
 
     // Only emit this if we're also emitting debug info.
-    if (!(m_fGeneratePDB && (m_pSymWriter || IsPortablePdb())))
+    if (!m_fGeneratePDB)
         return S_OK;
 
     IMAGE_DEBUG_DIRECTORY  debugDirIDD;
@@ -220,80 +220,42 @@ HRESULT Assembler::CreateDebugDirectory()
     } param;
     param.debugDirData = NULL;
 
-    if (m_pSymWriter)   // CLASSIC
-    {
-        // Get the debug info from the symbol writer.
-        if (FAILED(hr=m_pSymWriter->GetDebugInfo(NULL, 0, &param.debugDirDataSize, NULL)))
-            return hr;
+    // get module ID
+    DWORD rsds = 0x53445352;
+    DWORD pdbAge = 0x1;
+    DWORD len = sizeof(rsds) + sizeof(GUID) + sizeof(pdbAge) + (DWORD)strlen(m_szPdbFileName) + 1;
+    BYTE* dbgDirData = new BYTE[len];
 
-        // Will there even be any?
-        if (param.debugDirDataSize == 0)
-            return S_OK;
+    DWORD offset = 0;
+    memcpy_s(dbgDirData + offset, len, &rsds, sizeof(rsds));                            // RSDS
+    offset += sizeof(rsds);
+    memcpy_s(dbgDirData + offset, len, m_pPortablePdbWriter->GetGuid(), sizeof(GUID)); // PDB GUID
+    offset += sizeof(GUID);
+    memcpy_s(dbgDirData + offset, len, &pdbAge, sizeof(pdbAge));                        // PDB AGE
+    offset += sizeof(pdbAge);
+    memcpy_s(dbgDirData + offset, len, m_szPdbFileName, strlen(m_szPdbFileName) + 1);   // PDB PATH
 
-        // Make some room for the data.
-        PAL_TRY(Param *, pParam, &param) {
-            pParam->debugDirData = new BYTE[pParam->debugDirDataSize];
-        } PAL_EXCEPT(EXCEPTION_EXECUTE_HANDLER) {
-            hr = E_FAIL;
-        } PAL_ENDTRY
+    debugDirIDD.Characteristics = 0;
+    debugDirIDD.TimeDateStamp = m_pPortablePdbWriter->GetTimestamp();
+    debugDirIDD.MajorVersion = 0x100;
+    debugDirIDD.MinorVersion = 0x504d;
+    debugDirIDD.Type = IMAGE_DEBUG_TYPE_CODEVIEW;
+    debugDirIDD.SizeOfData = len;
+    debugDirIDD.AddressOfRawData = 0; // will be updated bellow
+    debugDirIDD.PointerToRawData = 0; // will be updated bellow
 
-        if(FAILED(hr)) return hr;
-        // Actually get the data now.
-        if (FAILED(hr = m_pSymWriter->GetDebugInfo(&debugDirIDD,
-                                                   param.debugDirDataSize,
-                                                   NULL,
-                                                   param.debugDirData)))
-            goto ErrExit;
+    param.debugDirDataSize = len;
 
-        // Grab the timestamp of the PE file.
-        DWORD fileTimeStamp;
+    // Make some room for the data.
+    PAL_TRY(Param*, pParam, &param) {
+        pParam->debugDirData = new BYTE[pParam->debugDirDataSize];
+    } PAL_EXCEPT(EXCEPTION_EXECUTE_HANDLER) {
+        hr = E_FAIL;
+    } PAL_ENDTRY
 
-        if (FAILED(hr = m_pCeeFileGen->GetFileTimeStamp(m_pCeeFile,
-                                                        &fileTimeStamp)))
-            goto ErrExit;
+    if (FAILED(hr)) return hr;
 
-        // Fill in the directory entry.
-        debugDirIDD.TimeDateStamp = VAL32(fileTimeStamp);
-    }
-    else if (IsPortablePdb())   // PORTABLE
-    {
-        // get module ID
-        DWORD rsds = 0x53445352;
-        DWORD pdbAge = 0x1;
-        DWORD len = sizeof(rsds) + sizeof(GUID) + sizeof(pdbAge) + (DWORD)strlen(m_szPdbFileName) + 1;
-        BYTE* dbgDirData = new BYTE[len];
-
-        DWORD offset = 0;
-        memcpy_s(dbgDirData + offset, len, &rsds, sizeof(rsds));                            // RSDS
-        offset += sizeof(rsds);
-        memcpy_s(dbgDirData + offset, len, m_pPortablePdbWriter->GetGuid(), sizeof(GUID)); // PDB GUID
-        offset += sizeof(GUID);
-        memcpy_s(dbgDirData + offset, len, &pdbAge, sizeof(pdbAge));                        // PDB AGE
-        offset += sizeof(pdbAge);
-        memcpy_s(dbgDirData + offset, len, m_szPdbFileName, strlen(m_szPdbFileName) + 1);   // PDB PATH
-
-        debugDirIDD.Characteristics = 0;
-        debugDirIDD.TimeDateStamp = m_pPortablePdbWriter->GetTimestamp();
-        debugDirIDD.MajorVersion = 0x100;
-        debugDirIDD.MinorVersion = 0x504d;
-        debugDirIDD.Type = IMAGE_DEBUG_TYPE_CODEVIEW;
-        debugDirIDD.SizeOfData = len;
-        debugDirIDD.AddressOfRawData = 0; // will be updated bellow
-        debugDirIDD.PointerToRawData = 0; // will be updated bellow
-
-        param.debugDirDataSize = len;
-
-        // Make some room for the data.
-        PAL_TRY(Param*, pParam, &param) {
-            pParam->debugDirData = new BYTE[pParam->debugDirDataSize];
-        } PAL_EXCEPT(EXCEPTION_EXECUTE_HANDLER) {
-            hr = E_FAIL;
-        } PAL_ENDTRY
-
-        if (FAILED(hr)) return hr;
-
-        param.debugDirData = dbgDirData;
-    }
+    param.debugDirData = dbgDirData;
 
     // Grab memory in the section for our stuff.
     // Note that UpdateResource doesn't work correctly if the debug directory is

--- a/src/coreclr/ilasm/writer_enc.cpp
+++ b/src/coreclr/ilasm/writer_enc.cpp
@@ -12,17 +12,11 @@
 int ist=0;
 #define REPT_STEP   //printf("Step %d\n",++ist);
 
-HRESULT Assembler::InitMetaDataForENC(__in __nullterminated WCHAR* wzOrigFileName, BOOL generatePdb, PdbFormat pdbFormat)
+HRESULT Assembler::InitMetaDataForENC(__in __nullterminated WCHAR* wzOrigFileName, BOOL generatePdb)
 {
     HRESULT             hr = E_FAIL;
 
     if((wzOrigFileName==NULL)||(*wzOrigFileName == 0)||(m_pDisp==NULL)) return hr;
-    if (m_pSymWriter != NULL)
-    {
-        m_pSymWriter->Close();
-        m_pSymWriter->Release();
-        m_pSymWriter = NULL;
-    }
     if (m_pImporter != NULL)
     {
         m_pImporter->Release();
@@ -68,7 +62,7 @@ HRESULT Assembler::InitMetaDataForENC(__in __nullterminated WCHAR* wzOrigFileNam
         goto exit;
 
     //WszSetEnvironmentVariable(L"COMP_ENC_EMIT", wzOrigFileName);
-    if(!Init(generatePdb, pdbFormat)) goto exit; // close and re-open CeeFileGen and CeeFile
+    if(!Init(generatePdb)) goto exit; // close and re-open CeeFileGen and CeeFile
     hr = S_OK;
 
 
@@ -434,12 +428,6 @@ REPT_STEP
 
 
     // release all interfaces
-    if (m_pSymWriter != NULL)
-    {
-        m_pSymWriter->Close();
-        m_pSymWriter->Release();
-        m_pSymWriter = NULL;
-    }
     if (m_pImporter != NULL)
     {
         m_pImporter->Release();


### PR DESCRIPTION
I do not expect we will ever add the classic PDB support back in ilasm.

Fixes #45492