### PR TITLE
Replace remaining Environment.GetResourceString calls with SR properties

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.Mono.cs
@@ -65,25 +65,4 @@ namespace System
         [DoesNotReturn]
         public static extern void FailFast(string? message, Exception? exception, string? errorSource);
     }
-
-    #region referencesource dependencies - to be removed
-
-    public partial class Environment
-    {
-        internal static string GetResourceString(string key)
-        {
-            return key;
-        }
-
-        internal static string GetResourceString(string key, CultureInfo culture)
-        {
-            return key;
-        }
-
-        internal static string GetResourceString(string key, params object?[] values)
-        {
-            return string.Format(CultureInfo.InvariantCulture, key, values);
-        }
-    }
-    #endregion
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
@@ -146,16 +146,13 @@ namespace System.Reflection.Emit
             return InternalResolve();
         }
 
-        public override Guid GUID
-        {
-            get { throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType")); }
-        }
+        public override Guid GUID => throw new NotSupportedException(SR.NotSupported_NonReflectedType);
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public override object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target,
             object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         public override Module Module
@@ -181,10 +178,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override RuntimeTypeHandle TypeHandle
-        {
-            get { throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType")); }
-        }
+        public override RuntimeTypeHandle TypeHandle => throw new NotSupportedException(SR.NotSupported_NonReflectedType);
 
         public override string? Namespace
         {
@@ -200,108 +194,108 @@ namespace System.Reflection.Emit
         protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder? binder,
                 CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder,
                 CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         public override MethodInfo[] GetMethods(BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
         public override FieldInfo GetField(string name, BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
         public override FieldInfo[] GetFields(BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         public override Type GetInterface(string name, bool ignoreCase)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         public override Type[] GetInterfaces()
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
         public override EventInfo GetEvent(string name, BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)]
         public override EventInfo[] GetEvents()
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
         protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder,
                 Type? returnType, Type[]? types, ParameterModifier[]? modifiers)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
         public override PropertyInfo[] GetProperties(BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
         public override Type[] GetNestedTypes(BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
         public override Type GetNestedType(string name, BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public override MemberInfo[] GetMembers(BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         public override InterfaceMapping GetInterfaceMap(Type interfaceType)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
         public override EventInfo[] GetEvents(BindingFlags bindingAttr)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         protected override TypeAttributes GetAttributeFlagsImpl()
@@ -347,17 +341,17 @@ namespace System.Reflection.Emit
 
         public override object[] GetCustomAttributes(bool inherit)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
+            throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }
     }
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
@@ -491,7 +491,7 @@ namespace System.Reflection.Emit
 
         public override Type MakeGenericType(params Type[] typeArguments)
         {
-            throw new InvalidOperationException(Environment.GetResourceString("Arg_NotGenericTypeDefinition"));
+            throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this));
         }
 
         public override Type MakePointerType()

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -88,12 +88,12 @@ namespace System.Reflection
                 {
                     if (target == null)
                     {
-                        throw new TargetException(Environment.GetResourceString("RFLCT.Targ_StatFldReqTarg"));
+                        throw new TargetException(SR.RFLCT_Targ_StatFldReqTarg);
                     }
                     else
                     {
                         throw new ArgumentException(
-                            string.Format(CultureInfo.CurrentUICulture, Environment.GetResourceString("Arg_FieldDeclTarget"),
+                            SR.Format(SR.Arg_FieldDeclTarget,
                                 Name, DeclaringType, target.GetType()));
                     }
                 }
@@ -113,7 +113,7 @@ namespace System.Reflection
         public override void SetValueDirect(TypedReference obj, object value)
         {
             if (obj.IsNull)
-                throw new ArgumentException(Environment.GetResourceString("Arg_TypedReference_Null"));
+                throw new ArgumentException(SR.Arg_TypedReference_Null);
 
             unsafe
             {
@@ -127,7 +127,7 @@ namespace System.Reflection
         public override object GetValueDirect(TypedReference obj)
         {
             if (obj.IsNull)
-                throw new ArgumentException(Environment.GetResourceString("Arg_TypedReference_Null"));
+                throw new ArgumentException(SR.Arg_TypedReference_Null);
 
             unsafe
             {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -427,7 +427,7 @@ namespace System.Reflection
                 if (arg == Type.Missing)
                 {
                     if (pi.DefaultValue == DBNull.Value)
-                        throw new ArgumentException(Environment.GetResourceString("Arg_VarMissNull"), "parameters");
+                        throw new ArgumentException(SR.Arg_VarMissNull, "parameters");
 
                     args[i] = pi.DefaultValue;
                     continue;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -167,7 +167,7 @@ namespace System
         {
             if (type.IsPointer || type.IsByRef || type == typeof(void))
                 throw new ArgumentException(
-                    Environment.GetResourceString("Argument_NeverValidGenericArgument", type.ToString()));
+                    SR.Format(SR.Argument_NeverValidGenericArgument, type));
         }
 
         internal static void SanityCheckGenericArguments(RuntimeType[] genericArguments, RuntimeType[] genericParamters)
@@ -185,7 +185,7 @@ namespace System
 
             if (genericArguments.Length != genericParamters.Length)
                 throw new ArgumentException(
-                    Environment.GetResourceString("Argument_NotEnoughGenArguments", genericArguments.Length, genericParamters.Length));
+                    SR.Format(SR.Argument_NotEnoughGenArguments, genericArguments.Length, genericParamters.Length));
         }
 
         private static void SplitName(string? fullname, out string? name, out string? ns)
@@ -834,7 +834,7 @@ namespace System
                     {
                         MethodInfo methodInfo = candidates[j];
                         if (!System.DefaultBinder.CompareMethodSig(methodInfo, firstCandidate))
-                            throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                            throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
                     }
 
                     // All the methods have the exact same name and sig so return the most derived one.
@@ -905,7 +905,7 @@ namespace System
                 {
                     if (returnType is null)
                         // if we are here we have no args or property type to select over and we have more than one property with that name
-                        throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                        throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
                 }
             }
 
@@ -938,7 +938,7 @@ namespace System
                 if ((bindingAttr & eventInfo.BindingFlags) == eventInfo.BindingFlags)
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                        throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                     match = eventInfo;
                 }
@@ -969,7 +969,7 @@ namespace System
                     if (match != null)
                     {
                         if (ReferenceEquals(fieldInfo.DeclaringType, match.DeclaringType))
-                            throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                            throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                         if ((match.DeclaringType!.IsInterface == true) && (fieldInfo.DeclaringType!.IsInterface == true))
                             multipleStaticFieldMatches = true;
@@ -981,7 +981,7 @@ namespace System
             }
 
             if (multipleStaticFieldMatches && match!.DeclaringType!.IsInterface)
-                throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
             return match;
         }
@@ -1030,7 +1030,7 @@ namespace System
                 if (FilterApplyType(iface, bindingAttr, name, false, ns))
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                        throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                     match = iface;
                 }
@@ -1059,7 +1059,7 @@ namespace System
                 if (FilterApplyType(nestedType, bindingAttr, name, false, ns))
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                        throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                     match = nestedType;
                 }
@@ -1186,7 +1186,7 @@ namespace System
             get
             {
                 if (!IsGenericParameter)
-                    throw new InvalidOperationException(Environment.GetResourceString("Arg_NotGenericParameter"));
+                    throw new InvalidOperationException(SR.Arg_NotGenericParameter);
 
                 return GetGenericParameterAttributes();
             }
@@ -1219,11 +1219,10 @@ namespace System
             RuntimeType[] instantiationRuntimeType = new RuntimeType[instantiation.Length];
 
             if (!IsGenericTypeDefinition)
-                throw new InvalidOperationException(
-                    Environment.GetResourceString("Arg_NotGenericTypeDefinition", this));
+                throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this));
 
             if (GetGenericArguments().Length != instantiation.Length)
