### PR TITLE
Fix and enable again stack overflow tests

### DIFF
--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -70,9 +70,9 @@ namespace TestStackOverflow
             List<string> lines;
             if (TestStackOverflow("stackoverflow", "smallframe main", out lines))
             {
-                if (!lines[lines.Count - 1].EndsWith("at TestStackOverflow.Program.Main(System.String[])"))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.Main(System.String[])")))
                 {
-                    Console.WriteLine("Missing \"Main\" method frame at the last line");
+                    Console.WriteLine("Missing \"Main\" method frame");
                     return false;
                 }
 
@@ -222,9 +222,9 @@ namespace TestStackOverflow
             List<string> lines;
             if (TestStackOverflow("stackoverflow3", "", out lines))
             {
-                if (!lines[lines.Count - 1].EndsWith("at TestStackOverflow3.Program.Main()"))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow3.Program.Main()")))
                 {
-                    Console.WriteLine("Missing \"Main\" method frame at the last line");
+                    Console.WriteLine("Missing \"Main\" method frame");
                     return false;
                 }
 

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -24,6 +24,8 @@ namespace TestStackOverflow
             testProcess.StartInfo.Arguments = $"{Path.Combine(s_currentPath, "..", testName, $"{testName}.dll")} {testArgs}";
             testProcess.StartInfo.UseShellExecute = false;
             testProcess.StartInfo.RedirectStandardError = true;
+            // Prevent dump generation for the child processes that will fail with stack overflow
+            testProcess.EnvironmentVariables.Add("COMPlus_DbgEnableMiniDump", "0");
             testProcess.ErrorDataReceived += (sender, line) => 
             {
                 Console.WriteLine($"\"{line.Data}\"");

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -111,13 +111,13 @@ namespace TestStackOverflow
             List<string> lines;
             if (TestStackOverflow("stackoverflow", "largeframe main", out lines))
             {
-                if (!lines[lines.Count - 1].EndsWith("at TestStackOverflow.Program.Main(System.String[])"))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.Main(System.String[])")))
                 {
-                    Console.WriteLine("Missing \"Main\" method frame at the last line");
+                    Console.WriteLine("Missing \"Main\" method frame");
                     return false;
                 }
 
-                if (!lines.Exists(elem => elem.EndsWith("TestStackOverflow.Program.Test(Boolean)")))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.Test(Boolean)")))
                 {
                     Console.WriteLine("Missing \"Test\" method frame");
                     return false;

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.csproj
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <Optimize>false</Optimize>
     <CLRTestKind>BuildAndRun</CLRTestKind>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -140,9 +140,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/1514/InterlockExchange/*">
             <Issue>https://github.com/dotnet/runtime/issues/12166</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">	
-            <Issue>https://github.com/dotnet/runtime/issues/46175</Issue>	
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Arm32 All OS -->


### PR DESCRIPTION
1. On Linux ARM in checked / debug build, the unwinder was printing a
debug info into the console output, confusing the stack overflow tester
process. It was expecting the Main method frame to be at the last line.
This fix relaxes it to check just for presence of the main frame.
2. On Windows x86 with GC stress C, one of the tests failed with exit code
0xc0000005 instead of 0xc000000cd. I believe this is a bad interaction
with the invalid instruction injection / processing around the stack
overflow. So I have excluded these tests from GC stress testing.