### PR TITLE
Sgen: Update progress when importing types

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -261,7 +261,7 @@ namespace Microsoft.XmlSerializer.Generator
                     {
                         if (verbose)
                         {
-                            Console.WriteLine($"Importing {type.Name} ({i + 1}/{types.Length})");
+                            Console.WriteLine(SR.Format(SR.ImportInfo, type.Name, i + 1, types.Length));
                         }
 
                         bool isObsolete = false;

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -254,15 +254,16 @@ namespace Microsoft.XmlSerializer.Generator
             for (int i = 0; i < types.Length; i++)
             {
                 Type type = types[i];
-                if (verbose)
-                {
-                    Console.WriteLine($"Importing {type.Name} ({i + 1}/{types.Length})");
-                }
 
                 try
                 {
                     if (type != null)
                     {
+                        if (verbose)
+                        {
+                            Console.WriteLine($"Importing {type.Name} ({i + 1}/{types.Length})");
+                        }
+                        
                         bool isObsolete = false;
                         object[] obsoleteAttributes = type.GetCustomAttributes(typeof(ObsoleteAttribute), false);
                         foreach (object attribute in obsoleteAttributes)

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -37,7 +37,7 @@ namespace Microsoft.XmlSerializer.Generator
             bool noLogo = false;
             bool parsableErrors = false;
             bool silent = false;
-            bool warnings = false;
+            bool verbose = false;
 
             AppDomain.CurrentDomain.AssemblyResolve += SgenAssemblyResolver;
 
@@ -121,7 +121,7 @@ namespace Microsoft.XmlSerializer.Generator
                     }
                     else if (ArgumentMatch(arg, "verbose"))
                     {
-                        warnings = true;
+                        verbose = true;
                     }
                     else if (ArgumentMatch(arg, "reference"))
                     {
@@ -190,7 +190,7 @@ namespace Microsoft.XmlSerializer.Generator
                     ParseReferences();
                 }
 
-                GenerateFile(types, assembly, proxyOnly, silent, warnings, force, codePath, parsableErrors);
+                GenerateFile(types, assembly, proxyOnly, silent, verbose, force, codePath, parsableErrors);
             }
             catch (Exception e)
             {
@@ -206,7 +206,7 @@ namespace Microsoft.XmlSerializer.Generator
             return 0;
         }
 
-        private void GenerateFile(List<string> typeNames, string assemblyName, bool proxyOnly, bool silent, bool warnings, bool force, string outputDirectory, bool parsableerrors)
+        private void GenerateFile(List<string> typeNames, string assemblyName, bool proxyOnly, bool silent, bool verbose, bool force, string outputDirectory, bool parsableerrors)
         {
             Assembly assembly = LoadAssembly(assemblyName, true);
             Type[] types;
@@ -254,6 +254,10 @@ namespace Microsoft.XmlSerializer.Generator
             for (int i = 0; i < types.Length; i++)
             {
                 Type type = types[i];
+                if (verbose)
+                {
+                    Console.WriteLine($"Importing {type.Name} ({i + 1}/{types.Length})");
+                }
 
                 try
                 {
@@ -279,7 +283,7 @@ namespace Microsoft.XmlSerializer.Generator
                 //Ignore the FileNotFoundException when call GetCustomAttributes e.g. if the type uses the attributes defined in a different assembly
                 catch (FileNotFoundException e)
                 {
-                    if (warnings)
+                    if (verbose)
                     {
                         Console.Out.WriteLine(FormatMessage(parsableerrors, true, SR.Format(SR.InfoIgnoreType, type.FullName)));
                         WriteWarning(e, parsableerrors);
@@ -290,7 +294,7 @@ namespace Microsoft.XmlSerializer.Generator
 
                 if (!proxyOnly)
                 {
-                    ImportType(type, mappings, importedTypes, warnings, importer, parsableerrors);
+                    ImportType(type, mappings, importedTypes, verbose, importer, parsableerrors);
                 }
             }
 

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -263,7 +263,7 @@ namespace Microsoft.XmlSerializer.Generator
                         {
                             Console.WriteLine($"Importing {type.Name} ({i + 1}/{types.Length})");
                         }
-                        
+
                         bool isObsolete = false;
                         object[] obsoleteAttributes = type.GetCustomAttributes(typeof(ObsoleteAttribute), false);
                         foreach (object attribute in obsoleteAttributes)

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -3453,4 +3453,7 @@ Usage: dotnet {0} [--assembly &lt;assembly file path&gt;] [--type &lt;type name&
   <data name="CompilingScriptsNotSupported" xml:space="preserve">
     <value>Compiling JScript/CSharp scripts is not supported</value>
   </data>
+  <data name="ImportInfo" xml:space="preserve">
+    <value>Importing {0} ({1}/{2})</value>
+  </data>
 </root>


### PR DESCRIPTION
When working with very large auto-generated types, Microsoft.XmlSerializer.Generator can take several hours to complete.
(at first I thought it was simply stuck)
it would be extremely useful to have some kind of progress report as suggested by this PR.
The progress report is only printed when verbose is enabled.