### PR TITLE
Enable File.Copy to EXFAT volumes when not running as root

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1165,14 +1165,13 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
         while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
 #endif
     }
-    if (ret != 0)
+    if (ret != 0 && errno != EPERM)
     {
         return -1;
     }
-
     // Then copy permissions.
     while ((ret = fchmod(outFd, sourceStat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO))) < 0 && errno == EINTR);
-    if (ret != 0)
+    if (ret != 0 && errno != EPERM)
     {
         return -1;
     }

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1165,13 +1165,17 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
         while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
 #endif
     }
+    // If we copied to a filesystem (eg EXFAT) that does not preserve POSIX ownership, all files appear
+    // to be owned by root. If we aren't running as root, then we won't be an owner of our new file, and 
+    // attempting to copy metadata to it will fail with EPERM. We have copied successfully, we just can't
+    // copy metadata. The best thing we can do is skip copying the metadata.
     if (ret != 0 && errno != EPERM)
     {
         return -1;
     }
     // Then copy permissions.
     while ((ret = fchmod(outFd, sourceStat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO))) < 0 && errno == EINTR);
-    if (ret != 0 && errno != EPERM)
+    if (ret != 0 && errno != EPERM) // See EPERM comment above
     {
         return -1;
     }

--- a/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
@@ -76,6 +76,29 @@ namespace System.IO.ManualTests
             });
         }
 
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        public static void FileCopy_WorksToExFatVolume()
+        {
+            // We copy attributes after copying the file; when copying to EXFAT,
+            // where all files appeared to be owned by root, we can't copy attributes
+            // (unless we're root) and should skip silently
+
+            /* This test requires an EXFAT partition. That can be created in memory like this:
+
+            sudo mkdir /mnt/ramdisk
+            sudo mount -t ramfs ramfs /mnt/ramdisk
+            sudo dd if=/dev/zero of=/mnt/ramdisk/exfat.image bs=1M count=512
+            sudo mkfs.exfat /mnt/ramdisk/exfat.image
+            sudo mkdir /mnt/exfatrd
+            sudo mount -o loop /mnt/ramdisk/exfat.image /mnt/exfatrd
+
+            */
+
+            File.WriteAllText("/mnt/exfatrd/1", "content");
+            File.Copy("/mnt/exfatrd/1", "/mnt/exfatrd/2");
+            Assert.True(File.Exists("/mnt/exfatrd/2"));
+        }
 
         const long InitialFileSize = 1024;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/45730

In File.Copy on Linux, after successfully copying the file we copy over the access and modified time, and copy the access permissions. See #16366 for why this was done: it's because on Windows, CopyFileEx preserves them, and some programs took a dependency on this e.g., for up to dateness checks, and arguably it's always been documented that File.Copy copies 'attributes'.

The problem on exfat volumes is that this file system does not store POSIX ownership; when viewed from Linux, all files appear to be owned by root. When we copy to such a volume, the copy succeeds if we have write permissions, but subsequently setting the timestamps and access permissions fails because (unless running as root) we need to own the file, and only root owns it. This manifests as `System.IO.IOException: Operation not permitted.` even though the file is successfully copied. 

The workaround if you want to copy to an exfat volume on Linux is to either implement File.Copy yourself, or run as root.

The fix is to ignore EPERM when setting the time stamps and permissions. That gives a reasonable outcome, the file is copied in the best way that we can achieve given the filesystem limitations.

Note that "touch" does succeed against files on exfat if you do not supply a time -- the man page for utimensat notes that to set current time only requires write access, to set a specific time requires ownership rights or sufficient privileges (eg., root) -- and on exfat, only root ever has ownership rights. Conceivably we could at least set the current time, therefore, but it's not clear that's an improvement.

I don't think there's a good way to write a test but I tested manually on an exfat volume.