### PR TITLE
Fix missing versions file and variable for packages

### DIFF
--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -34,7 +34,7 @@
   -->
   <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskAssembly)"/>
   <Target Name="UpdatePackageIndexWithStableVersions"
-          BeforeTargets="Build"
+          BeforeTargets="Build;Pack"
           Condition="'$(DotNetFinalVersionKind)' == 'release'">
     <ItemGroup>
       <!--
@@ -62,7 +62,7 @@
 
   <!-- Generate a version text file we include in our packages -->
   <Target Name="GenerateVersionFileForPackages"
-          BeforeTargets="Build"
+          BeforeTargets="Build;Pack"
           DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager">
     <Error Condition="'$(SourceRevisionId)' == ''" Text="SourceRevisionId is not set, which means the SourceLink targets are not included in the build. Those are needed to produce a correct sha for our build outputs." />
 
@@ -74,7 +74,7 @@
 
   <Target Name="SetAzureDevOpsVariableForBuiltPackages"
           Condition="'$(ContinuousIntegrationBuild)' == 'true'"
-          AfterTargets="Build">
+          AfterTargets="Build;Pack">
     <ItemGroup>
       <_PackageReports Include="$(PackageReportDir)*.json" />
     </ItemGroup>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/runtime/commit/f272bc5cf7737a3ce73b88083fed5cace52a2b16 which changed the default target from Build to Pack. Hooking onto both Build and Pack just for safety.

This is causing a) libraries runtime specific packages not being uploaded in official builds and b) version files missing.