### PR TITLE
Pinning package version for packages not being serviced

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Pinning package version for packages not being serviced. -->
+    <PackageVersion>5.0.0</PackageVersion>
     <BeforeTargetFrameworkInferenceTargets>$(RepositoryEngineeringDir)BeforeTargetFrameworkInference.targets</BeforeTargetFrameworkInferenceTargets>
     <IsSourceProject>$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectDirectory), 'src%24'))</IsSourceProject>
     <IsReferenceAssembly Condition="'$(IsReferenceAssembly)' == '' and ($(MSBuildProjectFullPath.Contains('\ref\')) or $(MSBuildProjectFullPath.Contains('/ref/')))">true</IsReferenceAssembly>


### PR DESCRIPTION
This change fixes the problem of inconsistent package index. when we build with the stable flag on , the build system updates the package index to reflect the new package version as stable which is not true for packages not being serviced.

This is also required for sourcebuild which builds all the packages in servicing release as well