### PR TITLE
Add property to disable building all libs packages

### DIFF
--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
     <AdditionalBuildTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalBuildTargetFrameworks);package-$(Configuration)</AdditionalBuildTargetFrameworks>
+    <BuildAllPackages Condition="'$(BuildAllOOBPackages)' == ''">true</BuildAllPackages>
+    <BuildAllOOBPackages Condition="'$(BuildAllOOBPackages)' == '' and '$(BuildAllPackages)' != 'true'">false</BuildAllOOBPackages>
     <BuildAllOOBPackages Condition="'$(BuildAllOOBPackages)' == ''">true</BuildAllOOBPackages>
   </PropertyGroup>
   
@@ -15,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" />
+    <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" Condition="'$(BuildAllPackages)' == 'true'" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\**\*.pkgproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
   </ItemGroup>


### PR DESCRIPTION
Contributes towards: https://github.com/dotnet/runtimelab/issues/465

There are certain experiments in `dotnet/runtimelab` that don't need to build any libraries packages, we currently only offered a hook to disabled OOB packages.

cc: @jkotas 