### PR TITLE
Start thread pool worker threads in the default execution context

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -212,9 +212,6 @@ namespace System.Threading
             StartupSetApartmentStateInternal();
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
-            // Attach current thread's security principal object to the new
-            // thread. Be careful not to bind the current thread to a principal
-            // if it's not already bound.
             if (_delegate != null)
             {
                 // If we reach here with a null delegate, something is broken. But we'll let the StartInternal method take care of
@@ -226,6 +223,29 @@ namespace System.Threading
                 t.SetExecutionContextHelper(ec);
             }
 
+            StartInternal();
+        }
+
+        [UnsupportedOSPlatform("browser")]
+        internal void UnsafeStart(object? parameter)
+        {
+            // We expect the thread to be setup with a ParameterizedThreadStart if this Start is called.
+            Debug.Assert(_delegate is ThreadStart);
+
+            _threadStartArg = parameter;
+            UnsafeStart();
+        }
+
+        [UnsupportedOSPlatform("browser")]
+        internal void UnsafeStart()
+        {
+#if FEATURE_COMINTEROP_APARTMENT_SUPPORT
+            // Eagerly initialize the COM Apartment state of the thread if we're allowed to.
+            StartupSetApartmentStateInternal();
+#endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
+
+            Debug.Assert(_delegate != null);
+            Debug.Assert(_delegate!.Target is ThreadHelper);
             StartInternal();
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -70,7 +70,7 @@ namespace System.Threading
             _startArg = obj;
 
             ExecutionContext? context = _executionContext;
-            if (context != null)
+            if (context != null && !context.IsDefault)
             {
                 ExecutionContext.RunInternal(context, s_threadStartContextCallback, this);
             }
@@ -87,7 +87,7 @@ namespace System.Threading
             Debug.Assert(_start is ThreadStart);
 
             ExecutionContext? context = _executionContext;
-            if (context != null)
+            if (context != null && !context.IsDefault)
             {
                 ExecutionContext.RunInternal(context, s_threadStartContextCallback, this);
             }
@@ -222,8 +222,7 @@ namespace System.Threading
                 Debug.Assert(_delegate.Target is ThreadHelper);
                 var t = (ThreadHelper)_delegate.Target;
 
-                ExecutionContext? ec = ExecutionContext.Capture();
-                t.SetExecutionContextHelper(ec);
+                t.SetExecutionContextHelper(CurrentThread._executionContext);
             }
 
             StartInternal();

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -222,7 +222,8 @@ namespace System.Threading
                 Debug.Assert(_delegate.Target is ThreadHelper);
                 var t = (ThreadHelper)_delegate.Target;
 
-                t.SetExecutionContextHelper(CurrentThread._executionContext);
+                ExecutionContext? ec = ExecutionContext.Capture();
+                t.SetExecutionContextHelper(ec);
             }
 
             StartInternal();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -178,8 +178,6 @@ namespace System.Threading
                     gateThread.IsBackground = true;
                     gateThread.Name = ".NET ThreadPool Gate";
                     gateThread.Start();
-
-                    currentThread._executionContext = previousExecutionContext;
                 }
                 catch
                 {
@@ -189,6 +187,8 @@ namespace System.Threading
                     Interlocked.Exchange(ref threadPoolInstance._separated.gateThreadRunningState, 0);
                     throw;
                 }
