### PR TITLE
a bit more cleanup for regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -11256,6 +11256,7 @@ void gc_heap::make_generation (int gen_num, heap_segment* seg, uint8_t* start)
     gen->gen_num = gen_num;
 #ifndef USE_REGIONS
     gen->allocation_start = start;
+    gen->plan_allocation_start = 0;
 #endif //USE_REGIONS
     gen->allocation_context.alloc_ptr = 0;
     gen->allocation_context.alloc_limit = 0;
@@ -11271,7 +11272,6 @@ void gc_heap::make_generation (int gen_num, heap_segment* seg, uint8_t* start)
     gen->tail_ro_region = 0;
 #endif //USE_REGIONS
     gen->allocation_segment = seg;
-    gen->plan_allocation_start = 0;
     gen->free_list_space = 0;
     gen->pinned_allocated = 0;
     gen->free_list_allocated = 0;
@@ -17026,11 +17026,13 @@ uint8_t* gc_heap::allocate_in_condemned_generations (generation* gen,
                                                   uint8_t* old_loc
                                                   REQD_ALIGN_AND_OFFSET_DCL)
 {
+#ifndef USE_REGIONS
     // Make sure that the youngest generation gap hasn't been allocated
     if (settings.promotion)
     {
         assert (generation_plan_allocation_start (youngest_generation) == 0);
     }
+#endif //!USE_REGIONS
 
     size = Align (size);
     assert (size >= Align (min_obj_size));
@@ -25247,7 +25249,10 @@ void gc_heap::plan_phase (int condemned_gen_number)
         generation_allocated_in_pinned_free (condemned_gen2) = 0;
         generation_allocated_since_last_pin (condemned_gen2) = 0;
 #endif //FREE_USAGE_STATS
+
+#ifndef USE_REGIONS
         generation_plan_allocation_start (condemned_gen2) = 0;
+#endif //!USE_REGIONS
         generation_allocation_segment (condemned_gen2) =
             heap_segment_rw (generation_start_segment (condemned_gen2));
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -778,7 +778,7 @@ public:
     PTR_heap_segment start_segment;
 #ifndef USE_REGIONS
     uint8_t*        allocation_start;
-#endif //USE_REGIONS
+#endif //!USE_REGIONS
     heap_segment*   allocation_segment;
     uint8_t*        allocation_context_start_region;
 #ifdef USE_REGIONS
@@ -797,8 +797,10 @@ public:
     size_t          free_list_space;
     size_t          free_obj_space;
     size_t          allocation_size;
+#ifndef USE_REGIONS
     uint8_t*        plan_allocation_start;
     size_t          plan_allocation_start_size;
+#endif //!USE_REGIONS
 
     // this is the pinned plugs that got allocated into this gen.
     size_t          pinned_allocated;
@@ -4902,6 +4904,7 @@ heap_segment*& generation_allocation_segment (generation* inst)
 {
   return inst->allocation_segment;
 }
+#ifndef USE_REGIONS
 inline
 uint8_t*& generation_plan_allocation_start (generation* inst)
 {
@@ -4912,6 +4915,7 @@ size_t& generation_plan_allocation_start_size (generation* inst)
 {
   return inst->plan_allocation_start_size;
 }
+#endif //!USE_REGIONS
 inline
 uint8_t*& generation_allocation_context_start_region (generation* inst)
 {


### PR DESCRIPTION
got rid of the 2 fields related to plan_allocation_start since regions do not need them. 