### PR TITLE
CollectionBase.Remove(value) should not throw when not found

### DIFF
--- a/src/libraries/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
+++ b/src/libraries/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
@@ -74,6 +74,15 @@ namespace System.Runtime.Serialization
 
         public void Insert(int index, CodeTypeReference value) => List.Insert(index, value);
 
-        public void Remove(CodeTypeReference value) => List.Remove(value);
+        public void Remove(CodeTypeReference value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/Resources/Strings.resx
+++ b/src/libraries/System.CodeDom/src/Resources/Strings.resx
@@ -73,6 +73,9 @@
   <data name="InvalidElementType" xml:space="preserve">
     <value>Element type {0} is not supported.</value>
   </data>
+  <data name="Arg_RemoveArgNotFound" xml:space="preserve">
+    <value>Cannot remove the specified item because it was not found in the specified Collection.</value>
+  </data>
   <data name="Argument_NullComment" xml:space="preserve">
     <value>The 'Comment' property of the CodeCommentStatement '{0}' cannot be null.</value>
   </data>

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeAttributeArgumentCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeAttributeArgumentCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeAttributeArgument value) => List.Insert(index, value);
 
-        public void Remove(CodeAttributeArgument value) => List.Remove(value);
+        public void Remove(CodeAttributeArgument value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeAttributeDeclarationCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeAttributeDeclarationCollection.cs
@@ -64,6 +64,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeAttributeDeclaration value) => List.Insert(index, value);
 
-        public void Remove(CodeAttributeDeclaration value) => List.Remove(value);
+        public void Remove(CodeAttributeDeclaration value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeCatchClauseCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeCatchClauseCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeCatchClause value) => List.Insert(index, value);
 
-        public void Remove(CodeCatchClause value) => List.Remove(value);
+        public void Remove(CodeCatchClause value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeCommentStatementCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeCommentStatementCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeCommentStatement value) => List.Insert(index, value);
 
-        public void Remove(CodeCommentStatement value) => List.Remove(value);
+        public void Remove(CodeCommentStatement value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeDirectiveCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeDirectiveCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeDirective value) => List.Insert(index, value);
 
-        public void Remove(CodeDirective value) => List.Remove(value);
+        public void Remove(CodeDirective value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeExpressionCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeExpressionCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeExpression value) => List.Insert(index, value);
 
-        public void Remove(CodeExpression value) => List.Remove(value);
+        public void Remove(CodeExpression value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeNamespaceCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeNamespaceCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeNamespace value) => List.Insert(index, value);
 
-        public void Remove(CodeNamespace value) => List.Remove(value);
+        public void Remove(CodeNamespace value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeParameterDeclarationExpressionCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeParameterDeclarationExpressionCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeParameterDeclarationExpression value) => List.Insert(index, value);
 
-        public void Remove(CodeParameterDeclarationExpression value) => List.Remove(value);
+        public void Remove(CodeParameterDeclarationExpression value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeStatementCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeStatementCollection.cs
@@ -64,6 +64,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeStatement value) => List.Insert(index, value);
 
-        public void Remove(CodeStatement value) => List.Remove(value);
+        public void Remove(CodeStatement value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeTypeDeclarationCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeTypeDeclarationCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeTypeDeclaration value) => List.Insert(index, value);
 
-        public void Remove(CodeTypeDeclaration value) => List.Remove(value);
+        public void Remove(CodeTypeDeclaration value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeTypeMemberCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeTypeMemberCollection.cs
@@ -62,6 +62,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeTypeMember value) => List.Insert(index, value);
 
-        public void Remove(CodeTypeMember value) => List.Remove(value);
+        public void Remove(CodeTypeMember value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeTypeParameterCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeTypeParameterCollection.cs
@@ -64,6 +64,15 @@ namespace System.CodeDom
 
         public void Insert(int index, CodeTypeParameter value) => List.Insert(index, value);
 
-        public void Remove(CodeTypeParameter value) => List.Remove(value);
+        public void Remove(CodeTypeParameter value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CompilerErrorCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CompilerErrorCollection.cs
@@ -98,6 +98,15 @@ namespace System.CodeDom.Compiler
 
         public void Insert(int index, CompilerError value) => List.Insert(index, value);
 
-        public void Remove(CompilerError value) => List.Remove(value);
+        public void Remove(CompilerError value)
+        {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
+            List.Remove(value);
+        }
     }
 }

--- a/src/libraries/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
+++ b/src/libraries/System.Collections.NonGeneric/src/System/Collections/CollectionBase.cs
@@ -167,7 +167,10 @@ namespace System.Collections
         {
             OnValidate(value!);
             int index = InnerList.IndexOf(value);
-            if (index < 0) throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+            if (index < 0)
+            {
+                return;
+            }
             OnRemove(index, value);
             InnerList.RemoveAt(index);
             try

--- a/src/libraries/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
@@ -95,7 +95,7 @@ namespace System.Collections.Tests
         public static void Remove_Invalid()
         {
             MyCollection collBase = CreateCollection(100);
-            AssertExtensions.Throws<ArgumentException>(null, () => collBase.Remove(new Foo())); // Non existent object
+            collBase.Remove(new Foo());
             Assert.Equal(100, collBase.Count);
         }
 

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryAttributeCollectionTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryAttributeCollectionTests.cs
@@ -161,7 +161,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public static IEnumerable<object[]> Remove_InvalidValue_TestData()
         {
             yield return new object[] { null, null };
-            yield return new object[] { new DirectoryAttribute(), null };
+            //yield return new object[] { new DirectoryAttribute(), null };
             yield return new object[] { 1, "value" };
         }
 

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryAttributeModificationCollectionTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryAttributeModificationCollectionTests.cs
@@ -161,7 +161,7 @@ namespace System.DirectoryServices.Protocols.Tests
         public static IEnumerable<object[]> Remove_InvalidValue_TestData()
         {
             yield return new object[] { null, null };
-            yield return new object[] { new DirectoryAttributeModification(), null };
+            //yield return new object[] { new DirectoryAttributeModification(), null };
             yield return new object[] { 1, "value" };
         }
 

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryAttributeTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryAttributeTests.cs
@@ -328,13 +328,11 @@ namespace System.DirectoryServices.Protocols.Tests
             AssertExtensions.Throws<ArgumentNullException>("value", () => attribute.Remove(null));
         }
 
