### PR TITLE
[mono] Make HelloWorld and wasm samples compile again

### DIFF
--- a/src/mono/netcore/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/netcore/sample/HelloWorld/HelloWorld.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
   </PropertyGroup>
 

--- a/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <TargetArchitecture>wasm</TargetArchitecture>
     <TargetOS>Browser</TargetOS>
     <MicrosoftNetCoreAppRuntimePackRidDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\$(Configuration)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackRidDir>

--- a/src/mono/netcore/sample/wasm/console/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/console/WasmSample.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <TargetArchitecture>wasm</TargetArchitecture>
     <TargetOS>Browser</TargetOS>
     <MicrosoftNetCoreAppRuntimePackRidDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\$(Configuration)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackRidDir>


### PR DESCRIPTION
Since 296aaf818ec02101226845aea39ca14d32519cf2 it seems we need `$(NetCoreAppToolCurrent)` as the `TargetFramework`