### PR TITLE
Log ulimit and related values for test failures

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 usage()
 {
@@ -134,6 +134,7 @@ if [ "$(uname -s)" == "Darwin" ]; then
   if [[ ! -d "/cores" || ! "$(ls -A /cores)" ]]; then
     ulimit -c unlimited
   fi
+
 elif [ "$(uname -s)" == "Linux" ]; then
   # On Linux, we'll enable core file generation unconditionally, and if a dump
   # is generated, we will print some useful information from it and delete the
@@ -169,6 +170,11 @@ fi
 
 # ======================= BEGIN Core File Inspection =========================
 pushd $EXECUTION_DIR >/dev/null
+
+if [[ $test_exitcode -ne 0 ]]; then
+  echo ulimit -c value: $(ulimit -c)
+fi
+
 if [[ "$(uname -s)" == "Linux" && $test_exitcode -ne 0 ]]; then
   if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
      have_sleep=$(which sleep)
@@ -177,7 +183,13 @@ if [[ "$(uname -s)" == "Linux" && $test_exitcode -ne 0 ]]; then
           sleep 10s
      fi
   fi
+
+  echo cat /proc/sys/kernel/core_pattern: $(cat /proc/sys/kernel/core_pattern)
+  echo cat /proc/sys/kernel/core_uses_pid: $(cat /proc/sys/kernel/core_uses_pid)
+  echo cat /proc/sys/kernel/coredump_filter: $(cat /proc/sys/kernel/coredump_filter)
+
   echo Looking around for any Linux dump..
+
   # Depending on distro/configuration, the core files may either be named "core"
   # or "core.<PID>" by default. We read /proc/sys/kernel/core_uses_pid to
   # determine which it is.
@@ -211,3 +223,4 @@ if [ "$test_exitcode" == "1" ]; then
 else
   exit $test_exitcode
 fi
+


### PR DESCRIPTION
I want to understand why we are not getting dumps for cases like this

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-heads-master-e8d9bc08dc2441d7a0/System.IO.FileSystem.Tests/console.547b5a51.log?sv=2019-07-07&se=2021-01-06T01%3A52%3A38Z&sr=c&sp=rl&sig=DG1seb%2FgKbIzrNgJNwQwHSbwyf0EG5DTpgG8jpxfwZk%3D

```
   at System.Threading.ThreadHelper.ThreadStart(System.Object)
./RunTests.sh: line 161:    21 Aborted                 (core dumped) "$RUNTIME_PATH/dotnet" exec --runtimeconfig System.IO.FileSystem.Tests.runtimeconfig.json --depsfile System.IO.FileSystem.Tests.deps.json xunit.console.dll System.IO.FileSystem.Tests.dll -xml testResults.xml -nologo -nocolor -notrait category=IgnoreForCI -notrait category=OuterLoop -notrait category=failing $RSP_FILE
/root/helix/work/workitem
----- end Thu Dec 17 02:03:57 UTC 2020 ----- exit code 134 ----------------------------------------------------------
exit code 134 means SIGABRT Abort. Managed or native assert, or runtime check such as heap corruption, caused call to abort(). Core dumped.
Waiting a few seconds for any dump to be written..
Looking around for any Linux dump..
... found no dump in /root/helix/work/workitem
+ export '_commandExitCode=134'
```

Although we are currently setting ulimit in this file, if I understand correctly part or all of the responsibility is on Helix ([eg this](https://dnceng.visualstudio.com/internal/_search?action=contents&text=ulimit&type=code&lp=code-Project&filters=ProjectFilters%7Binternal%7DRepositoryFilters%7Bdotnet-helix-machines%7D&pageSize=25&result=DefaultCollection%2Finternal%2Fdotnet-helix-machines%2FGBmaster%2F%2Fartifacts%2FreadmeDumps.md)) so the work done in here to set these may be redundant. Still it seems like a useful place to at least log the values.