### PR TITLE
System.Linq Orderby performance optimization

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -18,7 +18,11 @@ namespace System.Linq
             {
                 return buffer._items;
             }
-
+            if (CanInPlaceSort())
+            {
+                SortElements(buffer);
+                return buffer._items;
+            }
             TElement[] array = new TElement[count];
             int[] map = SortedMap(buffer);
             for (int i = 0; i != array.Length; i++)
@@ -33,16 +37,21 @@ namespace System.Linq
         {
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
             int count = buffer._count;
-            List<TElement> list = new List<TElement>(count);
-            if (count > 0)
+            if (count == 0)
             {
-                int[] map = SortedMap(buffer);
-                for (int i = 0; i != count; i++)
-                {
-                    list.Add(buffer._items[map[i]]);
-                }
+                return new List<TElement>(count);
             }
-
+            if (CanInPlaceSort())
+            {
+                SortElements(buffer);
+                return new List<TElement>(buffer._items);
+            }
+            List<TElement> list = new List<TElement>(count);
+            int[] map = SortedMap(buffer);
+            for (int i = 0; i != count; i++)
+            {
+                list.Add(buffer._items[map[i]]);
+            }
             return list;
         }
 


### PR DESCRIPTION
When performing OrderBy an int[] map is used to track the order of the items in the buffer. In the cases when there isn't a secondary sort however the items in the buffer can be sorted in place using ArraySortHelper which takes a Span of keys and a separate Span of items. In GetEnumerator and ToList this removes the need for the int[] map allocation and in ToArray it reuses the buffer array instead of allocating a new one.
The two open issues are:
1) Is there a better way to decide when to apply this optimization.
2) Whether classes should be allowed, for lower length it is slightly slower but has significantly lower memory allocation for ToArray
https://github.com/dotnet/performance/compare/master...johnthcall:OrderBySingleSort?expand=1

|        Method | Toolchain |     N |            Mean |           Error | Ratio | Allocated |
|-------------- |-----------|------ |----------------:|----------------:|------:|----------:|
|  StringToList |        pr |    10 |      2,558.9 ns |       135.43 ns |  1.00 |     488 B |
|  StringToList |  upstream |    10 |      2,524.6 ns |       144.37 ns |  0.99 |     616 B |
|               |           |       |                 |                 |       |           |
| StringToArray |        pr |    10 |      2,503.1 ns |       102.37 ns |  1.00 |     352 B |
| StringToArray |  upstream |    10 |      2,516.3 ns |       100.05 ns |  1.01 |     584 B |
|               |           |       |                 |                 |       |           |
|    LongToList |        pr |    10 |        244.6 ns |        11.17 ns |  1.00 |     456 B |
|    LongToList |  upstream |    10 |        381.1 ns |        22.69 ns |  1.56 |     584 B |
|               |           |       |                 |                 |       |           |
|   LongToArray |        pr |    10 |        185.5 ns |         8.24 ns |  1.00 |     320 B |
|   LongToArray |  upstream |    10 |        368.7 ns |        16.02 ns |  1.99 |     552 B |
|               |           |       |                 |                 |       |           |
|    ByteToList |        pr |    10 |        208.5 ns |         7.97 ns |  1.00 |     264 B |
|    ByteToList |  upstream |    10 |        281.9 ns |        14.82 ns |  1.35 |     392 B |
|               |           |       |                 |                 |       |           |
|   ByteToArray |        pr |    10 |        162.1 ns |        10.05 ns |  1.00 |     192 B |
|   ByteToArray |  upstream |    10 |        265.9 ns |        12.39 ns |  1.65 |     360 B |
|               |           |       |                 |                 |       |           |
|  StringToList |        pr |   200 |     93,643.9 ns |     3,403.92 ns |  1.00 |    5048 B |
|  StringToList |  upstream |   200 |     97,151.2 ns |     4,114.54 ns |  1.04 |    5936 B |
|               |           |       |                 |                 |       |           |
| StringToArray |        pr |   200 |     94,181.4 ns |     4,961.81 ns |  1.00 |    3392 B |
| StringToArray |  upstream |   200 |     94,923.1 ns |     3,305.63 ns |  1.02 |    5904 B |
|               |           |       |                 |                 |       |           |
|    LongToList |        pr |   200 |      2,787.4 ns |       121.50 ns |  1.00 |    5016 B |
|    LongToList |  upstream |   200 |     13,183.1 ns |       494.75 ns |  4.76 |    5904 B |
|               |           |       |                 |                 |       |           |
|   LongToArray |        pr |   200 |      2,635.8 ns |        90.17 ns |  1.00 |    3360 B |
|   LongToArray |  upstream |   200 |     13,197.0 ns |       598.67 ns |  5.01 |    5872 B |
|               |           |       |                 |                 |       |           |
|    ByteToList |        pr |   200 |      2,565.9 ns |       116.72 ns |  1.00 |     816 B |
|    ByteToList |  upstream |   200 |     12,553.4 ns |       538.90 ns |  4.90 |    1704 B |
|               |           |       |                 |                 |       |           |
|   ByteToArray |        pr |   200 |      2,501.8 ns |       158.85 ns |  1.00 |     560 B |
|   ByteToArray |  upstream |   200 |     12,389.3 ns |       617.73 ns |  4.97 |    1672 B |
|               |           |       |                 |                 |       |           |
|  StringToList |        pr |  3000 |  2,445,032.7 ns |    95,625.27 ns |  1.00 |   72249 B |
|  StringToList |  upstream |  3000 |  2,445,737.2 ns |   118,153.78 ns |  1.00 |   84337 B |
|               |           |       |                 |                 |       |           |
| StringToArray |        pr |  3000 |  2,435,115.9 ns |   128,939.81 ns |  1.00 |   48193 B |
| StringToArray |  upstream |  3000 |  2,482,575.2 ns |   101,295.32 ns |  1.03 |   84305 B |
|               |           |       |                 |                 |       |           |
|    LongToList |        pr |  3000 |    147,456.0 ns |     6,842.61 ns |  1.00 |   72216 B |
|    LongToList |  upstream |  3000 |    347,817.5 ns |    18,424.76 ns |  2.36 |   84304 B |
|               |           |       |                 |                 |       |           |
|   LongToArray |        pr |  3000 |    142,437.5 ns |     5,539.96 ns |  1.00 |   48160 B |
|   LongToArray |  upstream |  3000 |    358,586.4 ns |    17,107.91 ns |  2.53 |   84272 B |
|               |           |       |                 |                 |       |           |
|    ByteToList |        pr |  3000 |    125,136.6 ns |     6,217.83 ns |  1.00 |    9216 B |
|    ByteToList |  upstream |  3000 |    366,918.6 ns |    17,157.38 ns |  2.93 |   21304 B |
|               |           |       |                 |                 |       |           |
|   ByteToArray |        pr |  3000 |    121,837.0 ns |     3,701.15 ns |  1.00 |    6160 B |
|   ByteToArray |  upstream |  3000 |    357,398.5 ns |    13,957.32 ns |  2.94 |   21272 B |