### PR TITLE
Backport parts of EventPipe PR 43711 not currently in C library.

### DIFF
--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -384,6 +384,8 @@ ds_ipc_stream_factory_get_next_available_stream (ds_ipc_error_callback_func call
 					EP_ASSERT (port != NULL);
 					if (!stream) {  // only use first signaled stream; will get others on subsequent calls
 						stream = ds_port_get_connected_stream_vcall (port, callback);
+						if (!stream)
+							saw_error = true;
 						_ds_current_port = port;
 					}
 					DS_LOG_INFO_2 ("ds_ipc_stream_factory_get_next_available_stream - SIG :: Poll attempt: %d, connection %d signalled.\n", poll_attempts, connection_id);


### PR DESCRIPTION
Backport of missing parts from #43711 , parts of this was already fixed in EventPipe C library when initially detected and reported as and issue in C++ library.