### PR TITLE
[release\5.0] Fix for Issue 44762 - Incorrect optimization of LoadVector intrinsics

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -19110,7 +19110,7 @@ bool GenTreeHWIntrinsic::OperIsMemoryStore() const
     return false;
 }
 
-// Returns true for the HW Intrinsic instructions that have MemoryLoad semantics, false otherwise
+// Returns true for the HW Intrinsic instructions that have MemoryLoad or MemoryStore semantics, false otherwise
 bool GenTreeHWIntrinsic::OperIsMemoryLoadOrStore() const
 {
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64)

--- a/src/coreclr/src/jit/liveness.cpp
+++ b/src/coreclr/src/jit/liveness.cpp
@@ -300,6 +300,19 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             fgCurMemoryDef |= memoryKindSet(GcHeap, ByrefExposed);
             break;
 
+#ifdef FEATURE_SIMD
+        case GT_SIMD:
+        {
+            GenTreeSIMD* simdNode = tree->AsSIMD();
+            if (simdNode->OperIsMemoryLoad())
+            {
+                // This instruction loads from memory and we need to record this information
+                fgCurMemoryUse |= memoryKindSet(GcHeap, ByrefExposed);
+            }
+            break;
+        }
+#endif // FEATURE_SIMD
+
 #ifdef FEATURE_HW_INTRINSICS
         case GT_HWINTRINSIC:
         {
@@ -319,7 +332,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
             }
             break;
         }
-#endif
+#endif // FEATURE_HW_INTRINSICS
 
         // For now, all calls read/write GcHeap/ByrefExposed, writes in their entirety.  Might tighten this case later.
         case GT_CALL:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+
+namespace IntrinsicsMisoptimizationTest {
+    class Program {
+        unsafe static void WriteArray (float* ptr, int count)
+        {
+            Console.Write ("[");
+            for (int i = 0; i < count; i++)
+            {
+                if (i > 0)
+                    Console.Write (", ");
+
+                Console.Write (ptr [i]);
+            }
+            Console.WriteLine ("]");
+        }
+
+        unsafe static bool TestXmm_NoCSE()
+        {
+            const int VecLen = 4;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector128 (mem);
+
+                    memSpan.Fill (75);
+                    x2 = Avx.LoadVector128 (mem);
+
+                    x3 = Avx.Add (x1, x2);
+
+                    Avx.Store (mem, x3);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3;
+
+                    memSpan.Fill (25);
+                    x1 = AdvSimd.LoadVector128 (mem);
+
+                    memSpan.Fill (75);
+                    x2 = AdvSimd.LoadVector128 (mem);
+
+                    x3 = AdvSimd.Add (x1, x2);
+
+                    AdvSimd.Store (mem, x3);
+                    WriteArray (mem, VecLen);
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("XMM_NoCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        unsafe static bool TestXmm_CanCSE()
+        {
+            const int VecLen = 4;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3, x4;
+                    Vector128<float> x5, x6, x7;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector128 (mem);
+                    x2 = Avx.LoadVector128 (mem);
+                    x3 = Avx.LoadVector128 (mem);
+                    x4 = Avx.LoadVector128 (mem);
+
+                    x5 = Avx.Add (x1, x2);
+                    x6 = Avx.Add (x3, x4);
+                    x7 = Avx.Add (x5, x6);
+
+                    Avx.Store (mem, x7);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Vector128<float> x1, x2, x3, x4;
+                    Vector128<float> x5, x6, x7;
+
+                    memSpan.Fill (25);
+                    x1 = AdvSimd.LoadVector128 (mem);
+                    x2 = AdvSimd.LoadVector128 (mem);
+                    x3 = AdvSimd.LoadVector128 (mem);
+                    x4 = AdvSimd.LoadVector128 (mem);
+
+                    x5 = AdvSimd.Add (x1, x2);
+                    x6 = AdvSimd.Add (x3, x4);
+                    x7 = AdvSimd.Add (x5, x6);
+
+                    AdvSimd.Store (mem, x7);
+                    WriteArray (mem, VecLen);
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("XMM_CanCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        unsafe static bool TestYmm_NoCSE()
+        {
+            const int VecLen = 8;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector256<float> x1, x2, x3;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector256 (mem);
+
+                    memSpan.Fill (75);
+                    x2 = Avx.LoadVector256 (mem);
+                    
+                    x3 = Avx.Add (x1, x2);
+
+                    Avx.Store (mem, x3);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Console.WriteLine("Vector256 not supported");
+                    return true;
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("YMM_NoCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        unsafe static bool TestYmm_CanCSE()
+        {
+            const int VecLen = 8;
+
+            int result = -1;
+            var mem = stackalloc float [VecLen];
+            var memSpan = new Span<float> (mem, VecLen);
+            for (int i = 0; i < 1; i++)
+            {
+                if (Avx.IsSupported)
+                {
+                    Vector256<float> x1, x2, x3, x4;
+                    Vector256<float> x5, x6, x7;
+
+                    memSpan.Fill (25);
+                    x1 = Avx.LoadVector256 (mem);
+                    x2 = Avx.LoadVector256 (mem);
+                    x3 = Avx.LoadVector256 (mem);
+                    x4 = Avx.LoadVector256 (mem);
+
+                    x5 = Avx.Add (x1, x2);
+                    x6 = Avx.Add (x3, x4);
+                    x7 = Avx.Add (x5, x6);
+
+                    Avx.Store (mem, x7);
+                    WriteArray (mem, VecLen);
+                }
+                else if (AdvSimd.IsSupported)
+                {
+                    Console.WriteLine("Vector256 not supported");
+                    return true;
+                }
+                else
+                {
+                    Console.WriteLine("Hardware Intrinsics not supported");
+                    return true;
+                }
+            }
+
+            if (mem[0] != 100.00)
+            {
+                Console.WriteLine("YMM_CanCSE Test Failed");
+                return false;
+            }
+            return true;
+        }
+
+        static int Main (string [] args)
+        {
+            bool result = true;
+            result &= TestXmm_NoCSE();
+            result &= TestYmm_NoCSE();
+            result &= TestXmm_CanCSE();
+            result &= TestYmm_CanCSE();
+
+            if (result == true)
+            {
+                return 100;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_44762/Runtime_44762.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #45134 to release/5.0

Fixes: #44762

## Customer Impact

Reported by customer who is using Hardware Intrinsic instructions.  When optimizing we would incorrectly perform a CSE involving a Hardware Intrinsic load instruction.  This leads to incorrect values being computed in the XMM/YMM registers.

## Regression?

Yes, this is a regression from .NET Core 3.1

## Testing

Manual, new unit test, CLR outerloop,  asm diffs.

## Risk

Low

* Fix for Issue 44762
  Treat both SIMD and HWIntrinsic Memory Loads as Byref Exposed Loads that depend upon the global byref memory state.
  In liveness added byref use for SIMD Memory Loads
  Corrected the comment for GenTreeHWIntrinsic::OperIsMemoryLoadOrStore()
  Added test case Runtime_44762.cs
