### PR TITLE
Speed up ArrayBufferWriter.Clear for value types.

### DIFF
--- a/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
+++ b/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
@@ -89,9 +89,9 @@ namespace System.Buffers
 #if NETSTANDARD2_1
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 _buffer.AsSpan(0, _index).Clear();
-#else                
+#else
             _buffer.AsSpan(0, _index).Clear();
-#endif            
+#endif
             _index = 0;
         }
 

--- a/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
+++ b/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.Buffers
 {
@@ -85,7 +86,12 @@ namespace System.Buffers
         public void Clear()
         {
             Debug.Assert(_buffer.Length >= _index);
+#if NETSTANDARD2_1
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                _buffer.AsSpan(0, _index).Clear();
+#else                
             _buffer.AsSpan(0, _index).Clear();
+#endif            
             _index = 0;
         }
 


### PR DESCRIPTION
Like for collections (List&lt;T&gt;.clear for example), only zero out the
array underlying ArrayBufferWriter&lt;T&gt; if T is a reference type or
contains references. This substantially speeds up this call in the
common case of using ArrayBufferWriter&lt;byte&gt;.