### PR TITLE
Fix macOS arm64 signature corruption at install

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -63,4 +63,4 @@ else()
     _install (FILES $<TARGET_PDB_FILE:superpmi-shim-collector> DESTINATION PDB)
 endif(CLR_CMAKE_HOST_UNIX)
 
-_install (TARGETS superpmi-shim-collector DESTINATION .)
+_install (PROGRAMS $<TARGET_FILE:superpmi-shim-collector> DESTINATION .)

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -65,4 +65,4 @@ else()
     _install (FILES $<TARGET_PDB_FILE:superpmi-shim-counter> DESTINATION PDB)
 endif(CLR_CMAKE_HOST_UNIX)
 
-_install (TARGETS superpmi-shim-counter DESTINATION .)
+_install (PROGRAMS $<TARGET_FILE:superpmi-shim-counter> DESTINATION .)

--- a/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -64,4 +64,4 @@ else()
     _install (FILES $<TARGET_PDB_FILE:superpmi-shim-simple> DESTINATION PDB)
 endif(CLR_CMAKE_HOST_UNIX)
 
-_install (TARGETS superpmi-shim-simple DESTINATION .)
+_install (PROGRAMS $<TARGET_FILE:superpmi-shim-simple> DESTINATION .)

--- a/src/installer/corehost/cli/fxr/standalone/CMakeLists.txt
+++ b/src/installer/corehost/cli/fxr/standalone/CMakeLists.txt
@@ -37,5 +37,5 @@ if(CLR_CMAKE_HOST_UNIX)
     set_property(TARGET hostfxr APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
 endif(CLR_CMAKE_HOST_UNIX)
 
-install_with_stripped_symbols(hostfxr TARGETS corehost)
+install_with_stripped_symbols(hostfxr PROGRAMS corehost)
 target_link_libraries(hostfxr libhostcommon)

--- a/src/installer/corehost/cli/hostpolicy/standalone/CMakeLists.txt
+++ b/src/installer/corehost/cli/hostpolicy/standalone/CMakeLists.txt
@@ -32,5 +32,5 @@ if(CLR_CMAKE_HOST_UNIX)
     set_property(TARGET hostpolicy APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
 endif(CLR_CMAKE_HOST_UNIX)
 
-install_with_stripped_symbols(hostpolicy TARGETS corehost)
+install_with_stripped_symbols(hostpolicy PROGRAMS corehost)
 target_link_libraries(hostpolicy libhostcommon)

--- a/src/installer/corehost/cli/nethost/CMakeLists.txt
+++ b/src/installer/corehost/cli/nethost/CMakeLists.txt
@@ -36,7 +36,7 @@ endif(WIN32)
 install(FILES ../coreclr_delegates.h DESTINATION corehost)
 install(FILES ../hostfxr.h DESTINATION corehost)
 install(FILES nethost.h DESTINATION corehost)
-install_with_stripped_symbols(nethost TARGETS corehost)
+install_with_stripped_symbols(nethost PROGRAMS corehost)
 
 # Only Windows creates a symbols file for static libs.
 if (WIN32)

--- a/src/installer/corehost/cli/test/mockcoreclr/CMakeLists.txt
+++ b/src/installer/corehost/cli/test/mockcoreclr/CMakeLists.txt
@@ -16,4 +16,4 @@ endif()
 
 include(../testlib.cmake)
 
-install_with_stripped_symbols(mockcoreclr TARGETS corehost_test)
+install_with_stripped_symbols(mockcoreclr PROGRAMS corehost_test)

--- a/src/installer/corehost/cli/test/mockhostfxr/CMakeLists.txt
+++ b/src/installer/corehost/cli/test/mockhostfxr/CMakeLists.txt
@@ -11,4 +11,4 @@ set(SOURCES
 
 include(../testlib.cmake)
 
-install_with_stripped_symbols(mockhostfxr_2_2 TARGETS corehost_test)
+install_with_stripped_symbols(mockhostfxr_2_2 PROGRAMS corehost_test)

--- a/src/installer/corehost/cli/test/mockhostpolicy/CMakeLists.txt
+++ b/src/installer/corehost/cli/test/mockhostpolicy/CMakeLists.txt
@@ -11,4 +11,4 @@ set(SOURCES
 
 include(../testlib.cmake)
 
-install_with_stripped_symbols(mockhostpolicy TARGETS corehost_test)
+install_with_stripped_symbols(mockhostpolicy PROGRAMS corehost_test)


### PR DESCRIPTION
Using `install(TARGET...)` for copying built binaries into the artifacts/bin/
results in cmake calling install_name_tool on the binary to set its id, which
invalidates the code signature on macOS arm64.
We were using `install(TARGET...)` only in the installer, libraries and coreclr
use `install(PROGRAMS...)`.
This change fixes the problem by replacing the `install(TARGET...)` by
`install(PROGRAMS...)`. Even though the `install(TARGET...)` is the intended
way to install executables produced by the build in cmake, it is meant for
installing the binaries to their final location (like /usr/local/bin etc).
But we don't use install in this way, we use it to copy the result into our
`artifacts/bin/...` subfolder where the path doesn't match the final binary
location in any way. So the extra massaging that cmake does for `install(TARGET...`
is useless for our purposes anyways.

Close #46369