### PR TITLE
Fix wrong XHARNESS_CLI_COMMAND in wasm README

### DIFF
--- a/eng/testing/AndroidRunnerTemplate.sh
+++ b/eng/testing/AndroidRunnerTemplate.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
+# NOTE: this script is only used locally, on CI we use the Helix SDK from arcade
+
 EXECUTION_DIR=$(dirname $0)
+ASSEMBLY_NAME=$1
+TARGET_ARCH=$2
+TARGET_OS=$3
+TEST_NAME=$4
+XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
 
 cd $EXECUTION_DIR
 
@@ -16,22 +23,19 @@ while true; do
     fi
 done
 
-if [ -z "$HELIX_WORKITEM_UPLOAD_ROOT" ]; then
-    XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
-else
-    XHARNESS_OUT="$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output"
-fi
-
 if [ ! -z "$XHARNESS_CLI_PATH" ]; then
-	# When running in CI, we only have the .NET runtime available
-	# We need to call the XHarness CLI DLL directly via dotnet exec
-	HARNESS_RUNNER="dotnet exec $XHARNESS_CLI_PATH"
+    # Allow overriding the path to the XHarness CLI DLL,
+    # we need to call it directly via dotnet exec
+    HARNESS_RUNNER="dotnet exec $XHARNESS_CLI_PATH"
 else
 	HARNESS_RUNNER="dotnet xharness"
 fi
 
-# RunCommands defined in tests.mobile.targets
-[[RunCommands]]
+$HARNESS_RUNNER android test                \
+    --instrumentation="net.dot.MonoRunner"  \
+    --package-name="net.dot.$ASSEMBLY_NAME" \
+    --app="$EXECUTION_DIR/bin/$TEST_NAME.apk" \
+    --output-directory="$XHARNESS_OUT"
 
 _exitCode=$?
 

--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -56,7 +56,15 @@ else
     export XHARNESS_OUT="$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output"
 fi
 
-dotnet xharness ios test  \
+if [ ! -z "$XHARNESS_CLI_PATH" ]; then
+    # When running in CI, we only have the .NET runtime available
+    # We need to call the XHarness CLI DLL directly via dotnet exec
+    HARNESS_RUNNER="dotnet exec $XHARNESS_CLI_PATH"
+else
+    HARNESS_RUNNER="dotnet xharness"
+fi
+
+$HARNESS_RUNNER ios test  \
     --targets="$TARGET"   \
     --app="$APP_BUNDLE"   \
     --xcode="$XCODE_PATH" \

--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -1,43 +1,33 @@
 ﻿#!/usr/bin/env bash
 
+# NOTE: this script is only used locally, on CI we use the Helix SDK from arcade
+
 EXECUTION_DIR=$(dirname $0)
-[[RunCommands]]
+ASSEMBLY_NAME=$1
+TARGET_ARCH=$2
+TARGET_OS=$3
+TEST_NAME=$4
+XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+XCODE_PATH=$(xcode-select -p)/../..
 
-TARGET_DEVICE=ios-device
-TARGET_SIMULATOR=ios-simulator-64
-TARGET_SDK=iphoneos
-TARGET_SIMULATOR_SDK=iphonesimulator
+if [[ "$TARGET_OS" == "iOS" && "$TARGET_ARCH" == "x86" ]]; then TARGET=ios-simulator-32; fi
+if [[ "$TARGET_OS" == "iOS" && "$TARGET_ARCH" == "x64" ]]; then TARGET=ios-simulator-64; fi
+if [[ "$TARGET_OS" == "iOS" && "$TARGET_ARCH" == "arm" ]]; then TARGET=ios-device; fi
+if [[ "$TARGET_OS" == "iOS" && "$TARGET_ARCH" == "arm64" ]]; then TARGET=ios-device; fi
 
-if [ "$TARGET_OS" == "tvOS" ]; then
-    TARGET_DEVICE=tvos-device
-    TARGET_SIMULATOR=tvos-simulator
-    TARGET_SDK=appletvos
-    TARGET_SIMULATOR_SDK=appletvsimulator
-fi
-
+if [[ "$TARGET_OS" == "tvOS" && "$TARGET_ARCH" == "x64" ]]; then TARGET=tvos-simulator; fi
+if [[ "$TARGET_OS" == "tvOS" && "$TARGET_ARCH" == "arm64" ]]; then TARGET=tvos-device; fi
 
 # "Release" in SCHEME_SDK is what xcode produces (see "bool Optimized" property in AppleAppBuilderTask)
