### PR TITLE
Introduce CallConvSuppressGCTransition type to enable suppressing the transition frame for unmanaged function pointer calls

### DIFF
--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -1873,6 +1873,7 @@ typedef enum LoadHintEnum
 #define CMOD_CALLCONV_NAME_STDCALL              "CallConvStdcall"
 #define CMOD_CALLCONV_NAME_THISCALL             "CallConvThiscall"
 #define CMOD_CALLCONV_NAME_FASTCALL             "CallConvFastcall"
+#define CMOD_CALLCONV_NAME_SUPPRESSGCTRANSITION "CallConvSuppressGCTransition"
 
 #endif // MACROS_NOT_SUPPORTED
 

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -1065,7 +1065,7 @@ enum CorInfoSigInfoFlags
 {
     CORINFO_SIGFLAG_IS_LOCAL_SIG           = 0x01,
     CORINFO_SIGFLAG_IL_STUB                = 0x02,
-    CORINFO_SIGFLAG_SUPPRESS_GC_TRANSITION = 0x04,
+    // unused                              = 0x04,
     CORINFO_SIGFLAG_FAT_CALL               = 0x08,
 };
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -370,7 +370,7 @@ namespace Internal.JitInterface
     {
         CORINFO_SIGFLAG_IS_LOCAL_SIG = 0x01,
         CORINFO_SIGFLAG_IL_STUB = 0x02,
-        CORINFO_SIGFLAG_SUPPRESS_GC_TRANSITION = 0x04,
+        // unused = 0x04,
         CORINFO_SIGFLAG_FAT_CALL = 0x08,
     };
 

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -417,7 +417,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
 
     pMT->SetParentMethodTable(pParentClass);
 
-    // Method tables for arrays of generic type parameters are needed for type analysis. 
+    // Method tables for arrays of generic type parameters are needed for type analysis.
     // No instances will be created, so we can use 0 as element size.
     DWORD dwComponentSize = CorTypeInfo::IsGenericVariable(elemType) ?
                                 0 :
@@ -751,7 +751,7 @@ class ArrayOpLinker : public ILStubLinker
 
 public:
     ArrayOpLinker(ArrayMethodDesc * pMD)