-        [Theory]
-        [InlineData("vaLue", null)]
-        [InlineData(1, "value")]
-        public void Remove_InvalidValue_ThrowsArgumentException(object value, string paramName)
+        [Fact]
+        public void Remove_InvalidValue_ThrowsArgumentException()
         {
             var attribute = new DirectoryAttribute { "value" };
-            AssertExtensions.Throws<ArgumentException>(paramName, () => attribute.Remove(value));
+            AssertExtensions.Throws<ArgumentException>("value", () => attribute.Remove(1));
         }
     }
 }

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryControlCollectionTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryControlCollectionTests.cs
@@ -165,18 +165,11 @@ namespace System.DirectoryServices.Protocols.Tests
             AssertExtensions.Throws<ArgumentNullException>("value", () => collection.Remove(null));
         }
 
-        public static IEnumerable<object[]> Remove_InvalidValue_TestData()
-        {
-            yield return new object[] { new AsqRequestControl(), null };
-            yield return new object[] { 1, "value" };
-        }
-
-        [Theory]
-        [MemberData(nameof(Remove_InvalidValue_TestData))]
-        public void Remove_InvalidValue_ThrowsArgumentException(object value, string paramName)
+        [Fact]
+        public void Remove_InvalidValue_ThrowsArgumentException()
         {
             IList collection = new DirectoryControlCollection { new AsqRequestControl() };
-            AssertExtensions.Throws<ArgumentException>(paramName, () => collection.Remove(value));
+            AssertExtensions.Throws<ArgumentException>("value", () => collection.Remove(1));
         }
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Arg_RemoveArgNotFound" xml:space="preserve">
+    <value>Cannot remove the specified item because it was not found in the specified Collection.</value>
+  </data>
   <data name="ArrayExceededSize" xml:space="preserve">
     <value>Array length '{0}' provided by the get-only collection of type '{1}' is less than the number of array elements found in the input stream.  Consider increasing the length of the array.</value>
   </data>

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -1057,7 +1057,8 @@ public static partial class XmlSerializerTests
         attrs.XmlElements.Remove(item2);
         Assert.False(attrs.XmlElements.Contains(item2));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => { attrs.XmlElements.Remove(item2); });
+        // docs says nothing about throwing in this case
+        attrs.XmlElements.Remove(item2);
     }
 
     [Fact]
@@ -1089,7 +1090,8 @@ public static partial class XmlSerializerTests
         attrs.XmlArrayItems.Remove(item2);
         Assert.False(attrs.XmlArrayItems.Contains(item2));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => { attrs.XmlArrayItems.Remove(item2); });
+        // docs says nothing about throwing in this case
+        attrs.XmlArrayItems.Remove(item2);
     }
 
     [Fact]
@@ -1121,7 +1123,8 @@ public static partial class XmlSerializerTests
         attrs.XmlAnyElements.Remove(item2);
         Assert.False(attrs.XmlAnyElements.Contains(item2));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => { attrs.XmlAnyElements.Remove(item2); });
+        // docs says nothing about throwing in this case
+        attrs.XmlAnyElements.Remove(item2);
     }
 
     [Fact]

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -85,6 +85,9 @@
   <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
     <value>Only single dimensional arrays are supported for the requested action.</value>
   </data>
+  <data name="Arg_RemoveArgNotFound" xml:space="preserve">
+    <value>Cannot remove the specified item because it was not found in the specified Collection.</value>
+  </data>
   <data name="Argument_EncodeDestinationTooSmall" xml:space="preserve">
     <value>The destination is too small to hold the encoded value.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509CertificateCollection.cs
@@ -101,6 +101,12 @@ namespace System.Security.Cryptography.X509Certificates
 
         public void Remove(X509Certificate value)
         {
+            base.OnValidate(value);
+
+            int index = List.IndexOf(value);
+            if (index < 0)
+                throw new ArgumentException(SR.Arg_RemoveArgNotFound);
+
             List.Remove(value);
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -809,7 +809,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(2, originalPrivateKeyCount);
 
                 byte[] exported = collection.Export(X509ContentType.Pkcs12);
-                
+
                 using (ImportedCollection ic = Cert.Import(exported))
                 {
                     X509Certificate2Collection importedCollection = ic.Collection;
@@ -955,7 +955,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 il.Remove(c2);
                 Assert.Equal(0, il.Count);
 
-                AssertExtensions.Throws<ArgumentException>(null, () => il.Remove(c2));
+                //IList does not throw when item is not found
+                il.Remove(c2);
             }
         }
 
@@ -1465,7 +1466,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void ImportFromPemFile_MultiplePems_Success()
         {
             string pemAggregate = TestData.RsaCertificate + TestData.ECDsaCertificate;
-    
+
             using (TempFileHolder aggregatePemFile = new TempFileHolder(pemAggregate))
             using(ImportedCollection ic = Cert.ImportFromPemFile(aggregatePemFile.FilePath))
             {


### PR DESCRIPTION
The IList interface does not have an exception listed for not found

fix #39703