### PR TITLE
use a different way of removing the access for the temporary test account

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -473,7 +473,7 @@ namespace System.Diagnostics.Tests
                 p = CreateProcessLong();
 
                 // ensure the new user can access the .exe (otherwise you get Access is denied exception)
-                SetAccessControl(username, p.StartInfo.FileName, AccessControlType.Allow);
+                SetAccessControl(username, p.StartInfo.FileName, true);
 
                 p.StartInfo.LoadUserProfile = true;
                 p.StartInfo.UserName = username;
@@ -500,7 +500,7 @@ namespace System.Diagnostics.Tests
             }
             finally
             {
-                SetAccessControl(username, p.StartInfo.FileName, AccessControlType.Deny); // revoke the access
+                SetAccessControl(username, p.StartInfo.FileName, false); // remove the access
 
                 Assert.Equal(Interop.ExitCodes.NERR_Success, Interop.NetUserDel(null, username));
 
@@ -516,11 +516,21 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        private static void SetAccessControl(string userName, string filePath, AccessControlType accessControlType)
+        private static void SetAccessControl(string userName, string filePath, bool add)
         {
             FileInfo fileInfo = new FileInfo(filePath);
             FileSecurity accessControl = fileInfo.GetAccessControl();
-            accessControl.AddAccessRule(new FileSystemAccessRule(userName, FileSystemRights.ReadAndExecute, accessControlType));
+            FileSystemAccessRule fileSystemAccessRule = new FileSystemAccessRule(userName, FileSystemRights.ReadAndExecute, AccessControlType.Allow);
+
+            if (add)
+            {
+                accessControl.AddAccessRule(fileSystemAccessRule);
+            }
+            else
+            {
+                accessControl.RemoveAccessRule(fileSystemAccessRule);
+            }
+
             fileInfo.SetAccessControl(accessControl);
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -473,7 +473,7 @@ namespace System.Diagnostics.Tests
                 p = CreateProcessLong();
 
                 // ensure the new user can access the .exe (otherwise you get Access is denied exception)
-                SetAccessControl(username, p.StartInfo.FileName, true);
+                SetAccessControl(username, p.StartInfo.FileName, add: true);
 
                 p.StartInfo.LoadUserProfile = true;
                 p.StartInfo.UserName = username;
@@ -500,7 +500,7 @@ namespace System.Diagnostics.Tests
             }
             finally
             {
-                SetAccessControl(username, p.StartInfo.FileName, false); // remove the access
+                SetAccessControl(username, p.StartInfo.FileName, add: false); // remove the access
 
                 Assert.Equal(Interop.ExitCodes.NERR_Success, Interop.NetUserDel(null, username));
 


### PR DESCRIPTION
@danmosemsft  Based on what I can see in Kusto my previous PR (#46213) has not solved the problem and this test has failed 140 times since the 25th of December.

I've changed the logic to use `RemoveAccessRule` instead of adding a new `AccessControlType.Deny` rule

fixes #46208