### PR TITLE
Remove nonsensical comments about fixed statement

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -1186,7 +1186,7 @@ namespace System
 
             private static unsafe int WriteFileNative(IntPtr hFile, ReadOnlySpan<byte> bytes, bool useFileAPIs)
             {
-                // You can't use the fixed statement on an array of length 0.
+                // The fixed statement maps an empty ReadOnlySpan to nullptr.
                 if (bytes.IsEmpty)
                     return Interop.Errors.ERROR_SUCCESS;
 

--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -1186,7 +1186,6 @@ namespace System
 
             private static unsafe int WriteFileNative(IntPtr hFile, ReadOnlySpan<byte> bytes, bool useFileAPIs)
             {
-                // The fixed statement maps an empty ReadOnlySpan to nullptr.
                 if (bytes.IsEmpty)
                     return Interop.Errors.ERROR_SUCCESS;
 

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -322,7 +322,6 @@ namespace System.IO.Pipes
             DebugAssertHandleValid(handle);
             Debug.Assert((_isAsync && overlapped != null) || (!_isAsync && overlapped == null), "Async IO parameter screwup in call to ReadFileNative.");
 
-            // The fixed statement maps an empty Span to nullptr.
             // Note that async callers check to avoid calling this first, so they can call user's callback.
             if (buffer.Length == 0)
             {
@@ -360,7 +359,6 @@ namespace System.IO.Pipes
             DebugAssertHandleValid(handle);
             Debug.Assert((_isAsync && overlapped != null) || (!_isAsync && overlapped == null), "Async IO parameter screwup in call to WriteFileNative.");
 
-            // The fixed statement maps an empty ReadOnlySpan to nullptr.
             // Note that async callers check to avoid calling this first, so they can call user's callback.
             if (buffer.Length == 0)
             {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -322,8 +322,8 @@ namespace System.IO.Pipes
             DebugAssertHandleValid(handle);
             Debug.Assert((_isAsync && overlapped != null) || (!_isAsync && overlapped == null), "Async IO parameter screwup in call to ReadFileNative.");
 
-            // You can't use the fixed statement on an array of length 0. Note that async callers
-            // check to avoid calling this first, so they can call user's callback
+            // The fixed statement maps an empty Span to nullptr.
+            // Note that async callers check to avoid calling this first, so they can call user's callback.
             if (buffer.Length == 0)
             {
                 errorCode = 0;
@@ -360,8 +360,8 @@ namespace System.IO.Pipes
             DebugAssertHandleValid(handle);
             Debug.Assert((_isAsync && overlapped != null) || (!_isAsync && overlapped == null), "Async IO parameter screwup in call to WriteFileNative.");
 
-            // You can't use the fixed statement on an array of length 0. Note that async callers
-            // check to avoid calling this first, so they can call user's callback
+            // The fixed statement maps an empty ReadOnlySpan to nullptr.
+            // Note that async callers check to avoid calling this first, so they can call user's callback.
             if (buffer.Length == 0)
             {
                 errorCode = 0;

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1411,7 +1411,6 @@ namespace System.IO.Ports
             if (bytes.Length - offset < count)
                 throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
 
-            // The fixed statement maps an empty array to nullptr.
             if (bytes.Length == 0)
             {
                 hr = 0;
@@ -1461,7 +1460,6 @@ namespace System.IO.Ports
             if (bytes.Length - offset < count)
                 throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
 
-            // The fixed statement maps an empty array to nullptr.
             if (bytes.Length == 0)
             {
                 hr = 0;

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1411,7 +1411,7 @@ namespace System.IO.Ports
             if (bytes.Length - offset < count)
                 throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
 
-            // You can't use the fixed statement on an array of length 0.
+            // The fixed statement maps an empty array to nullptr.
             if (bytes.Length == 0)
             {
                 hr = 0;
@@ -1461,7 +1461,7 @@ namespace System.IO.Ports
             if (bytes.Length - offset < count)
                 throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
 
-            // You can't use the fixed statement on an array of length 0.
+            // The fixed statement maps an empty array to nullptr.
             if (bytes.Length == 0)
             {
                 hr = 0;


### PR DESCRIPTION
Update comments about using fixed statement on an empty array/span.