### PR TITLE
Allow idle timeout to be inherited from listener instead of default of 2 minutes

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -62,7 +62,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             _connected = true;
 
             SetCallbackHandler();
-            SetIdleTimeout(TimeSpan.FromSeconds(120));
         }
 
         // constructor for outbound connections

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -50,6 +50,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             _sslOptions = options.ServerAuthenticationOptions!;
             _listenEndPoint = options.ListenEndPoint!;
 
+            SetIdleTimeout(options.IdleTimeout);
+
             _ptr = _session.ListenerOpen(options);
         }
 
@@ -137,6 +139,11 @@ namespace System.Net.Quic.Implementations.MsQuic
                 "Failed to start listener.");
 
             SetListenPort();
+        }
+
+        private void SetIdleTimeout(TimeSpan timeout)
+        {
+            MsQuicParameterHelpers.SetULongParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.LISTENER, (uint)QUIC_PARAM_CONN.IDLE_TIMEOUT, (ulong)timeout.TotalMilliseconds);
         }
 
         internal override void Close()


### PR DESCRIPTION
Noticed that setting the listener timeout wasn't affecting connection timeouts.

Hard to test without having a way of getting the idle timeout for a connection, which would require public API. Could potentially have a connection timeout with a 1 second limit; that's probably the best way we could test this.