### PR TITLE
Remove extraneous UsingTask

### DIFF
--- a/src/installer/tests/PrepareTestAssets/PrepareTestAssets.proj
+++ b/src/installer/tests/PrepareTestAssets/PrepareTestAssets.proj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <UsingTask TaskName="CopyNupkgAndChangeVersion" AssemblyFile="$(InstallerTasksAssemblyPath)" />
-
   <Target Name="PrepareTestAssets"
           DependsOnTargets="
             GetNETCoreAppRuntimePackVersion;


### PR DESCRIPTION
We no longer use the CopyNupkgAndChangeVersion task, so we can remove it.