### PR TITLE
Try to make ProcessNameMatchesScriptName test more reliable

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -172,6 +172,8 @@ namespace System.Diagnostics.Tests
                     Assert.Contains($"({scriptName.Substring(0, 15)})", stat);
                     string cmdline = File.ReadAllText($"/proc/{process.Id}/cmdline");
 
+                    // cmdLine can sometimes be null: https://github.com/dotnet/runtime/issues/13757
+                    // according to docs, it's when the process is a zombie: https://man7.org/linux/man-pages/man5/proc.5.html
                     if (string.IsNullOrEmpty(cmdline))
                     {
                         Assert.True(process.HasExited, $"/proc/{process.Id}/cmdline was empty, but the process was not a zombie");

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -171,14 +171,24 @@ namespace System.Diagnostics.Tests
                     string stat = File.ReadAllText($"/proc/{process.Id}/stat");
                     Assert.Contains($"({scriptName.Substring(0, 15)})", stat);
                     string cmdline = File.ReadAllText($"/proc/{process.Id}/cmdline");
-                    Assert.Equal($"/bin/sh\0{filename}\0", cmdline);
 
-                    Assert.Equal(scriptName, process.ProcessName);
+                    if (string.IsNullOrEmpty(cmdline))
+                    {
+                        Assert.True(process.HasExited, $"/proc/{process.Id}/cmdline was empty, but the process was not a zombie");
+                    }
+                    else
+                    {
+                        Assert.Equal($"/bin/sh\0{filename}\0", cmdline);
+                        Assert.Equal(scriptName, process.ProcessName);
+                    }
                 }
                 finally
                 {
-                    process.Kill();
-                    process.WaitForExit();
+                    if (!process.HasExited)
+                    {
+                        process.Kill();
+                        process.WaitForExit();
+                    }
                 }
             }
         }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -159,7 +159,7 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(~TestPlatforms.OSX)] // On OSX, ProcessName returns the script interpreter.
         public void ProcessNameMatchesScriptName()
         {
-            string scriptName = GetTestFileName();
+            const string scriptName = nameof(ProcessNameMatchesScriptName);
             string filename = Path.Combine(TestDirectory, scriptName);
             File.WriteAllText(filename, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
             ChMod(filename, "744"); // set x-bit

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -161,7 +161,7 @@ namespace System.Diagnostics.Tests
         {
             const string scriptName = nameof(ProcessNameMatchesScriptName);
             string filename = Path.Combine(TestDirectory, scriptName);
-            File.WriteAllText(filename, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
+            File.WriteAllText(filename, $"#!/bin/sh\n/bin/sleep 600\n"); // sleep 10 min.
             ChMod(filename, "744"); // set x-bit
 
             using (var process = Process.Start(new ProcessStartInfo { FileName = filename }))


### PR DESCRIPTION
This very simple test can sometimes fail: https://github.com/dotnet/runtime/issues/13757

I was not able to reproduce it, but based on the logs attached to the original issue I believe that the `GetTestFileName` might in theory be returning some non-ascii characters and Linux might not like it, so I've replaced it with `const` value
![image](https://user-images.githubusercontent.com/6011991/102788790-7b29cf80-43a3-11eb-8673-5c7c42b8db39.png)

According to [man docs](https://man7.org/linux/man-pages/man5/proc.5.html) the file might be empty if the process is a zombie (it has already exited but parent process has not acknowledged that yet) so I've added a check for that.

> This read-only file holds the complete command line for the
              process, unless the process is a zombie.  In the latter case,
              there is nothing in this file: that is, a read on this file
              will return 0 characters.

I am not a Linux expert, but I guess that `sleep 600` could become a zombie right away only if there is a custom alias for the `sleep` command. I don't know if it's possible, but I think that we can just use full path to be 100% sure we are calling the actual `/bin/sleep`.

Fixes #13757

@tmds is there any chance you could take a look? It's nothing urgent, I just want to get rid of unstable tests from my areas.