### PR TITLE
Bump Microsoft.DotNet.SharedFramework.Sdk version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,13 +66,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>26b005488dd7ddf6356873cb01a7b763a82a9622</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="6.0.0-beta.20616.18">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="6.0.0-beta.20621.12">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>26b005488dd7ddf6356873cb01a7b763a82a9622</Sha>
+      <Sha>3ba79fbd73d6765b67d0f75ac9dac148d6bea346</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.20616.18">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.20621.12">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>26b005488dd7ddf6356873cb01a7b763a82a9622</Sha>
+      <Sha>3ba79fbd73d6765b67d0f75ac9dac148d6bea346</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20200806.6">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/global.json
+++ b/global.json
@@ -14,9 +14,9 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.20616.18",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20616.18",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "6.0.0-beta.20616.18",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "6.0.0-beta.20621.12",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20616.18",
-    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.20616.18",
+    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.20621.12",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "6.0.0-alpha.1.20620.2",
     "Microsoft.Build.NoTargets": "2.0.1",


### PR DESCRIPTION
Brings in https://github.com/dotnet/arcade/pull/6716 which is required to unblock https://github.com/dotnet/installer/pull/9172

/cc @jkoritzinsky 