### PR TITLE
Fix arm64 apple hfa<float>.

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3655,7 +3655,7 @@ public:
         assert(varDsc->lvType == TYP_SIMD12);
         assert(varDsc->lvExactSize == 12);
 
-#if defined(TARGET_64BIT)
+#if defined(TARGET_64BIT) && !defined(OSX_ARM64_ABI)
         assert(varDsc->lvSize() == 16);
 #endif // defined(TARGET_64BIT)
 

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -341,10 +341,23 @@ unsigned CILJit::getMaxIntrinsicSIMDVectorLength(CORJIT_FLAGS cpuCompileFlags)
 #endif // !FEATURE_SIMD
 }
 
-/*****************************************************************************
- * Returns the number of bytes required for the given type argument
- */
-
+//------------------------------------------------------------------------
+// eeGetArgSize: Returns the number of bytes required for the given type argument
+//   including padding after the actual value.
+//
+// Arguments:
+//   list - the arg list handle pointing to the argument
+//   sig  - the signature for the arg's method
+//
+// Return value:
+//   the number of stack slots in stack arguments for the call.
+//
+// Notes:
+//   - On most platforms arguments are passed with TARGET_POINTER_SIZE alignment,
+//   so all types take an integer number of TARGET_POINTER_SIZE slots.
+//   It is different for arm64 apple that packs some types without alignment and padding.
+//   If the argument is passed by reference then the method returns REF size.
+//
 unsigned Compiler::eeGetArgSize(CORINFO_ARG_LIST_HANDLE list, CORINFO_SIG_INFO* sig)
 {
 #if defined(TARGET_AMD64)
@@ -370,6 +383,10 @@ unsigned Compiler::eeGetArgSize(CORINFO_ARG_LIST_HANDLE list, CORINFO_SIG_INFO* 
     CORINFO_CLASS_HANDLE argClass;
     CorInfoType          argTypeJit = strip(info.compCompHnd->getArgType(sig, list, &argClass));
     var_types            argType    = JITtype2varType(argTypeJit);
+    unsigned             argSize;
+
+    var_types hfaType = GetHfaType(argClass); // set to float or double if it is an HFA, otherwise TYP_UNDEF
+    bool      isHfa   = (hfaType != TYP_UNDEF);
 
     if (varTypeIsStruct(argType))
     {
@@ -395,8 +412,7 @@ unsigned Compiler::eeGetArgSize(CORINFO_ARG_LIST_HANDLE list, CORINFO_SIG_INFO* 
             // Is the struct larger than 16 bytes
             if (structSize > (2 * TARGET_POINTER_SIZE))
             {
-                var_types hfaType = GetHfaType(argClass); // set to float or double if it is an HFA, otherwise TYP_UNDEF
-                bool      isHfa   = (hfaType != TYP_UNDEF);
+
 #ifndef TARGET_UNIX
                 if (info.compIsVarArgs)
                 {
@@ -412,29 +428,59 @@ unsigned Compiler::eeGetArgSize(CORINFO_ARG_LIST_HANDLE list, CORINFO_SIG_INFO* 
                     return TARGET_POINTER_SIZE;
                 }
             }
-            // otherwise will we pass this struct by value in multiple registers
         }
-#elif defined(TARGET_ARM)
-//  otherwise will we pass this struct by value in multiple registers
-#else
+#elif !defined(TARGET_ARM)
         NYI("unknown target");
 #endif // defined(TARGET_XXX)
 #endif // FEATURE_MULTIREG_ARGS
 
-        // we pass this struct by value in multiple registers
-        return roundUp(structSize, TARGET_POINTER_SIZE);
+        // Otherwise we will pass this struct by value in multiple registers/stack bytes.
+        argSize = structSize;
     }
     else
     {
-#if !defined(OSX_ARM64_ABI)
-        unsigned argSize = sizeof(int) * genTypeStSz(argType);
-        argSize = roundUp(argSize, TARGET_POINTER_SIZE);
-#else
-        unsigned argSize = genTypeSize(argType);
-#endif
-        assert(0 < argSize && argSize <= sizeof(__int64));
-        return argSize;
+        argSize = genTypeSize(argType);
     }
+    const unsigned argAlignment       = eeGetArgAlignment(argType, (hfaType == TYP_FLOAT));
+    const unsigned argSizeWithPadding = roundUp(argSize, argAlignment);
+    return argSizeWithPadding;
+
+#endif
+}
+
+//------------------------------------------------------------------------
+// eeGetArgAlignment: Return arg passing alignment for the given type.
+//
+// Arguments:
+//   type - the argument type
+//   isFloatHfa - is it an HFA<float> type
+//
+// Return value:
+//   the required alignment in bytes.
+//
+// Notes:
+//   It currently doesn't return smaller than required alignment for arm32 (4 bytes for double and int64)
+//   but it does not lead to issues because its alignment requirements are satisfied in other code parts.
+//   TODO: fix this function and delete the other code that is handling this.
+//
+// static
+unsigned Compiler::eeGetArgAlignment(var_types type, bool isFloatHfa)
+{
+#if defined(OSX_ARM64_ABI)
+    if (isFloatHfa)
+    {
+        assert(varTypeIsStruct(type));
+        return sizeof(float);
+    }
+    if (varTypeIsStruct(type))
+    {
+        return TARGET_POINTER_SIZE;
+    }
+    const unsigned argSize = genTypeSize(type);
+    assert((0 < argSize) && (argSize <= TARGET_POINTER_SIZE));
+    return argSize;
+#else
+    return TARGET_POINTER_SIZE;
 #endif
 }
 

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -385,11 +385,13 @@ unsigned Compiler::eeGetArgSize(CORINFO_ARG_LIST_HANDLE list, CORINFO_SIG_INFO* 
     var_types            argType    = JITtype2varType(argTypeJit);
     unsigned             argSize;
 
-    var_types hfaType = GetHfaType(argClass); // set to float or double if it is an HFA, otherwise TYP_UNDEF
-    bool      isHfa   = (hfaType != TYP_UNDEF);
+    var_types hfaType = TYP_UNDEF;
+    bool      isHfa   = false;
 
     if (varTypeIsStruct(argType))
     {
+        hfaType             = GetHfaType(argClass);
+        isHfa               = (hfaType != TYP_UNDEF);
         unsigned structSize = info.compCompHnd->getClassSize(argClass);
 
         // make certain the EE passes us back the right thing for refanys

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1079,7 +1079,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
             assert((argSize % TARGET_POINTER_SIZE) == 0);
             assert((varDscInfo->stackArgSize % TARGET_POINTER_SIZE) == 0);
 #endif // !OSX_ARM64_ABI
-            JITDUMP("set user arg V%02u offset to %u\n", varDscInfo->stackArgSize);
+            JITDUMP("set user arg V%02u offset to %u\n", varDscInfo->varNum, varDscInfo->stackArgSize);
             varDsc->SetStackOffset(varDscInfo->stackArgSize);
             varDscInfo->stackArgSize += argSize;
 #endif // FEATURE_FASTTAILCALL

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -622,6 +622,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
         ;
     }
 
+    // Process each user arg.
     for (unsigned i = 0; i < numUserArgs;
          i++, varDscInfo->varNum++, varDscInfo->varDsc++, argLst = info.compCompHnd->getArgNext(argLst))
     {
@@ -642,9 +643,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
         // For ARM, ARM64, and AMD64 varargs, all arguments go in integer registers
         var_types argType = mangleVarArgsType(varDsc->TypeGet());
 
-#ifdef TARGET_ARM
         var_types origArgType = argType;
-#endif // TARGET_ARM
 
         // ARM softfp calling convention should affect only the floating point arguments.
         // Otherwise there appear too many surplus pre-spills and other memory operations
@@ -689,7 +688,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
             // We have an HFA argument, so from here on out treat the type as a float, double, or vector.
             // The orginal struct type is available by using origArgType.
             // We also update the cSlots to be the number of float/double/vector fields in the HFA.
-            argType = hfaType;
+            argType = hfaType; // TODO-Cleanup: remove this asignment and mark `argType` as const.
             varDsc->SetHfaType(hfaType);
             cSlots = varDsc->lvHfaSlots();
         }
@@ -1067,18 +1066,14 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
 #endif // TARGET_XXX
 
 #if FEATURE_FASTTAILCALL
+            const unsigned argAlignment = eeGetArgAlignment(origArgType, (hfaType == TYP_FLOAT));
 #if defined(OSX_ARM64_ABI)
-            unsigned argAlignment = TARGET_POINTER_SIZE;
-            if (argSize <= TARGET_POINTER_SIZE)
-            {
-                argAlignment = argSize;
-            }
             varDscInfo->stackArgSize = roundUp(varDscInfo->stackArgSize, argAlignment);
-            assert(argSize % argAlignment == 0);
-#else  // !OSX_ARM64_ABI
-            assert((argSize % TARGET_POINTER_SIZE) == 0);
-            assert((varDscInfo->stackArgSize % TARGET_POINTER_SIZE) == 0);
-#endif // !OSX_ARM64_ABI
+#endif // OSX_ARM64_ABI
+
+            assert((argSize % argAlignment) == 0);
+            assert((varDscInfo->stackArgSize % argAlignment) == 0);
+
             JITDUMP("set user arg V%02u offset to %u\n", varDscInfo->varNum, varDscInfo->stackArgSize);
             varDsc->SetStackOffset(varDscInfo->stackArgSize);
             varDscInfo->stackArgSize += argSize;
@@ -1111,9 +1106,9 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
             varDsc->lvHasLdAddrOp = 1;
             lvaSetVarAddrExposed(varDscInfo->varNum);
         }
+    }
 
-    } // for each user arg
-    compArgSize = roundUp(compArgSize, TARGET_POINTER_SIZE);
+    compArgSize = GetOutgoingArgByteSize(compArgSize);
 
 #ifdef TARGET_ARM
     if (doubleAlignMask != RBM_NONE)
