### PR TITLE
improve List's indexer Set performance by 10% by doing array bound check on our own

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -154,12 +154,18 @@ namespace System.Collections.Generic
 
             set
             {
-                if ((uint)index >= (uint)_size)
+                T[] array = _items;
+
+                // doing the array boundry check on our own here improves the perf by 10%
+                if ((uint)index < (uint)_size && (uint)index < (uint)array.Length)
+                {
+                    array[index] = value;
+                    _version++;
+                }
+                else
                 {
                     ThrowHelper.ThrowArgumentOutOfRange_IndexException();
                 }
-                _items[index] = value;
-                _version++;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -156,7 +156,7 @@ namespace System.Collections.Generic
             {
                 T[] array = _items;
 
-                // doing the array boundry check on our own here improves the perf by 10%
+                // doing the array boundary check on our own here improves the perf by 10%
                 if ((uint)index < (uint)_size && (uint)index < (uint)array.Length)
                 {
                     array[index] = value;


### PR DESCRIPTION
Contributes to #29091

```cmd
git clone https://github.com/dotnet/performance.git
py .\performance\scripts\benchmarks_ci.py -f netcoreapp5.0 
--filter *IndexerSet<*.List 
--bdn-arguments="--join true --disasm true" 
--corerun 
    C:\Projects\runtime\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\before\CoreRun.exe 
    C:\Projects\runtime\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\after\CoreRun.exe
```


```ini
 BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.18363.1256 (1909/November2019Update/19H2)
 Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
 .NET SDK=5.0.100-rc.2.20480.7
   [Host]     : .NET 5.0.0 (5.0.20.47505), X64 RyuJIT
   Job-LMUIVC : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT
   Job-YJWJDM : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT

 PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  IterationTime=250.0000 ms
 MaxIterationCount=20  MinIterationCount=15  WarmupCount=1
```

 |                      Type | Method |           Toolchain | Size |     Mean | Ratio |
 |-------------------------- |------- |-------------------- |----- |---------:|------:|
 |         IndexerSet&lt;Int32&gt; |   List |  \after\CoreRun.exe |  512 | 810.8 ns |  0.84 |
 |         IndexerSet&lt;Int32&gt; |   List | \before\CoreRun.exe |  512 | 963.5 ns |  1.00 |
 |                           |        |                     |      |          |       |
 |        IndexerSet&lt;String&gt; |   List |  \after\CoreRun.exe |  512 | 816.1 ns |  0.91 |
 |        IndexerSet&lt;String&gt; |   List | \before\CoreRun.exe |  512 | 895.8 ns |  1.00 |

[Disasm diff](https://www.diffchecker.com/Ho3szRnc)


<details>

## IndexerSet&lt;Int32&gt;

### BEFORE:
```assembly
; System.Collections.IndexerSet`1[[System.Int32, System.Private.CoreLib]].List()
       sub       rsp,28
       mov       rax,[rcx+18]
       xor       edx,edx
       mov       ecx,[rax+10]
       test      ecx,ecx
       jle       short M00_L01
M00_L00:
       cmp       edx,ecx
       jae       short M00_L02
       mov       r8,[rax+8]
       cmp       edx,[r8+8]
       jae       short M00_L03
       movsxd    r9,edx
       xor       r10d,r10d
       mov       [r8+r9*4+10],r10d
       inc       dword ptr [rax+14]
       inc       edx
       cmp       edx,ecx
       jl        short M00_L00
M00_L01:
       add       rsp,28
       ret
M00_L02:
       call      System.ThrowHelper.ThrowArgumentOutOfRange_IndexException()
       int       3
M00_L03:
       call      CORINFO_HELP_RNGCHKFAIL
       int       3
; Total bytes of code 68
```
**Method was not JITted yet.**
System.ThrowHelper.ThrowArgumentOutOfRange_IndexException()


### AFTER
```assembly
; System.Collections.IndexerSet`1[[System.Int32, System.Private.CoreLib]].List()
       sub       rsp,28
       mov       rax,[rcx+18]
       xor       edx,edx
       mov       ecx,[rax+10]
       test      ecx,ecx
       jle       short M00_L01
       mov       r8,[rax+8]
M00_L00:
       mov       r9,r8
       cmp       edx,ecx
       jae       short M00_L02
       mov       r10d,[r9+8]
       cmp       r10d,edx
       jbe       short M00_L02
       movsxd    r10,edx
       xor       r11d,r11d
       mov       [r9+r10*4+10],r11d
       inc       dword ptr [rax+14]
       inc       edx
       cmp       edx,ecx
       jl        short M00_L00
M00_L01:
       add       rsp,28
       ret
M00_L02:
       call      System.ThrowHelper.ThrowArgumentOutOfRange_IndexException()
       int       3
; Total bytes of code 68
```
**Method was not JITted yet.**
System.ThrowHelper.ThrowArgumentOutOfRange_IndexException()