### PR TITLE
Fix publishing of special debugging assets under CLR key

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -22,12 +22,12 @@ try {
   $optionalParams = [System.Collections.ArrayList]::new()
 
   if ("" -ne $ArtifactsPublishingAdditionalParameters) {
-    $optionalParams.Add("artifact-publishing-parameters") | Out-Null
+    $optionalParams.Add("--artifact-publishing-parameters") | Out-Null
     $optionalParams.Add($ArtifactsPublishingAdditionalParameters) | Out-Null
   }
 
   if ("" -ne $SymbolPublishingAdditionalParameters) {
-    $optionalParams.Add("symbol-publishing-parameters") | Out-Null
+    $optionalParams.Add("--symbol-publishing-parameters") | Out-Null
     $optionalParams.Add($SymbolPublishingAdditionalParameters) | Out-Null
   }
 
@@ -72,7 +72,7 @@ try {
   }
 
   Write-Host 'done.'
-} 
+}
 catch {
   Write-Host $_
   Write-PipelineTelemetryError -Category 'PromoteBuild' -Message "There was an error while trying to publish build '$BuildId' to default channels."

--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -49,6 +49,6 @@ stages:
         -TsaRepositoryName "$(TsaRepositoryName)"
         -TsaCodebaseName "$(TsaCodebaseName)"
         -TsaPublish $True
-
+    symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
     # Publish to blob storage.
     publishInstallersAndChecksums: true


### PR DESCRIPTION
This responds to dotnet/arcade#6679.

That PR switches from using the symuploader task to upload symbols to hosting the `PublishOperation` inside the publishing task in the SDK. The default is set to not use special symbol indexing. This repo should be the only one needing it, so that makes sense.

cc: @tommcdon