### PR TITLE
[wasm] emit a message if provision-wasm will be a no-op

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -48,6 +48,8 @@ provision-wasm: .stamp-wasm-install-and-select-$(EMSCRIPTEN_VERSION)
 	@echo "Installed emsdk into EMSDK_PATH=$(TOP)/src/mono/wasm/emsdk"
 else
 provision-wasm:
+	@echo "----------------------------------------------------------"
+	@echo "Not doing anything for provision-wasm. To fix this EMSDK_PATH should either be unset, or set to $(TOP)/src/mono/wasm/emsdk"
 endif
 
 MONO_OBJ_DIR=$(OBJDIR)/mono/Browser.wasm.$(CONFIG)


### PR DESCRIPTION
If `$EMSDK_PATH` is set to a non-default path, then `provision-wasm`
doesn't do anything, silently! Instead, inform the user why it isn't
doing anything.