### PR TITLE
Remove some dead stuff

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
@@ -1093,11 +1093,7 @@ namespace System.DirectoryServices.Protocols
             bool success = false;
             if (ldapConnection != null && ldapConnection._ldapHandle != null && !ldapConnection._ldapHandle.IsInvalid)
             {
-                try { }
-                finally
-                {
-                    ldapConnection._ldapHandle.DangerousAddRef(ref success);
-                }
+                ldapConnection._ldapHandle.DangerousAddRef(ref success);
             }
 
             return success;
@@ -1107,11 +1103,7 @@ namespace System.DirectoryServices.Protocols
         {
             if (ldapConnection != null && ldapConnection._ldapHandle != null && !ldapConnection._ldapHandle.IsInvalid)
             {
-                try { }
-                finally
-                {
-                    ldapConnection._ldapHandle.DangerousRelease();
-                }
+                ldapConnection._ldapHandle.DangerousRelease();
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityCriticalAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityCriticalAttribute.cs
@@ -3,9 +3,7 @@
 
 namespace System.Security
 {
-    // SecurityCriticalAttribute
-    //  Indicates that the decorated code or assembly performs security critical operations (e.g. Assert, "unsafe", LinkDemand, etc.)
-    //  The attribute can be placed on most targets, except on arguments/return values.
+    // Has no effect in .NET Core
     [AttributeUsage(AttributeTargets.Assembly |
                     AttributeTargets.Class |
                     AttributeTargets.Struct |

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityRulesAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityRulesAttribute.cs
@@ -3,13 +3,7 @@
 
 namespace System.Security
 {
-    // SecurityRulesAttribute
-    //
-    // Indicates which set of security rules an assembly was authored against, and therefore which set of
-    // rules the runtime should enforce on the assembly.  For instance, an assembly marked with
-    // [SecurityRules(SecurityRuleSet.Level1)] will follow the v2.0 transparency rules, where transparent code
-    // can call a LinkDemand by converting it to a full demand, public critical methods are implicitly
-    // treat as safe, and the remainder of the v2.0 rules apply.
+    // Has no effect in .NET Core
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public sealed class SecurityRulesAttribute : Attribute
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecuritySafeCriticalAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecuritySafeCriticalAttribute.cs
@@ -3,15 +3,7 @@
 
 namespace System.Security
 {
-    // SecuritySafeCriticalAttribute:
-    // Indicates that the code may contain violations to the security critical rules (e.g. transitions from
-    //      critical to non-public transparent, transparent to non-public critical, etc.), has been audited for
-    //      security concerns and is considered security clean. Also indicates that the code is considered SecurityCritical.
-    // The effect of this attribute is as if the code was marked [SecurityCritical][SecurityTreatAsSafe].
-    // At assembly-scope, all rule checks will be suppressed within the assembly and for calls made against the assembly.
-    // At type-scope, all rule checks will be suppressed for members within the type and for calls made against the type.
-    // At member level (e.g. field and method) the code will be treated as public - i.e. no rule checks for the members.
-
+    // Has no effect in .NET Core
     [AttributeUsage(AttributeTargets.Class |
                     AttributeTargets.Struct |
                     AttributeTargets.Enum |

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityTransparentAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityTransparentAttribute.cs
@@ -3,12 +3,7 @@
 
 namespace System.Security
 {
-    // SecurityTransparentAttribute:
-    // Indicates the assembly contains only transparent code.
-    // Security critical actions will be restricted or converted into less critical actions. For example,
-    // Assert will be restricted, SuppressUnmanagedCode, LinkDemand, unsafe, and unverifiable code will be converted
-    // into Full-Demands.
-
+    // Has no effect in .NET Core
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
     public sealed class SecurityTransparentAttribute : Attribute
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityTreatAsSafeAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityTreatAsSafeAttribute.cs
@@ -3,14 +3,7 @@
 
 namespace System.Security
 {
-    // SecurityTreatAsSafeAttribute:
-    // Indicates that the code may contain violations to the security critical rules (e.g. transitions from
-    //      critical to non-public transparent, transparent to non-public critical, etc.), has been audited for
-    //      security concerns and is considered security clean.
-    // At assembly-scope, all rule checks will be suppressed within the assembly and for calls made against the assembly.
-    // At type-scope, all rule checks will be suppressed for members within the type and for calls made against the type.
-    // At member level (e.g. field and method) the code will be treated as public - i.e. no rule checks for the members.
-
+    // Has no effect in .NET Core
     [AttributeUsage(AttributeTargets.Assembly |
                     AttributeTargets.Class |
                     AttributeTargets.Struct |

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SuppressUnmanagedCodeSecurityAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SuppressUnmanagedCodeSecurityAttribute.cs
@@ -3,8 +3,7 @@
 
 namespace System.Security
 {
-    // SuppressUnmanagedCodeSecurityAttribute:
-    //  This attribute has no functional impact in CoreCLR.
+    // Has no effect in .NET Core
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
     public sealed class SuppressUnmanagedCodeSecurityAttribute : Attribute
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -341,16 +341,10 @@ namespace System.Threading
                         }
                     }
                 }
-                // entering the lock and incrementing waiters must not suffer a thread-abort, else we cannot
-                // clean up m_waitCount correctly, which may lead to deadlock due to non-woken waiters.
-                try { }
-                finally
+                Monitor.Enter(m_lockObjAndDisposed, ref lockTaken);
+                if (lockTaken)
                 {
-                    Monitor.Enter(m_lockObjAndDisposed, ref lockTaken);
-                    if (lockTaken)
-                    {
-                        m_waitCount++;
-                    }
+                    m_waitCount++;
                 }
 
                 // If there are any async waiters, for fairness we'll get in line behind

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -342,10 +342,7 @@ namespace System.Threading
                     }
                 }
                 Monitor.Enter(m_lockObjAndDisposed, ref lockTaken);
-                if (lockTaken)
-                {
-                    m_waitCount++;
-                }
+                m_waitCount++;
 
                 // If there are any async waiters, for fairness we'll get in line behind
                 // then by translating our synchronous wait into an asynchronous one that we

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ProducerConsumerQueues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ProducerConsumerQueues.cs
@@ -181,14 +181,8 @@ namespace System.Threading.Tasks
             newSegment.m_state.m_last = 1;
             newSegment.m_state.m_lastCopy = 1;
 
-            try { }
-            finally
-            {
-                // Finally block to protect against corruption due to a thread abort
-                // between setting m_next and setting m_tail.
-                Volatile.Write(ref m_tail.m_next, newSegment); // ensure segment not published until item is fully stored
-                m_tail = newSegment;
-            }
+            Volatile.Write(ref m_tail.m_next, newSegment); // ensure segment not published until item is fully stored
+            m_tail = newSegment;
         }
 
         /// <summary>Attempts to dequeue an item from the queue.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -122,17 +122,12 @@ namespace System.Threading
             _valueFactory = valueFactory;
             _trackAllValues = trackAllValues;
 
-            // Assign the ID and mark the instance as initialized. To avoid leaking IDs, we assign the ID and set _initialized
-            // in a finally block, to avoid a thread abort in between the two statements.
-            try { }
-            finally
-            {
-                _idComplement = ~s_idManager.GetId();
+            // Assign the ID and mark the instance as initialized.
+             _idComplement = ~s_idManager.GetId();
 
-                // As the last step, mark the instance as fully initialized. (Otherwise, if _initialized=false, we know that an exception
-                // occurred in the constructor.)
-                _initialized = true;
-            }
+            // As the last step, mark the instance as fully initialized. (Otherwise, if _initialized=false, we know that an exception
+            // occurred in the constructor.)
+            _initialized = true;
         }
 
         /// <summary>

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -1,16 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-** Class:  Privilege
-**
-** Purpose: Managed wrapper for NT privileges.
-**
-** Date:  July 1, 2004
-**
-===========================================================*/
-
 using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System.Collections;
@@ -27,10 +17,9 @@ using Luid = Interop.Advapi32.LUID;
 
 namespace System.Security.AccessControl
 {
-#if false
-    internal delegate void PrivilegedHelper();
-#endif
-
+    /// <summary>
+    /// Managed wrapper for NT privileges
+    /// </summary>
     internal sealed class Privilege
     {
         [ThreadStatic]
@@ -198,85 +187,78 @@ namespace System.Security.AccessControl
 
                 try
                 {
-                    // Make the sequence non-interruptible
-                }
-                finally
-                {
-                    try
+                    //
+                    // Open the thread token; if there is no thread token, get one from
+                    // the process token by impersonating self.
+                    //
+
+                    SafeTokenHandle? threadHandleBefore = this.threadHandle;
+                    error = FCall.OpenThreadToken(
+                                  TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
+                                  WinSecurityContext.Process,
+                                  out this.threadHandle);
+                    unchecked { error &= ~(int)0x80070000; }
+
+                    if (error != 0)
                     {
-                        //
-                        // Open the thread token; if there is no thread token, get one from
-                        // the process token by impersonating self.
-                        //
-
-                        SafeTokenHandle? threadHandleBefore = this.threadHandle;
-                        error = FCall.OpenThreadToken(
-                                      TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
-                                      WinSecurityContext.Process,
-                                      out this.threadHandle);
-                        unchecked { error &= ~(int)0x80070000; }
-
-                        if (error != 0)
+                        if (success == true)
                         {
+                            this.threadHandle = threadHandleBefore;
+
+                            if (error != Interop.Errors.ERROR_NO_TOKEN)
+                            {
+                                success = false;
+                            }
+
+                            System.Diagnostics.Debug.Assert(this.isImpersonating == false, "Incorrect isImpersonating state");
+
                             if (success == true)
                             {
-                                this.threadHandle = threadHandleBefore;
+                                error = 0;
+                                if (false == Interop.Advapi32.DuplicateTokenEx(
+                                                processHandle,
+                                                TokenAccessLevels.Impersonate | TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
+                                                IntPtr.Zero,
+                                                Interop.Advapi32.SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation,
+                                                System.Security.Principal.TokenType.TokenImpersonation,
+                                                ref this.threadHandle))
+                                {
+                                    error = Marshal.GetLastWin32Error();
+                                    success = false;
+                                }
+                            }
 
-                                if (error != Interop.Errors.ERROR_NO_TOKEN)
+                            if (success == true)
+                            {
+                                error = FCall.SetThreadToken(this.threadHandle);
+                                unchecked { error &= ~(int)0x80070000; }
+
+                                if (error != 0)
                                 {
                                     success = false;
                                 }
-
-                                System.Diagnostics.Debug.Assert(this.isImpersonating == false, "Incorrect isImpersonating state");
-
-                                if (success == true)
-                                {
-                                    error = 0;
-                                    if (false == Interop.Advapi32.DuplicateTokenEx(
-                                                    processHandle,
-                                                    TokenAccessLevels.Impersonate | TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
-                                                    IntPtr.Zero,
-                                                    Interop.Advapi32.SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation,
-                                                    System.Security.Principal.TokenType.TokenImpersonation,
-                                                    ref this.threadHandle))
-                                    {
-                                        error = Marshal.GetLastWin32Error();
-                                        success = false;
-                                    }
-                                }
-
-                                if (success == true)
-                                {
-                                    error = FCall.SetThreadToken(this.threadHandle);
-                                    unchecked { error &= ~(int)0x80070000; }
-
-                                    if (error != 0)
-                                    {
-                                        success = false;
-                                    }
-                                }
-
-                                if (success == true)
-                                {
-                                    this.isImpersonating = true;
-                                }
                             }
-                            else
+
+                            if (success == true)
                             {
-                                error = cachingError;
+                                this.isImpersonating = true;
                             }
                         }
                         else
                         {
-                            success = true;
+                            error = cachingError;
                         }
                     }
-                    finally
+                    else
                     {
-                        if (!success)
-                        {
-                            Dispose();
-                        }
+                        success = true;
+                    }
+                }
+                finally
+                {
+                    if (!success)
+                    {
+                        Dispose();
                     }
                 }
 
@@ -439,92 +421,76 @@ namespace System.Security.AccessControl
                 throw new InvalidOperationException(SR.InvalidOperation_MustRevertPrivilege);
             }
 
-            //
-            // Need to make this block of code non-interruptible so that it would preserve
-            // consistency of thread oken state even in the face of catastrophic exceptions
-            //
-
             try
             {
                 //
-                // The payload is entirely in the finally block
-                // This is how we ensure that the code will not be
-                // interrupted by catastrophic exceptions
+                // Retrieve TLS state
                 //
+
+                this.tlsContents = t_tlsSlotData;
+
+                if (this.tlsContents == null)
+                {
+                    this.tlsContents = new TlsContents();
+                    t_tlsSlotData = this.tlsContents;
+                }
+                else
+                {
+                    this.tlsContents.IncrementReferenceCount();
+                }
+
+                Interop.Advapi32.TOKEN_PRIVILEGE newState;
+                newState.PrivilegeCount = 1;
+                newState.Privileges.Luid = this.luid;
+                newState.Privileges.Attributes = enable ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED;
+
+                Interop.Advapi32.TOKEN_PRIVILEGE previousState = default;
+                uint previousSize = 0;
+
+                //
+                // Place the new privilege on the thread token and remember the previous state.
+                //
+
+                if (!Interop.Advapi32.AdjustTokenPrivileges(
+                                  this.tlsContents.ThreadHandle,
+                                  false,
+                                  &newState,
+                                  (uint)sizeof(Interop.Advapi32.TOKEN_PRIVILEGE),
+                                  &previousState,
+                                  &previousSize))
+                {
+                    error = Marshal.GetLastWin32Error();
+                }
+                else if (Interop.Errors.ERROR_NOT_ALL_ASSIGNED == Marshal.GetLastWin32Error())
+                {
+                    error = Interop.Errors.ERROR_NOT_ALL_ASSIGNED;
+                }
+                else
+                {
+                    //
+                    // This is the initial state that revert will have to go back to
+                    //
+
+                    this.initialState = ((previousState.Privileges.Attributes & Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED) != 0);
+
+                    //
+                    // Remember whether state has changed at all
+                    //
+
+                    this.stateWasChanged = (this.initialState != enable);
+
+                    //
+                    // If we had to impersonate, or if the privilege state changed we'll need to revert
+                    //
+
+                    this.needToRevert = this.tlsContents.IsImpersonating || this.stateWasChanged;
+                }
             }
             finally
             {
-                try
+                if (!this.needToRevert)
                 {
-                    //
-                    // Retrieve TLS state
-                    //
-
-                    this.tlsContents = t_tlsSlotData;
-
-                    if (this.tlsContents == null)
-                    {
-                        this.tlsContents = new TlsContents();
-                        t_tlsSlotData = this.tlsContents;
-                    }
-                    else
-                    {
-                        this.tlsContents.IncrementReferenceCount();
-                    }
-
-                    Interop.Advapi32.TOKEN_PRIVILEGE newState;
-                    newState.PrivilegeCount = 1;
-                    newState.Privileges.Luid = this.luid;
-                    newState.Privileges.Attributes = enable ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED;
-
-                    Interop.Advapi32.TOKEN_PRIVILEGE previousState = default;
-                    uint previousSize = 0;
-
-                    //
-                    // Place the new privilege on the thread token and remember the previous state.
-                    //
-
-                    if (!Interop.Advapi32.AdjustTokenPrivileges(
-                                      this.tlsContents.ThreadHandle,
-                                      false,
-                                      &newState,
-                                      (uint)sizeof(Interop.Advapi32.TOKEN_PRIVILEGE),
-                                      &previousState,
-                                      &previousSize))
-                    {
-                        error = Marshal.GetLastWin32Error();
-                    }
-                    else if (Interop.Errors.ERROR_NOT_ALL_ASSIGNED == Marshal.GetLastWin32Error())
-                    {
-                        error = Interop.Errors.ERROR_NOT_ALL_ASSIGNED;
-                    }
-                    else
-                    {
-                        //
-                        // This is the initial state that revert will have to go back to
-                        //
-
-                        this.initialState = ((previousState.Privileges.Attributes & Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED) != 0);
-
-                        //
-                        // Remember whether state has changed at all
-                        //
-
-                        this.stateWasChanged = (this.initialState != enable);
-
-                        //
-                        // If we had to impersonate, or if the privilege state changed we'll need to revert
-                        //
-
-                        this.needToRevert = this.tlsContents.IsImpersonating || this.stateWasChanged;
-                    }
-                }
-                finally
-                {
-                    if (!this.needToRevert)
-                    {
-                        this.Reset();
-                    }
+                    this.Reset();
                 }
             }
 
@@ -562,57 +528,42 @@ namespace System.Security.AccessControl
                 return;
             }
 
-            //
-            // This code must be eagerly prepared and non-interruptible.
-            //
+            bool success = true;
 
             try
             {
                 //
-                // The payload is entirely in the finally block
-                // This is how we ensure that the code will not be
-                // interrupted by catastrophic exceptions
+                // Only call AdjustTokenPrivileges if we're not going to be reverting to self,
+                // on this Revert, since doing the latter obliterates the thread token anyway
                 //
+
+                if (this.stateWasChanged &&
+                    (this.tlsContents!.ReferenceCountValue > 1 ||
+                      !this.tlsContents.IsImpersonating))
+                {
+                    Interop.Advapi32.TOKEN_PRIVILEGE newState;
+                    newState.PrivilegeCount = 1;
+                    newState.Privileges.Luid = this.luid;
+                    newState.Privileges.Attributes = (this.initialState ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED);
+
+                    if (!Interop.Advapi32.AdjustTokenPrivileges(
+                                      this.tlsContents.ThreadHandle,
+                                      false,
+                                      &newState,
+                                      0,
+                                      null,
+                                      null))
+                    {
+                        error = Marshal.GetLastWin32Error();
+                        success = false;
+                    }
+                }
             }
             finally
             {
-                bool success = true;
-
-                try
+                if (success)
                 {
-                    //
-                    // Only call AdjustTokenPrivileges if we're not going to be reverting to self,
-                    // on this Revert, since doing the latter obliterates the thread token anyway
-                    //
-
-                    if (this.stateWasChanged &&
-                        (this.tlsContents!.ReferenceCountValue > 1 ||
-                          !this.tlsContents.IsImpersonating))
-                    {
-                        Interop.Advapi32.TOKEN_PRIVILEGE newState;
-                        newState.PrivilegeCount = 1;
-                        newState.Privileges.Luid = this.luid;
-                        newState.Privileges.Attributes = (this.initialState ? Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_ENABLED : Interop.Advapi32.SEPrivileges.SE_PRIVILEGE_DISABLED);
-
-                        if (!Interop.Advapi32.AdjustTokenPrivileges(
-                                          this.tlsContents.ThreadHandle,
-                                          false,
-                                          &newState,
-                                          0,
-                                          null,
-                                          null))
-                        {
-                            error = Marshal.GetLastWin32Error();
-                            success = false;
-                        }
-                    }
-                }
-                finally
-                {
-                    if (success)
-                    {
-                        this.Reset();
-                    }
+                    this.Reset();
                 }
             }
 
@@ -630,35 +581,6 @@ namespace System.Security.AccessControl
                 throw new InvalidOperationException();
             }
         }
-#if false
-        public static void RunWithPrivilege( string privilege, bool enabled, PrivilegedHelper helper )
-        {
-            if ( helper == null )
-            {
-                throw new ArgumentNullException( "helper" );
-            }
-
-            Privilege p = new Privilege( privilege );
-
-            try
-            {
-                if (enabled)
-                {
-                    p.Enable();
-                }
-                else
-                {
-                    p.Disable();
-                }
-
-                helper();
-            }
-            finally
-            {
-                p.Revert();
-            }
-        }
-#endif
 
         private void Reset()
         {

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -12,8 +12,8 @@ using System.Runtime.Versioning;
 using System.Security.Principal;
 using System.Threading;
 using CultureInfo = System.Globalization.CultureInfo;
-using FCall = System.Security.Principal.Win32;
 using Luid = Interop.Advapi32.LUID;
+using static System.Security.Principal.Win32;
 
 namespace System.Security.AccessControl
 {
@@ -193,7 +193,7 @@ namespace System.Security.AccessControl
                     //
 
                     SafeTokenHandle? threadHandleBefore = this.threadHandle;
-                    error = FCall.OpenThreadToken(
+                    error = OpenThreadToken(
                                   TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges,
                                   WinSecurityContext.Process,
                                   out this.threadHandle);
@@ -230,7 +230,7 @@ namespace System.Security.AccessControl
 
                             if (success == true)
                             {
-                                error = FCall.SetThreadToken(this.threadHandle);
+                                error = SetThreadToken(this.threadHandle);
                                 unchecked { error &= ~(int)0x80070000; }
 
                                 if (error != 0)


### PR DESCRIPTION
Removed some CER related try/catches I noticed, a little dead code and some unnecessary comments.

There's still some of those try/catches, but most are in code that is also built for .NET Framework.

whitespace off https://github.com/dotnet/runtime/pull/46494/files?diff=split&w=1