### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/src/mono/mono/mini/Makefile.am.in
+++ b/src/mono/mono/mini/Makefile.am.in
@@ -221,16 +221,18 @@ AM_CPPFLAGS = $(LIBGC_CPPFLAGS)
 mono_sgen_SOURCES =
 mono_sgen_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
 
+BUILD_DATE = $(shell SOURCE_DATE_EPOCH="$${SOURCE_DATE_EPOCH:-$$(date +%s)}" ;date -u -d "@$$SOURCE_DATE_EPOCH" 2>/dev/null || date -u -r "$$SOURCE_DATE_EPOCH" 2>/dev/null || date -u)
+
 # We build this after libmono was built so it contains the date when the final
 # link was done
 if SUPPORT_BOEHM
 buildver-boehm.h: libmini.la $(monodir)/mono/metadata/libmonoruntime.la
-	@echo "const char *build_date = \"`date`\";" > buildver-boehm.h
+	@echo "const char *build_date = \"$(BUILD_DATE)\";" > buildver-boehm.h
 libmain_a-main.$(OBJEXT): buildver-boehm.h
 endif
 
 buildver-sgen.h: libmini.la $(monodir)/mono/metadata/libmonoruntimesgen.la $(monodir)/mono/sgen/libmonosgen.la
-	@echo "const char *build_date = \"`date`\";" > buildver-sgen.h
+	@echo "const char *build_date = \"$(BUILD_DATE)\";" > buildver-sgen.h
 
 libmain_a-main-sgen.$(OBJEXT): buildver-sgen.h
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20690,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call works with different variants of the date command.

Also use UTC to be independent of timezone.

This helps a bit towards deterministic mono builds = issue mono/mono#20172

This PR was done while working on reproducible builds for openSUSE.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->