### PR TITLE
[release/5.0] Add variable lifetime update for GT_STOREIND for arm/arm64

### DIFF
--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -1345,6 +1345,9 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
         }
 
         GetEmitter()->emitInsLoadStoreOp(ins_Store(type), emitActualTypeSize(type), data->GetRegNum(), tree);
+
+        // If store was to a variable, update variable liveness after instruction was emitted.
+        genUpdateLife(tree);
     }
 }
 

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -3233,6 +3233,9 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
         }
 
         GetEmitter()->emitInsLoadStoreOp(ins, emitActualTypeSize(type), dataReg, tree);
+
+        // If store was to a variable, update variable liveness after instruction was emitted.
+        genUpdateLife(tree);
     }
 }
 


### PR DESCRIPTION
Port #46059 to release/5.0

Fix #45557 for arm/arm64. x86/x64 version of the fix was ported to release/5.0 with https://github.com/dotnet/runtime/pull/45947

Fixes #46023

## Customer Impact

Reported by Roslyn. Bad GC info can lead to an unexplained crash that can't easily be found or worked around.

## Regression?

Yes, this is a regression from .NET Core 3.1

## Testing

Manual, new unit test, CLR outerloop, SuperPMI asm diffs.

## Risk

Low