### PR TITLE
Disable tests for 43931 and 46030

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -170,6 +170,7 @@ namespace System.Net.Sockets.Tests
         {
             if (useDnsEndPoint)
             {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/43931")]
                 throw new SkipTestException("https://github.com/dotnet/runtime/issues/43931");
             }
 
@@ -270,6 +271,7 @@ namespace System.Net.Sockets.Tests
         {
             if (useDnsEndPoint)
             {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/46030")]
                 throw new SkipTestException("https://github.com/dotnet/runtime/issues/46030");
             }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -168,6 +168,11 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(SocketMethods_WithBools_MemberData))]
         public void EventSource_SocketConnectFailure_LogsConnectFailed(string connectMethod, bool useDnsEndPoint)
         {
+            if (useDnsEndPoint)
+            {
+                throw new SkipTestException("https://github.com/dotnet/runtime/issues/43931");
+            }
+
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);
@@ -263,6 +268,11 @@ namespace System.Net.Sockets.Tests
         [InlineData("Eap", false)]
         public void EventSource_ConnectAsyncCanceled_LogsConnectFailed(string connectMethod, bool useDnsEndPoint)
         {
+            if (useDnsEndPoint)
+            {
+                throw new SkipTestException("https://github.com/dotnet/runtime/issues/46030");
+            }
+
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);


### PR DESCRIPTION
Disable DNS connect socket tests.

Tracked by #43931, #46030.