### PR TITLE
Ignore PLT and etext symbols during verification

### DIFF
--- a/src/libraries/Native/Unix/verify-entrypoints.sh
+++ b/src/libraries/Native/Unix/verify-entrypoints.sh
@@ -17,6 +17,8 @@ for line in $($nmCommand $1); do
     case ${BASH_REMATCH[1]} in
       init) ;;
       fini) ;;
+      etext) ;;
+      PROCEDURE_LINKAGE_TABLE_) ;;
       *)    dllList+=(${BASH_REMATCH[1]});;
     esac
   fi


### PR DESCRIPTION
illumos leg started failing while building libs subset, after overrider change was checked in.

logs: https://github.com/am11/runtime/runs/1575054078.
excerpt:
```sh
2020-12-18T07:31:36.1337694Z   [ 36%] Building C object System.Native/CMakeFiles/System.Native.dir/__/version.c.o
2020-12-18T07:31:36.1551344Z   [ 37%] Linking C shared library libSystem.Native.so
2020-12-18T07:31:36.1862206Z   Verifying System.Native entry points against entrypoints.c 
2020-12-18T07:31:36.2435816Z EXEC : error : /runtime/src/libraries/Native/Unix/System.Native/entrypoints.c file did not match entries exported from /runtime/artifacts/obj/native/net6.0-illumos-Release-x64/System.Native/libSystem.Native.so [/runtime/src/libraries/Native/build-native.proj]
2020-12-18T07:31:36.2437602Z   DIFFERENCES FOUND: 
2020-12-18T07:31:36.2463818Z   etext,PROCEDURE_LINKAGE_TABLE_
2020-12-18T07:31:36.2483633Z   System.Native/CMakeFiles/System.Native.dir/build.make:462: recipe for target 'System.Native/libSystem.Native.so' failed
2020-12-18T07:31:36.2485045Z   CMakeFiles/Makefile2:394: recipe for target 'System.Native/CMakeFiles/System.Native.dir/all' failed
2020-12-18T07:31:36.2485983Z   make[2]: *** [System.Native/libSystem.Native.so] Error 2
2020-12-18T07:31:36.2487271Z   make[2]: *** Deleting file 'System.Native/libSystem.Native.so'
```