### PR TITLE
[tests] Accept GUIDs from .NET Framework in ccw-class-iface test.

### DIFF
--- a/src/mono/mono/tests/ccw-class-iface.cs
+++ b/src/mono/mono/tests/ccw-class-iface.cs
@@ -213,14 +213,17 @@ public class Tests
             return 5;
         }
 
-        /*TODO: Fix GUID when we support generated class GUIDs*/
-        if (typeof(TestParent).GUID != Guid.Empty)
+        /*TODO: Reject Guid.Empty when we support generated class GUIDs*/
+        if (typeof(TestParent).GUID != Guid.Empty &&
+			typeof(TestParent).GUID != new Guid("7dcc27e3-e226-35ca-a942-2286b21f2525"))
         {
             Console.Error.WriteLine("Unexpected typeof(TestParent).GUID: {0}", typeof(TestParent).GUID);
             return 6;
         }
 
-        if (typeof(int).GUID != Guid.Empty)
+        /*TODO: Reject Guid.Empty when we support generated class GUIDs*/
+        if (typeof(int).GUID != Guid.Empty &&
+			typeof(int).GUID != new Guid("a310fadd-7c33-377c-9d6b-599b0317d7f2"))
         {
             Console.Error.WriteLine("Unexpected typeof(int).GUID: {0}", typeof(int).GUID);
             return 7;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20671,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The commit d5f338c088defdf81f4374f4e6fbff75c9b1e554 broke the ccw-class-iface test on Windows under .NET Framework. A couple of the tests expect Guid.Empty, but Mono only produces Guid.Empty because GUID generation isn't yet implemented for those classes.

This patch adds the values produced by .NET Framework as accepted values, while still accepting Guid.Empty for now.