### PR TITLE
Make testing wasm on windows in runtimelab easier  by using MSBuild IsOSPlatform not TargetOS

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -1,22 +1,22 @@
 <Project>
   <PropertyGroup>
-    <RunScriptInputName Condition="'$(TargetOS)' == 'windows'">RunnerTemplate.cmd</RunScriptInputName>
-    <RunScriptInputName Condition="'$(TargetOS)' != 'windows'">RunnerTemplate.sh</RunScriptInputName>
+    <RunScriptInputName Condition="$([MSBuild]::IsOSPlatform('windows'))">RunnerTemplate.cmd</RunScriptInputName>
+    <RunScriptInputName Condition="!$([MSBuild]::IsOSPlatform('windows'))">RunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">AppleRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Android'">AndroidRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Browser'">WasmRunnerTemplate.sh</RunScriptInputName>
 
     <RunScriptInputPath>$(MSBuildThisFileDirectory)$(RunScriptInputName)</RunScriptInputPath>
 
-    <RunScriptOutputName Condition="'$(TargetOS)' == 'windows'">RunTests.cmd</RunScriptOutputName>
-    <RunScriptOutputName Condition="'$(TargetOS)' != 'windows'">RunTests.sh</RunScriptOutputName>
+    <RunScriptOutputName Condition="$([MSBuild]::IsOSPlatform('windows'))">RunTests.cmd</RunScriptOutputName>
+    <RunScriptOutputName Condition="!$([MSBuild]::IsOSPlatform('windows'))">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(OutDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
 
-    <RunScriptHostDir Condition="'$(TargetOS)' == 'windows'">%RUNTIME_PATH%\</RunScriptHostDir>
-    <RunScriptHostDir Condition="'$(TargetOS)' != 'windows'">$RUNTIME_PATH/</RunScriptHostDir>
+    <RunScriptHostDir Condition="$([MSBuild]::IsOSPlatform('windows'))">%RUNTIME_PATH%\</RunScriptHostDir>
+    <RunScriptHostDir Condition="!$([MSBuild]::IsOSPlatform('windows'))">$RUNTIME_PATH/</RunScriptHostDir>
 
-    <RunScriptHost Condition="'$(TargetOS)' == 'windows'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
-    <RunScriptHost Condition="'$(TargetOS)' != 'windows'">$(RunScriptHostDir)dotnet</RunScriptHost>
+    <RunScriptHost Condition="$([MSBuild]::IsOSPlatform('windows'))">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
+    <RunScriptHost Condition="!$([MSBuild]::IsOSPlatform('windows'))">$(RunScriptHostDir)dotnet</RunScriptHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -1,22 +1,22 @@
 <Project>
   <PropertyGroup>
-    <RunScriptInputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunnerTemplate.cmd</RunScriptInputName>
-    <RunScriptInputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunnerTemplate.sh</RunScriptInputName>
+    <RunScriptInputName Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunnerTemplate.cmd</RunScriptInputName>
+    <RunScriptInputName Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">AppleRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Android'">AndroidRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Browser'">WasmRunnerTemplate.sh</RunScriptInputName>
 
     <RunScriptInputPath>$(MSBuildThisFileDirectory)$(RunScriptInputName)</RunScriptInputPath>
 
-    <RunScriptOutputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunTests.cmd</RunScriptOutputName>
-    <RunScriptOutputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
+    <RunScriptOutputName Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunTests.cmd</RunScriptOutputName>
+    <RunScriptOutputName Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(OutDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
 
-    <RunScriptHostDir Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">%RUNTIME_PATH%\</RunScriptHostDir>
-    <RunScriptHostDir Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
+    <RunScriptHostDir Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">%RUNTIME_PATH%\</RunScriptHostDir>
+    <RunScriptHostDir Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
 
-    <RunScriptHost Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
-    <RunScriptHost Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
+    <RunScriptHost Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
+    <RunScriptHost Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -1,22 +1,22 @@
 <Project>
   <PropertyGroup>
-    <RunScriptInputName Condition="$([MSBuild]::IsOSPlatform('windows'))">RunnerTemplate.cmd</RunScriptInputName>
-    <RunScriptInputName Condition="!$([MSBuild]::IsOSPlatform('windows'))">RunnerTemplate.sh</RunScriptInputName>
+    <RunScriptInputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunnerTemplate.cmd</RunScriptInputName>
+    <RunScriptInputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">AppleRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Android'">AndroidRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Browser'">WasmRunnerTemplate.sh</RunScriptInputName>
 
     <RunScriptInputPath>$(MSBuildThisFileDirectory)$(RunScriptInputName)</RunScriptInputPath>
 
-    <RunScriptOutputName Condition="$([MSBuild]::IsOSPlatform('windows'))">RunTests.cmd</RunScriptOutputName>
-    <RunScriptOutputName Condition="!$([MSBuild]::IsOSPlatform('windows'))">RunTests.sh</RunScriptOutputName>
+    <RunScriptOutputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunTests.cmd</RunScriptOutputName>
+    <RunScriptOutputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(OutDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
 
-    <RunScriptHostDir Condition="$([MSBuild]::IsOSPlatform('windows'))">%RUNTIME_PATH%\</RunScriptHostDir>
-    <RunScriptHostDir Condition="!$([MSBuild]::IsOSPlatform('windows'))">$RUNTIME_PATH/</RunScriptHostDir>
+    <RunScriptHostDir Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">%RUNTIME_PATH%\</RunScriptHostDir>
+    <RunScriptHostDir Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
 
-    <RunScriptHost Condition="$([MSBuild]::IsOSPlatform('windows'))">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
-    <RunScriptHost Condition="!$([MSBuild]::IsOSPlatform('windows'))">$(RunScriptHostDir)dotnet</RunScriptHost>
+    <RunScriptHost Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
+    <RunScriptHost Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -138,8 +138,8 @@
 
   <!-- Set Test Wrapper running host OS -->
   <PropertyGroup>
-    <TestWrapperTargetsWindows>false</TestWrapperTargetsWindows>
-    <TestWrapperTargetsWindows Condition=" ('$(TargetsWindows)' != '' And '$(TargetsWindows)' ) OR ('$(TargetOS)' == 'Android' And '$(TargetArchitecture)' == 'arm64' )">true</TestWrapperTargetsWindows>
+     <TestWrapperTargetsWindows>true</TestWrapperTargetsWindows>
+    <TestWrapperTargetsWindows Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">false</TestWrapperTargetsWindows>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR changes the switch for `.cmd`/`.sh` to be based on `$([MSBuild]::IsOSPlatform('windows'))` instead of `'$(TargetOS)' == 'windows'`  This helps in running the Wasm tests on Windows in the runtimelab branch, and should be ok here in runtime.  Will help with future merging.