### PR TITLE
[wasm] Remove MainAssembly parameter from WasmAppBuilder

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -76,7 +76,6 @@
     <WasmAppBuilder
       AppDir="$(WasmAppDir)"
       MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackRidDir)"
-      MainAssembly="$(WasmMainAssemblyPath)"
       MainJS="$(WasmMainJSPath)"
       Assemblies="@(_WasmAssemblies)"
       InvariantGlobalization="$(WasmInvariantGlobalization)"

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -21,8 +21,6 @@ public class WasmAppBuilder : Task
     [Required]
     public string? MicrosoftNetCoreAppRuntimePackDir { get; set; }
     [Required]
-    public string? MainAssembly { get; set; }
-    [Required]
     public string? MainJS { get; set; }
     [Required]
     public string[]? Assemblies { get; set; }
@@ -98,8 +96,6 @@ public class WasmAppBuilder : Task
 
     public override bool Execute ()
     {
-        if (!File.Exists(MainAssembly))
-            throw new ArgumentException($"File MainAssembly='{MainAssembly}' doesn't exist.");
         if (!File.Exists(MainJS))
             throw new ArgumentException($"File MainJS='{MainJS}' doesn't exist.");
         if (!InvariantGlobalization && string.IsNullOrEmpty(IcuDataFileName))
@@ -120,12 +116,6 @@ public class WasmAppBuilder : Task
 
             if (asm.EndsWith("System.Private.CoreLib.dll"))
                 runtimeSourceDir = Path.GetDirectoryName(asm);
-        }
-
-        if (MainAssembly != null)
-        {
-            if (!_assemblies.Contains(MainAssembly))
-                _assemblies.Add(MainAssembly);
         }
 
         var config = new WasmAppConfig ();


### PR DESCRIPTION
This PR looks to remove the MainAssembly parameter in WasmAppBuilder. Functionally, the `MainAssembly` is processed like all other assemblies in `Assembly`, and it does not need to be special cased.

With recent work to move wasm app building targets to `WasmApp.targets` in https://github.com/dotnet/runtime/pull/45977, the only instance of WasmAppBuilder task in this repository lies in that target, and the `MainAssembly` (`WasmMainAssemblyPath`) is already folded into `Assemblies` (`_WasmAssemblies`) in `_BeforeWasmBuildApp`, making the MainAssembly parameter unnecessary.