### PR TITLE
Enable COMPlus_JitDisasmWithGC by default

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -143,7 +143,7 @@ CONFIG_METHODSET(JitDebugBreak, W("JitDebugBreak"))
 CONFIG_METHODSET(JitDisasm, W("JitDisasm"))                  // Dumps disassembly for specified method
 CONFIG_STRING(JitDisasmAssemblies, W("JitDisasmAssemblies")) // Only show JitDisasm and related info for methods
                                                              // from this semicolon-delimited list of assemblies.
-CONFIG_INTEGER(JitDisasmWithGC, W("JitDisasmWithGC"), 0)     // Dump interleaved GC Info for any method disassembled.
+CONFIG_INTEGER(JitDisasmWithGC, W("JitDisasmWithGC"), 1)     // Dump interleaved GC Info for any method disassembled.
 CONFIG_METHODSET(JitDump, W("JitDump"))                      // Dumps trees for specified method
 CONFIG_METHODSET(JitEHDump, W("JitEHDump"))                  // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(JitExclude, W("JitExclude"))


### PR DESCRIPTION
Change the default disassembly output to include interleaved GC info
using the `COMPlus_JitDisasmWithGC` mechanism. With this, asm diffs
will automatically include GC info diffs. You can revert to the previous behavior
(no interleaved GC info) by setting `COMPlus_JitDisasmWithGC=0`.

Note that `COMPlus_JitDisasmWithGC` uses codegen GC tracking info to
display GC info; it does not decode the actual generated GC info or the
emitter-level GC tracking info, so there can still be GC info bugs not
shown with this display.

The motivation behind this change to make GC info tracking more visible
for all JIT changes.

The output is roughly like the SOS `u -gcinfo` display.

Example (with lots of GC info):
```
call     System.Collections.Immutable.ImmutableArray:ToImmutableArray(System.Collections.Generic.IEnumerable`1[__Canon]):System.Collections.Immutable.ImmutableArray`1[__Canon]
; gcrRegs -[rdx rdi] +[rax]
; gcr arg pop 0
mov      gword ptr [rbp-80H], rax
; GC ptr vars +{V25}
mov      rdx, r14
; gcrRegs +[rdx]
mov      rcx, 0xD1FFAB1E
; GC ptr vars -{V25}
call     System.Collections.Immutable.ImmutableArray:ToImmutableArray(System.Collections.Generic.IEnumerable`1[__Canon]):System.Collections.Immutable.ImmutableArray`1[__Canon]
; gcrRegs -[rdx r14]
; gcr arg pop 0
mov      gword ptr [rbp-88H], rax
; GC ptr vars +{V26}
```

Related: #41647