### PR TITLE
[RyuJIT] Intrinsify Object.MemberwiseClone()

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Object.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Object.CoreCLR.cs
@@ -16,6 +16,7 @@ namespace System
         // object.  This is always a shallow copy of the instance. The method is protected
         // so that other object may only call this method on themselves.  It is intended to
         // support the ICloneable interface.
+        [Intrinsic]
         protected unsafe object MemberwiseClone()
         {
             object clone = RuntimeHelpers.AllocateUninitializedClone(this);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17759,7 +17759,8 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
             GenTreeCall* call = tree->AsCall();
             if (call->gtFlags & CORINFO_FLG_JIT_INTRINSIC)
             {
-                if (lookupNamedIntrinsic(call->gtCallMethHnd) == NI_System_Array_Clone)
+                NamedIntrinsic ni = lookupNamedIntrinsic(call->gtCallMethHnd);
+                if ((ni == NI_System_Array_Clone) || (ni == NI_System_Object_MemberwiseClone))
                 {
                     objClass = gtGetClassHandle(call->gtCallThisArg->GetNode(), pIsExact, pIsNonNull);
                     break;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4816,6 +4816,13 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                 result = NI_System_Array_Clone;
             }
         }
+        else if (strcmp(className, "Object") == 0)
+        {
+            if (strcmp(methodName, "MemberwiseClone") == 0)
+            {
+                result = NI_System_Object_MemberwiseClone;
+            }
+        }
         else if (strcmp(className, "Type") == 0)
         {
             if (strcmp(methodName, "get_IsValueType") == 0)

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -44,6 +44,7 @@ enum NamedIntrinsic : unsigned short
     NI_System_Type_IsAssignableFrom,
     NI_System_Type_IsAssignableTo,
     NI_System_Array_Clone,
+    NI_System_Object_MemberwiseClone,
 
     // These are used by HWIntrinsics but are defined more generally
     // to allow dead code optimization and handle the recursion case


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/pull/45311#issuecomment-748289549
```
Total bytes of delta: -2419 (-0.00% of base)
    diff is an improvement.

Top file improvements (bytes):
       -1754 : System.Private.Xml.dasm (-0.05% of base)
        -434 : System.Private.CoreLib.dasm (-0.01% of base)
        -131 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -69 : System.Drawing.Common.dasm (-0.02% of base)
         -31 : Microsoft.CodeAnalysis.dasm (-0.00% of base)

5 total files with Code Size differences (5 improved, 0 regressed), 264 unchanged.

Top method improvements (bytes):
        -190 (-6.38% of base) : System.Private.Xml.dasm - Compiler:CompileElement(XmlSchemaElement):this
        -190 (-6.83% of base) : System.Private.Xml.dasm - SchemaCollectionCompiler:CompileElement(XmlSchemaElement):this
        -159 (-12.42% of base) : System.Private.Xml.dasm - XmlSchemaComplexType:Clone(XmlSchema):XmlSchemaObject:this
        -155 (-37.17% of base) : System.Private.Xml.dasm - XmlSchemaElement:Clone(XmlSchema):XmlSchemaObject:this
        -124 (-55.61% of base) : System.Private.Xml.dasm - XmlSchemaAttribute:Clone():XmlSchemaObject:this
         -73 (-29.92% of base) : System.Private.Xml.dasm - XmlSchemaSimpleTypeUnion:Clone():XmlSchemaObject:this
         -62 (-53.45% of base) : System.Private.Xml.dasm - XmlSchemaSimpleTypeList:Clone():XmlSchemaObject:this
         -62 (-53.45% of base) : System.Private.Xml.dasm - XmlSchemaSimpleTypeRestriction:Clone():XmlSchemaObject:this
         -42 (-70.00% of base) : System.Private.CoreLib.dasm - Calendar:Clone():Object:this
         -42 (-70.00% of base) : System.Private.CoreLib.dasm - TextInfo:Clone():Object:this
         -39 (-45.35% of base) : System.Private.Xml.dasm - XsltOutput:CreateDerivedOutput(int):XsltOutput:this
         -38 (-67.86% of base) : System.Drawing.Common.dasm - PrinterSettings:Clone():Object:this
         -38 (-27.94% of base) : System.Private.CoreLib.dasm - Calendar:ReadOnly(Calendar):Calendar
         -38 (-64.41% of base) : System.Private.CoreLib.dasm - NumberFormatInfo:Clone():Object:this
         -38 (-26.76% of base) : System.Private.CoreLib.dasm - NumberFormatInfo:ReadOnly(NumberFormatInfo):NumberFormatInfo
         -38 (-27.94% of base) : System.Private.CoreLib.dasm - TextInfo:ReadOnly(TextInfo):TextInfo
         -38 (-67.86% of base) : System.Private.CoreLib.dasm - Encoding:Clone():Object:this
         -36 (-70.59% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CommandOptions:Clone():CommandOptions:this
         -36 (-70.59% of base) : System.Private.CoreLib.dasm - MarshalByRefObject:MemberwiseClone(bool):MarshalByRefObject:this
         -36 (-70.59% of base) : System.Private.Xml.dasm - XmlQualifiedName:Clone():XmlQualifiedName:this

Top method improvements (percentages):
         -36 (-70.59% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - CommandOptions:Clone():CommandOptions:this
         -36 (-70.59% of base) : System.Private.CoreLib.dasm - MarshalByRefObject:MemberwiseClone(bool):MarshalByRefObject:this
         -36 (-70.59% of base) : System.Private.Xml.dasm - XmlQualifiedName:Clone():XmlQualifiedName:this
         -36 (-70.59% of base) : System.Private.Xml.dasm - SchemaAttDef:Clone():SchemaAttDef:this
         -36 (-70.59% of base) : System.Private.Xml.dasm - SchemaElementDecl:Clone():SchemaElementDecl:this
         -36 (-70.59% of base) : System.Private.Xml.dasm - XmlSchemaObject:Clone():XmlSchemaObject:this
         -36 (-70.59% of base) : System.Private.Xml.dasm - QilNode:ShallowClone(QilFactory):QilNode:this
         -42 (-70.00% of base) : System.Private.CoreLib.dasm - Calendar:Clone():Object:this
         -42 (-70.00% of base) : System.Private.CoreLib.dasm - TextInfo:Clone():Object:this
         -38 (-67.86% of base) : System.Drawing.Common.dasm - PrinterSettings:Clone():Object:this
         -38 (-67.86% of base) : System.Private.CoreLib.dasm - Encoding:Clone():Object:this
         -38 (-64.41% of base) : System.Private.CoreLib.dasm - NumberFormatInfo:Clone():Object:this
        -124 (-55.61% of base) : System.Private.Xml.dasm - XmlSchemaAttribute:Clone():XmlSchemaObject:this
         -22 (-55.00% of base) : System.Private.Xml.dasm - XmlReaderSettings:Clone():XmlReaderSettings:this
         -62 (-53.45% of base) : System.Private.Xml.dasm - XmlSchemaSimpleTypeList:Clone():XmlSchemaObject:this
         -62 (-53.45% of base) : System.Private.Xml.dasm - XmlSchemaSimpleTypeRestriction:Clone():XmlSchemaObject:this
         -39 (-45.35% of base) : System.Private.Xml.dasm - XsltOutput:CreateDerivedOutput(int):XsltOutput:this
         -31 (-37.80% of base) : Microsoft.CodeAnalysis.dasm - ILBuilder:GetSnapshot():ILBuilder:this
        -155 (-37.17% of base) : System.Private.Xml.dasm - XmlSchemaElement:Clone(XmlSchema):XmlSchemaObject:this
         -31 (-36.90% of base) : System.Private.Xml.dasm - QilList:ShallowClone(QilFactory):QilNode:this
```
/cc @AndyAyersMS 