### PR TITLE
Fix over-estimation for vbroadcast* instructions

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -1946,7 +1946,7 @@ inline UNATIVE_OFFSET emitter::emitInsSizeRR(instruction ins, regNumber reg1, re
 
     if ((code & 0xFF00) != 0)
     {
-        sz = 5;
+        sz = IsSSEOrAVXInstruction(ins) ? emitInsSize(code) : 5;
     }
     else
     {


### PR DESCRIPTION
Find accurate instruction size for `vbroadcast*` instructions. Gives some saving in allocation size.

```
Summary of Allocation Size diffs:
(Lower is better)

Total bytes of base: 51942987
Total bytes of diff: 51942836
Total bytes of delta: -151 (-0.00% of base)
    diff is an improvement.

Top file improvements (bytes):
        -143 : System.Private.CoreLib.dasm (-0.00% of base)
          -3 : System.Text.Json.dasm (-0.00% of base)
          -2 : System.Memory.dasm (-0.00% of base)
          -1 : System.Collections.dasm (-0.00% of base)
          -1 : System.Net.WebSockets.dasm (-0.00% of base)
          -1 : System.Net.WebSockets.WebSocketProtocol.dasm (-0.00% of base)

6 total files with Allocation Size differences (6 improved, 0 regressed), 262 unchanged.

Top method improvements (bytes):
         -10 (-0.91% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOfAny(byref,ushort,ushort,ushort,ushort,ushort,int):int
          -8 (-0.87% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOfAny(byref,ushort,ushort,ushort,ushort,int):int
          -6 (-0.35% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOfAny(byref,ubyte,ubyte,ubyte,int):int (2 methods)
          -6 (-0.81% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOfAny(byref,ushort,ushort,ushort,int):int
          -4 (-0.49% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
          -4 (-0.77% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:NarrowUtf16ToAscii_Sse2(long,long,long):long
          -4 (-0.28% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOfAny(byref,ubyte,ubyte,int):int (2 methods)
          -4 (-0.67% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOfAny(byref,ushort,ushort,int):int
          -4 (-0.49% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
          -4 (-0.77% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:NarrowUtf16ToLatin1_Sse2(long,long,long):long
          -3 (-0.31% of base) : System.Text.Json.dasm - System.Text.Json.JsonReaderHelper:IndexOfOrLessThan(byref,ubyte,ubyte,ubyte,int):int
          -3 (-0.46% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOf(byref,ushort,int):int
          -3 (-0.29% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:IndexOf(byref,ubyte,int):int (2 methods)
          -3 (-0.18% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:LastIndexOfAny(byref,ubyte,ubyte,ubyte,int):int (2 methods)
          -2 (-0.67% of base) : System.Private.CoreLib.dasm - System.String:Replace(ushort,ushort):System.String:this
          -2 (-0.15% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:LastIndexOfAny(byref,ubyte,ubyte,int):int (2 methods)
          -2 (-3.17% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector4:Lerp(System.Numerics.Vector4,System.Numerics.Vector4,float):System.Numerics.Vector4
          -2 (-0.28% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Default(long,long):long
          -2 (-0.28% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Default(long,long):long
          -1 (-0.06% of base) : System.Collections.dasm - System.Collections.BitArray:CopyTo(System.Array,int):this

Top method improvements (percentages):
          -1 (-14.29% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.X86.Bmi1:ExtractLowestSetBit(int):int
          -1 (-14.29% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.X86.Bmi1:GetMaskUpToLowestSetBit(int):int
          -1 (-14.29% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.X86.Bmi1:ResetLowestSetBit(int):int
          -1 (-14.29% of base) : System.Private.CoreLib.dasm - X64:ExtractLowestSetBit(long):long
          -1 (-14.29% of base) : System.Private.CoreLib.dasm - X64:GetMaskUpToLowestSetBit(long):long
          -1 (-14.29% of base) : System.Private.CoreLib.dasm - X64:ResetLowestSetBit(long):long
          -1 (-5.56% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(float):System.Runtime.Intrinsics.Vector128`1[Single]
          -1 (-4.76% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(double):System.Runtime.Intrinsics.Vector256`1[Double]
          -1 (-4.76% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(float):System.Runtime.Intrinsics.Vector256`1[Single]
          -1 (-4.35% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector4:op_Multiply(System.Numerics.Vector4,float):System.Numerics.Vector4
          -1 (-4.35% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(int):System.Runtime.Intrinsics.Vector128`1[Int32]
          -1 (-4.35% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(long):System.Runtime.Intrinsics.Vector128`1[Int64]
          -1 (-4.35% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(int):System.Runtime.Intrinsics.Vector128`1[UInt32]
          -1 (-4.35% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(long):System.Runtime.Intrinsics.Vector128`1[UInt64]
          -1 (-3.85% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(ubyte):System.Runtime.Intrinsics.Vector128`1[Byte]
          -1 (-3.85% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(ushort):System.Runtime.Intrinsics.Vector128`1[UInt16]
          -1 (-3.85% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(int):System.Runtime.Intrinsics.Vector256`1[Int32]
          -1 (-3.85% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(long):System.Runtime.Intrinsics.Vector256`1[Int64]
          -1 (-3.85% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(int):System.Runtime.Intrinsics.Vector256`1[UInt32]
          -1 (-3.85% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256:Create(long):System.Runtime.Intrinsics.Vector256`1[UInt64]
```

Thanks @tannergooding  for the help!