### PR TITLE
use nuget pack task from the package instead of the sdk

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,10 +56,11 @@
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20621.12</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksPackagingVersion>
-    <NuGetBuildTasksPackVersion>5.9.0-preview.2</NuGetBuildTasksPackVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.20621.12</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.20621.12</MicrosoftDotNetVersionToolsTasksVersion>
+    <!-- NuGet dependencies -->
+    <NuGetBuildTasksPackVersion>5.9.0-preview.2</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppVersion>6.0.0-alpha.1.20612.4</MicrosoftNETCoreAppVersion>
     <MicrosoftNETCoreDotNetHostVersion>6.0.0-alpha.1.20620.6</MicrosoftNETCoreDotNetHostVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20621.12</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksPackagingVersion>
-    <NuGetBuildTasksPackVersionVersion>5.9.0-preview.2</NuGetBuildTasksPackVersionVersion>
+    <NuGetBuildTasksPackVersion>5.9.0-preview.2</NuGetBuildTasksPackVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.20621.12</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.20621.12</MicrosoftDotNetVersionToolsTasksVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,6 +56,7 @@
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20621.12</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksPackagingVersion>
+    <NuGetBuildTasksPackVersionVersion>5.9.0-preview.2</NuGetBuildTasksPackVersionVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.20621.12</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.20621.12</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.20621.12</MicrosoftDotNetVersionToolsTasksVersion>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -127,8 +127,9 @@
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <PackageReference Include="nuget.build.tasks.pack" Version="$(NuGetBuildTasksPackVersionVersion)" />
+  <!-- TODO: Remove when all required nuget pack features are part of the consumed SDK. -->
+  <ItemGroup Condition="'$(IsPackable)' == 'true' and '$(MSBuildProjectExtension)' != '.csproj'">
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="$(NuGetBuildTasksPackVersion)" />
   </ItemGroup>
 
   <Target Name="SetGenApiProperties"

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -127,6 +127,10 @@
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <PackageReference Include="nuget.build.tasks.pack" Version="$(NuGetBuildTasksPackVersionVersion)" />
+  </ItemGroup>
+
   <Target Name="SetGenApiProperties"
           BeforeTargets="GenerateReferenceAssemblySource">
     <PropertyGroup>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -128,7 +128,7 @@
   </ItemGroup>
 
   <!-- TODO: Remove when all required nuget pack features are part of the consumed SDK. -->
-  <ItemGroup Condition="'$(IsPackable)' == 'true' and '$(MSBuildProjectExtension)' != '.csproj'">
+  <ItemGroup Condition="'$(IsPackable)' == 'true' and '$(MSBuildProjectExtension)' != '.pkgproj'">
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="$(NuGetBuildTasksPackVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46337

We are adding this to utlize the new features associated with the pack task. 
Tested locally if the libraries projects are using the new pack task. 