### PR TITLE
Update testing.md

### DIFF
--- a/docs/workflow/testing/mono/testing.md
+++ b/docs/workflow/testing/mono/testing.md
@@ -5,7 +5,7 @@ Before running tests, [build Mono](../../building/mono/README.md) using the desi
 ## Runtime Tests
 ### Desktop Mono:
 
-To build the runtime tests for Mono JIT or interpreter, execute the following command from `$(REPO_ROOT)/src/tests`
+To build the runtime tests for Mono JIT or interpreter, build CoreCLR and execute the following command from `$(REPO_ROOT)/src/tests`
 ```
 ./build.sh excludemonofailures <release|debug>
 ```


### PR DESCRIPTION
The current framework relays on CoreCLR to create the Core_Root and then patch it with mono runtime. So building CoreCLR is required before building runtime tests for desktop Mono