-        : ILStubLinker(pMD->GetModule(), pMD->GetSignature(), &m_emptyContext, pMD, TRUE, TRUE, FALSE)
+        : ILStubLinker(pMD->GetModule(), pMD->GetSignature(), &m_emptyContext, pMD, (ILStubLinkerFlags)(ILSTUB_LINKER_FLAG_STUB_HAS_THIS | ILSTUB_LINKER_FLAG_TARGET_HAS_THIS))
     {
         m_pCode = NewCodeStream(kDispatch);
         m_pMD = pMD;

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -2190,7 +2190,7 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
         BOOL fReturnVal = !sig.IsReturnTypeVoid();
 
         SigTypeContext emptyContext;
-        ILStubLinker sl(pMD->GetModule(), pMD->GetSignature(), &emptyContext, pMD, TRUE, TRUE, FALSE);
+        ILStubLinker sl(pMD->GetModule(), pMD->GetSignature(), &emptyContext, pMD, (ILStubLinkerFlags)(ILSTUB_LINKER_FLAG_STUB_HAS_THIS | ILSTUB_LINKER_FLAG_TARGET_HAS_THIS));
 
         ILCodeStream *pCode = sl.NewCodeStream(ILStubLinker::kDispatch);
 
@@ -2374,7 +2374,7 @@ PCODE COMDelegate::GetWrapperInvoke(MethodDesc* pMD)
         BOOL fReturnVal = !sig.IsReturnTypeVoid();
 
         SigTypeContext emptyContext;
-        ILStubLinker sl(pMD->GetModule(), pMD->GetSignature(), &emptyContext, pMD, TRUE, TRUE, FALSE);
+        ILStubLinker sl(pMD->GetModule(), pMD->GetSignature(), &emptyContext, pMD, (ILStubLinkerFlags)(ILSTUB_LINKER_FLAG_STUB_HAS_THIS | ILSTUB_LINKER_FLAG_TARGET_HAS_THIS));
 
         ILCodeStream *pCode = sl.NewCodeStream(ILStubLinker::kDispatch);
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -774,7 +774,7 @@ DEFINE_CLASS(CALLCONV_CDECL,                 CompilerServices,       CallConvCde
 DEFINE_CLASS(CALLCONV_STDCALL,               CompilerServices,       CallConvStdcall)
 DEFINE_CLASS(CALLCONV_THISCALL,              CompilerServices,       CallConvThiscall)
 DEFINE_CLASS(CALLCONV_FASTCALL,              CompilerServices,       CallConvFastcall)
-DEFINE_CLASS(CALLCONV_SUPRESS_GC_TRANSITION, CompilerServices,       CallConvSuppressGCTransition)
+DEFINE_CLASS(CALLCONV_SUPPRESSGCTRANSITION,  CompilerServices,       CallConvSuppressGCTransition)
 
 DEFINE_CLASS_U(Interop,                SafeHandle,         SafeHandle)
 DEFINE_FIELD_U(handle,                     SafeHandle,            m_handle)

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -770,6 +770,12 @@ DEFINE_CLASS(RUNTIME_WRAPPED_EXCEPTION, CompilerServices,   RuntimeWrappedExcept
 DEFINE_METHOD(RUNTIME_WRAPPED_EXCEPTION, OBJ_CTOR,          .ctor,                      IM_Obj_RetVoid)
 DEFINE_FIELD(RUNTIME_WRAPPED_EXCEPTION, WRAPPED_EXCEPTION,  _wrappedException)
 
+DEFINE_CLASS(CALLCONV_CDECL,                 CompilerServices,       CallConvCdecl)
+DEFINE_CLASS(CALLCONV_STDCALL,               CompilerServices,       CallConvStdcall)
+DEFINE_CLASS(CALLCONV_THISCALL,              CompilerServices,       CallConvThiscall)
+DEFINE_CLASS(CALLCONV_FASTCALL,              CompilerServices,       CallConvFastcall)
+DEFINE_CLASS(CALLCONV_SUPRESS_GC_TRANSITION, CompilerServices,       CallConvSuppressGCTransition)
+
 DEFINE_CLASS_U(Interop,                SafeHandle,         SafeHandle)
 DEFINE_FIELD_U(handle,                     SafeHandle,            m_handle)
 DEFINE_FIELD_U(_state,                     SafeHandle,            m_state)

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -6741,7 +6741,6 @@ PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD)
         // need to convert the CALLI signature to stub signature with managed calling convention
         BYTE callConv = MetaSig::GetCallingConvention(pVASigCookie->pModule, signature);
 
-
         // Unmanaged calling convention indicates modopt should be read
         if (callConv == IMAGE_CEE_CS_CALLCONV_UNMANAGED)
         {

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2583,13 +2583,7 @@ void PInvokeStaticSigInfo::PreInit(MethodDesc* pMD)
 PInvokeStaticSigInfo::PInvokeStaticSigInfo(
     MethodDesc* pMD, LPCUTF8 *pLibName, LPCUTF8 *pEntryPointName)
 {
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+    STANDARD_VM_CONTRACT;
 
     DllImportInit(pMD, pLibName, pEntryPointName);
 
@@ -2600,10 +2594,7 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(MethodDesc* pMD, ThrowOnError throwOn
 {
     CONTRACTL
     {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-
+        STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pMD));
     }
     CONTRACTL_END;
@@ -2701,9 +2692,7 @@ PInvokeStaticSigInfo::PInvokeStaticSigInfo(
 {
     CONTRACTL
     {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
+        STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pModule));
     }
@@ -2721,9 +2710,7 @@ void PInvokeStaticSigInfo::DllImportInit(MethodDesc* pMD, LPCUTF8 *ppLibName, LP
 {
     CONTRACTL
     {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
+        STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pMD));
 
@@ -3003,13 +2990,7 @@ namespace
         _Out_ CorPinvokeMap *pPinvokeMapOut,
         _Out_ UINT *errorResID)
     {
-        CONTRACTL
-        {
-            THROWS;
-            GC_TRIGGERS;
-            MODE_ANY;
-        }
-        CONTRACTL_END
+        STANDARD_VM_CONTRACT;
 
         CorUnmanagedCallingConvention callConvMaybe;
         bool suppressGCTransition;

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2983,7 +2983,8 @@ namespace
         CONTRACTL_END
 
         CorUnmanagedCallingConvention callConvMaybe;
-        HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(pModule, pSig, cSig, &callConvMaybe, errorResID);
+        bool suppressGCTransition;
+        HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(pModule, pSig, cSig, &callConvMaybe, &suppressGCTransition, errorResID);
         if (hr != S_OK)
             return hr;
 
@@ -6736,12 +6737,14 @@ PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD)
         // need to convert the CALLI signature to stub signature with managed calling convention
         BYTE callConv = MetaSig::GetCallingConvention(pVASigCookie->pModule, signature);
 
+        bool suppressGCTransition = false;
+
         // Unmanaged calling convention indicates modopt should be read
         if (callConv == IMAGE_CEE_CS_CALLCONV_UNMANAGED)
         {
             CorUnmanagedCallingConvention callConvMaybe;
             UINT errorResID;
-            HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(pVASigCookie->pModule, signature.GetRawSig(), signature.GetRawSigLen(), &callConvMaybe, &errorResID);
+            HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(pVASigCookie->pModule, signature.GetRawSig(), signature.GetRawSigLen(), &callConvMaybe, &suppressGCTransition, &errorResID);
             if (FAILED(hr))
                 COMPlusThrowHR(hr, errorResID);
 

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -260,8 +260,9 @@ protected:
                 BOOL fStubHasThis,
                 DWORD dwStubFlags,
                 int iLCIDParamIdx,
-                MethodDesc* pTargetMD)
-            : m_slIL(dwStubFlags, pStubModule, signature, pTypeContext, pTargetMD, iLCIDParamIdx, fTargetHasThis, fStubHasThis)
+                MethodDesc* pTargetMD,
+                BOOL fSuppressGCTransition)
+            : m_slIL(dwStubFlags, pStubModule, signature, pTypeContext, pTargetMD, iLCIDParamIdx, fTargetHasThis, fStubHasThis, fSuppressGCTransition)
     {
         STANDARD_VM_CONTRACT;
 
@@ -1225,7 +1226,8 @@ public:
             FALSE,
             dwStubFlags,
             -1 /* We have no LCID parameter */,
-            nullptr),
+            nullptr,
+            FALSE),
         m_nativeSize(pMT->GetNativeSize())
     {
         LIMITED_METHOD_CONTRACT;
@@ -1353,7 +1355,8 @@ public:
                 StubHasThis(dwStubFlags),
                 dwStubFlags,
                 iLCIDParamIdx,
-                pTargetMD)
+                pTargetMD,
+                SF_IsForwardStub(dwStubFlags) && pTargetMD->ShouldSuppressGCTransition())
     {
         STANDARD_VM_CONTRACT;
 
@@ -1406,7 +1409,8 @@ public:
                 TRUE,
                 dwStubFlags,
                 iLCIDParamIdx,
-                pTargetMD)
+                pTargetMD,
+                FALSE)
     {
         STANDARD_VM_CONTRACT;
 
@@ -1474,7 +1478,8 @@ public:
                 TRUE,
                 dwStubFlags,
                 iLCIDParamIdx,
-                pTargetMD)
+                pTargetMD,
+                FALSE)
     {
         STANDARD_VM_CONTRACT;
     }