@@ -3656,6 +3651,46 @@ void LclVarDsc::lvaDisqualifyVar()
 }
 #endif // ASSERTION_PROP
 
+unsigned LclVarDsc::lvSize() const // Size needed for storage representation. Only used for structs or TYP_BLK.
+{
+    // TODO-Review: Sometimes we get called on ARM with HFA struct variables that have been promoted,
+    // where the struct itself is no longer used because all access is via its member fields.
+    // When that happens, the struct is marked as unused and its type has been changed to
+    // TYP_INT (to keep the GC tracking code from looking at it).
+    // See Compiler::raAssignVars() for details. For example:
+    //      N002 (  4,  3) [00EA067C] -------------               return    struct $346
+    //      N001 (  3,  2) [00EA0628] -------------                  lclVar    struct(U) V03 loc2
+    //                                                                        float  V03.f1 (offs=0x00) -> V12 tmp7
+    //                                                                        f8 (last use) (last use) $345
+    // Here, the "struct(U)" shows that the "V03 loc2" variable is unused. Not shown is that V03
+    // is now TYP_INT in the local variable table. It's not really unused, because it's in the tree.
+
+    assert(varTypeIsStruct(lvType) || (lvType == TYP_BLK) || (lvPromoted && lvUnusedStruct));
+
+    if (lvIsParam)
+    {
+        assert(varTypeIsStruct(lvType));
+        const bool     isFloatHfa   = (lvIsHfa() && (GetHfaType() == TYP_FLOAT));
+        const unsigned argAlignment = Compiler::eeGetArgAlignment(lvType, isFloatHfa);
+        return roundUp(lvExactSize, argAlignment);
+    }
+
+#if defined(FEATURE_SIMD) && !defined(TARGET_64BIT)
+    // For 32-bit architectures, we make local variable SIMD12 types 16 bytes instead of just 12. We can't do
+    // this for arguments, which must be passed according the defined ABI. We don't want to do this for
+    // dependently promoted struct fields, but we don't know that here. See lvaMapSimd12ToSimd16().
+    // (Note that for 64-bits, we are already rounding up to 16.)
+    if (lvType == TYP_SIMD12)
+    {
+        assert(!lvIsParam);
+        assert(lvExactSize == 12);
+        return 16;
+    }
+#endif // defined(FEATURE_SIMD) && !defined(TARGET_64BIT)
+
+    return roundUp(lvExactSize, TARGET_POINTER_SIZE);
+}
+
 /**********************************************************************************
 * Get stack size of the varDsc.
 */
