### PR TITLE
Windows build.cmd doesn't support -cmakeargs.

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -17,6 +17,7 @@ Param(
   [ValidateSet("Debug","Release")][string][Alias('lc')]$librariesConfiguration,
   [ValidateSet("CoreCLR","Mono")][string][Alias('rf')]$runtimeFlavor,
   [switch]$ninja,
+  [string]$cmakeargs,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -76,6 +77,7 @@ function Get-Help() {
   Write-Host ""
 
   Write-Host "Native build settings:"
+  Write-Host "  -cmakeargs              User-settable additional arguments passed to CMake."
   Write-Host "  -ninja                  Use Ninja instead of MSBuild to run the native build."
 
   Write-Host "Command-line arguments not listed above are passed through to MSBuild."
@@ -229,6 +231,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "allconfigurations"      { $arguments += " /p:BuildAllConfigurations=true" }
     "properties"             { $arguments += " " + $properties }
     "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }
+    "cmakeargs"              { $arguments += " /p:CMakeArgs=`"$($PSBoundParameters[$argument])`"" }
     "ninja"                  { $arguments += " /p:Ninja=$($PSBoundParameters[$argument])" }
     # configuration and arch can be specified multiple times, so they should be no-ops here
     "configuration"          {}

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -8,7 +8,8 @@
           AfterTargets="Build">
     <ItemGroup>
       <_CoreClrBuildArg Condition="'$(TargetArchitecture)' != ''" Include="-$(TargetArchitecture)" />
-      <_CoreClrBuildArg Include="$(CMakeArgs)" />
+      <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows)) and '$(CMakeArgs)' != ''" Include="$(CMakeArgs)" />
+      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and '$(CMakeArgs)' != ''" Include="-cmakeargs &quot;$(CMakeArgs)&quot;" />
       <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
       <_CoreClrBuildArg Include="$(Compiler)" />
       <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -123,6 +123,7 @@
       <_MonoCMakeArgs Include="-DCMAKE_INSTALL_PREFIX=$(MonoObjDir)out"/>
       <_MonoCMakeArgs Include="-DCMAKE_INSTALL_LIBDIR=lib"/>
       <_MonoCMakeArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)"/>
+      <_MonoCMakeArgs Condition="'$(CMakeArgs)' != ''" Include="$(CMakeArgs)"/>
       <_MonoCMakeArgs Condition="'$(MonoEnableLLVM)' == 'true'" Include="-DLLVM_PREFIX=$(MonoLLVMDir)" />
     </ItemGroup>
 


### PR DESCRIPTION
build.sh supports -cmakeargs making it is possible to pass custom cmake arguments down to native cmake steps, but this feature is missing on Windows when using build.cmd. Trying to do:

.\build.cmd -subset clr -c release -cmakeargs "-DFEATURE_PERFTRACING_C_LIB=1"

on Windows will result in an error since -cmakeargs is not a known command in build.ps1.

Commit adds support for -cmakeargs in build.cmd making sure it gets passed down to runtime build on both CoreClr as well as Mono.