### PR TITLE
[mono] Add DISABLE_NONBLITTABLE for non-blittable marshaling

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -441,6 +441,9 @@
 /* Some VES is available at runtime */
 #cmakedefine ENABLE_ILGEN 1
 
+/* Disable non-blittable marshalling */
+#cmakedefine DISABLE_NONBLITTABLE
+
 /* Disable SIMD intrinsics related optimizations. */
 #cmakedefine DISABLE_SIMD 1
 

--- a/src/mono/mono/metadata/marshal-internals.h
+++ b/src/mono/mono/metadata/marshal-internals.h
@@ -9,6 +9,7 @@
 #include <config.h>
 #include <glib.h>
 #include <mono/metadata/object-internals.h>
+#include <mono/metadata/marshal.h>
 
 MonoObjectHandle
 mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error);
@@ -42,5 +43,8 @@ typedef enum {
 
 void
 mono_marshal_noilgen_init (void);
+
+void
+mono_marshal_noilgen_init_blittable (MonoMarshalCallbacks *cb);
 
 #endif /* __MONO_METADATA_MARSHAL_INTERNALS_H__ */

--- a/src/mono/mono/metadata/marshal-noilgen.c
+++ b/src/mono/mono/metadata/marshal-noilgen.c
@@ -7,6 +7,79 @@
 
 #ifndef ENABLE_ILGEN
 static int
+emit_marshal_array_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+					MonoMarshalSpec *spec,
+					int conv_arg, MonoType **conv_arg_type,
+					MarshalAction action)
+{
+	MonoType *int_type = mono_get_int_type ();
+	MonoType *object_type = mono_get_object_type ();
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		*conv_arg_type = object_type;
+		break;
+	case MARSHAL_ACTION_MANAGED_CONV_IN:
+		*conv_arg_type = int_type;
+		break;
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_ptr_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		  MonoMarshalSpec *spec, int conv_arg,
+		  MonoType **conv_arg_type, MarshalAction action)
+{
+	return conv_arg;
+}
+
+static int
+emit_marshal_scalar_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		     MonoMarshalSpec *spec, int conv_arg,
+		     MonoType **conv_arg_type, MarshalAction action)
+{
+	return conv_arg;
+}
+#endif
+
+#if !defined(ENABLE_ILGEN) || defined(DISABLE_NONBLITTABLE)
+static int
+emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		      MonoMarshalSpec *spec,
+		      int conv_arg, MonoType **conv_arg_type,
+		      MarshalAction action)
+{
+	MonoType *int_type = mono_get_int_type ();
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		if (t->byref)
+			*conv_arg_type = int_type;
+		else
+			*conv_arg_type = mono_marshal_boolean_conv_in_get_local_type (spec, NULL);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN: {
+		MonoClass* conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, NULL);
+		if (t->byref)
+			*conv_arg_type = m_class_get_this_arg (conv_arg_class);
+		else
+			*conv_arg_type = m_class_get_byval_arg (conv_arg_class);
+		break;
+	}
+
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_char_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		   MonoMarshalSpec *spec, int conv_arg,
+		   MonoType **conv_arg_type, MarshalAction action)
+{
+	return conv_arg;
+}
+
+static int
 emit_marshal_custom_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					 MonoMarshalSpec *spec,
 					 int conv_arg, MonoType **conv_arg_type,
@@ -90,76 +163,16 @@ emit_marshal_object_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 }
 
 static int
-emit_marshal_array_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
-					MonoMarshalSpec *spec,
-					int conv_arg, MonoType **conv_arg_type,
-					MarshalAction action)
+emit_marshal_variant_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		     MonoMarshalSpec *spec,
+		     int conv_arg, MonoType **conv_arg_type,
+		     MarshalAction action)
 {
-	MonoType *int_type = mono_get_int_type ();
-	MonoType *object_type = mono_get_object_type ();
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		*conv_arg_type = object_type;
-		break;
-	case MARSHAL_ACTION_MANAGED_CONV_IN:
-		*conv_arg_type = int_type;
-		break;
-	}
-	return conv_arg;
+	g_assert_not_reached ();
 }
+#endif
 
