### PR TITLE
Make StartInfo_TextFile_ShellExecute test more reliable

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/FileAssociations.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/FileAssociations.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32;
+
+namespace System.Diagnostics.Tests
+{
+    internal static class FileAssociations
+    {
+        private const int SHCNE_ASSOCCHANGED = 0x8000000;
+        private const int SHCNF_FLUSH = 0x1000;
+
+        internal static void EnsureAssociationSet(string extension, string fileTypeDescription, string exePath, string programId)
+        {
+            bool commit = false;
+
+            commit |= SetCurrentUserRegistryKey(@"Software\Classes\" + extension, programId);
+            commit |= SetCurrentUserRegistryKey(@"Software\Classes\" + programId, fileTypeDescription);
+            commit |= SetCurrentUserRegistryKey($@"Software\Classes\{programId}\shell\open\command", "\"" + exePath + "\" \"%1\"");
+
+            if (commit)
+            {
+                Interop.SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_FLUSH, IntPtr.Zero, IntPtr.Zero);
+            }
+
+            static bool SetCurrentUserRegistryKey(string keyPath, string value)
+            {
+                // using CurrentUser should avoid the need of using Admin account
+                using (var key = Registry.CurrentUser.CreateSubKey(keyPath))
+                {
+                    if (key.GetValue(null) as string != value)
+                    {
+                        key.SetValue(null, value);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.Process/tests/Interop.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/Interop.cs
@@ -84,6 +84,9 @@ namespace System.Diagnostics.Tests
         [DllImport("advapi32.dll")]
         internal static extern bool GetTokenInformation(SafeProcessHandle TokenHandle, uint TokenInformationClass, IntPtr TokenInformation, int TokenInformationLength, ref int ReturnLength);
 
+        [DllImport("shell32.dll")]
+        internal static extern int SHChangeNotify(int eventId, int flags, IntPtr item1, IntPtr item2);
+
         internal static void NetUserAdd(string username, string password)
         {
             USER_INFO_1 userInfo = new USER_INFO_1();

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -969,12 +969,9 @@ namespace System.Diagnostics.Tests
             ProcessStartInfo info = new ProcessStartInfo
             {
                 UseShellExecute = true,
-                FileName = "notepad.exe",
-                Arguments = null,
+                FileName = tempFile,
                 WindowStyle = ProcessWindowStyle.Minimized
             };
-
-            info.ArgumentList.Add(tempFile);
 
             using (var process = Process.Start(info))
             {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -963,7 +963,13 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void StartInfo_TextFile_ShellExecute()
         {
-            string tempFile = GetTestFilePath() + ".txt";
+            // create a new extension that nobody else should be using
+            const string fileExtension = ".dotnetRuntimeTestExtension";
+            // associate Notepad with the new extension
+            FileAssociations.EnsureAssociationSet(fileExtension, "Used For Testing ShellExecute", "notepad.exe", "Notepad");
+            // from here we can try to open with with given extension and be sure that Notepad is going to open it (not other text file editor like Notepad++)
+
+            string tempFile = GetTestFilePath() + fileExtension;
             File.WriteAllText(tempFile, $"StartInfo_TextFile_ShellExecute");
 
             ProcessStartInfo info = new ProcessStartInfo

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -963,9 +963,6 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void StartInfo_TextFile_ShellExecute()
         {
-            if (Thread.CurrentThread.CurrentCulture.ToString() != "en-US")
-                return; // [ActiveIssue(https://github.com/dotnet/runtime/issues/25823)]
-
             string tempFile = GetTestFilePath() + ".txt";
             File.WriteAllText(tempFile, $"StartInfo_TextFile_ShellExecute");
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -936,7 +936,7 @@ namespace System.Diagnostics.Tests
             ProcessStartInfo info = new ProcessStartInfo
             {
                 UseShellExecute = useShellExecute,
-                FileName = @"notepad.exe",
+                FileName = "notepad.exe",
                 Arguments = tempFile,
                 WindowStyle = ProcessWindowStyle.Minimized
             };
@@ -956,7 +956,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), // Nano does not support UseShellExecute
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), // Nano does not support UseShellExecute and has not notepad
                                                     nameof(PlatformDetection.IsNotWindowsServerCore), // https://github.com/dotnet/runtime/issues/26231
                                                     nameof(PlatformDetection.IsNotWindows8x))] // https://github.com/dotnet/runtime/issues/22007
         [OuterLoop("Launches notepad")]
@@ -1145,7 +1145,7 @@ namespace System.Diagnostics.Tests
             ProcessStartInfo info = new ProcessStartInfo
             {
                 UseShellExecute = useShellExecute,
-                FileName = @"notepad.exe",
+                FileName = "notepad.exe",
                 Arguments = null,
                 WindowStyle = ProcessWindowStyle.Minimized
             };

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -972,9 +972,12 @@ namespace System.Diagnostics.Tests
             ProcessStartInfo info = new ProcessStartInfo
             {
                 UseShellExecute = true,
-                FileName = tempFile,
+                FileName = "notepad.exe",
+                Arguments = null,
                 WindowStyle = ProcessWindowStyle.Minimized
             };
+
+            info.ArgumentList.Add(tempFile);
 
             using (var process = Process.Start(info))
             {

--- a/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
     <Compile Include="DelegateSynchronizeInvoke.cs" />
+    <Compile Include="FileAssociations.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="Interop.cs" />
     <Compile Include="ProcessCollectionTests.cs" />


### PR DESCRIPTION
**edit:**  introduce a new, unique extension and use the registry to associate it with Notepad to be always sure that it's going to be used

Fixes #25823