### PR TITLE
Fix ILVerify Default Method Verification

### DIFF
--- a/src/coreclr/tools/ILVerification/TypeVerifier.cs
+++ b/src/coreclr/tools/ILVerification/TypeVerifier.cs
@@ -94,7 +94,7 @@ namespace Internal.TypeVerifier
                     // Look for missing method implementation
                     foreach (MethodDesc method in implementedInterface.InterfaceType.GetAllMethods())
                     {
-                        if (method.Signature.IsStatic)
+                        if (!method.IsAbstract)
                         {
                             continue;
                         }

--- a/src/tests/ilverify/ILTests/InterfaceImplementation.il
+++ b/src/tests/ilverify/ILTests/InterfaceImplementation.il
@@ -448,3 +448,30 @@
 	{
 	}
 }
+
+.class public auto ansi beforefieldinit ChildClassDoesNotImplementDefaultInterfaceMethod_ValidType_Valid
+	extends [System.Runtime]System.Object
+	implements [InterfaceDefinition]IDefaultImplInterface
+{
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	}
+}
+
+.class interface public auto ansi abstract IDefaultImplInterface
+{
+    .method public hidebysig newslot virtual 
+		instance void DefaultImplementation () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+}

--- a/src/tests/ilverify/ILTests/InterfaceImplementation.il
+++ b/src/tests/ilverify/ILTests/InterfaceImplementation.il
@@ -451,8 +451,32 @@
 
 .class public auto ansi beforefieldinit ChildClassDoesNotImplementDefaultInterfaceMethod_ValidType_Valid
 	extends [System.Runtime]System.Object
-	implements [InterfaceDefinition]IDefaultImplInterface
+	implements IDefaultImplInterface
 {
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	}
+}
+
+.class public auto ansi beforefieldinit ChildClassDoesImplementDefaultInterfaceMethod_ValidType_Valid
+	extends [System.Runtime]System.Object
+	implements IDefaultImplInterface
+{
+	.method public final hidebysig newslot virtual 
+		instance void DefaultImplementation () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+
 	.method public hidebysig specialname rtspecialname 
 		instance void .ctor () cil managed 
 	{


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46236

The fix involves checking whether an interface method has a method body, as opposed to static, to avoid the search for an implementation in a child class. 

I think the ILVerify building/testing workflow should be documented somewhere. It took me quite some time to figure out that the tests were only built when using `priority=1`.
Furthermore, I ran into the issue of running `dotnet test` in the ILVerify tests folder. This supposedly permanently breaks your build until you clean all artifacts and recompile (https://github.com/dotnet/runtime/issues/43967).
Finding and fixing the issue took about half an hour, managing to get the tests working as a first time contributor to the ILVerify tool took about 4 hours.