### PR TITLE
Fix setting timeout too early for QuicConnectionlistener

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -54,7 +54,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         });
 
         // constructor for inbound connections
-        public MsQuicConnection(IPEndPoint localEndPoint, IPEndPoint remoteEndPoint, IntPtr nativeObjPtr)
+        public MsQuicConnection(IPEndPoint localEndPoint, IPEndPoint remoteEndPoint, IntPtr nativeObjPtr, TimeSpan idleTimeout)
         {
             _localEndPoint = localEndPoint;
             _remoteEndPoint = remoteEndPoint;
@@ -62,6 +62,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             _connected = true;
 
             SetCallbackHandler();
+
+            SetIdleTimeout(idleTimeout);
         }
 
         // constructor for outbound connections

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -50,9 +50,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             _sslOptions = options.ServerAuthenticationOptions!;
             _listenEndPoint = options.ListenEndPoint!;
 
-            SetIdleTimeout(options.IdleTimeout);
-
             _ptr = _session.ListenerOpen(options);
+
+            SetIdleTimeout(options.IdleTimeout);
         }
 
         internal override IPEndPoint ListenEndPoint

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -51,8 +51,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             _listenEndPoint = options.ListenEndPoint!;
 
             _ptr = _session.ListenerOpen(options);
-
-            SetIdleTimeout(options.IdleTimeout);
         }
 
         internal override IPEndPoint ListenEndPoint
@@ -141,11 +139,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             SetListenPort();
         }
 
-        private void SetIdleTimeout(TimeSpan timeout)
-        {
-            MsQuicParameterHelpers.SetULongParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.LISTENER, (uint)QUIC_PARAM_CONN.IDLE_TIMEOUT, (ulong)timeout.TotalMilliseconds);
-        }
-
         internal override void Close()
         {
             ThrowIfDisposed();
@@ -173,7 +166,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                             IPEndPoint localEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(ref *(SOCKADDR_INET*)connectionInfo.LocalAddress);
                             IPEndPoint remoteEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(ref *(SOCKADDR_INET*)connectionInfo.RemoteAddress);
 
-                            MsQuicConnection msQuicConnection = new MsQuicConnection(localEndPoint, remoteEndPoint, evt.Data.NewConnection.Connection);
+                            MsQuicConnection msQuicConnection = new MsQuicConnection(localEndPoint, remoteEndPoint, evt.Data.NewConnection.Connection, _options.IdleTimeout);
                             msQuicConnection.SetNegotiatedAlpn(connectionInfo.NegotiatedAlpn, connectionInfo.NegotiatedAlpnLength);
 
                             _acceptConnectionQueue.Writer.TryWrite(msQuicConnection);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -56,6 +56,33 @@ namespace System.Net.Quic.Tests
             Assert.Equal(100, serverConnection.GetRemoteAvailableUnidirectionalStreamCount());
         }
 
+        [Fact]
+        [OuterLoop("May take serveral seconds")]
+        public async Task SetListenerTimeoutWorksWithSmallTimeout()
+        {
+            var quicOptions = new QuicListenerOptions();
+            quicOptions.IdleTimeout = TimeSpan.FromSeconds(10);
+            quicOptions.ServerAuthenticationOptions = GetSslServerAuthenticationOptions();
+            quicOptions.ListenEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+
+            using QuicListener listener = new QuicListener(QuicImplementationProviders.MsQuic, quicOptions);
+            listener.Start();
+
+            QuicClientConnectionOptions options = new QuicClientConnectionOptions()
+            {
+                RemoteEndPoint = listener.ListenEndPoint,
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions(),
+                //IdleTimeout = TimeSpan.FromSeconds(10)
+            };
+
+            using QuicConnection clientConnection = new QuicConnection(QuicImplementationProviders.MsQuic, options);
+            ValueTask clientTask = clientConnection.ConnectAsync();
+            using QuicConnection serverConnection = await listener.AcceptConnectionAsync();
+            await clientTask;
+
+            await Assert.ThrowsAsync<QuicOperationAbortedException>(async () => await serverConnection.AcceptStreamAsync().TimeoutAfter(100000));
+        }
+
         [Theory]
         [MemberData(nameof(WriteData))]
         public async Task WriteTests(int[][] writes, WriteType writeType)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -72,7 +72,6 @@ namespace System.Net.Quic.Tests
             {
                 RemoteEndPoint = listener.ListenEndPoint,
                 ClientAuthenticationOptions = GetSslClientAuthenticationOptions(),
-                //IdleTimeout = TimeSpan.FromSeconds(10)
             };
 
             using QuicConnection clientConnection = new QuicConnection(QuicImplementationProviders.MsQuic, options);


### PR DESCRIPTION
https://github.com/jkotalik/runtime/commit/c2d8435e1e752c09c8044410511772eaf5d6060a#diff-6d3fe858ef1f16865f1d2fa64570caea09ef45cd4836e45a66006603de33d76e had an issue where it says we are getting an invalid parameter when calling the API. Attempt to fix via calling SetTimeout later.

I'm also hitting an issue where I can't build runtime locally with package restore failures for xunit. I'm running
```
.\build.cmd clr+libs -rc Release
.\build.cmd -vs System.Net.Quic
```

and I'm hitting issues with it in VS restoring xunit