-if [ "$TARGET_ARCH" == "arm" ]; then
-    TARGET=$TARGET_DEVICE
-    SCHEME_SDK="Release-$TARGET_SDK"
-elif [ "$TARGET_ARCH" == "arm64" ]; then
-    TARGET=$TARGET_DEVICE
-    SCHEME_SDK="Release-$TARGET_SDK"
-elif [ "$TARGET_ARCH" == "x64" ]; then
-    TARGET=$TARGET_SIMULATOR
-    SCHEME_SDK="Release-$TARGET_SIMULATOR_SDK"
-elif [ "$TARGET_ARCH" == "x86" ] && [ "$TARGET_OS" == "iOS" ]; then
-    TARGET=ios-simulator-32
-    SCHEME_SDK="Release-$TARGET_SIMULATOR_SDK"
-else
-    echo "Unknown OS & architecture: $TARGET_OS $TARGET_ARCH"
-    exit 1
-fi
+if [[ "$TARGET" == "ios-simulator-"* ]]; then SCHEME_SDK=Release-iphonesimulator; fi
+if [[ "$TARGET" == "tvos-simulator" ]]; then SCHEME_SDK=Release-appletvsimulator; fi
+if [[ "$TARGET" == "ios-device" ]]; then SCHEME_SDK=Release-iphoneos; fi
+if [[ "$TARGET" == "tvos-device" ]]; then SCHEME_SDK=Release-appletvos; fi
 
-APP_BUNDLE=$EXECUTION_DIR/$TEST_NAME/$SCHEME_SDK/$TEST_NAME.app
+cd $EXECUTION_DIR
 
 # it doesn't support parallel execution yet, so, here is a hand-made semaphore:
-LOCKDIR=/tmp/runonsim.lock
+LOCKDIR=/tmp/appletests.lock
 while true; do
     if mkdir "$LOCKDIR"
     then
@@ -48,27 +38,19 @@ while true; do
     fi
 done
 
-XCODE_PATH="`xcode-select -p`/../.."
-
-if [ -z "$HELIX_WORKITEM_UPLOAD_ROOT" ]; then
-    export XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
-else
-    export XHARNESS_OUT="$HELIX_WORKITEM_UPLOAD_ROOT/xharness-output"
-fi
-
 if [ ! -z "$XHARNESS_CLI_PATH" ]; then
-    # When running in CI, we only have the .NET runtime available
-    # We need to call the XHarness CLI DLL directly via dotnet exec
+    # Allow overriding the path to the XHarness CLI DLL,
+    # we need to call it directly via dotnet exec
     HARNESS_RUNNER="dotnet exec $XHARNESS_CLI_PATH"
 else
     HARNESS_RUNNER="dotnet xharness"
 fi
 
-$HARNESS_RUNNER ios test  \
-    --targets="$TARGET"   \
-    --app="$APP_BUNDLE"   \
-    --xcode="$XCODE_PATH" \
-    --output-directory=$XHARNESS_OUT
+$HARNESS_RUNNER ios test    \
+    --app="$EXECUTION_DIR/$TEST_NAME/$SCHEME_SDK/$TEST_NAME.app" \
+    --targets="$TARGET" \
+    --xcode="$XCODE_PATH"   \
+    --output-directory="$XHARNESS_OUT"
 
 _exitCode=$?
 

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -13,15 +13,6 @@
     <RunScriptCommand>$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js --output-directory=$XHARNESS_OUT --  $(RunTestsJSArguments) --run WasmTestRunner.dll $(AssemblyName).dll</RunScriptCommand>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetOS)' == 'Android'">
-    <RunScriptCommand>$HARNESS_RUNNER android test --instrumentation="net.dot.MonoRunner" --package-name="net.dot.$(AssemblyName)" --app=$EXECUTION_DIR/bin/$(TestProjectName).apk --output-directory=$XHARNESS_OUT -v --</RunScriptCommand>
-  </PropertyGroup>
-  <ItemGroup>
-    <RunScriptCommands Include="TEST_NAME=$(TestProjectName)" />
-    <RunScriptCommands Include="TARGET_OS=$(TargetOS)" />
-    <RunScriptCommands Include="TARGET_ARCH=$(TargetArchitecture)" />
-  </ItemGroup>
-
   <!-- Generate a self-contained app bundle for Android with tests. -->
   <UsingTask Condition="'$(TargetOS)' == 'Android'"
              TaskName="AndroidAppBuilderTask"
@@ -45,7 +36,7 @@
           SourceFiles="$(ANDROID_OPENSSL_AAR)\prefab\modules\ssl\libs\android.$(AndroidAbi)\libssl.so"
           DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true"/>
 
