### PR TITLE
Optimize DateTime constructors (DateToTicks and IsLeapYear)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -635,8 +635,8 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRange_BadYearMonthDay();
             }
 
-            int y = year - 1;
-            int n = y * 365 + y / 4 - y / 100 + y / 400 + days[month - 1] + day - 1;
+            uint y = (uint)(year - 1);
+            uint n = y * 365 + y / 4 - y / 100 + y / 400 + (uint)days[month - 1] + (uint)day - 1;
             return n * TicksPerDay;
         }
 
@@ -1130,7 +1130,9 @@ namespace System
             {
                 ThrowHelper.ThrowArgumentOutOfRange_Year();
             }
-            return (year & 3) == 0 && ((year & 15) == 0 || (year % 25) != 0);
+            return (year & 3) == 0 && ((year & 15) == 0 ||
+                   // TODO: optimize "(uint)year % 25 != 0" in JIT to produce:
+                   (year * -1030792151 > 171798691));
         }
 
         // Constructs a DateTime from a string. The string must specify a

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1132,7 +1132,7 @@ namespace System
             }
             return (year & 3) == 0 && ((year & 15) == 0 ||
                    // TODO: optimize "(uint)year % 25 != 0" in JIT to produce:
-                   (year * -1030792151 > 171798691));
+                   ((uint)(year * -1030792151) > 171798691));
         }
 
         // Constructs a DateTime from a string. The string must specify a


### PR DESCRIPTION
Just a nano-optimization to make some of the `DateTime` constructors a bit faster, e.g.:
```csharp
[Benchmark]
public DateTime CreateDate_const()
{
    return new DateTime(2021, 5, 20);
}

[Benchmark]
[Arguments(2021, 5, 20)]
public DateTime CreateDate_var(int y, int m, int d)
{
    return new DateTime(y, m, d); // and other constructors with DateToTicks/IsLeapYear checks inside
}

/*

            |           Method |      Mean |
            |----------------- |----------:|
     master | CreateDate_const | 0.3712 ns |
     PR     | CreateDate_const | 0.2356 ns |
     master |   CreateDate_var | 2.6116 ns |
     PR     |   CreateDate_var | 2.1922 ns |

*/
```
Codegen diff for `CreateDate_var`: https://www.diffchecker.com/BOTFFqql (336 bytes -> 286 bytes), for arm64: https://www.diffchecker.com/H8xUCOtO (448 bytes -> 400 bytes)

Feel free to close if you think the hacks aren't worth it 🙂