@@ -5461,8 +5496,8 @@ void Compiler::lvaAssignVirtualFrameOffsetsToArgs()
     {
         if (!lvaIsPreSpilled(stkLclNum, preSpillMask))
         {
-            argOffs =
-                lvaAssignVirtualFrameOffsetToArg(stkLclNum, eeGetArgSize(argLst, &info.compMethodInfo->args), argOffs);
+            const unsigned argSize = eeGetArgSize(argLst, &info.compMethodInfo->args);
+            argOffs                = lvaAssignVirtualFrameOffsetToArg(stkLclNum, argSize, argOffs);
             argLcls++;
         }
         argLst = info.compCompHnd->getArgNext(argLst);
@@ -5474,11 +5509,9 @@ void Compiler::lvaAssignVirtualFrameOffsetsToArgs()
     {
         unsigned argumentSize = eeGetArgSize(argLst, &info.compMethodInfo->args);
 
-#ifdef UNIX_AMD64_ABI
-        // On the stack frame the homed arg always takes a full number of slots
-        // for proper stack alignment. Make sure the real struct size is properly rounded up.
-        argumentSize = roundUp(argumentSize, TARGET_POINTER_SIZE);
-#endif // UNIX_AMD64_ABI
+#if !defined(OSX_ARM64_ABI)
+        assert(argumentSize % TARGET_POINTER_SIZE == 0);
+#endif // !defined(OSX_ARM64_ABI)
 
         argOffs =
             lvaAssignVirtualFrameOffsetToArg(lclNum++, argumentSize, argOffs UNIX_AMD64_ABI_ONLY_ARG(&callerArgOffset));
@@ -5858,19 +5891,14 @@ int Compiler::lvaAssignVirtualFrameOffsetToArg(unsigned lclNum,
                 break;
         }
 #endif // TARGET_ARM
+        const bool     isFloatHfa   = (varDsc->lvIsHfa() && (varDsc->GetHfaType() == TYP_FLOAT));
+        const unsigned argAlignment = eeGetArgAlignment(varDsc->lvType, isFloatHfa);
 #if defined(OSX_ARM64_ABI)
-        unsigned argAlignment = TARGET_POINTER_SIZE;
-        if (argSize <= TARGET_POINTER_SIZE)
-        {
-            argAlignment = argSize;
-        }
-        argOffs = roundUp(argOffs, argAlignment);
-        assert((argOffs % argAlignment) == 0);
-#else  // !OSX_ARM64_ABI
-        assert((argSize % TARGET_POINTER_SIZE) == 0);
-        assert((argOffs % TARGET_POINTER_SIZE) == 0);
-#endif // !OSX_ARM64_ABI
+        argOffs                     = roundUp(argOffs, argAlignment);
+#endif // OSX_ARM64_ABI
 
+        assert((argSize % argAlignment) == 0);
+        assert((argOffs % argAlignment) == 0);
         varDsc->SetStackOffset(argOffs);
     }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5953,7 +5953,12 @@ void Lowering::CheckNode(Compiler* compiler, GenTree* node)
         {
             unsigned   lclNum = node->AsLclVarCommon()->GetLclNum();
             LclVarDsc* lclVar = &compiler->lvaTable[lclNum];
-            assert(node->TypeGet() != TYP_SIMD12 || compiler->lvaIsFieldOfDependentlyPromotedStruct(lclVar));
+#ifdef DEBUG
+            if (node->TypeIs(TYP_SIMD12))
+            {
+                assert(compiler->lvaIsFieldOfDependentlyPromotedStruct(lclVar) || (lclVar->lvSize() == 12));
+            }
+#endif // DEBUG
         }
         break;
 #endif // TARGET_64BIT


### PR DESCRIPTION
Apple Arm64 does not require struct alignment for HFA<float>, instead, it uses 4-byte stack alignment for this type. Add Jit support for this. Closes https://github.com/dotnet/runtime/issues/45780.

The changes:

0296b35c8f5: A small fix in dump printing.

ac6fada9b3c: Keep the aligned size in `fgArgInfo`.

There were no users that required the exact size, but keeping it required roundings all over the place.
So now both `fgArgInfo` and `GenTreePutArg` keep the align size (with padding after the arg value), but the alignment is different on different platforms.

ee4076f1076: Fix float HFA stack passing.

Apple doesn't require struct alignment for it. 
The main change is introducing `eeGetArgAlignment` that returns alignment for an argument type. I am planning to extend this method soon (see https://github.com/dotnet/runtime/issues/46026).
The second change is fix for `LclVarDsc::lvSize()` so it returns `12` for such variables.

Also, I am trying to use less `#if defined(OSX_ARM64_ABI)` to make https://github.com/dotnet/runtime/issues/45501 easier.

2d87c52d2a0: Fix `lvaMapSimd12ToSimd16` for arm64 apple arguments.

Now when `lvSize` returns `12` for `SIMD12` arguments on arm64 apple we need to fix some asserts that do not expect it.

<details>
  <summary>Fixes 46 tests (including pri1 tests):</summary>

```
JIT/Methodical/explicit/rotate/_dbgrotarg_double/_dbgrotarg_double.sh
JIT/Methodical/explicit/rotate/_opt_dbgrotarg_float/_opt_dbgrotarg_float.sh
JIT/Methodical/explicit/rotate/_opt_dbgrotarg_double/_opt_dbgrotarg_double.sh
JIT/Methodical/explicit/rotate/_il_relrotarg_objref/_il_relrotarg_objref.sh
JIT/jit64/hfa/main/testG/hfa_nd2G_r/hfa_nd2G_r.sh
JIT/jit64/hfa/main/testG/hfa_sd2G_d/hfa_sd2G_d.sh
JIT/jit64/hfa/main/testG/hfa_sd2G_r/hfa_sd2G_r.sh
JIT/jit64/hfa/main/testG/hfa_nd2G_d/hfa_nd2G_d.sh
JIT/jit64/hfa/main/testG/hfa_nf2G_d/hfa_nf2G_d.sh
JIT/jit64/hfa/main/testA/hfa_sf1A_d/hfa_sf1A_d.sh
JIT/jit64/hfa/main/testA/hfa_nf1A_r/hfa_nf1A_r.sh
JIT/jit64/hfa/main/testA/hfa_sf0A_d/hfa_sf0A_d.sh
JIT/jit64/hfa/main/testA/hfa_nf0A_r/hfa_nf0A_r.sh
JIT/jit64/hfa/main/testA/hfa_nf2A_d/hfa_nf2A_d.sh
JIT/jit64/hfa/main/testA/hfa_sf2A_r/hfa_sf2A_r.sh
JIT/jit64/hfa/main/testA/hfa_sd2A_r/hfa_sd2A_r.sh
JIT/jit64/hfa/main/testA/hfa_nd2A_d/hfa_nd2A_d.sh
JIT/jit64/hfa/main/testA/hfa_nf1A_d/hfa_nf1A_d.sh
JIT/jit64/hfa/main/testA/hfa_sf1A_r/hfa_sf1A_r.sh
JIT/jit64/hfa/main/testA/hfa_nf0A_d/hfa_nf0A_d.sh
JIT/jit64/hfa/main/testA/hfa_sf0A_r/hfa_sf0A_r.sh
JIT/jit64/hfa/main/testA/hfa_sf2A_d/hfa_sf2A_d.sh
JIT/jit64/hfa/main/testA/hfa_nf2A_r/hfa_nf2A_r.sh
JIT/jit64/hfa/main/testA/hfa_nd2A_r/hfa_nd2A_r.sh
JIT/jit64/hfa/main/testA/hfa_sd2A_d/hfa_sd2A_d.sh
JIT/jit64/hfa/main/testC/hfa_sf1C_r/hfa_sf1C_r.sh
JIT/jit64/hfa/main/testC/hfa_nf1C_d/hfa_nf1C_d.sh
JIT/jit64/hfa/main/testC/hfa_sf0C_r/hfa_sf0C_r.sh
JIT/jit64/hfa/main/testC/hfa_nf0C_d/hfa_nf0C_d.sh
JIT/jit64/hfa/main/testC/hfa_nf1C_r/hfa_nf1C_r.sh
JIT/jit64/hfa/main/testC/hfa_sf1C_d/hfa_sf1C_d.sh
JIT/jit64/hfa/main/testC/hfa_nf0C_r/hfa_nf0C_r.sh
JIT/jit64/hfa/main/testC/hfa_sf0C_d/hfa_sf0C_d.sh
JIT/jit64/hfa/main/testC/hfa_nf2C_d/hfa_nf2C_d.sh
JIT/jit64/hfa/main/testB/hfa_nf2B_d/hfa_nf2B_d.sh
JIT/jit64/hfa/main/testB/hfa_sf2B_r/hfa_sf2B_r.sh
JIT/jit64/hfa/main/testB/hfa_sd2B_r/hfa_sd2B_r.sh
JIT/jit64/hfa/main/testB/hfa_nd2B_d/hfa_nd2B_d.sh
JIT/jit64/hfa/main/testB/hfa_sf0B_d/hfa_sf0B_d.sh
JIT/jit64/hfa/main/testB/hfa_nf0B_r/hfa_nf0B_r.sh
JIT/jit64/hfa/main/testB/hfa_sf2B_d/hfa_sf2B_d.sh
JIT/jit64/hfa/main/testB/hfa_nf2B_r/hfa_nf2B_r.sh
JIT/jit64/hfa/main/testB/hfa_nd2B_r/hfa_nd2B_r.sh
JIT/jit64/hfa/main/testB/hfa_sd2B_d/hfa_sd2B_d.sh
JIT/jit64/hfa/main/testB/hfa_nf0B_d/hfa_nf0B_d.sh
JIT/jit64/hfa/main/testB/hfa_sf0B_r/hfa_sf0B_r.sh

```

</details>

Note: it does not fully fix 
```
JIT/HardwareIntrinsics/General/Vector128/Vector128_r/Vector128_r.sh
JIT/HardwareIntrinsics/General/Vector128/Vector128_ro/Vector128_ro.sh
JIT/HardwareIntrinsics/General/Vector256/Vector256_r/Vector256_r.sh
JIT/HardwareIntrinsics/General/Vector256/Vector256_ro/Vector256_ro.sh
```
because they are using reflection and additional VM fixes are needed.