### PR TITLE
Make the native thread pool initialization variable volatile

### DIFF
--- a/src/coreclr/vm/win32threadpool.cpp
+++ b/src/coreclr/vm/win32threadpool.cpp
@@ -112,7 +112,7 @@ int ThreadpoolMgr::ThreadAdjustmentInterval;
 #define GATE_THREAD_DELAY_TOLERANCE 50 /*milliseconds*/
 #define DELAY_BETWEEN_SUSPENDS (5000 + GATE_THREAD_DELAY) // time to delay between suspensions
 
-LONG ThreadpoolMgr::Initialization=0;           // indicator of whether the threadpool is initialized.
+Volatile<LONG> ThreadpoolMgr::Initialization = 0;            // indicator of whether the threadpool is initialized.
 
 bool ThreadpoolMgr::s_usePortableThreadPool = false;
 

--- a/src/coreclr/vm/win32threadpool.h
+++ b/src/coreclr/vm/win32threadpool.h
@@ -1038,7 +1038,7 @@ private:
 #endif // #ifndef DACCESS_COMPILE
     // Private variables
 
-    static LONG Initialization;                         // indicator of whether the threadpool is initialized.
+    static Volatile<LONG> Initialization;                         // indicator of whether the threadpool is initialized.
 
     static bool s_usePortableThreadPool;
 


### PR DESCRIPTION
- Necessary on arm32/arm64 such that if `IsInitialized()` returns true, initialized variables will also be observed correctly
- Fixes https://github.com/dotnet/runtime/issues/46084