### PR TITLE
Delete a double folder separator in crossgen proj.

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -8,18 +8,18 @@
       <UseCrossgen2 Condition="'$(UseCrossgen2)' == ''">false</UseCrossgen2>
 
       <OSPlatformConfig>$(TargetOS).$(TargetArchitecture).$(Configuration)</OSPlatformConfig>
-      <RootBinDir>$(RepoRoot)\artifacts</RootBinDir>
-      <LogsDir>$(RootBinDir)\log</LogsDir>
-      <BinDir>$(RootBinDir)\bin\coreclr\$(OSPlatformConfig)</BinDir>
-      <IntermediatesDir>$(RootBinDir)\obj\coreclr\$(OSPlatformConfig)</IntermediatesDir>
-      <CrossGenCoreLibLog>$(LogsDir)\CrossgenCoreLib_$(TargetOS)__$(TargetArchitecture)__$(Configuration).log</CrossGenCoreLibLog>
+      <RootBinDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</RootBinDir>
+      <LogsDir>$([MSBuild]::NormalizeDirectory('$(RootBinDir)', 'log'))</LogsDir>
+      <BinDir>$([MSBuild]::NormalizeDirectory('$(RootBinDir)', 'bin', 'coreclr', $(OSPlatformConfig)))</BinDir>
+      <IntermediatesDir>$([MSBuild]::NormalizeDirectory('$(RootBinDir)', 'obj', 'coreclr', $(OSPlatformConfig)))</IntermediatesDir>
+      <CrossGenCoreLibLog>$([MSBuild]::NormalizePath('$(LogsDir)', 'CrossgenCoreLib_$(TargetOS)__$(TargetArchitecture)__$(Configuration).log'))</CrossGenCoreLibLog>
       <ExeExtension Condition="'$(OS)' == 'Windows_NT'">.exe</ExeExtension>
-      <DotNetCli>$(RepoRoot)/dotnet.sh</DotNetCli>
-      <DotNetCli Condition="'$(OS)' == 'Windows_NT'">$(RepoRoot)\dotnet.cmd</DotNetCli>
+      <DotNetCli>$([MSBuild]::NormalizePath('$(RepoRoot)', 'dotnet.sh'))</DotNetCli>
+      <DotNetCli Condition="'$(OS)' == 'Windows_NT'">$([MSBuild]::NormalizePath('$(RepoRoot)', 'dotnet.cmd'))</DotNetCli>
 
       <CoreLibAssemblyName>System.Private.CoreLib</CoreLibAssemblyName>
-      <CoreLibInputPath>$(BinDir)\IL\$(CoreLibAssemblyName).dll</CoreLibInputPath>
-      <CoreLibOutputPath>$(BinDir)\$(CoreLibAssemblyName).dll</CoreLibOutputPath>
+      <CoreLibInputPath>$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '$(CoreLibAssemblyName).dll'))</CoreLibInputPath>
+      <CoreLibOutputPath>$([MSBuild]::NormalizePath('$(BinDir)', '$(CoreLibAssemblyName).dll'))</CoreLibOutputPath>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -41,10 +41,10 @@
       <BuildPerfMap>false</BuildPerfMap>
       <BuildPerfMap Condition="$(BuildDll) and '$(TargetOS)' == 'Linux'">true</BuildPerfMap>
 
-      <CrossGen1Cmd>$(BinDir)\$(CrossDir)\crossgen$(ExeExtension)</CrossGen1Cmd>
+      <CrossGen1Cmd>$([MSBuild]::NormalizePath('$(BinDir)', '$(CrossDir)', 'crossgen$(ExeExtension)'))</CrossGen1Cmd>
       <CrossGen1Cmd>$(CrossGen1Cmd) /nologo</CrossGen1Cmd>
       <CrossGen1Cmd>$(CrossGen1Cmd) <!-- IbcTuning --></CrossGen1Cmd>
-      <CrossGen1Cmd>$(CrossGen1Cmd) /Platform_Assemblies_Paths "$(BinDir)\IL"</CrossGen1Cmd>
+      <CrossGen1Cmd>$(CrossGen1Cmd) /Platform_Assemblies_Paths "$([MSBuild]::NormalizePath('$(BinDir)', 'IL'))"</CrossGen1Cmd>
     </PropertyGroup>
 
     <MakeDir
@@ -54,9 +54,9 @@
       Text="Generating native image of System.Private.CoreLib for $(OSPlatformConfig). Logging to $(CrossGenCoreLibLog)" />
 
     <PropertyGroup>
