### PR TITLE
Add option to ignore reference cycles on serialization

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -559,6 +559,7 @@ namespace System.Text.Json.Serialization
     {
         protected ReferenceHandler() { }
         public static System.Text.Json.Serialization.ReferenceHandler Preserve { get { throw null; } }
+        public static System.Text.Json.Serialization.ReferenceHandler IgnoreCycle { get { throw null; } }
         public abstract System.Text.Json.Serialization.ReferenceResolver CreateResolver();
     }
     public sealed partial class ReferenceHandler<T> : System.Text.Json.Serialization.ReferenceHandler where T : System.Text.Json.Serialization.ReferenceResolver, new()

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -559,7 +559,7 @@ namespace System.Text.Json.Serialization
     {
         protected ReferenceHandler() { }
         public static System.Text.Json.Serialization.ReferenceHandler Preserve { get { throw null; } }
-        public static System.Text.Json.Serialization.ReferenceHandler IgnoreCycle { get { throw null; } }
+        public static System.Text.Json.Serialization.ReferenceHandler IgnoreCycles { get { throw null; } }
         public abstract System.Text.Json.Serialization.ReferenceResolver CreateResolver();
     }
     public sealed partial class ReferenceHandler<T> : System.Text.Json.Serialization.ReferenceHandler where T : System.Text.Json.Serialization.ReferenceResolver, new()

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -64,6 +64,8 @@
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIncludeAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonNumberHandlingAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyNameAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\IgnoreReferenceResolver.cs" />
+    <Compile Include="System\Text\Json\Serialization\ReferenceEqualsWrapper.cs" />
     <Compile Include="System\Text\Json\Serialization\ClassType.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterList.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ArrayConverter.cs" />
@@ -128,6 +130,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt64Converter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UriConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\VersionConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\IgnoreReferenceHandler.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonCamelCaseNamingPolicy.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonClassInfo.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonClassInfo.Cache.cs" />

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -177,6 +177,7 @@
     <Compile Include="System\Text\Json\Serialization\ReadStackFrame.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceHandler.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceHandlerOfT.cs" />
+    <Compile Include="System\Text\Json\Serialization\ReferenceHandlingStrategy.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceResolver.cs" />
     <Compile Include="System\Text\Json\Serialization\ReflectionEmitMemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\ReflectionMemberAccessor.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -133,7 +133,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 // Handle the metadata properties.
-                bool preserveReferences = options.ReferenceHandler != null;
+                bool preserveReferences = JsonSerializer.IsPreserveReferencesEnabled(options);
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
                     if (JsonSerializer.ResolveMetadataForJsonObject<TCollection>(ref reader, ref state, options))
@@ -272,8 +272,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 state.Current.ProcessedStartToken = true;
                 writer.WriteStartObject();
