### PR TITLE
Compile System.Private.CoreLib with Crossgen2 by default, take 2

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -8,7 +8,7 @@
           AfterTargets="Build">
     <PropertyGroup>
       <!-- Default for using Crossgen2 when not set externally -->
-      <UseCrossgen2 Condition="'$(UseCrossgen2)' == ''">false</UseCrossgen2>
+      <UseCrossgen2 Condition="'$(UseCrossgen2)' == ''">true</UseCrossgen2>
 
       <OSPlatformConfig>$(TargetOS).$(TargetArchitecture).$(Configuration)</OSPlatformConfig>
       <RootBinDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</RootBinDir>


### PR DESCRIPTION
After Bruce's and JanK's fixes I'm no longer able to repro the
previously observed x86 failures in libraries tests locally so I'm
switching back to lab testing; I plan to run several rounds of
PR and outerloop tests to increase my confidence in the change.

Thanks

Tomas

/cc @dotnet/crossgen-contrib