### PR TITLE
Respect PackAllLibraries property for all libraries packages

### DIFF
--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.proj
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-  <ItemGroup Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(PackAllLibraries)' == 'true' And ('$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true')">
     <Project Include="Microsoft.NETCore.Platforms.pkgproj" />
   </ItemGroup>
 

--- a/src/libraries/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.proj
+++ b/src/libraries/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-  <ItemGroup Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(PackAllLibraries)' == 'true' And ('$(BuildingAnOfficialBuildLeg)' != 'true' Or '$(BuildAllConfigurations)' == 'true')">
     <Project Include="Microsoft.NETCore.Targets.pkgproj"/>
   </ItemGroup>
 

--- a/src/libraries/pkg/runtime.native.System.IO.Ports/netcoreapp.rids.props
+++ b/src/libraries/pkg/runtime.native.System.IO.Ports/netcoreapp.rids.props
@@ -1,5 +1,5 @@
 ﻿<Project>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PackAllLibraries)' == 'true'">
     <BuildRID Include="linux-arm">
       <Platform>arm</Platform>
     </BuildRID>

--- a/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.proj
+++ b/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-  <ItemGroup Condition="'$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(PackAllLibraries)' == 'true' And '$(BuildAllConfigurations)' == 'true'">
     <!-- identity project built in AllConfigurations leg, runtime specific projects are included through netcoreapp.rids.props -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>


### PR DESCRIPTION
A few libraries packages were still building even when PackAllLibraries was set to false.