-                throw new ArgumentException(Environment.GetResourceString("Argument_GenericArgsCount"), nameof(instantiation));
+                throw new ArgumentException(SR.Argument_GenericArgsCount, nameof(instantiation));
 
             for (int i = 0; i < instantiation.Length; i++)
             {
@@ -1263,7 +1262,8 @@ namespace System
             get
             {
                 if (!IsGenericParameter)
-                    throw new InvalidOperationException(Environment.GetResourceString("Arg_NotGenericParameter"));
+                    throw new InvalidOperationException(SR.Arg_NotGenericParameter);
+
                 return GetGenericParameterPosition();
             }
         }
@@ -1286,12 +1286,12 @@ namespace System
             object?[]? providedArgs, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParams)
         {
             if (IsGenericParameter)
-                throw new InvalidOperationException(Environment.GetResourceString("Arg_GenericParameter"));
+                throw new InvalidOperationException(SR.Arg_GenericParameter);
 
             #region Preconditions
             if ((bindingFlags & InvocationMask) == 0)
                 // "Must specify binding flags describing the invoke operation required."
-                throw new ArgumentException(Environment.GetResourceString("Arg_NoAccessSpec"), nameof(bindingFlags));
+                throw new ArgumentException(SR.Arg_NoAccessSpec, nameof(bindingFlags));
 
             // Provide a default binding mask if none is provided
             if ((bindingFlags & MemberBindingMask) == 0)
@@ -1309,13 +1309,13 @@ namespace System
                 {
                     if (namedParams.Length > providedArgs.Length)
                         // "Named parameter array can not be bigger than argument array."
-                        throw new ArgumentException(Environment.GetResourceString("Arg_NamedParamTooBig"), nameof(namedParams));
+                        throw new ArgumentException(SR.Arg_NamedParamTooBig, nameof(namedParams));
                 }
                 else
                 {
                     if (namedParams.Length != 0)
                         // "Named parameter array can not be bigger than argument array."
-                        throw new ArgumentException(Environment.GetResourceString("Arg_NamedParamTooBig"), nameof(namedParams));
+                        throw new ArgumentException(SR.Arg_NamedParamTooBig, nameof(namedParams));
                 }
             }
             #endregion
