### PR TITLE
fix and re-enable TestCheckChildProcessUserAndGroupIds test

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Security;
 using Xunit;
-using Xunit.Sdk;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 
@@ -527,7 +526,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(groupId, getgid().ToString());
             Assert.Equal(groupId, getegid().ToString());
 
-            var expectedGroups = new HashSet<uint>(groupIdsJoined.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => uint.Parse(s)));
+            var expectedGroups = new HashSet<uint>(groupIdsJoined.Split(',').Select(s => uint.Parse(s)));
 
             if (bool.Parse(checkGroupsExact))
             {
@@ -548,7 +547,6 @@ namespace System.Diagnostics.Tests
             string userId = GetUserId(userName);
             string userGroupId = GetUserGroupId(userName);
             string userGroupIds = GetUserGroupIds(userName);
-
             // If this test runs as the user, we expect to be able to match the user groups exactly.
             // Except on OSX, where getgrouplist may return a list of groups truncated to NGROUPS_MAX.
             bool checkGroupsExact = userId == geteuid().ToString() &&
@@ -629,7 +627,6 @@ namespace System.Diagnostics.Tests
         {
             string[] groupIds = StartAndReadToEnd("id", new[] { "-G" })
                 .Split(new[] { ' ', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-
             return new HashSet<uint>(groupIds.Select(s => uint.Parse(s)));
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -547,15 +547,7 @@ namespace System.Diagnostics.Tests
             string userName = GetCurrentRealUserName();
             string userId = GetUserId(userName);
             string userGroupId = GetUserGroupId(userName);
-            string userGroupIds = GetUserGroupIdsJoined(userName);
-
-            HashSet<uint> groupIdsFromIdGCommand = new HashSet<uint>(GetUserGroupIds(userName));
-            HashSet<uint> groupIdsFromLibc = GetGroups();
-
-            if (!groupIdsFromIdGCommand.SetEquals(groupIdsFromLibc))
-            {
-                throw new XunitException($"id -G returned: {string.Join(", ", groupIdsFromIdGCommand)}{Environment.NewLine}getgroups returned: {string.Join(", ", groupIdsFromLibc)}");
-            }
+            string userGroupIds = GetGroupIds();
 
             // If this test runs as the user, we expect to be able to match the user groups exactly.
             // Except on OSX, where getgrouplist may return a list of groups truncated to NGROUPS_MAX.
@@ -591,7 +583,7 @@ namespace System.Diagnostics.Tests
 
                 string userId = GetUserId(username);
                 string userGroupId = GetUserGroupId(username);
-                string userGroupIds = GetUserGroupIdsJoined(username);
+                string userGroupIds = GetGroupIds();
 
                 if (bool.Parse(useRootGroupsArg))
                 {
@@ -626,17 +618,7 @@ namespace System.Diagnostics.Tests
         private static string GetUserGroupId(string username)
             => StartAndReadToEnd("id", new[] { "-g", username }).Trim('\n');
 
-        private static IEnumerable<uint> GetUserGroupIds(string username)
-        {
-            string[] groupIds = StartAndReadToEnd("id", new[] { "-G", username })
-                                    .Split(new[] { ' ', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-            return groupIds.Select(s => uint.Parse(s)).OrderBy(id => id);
-        }
-
-        private static string GetUserGroupIdsJoined(string username)
-        {
-            return string.Join(",", GetUserGroupIds(username));
-        }
+        private static string GetGroupIds() => string.Join(",", GetGroups());
 
         private static string GetCurrentRealUserName()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -527,7 +527,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(groupId, getgid().ToString());
             Assert.Equal(groupId, getegid().ToString());
 
-            var expectedGroups = new HashSet<uint>(groupIdsJoined.Split(',').Select(s => uint.Parse(s)));
+            var expectedGroups = new HashSet<uint>(groupIdsJoined.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => uint.Parse(s)));
 
             if (bool.Parse(checkGroupsExact))
             {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -541,7 +541,6 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/28922", TestPlatforms.AnyUnix)]
         public unsafe void TestCheckChildProcessUserAndGroupIds()
         {
             string userName = GetCurrentRealUserName();


### PR DESCRIPTION
fixes #28922

Explanation: This test gets the current user: name, id, and groups:

https://github.com/dotnet/runtime/blob/721fb97f442d14882943c8462d64f84616014d10/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs#L546-L549

and starts a process using the given user name:

https://github.com/dotnet/runtime/blob/721fb97f442d14882943c8462d64f84616014d10/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs#L557

It was failing because so far we were using two different ways of getting the user group Ids:

- `id -G $username` to get the expected ids (called from parent process)
- `libc.getgroups` to get the actual ids (called from child process started as given user)

There are some differences in what `id -G` and `libc.getgroups` can return and I've  verified that by just comparing the output without starting any new processes (see  https://github.com/dotnet/runtime/issues/28922#issuecomment-748035051 for details).

The solution is to use `id -G` for getting both the expected and actual ids. The parent process passes the username to the command, the child command passes no username to get it for the current user (the test verifies if the process was started as the given user)