### PR TITLE
Apple Silicon Fix GCStressC

### DIFF
--- a/src/coreclr/pal/src/exception/machexception.cpp
+++ b/src/coreclr/pal/src/exception/machexception.cpp
@@ -398,7 +398,13 @@ void PAL_DispatchException(PCONTEXT pContext, PEXCEPTION_RECORD pExRecord, MachE
 
     if (continueExecution)
     {
+#if defined(HOST_ARM64)
+        // RtlRestoreContext assembly corrupts X16 & X17, so it cannot be
+        // used for GCStress=C restore
+        MachSetThreadContext(pContext);
+#else
         RtlRestoreContext(pContext, pExRecord);
+#endif
     }
 
     // Send the forward request to the exception thread to process

--- a/src/coreclr/vm/gccover.cpp
+++ b/src/coreclr/vm/gccover.cpp
@@ -1239,6 +1239,10 @@ bool IsGcCoverageInterrupt(LPVOID ip)
 
 void RemoveGcCoverageInterrupt(TADDR instrPtr, BYTE * savedInstrPtr, GCCoverageInfo* gcCover, DWORD offset)
 {
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+        auto jitWriteEnableHolder = PAL_JITWriteEnable(true);
+#endif // defined(HOST_OSX) && defined(HOST_ARM64)
+
 #ifdef TARGET_ARM
         if (GetARMInstructionLength(savedInstrPtr) == 2)
             *(WORD *)instrPtr  = *(WORD *)savedInstrPtr;

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -3888,6 +3888,10 @@ void Thread::CommitGCStressInstructionUpdate()
         assert(pbDestCode != NULL);
         assert(pbSrcCode != NULL);
 
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+        auto jitWriteEnableHolder = PAL_JITWriteEnable(true);
+#endif // defined(HOST_OSX) && defined(HOST_ARM64)
+
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
 
         *pbDestCode = *pbSrcCode;


### PR DESCRIPTION
With this fix, I am able to run `COMPlus_GCStress=C` on Apple Silicon.

I have run the `prioirity1` tests twice

- Most `prioirity1` tests pass.
- 45 tests failed in both runs (see below)
- 145 tests failed in one of the two runs (see below)
  - 5 of these never finished and were manually terminated with `kill -9` (see below)
- Many of the failures look related to `float`/`double`/`hfa`

I suspect the floating point / SIMD registers are not being correctly captured and/or restored.  I intend to treat this as a separate issue.

Failed both times
```
   2 baseservices.threading.interlocked.compareexchange.compareexchangefloat.compareexchangefloat.sh
   2 ilasm.PortablePdb.IlasmPortablePdbTests.IlasmPortablePdbTests.sh
   2 ilasm.System.Runtime.CompilerServices.MethodImplOptionsTests.MethodImplOptionsTests.sh
   2 Interop.UnmanagedCallersOnly.UnmanagedCallersOnlyTest.UnmanagedCallersOnlyTest.sh
   2 JIT.CodeGenBringUpTests.StaticCalls_r.StaticCalls_r.sh
   2 JIT.Directed.cmov.Double_Or_Op_cs_d.Double_Or_Op_cs_d.sh
   2 JIT.Directed.cmov.Double_Or_Op_cs_r.Double_Or_Op_cs_r.sh
   2 JIT.Directed.cmov.Double_Xor_Op_cs_r.Double_Xor_Op_cs_r.sh
   2 JIT.Directed.cmov.Float_And_Op_cs_d.Float_And_Op_cs_d.sh
   2 JIT.Directed.cmov.Float_And_Op_cs_r.Float_And_Op_cs_r.sh
   2 JIT.Directed.cmov.Float_Or_Op_cs_d.Float_Or_Op_cs_d.sh
   2 JIT.Generics.Fields.instance_passing_struct01.instance_passing_struct01.sh
   2 JIT.Generics.Parameters.static_passing_class01.static_passing_class01.sh
   2 JIT.Intrinsics.MathFusedMultiplyAdd_r.MathFusedMultiplyAdd_r.sh
   2 JIT.jit64.gc.regress.vswhidbey.339415.339415.sh
   2 JIT.jit64.hfa.main.testA.hfa_nf1A_r.hfa_nf1A_r.sh
   2 JIT.jit64.hfa.main.testA.hfa_sd2A_d.hfa_sd2A_d.sh
   2 JIT.jit64.hfa.main.testA.hfa_sf0A_r.hfa_sf0A_r.sh
   2 JIT.jit64.hfa.main.testB.hfa_nf2B_d.hfa_nf2B_d.sh
   2 JIT.jit64.hfa.main.testB.hfa_sd2B_d.hfa_sd2B_d.sh
   2 JIT.jit64.hfa.main.testC.hfa_nf2C_d.hfa_nf2C_d.sh
   2 JIT.jit64.hfa.main.testE.hfa_sd1E_r.hfa_sd1E_r.sh
   2 JIT.jit64.hfa.main.testG.hfa_nd0G_r.hfa_nd0G_r.sh
   2 JIT.jit64.hfa.main.testG.hfa_nf1G_d.hfa_nf1G_d.sh
   2 JIT.jit64.hfa.main.testG.hfa_sd0G_r.hfa_sd0G_r.sh
   2 JIT.jit64.hfa.main.testG.hfa_sd1G_d.hfa_sd1G_d.sh
   2 JIT.jit64.hfa.main.testG.hfa_sd2G_r.hfa_sd2G_r.sh
   2 JIT.jit64.hfa.main.testG.hfa_sf0G_r.hfa_sf0G_r.sh
   2 JIT.Methodical.Arrays.huge._il_dbghuge_objref._il_dbghuge_objref.sh
   2 JIT.Methodical.AsgOp.r4.r4_cs_d.r4_cs_d.sh
   2 JIT.Methodical.AsgOp.r8.r8_cs_r.r8_cs_r.sh
   2 JIT.Methodical.divrem.rem.r4rem_cs_d.r4rem_cs_d.sh
   2 JIT.Methodical.divrem.rem.r8rem_cs_d.r8rem_cs_d.sh
   2 JIT.Methodical.MDArray.DataTypes.double_cs_d.double_cs_d.sh
   2 JIT.Methodical.MDArray.DataTypes.float_cs_d.float_cs_d.sh
   2 JIT.Performance.CodeQuality.Math.Functions.Functions.Functions.sh
   2 JIT.Regression.CLR-x86-JIT.v2.1.b608066.b608066.b608066.sh
   2 JIT.Regression.CLR-x86-JIT.v2.1.DDB.b49778.b49778.b49778.sh
   2 JIT.SIMD.VectorCeilFloor_r.VectorCeilFloor_r.sh
   2 JIT.SIMD.VectorExp_r.VectorExp_r.sh
   2 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest1248.Generated1248.Generated1248.sh
   2 profiler.elt.slowpatheltenter.slowpatheltenter.sh
   2 profiler.elt.slowpatheltleave.slowpatheltleave.sh
   2 profiler.transitions.transitions.transitions.sh
   2 profiler.unittest.releaseondetach.releaseondetach.sh
```

Manually terminated
```
   1 JIT.Methodical.Invoke.deep._dbgdeep._dbgdeep.sh
   1 JIT.Methodical.Invoke.deep._il_dbgdeep1._il_dbgdeep1.sh
   1 JIT.Methodical.Invoke.deep._il_dbgdeep2._il_dbgdeep2.sh
   1 JIT.Methodical.Invoke.deep._reldeep._reldeep.sh
   1 JIT.Methodical.Invoke.deep._speed_dbgdeep._speed_dbgdeep.sh
```

Failed Once
```
   1 Interop.PInvoke.Vector2_3_4.Vector2_3_4.Vector2_3_4.sh
   1 JIT.CodeGenBringUpTests.DblArea_r.DblArea_r.sh
   1 JIT.CodeGenBringUpTests.DblArray_d.DblArray_d.sh
   1 JIT.CodeGenBringUpTests.DblAvg2_d.DblAvg2_d.sh
   1 JIT.CodeGenBringUpTests.DblFillArray_do.DblFillArray_do.sh
   1 JIT.CodeGenBringUpTests.DblRem_r.DblRem_r.sh
   1 JIT.CodeGenBringUpTests.FPConvF2F_r.FPConvF2F_r.sh
   1 JIT.CodeGenBringUpTests.InstanceCalls_do.InstanceCalls_do.sh
   1 JIT.CodeGenBringUpTests.InstanceCalls_r.InstanceCalls_r.sh
   1 JIT.CodeGenBringUpTests.JTrueLtFP_d.JTrueLtFP_d.sh
   1 JIT.CodeGenBringUpTests.JTrueLtFP_r.JTrueLtFP_r.sh
   1 JIT.CodeGenBringUpTests.OpMembersOfStructLocal_d.OpMembersOfStructLocal_d.sh
   1 JIT.CodeGenBringUpTests.StaticCalls_d.StaticCalls_d.sh
   1 JIT.Directed.cmov.Double_And_Op_cs_r.Double_And_Op_cs_r.sh
   1 JIT.Directed.cmov.Double_No_Op_cs_d.Double_No_Op_cs_d.sh
   1 JIT.Directed.cmov.Double_No_Op_cs_r.Double_No_Op_cs_r.sh
   1 JIT.Directed.cmov.Double_Xor_Op_cs_d.Double_Xor_Op_cs_d.sh
   1 JIT.Directed.cmov.Float_No_Op_cs_d.Float_No_Op_cs_d.sh
   1 JIT.Directed.cmov.Float_Or_Op_cs_r.Float_Or_Op_cs_r.sh
   1 JIT.Directed.cmov.Float_Xor_Op_cs_r.Float_Xor_Op_cs_r.sh
   1 JIT.Directed.coverage.oldtests.cse2_cs_r.cse2_cs_r.sh
   1 JIT.Directed.coverage.oldtests.lclfldadd_cs_r.lclfldadd_cs_r.sh
   1 JIT.Directed.coverage.oldtests.lclfldrem_cs_r.lclfldrem_cs_r.sh
   1 JIT.Directed.coverage.oldtests.lclfldsub_cs_r.lclfldsub_cs_r.sh
   1 JIT.Directed.intrinsic.pow.pow0_cs_d.pow0_cs_d.sh
   1 JIT.Directed.intrinsic.pow.pow2_cs_d.pow2_cs_d.sh
   1 JIT.Directed.intrinsic.pow.pow3_cs_d.pow3_cs_d.sh
   1 JIT.Directed.perffix.primitivevt.callconv1_cs_ro.callconv1_cs_ro.sh
   1 JIT.Directed.perffix.primitivevt.mixed2_cs_d.mixed2_cs_d.sh
   1 JIT.Directed.VectorABI.VectorMgdMgd_r.VectorMgdMgd_r.sh
   1 JIT.Generics.Arrays.ConstructedTypes.Jagged.struct02.struct02.sh
   1 JIT.Generics.Locals.instance_passing_struct01.instance_passing_struct01.sh
   1 JIT.Generics.Locals.static_passing_struct01.static_passing_struct01.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.AdvSimd_Part0_r.AdvSimd_Part0_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.AdvSimd_Part10_r.AdvSimd_Part10_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.AdvSimd_Part11_r.AdvSimd_Part11_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.AdvSimd_Part13_r.AdvSimd_Part13_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.AdvSimd_Part14_r.AdvSimd_Part14_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.AdvSimd_Part15_r.AdvSimd_Part15_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.AdvSimd_Part9_r.AdvSimd_Part9_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.Arm64.AdvSimd.Arm64_Part0_r.AdvSimd.Arm64_Part0_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.Arm64.AdvSimd.Arm64_Part3_r.AdvSimd.Arm64_Part3_r.sh
   1 JIT.HardwareIntrinsics.Arm.AdvSimd.Arm64.AdvSimd.Arm64_Part5_r.AdvSimd.Arm64_Part5_r.sh
   1 JIT.HardwareIntrinsics.Arm.ArmBase.Arm64.ArmBase.Arm64_r.ArmBase.Arm64_r.sh
   1 JIT.HardwareIntrinsics.General.Vector128_1.Vector128_1_r.Vector128_1_r.sh
   1 JIT.HardwareIntrinsics.X86.Pclmulqdq.Pclmulqdq_r.Pclmulqdq_r.sh
   1 JIT.IL_Conformance.Old.Conformance_Base.ldc_ret_r8.ldc_ret_r8.sh
   1 JIT.Intrinsics.MathCeilingDouble_r.MathCeilingDouble_r.sh
   1 JIT.Intrinsics.MathFloorSingle_r.MathFloorSingle_r.sh
   1 JIT.jit64.hfa.main.testA.hfa_nd0A_r.hfa_nd0A_r.sh
   1 JIT.jit64.hfa.main.testA.hfa_nd2A_d.hfa_nd2A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_nd2A_r.hfa_nd2A_r.sh
   1 JIT.jit64.hfa.main.testA.hfa_nf0A_d.hfa_nf0A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_nf1A_d.hfa_nf1A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_nf2A_d.hfa_nf2A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_sd0A_d.hfa_sd0A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_sd1A_d.hfa_sd1A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_sd2A_r.hfa_sd2A_r.sh
   1 JIT.jit64.hfa.main.testA.hfa_sf0A_d.hfa_sf0A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_sf1A_d.hfa_sf1A_d.sh
   1 JIT.jit64.hfa.main.testA.hfa_sf2A_r.hfa_sf2A_r.sh
   1 JIT.jit64.hfa.main.testB.hfa_nf0B_r.hfa_nf0B_r.sh
   1 JIT.jit64.hfa.main.testB.hfa_sd0B_d.hfa_sd0B_d.sh
   1 JIT.jit64.hfa.main.testB.hfa_sd0B_r.hfa_sd0B_r.sh
   1 JIT.jit64.hfa.main.testB.hfa_sd2B_r.hfa_sd2B_r.sh
   1 JIT.jit64.hfa.main.testB.hfa_sf0B_d.hfa_sf0B_d.sh
   1 JIT.jit64.hfa.main.testC.hfa_nd0C_d.hfa_nd0C_d.sh
   1 JIT.jit64.hfa.main.testC.hfa_nd0C_r.hfa_nd0C_r.sh
   1 JIT.jit64.hfa.main.testC.hfa_nd2C_d.hfa_nd2C_d.sh
   1 JIT.jit64.hfa.main.testC.hfa_nf2C_r.hfa_nf2C_r.sh
   1 JIT.jit64.hfa.main.testC.hfa_sd0C_d.hfa_sd0C_d.sh
   1 JIT.jit64.hfa.main.testC.hfa_sd2C_d.hfa_sd2C_d.sh
   1 JIT.jit64.hfa.main.testC.hfa_sd2C_r.hfa_sd2C_r.sh
   1 JIT.jit64.hfa.main.testC.hfa_sf1C_d.hfa_sf1C_d.sh
   1 JIT.jit64.hfa.main.testC.hfa_sf2C_r.hfa_sf2C_r.sh
   1 JIT.jit64.hfa.main.testE.hfa_nd1E_r.hfa_nd1E_r.sh
   1 JIT.jit64.hfa.main.testE.hfa_sd2E_d.hfa_sd2E_d.sh
   1 JIT.jit64.hfa.main.testE.hfa_sf0E_d.hfa_sf0E_d.sh
   1 JIT.jit64.hfa.main.testE.hfa_sf2E_d.hfa_sf2E_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_nd0G_d.hfa_nd0G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_nd1G_d.hfa_nd1G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_nd1G_r.hfa_nd1G_r.sh
   1 JIT.jit64.hfa.main.testG.hfa_nd2G_r.hfa_nd2G_r.sh
   1 JIT.jit64.hfa.main.testG.hfa_nf0G_d.hfa_nf0G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_nf1G_r.hfa_nf1G_r.sh
   1 JIT.jit64.hfa.main.testG.hfa_nf2G_d.hfa_nf2G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_sd0G_d.hfa_sd0G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_sd1G_r.hfa_sd1G_r.sh
   1 JIT.jit64.hfa.main.testG.hfa_sd2G_d.hfa_sd2G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_sf0G_d.hfa_sf0G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_sf2G_d.hfa_sf2G_d.sh
   1 JIT.jit64.hfa.main.testG.hfa_sf2G_r.hfa_sf2G_r.sh
   1 JIT.Methodical.Arrays.huge._il_relhuge_objref._il_relhuge_objref.sh
   1 JIT.Methodical.AsgOp.r8.r8flat_cs_d.r8flat_cs_d.sh
   1 JIT.Methodical.AsgOp.r8.r8_cs_d.r8_cs_d.sh
   1 JIT.Methodical.divrem.rem.r4rem_cs_r.r4rem_cs_r.sh
   1 JIT.Methodical.explicit.coverage.seq_float_1_d.seq_float_1_d.sh
   1 JIT.Methodical.fp.exgen.1000w1d_cs_d.1000w1d_cs_d.sh
   1 JIT.Methodical.fp.exgen.1000w1d_cs_r.1000w1d_cs_r.sh
   1 JIT.Methodical.fp.exgen.10w250d_cs_r.10w250d_cs_r.sh
   1 JIT.Methodical.fp.exgen.10w5d_cs_d.10w5d_cs_d.sh
   1 JIT.Methodical.MDArray.DataTypes.double_cs_r.double_cs_r.sh
   1 JIT.Methodical.NaN.arithm32_d.arithm32_d.sh
   1 JIT.Methodical.NaN.arithm32_r.arithm32_r.sh
   1 JIT.Methodical.NaN.arithm64_cs_d.arithm64_cs_d.sh
   1 JIT.Methodical.NaN.intrinsic_cs_ro.intrinsic_cs_ro.sh
   1 JIT.Methodical.NaN.r4NaNadd_cs_d.r4NaNadd_cs_d.sh
   1 JIT.Methodical.NaN.r4NaNdiv_cs_d.r4NaNdiv_cs_d.sh
   1 JIT.Methodical.NaN.r4NaNdiv_cs_r.r4NaNdiv_cs_r.sh
   1 JIT.Methodical.NaN.r4NaNmul_cs_d.r4NaNmul_cs_d.sh
   1 JIT.Methodical.NaN.r4NaNmul_cs_r.r4NaNmul_cs_r.sh
   1 JIT.Methodical.NaN.r4NaNrem_cs_d.r4NaNrem_cs_d.sh
   1 JIT.Methodical.NaN.r8NaNadd_cs_r.r8NaNadd_cs_r.sh
   1 JIT.Methodical.NaN.r8NaNmul_cs_d.r8NaNmul_cs_d.sh
   1 JIT.Methodical.NaN.r8NaNmul_cs_r.r8NaNmul_cs_r.sh
   1 JIT.Methodical.NaN.r8NaNsub_cs_d.r8NaNsub_cs_d.sh
   1 JIT.Methodical.Overflow.FloatOvfToInt2_d.FloatOvfToInt2_d.sh
   1 JIT.opt.JitMinOpts.Perf.CodeSize1.CodeSize1.sh
   1 JIT.Performance.CodeQuality.BenchmarksGame.regex-redux.regex-redux-1.regex-redux-1.sh
   1 JIT.Regression.CLR-x86-JIT.V1-M12-Beta2.b50145.b50145a.b50145a.sh
   1 JIT.Regression.Dev11.External.dev11_132534.CSharpPart.CSharpPart.sh
   1 JIT.SIMD.AbsSqrt_r.AbsSqrt_r.sh
   1 JIT.SIMD.AddingSequence_r.AddingSequence_r.sh
   1 JIT.SIMD.VectorAbs_r.VectorAbs_r.sh
   1 JIT.SIMD.VectorAdd_r.VectorAdd_r.sh
   1 JIT.SIMD.VectorArray_ro.VectorArray_ro.sh
   1 JIT.SIMD.VectorCast_r.VectorCast_r.sh
   1 JIT.SIMD.VectorConvert_ro_Target_64Bit.VectorConvert_ro_Target_64Bit.sh
   1 JIT.SIMD.VectorExp_ro.VectorExp_ro.sh
   1 JIT.SIMD.VectorMin_r.VectorMin_r.sh
   1 JIT.SIMD.VectorRelOp_r.VectorRelOp_r.sh
   1 JIT.SIMD.VectorSet_r.VectorSet_r.sh
   1 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest543.Generated543.Generated543.sh
   1 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest627.Generated627.Generated627.sh
   1 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest637.Generated637.Generated637.sh
   1 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest745.Generated745.Generated745.sh
   1 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest785.Generated785.Generated785.sh
   1 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest804.Generated804.Generated804.sh
   1 Loader.classloader.TypeGeneratorTests.TypeGeneratorTest895.Generated895.Generated895.sh
```