@@ -1323,7 +1323,7 @@ namespace System
             #region Check that any named paramters are not null
             if (namedParams != null && Array.IndexOf<string?>(namedParams, null) != -1)
                 // "Named parameter value must not be null."
-                throw new ArgumentException(Environment.GetResourceString("Arg_NamedParamNull"), nameof(namedParams));
+                throw new ArgumentException(SR.Arg_NamedParamNull, nameof(namedParams));
             #endregion
 
             int argCnt = (providedArgs != null) ? providedArgs.Length : 0;
@@ -1339,7 +1339,7 @@ namespace System
             {
                 if ((bindingFlags & BindingFlags.CreateInstance) != 0 && (bindingFlags & BinderNonCreateInstance) != 0)
                     // "Can not specify both CreateInstance and another access type."
-                    throw new ArgumentException(Environment.GetResourceString("Arg_CreatInstAccess"), nameof(bindingFlags));
+                    throw new ArgumentException(SR.Arg_CreatInstAccess, nameof(bindingFlags));
 
                 return Activator.CreateInstance(this, bindingFlags, binder, providedArgs, culture);
             }
@@ -1370,11 +1370,11 @@ namespace System
                 {
                     if (IsSetField)
                         // "Can not specify both Get and Set on a field."
-                        throw new ArgumentException(Environment.GetResourceString("Arg_FldSetGet"), nameof(bindingFlags));
+                        throw new ArgumentException(SR.Arg_FldSetGet, nameof(bindingFlags));
 
                     if ((bindingFlags & BindingFlags.SetProperty) != 0)
                         // "Can not specify both GetField and SetProperty."
-                        throw new ArgumentException(Environment.GetResourceString("Arg_FldGetPropSet"), nameof(bindingFlags));
+                        throw new ArgumentException(SR.Arg_FldGetPropSet, nameof(bindingFlags));
                 }
                 else
                 {
@@ -1385,11 +1385,11 @@ namespace System
 
                     if ((bindingFlags & BindingFlags.GetProperty) != 0)
                         // "Can not specify both SetField and GetProperty."
-                        throw new ArgumentException(Environment.GetResourceString("Arg_FldSetPropGet"), nameof(bindingFlags));
+                        throw new ArgumentException(SR.Arg_FldSetPropGet, nameof(bindingFlags));
 
                     if ((bindingFlags & BindingFlags.InvokeMethod) != 0)
                         // "Can not specify Set on a Field and Invoke on a method."
-                        throw new ArgumentException(Environment.GetResourceString("Arg_FldSetInvoke"), nameof(bindingFlags));
+                        throw new ArgumentException(SR.Arg_FldSetInvoke, nameof(bindingFlags));
                 }
                 #endregion
 
