### PR TITLE
Don't include hostfxr or hostpolicy in the platform manifest.

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -152,12 +152,6 @@
     <PlatformManifestFileEntry Include="createdump.exe" IsNative="true" />
     <PlatformManifestFileEntry Include="createdump" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclrtraceptprovider.so" IsNative="true" />
-    <PlatformManifestFileEntry Include="hostpolicy.dll" IsNative="true" />
-    <PlatformManifestFileEntry Include="libhostpolicy.so" IsNative="true" />
-    <PlatformManifestFileEntry Include="libhostpolicy.dylib" IsNative="true" />
-    <PlatformManifestFileEntry Include="hostfxr.dll" IsNative="true" />
-    <PlatformManifestFileEntry Include="libhostfxr.so" IsNative="true" />
-    <PlatformManifestFileEntry Include="libhostfxr.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="Microsoft.DiaSymReader.Native.x86.dll" IsNative="true" FallbackFileVersion="$(MicrosoftDiaSymReaderNativeFileVersion)" />
     <PlatformManifestFileEntry Include="Microsoft.DiaSymReader.Native.amd64.dll" IsNative="true" FallbackFileVersion="$(MicrosoftDiaSymReaderNativeFileVersion)" />
     <PlatformManifestFileEntry Include="Microsoft.DiaSymReader.Native.arm.dll" IsNative="true" FallbackFileVersion="$(MicrosoftDiaSymReaderNativeFileVersion)" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
@@ -39,6 +39,20 @@
     <OverridePackageId>$(SharedFrameworkName).Runtime.$(RuntimeSpecificFrameworkSuffix).$(RuntimeIdentifier)</OverridePackageId>
   </PropertyGroup>
 
+  <!-- 
+    hostpolicy and hostfxr aren't in the platform manifest in the ref pack and cannot be without breaking things upstack.
+    We add the entries here to ensure that we don't fail the validation that every file included in the runtime pack is in the platform manifest
+    without adding the entries to the manifest in the ref pack.
+  -->
+  <ItemGroup>
+    <PlatformManifestFileEntry Include="hostpolicy.dll" IsNative="true" />
+    <PlatformManifestFileEntry Include="libhostpolicy.so" IsNative="true" />
+    <PlatformManifestFileEntry Include="libhostpolicy.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Include="hostfxr.dll" IsNative="true" />
+    <PlatformManifestFileEntry Include="libhostfxr.so" IsNative="true" />
+    <PlatformManifestFileEntry Include="libhostfxr.dylib" IsNative="true" />
+  </ItemGroup>
+
   <Target Name="AddLinuxPackageInformation" BeforeTargets="GetDebInstallerJsonProperties;GetRpmInstallerJsonProperties">
     <ItemGroup>
       <LinuxPackageDependency Include="dotnet-hostfxr-$(MajorVersion).$(MinorVersion);dotnet-runtime-deps-$(MajorVersion).$(MinorVersion)" Version="$(InstallerPackageVersion)" />


### PR DESCRIPTION
The SDK relies on these files not being in the platform manifest even though they're in the runtime pack and the runtime pack's RuntimeList.xml