@@ -1540,8 +1545,9 @@ NDirectStubLinker::NDirectStubLinker(
             MethodDesc* pTargetMD,
             int  iLCIDParamIdx,
             BOOL fTargetHasThis,
-            BOOL fStubHasThis)
-     : ILStubLinker(pModule, signature, pTypeContext, pTargetMD, fTargetHasThis, fStubHasThis, !SF_IsCOMStub(dwStubFlags), SF_IsReverseStub(dwStubFlags)),
+            BOOL fStubHasThis,
+            BOOL fSuppressGCTransition)
+     : ILStubLinker(pModule, signature, pTypeContext, pTargetMD, fTargetHasThis, fStubHasThis, !SF_IsCOMStub(dwStubFlags), SF_IsReverseStub(dwStubFlags), fSuppressGCTransition),
     m_pCleanupFinallyBeginLabel(NULL),
     m_pCleanupFinallyEndLabel(NULL),
     m_pSkipExceptionCleanupLabel(NULL),

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -3007,13 +3007,7 @@ namespace
 
 void PInvokeStaticSigInfo::InitCallConv(CorPinvokeMap callConv, BOOL bIsVarArg)
 {
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END
+    STANDARD_VM_CONTRACT;
 
     // Convert WinAPI methods to either StdCall or CDecl based on if they are varargs or not.
     if (callConv == pmCallConvWinapi)

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -445,7 +445,8 @@ public:
                 MethodDesc* pTargetMD,
                 int  iLCIDParamIdx,
                 BOOL fTargetHasThis,
-                BOOL fStubHasThis);
+                BOOL fStubHasThis,
+                BOOL fSuppressGCTransition);
 
     void    SetCallingConvention(CorPinvokeMap unmngCallConv, BOOL fIsVarArg);
 

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -152,8 +152,8 @@ enum NDirectStubFlags
     NDIRECTSTUB_FL_FIELDSETTER              = 0x00004000, // COM->CLR field setter
 #endif // FEATURE_COMINTEROP
     NDIRECTSTUB_FL_SUPPRESSGCTRANSITION     = 0x00008000,
-    // unused                               = 0x00010000,
-    // unused                               = 0x00020000,
+    NDIRECTSTUB_FL_STUB_HAS_THIS            = 0x00010000,
+    NDIRECTSTUB_FL_TARGET_HAS_THIS          = 0x00020000,
     // unused                               = 0x00040000,
     // unused                               = 0x00080000,
     // unused                               = 0x00100000,
@@ -162,12 +162,11 @@ enum NDirectStubFlags
     // unused                               = 0x00800000,
 
     // internal flags -- these won't ever show up in an NDirectStubHashBlob
-    NDIRECTSTUB_FL_STUB_HAS_THIS            = 0x10000000,
-    NDIRECTSTUB_FL_TARGET_HAS_THIS          = 0x20000000,
+    // unused                               = 0x10000000,
 
 #ifdef FEATURE_COMINTEROP
-    NDIRECTSTUB_FL_COMLATEBOUND             = 0x40000000,   // we use a generic stub for late bound calls
-    NDIRECTSTUB_FL_COMEVENTCALL             = 0x80000000,   // we use a generic stub for event calls
+    NDIRECTSTUB_FL_COMLATEBOUND             = 0x20000000,   // we use a generic stub for late bound calls
+    NDIRECTSTUB_FL_COMEVENTCALL             = 0x40000000,   // we use a generic stub for event calls
 #endif // FEATURE_COMINTEROP
 
     // Note: The upper half of the range is reserved for ILStubTypes enum

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -152,8 +152,9 @@ enum NDirectStubFlags
     NDIRECTSTUB_FL_FIELDSETTER              = 0x00004000, // COM->CLR field setter
 #endif // FEATURE_COMINTEROP
     NDIRECTSTUB_FL_SUPPRESSGCTRANSITION     = 0x00008000,
-    NDIRECTSTUB_FL_STUB_HAS_THIS            = 0x00010000,
-    NDIRECTSTUB_FL_TARGET_HAS_THIS          = 0x00020000,
+    // unused                               = 0x00010000,
+    // unused                               = 0x00020000,
+    // unused                               = 0x00040000,
     // unused                               = 0x00080000,
     // unused                               = 0x00100000,
     // unused                               = 0x00200000,
@@ -161,11 +162,12 @@ enum NDirectStubFlags
     // unused                               = 0x00800000,
 
     // internal flags -- these won't ever show up in an NDirectStubHashBlob
-    // unused                               = 0x10000000,
+    NDIRECTSTUB_FL_STUB_HAS_THIS            = 0x10000000,
+    NDIRECTSTUB_FL_TARGET_HAS_THIS          = 0x20000000,
 
 #ifdef FEATURE_COMINTEROP
-    NDIRECTSTUB_FL_COMLATEBOUND             = 0x20000000,   // we use a generic stub for late bound calls
-    NDIRECTSTUB_FL_COMEVENTCALL             = 0x40000000,   // we use a generic stub for event calls
+    NDIRECTSTUB_FL_COMLATEBOUND             = 0x40000000,   // we use a generic stub for late bound calls
+    NDIRECTSTUB_FL_COMEVENTCALL             = 0x80000000,   // we use a generic stub for event calls
 #endif // FEATURE_COMINTEROP
 
     // Note: The upper half of the range is reserved for ILStubTypes enum

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -152,8 +152,8 @@ enum NDirectStubFlags
     NDIRECTSTUB_FL_FIELDSETTER              = 0x00004000, // COM->CLR field setter
 #endif // FEATURE_COMINTEROP
     NDIRECTSTUB_FL_SUPPRESSGCTRANSITION     = 0x00008000,