@@ -1438,7 +1438,7 @@ namespace System
                                 }
                                 catch (InvalidCastException)
                                 {
-                                    throw new ArgumentException(Environment.GetResourceString("Arg_IndexMustBeInt"));
+                                    throw new ArgumentException(SR.Arg_IndexMustBeInt);
                                 }
                             }
 
@@ -1463,7 +1463,7 @@ namespace System
                     {
                         #region Get the field value
                         if (argCnt != 0)
-                            throw new ArgumentException(Environment.GetResourceString("Arg_FldGetArgErr"), nameof(bindingFlags));
+                            throw new ArgumentException(SR.Arg_FldGetArgErr, nameof(bindingFlags));
 
                         return selFld.GetValue(target);
                         #endregion
@@ -1472,7 +1472,7 @@ namespace System
                     {
                         #region Set the field Value
                         if (argCnt != 1)
-                            throw new ArgumentException(Environment.GetResourceString("Arg_FldSetArgErr"), nameof(bindingFlags));
+                            throw new ArgumentException(SR.Arg_FldSetArgErr, nameof(bindingFlags));
 
                         selFld.SetValue(target, providedArgs![0], bindingFlags, binder, culture);
 
@@ -1523,7 +1523,7 @@ namespace System
                     Debug.Assert(!IsSetField);
 
                     if (isSetProperty)
-                        throw new ArgumentException(Environment.GetResourceString("Arg_PropSetGet"), nameof(bindingFlags));
+                        throw new ArgumentException(SR.Arg_PropSetGet, nameof(bindingFlags));
                 }
                 else
                 {
@@ -1532,7 +1532,7 @@ namespace System
                     Debug.Assert(!IsGetField);
 
                     if ((bindingFlags & BindingFlags.InvokeMethod) != 0)
-                        throw new ArgumentException(Environment.GetResourceString("Arg_PropSetInvoke"), nameof(bindingFlags));
+                        throw new ArgumentException(SR.Arg_PropSetInvoke, nameof(bindingFlags));
                 }
                 #endregion
             }
@@ -1684,16 +1684,15 @@ namespace System
         private void CreateInstanceCheckThis()
         {
             if (ContainsGenericParameters)
-                throw new ArgumentException(
-                    Environment.GetResourceString("Acc_CreateGenericEx", this));
+                throw new ArgumentException(SR.Format(SR.Acc_CreateGenericEx, this));
 
-            Type elementType = this.GetRootElementType();
+            Type elementType = GetRootElementType();
 
             if (ReferenceEquals(elementType, typeof(ArgIterator)))
-                throw new NotSupportedException(Environment.GetResourceString("Acc_CreateArgIterator"));
+                throw new NotSupportedException(SR.Acc_CreateArgIterator);
 
             if (ReferenceEquals(elementType, typeof(void)))
-                throw new NotSupportedException(Environment.GetResourceString("Acc_CreateVoid"));
+                throw new NotSupportedException(SR.Acc_CreateVoid);
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2082:UnrecognizedReflectionPattern",
@@ -1756,7 +1755,7 @@ namespace System
 
                         if (cons == null)
                         {
-                            throw new MissingMethodException(Environment.GetResourceString("MissingConstructor_Name", FullName));
+                            throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, FullName));
                         }
 
                         MethodBase? invokeMethod;
@@ -1770,7 +1769,7 @@ namespace System
 
                         if (invokeMethod == null)
                         {
-                            throw new MissingMethodException(Environment.GetResourceString("MissingConstructor_Name", FullName));
+                            throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, FullName));
                         }
 
                         if (invokeMethod.GetParametersNoCopy().Length == 0)
