### PR TITLE
Fix crossgen2 of Vector<T> while AbiStable set

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1036,6 +1036,10 @@ namespace Internal.JitInterface
                 if (owningDefType != null && VectorOfTFieldLayoutAlgorithm.IsVectorOfTType(owningDefType))
                 {
                     VerifyMethodSignatureIsStable(method.Signature);
+                    if (!owningDefType.LayoutAbiStable)
+                    {
+                        throw new RequiresRuntimeJitException("This type layout is unstable");
+                    }
                 }
             }
 #endif

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1035,7 +1035,7 @@ namespace Internal.JitInterface
                 DefType owningDefType = method.OwningType as DefType;
                 if (owningDefType != null && VectorOfTFieldLayoutAlgorithm.IsVectorOfTType(owningDefType))
                 {
-                    throw new RequiresRuntimeJitException("This function is using SIMD intrinsics, their size is machine specific");
+                    VerifyMethodSignatureIsStable(method.Signature);
                 }
             }
 #endif

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -157,7 +157,7 @@ namespace ILCompiler
         public override ComputedInstanceFieldLayout ComputeInstanceLayout(DefType type, InstanceLayoutKind layoutKind)
         {
             DefType similarSpecifiedVector = GetSimilarVector(type);
-            if (similarSpecifiedVector == null)
+            if (similarSpecifiedVector == null && !_vectorAbiIsStable)
             {
                 List<FieldAndOffset> fieldsAndOffsets = new List<FieldAndOffset>();
                 foreach (FieldDesc field in type.GetFields())
@@ -175,6 +175,20 @@ namespace ILCompiler
                     ByteCountAlignment = LayoutInt.Indeterminate,
                     Offsets = fieldsAndOffsets.ToArray(),
                     LayoutAbiStable = false,
+                };
+                return instanceLayout;
+            }
+            else if (similarSpecifiedVector == null && _vectorAbiIsStable)
+            {
+                ComputedInstanceFieldLayout layoutFromMetadata = _fallbackAlgorithm.ComputeInstanceLayout(type, layoutKind);
+                ComputedInstanceFieldLayout instanceLayout = new ComputedInstanceFieldLayout()
+                {
+                    ByteCountUnaligned = layoutFromMetadata.ByteCountUnaligned,
+                    ByteCountAlignment = layoutFromMetadata.ByteCountAlignment,
+                    FieldAlignment = layoutFromMetadata.FieldAlignment,
+                    FieldSize = layoutFromMetadata.FieldSize,
+                    Offsets = layoutFromMetadata.Offsets,
+                    LayoutAbiStable = _vectorAbiIsStable,
                 };
                 return instanceLayout;
             }


### PR DESCRIPTION
Methods `Vector<T>` aot compilation should perform after #40820. I don't exactly know how to count `instanceLayout`, question #45794, made it with `_fallbackAlgorithm.ComputeInstanceLayout()`.
First two points from #44948 conncted to `Vector<T>` methods should be fixed by this PR.

[calculator_vector_aggressivedel.nettrace.txt](https://github.com/dotnet/runtime/files/5696091/calculator_vector_aggressivedel.nettrace.txt)

cc @davidwrighton @jkotas @alpencolt 

Signed-off-by: Timur <t.mustafin@partner.samsung.com>