### PR TITLE
Fixes for disassembly support in x86-hosted R2RDump

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -75,7 +75,7 @@
     </PropertyGroup>
     
     <PropertyGroup Condition="$(BuildPdb)">
-      <CrossGenPdbCmd>$(BinDir)\r2rdump\r2rdump.exe</CrossGenPdbCmd>
+      <CrossGenPdbCmd>$(DotNetCli) $(BinDir)\r2rdump\r2rdump.dll</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --create-pdb</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --pdb-path:$(BinDir)\PDB</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --in:$(CoreLibOutputPath)</CrossGenPdbCmd>

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -75,7 +75,7 @@
     </PropertyGroup>
     
     <PropertyGroup Condition="$(BuildPdb)">
-      <CrossGenPdbCmd>$(DotNetCli) $(BinDir)\r2rdump\r2rdump.dll</CrossGenPdbCmd>
+      <CrossGenPdbCmd>$(BinDir)\r2rdump\r2rdump.exe</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --create-pdb</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --pdb-path:$(BinDir)\PDB</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --in:$(CoreLibOutputPath)</CrossGenPdbCmd>

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -31,7 +31,6 @@ namespace R2RDump
         public static extern void DumpCodeBlock(IntPtr Disasm, IntPtr Address, IntPtr Bytes, int Size);
 
         [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
-        [return: MarshalAs(UnmanagedType.I4)]
         public static extern int DumpInstruction(IntPtr Disasm, IntPtr Address, IntPtr Bytes, int Size);
 
         [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -28,10 +28,10 @@ namespace R2RDump
         public static extern IntPtr InitBufferedDisasm(TargetArch Target);
 
         [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void DumpCodeBlock(IntPtr Disasm, IntPtr Address, IntPtr Bytes, int Size);
+        public static extern void DumpCodeBlock(IntPtr Disasm, IntPtr Address, IntPtr Bytes, IntPtr Size);
 
         [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int DumpInstruction(IntPtr Disasm, IntPtr Address, IntPtr Bytes, int Size);
+        public static extern int DumpInstruction(IntPtr Disasm, IntPtr Address, IntPtr Bytes, IntPtr Size);
 
         [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetOutputBuffer();
@@ -48,7 +48,7 @@ namespace R2RDump
             fixed (byte* p = image)
             {
                 IntPtr ptr = (IntPtr)(p + imageOffset + rtfOffset);
-                instrSize = DumpInstruction(Disasm, new IntPtr(rtf.StartAddress + rtfOffset), ptr, rtf.Size);
+                instrSize = DumpInstruction(Disasm, new IntPtr(rtf.StartAddress + rtfOffset), ptr, new IntPtr(rtf.Size));
             }
             IntPtr pBuffer = GetOutputBuffer();
             instr = Marshal.PtrToStringAnsi(pBuffer);

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -24,23 +24,23 @@ namespace R2RDump
             Target_Arm64
         };
 
-        [DllImport(_dll)]
+        [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr InitBufferedDisasm(TargetArch Target);
 
-        [DllImport(_dll)]
-        public static extern void DumpCodeBlock(IntPtr Disasm, ulong Address, IntPtr Bytes, int Size);
+        [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void DumpCodeBlock(IntPtr Disasm, IntPtr Address, IntPtr Bytes, int Size);
 
-        [DllImport(_dll)]
+        [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I4)]
-        public static extern int DumpInstruction(IntPtr Disasm, ulong Address, IntPtr Bytes, int Size);
+        public static extern int DumpInstruction(IntPtr Disasm, IntPtr Address, IntPtr Bytes, int Size);
 
-        [DllImport(_dll)]
+        [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetOutputBuffer();
 
-        [DllImport(_dll)]
+        [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ClearOutputBuffer();
 
-        [DllImport(_dll)]
+        [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
         public static extern void FinishDisasm(IntPtr Disasm);
 
         public unsafe static int GetInstruction(IntPtr Disasm, RuntimeFunction rtf, int imageOffset, int rtfOffset, byte[] image, out string instr)
@@ -49,7 +49,7 @@ namespace R2RDump
             fixed (byte* p = image)
             {
                 IntPtr ptr = (IntPtr)(p + imageOffset + rtfOffset);
-                instrSize = DumpInstruction(Disasm, (ulong)(rtf.StartAddress + rtfOffset), ptr, rtf.Size);
+                instrSize = DumpInstruction(Disasm, new IntPtr(rtf.StartAddress + rtfOffset), ptr, rtf.Size);
             }
             IntPtr pBuffer = GetOutputBuffer();
             instr = Marshal.PtrToStringAnsi(pBuffer);

--- a/src/coreclr/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/tools/r2rdump/R2RDump.cs
@@ -542,14 +542,6 @@ namespace R2RDump
             return null;
         }
 
-        // TODO: Fix R2RDump issue where an R2R image cannot be dissassembled with the x86 CoreDisTools
-        // For the short term, we want to error out with a decent message explaining the unexpected error
-        // Issue https://github.com/dotnet/runtime/issues/10928
-        private static bool DisassemblerArchitectureSupported()
-        {
-            return RuntimeInformation.ProcessArchitecture != Architecture.X86;
-        }
-
         private int Run()
         {
             Disassembler disassembler = null;
@@ -576,16 +568,8 @@ namespace R2RDump
 
                     if (_options.Disasm)
                     {
-                        if (DisassemblerArchitectureSupported())
-                        {
-                            disassembler = new Disassembler(r2r, _options);
-                        }
-                        else
-                        {
-                            throw new ArgumentException($"The architecture of input file {filename} ({r2r.Machine.ToString()}) or the architecture of the disassembler tools ({System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString()}) is not supported.");
-                        }
+                        disassembler = new Disassembler(r2r, _options);
                     }
-
 
                     if (!_options.Diff)
                     {

--- a/src/coreclr/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/tools/r2rdump/R2RDump.csproj
@@ -5,7 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
     <Platforms>x64;x86;arm64;arm</Platforms>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <AssemblyKey>Open</AssemblyKey>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>


### PR DESCRIPTION
1) We need to remove the PlatformTarget spec to make sure
x86-hosted R2RDump actually runs under 32-bit host, otherwise it
fails to load x86-targeting coredistools.dll. Thanks to Michal
for pointing that out.

2) I have removed Zach's workaround blocking disassembly on x86.

3) Based on JanV's advice I have marked all the interface methods
as using the cdecl calling convention in accordance with the
native declarations.

4) I found out that Address was incorrectly declared as a 64-bit
integer in the PInvoke declaration while in reality it should be
an IntPtr (native int).

With these changes I'm for the first time able to disassemble
x86-targeting System.Private.CoreLib using the x86-hosted R2RDump.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 

Fixes: https://github.com/dotnet/runtime/issues/45857
Fixes: https://github.com/dotnet/runtime/issues/10928