@@ -1780,8 +1779,7 @@ namespace System
 
                                 Debug.Assert((invokeMethod.CallingConvention & CallingConventions.VarArgs) ==
                                                  CallingConventions.VarArgs);
-                                throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture,
-                                    Environment.GetResourceString("NotSupported_CallToVarArg")));
+                                throw new NotSupportedException(SR.NotSupported_CallToVarArg);
                             }
 
                             // fast path??
@@ -1937,19 +1935,19 @@ namespace System
             RuntimeConstructorInfo? ctor = GetDefaultConstructor();
             if (!nonPublic && ctor != null && !ctor.IsPublic)
             {
-                throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, FullName));
+                throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, this));
             }
 
             if (ctor == null)
             {
                 Type elementType = this.GetRootElementType();
                 if (ReferenceEquals(elementType, typeof(TypedReference)) || ReferenceEquals(elementType, typeof(RuntimeArgumentHandle)))
-                    throw new NotSupportedException(Environment.GetResourceString("NotSupported_ContainsStackPtr"));
+                    throw new NotSupportedException("NotSupported_ContainsStackPtr");
 
                 if (IsValueType)
                     return CreateInstanceInternal(this);
 
-                throw new MissingMethodException("Default constructor not found for type " + FullName);
+                throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, this));
             }
 
             // TODO: .net does more checks in unmanaged land in RuntimeTypeHandle::CreateInstance
@@ -1969,12 +1967,12 @@ namespace System
                 return res;
 
             if ((invokeAttr & BindingFlags.ExactBinding) == BindingFlags.ExactBinding)
-                throw new ArgumentException(string.Format(CultureInfo.CurrentUICulture, Environment.GetResourceString("Arg_ObjObjEx"), value!.GetType(), this));
+                throw new ArgumentException(SR.Format(SR.Arg_ObjObjEx, value!.GetType(), this));
 
             if (binder != null && binder != DefaultBinder)
                 return binder.ChangeType(value!, this, culture);
 
-            throw new ArgumentException(string.Format(CultureInfo.CurrentUICulture, Environment.GetResourceString("Arg_ObjObjEx"), value!.GetType(), this));
+            throw new ArgumentException(SR.Format(SR.Arg_ObjObjEx, value!.GetType(), this));
         }
 
         private object? TryConvertToType(object? value, ref bool failed)
@@ -2254,7 +2252,7 @@ namespace System
         public override Type[] GetGenericParameterConstraints()
         {
             if (!IsGenericParameter)
-                throw new InvalidOperationException(Environment.GetResourceString("Arg_NotGenericParameter"));
+                throw new InvalidOperationException(SR.Arg_NotGenericParameter);
 
             var paramInfo = new Mono.RuntimeGenericParamInfoHandle(RuntimeTypeHandle.GetGenericParameterInfo(this));
             Type[] constraints = paramInfo.Constraints;
@@ -2337,7 +2335,7 @@ namespace System
         public override InterfaceMapping GetInterfaceMap(Type ifaceType)
         {
             if (IsGenericParameter)
-                throw new InvalidOperationException(Environment.GetResourceString("Arg_GenericParameter"));
+                throw new InvalidOperationException(SR.Arg_GenericParameter);
 
             if (ifaceType is null)
                 throw new ArgumentNullException(nameof(ifaceType));
@@ -2345,7 +2343,7 @@ namespace System
             RuntimeType? ifaceRtType = ifaceType as RuntimeType;
 
             if (ifaceRtType == null)
-                throw new ArgumentException(Environment.GetResourceString("Argument_MustBeRuntimeType"), nameof(ifaceType));
+                throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(ifaceType));
 
             InterfaceMapping res;
             if (!ifaceType.IsInterface)

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -2265,7 +2265,7 @@ namespace System
             var gt = (RuntimeType)MakeGenericType(genericType, new Type[] { genericArgument });
             RuntimeConstructorInfo? ctor = gt.GetDefaultConstructor();
             if (ctor is null)
-                throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, gt.FullName));
+                throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, gt));
 
             return ctor.InternalInvoke(null, null, wrapExceptions: true)!;
         }


### PR DESCRIPTION
for textual exception messages when enabled