-static int
-emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
-		      MonoMarshalSpec *spec,
-		      int conv_arg, MonoType **conv_arg_type,
-		      MarshalAction action)
-{
-	MonoType *int_type = mono_get_int_type ();
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		if (t->byref)
-			*conv_arg_type = int_type;
-		else
-			*conv_arg_type = mono_marshal_boolean_conv_in_get_local_type (spec, NULL);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN: {
-		MonoClass* conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, NULL);
-		if (t->byref)
-			*conv_arg_type = m_class_get_this_arg (conv_arg_class);
-		else
-			*conv_arg_type = m_class_get_byval_arg (conv_arg_class);
-		break;
-	}
-
-	}
-	return conv_arg;
-}
-
-static int
-emit_marshal_ptr_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
-		  MonoMarshalSpec *spec, int conv_arg,
-		  MonoType **conv_arg_type, MarshalAction action)
-{
-	return conv_arg;
-}
-
-static int
-emit_marshal_char_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
-		   MonoMarshalSpec *spec, int conv_arg,
-		   MonoType **conv_arg_type, MarshalAction action)
-{
-	return conv_arg;
-}
-
-static int
-emit_marshal_scalar_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
-		     MonoMarshalSpec *spec, int conv_arg,
-		     MonoType **conv_arg_type, MarshalAction action)
-{
-	return conv_arg;
-}
-
+#ifndef ENABLE_ILGEN
 static void
 emit_managed_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, MonoGCHandle target_handle)
 {
@@ -206,15 +219,6 @@ emit_synchronized_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, Mo
 		return;
 	}
 
-}
-
-static int
-emit_marshal_variant_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
-		     MonoMarshalSpec *spec,
-		     int conv_arg, MonoType **conv_arg_type,
-		     MarshalAction action)
-{
-	g_assert_not_reached ();
 }
 
 static void
@@ -360,10 +364,10 @@ mono_marshal_noilgen_init (void)
 	MonoMarshalCallbacks cb;
 	cb.version = MONO_MARSHAL_CALLBACKS_VERSION;
 	cb.emit_marshal_array = emit_marshal_array_noilgen;
-	cb.emit_marshal_boolean = emit_marshal_boolean_noilgen;
 	cb.emit_marshal_ptr = emit_marshal_ptr_noilgen;
-	cb.emit_marshal_char = emit_marshal_char_noilgen;
 	cb.emit_marshal_scalar = emit_marshal_scalar_noilgen;
+	cb.emit_marshal_boolean = emit_marshal_boolean_noilgen;
+	cb.emit_marshal_char = emit_marshal_char_noilgen;
 	cb.emit_marshal_custom = emit_marshal_custom_noilgen;
 	cb.emit_marshal_asany = emit_marshal_asany_noilgen;
 	cb.emit_marshal_vtype = emit_marshal_vtype_noilgen;
@@ -406,6 +410,28 @@ mono_marshal_noilgen_init (void)
 #else
 void
 mono_marshal_noilgen_init (void)
+{
+}
+#endif
+
+#ifdef DISABLE_NONBLITTABLE
+void
+mono_marshal_noilgen_init_blittable (MonoMarshalCallbacks *cb)
+{
+	cb->emit_marshal_boolean = emit_marshal_boolean_noilgen;
+	cb->emit_marshal_char = emit_marshal_char_noilgen;
+	cb->emit_marshal_custom = emit_marshal_custom_noilgen;
+	cb->emit_marshal_asany = emit_marshal_asany_noilgen;
+	cb->emit_marshal_vtype = emit_marshal_vtype_noilgen;
+	cb->emit_marshal_string = emit_marshal_string_noilgen;
+	cb->emit_marshal_safehandle = emit_marshal_safehandle_noilgen;
+	cb->emit_marshal_handleref = emit_marshal_handleref_noilgen;
+	cb->emit_marshal_object = emit_marshal_object_noilgen;
+	cb->emit_marshal_variant = emit_marshal_variant_noilgen;
+}
+#else
+void
+mono_marshal_noilgen_init_blittable (MonoMarshalCallbacks *cb)
 {
 }
 #endif


### PR DESCRIPTION
This flag is not set by default on any platforms, but long-term it should be useful on wasm with the pinvoke generator work being done by the interop team.

This flag reduces around 13k in dotnet.wasm as of today (12/29/2020). However, that is a fairly low-end measurement because this PR only focused on the pinvoke marshaling rather than the full functionality. The structure of our marshaling callbacks means that even with icall linking, a lot of marshaling code will be kept around and unused, including all the string marshaling. 

To solve this, we can either give up on the ilgen functionality being in a separate library so it gets linked our normally or we can just have this flag cover marshaling functionality as a whole. I've split that part off into a followup PR since it's more likely to be contested, but I implemented the latter option (and also disable things like certain JIT icalls for the same reason). We also will want analyzers set up before this is useful, so hopefully this solution is fine in combination with an extra analyzer for the marshaling methods in question? We also need to finish converting the libraries over to function pointers where appropriate (see https://github.com/dotnet/runtime/commit/839b1343fbad61526fedcaa722f1ae48b298c543 for an example).