### PR TITLE
[wasm] provision-wasm: always install the "official" version

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -42,13 +42,9 @@ EMCC=source $(EMSDK_PATH)/emsdk_env.sh && emcc
 	cd $(EMSDK_LOCAL_PATH) && ./emsdk activate $(EMSCRIPTEN_VERSION)
 	touch $@
 
-ifeq ($(EMSDK_PATH),$(TOP)/src/mono/wasm/emsdk)
 provision-wasm: .stamp-wasm-install-and-select-$(EMSCRIPTEN_VERSION)
 	@echo "----------------------------------------------------------"
 	@echo "Installed emsdk into EMSDK_PATH=$(TOP)/src/mono/wasm/emsdk"
-else
-provision-wasm:
-endif
 
 MONO_OBJ_DIR=$(OBJDIR)/mono/Browser.wasm.$(CONFIG)
 MONO_INCLUDE_DIR=$(MONO_BIN_DIR)/include/mono-2.0

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -7,10 +7,11 @@ This depends on `emsdk` to be installed.
 * You can either install it yourself (https://emscripten.org/docs/getting_started/downloads.html), and set `EMSDK_PATH` to that. Make sure to have this set whenever building, or running tests for wasm.
 
 * Or you can run `make provision-wasm`, which will install it to `$reporoot/src/mono/wasm/emsdk`.
+Note: Irrespective of `$(EMSDK_PATH)`'s value, `provision-wasm` will always install into `$reporoot/src/mono/wasm/emsdk`.
 
 `EMSDK_PATH` is set to `$reporoot/src/mono/wasm/emsdk` by default, by the Makefile.
 
-Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that should have it set. But you might need to set it manually if
+Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that will have it set. But you might need to set it manually if
 you are directly using the `dotnet build`, or `build.sh`.
 
 ## Building


### PR DESCRIPTION
if `EMSDK_PATH` was unset, or set to the default path, then
`provision-wasm` target would become a no-op. Instead, always install it
to the default path.

It can be useful to have the official version available, even if you
have a different one installed, so you can do comparisons etc. - Zoltan