-
-                if (options.ReferenceHandler != null)
+                if (JsonSerializer.IsPreserveReferencesEnabled(options))
                 {
                     if (JsonSerializer.WriteReferenceForObject(this, dictionary, ref state, writer) == MetadataPropertyName.Ref)
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -133,7 +133,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 // Handle the metadata properties.
-                bool preserveReferences = JsonSerializer.IsPreserveReferencesEnabled(options);
+                bool preserveReferences = options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve;
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
                     if (JsonSerializer.ResolveMetadataForJsonObject<TCollection>(ref reader, ref state, options))
@@ -272,7 +272,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 state.Current.ProcessedStartToken = true;
                 writer.WriteStartObject();
-                if (JsonSerializer.IsPreserveReferencesEnabled(options))
+                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
                 {
                     if (JsonSerializer.WriteReferenceForObject(this, dictionary, ref state, writer) == MetadataPropertyName.Ref)
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -249,7 +249,6 @@ namespace System.Text.Json.Serialization.Converters
                     else
                     {
                         writer.WriteStartArray();
-
                     }
 
                     state.Current.DeclaredJsonPropertyInfo = state.Current.JsonClassInfo.ElementClassInfo!.PropertyInfoForClassInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -90,7 +90,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 // Slower path that supports continuation and preserved references.
 
-                bool preserveReferences = options.ReferenceHandler != null;
+                bool preserveReferences = JsonSerializer.IsPreserveReferencesEnabled(options);
                 if (state.Current.ObjectState == StackFrameObjectState.None)
                 {
                     if (reader.TokenType == JsonTokenType.StartArray)
@@ -236,12 +236,7 @@ namespace System.Text.Json.Serialization.Converters
                 if (!state.Current.ProcessedStartToken)
                 {
                     state.Current.ProcessedStartToken = true;
-
-                    if (options.ReferenceHandler == null)
-                    {
-                        writer.WriteStartArray();
-                    }
-                    else
+                    if (JsonSerializer.IsPreserveReferencesEnabled(options))
                     {
                         MetadataPropertyName metadata = JsonSerializer.WriteReferenceForCollection(this, value, ref state, writer);
                         if (metadata == MetadataPropertyName.Ref)
@@ -250,6 +245,11 @@ namespace System.Text.Json.Serialization.Converters
                         }
 
                         state.Current.MetadataPropertyName = metadata;
+                    }
+                    else
+                    {
+                        writer.WriteStartArray();
+
                     }
 
                     state.Current.DeclaredJsonPropertyInfo = state.Current.JsonClassInfo.ElementClassInfo!.PropertyInfoForClassInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -90,7 +90,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 // Slower path that supports continuation and preserved references.
 
-                bool preserveReferences = JsonSerializer.IsPreserveReferencesEnabled(options);
+                bool preserveReferences = options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve;
                 if (state.Current.ObjectState == StackFrameObjectState.None)
                 {
                     if (reader.TokenType == JsonTokenType.StartArray)
@@ -236,7 +236,7 @@ namespace System.Text.Json.Serialization.Converters
                 if (!state.Current.ProcessedStartToken)
                 {
                     state.Current.ProcessedStartToken = true;
-                    if (JsonSerializer.IsPreserveReferencesEnabled(options))
+                    if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
                     {
                         MetadataPropertyName metadata = JsonSerializer.WriteReferenceForCollection(this, value, ref state, writer);
                         if (metadata == MetadataPropertyName.Ref)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -75,7 +75,7 @@ namespace System.Text.Json.Serialization.Converters
                 // Handle the metadata properties.
                 if (state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.IsPreserveReferencesEnabled(options))
+                    if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
                     {
                         if (JsonSerializer.ResolveMetadataForJsonObject<T>(ref reader, ref state, options))
                         {
@@ -233,7 +233,7 @@ namespace System.Text.Json.Serialization.Converters
             if (!state.SupportContinuation)
             {
                 writer.WriteStartObject();
-                if (JsonSerializer.IsPreserveReferencesEnabled(options))
+                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
                 {
                     if (JsonSerializer.WriteReferenceForObject(this, objectValue, ref state, writer) == MetadataPropertyName.Ref)
                     {
@@ -288,7 +288,7 @@ namespace System.Text.Json.Serialization.Converters
                 if (!state.Current.ProcessedStartToken)
                 {
                     writer.WriteStartObject();
-                    if (JsonSerializer.IsPreserveReferencesEnabled(options))
+                    if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
                     {
                         if (JsonSerializer.WriteReferenceForObject(this, objectValue, ref state, writer) == MetadataPropertyName.Ref)
                         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -75,7 +75,7 @@ namespace System.Text.Json.Serialization.Converters
                 // Handle the metadata properties.
                 if (state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (options.ReferenceHandler != null)
+                    if (JsonSerializer.IsPreserveReferencesEnabled(options))
                     {
                         if (JsonSerializer.ResolveMetadataForJsonObject<T>(ref reader, ref state, options))
                         {
@@ -233,8 +233,7 @@ namespace System.Text.Json.Serialization.Converters
             if (!state.SupportContinuation)
             {
                 writer.WriteStartObject();
-
-                if (options.ReferenceHandler != null)
+                if (JsonSerializer.IsPreserveReferencesEnabled(options))
                 {
                     if (JsonSerializer.WriteReferenceForObject(this, objectValue, ref state, writer) == MetadataPropertyName.Ref)
                     {
@@ -289,8 +288,7 @@ namespace System.Text.Json.Serialization.Converters
                 if (!state.Current.ProcessedStartToken)
                 {
                     writer.WriteStartObject();
-
-                    if (options.ReferenceHandler != null)
+                    if (JsonSerializer.IsPreserveReferencesEnabled(options))
                     {
                         if (JsonSerializer.WriteReferenceForObject(this, objectValue, ref state, writer) == MetadataPropertyName.Ref)
                         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceHandler.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    internal sealed class IgnoreReferenceHandler : ReferenceHandler
+    {
+        public IgnoreReferenceHandler() => UsePreserveSemantics = false;
+
+        public override ReferenceResolver CreateResolver() => new IgnoreReferenceResolver();
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceHandler.cs
@@ -5,7 +5,7 @@ namespace System.Text.Json.Serialization
 {
     internal sealed class IgnoreReferenceHandler : ReferenceHandler
     {
-        public IgnoreReferenceHandler() => UsePreserveSemantics = false;
+        public IgnoreReferenceHandler() => HandlingStrategy = ReferenceHandlingStrategy.IgnoreCycle;
 
         public override ReferenceResolver CreateResolver() => new IgnoreReferenceResolver();
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceHandler.cs
@@ -5,7 +5,7 @@ namespace System.Text.Json.Serialization
 {
     internal sealed class IgnoreReferenceHandler : ReferenceHandler
     {
-        public IgnoreReferenceHandler() => HandlingStrategy = ReferenceHandlingStrategy.IgnoreCycle;
+        public IgnoreReferenceHandler() => HandlingStrategy = ReferenceHandlingStrategy.IgnoreCycles;
 
         public override ReferenceResolver CreateResolver() => new IgnoreReferenceResolver();
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceResolver.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.Json.Serialization
+{
+    internal sealed class IgnoreReferenceResolver : ReferenceResolver
+    {
+        // The stack of references on the branch of the current object graph, used to detect reference cycles.
+        private Stack<ReferenceEqualsWrapper>? _stackForCycleDetection;
+
+        internal override void PopReferenceForCycleDetection()
+        {
+            if (_stackForCycleDetection != null)
+            {
+                _stackForCycleDetection.Pop();
+            }
+        }
+
+        internal override bool ContainsReferenceForCycleDetection(object value)
+            => _stackForCycleDetection?.Contains(new ReferenceEqualsWrapper(value)) ?? false;
+
+        internal override void PushReferenceForCycleDetection(object value)
+        {
+            var wrappedValue = new ReferenceEqualsWrapper(value);
+
+            if (_stackForCycleDetection is null)
+            {
+                _stackForCycleDetection = new Stack<ReferenceEqualsWrapper>();
+            }
+
+            Debug.Assert(!_stackForCycleDetection.Contains(wrappedValue));
+            _stackForCycleDetection.Push(wrappedValue);
+        }
+
+        public override void AddReference(string referenceId, object value) => throw new InvalidOperationException();
+        public override string GetReference(object value, out bool alreadyExists) => throw new InvalidOperationException();
+        public override object ResolveReference(string referenceId) => throw new InvalidOperationException();
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IgnoreReferenceResolver.cs
@@ -13,10 +13,8 @@ namespace System.Text.Json.Serialization
 
         internal override void PopReferenceForCycleDetection()
         {
-            if (_stackForCycleDetection != null)
-            {
-                _stackForCycleDetection.Pop();
-            }
+            Debug.Assert(_stackForCycleDetection != null);
+            _stackForCycleDetection.Pop();
         }
 
         internal override bool ContainsReferenceForCycleDetection(object value)
@@ -36,7 +34,9 @@ namespace System.Text.Json.Serialization
         }
 
         public override void AddReference(string referenceId, object value) => throw new InvalidOperationException();
+
         public override string GetReference(object value, out bool alreadyExists) => throw new InvalidOperationException();
+
         public override object ResolveReference(string referenceId) => throw new InvalidOperationException();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json.Serialization
                 }
 
                 // Root object is a boxed value type, we need to push it to the reference stack before it gets unboxed here.
-                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycle && value != null)
+                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles && value != null)
                 {
                     state.ReferenceResolver.PushReferenceForCycleDetection(value);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
@@ -17,6 +17,14 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(TypeToConvert);
             }
 
+            // Root object is a boxed value type.
+            // Since value types are ignored when detecting cycles
+            // We need to push it before it gets unboxed.
+            if (value != null && IsValueType && JsonSerializer.IsIgnoreCyclesEnabled(options))
+            {
+                state.ReferenceResolver.PushReferenceForCycleDetection(value);
+            }
+
             T actualValue = (T)value!;
             return WriteCore(writer, actualValue, options, ref state);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json.Serialization
                 }
 
                 // Root object is a boxed value type, we need to push it to the reference stack before it gets unboxed here.
-                if (value != null && JsonSerializer.IsIgnoreCyclesEnabled(options))
+                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycle && value != null)
                 {
                     state.ReferenceResolver.PushReferenceForCycleDetection(value);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
@@ -11,18 +11,19 @@ namespace System.Text.Json.Serialization
             JsonSerializerOptions options,
             ref WriteStack state)
         {
-            // Value types can never have a null except for Nullable<T>.
-            if (value == null && IsValueType && Nullable.GetUnderlyingType(TypeToConvert) == null)
+            if (IsValueType)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(TypeToConvert);
-            }
+                // Value types can never have a null except for Nullable<T>.
+                if (value == null && Nullable.GetUnderlyingType(TypeToConvert) == null)
+                {
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(TypeToConvert);
+                }
 
-            // Root object is a boxed value type.
-            // Since value types are ignored when detecting cycles
-            // We need to push it before it gets unboxed.
-            if (value != null && IsValueType && JsonSerializer.IsIgnoreCyclesEnabled(options))
-            {
-                state.ReferenceResolver.PushReferenceForCycleDetection(value);
+                // Root object is a boxed value type, we need to push it to the reference stack before it gets unboxed here.
+                if (value != null && JsonSerializer.IsIgnoreCyclesEnabled(options))
+                {
+                    state.ReferenceResolver.PushReferenceForCycleDetection(value);
+                }
             }
 
             T actualValue = (T)value!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -323,7 +323,8 @@ namespace System.Text.Json.Serialization
                     writer.WriteNullValue();
                     return true;
                 }
-                // For boxed reference types: do not push when boxed in order to avoid false positives when we run above check for the converter of the unboxed value.
+                // For boxed reference types: do not push when boxed in order to avoid false positives
+                //   when we run the ContainsReferenceForCycleDetection check for the converter of the unboxed value.
                 if (!CanBePolymorphic)
                 {
                     resolver.PushReferenceForCycleDetection(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -320,7 +320,7 @@ namespace System.Text.Json.Serialization
             {
                 ReferenceResolver resolver = state.ReferenceResolver;
                 // Write null to break reference cycles.
-                if (resolver.ContainsReferenceForCycleDetection(value))
+                if (resolver.ContainsReferenceForCycleDetection(value!))
                 {
                     writer.WriteNullValue();
                     return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -313,7 +313,7 @@ namespace System.Text.Json.Serialization
             }
 
             bool ignoreCyclesPopReference = false;
-            if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycle &&
+            if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
                 !IsValueType && !IsNull(value))
             {
                 ReferenceResolver resolver = state.ReferenceResolver;
@@ -362,7 +362,7 @@ namespace System.Text.Json.Serialization
                     JsonConverter jsonConverter = state.Current.InitializeReEntry(type, options);
                     if (jsonConverter != this)
                     {
-                        if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycle &&
+                        if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
                             jsonConverter.IsValueType)
                         {
                             // For boxed value types: push the value before it gets unboxed on TryWriteAsObject.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -316,13 +316,16 @@ namespace System.Text.Json.Serialization
             if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
                 !IsValueType && !IsNull(value))
             {
+                Debug.Assert(value != null);
                 ReferenceResolver resolver = state.ReferenceResolver;
+
                 // Write null to break reference cycles.
-                if (resolver.ContainsReferenceForCycleDetection(value!))
+                if (resolver.ContainsReferenceForCycleDetection(value))
                 {
                     writer.WriteNullValue();
                     return true;
                 }
+
                 // For boxed reference types: do not push when boxed in order to avoid false positives
                 //   when we run the ContainsReferenceForCycleDetection check for the converter of the unboxed value.
                 if (!CanBePolymorphic)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -138,8 +138,9 @@ namespace System.Text.Json
         {
             T value = Get!(obj);
 
-            if (JsonSerializer.IsIgnoreCyclesEnabled(Options) && !Converter.IsValueType &&
-                value != null && state.ReferenceResolver.ContainsReferenceForCycleDetection(value))
+            if (Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycle &&
+                !Converter.IsValueType && value != null &&
+                state.ReferenceResolver.ContainsReferenceForCycleDetection(value))
             {
                 // If a reference cycle is detected, treat value as null.
                 value = default!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -138,7 +138,7 @@ namespace System.Text.Json
         {
             T value = Get!(obj);
 
-            if (Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycle &&
+            if (Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
                 !Converter.IsValueType && value != null &&
                 state.ReferenceResolver.ContainsReferenceForCycleDetection(value))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -138,6 +138,14 @@ namespace System.Text.Json
         {
             T value = Get!(obj);
 
+            if (JsonSerializer.IsIgnoreCyclesEnabled(Options) && !Converter.IsValueType &&
+                value != null && state.ReferenceResolver.ContainsReferenceForCycleDetection(value))
+            {
+                // If a reference cycle is detected, treat value as null.
+                value = default!;
+                Debug.Assert(value == null);
+            }
+
             if (IgnoreDefaultValuesOnWrite)
             {
                 // If value is null, it is a reference type or nullable<T>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -79,7 +79,7 @@ namespace System.Text.Json
                 unescapedPropertyName = propertyName;
             }
 
-            if (JsonSerializer.IsPreserveReferencesEnabled(options))
+            if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
             {
                 if (propertyName.Length > 0 && propertyName[0] == '$')
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -79,7 +79,7 @@ namespace System.Text.Json
                 unescapedPropertyName = propertyName;
             }
 
-            if (options.ReferenceHandler != null)
+            if (JsonSerializer.IsPreserveReferencesEnabled(options))
             {
                 if (propertyName.Length > 0 && propertyName[0] == '$')
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -84,11 +84,5 @@ namespace System.Text.Json
 
             return writtenMetadataName;
         }
-
-        internal static bool IsPreserveReferencesEnabled(JsonSerializerOptions options)
-            => options.ReferenceHandler?.UsePreserveSemantics ?? false;
-
-        internal static bool IsIgnoreCyclesEnabled(JsonSerializerOptions options)
-            => !options.ReferenceHandler?.UsePreserveSemantics ?? false;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -84,5 +84,11 @@ namespace System.Text.Json
 
             return writtenMetadataName;
         }
+
+        internal static bool IsPreserveReferencesEnabled(JsonSerializerOptions options)
+            => options.ReferenceHandler?.UsePreserveSemantics ?? false;
+
+        internal static bool IsIgnoreCyclesEnabled(JsonSerializerOptions options)
+            => !options.ReferenceHandler?.UsePreserveSemantics ?? false;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -492,7 +492,7 @@ namespace System.Text.Json
             }
         }
 
-        // The cached value used to determine if ReferenceHandler should use Preserve or IgnoreCycle semanitcs or None of them.
+        // The cached value used to determine if ReferenceHandler should use Preserve or IgnoreCycles semanitcs or None of them.
         internal ReferenceHandlingStrategy ReferenceHandlingStrategy = ReferenceHandlingStrategy.None;
 
         internal MemberAccessor MemberAccessorStrategy

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -89,6 +89,7 @@ namespace System.Text.Json
 
             Converters = new ConverterList(this, (ConverterList)options.Converters);
             EffectiveMaxDepth = options.EffectiveMaxDepth;
+            ReferenceHandlingStrategy = options.ReferenceHandlingStrategy;
 
             // _classes is not copied as sharing the JsonClassInfo and JsonPropertyInfo caches can result in
             // unnecessary references to type metadata, potentially hindering garbage collection on the source options.
@@ -487,8 +488,12 @@ namespace System.Text.Json
             {
                 VerifyMutable();
                 _referenceHandler = value;
+                ReferenceHandlingStrategy = value?.HandlingStrategy ?? ReferenceHandlingStrategy.None;
             }
         }
+
+        // The cached value used to determine if ReferenceHandler should use Preserve or IgnoreCycle semanitcs or None of them.
+        internal ReferenceHandlingStrategy ReferenceHandlingStrategy = ReferenceHandlingStrategy.None;
 
         internal MemberAccessor MemberAccessorStrategy
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -89,7 +89,7 @@ namespace System.Text.Json
 
             Current.NumberHandling = Current.JsonPropertyInfo.NumberHandling;
 
-            bool preserveReferences = options.ReferenceHandler != null;
+            bool preserveReferences = JsonSerializer.IsPreserveReferencesEnabled(options);
             if (preserveReferences)
             {
                 ReferenceResolver = options.ReferenceHandler!.CreateResolver(writing: false);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -89,7 +89,7 @@ namespace System.Text.Json
 
             Current.NumberHandling = Current.JsonPropertyInfo.NumberHandling;
 
-            bool preserveReferences = JsonSerializer.IsPreserveReferencesEnabled(options);
+            bool preserveReferences = options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve;
             if (preserveReferences)
             {
                 ReferenceResolver = options.ReferenceHandler!.CreateResolver(writing: false);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceEqualsWrapper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceEqualsWrapper.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Json.Serialization
+{
+    internal struct ReferenceEqualsWrapper : IEquatable<ReferenceEqualsWrapper>
+    {
+        private object _object;
+        public ReferenceEqualsWrapper(object obj) => _object = obj;
+        public override bool Equals(object? obj) => obj is ReferenceEqualsWrapper otherObj && Equals(otherObj);
+        public bool Equals(ReferenceEqualsWrapper obj) => ReferenceEquals(_object, obj._object);
+        public override int GetHashCode() => RuntimeHelpers.GetHashCode(_object);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization
     public abstract class ReferenceHandler
     {
         /// <summary>
-        /// Indicates whether this ReferenceHandler implementation should use <see cref="ReferenceHandlingStrategy.Preserve"/> semantics or <see cref="ReferenceHandlingStrategy.IgnoreCycle"/> semantics.
+        /// Indicates whether this ReferenceHandler implementation should use <see cref="ReferenceHandlingStrategy.Preserve"/> semantics or <see cref="ReferenceHandlingStrategy.IgnoreCycles"/> semantics.
         /// The defualt is Preserve.
         /// </summary>
         internal ReferenceHandlingStrategy HandlingStrategy = ReferenceHandlingStrategy.Preserve;
@@ -48,7 +48,7 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// Ignores an object when a reference cycle is detected during serialization.
         /// </summary>
-        public static ReferenceHandler IgnoreCycle { get; } = new IgnoreReferenceHandler();
+        public static ReferenceHandler IgnoreCycles { get; } = new IgnoreReferenceHandler();
 
         /// <summary>
         /// Returns the <see cref="ReferenceResolver "/> used for each serialization call.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
@@ -11,6 +11,11 @@ namespace System.Text.Json.Serialization
     public abstract class ReferenceHandler
     {
         /// <summary>
+        /// Whether we read and write preserve references or we ignore references when writing.
+        /// </summary>
+        internal bool UsePreserveSemantics = true;
+
+        /// <summary>
         /// Metadata properties will be honored when deserializing JSON objects and arrays into reference types and written when serializing reference types. This is necessary to create round-trippable JSON from objects that contain cycles or duplicate references.
         /// </summary>
         /// <remarks>
@@ -38,6 +43,11 @@ namespace System.Text.Json.Serialization
         /// If the JSON is not well-formed, a <see cref="JsonException"/> is thrown.
         /// </remarks>
         public static ReferenceHandler Preserve { get; } = new PreserveReferenceHandler();
+
+        /// <summary>
+        /// Ignores an object when a reference cycle is detected during serialization.
+        /// </summary>
+        public static ReferenceHandler IgnoreCycle { get; } = new IgnoreReferenceHandler();
 
         /// <summary>
         /// Returns the <see cref="ReferenceResolver "/> used for each serialization call.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
@@ -11,9 +11,10 @@ namespace System.Text.Json.Serialization
     public abstract class ReferenceHandler
     {
         /// <summary>
-        /// Whether we read and write preserve references or we ignore references when writing.
+        /// One of the enumeration values that indicates whether this ReferenceHandler implementation should use Preserve semantics or IgnoreCycle semantics.
+        /// The defualt is Preserve.
         /// </summary>
-        internal bool UsePreserveSemantics = true;
+        internal ReferenceHandlingStrategy HandlingStrategy = ReferenceHandlingStrategy.Preserve;
 
         /// <summary>
         /// Metadata properties will be honored when deserializing JSON objects and arrays into reference types and written when serializing reference types. This is necessary to create round-trippable JSON from objects that contain cycles or duplicate references.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandler.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization
     public abstract class ReferenceHandler
     {
         /// <summary>
-        /// One of the enumeration values that indicates whether this ReferenceHandler implementation should use Preserve semantics or IgnoreCycle semantics.
+        /// Indicates whether this ReferenceHandler implementation should use <see cref="ReferenceHandlingStrategy.Preserve"/> semantics or <see cref="ReferenceHandlingStrategy.IgnoreCycle"/> semantics.
         /// The defualt is Preserve.
         /// </summary>
         internal ReferenceHandlingStrategy HandlingStrategy = ReferenceHandlingStrategy.Preserve;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingStrategy.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingStrategy.cs
@@ -7,6 +7,6 @@ namespace System.Text.Json.Serialization
     {
         None,
         Preserve,
-        IgnoreCycle
+        IgnoreCycles
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingStrategy.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingStrategy.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    internal enum ReferenceHandlingStrategy
+    {
+        None,
+        Preserve,
+        IgnoreCycle
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceResolver.cs
@@ -33,5 +33,13 @@ namespace System.Text.Json.Serialization
         /// <param name="referenceId">The reference id related to the returned object.</param>
         /// <returns>The reference type object related to specified reference id.</returns>
         public abstract object ResolveReference(string referenceId);
+
+        // We are breaking single responsibility on this class internally.
+        // In the future, if this model is required to be exposed, we can add a base class and extend this class and a new class containing below members from that base class.
+        internal virtual void PopReferenceForCycleDetection() => throw new InvalidOperationException();
+
+        internal virtual void PushReferenceForCycleDetection(object value) => throw new InvalidOperationException();
+
+        internal virtual bool ContainsReferenceForCycleDetection(object value) => throw new InvalidOperationException();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -73,8 +73,9 @@ namespace System.Text.Json
             Current.DeclaredJsonPropertyInfo = jsonClassInfo.PropertyInfoForClassInfo;
             Current.NumberHandling = Current.DeclaredJsonPropertyInfo.NumberHandling;
 
-            if (options.ReferenceHandler != null)
+            if (options.ReferenceHandlingStrategy != ReferenceHandlingStrategy.None)
             {
+                Debug.Assert(options.ReferenceHandler != null);
                 ReferenceResolver = options.ReferenceHandler.CreateResolver(writing: true);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -75,7 +75,7 @@ namespace System.Text.Json
 
             if (options.ReferenceHandler != null)
             {
-                ReferenceResolver = options.ReferenceHandler!.CreateResolver(writing: true);
+                ReferenceResolver = options.ReferenceHandler.CreateResolver(writing: true);
             }
 
             SupportContinuation = supportContinuation;

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.IgnoreCycle.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.IgnoreCycle.cs
@@ -1,0 +1,324 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public class ReferenceHandlerTests_IgnoreCycle
+    {
+        private static readonly JsonSerializerOptions s_optionsIgnoreCycles =
+            new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.IgnoreCycle };
+
+        [Fact]
+        public async Task IgnoreCycles_OnObject()
+        {
+            var root = new Node();
+            root.Next = root;
+
+            await Test_Serialize_And_SerializeAsync(root, @"{""Next"":null}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnObject_NonProperty()
+        {
+            var node = new Node();
+            var rootList = new List<object>() { node };
+            node.Next = rootList;
+
+            await Test_Serialize_And_SerializeAsync(rootList, @"[{""Next"":null}]", s_optionsIgnoreCycles);
+        }
+
+        [Theory]
+        [InlineData(typeof(Dictionary<string, object>))]
+        [InlineData(typeof(GenericIDictionaryWrapper<string, object>))]
+        public async Task IgnoreCycles_OnDictionary(Type typeToSerialize)
+        {
+            var root = (ICollection<KeyValuePair<string, object>>)Activator.CreateInstance(typeToSerialize);
+            root.Add(new KeyValuePair<string, object>("self", root));
+
+            await Test_Serialize_And_SerializeAsync(root, @"{""self"":null}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnReadOnlyDictionary()
+        {
+            var innerDictionary = new Dictionary<string, object>();
+            var root = new ReadOnlyDictionary<string, object>(innerDictionary);
+
+            innerDictionary.Add("self", root);
+            await Test_Serialize_And_SerializeAsync(root, @"{""self"":null}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnIDictionary()
+        {
+            var root = new WrapperForIDictionary();
+            root.Add("self", root);
+            await Test_Serialize_And_SerializeAsync(root, @"{""self"":null}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnArray()
+        {
+            var root = new object[1];
+            root[0] = root;
+            await Test_Serialize_And_SerializeAsync(root, "[null]", s_optionsIgnoreCycles);
+        }
+
+        [Theory]
+        [InlineData(typeof(List<object>))]
+        [InlineData(typeof(GenericIListWrapper<object>))]
+        public async Task IgnoreCycles_OnLists(Type typeToSerialize)
+        {
+            var root = (IList<object>)Activator.CreateInstance(typeToSerialize);
+            root.Add(root);
+            await Test_Serialize_And_SerializeAsync(root, "[null]", s_optionsIgnoreCycles);
+        }
+
+        [Theory]
+        [InlineData(typeof(GenericISetWrapper<object>))]
+        [InlineData(typeof(GenericICollectionWrapper<object>))]
+        public async Task IgnoreCycles_OnCollections(Type typeToSerialize)
+        {
+            var root = (ICollection<object>)Activator.CreateInstance(typeToSerialize);
+            root.Add(root);
+            await Test_Serialize_And_SerializeAsync(root, "[null]", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnCollections_WithoutAddMethod()
+        {
+            var root = new Stack<object>();
+            root.Push(root);
+            await Test_Serialize_And_SerializeAsync(root, "[null]", s_optionsIgnoreCycles);
+
+            var root2 = new Queue<object>();
+            root2.Enqueue(root2);
+            await Test_Serialize_And_SerializeAsync(root2, "[null]", s_optionsIgnoreCycles);
+
+            var root3 = new ConcurrentStack<object>();
+            root3.Push(root3);
+            await Test_Serialize_And_SerializeAsync(root3, "[null]", s_optionsIgnoreCycles);
+
+            var root4 = new ConcurrentQueue<object>();
+            root4.Enqueue(root4);
+            await Test_Serialize_And_SerializeAsync(root4, "[null]", s_optionsIgnoreCycles);
+
+            var root5 = new Stack();
+            root5.Push(root5);
+            await Test_Serialize_And_SerializeAsync(root5, "[null]", s_optionsIgnoreCycles);
+
+            var root6 = new Queue();
+            root6.Enqueue(root6);
+            await Test_Serialize_And_SerializeAsync(root6, "[null]", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnExtensionData()
+        {
+            var root = new EmptyClassWithExtensionProperty();
+            root.MyOverflow.Add("root", root);
+            await Test_Serialize_And_SerializeAsync(root, @"{""root"":null}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnBoxedValueTypes()
+        {
+            IValueNode root = new ValueNode();
+            root.Next = root;
+
+            await Test_Serialize_And_SerializeAsync(root, @"{""Next"":null}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_OnBoxedValueTypes_AsProperty()
+        {
+            IValueNode node = new ValueNode();
+            node.Next = node;
+
+            var root = new Node();
+            root.Next = node;
+
+            await Test_Serialize_And_SerializeAsync(root, @"{""Next"":{""Next"":null}}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_DoesNotSupportPreserveSemantics()
+        {
+            // Object
+            var node = new NodeWithExtensionData();
+            node.Next = node;
+            string json = SerializeWithPreserve(node);
+
+            node = JsonSerializer.Deserialize<NodeWithExtensionData>(json, s_optionsIgnoreCycles);
+            Assert.True(node.MyOverflow.ContainsKey("$id"));
+            Assert.True(node.Next.MyOverflow.ContainsKey("$ref"));
+
+            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            node = await JsonSerializer.DeserializeAsync<NodeWithExtensionData>(ms, s_optionsIgnoreCycles);
+            Assert.True(node.MyOverflow.ContainsKey("$id"));
+            Assert.True(node.Next.MyOverflow.ContainsKey("$ref"));
+
+            // Dictionary
+            var dictionary = new RecursiveDictionary();
+            dictionary.Add("self", dictionary);
+            json = SerializeWithPreserve(dictionary);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<RecursiveDictionary>(json, s_optionsIgnoreCycles));
+            using var ms2 = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            await Assert.ThrowsAsync<JsonException>(() => JsonSerializer.DeserializeAsync<RecursiveDictionary>(ms2, s_optionsIgnoreCycles).AsTask());
+
+            // List
+            var list = new RecursiveList();
+            list.Add(list);
+            json = SerializeWithPreserve(list);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<RecursiveList>(json, s_optionsIgnoreCycles));
+            using var ms3 = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            await Assert.ThrowsAsync<JsonException>(() => JsonSerializer.DeserializeAsync<RecursiveList>(ms3, s_optionsIgnoreCycles).AsTask());
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_DoesNotSupportPreserveSemantics_Polymorphic()
+        {
+            // Object
+            var node = new Node();
+            node.Next = node;
+            string json = SerializeWithPreserve(node);
+
+            node = JsonSerializer.Deserialize<Node>(json, s_optionsIgnoreCycles);
+            JsonElement nodeAsJsonElement = Assert.IsType<JsonElement>(node.Next);
+            Assert.True(nodeAsJsonElement.GetProperty("$ref").GetString() == "1");
+
+            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            node = await JsonSerializer.DeserializeAsync<Node>(ms, s_optionsIgnoreCycles);
+            nodeAsJsonElement = Assert.IsType<JsonElement>(node.Next);
+            Assert.True(nodeAsJsonElement.GetProperty("$ref").GetString() == "1");
+
+            // Dictionary
+            var dictionary = new Dictionary<string, object>();
+            dictionary.Add("self", dictionary);
+            json = SerializeWithPreserve(dictionary);
+
+            dictionary = JsonSerializer.Deserialize<Dictionary<string, object>>(json, s_optionsIgnoreCycles);
+        }
+
+        private string SerializeWithPreserve<T>(T value)
+        {
+            var opts = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve };
+            return JsonSerializer.Serialize(value, opts);
+        }
+
+        // Test for correctness when the object reference is found on a sibling branch.
+        [Theory]
+        [InlineData(typeof(EmptyClass), "{}")]
+        [InlineData(typeof(EmptyStruct), "{}")]
+        [InlineData(typeof(object), "{}")]
+        [InlineData(typeof(Dictionary<string,object>), "{}")]
+        [InlineData(typeof(List<string>), "[]")]
+        public async Task AlreadySeenInstance_ShouldNotBeIgnoredOnSecondBranch(Type objectType, string objectPayload)
+        {
+            object obj = Activator.CreateInstance(objectType);
+            var root = new TreeNode();
+            root.Left = obj;
+            root.Right = obj;
+
+            await Test_Serialize_And_SerializeAsync(root, $@"{{""Left"":{objectPayload},""Right"":{objectPayload}}}", s_optionsIgnoreCycles);
+        }
+
+        [Fact]
+        public async Task IgnoreCycles_WhenWritingNull()
+        {
+            var opts = new JsonSerializerOptions
+            {
+                ReferenceHandler = ReferenceHandler.IgnoreCycle,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            // Reference cycles are treated as null, hence the JsonIgnoreCondition can be used to actually ignore the property.
+            var rootObj = new Node();
+            rootObj.Next = rootObj;
+
+            await Test_Serialize_And_SerializeAsync(rootObj, "{}", opts);
+
+            // JsonIgnoreCondition does not ignore nulls in collections, hence a reference loop should not omit writing it.
+            // This also helps us to avoid changing the length of a collection when the loop is detected in one of the elements.
+            var rootList = new List<object>();
+            rootList.Add(rootList);
+
+            await Test_Serialize_And_SerializeAsync(rootList, "[null]", opts);
+
+            var rootDictionary = new Dictionary<string, object>();
+            rootDictionary.Add("self", rootDictionary);
+
+            await Test_Serialize_And_SerializeAsync(rootDictionary, @"{""self"":null}", opts);
+        }
+
+        private async Task Test_Serialize_And_SerializeAsync(object obj, string expected, JsonSerializerOptions options)
+        {
+            string json = JsonSerializer.Serialize(obj, options);
+            Assert.Equal(expected, json);
+
+            using var ms = new MemoryStream();
+            await JsonSerializer.SerializeAsync(ms, obj, options).ConfigureAwait(false);
+            json = Encoding.UTF8.GetString(ms.ToArray());
+            Assert.Equal(expected, json);
+        }
+
+        private class Employee
+        {
+            public string Name { get; set; }
+            public Employee Manager { get; set; }
+            public List<Employee> Subordinates { get; set; }
+            public Dictionary<string, Employee> Colleagues { get; set; }
+        }
+
+        private class Node
+        {
+            public object Next { get; set; }
+        }
+
+        private class TreeNode
+        {
+            public object Left { get; set; }
+            public object Right { get; set; }
+        }
+
+        private struct ValueNode : IValueNode
+        {
+            public object Next { get; set; }
+        }
+
+        interface IValueNode
+        {
+            public object Next { get; set; }
+        }
+
+        private class EmptyClass { }
+        private struct EmptyStruct { }
+
+        private class EmptyClassWithExtensionProperty
+        {
+            [JsonExtensionData]
+            public Dictionary<string, object> MyOverflow { get; set; } = new Dictionary<string, object>();
+        }
+
+        private class NodeWithExtensionData
+        {
+            [JsonExtensionData]
+            public Dictionary<string, object> MyOverflow { get; set; } = new Dictionary<string, object>();
+            public NodeWithExtensionData Next { get; set; }
+        }
+
+        private class RecursiveDictionary : Dictionary<string, RecursiveDictionary> { }
+
+        private class RecursiveList : List<RecursiveList> { }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.IgnoreCycles.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.IgnoreCycles.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
-    public class ReferenceHandlerTests_IgnoreCycle
+    public class ReferenceHandlerTests_IgnoreCycles
     {
         private static readonly JsonSerializerOptions s_optionsIgnoreCycles =
             new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.IgnoreCycles };

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.IgnoreCycles.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.IgnoreCycles.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Tests
     public class ReferenceHandlerTests_IgnoreCycle
     {
         private static readonly JsonSerializerOptions s_optionsIgnoreCycles =
-            new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.IgnoreCycle };
+            new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.IgnoreCycles };
 
         [Fact]
         public async Task IgnoreCycles_OnObject()
@@ -319,7 +319,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             var opts = new JsonSerializerOptions
             {
-                ReferenceHandler = ReferenceHandler.IgnoreCycle,
+                ReferenceHandler = ReferenceHandler.IgnoreCycles,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -117,6 +117,7 @@
     <Compile Include="Serialization\ReadValueTests.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.Deserialize.cs" />
+    <Compile Include="Serialization\ReferenceHandlerTests.IgnoreCycle.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.Serialize.cs" />
     <Compile Include="Serialization\SampleTestData.OrderPayload.cs" />
     <Compile Include="Serialization\SerializationWrapper.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -117,7 +117,7 @@
     <Compile Include="Serialization\ReadValueTests.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.Deserialize.cs" />
-    <Compile Include="Serialization\ReferenceHandlerTests.IgnoreCycle.cs" />
+    <Compile Include="Serialization\ReferenceHandlerTests.IgnoreCycles.cs" />
     <Compile Include="Serialization\ReferenceHandlerTests.Serialize.cs" />
     <Compile Include="Serialization\SampleTestData.OrderPayload.cs" />
     <Compile Include="Serialization\SerializationWrapper.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/40099

This is a draft implementing a new API for `ReferenceHandler` capable of detect circularity on the input value of JsonSerializer.Serialize. A sample usage scenario would be the following:

```cs
class Node
{
    public string Description { get; set; }
    public object Next { get; set; }
}

void Test()
{
    var node = new Node { Description = "Node 1" };
    node.Next = node;
    
    var opts = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.IgnoreCycle };
    
    string json = JsonSerializer.Serialize(node, opts);
    Console.WriteLine(json); // Prints {"Description":"Node 1","Next":null}
}
```

**Note that reference cycles are broken by null tokens in JSON.**