### PR TITLE
Improve msg for corrupted perf counters

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/Resources/Strings.resx
@@ -120,13 +120,13 @@
     <value>Invalid value '{1}' for parameter '{0}'.</value>
   </data>
   <data name="CategoryHelpCorrupt" xml:space="preserve">
-    <value>Cannot load Category Help data because an invalid index '{0}' was read from the registry. Performance counters on '{1}' may need to be repaired.</value>
+    <value>Cannot load Category Help data because an invalid index '{0}' was read from the registry. Performance counters on the machine may need to be repaired.</value>
   </data>
   <data name="CounterNameCorrupt" xml:space="preserve">
-    <value>Cannot load Counter Name data because an invalid index '{0}' was read from the registry. Performance counters on '{1}' may need to be repaired.</value>
+    <value>Cannot load Counter Name data because an invalid index '{0}' was read from the registry. Performance counters on the machine may need to be repaired.</value>
   </data>
   <data name="CounterDataCorrupt" xml:space="preserve">
-    <value>Cannot load Performance Counter data because an unexpected registry key value type was read from '{0}'. Performance counters on '{1}' may need to be repaired.</value>
+    <value>Cannot load Performance Counter data because an unexpected registry key value type was read from '{0}'. Performance counters on the machine may need to be repaired.</value>
   </data>
   <data name="InstanceNameTooLong" xml:space="preserve">
     <value>Instance names used for writing to custom counters must be 127 characters or less.</value>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/Resources/Strings.resx
@@ -120,13 +120,13 @@
     <value>Invalid value '{1}' for parameter '{0}'.</value>
   </data>
   <data name="CategoryHelpCorrupt" xml:space="preserve">
-    <value>Cannot load Category Help data because an invalid index '{0}' was read from the registry.</value>
+    <value>Cannot load Category Help data because an invalid index '{0}' was read from the registry. Performance counters on '{1}' may need to be repaired.</value>
   </data>
   <data name="CounterNameCorrupt" xml:space="preserve">
-    <value>Cannot load Counter Name data because an invalid index '{0}' was read from the registry.</value>
+    <value>Cannot load Counter Name data because an invalid index '{0}' was read from the registry. Performance counters on '{1}' may need to be repaired.</value>
   </data>
   <data name="CounterDataCorrupt" xml:space="preserve">
-    <value>Cannot load Performance Counter data because an unexpected registry key value type was read from '{0}'.</value>
+    <value>Cannot load Performance Counter data because an unexpected registry key value type was read from '{0}'. Performance counters on '{1}' may need to be repaired.</value>
   </data>
   <data name="InstanceNameTooLong" xml:space="preserve">
     <value>Instance names used for writing to custom counters must be 127 characters or less.</value>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -1112,12 +1112,12 @@ namespace System.Diagnostics
                             if (isHelp)
                             {
                                 // Category Help Table
-                                throw new InvalidOperationException(SR.Format(SR.CategoryHelpCorrupt, names[index * 2], _machineName));
+                                throw new InvalidOperationException(SR.Format(SR.CategoryHelpCorrupt, names[index * 2]));
                             }
                             else
                             {
                                 // Counter Name Table
-                                throw new InvalidOperationException(SR.Format(SR.CounterNameCorrupt, names[index * 2], _machineName));
+                                throw new InvalidOperationException(SR.Format(SR.CounterNameCorrupt, names[index * 2]));
                             }
                         }
 
@@ -1364,7 +1364,7 @@ namespace System.Diagnostics
                 }
                 catch (InvalidCastException e)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.CounterDataCorrupt, perfDataKey.ToString(), machineName), e);
+                    throw new InvalidOperationException(SR.Format(SR.CounterDataCorrupt, perfDataKey.ToString()), e);
                 }
             }
 

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -1112,12 +1112,12 @@ namespace System.Diagnostics
                             if (isHelp)
                             {
                                 // Category Help Table
-                                throw new InvalidOperationException(SR.Format(SR.CategoryHelpCorrupt, names[index * 2]));
+                                throw new InvalidOperationException(SR.Format(SR.CategoryHelpCorrupt, names[index * 2], _machineName));
                             }
                             else
                             {
                                 // Counter Name Table
-                                throw new InvalidOperationException(SR.Format(SR.CounterNameCorrupt, names[index * 2]));
+                                throw new InvalidOperationException(SR.Format(SR.CounterNameCorrupt, names[index * 2], _machineName));
                             }
                         }
 
@@ -1364,7 +1364,7 @@ namespace System.Diagnostics
                 }
                 catch (InvalidCastException e)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.CounterDataCorrupt, perfDataKey.ToString()), e);
+                    throw new InvalidOperationException(SR.Format(SR.CounterDataCorrupt, perfDataKey.ToString(), machineName), e);
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/38756

All these failures have been on a single machine, which is now being paved. Also make the message clearer -- right now it looks like we have a bug, whereas this may happen because of corruption. Hopefully this message will help lead folks to  https://support.microsoft.com/en-us/help/2554336/how-to-manually-rebuild-performance-counters-for-windows-server-2008-6.