### PR TITLE
Fix FC_NO_TAILCALL with newer compilers

### DIFF
--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -185,7 +185,7 @@ void ECall::PopulateManagedCastHelpers()
 static CrstStatic gFCallLock;
 
 // This variable is used to force the compiler not to tailcall a function.
-int FC_NO_TAILCALL;
+RAW_KEYWORD(volatile) int FC_NO_TAILCALL;
 
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -926,7 +926,7 @@ void HCallAssert(void*& cache, void* target);
 // might do, which would otherwise confuse the epilog walker.
 //
 // * See #FC_INNER for more
-extern int FC_NO_TAILCALL;
+extern RAW_KEYWORD(volatile) int FC_NO_TAILCALL;
 #define FC_INNER_RETURN(type, expr)                                                        \
     type __retVal = expr;                                                                  \
     while (0 == FC_NO_TAILCALL) { }; /* side effect the compile can't remove */            \


### PR DESCRIPTION
The C11 standard treats trivial infinite loops as undefined behavior and allows
compilers to optimize them out completely.

Add "volatile" on FC_NO_TAILCALL to defeat this optimization