### PR TITLE
Add test for System.Diagnostics.Process.Responding

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1592,15 +1592,17 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [OuterLoop]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Pops UI
+        [OuterLoop("Launches notepad")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void MainWindowTitle_GetWithGui_ShouldRefresh_Windows()
         {
             const string ExePath = "notepad.exe";
             Assert.True(IsProgramInstalled(ExePath));
 
-            using (Process process = Process.Start(ExePath))
+            using (Process process = Process.Start(new ProcessStartInfo(ExePath)
+            {
+                WindowStyle = ProcessWindowStyle.Minimized
+            }))
             {
                 try
                 {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1664,7 +1664,7 @@ namespace System.Diagnostics.Tests
                 }
             }
 
-            static bool GetHaveResponding(Process process)=> (bool)typeof(Process)
+            static bool GetHaveResponding(Process process) => (bool)typeof(Process)
                     .GetField("_haveResponding", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)
                     .GetValue(process);
         }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1638,16 +1638,16 @@ namespace System.Diagnostics.Tests
 
                 try
                 {
-                    Assert.False(GetHaveResponding(process));
+                    for (int i = 0; i < 3; i++)
+                    {
+                        Assert.False(GetHaveResponding(process));
 
-                    Assert.True(process.Responding); // sets haveResponding to true
-                    Assert.True(GetHaveResponding(process));
+                        Assert.True(process.Responding // sets haveResponding to true
+                            || PlatformDetection.IsWindowsNanoServer); // underlying WinAPI returns false on Nano
+                        Assert.True(GetHaveResponding(process));
 
-                    process.Refresh(); // sets haveResponding to false
-                    Assert.False(GetHaveResponding(process));
-
-                    Assert.True(process.Responding); // sets haveResponding to true
-                    Assert.True(GetHaveResponding(process));
+                        process.Refresh(); // sets haveResponding to false
+                    }
                 }
                 finally
                 {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1556,10 +1556,9 @@ namespace System.Diagnostics.Tests
             var process = new Process();
             Assert.Throws<InvalidOperationException>(() => process.MainWindowHandle);
         }
-        
-        [Fact]
-        [OuterLoop]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Pops UI
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // it needs Notepad
+        [OuterLoop("Pops UI")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void MainWindowHandle_GetWithGui_ShouldRefresh_Windows()
         {
@@ -1591,8 +1590,8 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact]
-        [OuterLoop("Launches notepad")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // it needs Notepad
+        [OuterLoop("Pops UI")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void MainWindowTitle_GetWithGui_ShouldRefresh_Windows()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1640,24 +1640,28 @@ namespace System.Diagnostics.Tests
             {
                 process.Start();
 
-                Assert.False(GetHaveResponding(process));
-
-                Assert.True(process.Responding); // sets haveResponding to true
-                Assert.True(GetHaveResponding(process));
-
-                process.Refresh(); // sets haveResponding to false
-                Assert.False(GetHaveResponding(process));
-
-                Assert.True(process.Responding); // sets haveResponding to true
-                Assert.True(GetHaveResponding(process));
-
-
-                if (!process.HasExited)
+                try
                 {
-                    process.Kill();
-                }
+                    Assert.False(GetHaveResponding(process));
 
-                Assert.True(process.WaitForExit(WaitInMS));
+                    Assert.True(process.Responding); // sets haveResponding to true
+                    Assert.True(GetHaveResponding(process));
+
+                    process.Refresh(); // sets haveResponding to false
+                    Assert.False(GetHaveResponding(process));
+
+                    Assert.True(process.Responding); // sets haveResponding to true
+                    Assert.True(GetHaveResponding(process));
+                }
+                finally
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill();
+                    }
+
+                    Assert.True(process.WaitForExit(WaitInMS));
+                }
             }
 
             static bool GetHaveResponding(Process process)=> (bool)typeof(Process)

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1563,7 +1563,7 @@ namespace System.Diagnostics.Tests
         public void MainWindowHandle_GetWithGui_ShouldRefresh_Windows()
         {
             const string ExePath = "notepad.exe";
-            Assert.True(IsProgramInstalled(ExePath));
+            Assert.True(IsProgramInstalled(ExePath), "Notepad is not installed");
 
             using (Process process = Process.Start(ExePath))
             {
@@ -1596,12 +1596,9 @@ namespace System.Diagnostics.Tests
         public void MainWindowTitle_GetWithGui_ShouldRefresh_Windows()
         {
             const string ExePath = "notepad.exe";
-            Assert.True(IsProgramInstalled(ExePath));
+            Assert.True(IsProgramInstalled(ExePath), "Notepad is not installed");
 
-            using (Process process = Process.Start(new ProcessStartInfo(ExePath)
-            {
-                WindowStyle = ProcessWindowStyle.Minimized
-            }))
+            using (Process process = Process.Start(new ProcessStartInfo(ExePath)))
             {
                 try
                 {


### PR DESCRIPTION
 @eiriktsarpalis testing `Process.Responding` using a real unresponsive process would be very hard (or even close to impossible) to do properly 

I think that we just test the implementation to ensure that #36768 is not coming back

My motivation is that the implementation just checks if a boolean flag is set and calls WinAPI:

https://github.com/JeroenOortwijn/runtime/blob/c4d3ed52ed8c3763ab69dbc53376eca77e02abd4/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs#L275-L302


Fixes #40703