+
+                currentThread._executionContext = previousExecutionContext;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -184,29 +184,13 @@ namespace System.Threading
             {
                 _waitHandles[0] = _changeHandlesEvent.SafeWaitHandle;
 
-                // Starting a new thread transfers the current execution context to the new thread. Thread pool threads must
-                // start in the default context, so switch contexts temporarily.
-                Thread currentThread = Thread.CurrentThread;
-                ExecutionContext? previousExecutionContext = currentThread._executionContext;
-                currentThread._executionContext = null;
-
-                try
-                {
-                    Thread waitThread = new Thread(WaitThreadStart, SmallStackSizeBytes);
-                    waitThread.IsThreadPoolThread = true;
-                    waitThread.IsBackground = true;
-                    waitThread.Name = ".NET ThreadPool Wait";
-                    waitThread.Start();
-                }
-                catch
-                {
-                    // Note: we have a "catch" rather than a "finally" because we want to stop the first pass of EH here.
-                    // That way we can restore the previous context before any of our callers' EH filters run.
-                    currentThread._executionContext = previousExecutionContext;
-                    throw;
-                }
-
-                currentThread._executionContext = previousExecutionContext;
+                // Thread pool threads must start in the default execution context without transferring the context, so
+                // using UnsafeStart() instead of Start()
+                Thread waitThread = new Thread(WaitThreadStart, SmallStackSizeBytes);
+                waitThread.IsThreadPoolThread = true;
+                waitThread.IsBackground = true;
+                waitThread.Name = ".NET ThreadPool Wait";
+                waitThread.UnsafeStart();
             }
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -197,8 +197,6 @@ namespace System.Threading
                     waitThread.IsBackground = true;
                     waitThread.Name = ".NET ThreadPool Wait";
                     waitThread.Start();
-
-                    currentThread._executionContext = previousExecutionContext;
                 }
                 catch
                 {
@@ -207,6 +205,8 @@ namespace System.Threading
                     currentThread._executionContext = previousExecutionContext;
                     throw;
                 }
+
+                currentThread._executionContext = previousExecutionContext;
             }
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -292,11 +292,7 @@ namespace System.Threading
                     // start in the default context, so switch contexts temporarily if necessary.
                     Thread currentThread = Thread.CurrentThread;
                     ExecutionContext? previousExecutionContext = currentThread._executionContext;
-                    bool changeExecutionContext = previousExecutionContext != null && !previousExecutionContext.IsDefault;
-                    if (changeExecutionContext)
-                    {
-                        currentThread._executionContext = null;
-                    }
+                    currentThread._executionContext = null;
 
                     try
                     {
@@ -309,18 +305,11 @@ namespace System.Threading
                     {
                         // Note: we have a "catch" rather than a "finally" because we want to stop the first pass of EH here.
                         // That way we can restore the previous context before any of our callers' EH filters run.
-                        if (changeExecutionContext)
-                        {
-                            currentThread._executionContext = previousExecutionContext;
-                        }
-
+                        currentThread._executionContext = previousExecutionContext;
                         throw;
                     }
 
-                    if (changeExecutionContext)
-                    {
-                        currentThread._executionContext = previousExecutionContext;
-                    }
+                    currentThread._executionContext = previousExecutionContext;
                 }
                 catch (ThreadStartException)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -300,8 +300,6 @@ namespace System.Threading
                         workerThread.IsThreadPoolThread = true;
                         workerThread.IsBackground = true;
                         workerThread.Start();
-
-                        currentThread._executionContext = previousExecutionContext;
                     }
                     catch
                     {
@@ -310,6 +308,8 @@ namespace System.Threading
                         currentThread._executionContext = previousExecutionContext;
                         throw;
                     }
+
+                    currentThread._executionContext = previousExecutionContext;
                 }
                 catch (ThreadStartException)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -288,8 +288,8 @@ namespace System.Threading
             {
                 try
                 {
-                    // Starting a new thread transfers the current execution context to the new thread. Worker threads must
-                    // start in the default context, so switch contexts temporarily if necessary.
+                    // Starting a new thread transfers the current execution context to the new thread. Thread pool threads must
+                    // start in the default context, so switch contexts temporarily.
                     Thread currentThread = Thread.CurrentThread;
                     ExecutionContext? previousExecutionContext = currentThread._executionContext;
                     currentThread._executionContext = null;
@@ -300,6 +300,8 @@ namespace System.Threading
                         workerThread.IsThreadPoolThread = true;
                         workerThread.IsBackground = true;
                         workerThread.Start();
+
+                        currentThread._executionContext = previousExecutionContext;
                     }
                     catch
                     {
@@ -308,8 +310,6 @@ namespace System.Threading
                         currentThread._executionContext = previousExecutionContext;
                         throw;
                     }
-
-                    currentThread._executionContext = previousExecutionContext;
                 }
                 catch (ThreadStartException)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
