### PR TITLE
Add memory related logging to S.R.IS tests in Helix

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -14,18 +14,18 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
     public class DescriptionNameTests
     {
         // When running both inner and outer loop together, dump only once
-        private static bool dumpedRuntimeInfo = false;
+        private static bool s_dumpedRuntimeInfo = false;
 
-        private static bool isInHelix = Environment.GetEnvironmentVariables().Keys.Cast<string>().Where(key => key.StartsWith("HELIX")).Any();
+        private static readonly bool s_isInHelix = Environment.GetEnvironmentVariables().Keys.Cast<string>().Where(key => key.StartsWith("HELIX")).Any();
 
         [Fact]
         [PlatformSpecific(~TestPlatforms.Browser)] // throws PNSE when binariesLocation is not an empty string.
         public void DumpRuntimeInformationToConsole()
         {
-            if (dumpedRuntimeInfo || !isInHelix)
+            if (s_dumpedRuntimeInfo || !s_isInHelix)
                 return;
 
-            dumpedRuntimeInfo = true;
+            s_dumpedRuntimeInfo = true;
 
             // Not really a test, but useful to dump a variety of information to the test log to help
             // debug environmental issues, in particular in CI

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -130,15 +130,6 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             if (osd.Contains("Linux"))
             {
-                void OutputHandler(object sender, DataReceivedEventArgs e)
-                {
-                    string trimmed = e.Data?.Trim();
-                    if (!string.IsNullOrEmpty(trimmed) && trimmed[0] != '#') // skip comments in files
-                    {
-                        Console.WriteLine(e.Data);
-                    }
-                }
-
                 // Dump several procfs files and /etc/os-release
                 foreach (string path in new string[] { "/proc/self/mountinfo", "/proc/self/cgroup", "/proc/self/limits", "/etc/os-release", "/etc/sysctl.conf", "/proc/meminfo" })
                 {
@@ -150,7 +141,14 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                             cat.StartInfo.FileName = "cat";
                             cat.StartInfo.Arguments = path;
                             cat.StartInfo.RedirectStandardOutput = true;
-                            cat.OutputDataReceived += OutputHandler;
+                            cat.OutputDataReceived += (sender, e) =>
+                            {
+                                string trimmed = e.Data?.Trim();
+                                if (!string.IsNullOrEmpty(trimmed) && trimmed[0] != '#') // skip comments in files
+                                {
+                                    Console.WriteLine(e.Data);
+                                }
+                            };
                             cat.Start();
                             cat.BeginOutputReadLine();
                             cat.WaitForExit();


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/issues/46516. 

Adds logging related to memory -- /proc/meminfo and /etc/sysctl.cfg. Enable logging on inner loop, so it's done for all runs not just outer loop runs. Disable logging by default on dev machines as it's starting to get noisy. Skip commented lines (/etc/sysctl.cfg typically has a lot)


=== addendum ====
Given a failing Helix job, to find machine configuration you just need to find the System.Runtime.InteropServices console output for the same JobID. Eg., if the Regex tests failed in Job  "2d48e233-9b1d-41e6-b97e-d3ea04ddb6ab" then

https://engsrvprod.kusto.windows.net/engineeringdata?query=H4sIAAAAAAAEAHWQQW%2fCMAyF75X6H6ye4NA2TSsKaOwwtEnsMGlj084pMWqAOihJB0j78QtsjE5ouUSyn%2f2%2b53dt1jOHjYUwSNNP2NVoEB4UKVujhMkEpHDoVIM9zjiLMx5nJbBizPm4YAnPC%2bZfPwyuRm%2bB9K4XZ0z2QZC8NG5%2bGr7%2b19QoJLk5PIkGwTphnN0pV0M0P1hPmEQdk67UM54lLy0dUZMZOTR6O0fzoRZoz%2fUZLbVphFOakle0zkZd%2f%2fu9clMtTws9dpmXBePDQVfy3GKLV3xt5de3SQTa%2fKPQdv%2bNv9KKYK1IThQRGnjUlQVNx38mL%2fnujKBFfUpmcGnTGoW0aSN8SNM5g5%2f6vQCXxRB5nsejKpNxkeEgrkYlxjJHwQopq4GoTqNbo1e4cDDVZPUG34wKgzD4Amo36UoIAgAA&web=0

WorkItems 
| where Finished > now(-10d) and Finished < now(-1d)  
| where FriendlyName == "System.Runtime.InteropServices.RuntimeInformation.Tests"
| join kind=inner Jobs on JobId
| where Branch == "refs/heads/master"
| where JobName == "2d48e233-9b1d-41e6-b97e-d3ea04ddb6ab"
| project ConsoleUri

which gives https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-heads-master-2d48e2339b1d41e6b9/System.Runtime.InteropServices.RuntimeInformation.Tests/console.13d654c6.log?sv=2019-07-07&se=2021-01-20T11%3A42%3A44Z&sr=c&sp=rl&sig=7sh2QU0JaJBb4hS0wCjRKLuXWvvd4YqkbPWuDT4vhRo%3D which shows the configuration.
