### PR TITLE
Enable static graph restore binlog generation

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>  
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <GenerateRestoreUseStaticGraphEvaluationBinlog>true</GenerateRestoreUseStaticGraphEvaluationBinlog>
   </PropertyGroup>
   <ItemGroup>
     <ProjectToBuild Include="$(RepoRoot)Build.proj" />

--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -28,12 +28,12 @@
     </ItemGroup>
 
     <MSBuild Projects="@(TaskProject)"
-             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=Debug;Platform=AnyCPU"
-             Targets="Restore"/>
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=Debug;Platform=AnyCPU;RESTORE_TASK_BINLOG_PARAMETERS=$(ArtifactsLogDir)Restore-tasks.proj.binlog"
+             Targets="Restore" />
 
     <MSBuild Projects="@(TaskProject)"
              Properties="Configuration=Debug;Platform=AnyCPU"
-             Targets="Build"/>
+             Targets="Build" />
 
     <WriteLinesToFile File="$(TasksIntermediateFile)"
                       Lines="$(TasksIntermediateFile)"


### PR DESCRIPTION
Static graph restore runs out-of-proc outside of msbuild.exe. To be able to diagnose project evaluation issues during restore, setting the switch to tell Arcade to set an env var which tells NuGet's out-of-proc static graph console to generate a binlog. I tested this locally and couldn't notice a measurable perf impact.

In addition, setting the var to a different value in tasks.proj which runs in an extra restore invocation to avoid that binlog to be overwritten by the restore invocation that follows afterwards.