### PR TITLE
adding null check on provider registration

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -152,6 +152,11 @@ namespace Microsoft.Extensions.Logging
                 throw new ObjectDisposedException(nameof(LoggerFactory));
             }
 
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
             lock (_sync)
             {
                 AddProviderRegistration(provider, dispose: true);

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void AddProvider_ThrowsIfProviderIsNull()
+        {
+            var factory = new LoggerFactory();
+
+            Assert.Throws<ArgumentNullException>(() => ((ILoggerFactory)factory).AddProvider(null));
+        }
+
+        [Fact]
         public void CreateLogger_ThrowsAfterDisposed()
         {
             var factory = new LoggerFactory();


### PR DESCRIPTION
throwing argumentnull exception if the provider parameter is null. If the provider is null this can cause problems later in the chain

fix #45599