### PR TITLE
Follow-up fix for some PAL tests that compare sleep/wait times from one thread to another

### DIFF
--- a/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
@@ -37,7 +37,7 @@ VOID PALAPI APCFunc_SleepEx_test2(ULONG_PTR dwParam);
 DWORD PALAPI SleeperProc_SleepEx_test2(LPVOID lpParameter);
 
 DWORD ThreadSleepDelta;
-static volatile bool s_preWaitTimestampRecorded = 0;
+static volatile bool s_preWaitTimestampRecorded = false;
 
 PALTEST(threading_SleepEx_test2_paltest_sleepex_test2, "threading/SleepEx/test2/paltest_sleepex_test2")
 {

--- a/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
@@ -106,7 +106,8 @@ void RunTest_SleepEx_test2(BOOL AlertThread)
     DWORD dwThreadId = 0;
     int ret;
 
-    hThread = CreateThread( NULL, 
+    s_preWaitTimestampRecorded = false;
+    hThread = CreateThread( NULL,
                             0, 
                             (LPTHREAD_START_ROUTINE)SleeperProc_SleepEx_test2,
                             (LPVOID) AlertThread,

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
@@ -26,7 +26,7 @@ VOID PALAPI APCFunc_WFMO_test2(ULONG_PTR dwParam);
 DWORD PALAPI WaiterProc_WFMO_test2(LPVOID lpParameter);
 
 DWORD ThreadWaitDelta_WFMO_test2;
-static volatile bool s_preWaitTimestampRecorded = 0;
+static volatile bool s_preWaitTimestampRecorded = false;
 
 PALTEST(threading_WaitForMultipleObjectsEx_test2_paltest_waitformultipleobjectsex_test2, "threading/WaitForMultipleObjectsEx/test2/paltest_waitformultipleobjectsex_test2")
 {

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
@@ -93,6 +93,7 @@ void RunTest_WFMO_test2(BOOL AlertThread)
     DWORD dwThreadId = 0;
     int ret;
 
+    s_preWaitTimestampRecorded = false;
     hThread = CreateThread( NULL,
                             0,
                             (LPTHREAD_START_ROUTINE)WaiterProc_WFMO_test2,

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
@@ -26,7 +26,7 @@ DWORD PALAPI WaiterProc_WFSOExMutexTest(LPVOID lpParameter);
 
 DWORD ThreadWaitDelta_WFSOExMutexTest;
 HANDLE hMutex_WFSOExMutexTest;
-static volatile bool s_preWaitTimestampRecorded = 0;
+static volatile bool s_preWaitTimestampRecorded = false;
 
 PALTEST(threading_WaitForSingleObject_WFSOExMutexTest_paltest_waitforsingleobject_wfsoexmutextest, "threading/WaitForSingleObject/WFSOExMutexTest/paltest_waitforsingleobject_wfsoexmutextest")
 {

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
@@ -122,7 +122,8 @@ void RunTest_WFSOExMutexTest(BOOL AlertThread)
 
 	int ret=0;
 
-    hThread = CreateThread( NULL, 
+    s_preWaitTimestampRecorded = false;
+    hThread = CreateThread( NULL,
                             0, 
                             (LPTHREAD_START_ROUTINE)WaiterProc_WFSOExMutexTest,
                             (LPVOID) AlertThread,

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
@@ -25,7 +25,7 @@ VOID PALAPI APCFunc_WFSOExSemaphoreTest(ULONG_PTR dwParam);
 DWORD PALAPI WaiterProc_WFSOExSemaphoreTest(LPVOID lpParameter);
 
 DWORD ThreadWaitDelta_WFSOExSemaphoreTest;
-static volatile bool s_preWaitTimestampRecorded = 0;
+static volatile bool s_preWaitTimestampRecorded = false;
 
 PALTEST(threading_WaitForSingleObject_WFSOExSemaphoreTest_paltest_waitforsingleobject_wfsoexsemaphoretest, "threading/WaitForSingleObject/WFSOExSemaphoreTest/paltest_waitforsingleobject_wfsoexsemaphoretest")
 {

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
@@ -80,6 +80,7 @@ void RunTest_WFSOExSemaphoreTest(BOOL AlertThread)
     DWORD dwThreadId = 0;
     int ret;
 
+    s_preWaitTimestampRecorded = false;
     hThread = CreateThread( NULL,
                             0,
                             (LPTHREAD_START_ROUTINE)WaiterProc_WFSOExSemaphoreTest,

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
@@ -81,8 +81,9 @@ void RunTest_WFSOExThreadTest(BOOL AlertThread)
     DWORD dwThreadId = 0;
     int ret;
 
-   //Create thread  
-   hThread = CreateThread( NULL, 
+    //Create thread  
+    s_preWaitTimestampRecorded = false;
+    hThread = CreateThread( NULL,
                             0, 
                             (LPTHREAD_START_ROUTINE)WaiterProc_WFSOExThreadTest,
                             (LPVOID) AlertThread,

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
@@ -26,7 +26,7 @@ DWORD PALAPI WaiterProc_WFSOExThreadTest(LPVOID lpParameter);
 void WorkerThread_WFSOExThreadTest(void);
 
 int ThreadWaitDelta_WFSOExThreadTest;
-static volatile bool s_preWaitTimestampRecorded = 0;
+static volatile bool s_preWaitTimestampRecorded = false;
 
 PALTEST(threading_WaitForSingleObject_WFSOExThreadTest_paltest_waitforsingleobject_wfsoexthreadtest, "threading/WaitForSingleObject/WFSOExThreadTest/paltest_waitforsingleobject_wfsoexthreadtest")
 {


### PR DESCRIPTION
Follow-up fix to https://github.com/dotnet/runtime/pull/45948, need to reset the global variable before creating the thread, as the test runs more than once