### PR TITLE
Use destType for size instead of srcType when writing a variable from a register to the stack.

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -11836,10 +11836,10 @@ void CodeGen::genMultiRegStoreToLocal(GenTreeLclVar* lclNode)
             regNumber  varReg      = lclNode->GetRegByIndex(i);
             unsigned   fieldLclNum = varDsc->lvFieldLclStart + i;
             LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(fieldLclNum);
+            var_types  destType    = fieldVarDsc->TypeGet();
             if (varReg != REG_NA)
             {
-                var_types destType = fieldVarDsc->TypeGet();
-                hasRegs            = true;
+                hasRegs = true;
                 if (varReg != reg)
                 {
                     // We may need a cross register-file copy here.
@@ -11855,7 +11855,7 @@ void CodeGen::genMultiRegStoreToLocal(GenTreeLclVar* lclNode)
             {
                 if (!lclNode->AsLclVar()->IsLastUse(i))
                 {
-                    GetEmitter()->emitIns_S_R(ins_Store(srcType), emitTypeSize(srcType), reg, fieldLclNum, 0);
+                    GetEmitter()->emitIns_S_R(ins_Store(srcType), emitTypeSize(destType), reg, fieldLclNum, 0);
                 }
             }
             fieldVarDsc->SetRegNum(varReg);


### PR DESCRIPTION
If we use srcType, we'll in some cases do a 64-bit store instead of a 32-bit store or vice versa. This is causing random failures as described in #46172.

Alternative fix to #46172

I've validated that this PR has no diffs outside of P/Invoke stubs from the JIT in https://github.com/dotnet/runtime/commit/35fbaefa57f94268090dd28d432b6109e64a8c48 (the commit before #45625).

cc: @safern 