### PR TITLE
Run Wasm browser sample on Helix

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -260,7 +260,7 @@
       <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
         <PayloadArchive>%(Identity)</PayloadArchive>
         <!-- No RunTests script generated for the sample project so we just use the direct command -->
-        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>
+        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output -- --run WasmSample.dll</Command>
       </HelixWorkItem>
     </ItemGroup>
 
@@ -270,7 +270,7 @@
       <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
         <PayloadArchive>%(Identity)</PayloadArchive>
         <!-- No RunTests script generated for the sample project so we just use the direct command -->
-        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --browser=Chrome  --html-file=index.html --output-directory=$XHARNESS_OUT -- WasmSample.dll --testing</Command>
+        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --browser=Chrome  --html-file=index.html --output-directory=$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output -- WasmSample.dll --testing</Command>
       </HelixWorkItem>
     </ItemGroup>
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -260,7 +260,7 @@
       <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
         <PayloadArchive>%(Identity)</PayloadArchive>
         <!-- No RunTests script generated for the sample project so we just use the direct command -->
-        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>
+        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll --testing</Command>
       </HelixWorkItem>
     </ItemGroup>
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -260,7 +260,7 @@
       <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
         <PayloadArchive>%(Identity)</PayloadArchive>
         <!-- No RunTests script generated for the sample project so we just use the direct command -->
-        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll --testing</Command>
+        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>
       </HelixWorkItem>
     </ItemGroup>
 
@@ -270,7 +270,7 @@
       <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
         <PayloadArchive>%(Identity)</PayloadArchive>
         <!-- No RunTests script generated for the sample project so we just use the direct command -->
-        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --browser=Chrome  --html-file=index.html --output-directory=$XHARNESS_OUT</Command>
+        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --browser=Chrome  --html-file=index.html --output-directory=$XHARNESS_OUT -- WasmSample.dll --testing</Command>
       </HelixWorkItem>
     </ItemGroup>
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -254,13 +254,23 @@
       </HelixWorkItem>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
-      <!-- Create a work item for run-only WASM apps  -->
-      <_RunOnlyWorkItem Include="$(TestArchiveRoot)runonly/**/*.zip" />
+    <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(Scenario)' != 'WasmTestOnBrowser'">
+      <!-- Create a work item for run-only WASM console app  -->
+      <_RunOnlyWorkItem Include="$(TestArchiveRoot)runonly/**/console/*.zip" />
       <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
         <PayloadArchive>%(Identity)</PayloadArchive>
         <!-- No RunTests script generated for the sample project so we just use the direct command -->
         <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --engine=V8  --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=$XHARNESS_OUT -- --run WasmSample.dll</Command>
+      </HelixWorkItem>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(Scenario)' == 'WasmTestOnBrowser'">
+      <!-- Create a work item for run-only WASM browser app  -->
+      <_RunOnlyWorkItem Include="$(TestArchiveRoot)runonly/**/browser/*.zip" />
+      <HelixWorkItem Include="@(_RunOnlyWorkItem -> '%(FileName)')" >
+        <PayloadArchive>%(Identity)</PayloadArchive>
+        <!-- No RunTests script generated for the sample project so we just use the direct command -->
+        <Command>dotnet exec $XHARNESS_CLI_PATH wasm $XHARNESS_COMMAND  --app=. --browser=Chrome  --html-file=index.html --output-directory=$XHARNESS_OUT</Command>
       </HelixWorkItem>
     </ItemGroup>
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -175,7 +175,7 @@
     <ProjectReference Include="$(MonoProjectRoot)netcore\sample\iOS\Program.csproj"
                       BuildInParallel="false"
                       Condition="'$(ArchiveTests)' == 'true' and ('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS')" />
-    <ProjectReference Include="$(MonoProjectRoot)netcore\sample\wasm\console\WasmSample.csproj"
+    <ProjectReference Include="$(MonoProjectRoot)netcore\sample\wasm\**\WasmSample.csproj"
                       BuildInParallel="false"
                       Condition="'$(ArchiveTests)' == 'true' and '$(TargetOS)' == 'Browser'" />
   </ItemGroup>

--- a/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="WasmBuildApp">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
@@ -60,7 +60,10 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="CopySampleAppToHelixTestDir" Condition="'$(ArchiveTests)' == 'true'" AfterTargets="WasmBuildApp" DependsOnTargets="Publish">
+  <Target Name="CopySampleAppToHelixTestDir" 
+          Condition="'$(ArchiveTests)' == 'true'" 
+          AfterTargets="Build" 
+          DependsOnTargets="Publish">
     <PropertyGroup>
       <!-- Helix properties -->
       <!-- AnyCPU as Platform-->

--- a/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/browser/WasmSample.csproj
@@ -60,5 +60,19 @@
     </Content>
   </ItemGroup>
 
