### PR TITLE
Disable generating exports file for System.IO.Compression.Native on mobile

### DIFF
--- a/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
@@ -68,18 +68,18 @@ if (GEN_SHARED_LIB)
         ${NATIVE_LIBS_EXTRA}
     )
 
-    set(DEF_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/System.IO.Compression.Native_unixexports.src)
-    set(EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/System.IO.Compression.Native.exports)
-    generate_exports_file(${DEF_SOURCES} ${EXPORTS_FILE})
-    set_exports_linker_option(${EXPORTS_FILE})
-
-    add_custom_target(System.IO.Compression.Native_exports DEPENDS ${EXPORTS_FILE})
-    add_dependencies(System.IO.Compression.Native System.IO.Compression.Native_exports)
-
-    set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_FLAGS ${EXPORTS_LINKER_OPTION})
-    set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
-
     if (NOT CLR_CMAKE_TARGET_IOS AND NOT CLR_CMAKE_TARGET_TVOS AND NOT CLR_CMAKE_TARGET_ANDROID)
+        set(DEF_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/System.IO.Compression.Native_unixexports.src)
+        set(EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/System.IO.Compression.Native.exports)
+        generate_exports_file(${DEF_SOURCES} ${EXPORTS_FILE})
+        set_exports_linker_option(${EXPORTS_FILE})
+
+        add_custom_target(System.IO.Compression.Native_exports DEPENDS ${EXPORTS_FILE})
+        add_dependencies(System.IO.Compression.Native System.IO.Compression.Native_exports)
+
+        set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_FLAGS ${EXPORTS_LINKER_OPTION})
+        set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
+
         add_custom_command(TARGET System.IO.Compression.Native POST_BUILD
             COMMENT "Verifying System.IO.Compression.Native entry points against entrypoints.c "
             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../verify-entrypoints.sh


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/45995 added this and it relies on this code in configuretools.cmake to detect which linker is used: https://github.com/dotnet/runtime/blob/4bc323242d43dda85d490c0630c4637ffc092469/eng/native/configuretools.cmake#L66-L86

However passing `-Wl,--version` to the compiler doesn't seem to work when using the clang provided by the Android NDK, it still uses the system linker in `/usr/bin/ld`.
On OSX that one doesn't support the `--version` option so we don't detect LD_GNU which we'd need for providing the correct `-Wl,--version-script` compiler option.

It looks like this only passed on the PR because we build Android on Linux there and the system linker _is_ GNU there so the check was successful.

Disable the generation of the exports file on mobile platforms since we don't use it there anyway.