### PR TITLE
Fix couple of races in EventPipe C library.

### DIFF
--- a/src/coreclr/inc/shash.h
+++ b/src/coreclr/inc/shash.h
@@ -190,6 +190,9 @@ class EMPTY_BASES_DECL SHash : public TRAITS
     // updating an element rather than adding a duplicate.
     void AddOrReplace(const element_t & element);
 
+    // NoThrow version of AddOrReplace. Returns TRUE if element was added/replaced, FALSE otherwise.
+    BOOL AddOrReplaceNoThrow(const element_t &element);
+
     // Remove the first element matching the key from the hash table.
 
     void Remove(key_t key);

--- a/src/coreclr/inc/shash.inl
+++ b/src/coreclr/inc/shash.inl
@@ -170,6 +170,28 @@ void SHash<TRAITS>::AddOrReplace(const element_t &element)
 }
 
 template <typename TRAITS>
+BOOL SHash<TRAITS>::AddOrReplaceNoThrow(const element_t &element)
+{
+     CONTRACT(BOOL)
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        INSTANCE_CHECK;
+        static_assert(!TRAITS::s_supports_remove, "SHash::AddOrReplaceNoThrow is not implemented for SHash with support for remove operations.");
+        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*LookupPtr(TRAITS::GetKey(element)))));
+    }
+    CONTRACT_END;
+
+    static_assert(TRAITS::s_NoThrow, "This SHash does not support NOTHROW.");
+
+    BOOL haveSpace = CheckGrowthNoThrow();
+    if (haveSpace)
+        AddOrReplace(m_table, m_tableSize, element);
+
+    RETURN haveSpace;
+}
+
+template <typename TRAITS>
 void SHash<TRAITS>::Remove(key_t key)
 {
     CONTRACT_VOID

--- a/src/mono/mono/eventpipe/ep-rt-types-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-types-mono.h
@@ -52,7 +52,6 @@ struct _rt_mono_array_iterator_internal_t {
 
 struct _rt_mono_table_internal_t {
 	GHashTable *table;
-	uint32_t count;
 };
 
 struct _rt_mono_table_iterator_internal_t {

--- a/src/mono/mono/eventpipe/test/ep-thread-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-thread-tests.c
@@ -119,8 +119,8 @@ test_get_or_create_thread (void)
 
 	test_location = 3;
 
-	if (ep_rt_volatile_load_uint32_t ((const volatile uint32_t *)ep_thread_get_ref_count_ref (thread)) != 1) {
-		result = FAILED ("thread ref count should be 1");
+	if (ep_rt_volatile_load_uint32_t ((const volatile uint32_t *)ep_thread_get_ref_count_ref (thread)) == 0) {
+		result = FAILED ("thread ref count should not be 0");
 		ep_raise_error ();
 	}
 

--- a/src/native/eventpipe/ep-config.c
+++ b/src/native/eventpipe/ep-config.c
@@ -184,7 +184,7 @@ ep_config_init (EventPipeConfiguration *config)
 	ep_raise_error_if_nok (ep_rt_provider_list_is_valid (&config->provider_list));
 
 	EP_LOCK_ENTER (section1)
-		config->config_provider = provider_create (ep_config_get_default_provider_name_utf8 (), NULL, NULL, NULL, provider_callback_data_queue);
+		config->config_provider = provider_create_register (ep_config_get_default_provider_name_utf8 (), NULL, NULL, NULL, provider_callback_data_queue);
 	EP_LOCK_EXIT (section1)
 
 	ep_raise_error_if_nok (config->config_provider != NULL);

--- a/src/native/eventpipe/ep-event-source.c
+++ b/src/native/eventpipe/ep-event-source.c
@@ -60,7 +60,7 @@ static
 void
 event_source_fini (EventPipeEventSource *event_source)
 {
-	ep_provider_free (event_source->provider);
+	ep_delete_provider (event_source->provider);
 }
 
 EventPipeEventSource *

--- a/src/native/eventpipe/ep-provider-internals.h
+++ b/src/native/eventpipe/ep-provider-internals.h
@@ -40,14 +40,20 @@ provider_unset_config (
 void
 provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data);
 
+// Create and register provider.
 // _Requires_lock_held (ep)
 EventPipeProvider *
-provider_create (
+provider_create_register (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
 	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue);
+
+// Unregister and delete provider.
+// _Requires_lock_held (ep)
+void
+provider_unregister_delete (EventPipeProvider *provider);
 
 // Free provider.
 // _Requires_lock_held (ep)

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -427,7 +427,7 @@ ep_on_error:
 }
 
 EventPipeProvider *
-provider_create (
+provider_create_register (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
 	EventPipeCallbackDataFree callback_data_free_func,
@@ -436,6 +436,15 @@ provider_create (
 {
 	ep_requires_lock_held ();
 	return config_create_provider (ep_config_get (), provider_name, callback_func, callback_data_free_func, callback_data, provider_callback_data_queue);
+}
+
+void
+provider_unregister_delete (EventPipeProvider * provider)
+{
+	ep_return_void_if_nok (provider != NULL);
+
+	ep_requires_lock_held ();
+	config_delete_provider (ep_config_get (), provider);
 }
 
 void

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -88,7 +88,7 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 #define EP_RT_DECLARE_ARRAY_REVERSE_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DECLARE_ARRAY_REVERSE_ITERATOR_PREFIX(ep, array_name, array_type, iterator_type, item_type) \
 
-#define EP_RT_DECLARE_HASH_MAP_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
+#define EP_RT_DECLARE_HASH_MAP_BASE_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
 	static void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, alloc) (hash_map_type *hash_map, uint32_t (*hash_callback)(const void *), bool (*eq_callback)(const void *, const void *), void (*key_free_callback)(void *), void (*value_free_callback)(void *)); \
 	static void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, free) (hash_map_type *hash_map); \
 	static bool EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, add) (hash_map_type *hash_map, key_type key, value_type value); \
@@ -97,8 +97,12 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 	static uint32_t EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, count) (const hash_map_type *hash_map); \
 	static bool EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, is_valid) (const hash_map_type *hash_map);
 
+#define EP_RT_DECLARE_HASH_MAP_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
+	EP_RT_DECLARE_HASH_MAP_BASE_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
+	static bool EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, add_or_replace) (hash_map_type *hash_map, key_type key, value_type value);
+
 #define EP_RT_DECLARE_HASH_MAP_REMOVE_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
-	EP_RT_DECLARE_HASH_MAP_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
+	EP_RT_DECLARE_HASH_MAP_BASE_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
 	static void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, remove) (hash_map_type *hash_map, const key_type key);
 
 #define EP_RT_DECLARE_HASH_MAP(hash_map_name, hash_map_type, key_type, value_type) \

