### PR TITLE
Issue 45021

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -617,12 +617,14 @@ namespace Microsoft.Extensions.Primitives
         /// <returns></returns>
         public static bool IsNullOrEmpty(StringSegment value)
         {
+            bool res = false;
+
             if (!value.HasValue || value.Length == 0)
             {
-                return true;
+                res = true;
             }
 
-            return false;
+            return res;
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -427,21 +427,25 @@ namespace Microsoft.Extensions.Primitives
         public int IndexOf(char c, int start, int count)
         {
             int offset = Offset + start;
+            int index = -1;
 
-            if (!HasValue || start < 0 || (uint)offset > (uint)Buffer.Length)
+            if (HasValue)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-            }
+                if (start < 0 || (uint)offset > (uint)Buffer.Length)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                }
 
-            if (count < 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
-            }
+                if (count < 0)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
+                }
 
-            int index = AsSpan().Slice(start, count).IndexOf(c);
-            if (index >= 0)
-            {
-                index += start;
+                index = AsSpan().Slice(start, count).IndexOf(c);
+                if (index != -1)
+                {
+                    index -= Offset;
+                }
             }
 
             return index;

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -617,14 +617,12 @@ namespace Microsoft.Extensions.Primitives
         /// <returns></returns>
         public static bool IsNullOrEmpty(StringSegment value)
         {
-            bool res = false;
-
             if (!value.HasValue || value.Length == 0)
             {
-                res = true;
+                return true;
             }
 
-            return res;
+            return false;
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -427,25 +427,26 @@ namespace Microsoft.Extensions.Primitives
         public int IndexOf(char c, int start, int count)
         {
             int offset = Offset + start;
-            int index = -1;
 
-            if (HasValue)
+            if (start < 0 || (uint)offset > (uint)Buffer.Length)
             {
-                if (start < 0 || (uint)offset > (uint)Buffer.Length)
-                {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-                }
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+            }
 
-                if (count < 0)
-                {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
-                }
+            if (count < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
+            }
 
-                index = AsSpan().Slice(start, count).IndexOf(c);
-                if (index != -1)
-                {
-                    index -= Offset;
-                }
+            if (!HasValue)
+            {
+                return -1;
+            }
+
+            int index = AsSpan().Slice(start, count).IndexOf(c);
+            if (index != -1)
+            {
+                index += start;
             }
 
             return index;

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -196,6 +196,17 @@ namespace Microsoft.Extensions.Primitives
             Assert.False(hasValue);
         }
 
+        [Fact]
+        public void StringSegment_NullBuffer_SearchingReturnMinusOne()
+        {
+            const char item = 'c';
+            var segment = new StringSegment();
+
+            Assert.Equal(-1, segment.IndexOf(item));
+            Assert.Equal(-1, segment.IndexOfAny(new[]{item}));
+            Assert.Equal(-1, segment.LastIndexOf(item));
+        }
+
         [Theory]
         [InlineData("a", 0, 1, 0, 'a')]
         [InlineData("abc", 1, 1, 0, 'b')]


### PR DESCRIPTION
fix #45021
Didn't find any more incorrect handles except the example

Just to clarify, should it really throw an exception on null argument?
https://github.com/dotnet/runtime/blob/c142f162854185ba45f0fab678f8b28d1add3968/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs#L228-L233