-    // unused                               = 0x00010000,
-    // unused                               = 0x00020000,
+    NDIRECTSTUB_FL_STUB_HAS_THIS            = 0x00010000,
+    NDIRECTSTUB_FL_TARGET_HAS_THIS          = 0x00020000,
     // unused                               = 0x00080000,
     // unused                               = 0x00100000,
     // unused                               = 0x00200000,
@@ -443,10 +443,7 @@ public:
                 const Signature &signature,
                 SigTypeContext *pTypeContext,
                 MethodDesc* pTargetMD,
-                int  iLCIDParamIdx,
-                BOOL fTargetHasThis,
-                BOOL fStubHasThis,
-                BOOL fSuppressGCTransition);
+                int  iLCIDParamIdx);
 
     void    SetCallingConvention(CorPinvokeMap unmngCallConv, BOOL fIsVarArg);
 

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -150,7 +150,8 @@ enum NDirectStubFlags
 #ifdef FEATURE_COMINTEROP
     NDIRECTSTUB_FL_FIELDGETTER              = 0x00002000, // COM->CLR field getter
     NDIRECTSTUB_FL_FIELDSETTER              = 0x00004000, // COM->CLR field setter
-    // unused                               = 0x00008000,
+#endif // FEATURE_COMINTEROP
+    NDIRECTSTUB_FL_SUPPRESSGCTRANSITION     = 0x00008000,
     // unused                               = 0x00010000,
     // unused                               = 0x00020000,
     // unused                               = 0x00080000,
@@ -158,7 +159,6 @@ enum NDirectStubFlags
     // unused                               = 0x00200000,
     // unused                               = 0x00400000,
     // unused                               = 0x00800000,
