### PR TITLE
 Fix for ilasm generation of malformed PDB files due to empty body methods

### DIFF
--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -512,15 +512,6 @@ BOOL Assembler::EmitMethodBody(Method* pMethod, BinStr* pbsOut)
                 pFH = (COR_ILMETHOD_FAT*)(pMethod->m_pbsBody->ptr());
                 pFH->SetLocalVarSigTok(pMethod->m_LocalsSig);
             }
-            //--------------------------------------------------------------------------------
-            if(m_fGeneratePDB)
-            {
-                if (FAILED(m_pPortablePdbWriter->DefineSequencePoints(pMethod)))
-                    return FALSE;
-                if (FAILED(m_pPortablePdbWriter->DefineLocalScope(pMethod)))
-                    return FALSE;
-            } // end if(fIncludeDebugInfo)
-            //-----------------------------------------------------
 
             if(m_fFoldCode)
             {
@@ -597,6 +588,15 @@ BOOL Assembler::EmitMethodBody(Method* pMethod, BinStr* pbsOut)
             }
             m_pEmitter->SetRVA(pMethod->m_Tok,pMethod->m_headerOffset);
         }
+
+        if (m_fGeneratePDB)
+        {
+            if (FAILED(m_pPortablePdbWriter->DefineSequencePoints(pMethod)))
+                return FALSE;
+            if (FAILED(m_pPortablePdbWriter->DefineLocalScope(pMethod)))
+                return FALSE;
+        }
+
         return TRUE;
     }
     else return FALSE;

--- a/src/coreclr/ilasm/portable_pdb.cpp
+++ b/src/coreclr/ilasm/portable_pdb.cpp
@@ -223,6 +223,7 @@ HRESULT PortablePdbWriter::DefineSequencePoints(Method* method)
     LinePC* prevNonHiddenSeqPoint = NULL;
     LinePC* nextSeqPoint = NULL;
     BOOL isValid = TRUE;
+    BOOL hasEmptyMethodBody = method->m_LinePCList.COUNT() == 0;
 
     for (UINT32 i = 0; i < method->m_LinePCList.COUNT(); i++)
     {
@@ -304,9 +305,10 @@ HRESULT PortablePdbWriter::DefineSequencePoints(Method* method)
     }
 
     // finally define sequence points for the method
-    if (isValid && currSeqPoint != NULL)
+    if ((isValid && currSeqPoint != NULL) || hasEmptyMethodBody)
     {
-        ULONG documentRid = RidFromToken(currSeqPoint->pOwnerDocument->GetToken());
+        mdDocument document = hasEmptyMethodBody ? m_currentDocument->GetToken() : currSeqPoint->pOwnerDocument->GetToken();
+        ULONG documentRid = RidFromToken(document);
         hr = m_pdbEmitter->DefineSequencePoints(documentRid, blob->ptr(), blob->length());
     }
 

--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTester.cs
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTester.cs
@@ -118,10 +118,35 @@ namespace IlasmPortablePdbTests
             }
         }
 
+        // Tests whether the portable PDB MethodDebugInformation table has all the entries as MethoDef table
+        [Fact]
+        public void TestPortablePdbMethodDebugInformation1()
+        {
+            var ilSource = "TestMethodDebugInformation.il";
+
+            var ilasm = IlasmPortablePdbTesterCommon.GetIlasmFullPath(CoreRootVar, IlasmFile);
+            IlasmPortablePdbTesterCommon.Assemble(ilasm, ilSource, TestDir, out string dll, out string pdb);
+
+            using (var peStream = new FileStream(dll, FileMode.Open, FileAccess.Read))
+            {
+                using (var peReader = new PEReader(peStream))
+                {
+                    var peMdReader = peReader.GetMetadataReader();
+                    Assert.NotNull(peMdReader);
+                    using (var pdbReaderProvider = IlasmPortablePdbTesterCommon.GetMetadataReaderProvider(dll, pdb, peReader, false))
+                    {
+                        var portablePdbMdReader = pdbReaderProvider.GetMetadataReader();
+                        Assert.NotNull(portablePdbMdReader);
+                        Assert.Equal(peMdReader.MethodDefinitions.Count, portablePdbMdReader.MethodDebugInformation.Count);
+                    }
+                }
+            }
+        }
+
         // Tests whether the portable PDB has appropriate sequence points defined
         // The test source file includes external source reference and thus has 2 variants depending on OS type
         [Fact]
-        public void TestPortablePdbMethodDebugInformation()
+        public void TestPortablePdbMethodDebugInformation2()
         {
             var ilSource = IsUnix ? "TestMethodDebugInformation_unix.il" : "TestMethodDebugInformation_win.il";
 

--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTesterCommon.cs
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTesterCommon.cs
@@ -10,7 +10,7 @@ namespace IlasmPortablePdbTests
 {
     public static class IlasmPortablePdbTesterCommon
     {
-        public const string CommonIlasmArguments = "-nologo -dll -debug -pdbfmt=portable";
+        public const string CommonIlasmArguments = "-nologo -dll -debug";
 
         public static string GetIlasmFullPath(string coreRootVar, string ilasmFile)
         {

--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTests.csproj
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTests.csproj
@@ -35,6 +35,9 @@
     <None Include="TestFiles\TestLocalScopes4.il">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\TestMethodDebugInformation.il">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\TestMethodDebugInformation_unix.il">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/tests/ilasm/PortablePdb/TestFiles/TestMethodDebugInformation.il
+++ b/src/tests/ilasm/PortablePdb/TestFiles/TestMethodDebugInformation.il
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly TestMethodDebugInformation
+{
+}
+
+.class abstract auto ansi BaseTestMethodDebugInformationType extends [System.Runtime]System.Object
+{
+    // testing empty body methods
+    .method family hidebysig newslot virtual abstract 
+        instance int32 Foo() cil managed { }
+    
+    .method public hidebysig specialname rtspecialname 
+            instance void .ctor() cil managed
+    {
+          .maxstack  8
+          IL_0000:  ldarg.0
+          IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+          IL_0006:  ret
+    }
+}
+
+.class auto ansi beforefieldinit TestMethodDebugInformationType extends BaseTestMethodDebugInformationType
+{
+    .method family hidebysig virtual 
+        instance int32 Foo() cil managed
+    {
+         IL_0000:  nop
+         IL_0001:  ret
+    }
+}


### PR DESCRIPTION
There was an issue in ilasm where empty body methods were ignored when generating MethodDebugInformation table entries.
This caused generation of malformed PDB files, because the MethodDef and MethodDebugInformation table rows did not match.

Fixes #46124