+  <Target Name="CopySampleAppToHelixTestDir" Condition="'$(ArchiveTests)' == 'true'" AfterTargets="WasmBuildApp" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <!-- Helix properties -->
+      <!-- AnyCPU as Platform-->
+      <OSPlatformConfig>$(TargetOS).AnyCPU.$(Configuration)</OSPlatformConfig>
+      <HelixArchiveRoot>$(ArtifactsDir)helix/</HelixArchiveRoot>
+      <HelixArchiveRunOnlyRoot>$(HelixArchiveRoot)runonly/</HelixArchiveRunOnlyRoot>
+      <HelixArchiveRunOnlyAppsDir>$(HelixArchiveRunOnlyRoot)$(OSPlatformConfig)/browser/</HelixArchiveRunOnlyAppsDir>
+      <ZippedApp>$(OutputPath)/WasmBrowserSample.zip</ZippedApp>
+    </PropertyGroup>
+    <ZipDirectory SourceDirectory="$(AppDir)" DestinationFile="$(ZippedApp)" />
+    <Copy SourceFiles="$(ZippedApp)" DestinationFolder="$(HelixArchiveRunOnlyAppsDir)" />
+  </Target>
+
   <Import Project="$(MonoProjectRoot)\wasm\build\WasmApp.targets" />
 </Project>

--- a/src/mono/netcore/sample/wasm/browser/index.html
+++ b/src/mono/netcore/sample/wasm/browser/index.html
@@ -7,15 +7,44 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
-  <body>
+  <body onload="onLoad()">
     <h3 id="header">Wasm Browser Sample</h3>
     Result from Sample.Test.TestMeaning: <span id="out"></span>
     <script type='text/javascript'>
+      var is_testing = false;
+      var onLoad = function() {
+        var url = new URL(decodeURI(window.location));
+        let args = url.searchParams.getAll('arg');
+        is_testing = args !== undefined && (args.find(arg => arg == '--testing') !== undefined);
+      };
+
+      var test_exit = function(exit_code)
+      {
+        if (!is_testing) {
+          console.log(`test_exit: ${exitCode}`);
+          return;
+        }
+
+        /* Set result in a tests_done element, to be read by xharness */
+        var tests_done_elem = document.createElement("label");
+        tests_done_elem.id = "tests_done";
+        tests_done_elem.innerHTML = exit_code.toString();
+        document.body.appendChild(tests_done_elem);
+
+        console.log(`WASM EXIT ${exit_code}`);
+      };
+
       var App = {
         init: function () {
           var ret = BINDING.call_static_method("[WasmSample] Sample.Test:TestMeaning", []);
           document.getElementById("out").innerHTML = ret;
-          console.log ("ready");
+
+          if (is_testing)
+          {
+            console.debug(`ret: ${ret}`);
+            let exit_code = ret == 42 ? 0 : 1;
+            test_exit(exit_code);
+          }
         },
       };
     </script>

--- a/src/mono/netcore/sample/wasm/browser/runtime.js
+++ b/src/mono/netcore/sample/wasm/browser/runtime.js
@@ -4,12 +4,23 @@
 var Module = { 
     onRuntimeInitialized: function () {
         config.loaded_cb = function () {
-            App.init ();
+            try {
+                App.init ();
+            } catch (error) {
+                test_exit(1);
+                throw (error);
+            }
         };
         config.fetch_file_cb = function (asset) {
             return fetch (asset, { credentials: 'same-origin' });
         }
 
-        MONO.mono_load_runtime_and_bcl_args (config);
+        try
+        {
+            MONO.mono_load_runtime_and_bcl_args (config);
+        } catch (error) {
+            test_exit(1);
+            throw(error);
+        }
     },
 };

--- a/src/mono/netcore/sample/wasm/console/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/console/WasmSample.csproj
@@ -63,7 +63,7 @@
       <OSPlatformConfig>$(TargetOS).AnyCPU.$(Configuration)</OSPlatformConfig>
       <HelixArchiveRoot>$(ArtifactsDir)helix/</HelixArchiveRoot>
       <HelixArchiveRunOnlyRoot>$(HelixArchiveRoot)runonly/</HelixArchiveRunOnlyRoot>
-      <HelixArchiveRunOnlyAppsDir>$(HelixArchiveRunOnlyRoot)$(OSPlatformConfig)/</HelixArchiveRunOnlyAppsDir>
+      <HelixArchiveRunOnlyAppsDir>$(HelixArchiveRunOnlyRoot)$(OSPlatformConfig)/console/</HelixArchiveRunOnlyAppsDir>
       <ZippedApp>$(OutputPath)/WasmConsoleSample.zip</ZippedApp>
     </PropertyGroup>
     <ZipDirectory SourceDirectory="$(AppBundleDir)" DestinationFile="$(ZippedApp)" />


### PR DESCRIPTION
This is a continuation of https://github.com/dotnet/runtime/pull/45768 for the browser sample.
Which sample to run depends on the Helix scenario:
- the console sample runs under `normal` scenario;
- the browser sample runs under `WasmTestOnBrowser` scenario.

Relates to https://github.com/dotnet/runtime/issues/43865