### PR TITLE
Fixes DI deadlock when resolving singletons 

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -84,13 +84,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             // Check if we are in the situation where scoped service was promoted to singleton
             // and we need to lock the root
-            RuntimeResolverLock requiredScope = context.Scope == context.Scope.Engine.Root ?
-                RuntimeResolverLock.Root :
-                RuntimeResolverLock.Scope;
-            if (requiredScope == RuntimeResolverLock.Root)
-                return VisitRootCache(callSite, context);
-
-            return VisitCache(callSite, context, context.Scope, requiredScope);
+            return context.Scope == context.Scope.Engine.Root ?
+                VisitRootCache(callSite, context) :
+                VisitCache(callSite, context, context.Scope, RuntimeResolverLock.Scope);
         }
 
         private object VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -58,19 +58,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         }
 
         private readonly ConcurrentDictionary<ServiceCacheKey, object> _perSingletonLocks = new ConcurrentDictionary<ServiceCacheKey, object>();
-        private readonly object _resolveLock = new object();
 
         protected override object VisitRootCache(ServiceCallSite callSite, RuntimeResolverContext context)
         {
             if (!_perSingletonLocks.ContainsKey(callSite.Cache.Key))
             {
-                lock (_resolveLock)
-                {
-                    if (!_perSingletonLocks.ContainsKey(callSite.Cache.Key))
-                    {
-                        _perSingletonLocks.AddOrUpdate(callSite.Cache.Key, k => (object)k, (k, v) => v);
-                    }
-                }
+                _perSingletonLocks.AddOrUpdate(callSite.Cache.Key, k => callSite, (k, v) => v);
             }
 
             object lockedOn = _perSingletonLocks[callSite.Cache.Key];

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -440,17 +440,15 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             services.AddSingleton<Thing0>();
             services.AddTransient(sp =>
             {
-                if (ThreadId == 1)
-                {
-                    Action1();
-                }
-                else
+                if (ThreadId == 2)
                 {
                     // Let Thread 1 over take Thread 2
-                    Action2();
+                    _manualResetEvent.WaitOne();
                 }
 
-                return lazy.Value;
+                Thing1 value = lazy.Value;
+                _manualResetEvent.Set();
+                return value;
             });
             services.AddSingleton<Thing2>();
 
@@ -481,16 +479,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         private ManualResetEvent _manualResetEvent = new ManualResetEvent(false);
-
-        private void Action1()
-        {
-            _manualResetEvent.Set();
-        }
-
-        private void Action2()
-        {
-            _manualResetEvent.WaitOne();
-        }
 
         [Fact]
         public async Task GetRequiredService_BiggerObjectGraphWithOpenGenerics_NoDeadlock()
@@ -528,18 +516,16 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             });
 
             services.AddTransient(sp =>
-            {
-                if (ThreadId == 1)
-                {
-                    Action1();
-                }
-                else
+            { 
+                if (ThreadId == 2)
                 {
                     // Let Thread 1 over take Thread 2
-                    Action2();
+                    _manualResetEvent.WaitOne();
                 }
 
-                return lazy.Value;
+                Thing4 value = lazy.Value;
+                _manualResetEvent.Set();
+                return value;
             });
             services.AddSingleton<Thing5>();
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -595,7 +595,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
         private class Thing1
         {
-            public Thing1(Thing0 thing2)
+            public Thing1(Thing0 thing0)
             {
             }
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -375,6 +375,98 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
+        [ThreadStatic]
+        public static int ThreadId;
+
+        [Fact]
+        public async Task TestDeadlock()
+        {
+            // Thread 1: Thing1 (transient) -> Thing0 (singleton)
+            // Thread 2: Thing2 (singleton) -> Thing1 (transient) -> Thing0 (singleton)
+
+            // This reproduces the dead lock between the Lazy<T> and the IServiceProvider. Whenever singleton or scoped
+            // services are resolved a lock is taken (either globally for singletons or per scope for scoped).
+
+            // 1. Thread 1 resolves the Thing1 which is a transient service
+            // 2. In parallel, Thread 2 resolves Thing2 which is a singleton
+            // 3. Thread 1 enters the factory callback for Thing1 and takes the lazy lock
+            // 4. Thread 2 takes the singleton lock for the container when it resolves Thing2
+            // 5. Thread 2 enters the factory callback for Thing1 and waits on the lazy lock
+            // 6. Thread 1 calls GetRequiredService<Thing0> on the service provider, this waits for the singleton lock that Thread1 has
+            
+            // Thread 1 has the lazy lock and is waiting on the singleton lock
+            // Thread 2 has the singleton lock an is waiting on the lazy
+
+            var services = new ServiceCollection();
+
+            IServiceProvider sp = null;
+
+            var lazy = new Lazy<Thing1>(() =>
+            {
+                // Tries to take the singleton lock (global)
+                var thing0 = sp.GetRequiredService<Thing0>();
+                return new Thing1(thing0);
+            });
+
+            services.AddSingleton<Thing0>();
+            services.AddTransient(sp =>
+            {
+                if (ThreadId == 1)
+                {
+                    Thread.Sleep(1000);
+                }
+                else
+                {
+                    // Let Thread 1 over take Thread 2
+                    Thread.Sleep(3000);
+                }
+
+                return lazy.Value;
+            });
+            services.AddSingleton<Thing2>();
+
+            sp = services.BuildServiceProvider();
+
+            var t1 = Task.Run(() =>
+            {
+                ThreadId = 1;
+                using var scope1 = sp.CreateScope();
+                scope1.ServiceProvider.GetRequiredService<Thing1>();
+            });
+
+            var t2 = Task.Run(() =>
+            {
+                ThreadId = 2;
+                using var scope2 = sp.CreateScope();
+                scope2.ServiceProvider.GetRequiredService<Thing2>();
+            });
+
+            await t1;
+            await t2;
+        }
+
+        public class Thing2
+        {
+            public Thing2(Thing1 thing1)
+            {
+
+            }
+        }
+
+        public class Thing1
+        {
+            public Thing1(Thing0 thing2)
+            {
+            }
+        }
+
+        public class Thing0
+        {
+            public Thing0()
+            {
+            }
+        }
+
         private class DisposeServiceProviderInCtorAsyncDisposable : IFakeService, IAsyncDisposable
         {
             private readonly AsyncDisposable _asyncDisposable;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -375,98 +375,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
-        [ThreadStatic]
-        public static int ThreadId;
-
-        [Fact]
-        public async Task TestDeadlock()
-        {
-            // Thread 1: Thing1 (transient) -> Thing0 (singleton)
-            // Thread 2: Thing2 (singleton) -> Thing1 (transient) -> Thing0 (singleton)
-
-            // This reproduces the dead lock between the Lazy<T> and the IServiceProvider. Whenever singleton or scoped
-            // services are resolved a lock is taken (either globally for singletons or per scope for scoped).
-
-            // 1. Thread 1 resolves the Thing1 which is a transient service
-            // 2. In parallel, Thread 2 resolves Thing2 which is a singleton
-            // 3. Thread 1 enters the factory callback for Thing1 and takes the lazy lock
-            // 4. Thread 2 takes the singleton lock for the container when it resolves Thing2
-            // 5. Thread 2 enters the factory callback for Thing1 and waits on the lazy lock
-            // 6. Thread 1 calls GetRequiredService<Thing0> on the service provider, this waits for the singleton lock that Thread1 has
-            
-            // Thread 1 has the lazy lock and is waiting on the singleton lock
-            // Thread 2 has the singleton lock an is waiting on the lazy
-
-            var services = new ServiceCollection();
-
-            IServiceProvider sp = null;
-
-            var lazy = new Lazy<Thing1>(() =>
-            {
-                // Tries to take the singleton lock (global)
-                var thing0 = sp.GetRequiredService<Thing0>();
-                return new Thing1(thing0);
-            });
-
-            services.AddSingleton<Thing0>();
-            services.AddTransient(sp =>
-            {
-                if (ThreadId == 1)
-                {
-                    Thread.Sleep(1000);
-                }
-                else
-                {
-                    // Let Thread 1 over take Thread 2
-                    Thread.Sleep(3000);
-                }
-
-                return lazy.Value;
-            });
-            services.AddSingleton<Thing2>();
-
-            sp = services.BuildServiceProvider();
-
-            var t1 = Task.Run(() =>
-            {
-                ThreadId = 1;
-                using var scope1 = sp.CreateScope();
-                scope1.ServiceProvider.GetRequiredService<Thing1>();
-            });
-
-            var t2 = Task.Run(() =>
-            {
-                ThreadId = 2;
-                using var scope2 = sp.CreateScope();
-                scope2.ServiceProvider.GetRequiredService<Thing2>();
-            });
-
-            await t1;
-            await t2;
-        }
-
-        public class Thing2
-        {
-            public Thing2(Thing1 thing1)
-            {
-
-            }
-        }
-
-        public class Thing1
-        {
-            public Thing1(Thing0 thing2)
-            {
-            }
-        }
-
-        public class Thing0
-        {
-            public Thing0()
-            {
-            }
-        }
-
         private class DisposeServiceProviderInCtorAsyncDisposable : IFakeService, IAsyncDisposable
         {
             private readonly AsyncDisposable _asyncDisposable;
@@ -495,6 +403,90 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             public void Dispose()
             {
                 _disposable.Dispose();
+            }
+        }
+
+        [ThreadStatic]
+        public static int ThreadId;
+
+        [Fact]
+        public async Task GetRequiredService_UsesSingletonAndLazyLocks_NoDeadlock()
+        {
+            Thing0 thing0 = null;
+            Thing1 thing1 = null;
+            Thing2 thing2 = null;
+            IServiceProvider sp = null;
+
+            // Arrange
+            var services = new ServiceCollection();
+
+            var lazy = new Lazy<Thing1>(() =>
+            {
+                thing0 = sp.GetRequiredService<Thing0>();
+                return new Thing1(thing0);
+            });
+
+            services.AddSingleton<Thing0>();
+            services.AddTransient(sp =>
+            {
+                if (ThreadId == 1)
+                {
+                    Thread.Sleep(1000);
+                }
+                else
+                {
+                    // Let Thread 1 over take Thread 2
+                    Thread.Sleep(3000);
+                }
+
+                return lazy.Value;
+            });
+            services.AddSingleton<Thing2>();
+
+            sp = services.BuildServiceProvider();
+
+            var t1 = Task.Run(() =>
+            {
+                ThreadId = 1;
+                using var scope1 = sp.CreateScope();
+                thing1 = scope1.ServiceProvider.GetRequiredService<Thing1>();
+            });
+
+            var t2 = Task.Run(() =>
+            {
+                ThreadId = 2;
+                using var scope2 = sp.CreateScope();
+                thing2 = scope2.ServiceProvider.GetRequiredService<Thing2>();
+            });
+
+            // Act
+            await t1;
+            await t2;
+
+            // Assert
+            Assert.NotNull(thing0);
+            Assert.NotNull(thing1);
+            Assert.NotNull(thing2);
+        }
+
+        private class Thing2
+        {
+            public Thing2(Thing1 thing1)
+            {
+            }
+        }
+
+        private class Thing1
+        {
+            public Thing1(Thing0 thing2)
+            {
+            }
+        }
+
+        private class Thing0
+        {
+            public Thing0()
+            {
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -442,12 +442,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             {
                 if (ThreadId == 1)
                 {
-                    Thread.Sleep(1000);
+                    Action1();
                 }
                 else
                 {
                     // Let Thread 1 over take Thread 2
-                    Thread.Sleep(3000);
+                    Action2();
                 }
 
                 return lazy.Value;
@@ -478,6 +478,18 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.NotNull(thing0);
             Assert.NotNull(thing1);
             Assert.NotNull(thing2);
+        }
+
+        private ManualResetEvent _manualResetEvent = new ManualResetEvent(false);
+
+        private void Action1()
+        {
+            _manualResetEvent.Set();
+        }
+
+        private void Action2()
+        {
+            _manualResetEvent.WaitOne();
         }
 
         [Fact]
@@ -519,12 +531,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             {
                 if (ThreadId == 1)
                 {
-                    Thread.Sleep(1000);
+                    Action1();
                 }
                 else
                 {
                     // Let Thread 1 over take Thread 2
-                    Thread.Sleep(3000);
+                    Action2();
                 }
 
                 return lazy.Value;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -607,41 +607,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36458")]
-        public void GetRequiredService_CircularReference_ThrowsSOEAndHangs()
-        {
-            // Arrange
-            var services = new ServiceCollection();
-            services.AddSingleton<RecursiveThing>();
-            IServiceProvider sp = services.BuildServiceProvider();
-            using var scope1 = sp.CreateScope();
-
-            bool doesNotHang = Task.Run(() =>
-            {
-                SingleThreadedSynchronizationContext.Run(() =>
-                {
-                    // Act
-                    Assert.Throws<StackOverflowException>(() =>
-                    {
-                        // ctor disposes ServiceProvider
-                        var service = sp.GetRequiredService<RecursiveThing>();
-                    });
-                });
-            }).Wait(TimeSpan.FromSeconds(10));
-
-            // Assert
-            Assert.False(doesNotHang);
-        }
-
-        private class RecursiveThing
-        {
-            public RecursiveThing(IServiceProvider sp)
-            {
-                sp.GetRequiredService<RecursiveThing>();
-            }
-        }
-
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42160")] // We don't support value task services currently
         [Theory]
         [InlineData(ServiceLifetime.Transient)]


### PR DESCRIPTION
Introducing per singleton lock for the code path which resolves singletons.

The repro test case in https://github.com/dotnet/runtime/issues/35986#issuecomment-670302230 gets fixed with this change.

Fixes: https://github.com/dotnet/runtime/issues/35986