@@ -34,9 +34,11 @@ namespace System.Threading
             var timers = new List<TimerQueue>(Instances.Length);
             s_scheduledTimersToFire ??= new List<TimerQueue>(Instances.Length);
 
+            // The timer thread must start in the default execution context without transferring the context, so
+            // using UnsafeStart() instead of Start()
             Thread timerThread = new Thread(TimerThread);
             timerThread.IsBackground = true;
-            timerThread.Start();
+            timerThread.UnsafeStart();
 
             // Do this after creating the thread in case thread creation fails so that it will try again next time
             s_scheduledTimers = timers;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -254,6 +255,7 @@ namespace System.Threading
         [UnsupportedOSPlatform("browser")]
         public void Start()
         {
+            _executionContext = ExecutionContext.Capture();
             StartInternal(this);
         }
 
@@ -264,16 +266,46 @@ namespace System.Threading
                 throw new InvalidOperationException(SR.InvalidOperation_ThreadWrongThreadStart);
 
             m_start_arg = parameter;
-            StartInternal(this);
+            Start();
         }
 
         // Called from the runtime
         internal void StartCallback()
         {
+            ExecutionContext? context = _executionContext;
+            if (context != null && !context.IsDefault)
+            {
+                ExecutionContext.RunInternal(context, s_threadStartContextCallback, this);
+            }
+            else
+            {
+                StartCallbackWorker();
+            }
+        }
+
+        private static readonly ContextCallback s_threadStartContextCallback = new ContextCallback(StartCallback_Context);
+
+        private static void StartCallback_Context(object? state)
+        {
+            Debug.Assert(state is Thread);
+            ((Thread)state).StartCallbackWorker();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // otherwise an unnecessary long-lived stack frame in many threads
+        private void StartCallbackWorker()
+        {
             if (culture != null)
-                CurrentCulture = culture;
+            {
+                CultureInfo.CurrentCulture = culture;
+                culture = null;
+            }
+
             if (ui_culture != null)
-                CurrentUICulture = ui_culture;
+            {
+                CultureInfo.CurrentUICulture = ui_culture;
+                ui_culture = null;
+            }
+
             if (m_start is ThreadStart del)
             {
                 m_start = null;
@@ -281,6 +313,7 @@ namespace System.Threading
             }
             else
             {
+                Debug.Assert(m_start is ParameterizedThreadStart);
                 var pdel = (ParameterizedThreadStart)m_start!;
                 object? arg = m_start_arg;
                 m_start = null;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -288,6 +288,7 @@ namespace System.Threading
         internal void StartCallback()
         {
             ExecutionContext? context = _executionContext;
+            _executionContext = null;
             if (context != null && !context.IsDefault)
             {
                 ExecutionContext.RunInternal(context, s_threadStartContextCallback, this);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -269,6 +269,21 @@ namespace System.Threading
             Start();
         }
 
+        [UnsupportedOSPlatform("browser")]
+        internal void UnsafeStart()
+        {
+            StartInternal(this);
+        }
+
+        [UnsupportedOSPlatform("browser")]
+        internal void UnsafeStart(object parameter)
+        {
+            Debug.Assert(m_start is ThreadStart);
+
+            m_start_arg = parameter;
+            UnsafeStart();
+        }
+
         // Called from the runtime
         internal void StartCallback()
         {


### PR DESCRIPTION
The execution context transfers to new threads, and this creates an extra stack frame on the thread and may cause AsyncLocal value change notifications to be sent unnecessarily. Switched to the default context before creating a worker thread.