### PR TITLE
Fix bug in W3C ID version check

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -833,7 +833,8 @@ namespace System.Diagnostics
             // The version (00-fe) is used to indicate that this is a WC3 ID.
             return id.Length == 55 &&
                    ('0' <= id[0] && id[0] <= '9' || 'a' <= id[0] && id[0] <= 'f') &&
-                   ('0' <= id[1] && id[1] <= '9' || 'a' <= id[1] && id[1] <= 'e');
+                   ('0' <= id[1] && id[1] <= '9' || 'a' <= id[1] && id[1] <= 'f') &&
+                   (id[0] != 'f' || id[1] != 'f');
         }
 
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -832,7 +832,7 @@ namespace System.Diagnostics
             //  = 55 chars (see https://w3c.github.io/trace-context)
             // The version (00-fe) is used to indicate that this is a WC3 ID.
             return id.Length == 55 &&
-                   ((HexConverter.FromLowerChar(id[0]) << 4) + HexConverter.FromLowerChar(id[1]) < 255);
+                   ((HexConverter.FromLowerChar(id[0]) << 4) | HexConverter.FromLowerChar(id[1])) <= 0xfe;
         }
 
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -832,9 +832,7 @@ namespace System.Diagnostics
             //  = 55 chars (see https://w3c.github.io/trace-context)
             // The version (00-fe) is used to indicate that this is a WC3 ID.
             return id.Length == 55 &&
-                   ('0' <= id[0] && id[0] <= '9' || 'a' <= id[0] && id[0] <= 'f') &&
-                   ('0' <= id[1] && id[1] <= '9' || 'a' <= id[1] && id[1] <= 'f') &&
-                   (id[0] != 'f' || id[1] != 'f');
+                   ((HexConverter.FromLowerChar(id[0]) << 4) + HexConverter.FromLowerChar(id[1]) < 255);
         }
 
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -832,7 +832,9 @@ namespace System.Diagnostics
             //  = 55 chars (see https://w3c.github.io/trace-context)
             // The version (00-fe) is used to indicate that this is a WC3 ID.
             return id.Length == 55 &&
-                   ((HexConverter.FromLowerChar(id[0]) << 4) + HexConverter.FromLowerChar(id[1]) < 255);
+                   ('0' <= id[0] && id[0] <= '9' || 'a' <= id[0] && id[0] <= 'f') &&
+                   ('0' <= id[1] && id[1] <= '9' || 'a' <= id[1] && id[1] <= 'f') &&
+                   (id[0] != 'f' || id[1] != 'f');
         }
 
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -832,7 +832,7 @@ namespace System.Diagnostics
             //  = 55 chars (see https://w3c.github.io/trace-context)
             // The version (00-fe) is used to indicate that this is a WC3 ID.
             return id.Length == 55 &&
-                   ((HexConverter.FromLowerChar(id[0]) << 4) | HexConverter.FromLowerChar(id[1])) <= 0xfe;
+                   ((HexConverter.FromLowerChar(id[0]) << 4) + HexConverter.FromLowerChar(id[1]) < 255);
         }
 
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -599,22 +599,28 @@ namespace System.Diagnostics.Tests
             Activity activity0 = new Activity("activity0");
             Activity activity1 = new Activity("activity1");
             Activity activity2 = new Activity("activity2");
+            Activity activity3 = new Activity("activity3");
             activity0.SetParentId("01-0123456789abcdef0123456789abcdef-0123456789abcdef-00");
             activity0.Start();
             activity1.SetParentId("cc-1123456789abcdef0123456789abcdef-1123456789abcdef-00");
             activity1.Start();
             activity2.SetParentId("fe-2123456789abcdef0123456789abcdef-2123456789abcdef-00");
             activity2.Start();
+            activity3.SetParentId("ef-3123456789abcdef0123456789abcdef-3123456789abcdef-00");
+            activity3.Start();
 
             Assert.Equal(ActivityIdFormat.W3C, activity0.IdFormat);
             Assert.Equal(ActivityIdFormat.W3C, activity1.IdFormat);
             Assert.Equal(ActivityIdFormat.W3C, activity2.IdFormat);
+            Assert.Equal(ActivityIdFormat.W3C, activity3.IdFormat);
             Assert.Equal("0123456789abcdef0123456789abcdef", activity0.TraceId.ToHexString());
             Assert.Equal("1123456789abcdef0123456789abcdef", activity1.TraceId.ToHexString());
             Assert.Equal("2123456789abcdef0123456789abcdef", activity2.TraceId.ToHexString());
+            Assert.Equal("3123456789abcdef0123456789abcdef", activity3.TraceId.ToHexString());
             Assert.Equal("0123456789abcdef", activity0.ParentSpanId.ToHexString());
             Assert.Equal("1123456789abcdef", activity1.ParentSpanId.ToHexString());
             Assert.Equal("2123456789abcdef", activity2.ParentSpanId.ToHexString());
+            Assert.Equal("3123456789abcdef", activity3.ParentSpanId.ToHexString());
         }
 
         [Fact]


### PR DESCRIPTION
The [W3C Trace Context](https://www.w3.org/TR/trace-context-1/#version) only defines version `ff` as invalid. All other versions (00-fe) are valid.

The code contained a bug which treated all versions ending with `f` as invalid, including valid versions: `0f`, `1f`, `2f`, ..., `ef`.