-      <CrossGenDllCmd>$(DotNetCli) $(BinDir)\$(CrossDir)\crossgen2\crossgen2.dll</CrossGenDllCmd>
+      <CrossGenDllCmd>$(DotNetCli) $([MSBuild]::NormalizePath('$(BinDir)', '$(CrossDir)', 'crossgen2', 'crossgen2.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -o:$(CoreLibOutputPath)</CrossGenDllCmd>
-      <CrossGenDllCmd>$(CrossGenDllCmd) -r:$(BinDir)\IL\*.dll</CrossGenDllCmd>
+      <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -O</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) $(CoreLibInputPath)</CrossGenDllCmd>
@@ -75,16 +75,16 @@
     </PropertyGroup>
     
     <PropertyGroup Condition="$(BuildPdb)">
-      <CrossGenPdbCmd>$(DotNetCli) $(BinDir)\r2rdump\r2rdump.dll</CrossGenPdbCmd>
+      <CrossGenPdbCmd>$(DotNetCli) $([MSBuild]::NormalizePath('$(BinDir)', 'r2rdump', 'r2rdump.dll'))</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --create-pdb</CrossGenPdbCmd>
-      <CrossGenPdbCmd>$(CrossGenPdbCmd) --pdb-path:$(BinDir)\PDB</CrossGenPdbCmd>
+      <CrossGenPdbCmd>$(CrossGenPdbCmd) --pdb-path:$([MSBuild]::NormalizePath('$(BinDir)', 'PDB'))</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) --in:$(CoreLibOutputPath)</CrossGenPdbCmd>
     </PropertyGroup>
     
     <PropertyGroup Condition="$(BuildPdb) and '$(UseCrossgen2)' != 'true'">
-      <VsSetupCmd>call $(RepoRoot)\src\coreclr\setup_vs_tools.cmd &amp;&amp;</VsSetupCmd>
+      <VsSetupCmd>call $([MSBuild]::NormalizePath('$(RepoRoot)', 'src', 'coreclr', 'setup_vs_tools.cmd')) &amp;&amp;</VsSetupCmd>
 
-      <CrossGenPdbCmd>$(VsSetupCmd) $(CrossGen1Cmd) /CreatePdb "$(BinDir)\PDB"</CrossGenPdbCmd>
+      <CrossGenPdbCmd>$(VsSetupCmd) $(CrossGen1Cmd) /CreatePdb "$([MSBuild]::NormalizePath('$(BinDir)', 'PDB'))"</CrossGenPdbCmd>
       <CrossGenPdbCmd>$(CrossGenPdbCmd) "$(CoreLibOutputPath)"</CrossGenPdbCmd>
     </PropertyGroup>
     


### PR DESCRIPTION
`$(RepoRoot)` is declared here https://github.com/dotnet/runtime/blob/4bc323242d43dda85d490c0630c4637ffc092469/Directory.Build.props#L23  so it has a trailing `\` but its uses in crossgen-corelib.proj was adding another so we were getting double '\\'. 

VS does not accept a path with double '\\' so fix this for an easy copy-paste-run experience.

``` diff
--- "a/D:\\Sergey\\logs\\temp\\crossgenbefore"
+++ "b/D:\\Sergey\\logs\\temp\\crossgenafter"
@@ -9,22 +9,22 @@ build.cmd Clr.NativeCoreLib  -rc Checked -lc release -arch x64 /p:NoPgoOptimize=
   All projects are up-to-date for restore.
   Determining projects to restore...
   All projects are up-to-date for restore.
-  Generating native image of System.Private.CoreLib for windows.x64.Checked. Logging to D:\Sergey\git\runtime\\artifacts\log\CrossgenCoreLib_windows__x64__Checked.log
-  D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\\crossgen.exe /nologo  /Platform_Assemblies_Paths "D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\IL" /out "D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll" "D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\IL\System.Private.CoreLib.dll"
-  Native image D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll generated successfully.
-  call D:\Sergey\git\runtime\\src\coreclr\setup_vs_tools.cmd && D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\\crossgen.exe /nologo  /Platform_Assemblies_Paths "D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\IL" /CreatePdb "D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\PDB" "D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll"
+  Generating native image of System.Private.CoreLib for windows.x64.Checked. Logging to D:\Sergey\git\runtime\artifacts\log\CrossgenCoreLib_windows__x64__Checked.log
+  D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\crossgen.exe /nologo  /Platform_Assemblies_Paths "D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\IL" /out "D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll" "D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\IL\System.Private.CoreLib.dll"
+  Native image D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll generated successfully.
+  call D:\Sergey\git\runtime\src\coreclr\setup_vs_tools.cmd && D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\crossgen.exe /nologo  /Platform_Assemblies_Paths "D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\IL" /CreatePdb "D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\PDB" "D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll"
   Searching for Visual Studio installation
   "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
   **********************************************************************
   ** Visual Studio 2019 Developer Command Prompt v16.8.3
   ** Copyright (c) 2020 Microsoft Corporation
   **********************************************************************
-  Successfully generated PDB for native assembly 'D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll'.
+  Successfully generated PDB for native assembly 'D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\System.Private.CoreLib.dll'.
   Crossgenning of System.Private.CoreLib succeeded.  Finished at
-  Product binaries are available at D:\Sergey\git\runtime\\artifacts\bin\coreclr\windows.x64.Checked
+  Product binaries are available at D:\Sergey\git\runtime\artifacts\bin\coreclr\windows.x64.Checked\

 Build succeeded.
     0 Warning(s)
     0 Error(s)
```