-    <WriteLinesToFile File="$(PublishDir)xunit-excludes.txt" Lines="$(_withoutCategories.Replace(';', '%0dcategory='))" />
+    <WriteLinesToFile File="$(PublishDir)xunit-excludes.txt" Lines="$(XunitExcludesTxtFileContent)" />
 
     <RemoveDir Directories="$(BundleDir)" />
     <AndroidAppBuilderTask
@@ -86,7 +77,7 @@
            Text="'DevTeamProvisioning' needs to be set for device builds. Set it to 'UBF8T346G9' if you're part of the Microsoft team account." />
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />
 
-    <WriteLinesToFile File="$(PublishDir)xunit-excludes.txt" Lines="$(_withoutCategories.Replace(';', '%0dcategory='))" />
+    <WriteLinesToFile File="$(PublishDir)xunit-excludes.txt" Lines="$(XunitExcludesTxtFileContent)" />
 
     <PropertyGroup>
       <Optimized>true</Optimized>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -96,7 +96,7 @@
       <RunTestsCommand Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                   $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">$(RunTestsCommand) --runtime-path "$(TestHostRootPath.TrimEnd('\/'))"</RunTestsCommand>
       <RunTestsCommand Condition="'$(TestRspFile)' != '' and '$(RuntimeFlavor)' != 'Mono'">$(RunTestsCommand) --rsp-file "$(TestRspFile)"</RunTestsCommand>
-      <RunTestsCommand Condition="'$(TargetsMobile)' == 'true'">"$(RunScriptOutputPath)" $(AssemblyName) $(TargetArchitecture)</RunTestsCommand>
+      <RunTestsCommand Condition="'$(TargetsMobile)' == 'true'">"$(RunScriptOutputPath)" $(AssemblyName) $(TargetArchitecture) $(TargetOS) $(TestProjectName)</RunTestsCommand>
       <RunTestsCommand Condition="'$(TargetOS)' == 'Browser'">"$(RunScriptOutputPath)" $(JSEngine) $(AssemblyName).dll $(_withoutCategories.Replace(';', ' -notrait category='))</RunTestsCommand>
     </PropertyGroup>
 

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TestResultsName>testResults.xml</TestResultsName>
+    <UseXunitExcludesTxtFile Condition="'$(TargetOS)' == 'Android' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">true</UseXunitExcludesTxtFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsMobile)' != 'true'">
@@ -18,7 +19,7 @@
     <RunScriptCommand Condition="'$(XUnitShowProgress)' == 'true'">$(RunScriptCommand) -verbose</RunScriptCommand>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(UseXunitExcludesTxtFile)' != 'true'">
     <!-- Add local and global options to the argument stack. -->
     <RunScriptCommand Condition="'$(XUnitMethodName)' != ''">$(RunScriptCommand) -method $(XUnitMethodName)</RunScriptCommand>
     <RunScriptCommand Condition="'$(XUnitClassName)' != ''">$(RunScriptCommand) -class $(XUnitClassName)</RunScriptCommand>
@@ -29,6 +30,10 @@
 
     <!-- User passed in options. -->
     <RunScriptCommand Condition="'$(XUnitOptions)' != ''">$(RunScriptCommand) $(XUnitOptions)</RunScriptCommand>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseXunitExcludesTxtFile)' == 'true'">
+    <XunitExcludesTxtFileContent>$(_withoutCategories.Replace(';', '%0dcategory='))</XunitExcludesTxtFileContent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -51,11 +51,11 @@ These tests are run with `xharness wasm test-browser`, for running on the browse
 The wrapper script used to actually run these tests, accepts:
 
 `$XHARNESS_COMMAND`, which defaults to `test`.
-`$XHARNESS_CLI_COMMAND` (see next section)
+`$XHARNESS_CLI_PATH` (see next section)
 
 ### Using a local build of xharness
 
-* set `XHARNESS_CLI_COMMAND=/path/to/xharness/artifacts/bin/Microsoft.DotNet.XHarness.CLI/Debug/netcoreapp3.1/Microsoft.DotNet.XHarness.CLI.dll`
+* set `XHARNESS_CLI_PATH=/path/to/xharness/artifacts/bin/Microsoft.DotNet.XHarness.CLI/Debug/netcoreapp3.1/Microsoft.DotNet.XHarness.CLI.dll`
 
 ### Note: Additional msbuild arguments can be passed with: `make ..  MSBUILD_ARGS="/p:a=b"`
 


### PR DESCRIPTION
The variable is actually `XHARNESS_CLI_PATH`. Also added it to the AppleRunnerTemplate.sh script since it was missing there.

Also simplify iOS/Android scripts a bit.