-#endif // FEATURE_COMINTEROP
 
     // internal flags -- these won't ever show up in an NDirectStubHashBlob
     // unused                               = 0x10000000,

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9803,11 +9803,11 @@ namespace
             HRESULT hr;
             if (IsDynamicScope(mod))
             {
-                hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetDynamicResolver(mod), pSig, cbSig, &callConvMaybe, &errorResID);
+                hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetDynamicResolver(mod), pSig, cbSig, &callConvMaybe, pSuppressGCTransition, &errorResID);
             }
             else
             {
-                hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetModule(mod), pSig, cbSig, &callConvMaybe, &errorResID);
+                hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetModule(mod), pSig, cbSig, &callConvMaybe, pSuppressGCTransition, &errorResID);
             }
 
             if (FAILED(hr))

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9777,11 +9777,8 @@ namespace
 {
     CorInfoCallConvExtension getUnmanagedCallConvForSig(CORINFO_MODULE_HANDLE mod, PCCOR_SIGNATURE pSig, DWORD cbSig, bool* pSuppressGCTransition)
     {
-        CONTRACTL {
-            THROWS;
-            GC_TRIGGERS;
-            MODE_PREEMPTIVE;
-        } CONTRACTL_END;
+        STANDARD_VM_CONTRACT;
+
         SigParser parser(pSig, cbSig);
         ULONG rawCallConv;
         if (FAILED(parser.GetCallingConv(&rawCallConv)))
@@ -9829,11 +9826,7 @@ namespace
 
     CorInfoCallConvExtension getUnmanagedCallConvForMethod(MethodDesc* pMD, bool* pSuppressGCTransition)
     {
-        CONTRACTL {
-            THROWS;
-            GC_TRIGGERS;
-            MODE_PREEMPTIVE;
-        } CONTRACTL_END;
+        STANDARD_VM_CONTRACT;
 
         ULONG methodCallConv;
         PCCOR_SIGNATURE pSig;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9777,6 +9777,11 @@ namespace
 {
     CorInfoCallConvExtension getUnmanagedCallConvForSig(CORINFO_MODULE_HANDLE mod, PCCOR_SIGNATURE pSig, DWORD cbSig, bool* pSuppressGCTransition)
     {
+        CONTRACTL {
+            THROWS;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+        } CONTRACTL_END;
         SigParser parser(pSig, cbSig);
         ULONG rawCallConv;
         if (FAILED(parser.GetCallingConv(&rawCallConv)))
@@ -9800,15 +9805,7 @@ namespace
         {
             CorUnmanagedCallingConvention callConvMaybe;
             UINT errorResID;
-            HRESULT hr;
-            if (IsDynamicScope(mod))
-            {
-                hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetDynamicResolver(mod), pSig, cbSig, &callConvMaybe, pSuppressGCTransition, &errorResID);
-            }
-            else
-            {
-                hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(GetModule(mod), pSig, cbSig, &callConvMaybe, pSuppressGCTransition, &errorResID);
-            }
+            HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(mod, pSig, cbSig, &callConvMaybe, pSuppressGCTransition, &errorResID);
 
             if (FAILED(hr))
                 COMPlusThrowHR(hr, errorResID);
@@ -9832,6 +9829,12 @@ namespace
 
     CorInfoCallConvExtension getUnmanagedCallConvForMethod(MethodDesc* pMD, bool* pSuppressGCTransition)
     {
+        CONTRACTL {
+            THROWS;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+        } CONTRACTL_END;
+
         ULONG methodCallConv;
         PCCOR_SIGNATURE pSig;
         DWORD cbSig;
@@ -9913,7 +9916,7 @@ namespace
         }
         else
         {
-            return getUnmanagedCallConvForSig(CORINFO_MODULE_HANDLE(pMD->GetModule()), pSig, cbSig, pSuppressGCTransition);
+            return getUnmanagedCallConvForSig(GetScopeHandle(pMD->GetModule()), pSig, cbSig, pSuppressGCTransition);
         }
     }
 }

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -139,10 +139,10 @@ SIZE_T MethodDesc::SizeOf()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    SIZE_T size = s_ClassificationSizeTable[m_wFlags & 
-        (mdcClassification 
-        | mdcHasNonVtableSlot 
-        | mdcMethodImpl 
+    SIZE_T size = s_ClassificationSizeTable[m_wFlags &
+        (mdcClassification
+        | mdcHasNonVtableSlot
+        | mdcMethodImpl
 #ifdef FEATURE_COMINTEROP
         | mdcHasComPlusCallInfo
 #endif
@@ -151,7 +151,7 @@ SIZE_T MethodDesc::SizeOf()
 #ifdef FEATURE_PREJIT
     if (HasNativeCodeSlot())
     {
-        size += (*dac_cast<PTR_TADDR>(GetAddrOfNativeCodeSlot()) & FIXUP_LIST_MASK) ? 
+        size += (*dac_cast<PTR_TADDR>(GetAddrOfNativeCodeSlot()) & FIXUP_LIST_MASK) ?
             sizeof(FixupListSlot) : 0;
     }
 #endif

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1513,10 +1513,7 @@ Stub * CreateUnboxingILStubForSharedGenericValueTypeMethods(MethodDesc* pTargetM
                     pTargetMD->GetSignature(),
                     &typeContext,
                     pTargetMD,
-                    TRUE,           // fTargetHasThis
-                    TRUE,           // fStubHasThis
-                    FALSE           // fIsNDirectStub
-                    );
+                    (ILStubLinkerFlags)(ILSTUB_LINKER_FLAG_STUB_HAS_THIS | ILSTUB_LINKER_FLAG_TARGET_HAS_THIS));
 
     ILCodeStream *pCode = sl.NewCodeStream(ILStubLinker::kDispatch);
 
@@ -1616,14 +1613,13 @@ Stub * CreateInstantiatingILStub(MethodDesc* pTargetMD, void* pHiddenArg)
     }
 
     MetaSig msig(pTargetMD);
-
     ILStubLinker sl(pTargetMD->GetModule(),
                     pTargetMD->GetSignature(),
                     &typeContext,
                     pTargetMD,
-                    msig.HasThis(), // fTargetHasThis
-                    msig.HasThis(), // fStubHasThis
-                    FALSE           // fIsNDirectStub
+                    msig.HasThis()
+                        ? (ILStubLinkerFlags)(ILSTUB_LINKER_FLAG_STUB_HAS_THIS | ILSTUB_LINKER_FLAG_TARGET_HAS_THIS)
+                        : (ILStubLinkerFlags)ILSTUB_LINKER_FLAG_NONE
                     );
 
     ILCodeStream *pCode = sl.NewCodeStream(ILStubLinker::kDispatch);

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -5314,6 +5314,7 @@ namespace
         _In_ PCCOR_SIGNATURE pSig,
         _In_ ULONG cSig,
         _Out_ CorUnmanagedCallingConvention *callConvOut,
+        _Out_ bool* suppressGCTransitionOut,
         _Out_ UINT *errorResID)
     {
         CONTRACTL
@@ -5327,6 +5328,7 @@ namespace
         }
         CONTRACTL_END
 
+        *suppressGCTransitionOut = false;
         HRESULT hr;
 
         // Instantiations aren't relevant here
@@ -5371,6 +5373,12 @@ namespace
             if (::strcmp(typeNamespace, CMOD_CALLCONV_NAMESPACE) != 0)
                 continue;
 
+            if (::strcmp(typeName, CMOD_CALLCONV_NAME_SUPPRESSGCTRANSITION) == 0)
+            {
+                *suppressGCTransitionOut = true;
+                continue;
+            }
+
             const struct {
                 LPCSTR name;
                 CorUnmanagedCallingConvention value;
@@ -5412,10 +5420,11 @@ MetaSig::TryGetUnmanagedCallingConventionFromModOpt(
     _In_ PCCOR_SIGNATURE pSig,
     _In_ ULONG cSig,
     _Out_ CorUnmanagedCallingConvention *callConvOut,
+    _Out_ bool* suppressGCTransitionOut,
     _Out_ UINT *errorResID)
 {
     LIMITED_METHOD_CONTRACT;
-    return ::TryGetUnmanagedCallingConventionFromModOpt(pModule, pSig, cSig, callConvOut, errorResID);
+    return ::TryGetUnmanagedCallingConventionFromModOpt(pModule, pSig, cSig, callConvOut, suppressGCTransitionOut, errorResID);
 }
 
 //----------------------------------------------------------
@@ -5428,10 +5437,11 @@ MetaSig::TryGetUnmanagedCallingConventionFromModOpt(
     _In_ PCCOR_SIGNATURE pSig,
     _In_ ULONG cSig,
     _Out_ CorUnmanagedCallingConvention *callConvOut,
+    _Out_ bool* suppressGCTransitionOut,
     _Out_ UINT *errorResID)
 {
     LIMITED_METHOD_CONTRACT;
-    return ::TryGetUnmanagedCallingConventionFromModOpt(pModule, pSig, cSig, callConvOut, errorResID);
+    return ::TryGetUnmanagedCallingConventionFromModOpt(pModule, pSig, cSig, callConvOut, suppressGCTransitionOut, errorResID);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -5248,14 +5248,7 @@ namespace
         _Out_ LPCSTR *namespaceOut,
         _Out_ LPCSTR *nameOut)
     {
-        CONTRACTL
-        {
-            NOTHROW;
-            GC_NOTRIGGER;
-            FORBID_FAULT;
-            MODE_ANY;
-        }
-        CONTRACTL_END
+        STANDARD_VM_CONTRACT;
 
         IMDInternalImport *pInternalImport = pModule->GetMDImport();
         if (TypeFromToken(token) == mdtTypeDef)
@@ -5284,15 +5277,7 @@ namespace
         _Out_ LPCSTR *namespaceOut,
         _Out_ LPCSTR *nameOut)
     {
-        CONTRACTL
-        {
-            THROWS;
-            GC_TRIGGERS;
-            MODE_ANY;
-        }
-        CONTRACTL_END
-
-        GCX_PREEMP();
+        STANDARD_VM_CONTRACT;
 
         TypeHandle type;
         MethodDesc* pMD;
@@ -5313,13 +5298,7 @@ namespace
         _Out_ LPCSTR *namespaceOut,
         _Out_ LPCSTR *nameOut)
     {
-        CONTRACTL
-        {
-            THROWS;
-            GC_TRIGGERS;
-            MODE_ANY;
-        }
-        CONTRACTL_END
+        STANDARD_VM_CONTRACT;
 
         if (IsDynamicScope(pModule))
         {
@@ -5329,7 +5308,6 @@ namespace
         {
             return GetNameOfTypeRefOrDef(GetModule(pModule), token, namespaceOut, nameOut);
         }
-
     }
 }
 
@@ -5349,9 +5327,7 @@ MetaSig::TryGetUnmanagedCallingConventionFromModOpt(
 {
     CONTRACTL
     {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
+        STANDARD_VM_CHECK;
         PRECONDITION(callConvOut != NULL);
         PRECONDITION(errorResID != NULL);
     }

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -5329,6 +5329,7 @@ MetaSig::TryGetUnmanagedCallingConventionFromModOpt(
     {
         STANDARD_VM_CHECK;
         PRECONDITION(callConvOut != NULL);
+        PRECONDITION(suppressGCTransitionOut != NULL);
         PRECONDITION(errorResID != NULL);
     }
     CONTRACTL_END

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -5286,12 +5286,13 @@ namespace
     {
         CONTRACTL
         {
-            NOTHROW;
-            GC_NOTRIGGER;
-            FORBID_FAULT;
+            THROWS;
+            GC_TRIGGERS;
             MODE_ANY;
         }
         CONTRACTL_END
+
+        GCX_PREEMP();
 
         TypeHandle type;
         MethodDesc* pMD;
@@ -5319,9 +5320,8 @@ namespace
     {
         CONTRACTL
         {
-            NOTHROW;
-            GC_NOTRIGGER;
-            FORBID_FAULT;
+            THROWS;
+            GC_TRIGGERS;
             MODE_ANY;
             PRECONDITION(callConvOut != NULL);
             PRECONDITION(errorResID != NULL);

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -796,6 +796,23 @@ class MetaSig
             _Out_ CorUnmanagedCallingConvention *callConvOut,
             _Out_ UINT *errorResID);
 
+        //----------------------------------------------------------
+        // Gets the unmanaged calling convention by reading any modopts.
+        //
+        // Returns:
+        //   S_OK - Calling convention was read from modopt
+        //   S_FALSE - Calling convention was not read from modopt
+        //   COR_E_BADIMAGEFORMAT - Signature had an invalid format
+        //   COR_E_INVALIDPROGRAM - Program is considered invalid (more
+        //                          than one calling convention specified)
+        //----------------------------------------------------------
+        static HRESULT TryGetUnmanagedCallingConventionFromModOpt(
+            _In_ DynamicResolver *pModule,
+            _In_ PCCOR_SIGNATURE pSig,
+            _In_ ULONG cSig,
+            _Out_ CorUnmanagedCallingConvention *callConvOut,
+            _Out_ UINT *errorResID);
+
         static CorUnmanagedCallingConvention GetDefaultUnmanagedCallingConvention()
         {
 #ifdef TARGET_UNIX

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -794,6 +794,7 @@ class MetaSig
             _In_ PCCOR_SIGNATURE pSig,
             _In_ ULONG cSig,
             _Out_ CorUnmanagedCallingConvention *callConvOut,
+            _Out_ bool* suppressGCTransitionOut,
             _Out_ UINT *errorResID);
 
         //----------------------------------------------------------
@@ -811,6 +812,7 @@ class MetaSig
             _In_ PCCOR_SIGNATURE pSig,
             _In_ ULONG cSig,
             _Out_ CorUnmanagedCallingConvention *callConvOut,
+            _Out_ bool* suppressGCTransitionOut,
             _Out_ UINT *errorResID);
 
         static CorUnmanagedCallingConvention GetDefaultUnmanagedCallingConvention()

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -15,6 +15,7 @@
 #include "sigparser.h"
 #include "zapsig.h"
 #include "threads.h"
+#include "corinfo.h"
 
 #include "eecontract.h"
 #include "typectxt.h"
@@ -790,25 +791,7 @@ class MetaSig
         //                          than one calling convention specified)
         //----------------------------------------------------------
         static HRESULT TryGetUnmanagedCallingConventionFromModOpt(
-            _In_ Module *pModule,
-            _In_ PCCOR_SIGNATURE pSig,
-            _In_ ULONG cSig,
-            _Out_ CorUnmanagedCallingConvention *callConvOut,
-            _Out_ bool* suppressGCTransitionOut,
-            _Out_ UINT *errorResID);
-
-        //----------------------------------------------------------
-        // Gets the unmanaged calling convention by reading any modopts.
-        //
-        // Returns:
-        //   S_OK - Calling convention was read from modopt
-        //   S_FALSE - Calling convention was not read from modopt
-        //   COR_E_BADIMAGEFORMAT - Signature had an invalid format
-        //   COR_E_INVALIDPROGRAM - Program is considered invalid (more
-        //                          than one calling convention specified)
-        //----------------------------------------------------------
-        static HRESULT TryGetUnmanagedCallingConventionFromModOpt(
-            _In_ DynamicResolver *pModule,
+            _In_ CORINFO_MODULE_HANDLE pModule,
             _In_ PCCOR_SIGNATURE pSig,
             _In_ ULONG cSig,
             _Out_ CorUnmanagedCallingConvention *callConvOut,

--- a/src/coreclr/vm/stubgen.cpp
+++ b/src/coreclr/vm/stubgen.cpp
@@ -2167,6 +2167,9 @@ void FunctionSigBuilder::SetSig(PCCOR_SIGNATURE pSig, DWORD cSig)
 void
 FunctionSigBuilder::AddCallConvModOpt(mdToken token)
 {
+    LIMITED_METHOD_CONTRACT;
+    _ASSERTE(TypeFromToken(token) == mdtTypeDef || TypeFromToken(token) == mdtTypeRef);
+
     int temp;
     ULONG len = CorSigCompressToken(token, &temp);
     m_qbCallConvModOpts.ReSizeThrows(m_qbCallConvModOpts.Size() + 1 + len);
@@ -2400,10 +2403,7 @@ ILStubLinker::ILStubLinker(Module* pStubSigModule, const Signature &signature, S
         ULONG   uStubCallingConvInfo;
         IfFailThrow(m_managedSigPtr.GetCallingConvInfo(&uStubCallingConvInfo));
 
-        if ((flags & ILSTUB_LINKER_FLAG_STUB_HAS_THIS) != 0)
-        {
-            m_fHasThis = true;
-        }
+        m_fHasThis = (flags & ILSTUB_LINKER_FLAG_STUB_HAS_THIS) != 0;
 
         //
         // If target calling convention was specified, use it instead.

--- a/src/coreclr/vm/stubgen.cpp
+++ b/src/coreclr/vm/stubgen.cpp
@@ -2336,27 +2336,24 @@ static BOOL SigHasVoidReturnType(const Signature &signature)
     return (ELEMENT_TYPE_VOID == retType);
 }
 
-namespace
+static PTR_MethodTable GetModOptTypeForCallConv(CorUnmanagedCallingConvention callConv)
 {
-    PTR_MethodTable GetModOptTypeForCallConv(CorUnmanagedCallingConvention callConv)
+    switch(callConv)
     {
-        switch(callConv)
-        {
-            case IMAGE_CEE_UNMANAGED_CALLCONV_C:
-                return CoreLibBinder::GetClass(CLASS__CALLCONV_CDECL);
-                break;
-            case IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL:
-                return CoreLibBinder::GetClass(CLASS__CALLCONV_STDCALL);
-                break;
-            case IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL:
-                return CoreLibBinder::GetClass(CLASS__CALLCONV_THISCALL);
-                break;
-            case IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL:
-                return CoreLibBinder::GetClass(CLASS__CALLCONV_FASTCALL);
-                break;
-            default:
-                return NULL;
-        }
+        case IMAGE_CEE_UNMANAGED_CALLCONV_C:
+            return CoreLibBinder::GetClass(CLASS__CALLCONV_CDECL);
+            break;
+        case IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL:
+            return CoreLibBinder::GetClass(CLASS__CALLCONV_STDCALL);
+            break;
+        case IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL:
+            return CoreLibBinder::GetClass(CLASS__CALLCONV_THISCALL);
+            break;
+        case IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL:
+            return CoreLibBinder::GetClass(CLASS__CALLCONV_FASTCALL);
+            break;
+        default:
+            return NULL;
     }
 }
 
@@ -2465,10 +2462,10 @@ ILStubLinker::ILStubLinker(Module* pStubSigModule, const Signature &signature, S
         {
             switch((CorUnmanagedCallingConvention)uNativeCallingConv)
             {
-                case IMAGE_CEE_CS_CALLCONV_C:
-                case IMAGE_CEE_CS_CALLCONV_STDCALL:
-                case IMAGE_CEE_CS_CALLCONV_THISCALL:
-                case IMAGE_CEE_CS_CALLCONV_FASTCALL:
+                case IMAGE_CEE_UNMANAGED_CALLCONV_C:
+                case IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL:
+                case IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL:
+                case IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL:
                     m_nativeFnSigBuilder.AddCallConvModOpt(GetToken(GetModOptTypeForCallConv((CorUnmanagedCallingConvention)uNativeCallingConv)));
                     break;
                 default:

--- a/src/coreclr/vm/stubgen.h
+++ b/src/coreclr/vm/stubgen.h
@@ -234,6 +234,8 @@ public:
         m_callingConv = callingConv;
     }
 
+    void AddCallConvModOpt(mdToken token);
+
     CorCallingConvention GetCallingConv()
     {
         LIMITED_METHOD_CONTRACT;
@@ -266,6 +268,7 @@ public:
 protected:
     CorCallingConvention m_callingConv;
     CQuickBytes          m_qbReturnSig;
+    CQuickBytes          m_qbCallConvModOpts;
 };  // class FunctionSigBuilder
 
 #endif // DACCESS_COMPILE
@@ -461,7 +464,7 @@ class ILStubLinker
 public:
 
     ILStubLinker(Module* pModule, const Signature &signature, SigTypeContext *pTypeContext, MethodDesc *pMD,
-                 BOOL fTargetHasThis, BOOL fStubHasThis, BOOL fIsNDirectStub = FALSE, BOOL fIsReverseStub = FALSE);
+                 BOOL fTargetHasThis, BOOL fStubHasThis, BOOL fIsNDirectStub = FALSE, BOOL fIsReverseStub = FALSE, BOOL fSuppressGCTransition = FALSE);
     ~ILStubLinker();
 
     void GenerateCode(BYTE* pbBuffer, size_t cbBufferSize);

--- a/src/coreclr/vm/stubgen.h
+++ b/src/coreclr/vm/stubgen.h
@@ -454,6 +454,17 @@ struct ILStubEHClauseBuilder
     DWORD typeToken;
 };
 
+
+enum ILStubLinkerFlags
+{
+    ILSTUB_LINKER_FLAG_NONE                 = 0x00,
+    ILSTUB_LINKER_FLAG_TARGET_HAS_THIS      = 0x01,
+    ILSTUB_LINKER_FLAG_STUB_HAS_THIS        = 0x02,
+    ILSTUB_LINKER_FLAG_NDIRECT              = 0x04,
+    ILSTUB_LINKER_FLAG_REVERSE              = 0x08,
+    ILSTUB_LINKER_FLAG_SUPPRESSGCTRANSITION = 0x10,
+};
+
 //---------------------------------------------------------------------------------------
 //
 class ILStubLinker
@@ -463,8 +474,7 @@ class ILStubLinker
 
 public:
 
-    ILStubLinker(Module* pModule, const Signature &signature, SigTypeContext *pTypeContext, MethodDesc *pMD,
-                 BOOL fTargetHasThis, BOOL fStubHasThis, BOOL fIsNDirectStub = FALSE, BOOL fIsReverseStub = FALSE, BOOL fSuppressGCTransition = FALSE);
+    ILStubLinker(Module* pModule, const Signature &signature, SigTypeContext *pTypeContext, MethodDesc *pMD, ILStubLinkerFlags flags);
     ~ILStubLinker();
 
     void GenerateCode(BYTE* pbBuffer, size_t cbBufferSize);

--- a/src/coreclr/vm/tailcallhelp.cpp
+++ b/src/coreclr/vm/tailcallhelp.cpp
@@ -24,7 +24,7 @@ FCIMPL2(void*, TailCallHelp::AllocTailCallArgBuffer, INT32 size, void* gcDesc)
     _ASSERTE(size >= 0);
 
     void* result = GetThread()->GetTailCallTls()->AllocArgBuffer(size, gcDesc);
-    
+
     if (result == NULL)
         FCThrow(kOutOfMemoryException);
 
@@ -341,8 +341,7 @@ MethodDesc* TailCallHelp::CreateStoreArgsStub(TailCallInfo& info)
                     Signature(pSig, cbSig),
                     &emptyCtx,
                     NULL,
-                    FALSE,
-                    FALSE);
+                    ILSTUB_LINKER_FLAG_NONE);
 
     ILCodeStream* pCode = sl.NewCodeStream(ILStubLinker::kDispatch);
 
@@ -462,8 +461,7 @@ MethodDesc* TailCallHelp::CreateCallTargetStub(const TailCallInfo& info)
                     Signature(pSig, cbSig),
                     &emptyCtx,
                     NULL,
-                    FALSE,
-                    FALSE);
+                    ILSTUB_LINKER_FLAG_NONE);
 
     ILCodeStream* pCode = sl.NewCodeStream(ILStubLinker::kDispatch);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CallingConventions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CallingConventions.cs
@@ -15,6 +15,10 @@ namespace System.Runtime.CompilerServices
     {
         public CallConvStdcall() { }
     }
+    public class CallConvSuppressGCTransition
+    {
+        public CallConvSuppressGCTransition() { }
+    }
     public class CallConvThiscall
     {
         public CallConvThiscall() { }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CallingConventions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CallingConventions.cs
@@ -15,8 +15,19 @@ namespace System.Runtime.CompilerServices
     {
         public CallConvStdcall() { }
     }
+
+    /// <summary>
+    /// Indicates that a method should suppress the GC transition as part of the calling convention.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="System.Runtime.InteropServices.SuppressGCTransitionAttribute" /> describes the effects
+    /// of suppressing the GC transition on a native call.
+    /// </remarks>
     public class CallConvSuppressGCTransition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallConvSuppressGCTransition" /> class.
+        /// </summary>
         public CallConvSuppressGCTransition() { }
     }
     public class CallConvThiscall

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9132,6 +9132,10 @@ namespace System.Runtime.CompilerServices
     {
         public CallConvStdcall() { }
     }
+    public class CallConvSuppressGCTransition
+    {
+        public CallConvSuppressGCTransition() { }
+    }
     public partial class CallConvThiscall
     {
         public CallConvThiscall() { }

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
@@ -13,7 +13,7 @@ namespace
 }
 
 extern "C"
-BOOL DLL_EXPORT NextUInt(/* out */ uint32_t *n)
+BOOL DLL_EXPORT STDMETHODVCALLTYPE NextUInt(/* out */ uint32_t *n)
 {
     if (n == nullptr)
         return FALSE;

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionUtil.il
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionUtil.il
@@ -9,7 +9,7 @@
 .class public auto ansi beforefieldinit FunctionPointer
        extends [System.Runtime]System.Object
 {
-    .method hidebysig specialname rtspecialname 
+    .method hidebysig specialname rtspecialname
             instance void .ctor() cil managed
     {
         ldarg.0
@@ -24,7 +24,7 @@
         .maxstack  8
         ldarg.1
         ldarg.0
-        calli unmanaged stdcall int32 (int32*)
+        calli unmanaged cdecl int32 (int32*)
         ret
     }
 }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -140,8 +140,8 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/1514/InterlockExchange/*">
             <Issue>https://github.com/dotnet/runtime/issues/12166</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">	
-            <Issue>https://github.com/dotnet/runtime/issues/46175</Issue>	
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">
+            <Issue>https://github.com/dotnet/runtime/issues/46175</Issue>
         </ExcludeList>
     </ItemGroup>
 
@@ -2473,6 +2473,9 @@
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)JIT/IL_Conformance/Old/Base/ckfinite/**">
             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest/**">
+            <Issue>https://github.com/dotnet/runtime/issues/46451</Issue>
         </ExcludeList>
         <!-- End interpreter issues -->
     </ItemGroup>


### PR DESCRIPTION
Fixes #38134 for CoreCLR and crossgen2. This PR does not provide an implementation for Mono.