--- a/src/native/eventpipe/ep-sample-profiler.c
+++ b/src/native/eventpipe/ep-sample-profiler.c
@@ -223,7 +223,7 @@ ep_sample_profiler_init (EventPipeProviderCallbackDataQueue *provider_callback_d
 	ep_requires_lock_held ();
 
 	if (!_sampling_provider) {
-		_sampling_provider = provider_create (ep_config_get_sample_profiler_provider_name_utf8 (), NULL, NULL, NULL, provider_callback_data_queue);
+		_sampling_provider = provider_create_register (ep_config_get_sample_profiler_provider_name_utf8 (), NULL, NULL, NULL, provider_callback_data_queue);
 		ep_raise_error_if_nok (_sampling_provider != NULL);
 		_thread_time_event = provider_add_event (
 			_sampling_provider,
@@ -253,7 +253,7 @@ ep_sample_profiler_shutdown (void)
 
 	EP_ASSERT (_ref_count == 0);
 
-	provider_free (_sampling_provider);
+	provider_unregister_delete (_sampling_provider);
 
 	_sampling_provider = NULL;
 	_thread_time_event = NULL;

--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -45,7 +45,7 @@ EP_RT_DEFINE_THREAD_FUNC (streaming_thread)
 	if (!thread_params->thread || !ep_rt_thread_has_started (thread_params->thread))
 		return 1;
 
-	session->ipc_streaming_thread = ep_thread_get_or_create ();
+	session->ipc_streaming_thread = thread_params->thread;
 
 	bool success = true;
 	ep_rt_wait_event_handle_t *wait_event = ep_session_get_wait_event (session);

--- a/src/native/eventpipe/ep-session.h
+++ b/src/native/eventpipe/ep-session.h
@@ -24,7 +24,7 @@ struct _EventPipeSession {
 struct _EventPipeSession_Internal {
 #endif
 	// When the session is of IPC type, this becomes a reference to the streaming thread.
-	EventPipeThread *ipc_streaming_thread;
+	ep_rt_thread_handle_t ipc_streaming_thread;
 	// Event object used to signal Disable that the IPC streaming thread is done.
 	ep_rt_wait_event_handle_t rt_thread_shutdown_event;
 	// The set of configurations for each provider in the session.

--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -37,10 +37,6 @@ ep_thread_alloc (void)
 	instance->os_thread_id = ep_rt_thread_id_t_to_uint64_t (ep_rt_current_thread_get_id ());
 	memset (instance->session_state, 0, sizeof (instance->session_state));
 
-	EP_SPIN_LOCK_ENTER (&_ep_threads_lock, section1)
-		ep_raise_error_if_nok_holding_spin_lock (ep_rt_thread_list_append (&_ep_threads, instance), section1);
-	EP_SPIN_LOCK_EXIT (&_ep_threads_lock, section1)
-
 	instance->writing_event_in_progress = UINT32_MAX;
 
 ep_on_exit:
@@ -64,29 +60,9 @@ ep_thread_free (EventPipeThread *thread)
 		EP_ASSERT (thread->session_state [i] == NULL);
 	}
 #endif
-	bool found = false;
-	EP_SPIN_LOCK_ENTER (&_ep_threads_lock, section1)
-		// Remove ourselves from the global list
-		ep_rt_thread_list_iterator_t iterator = ep_rt_thread_list_iterator_begin (&_ep_threads);
-		while (!ep_rt_thread_list_iterator_end (&_ep_threads, &iterator)) {
-			if (ep_rt_thread_list_iterator_value (&iterator) == thread) {
-				ep_rt_thread_list_remove (&_ep_threads, thread);
-				found = true;
-				break;
-			}
-			ep_rt_thread_list_iterator_next (&iterator);
-		}
-	EP_SPIN_LOCK_EXIT (&_ep_threads_lock, section1)
 
-	EP_ASSERT (found || !"We couldn't find ourselves in the global thread list");
-
-ep_on_exit:
 	ep_rt_spin_lock_free (&thread->rt_lock);
 	ep_rt_object_free (thread);
-	return;
-
-ep_on_error:
-	ep_exit_error_handler ();
 }
 
 void
@@ -126,6 +102,61 @@ ep_thread_fini (void)
 		ep_rt_thread_list_free (&_ep_threads, NULL);
 		ep_rt_spin_lock_free (&_ep_threads_lock);
 	}
+}
+
+bool
+ep_thread_register (EventPipeThread *thread)
+{
+	ep_rt_spin_lock_requires_lock_not_held (&_ep_threads_lock);
+
+	ep_return_false_if_nok (thread != NULL);
+
+	bool result = false;
+
+	ep_thread_addref (thread);
+
+	ep_rt_spin_lock_aquire (&_ep_threads_lock);
+		result = ep_rt_thread_list_append (&_ep_threads, thread);
+	ep_rt_spin_lock_release (&_ep_threads_lock);
+
+	if (!result)
+		ep_thread_release (thread);
+
+	ep_rt_spin_lock_requires_lock_not_held (&_ep_threads_lock);
+
+	return result;
+}
+
+bool
+ep_thread_unregister (EventPipeThread *thread)
+{
+	ep_rt_spin_lock_requires_lock_not_held (&_ep_threads_lock);
+
+	ep_return_false_if_nok (thread != NULL);
+
+	bool found = false;
+	EP_SPIN_LOCK_ENTER (&_ep_threads_lock, section1)
+		// Remove ourselves from the global list
+		ep_rt_thread_list_iterator_t iterator = ep_rt_thread_list_iterator_begin (&_ep_threads);
+		while (!ep_rt_thread_list_iterator_end (&_ep_threads, &iterator)) {
+			if (ep_rt_thread_list_iterator_value (&iterator) == thread) {
+				ep_rt_thread_list_remove (&_ep_threads, thread);
+				ep_thread_release (thread);
+				found = true;
+				break;
+			}
+			ep_rt_thread_list_iterator_next (&iterator);
+		}
+	EP_SPIN_LOCK_EXIT (&_ep_threads_lock, section1)
+
+	EP_ASSERT (found || !"We couldn't find ourselves in the global thread list");
+
+ep_on_exit:
+	ep_rt_spin_lock_requires_lock_not_held (&_ep_threads_lock);
+	return found;
+
+ep_on_error:
+	ep_exit_error_handler ();
 }
 
 EventPipeThread *

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -89,6 +89,12 @@ ep_thread_init (void);
 void
 ep_thread_fini (void);
 
+bool
+ep_thread_register (EventPipeThread *thread);
+
+bool
+ep_thread_unregister (EventPipeThread *thread);
+
 EventPipeThread *
 ep_thread_get (void);
 


### PR DESCRIPTION
Fix primarily two main issues triggering races related to ref counting on EventPipeThread.

First was an incorrect mapping of hash map add method in CoreClr shim. Intent of this method was a add_replace, but CoreClr shim ended up with Add implementation. That could result in unreferenced threads being added into thread_sequence_number_map, that on free would release the ref count creating unbalance, triggering EventPipeThreads to be terminated to soon.

There is also a theoretical race (don't know if it has been hit) that manifests when we end up adding threads into thread_sequence_number_map instead of replacing an existing already ref counted item. If we add, then we will hit the same race, so added a fix making sure we detect this case and correctly makes an addref to the thread. This potential issue exists in C++ version of EventPipe library as well.

The other issue triggering another race related to ref counted threads. The streaming thread in C library used ep_thread_get_or_create to get a reference to itself. This will create an EventPipeThread instance in TLS, but it will also add thread into global thread list. Since the streaming thread doesn’t do additional writes of events it will not get a thread session state, meaning that it will keep its original ref count. This opens up a race when the TLS destructor decrements the reference count, and another thread disabling a session. The thread that disables the session will get a copy of all running threads, but if the thread running TLS destructor managed to be the first hitting ref count down to 0, but other thread will beat it taking locks protecting list, the thread with refcount == 0 will still be in the list copy, meaning the other thread will end up with a potentially freed object on its thread list copy.

I made two fixes for this issue, first, don’t use ep_thread_get_or_create from streaming thread, since there is an ability to get hold of runtime specific thread object, that will eliminate the race between a thread added into EventPipe, but not writing events, so it won’t have an thread session state holding an additional ref count. Second, since the race is still there due to the spit between ref count and lock protecting the list, I also made a change in the C library, moving the register/unregister on the list into the ep_thread_get_or_create (register) and TLS destructor (unregister), meaning that the list will track live threads currently using EventPipe library, and the EventPipeThread object is still ref counted, meaning that it still can outlive the lifetime of the physical thread.

Doing this split close the potential race condition (and even fix the scenario if we kept the streaming thread added into the global thread list). This hypothetical race condition exists in C++ library as well but might have been mitigated by ref counting thread session state and making sure the TLS destructor won’t race with a thread doing disable since thread session state ref count will be held past racy part of disable function.