### PR TITLE
disable ConnectCallback_UseUnixDomainSocket_Success on Windows

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2458,6 +2458,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(nameof(PlatformSupportsUnixDomainSockets))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/44183", TestPlatforms.Windows)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ConnectCallback_UseUnixDomainSocket_Success(bool useSsl)


### PR DESCRIPTION
while #44366 seems to make some improvement and it is failing predominantly on ARM, there are still some CI failures:

22 failures in last 30 days total, 5 on various x64 flavors. 

Since the HTTP logic is not really platforms dependent, this seems like some quirk of UDS one Windows or test bugs. 

contributes to  #44183