### PR TITLE
Disable TC for UnmanagedCallersOnly methods.

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -13024,22 +13024,6 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
 
     flags = GetCompileFlags(ftn, flags, &methodInfo);
 
-#ifdef FEATURE_TIERED_COMPILATION
-    // Clearing all tier flags and mark as optimized if the reverse P/Invoke
-    // flag is used and the function is eligible.
-    if (flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE)
-        && ftn->IsEligibleForTieredCompilation())
-    {
-        _ASSERTE(config->GetCallerGCMode() != CallerGCMode::Coop);
-
-        // Clear all possible states.
-        flags.Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
-        flags.Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER1);
-
-        config->SetJitSwitchedToOptimized();
-    }
-#endif // FEATURE_TIERED_COMPILATION
-
 #ifdef _DEBUG
     if (!flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_SKIP_VERIFICATION))
     {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -6820,7 +6820,7 @@ void CEEInfo::setMethodAttribs (
                 // UnmanagedCallersOnly methods that are switched to optimized must be optimized.
                 // Otherwise, tiered compilation will kick back in and try to tier them, which
                 // causes instability.
-                if (config->JitSwitchedToOptimized() && !ftn->HasUnmanagedCallersOnlyAttribute())
+                if (!config->JitSwitchedToOptimized() && !ftn->HasUnmanagedCallersOnlyAttribute())
                 {
                     config->SetJitSwitchedToMinOpt();
                 }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -6817,13 +6817,7 @@ void CEEInfo::setMethodAttribs (
             if (attribs & CORINFO_FLG_SWITCHED_TO_MIN_OPT)
             {
                 _ASSERTE(!ftn->IsJitOptimizationDisabled());
-                // UnmanagedCallersOnly methods that are switched to optimized must be optimized.
-                // Otherwise, tiered compilation will kick back in and try to tier them, which
-                // causes instability.
-                if (config->JitSwitchedToOptimized() && !ftn->HasUnmanagedCallersOnlyAttribute())
-                {
-                    config->SetJitSwitchedToMinOpt();
-                }
+                config->SetJitSwitchedToMinOpt();
             }
 #ifdef FEATURE_TIERED_COMPILATION
             else if (attribs & CORINFO_FLG_SWITCHED_TO_OPTIMIZED)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -6817,7 +6817,13 @@ void CEEInfo::setMethodAttribs (
             if (attribs & CORINFO_FLG_SWITCHED_TO_MIN_OPT)
             {
                 _ASSERTE(!ftn->IsJitOptimizationDisabled());
-                config->SetJitSwitchedToMinOpt();
+                // UnmanagedCallersOnly methods that are switched to optimized must be optimized.
+                // Otherwise, tiered compilation will kick back in and try to tier them, which
+                // causes instability.
+                if (config->JitSwitchedToOptimized() && !ftn->HasUnmanagedCallersOnlyAttribute())
+                {
+                    config->SetJitSwitchedToMinOpt();
+                }
             }
 #ifdef FEATURE_TIERED_COMPILATION
             else if (attribs & CORINFO_FLG_SWITCHED_TO_OPTIMIZED)

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -139,10 +139,10 @@ SIZE_T MethodDesc::SizeOf()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    SIZE_T size = s_ClassificationSizeTable[m_wFlags & 
-        (mdcClassification 
-        | mdcHasNonVtableSlot 
-        | mdcMethodImpl 
+    SIZE_T size = s_ClassificationSizeTable[m_wFlags &
+        (mdcClassification
+        | mdcHasNonVtableSlot
+        | mdcMethodImpl
 #ifdef FEATURE_COMINTEROP
         | mdcHasComPlusCallInfo
 #endif
@@ -151,7 +151,7 @@ SIZE_T MethodDesc::SizeOf()
 #ifdef FEATURE_PREJIT
     if (HasNativeCodeSlot())
     {
-        size += (*dac_cast<PTR_TADDR>(GetAddrOfNativeCodeSlot()) & FIXUP_LIST_MASK) ? 
+        size += (*dac_cast<PTR_TADDR>(GetAddrOfNativeCodeSlot()) & FIXUP_LIST_MASK) ?
             sizeof(FixupListSlot) : 0;
     }
 #endif
@@ -4866,7 +4866,11 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
         !IsJitOptimizationDisabled() &&
 
         // Policy - Tiered compilation is not disabled by the profiler
-        !CORProfilerDisableTieredCompilation())
+        !CORProfilerDisableTieredCompilation() &&
+
+        // Functional requirement - UnmanagedCallersOnly methods exit in Preemptive GC, which is incompatible with
+        // the lifetime management used for tiered compilation call counting today.
+        !HasUnmanagedCallersOnlyAttribute())
     {
         m_bFlags2 |= enum_flag2_IsEligibleForTieredCompilation;
         _ASSERTE(IsVersionable());

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -4866,11 +4866,7 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
         !IsJitOptimizationDisabled() &&
 
         // Policy - Tiered compilation is not disabled by the profiler
-        !CORProfilerDisableTieredCompilation() &&
-
-        // Functional requirement - UnmanagedCallersOnly methods exit in Preemptive GC, which is incompatible with
-        // the lifetime management used for tiered compilation call counting today.
-        !HasUnmanagedCallersOnlyAttribute())
+        !CORProfilerDisableTieredCompilation())
     {
         m_bFlags2 |= enum_flag2_IsEligibleForTieredCompilation;
         _ASSERTE(IsVersionable());

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2023,16 +2023,23 @@ public:
 
 private:
     PCODE PrepareILBasedCode(PrepareCodeConfig* pConfig);
+#ifdef FEATURE_TIERED_COMPILATION
+    PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldCountCalls);
+    PCODE JitCompileCode(PrepareCodeConfig* pConfig, bool shouldCountCalls);
+    PCODE JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, bool shouldCountCalls);
+    PCODE JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pLockEntry, bool shouldCountCalls, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags);
+#else
     PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig);
+    PCODE JitCompileCode(PrepareCodeConfig* pConfig);
+    PCODE JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry);
+    PCODE JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pLockEntry, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags);
+#endif
     PCODE GetPrecompiledNgenCode(PrepareCodeConfig* pConfig);
     PCODE GetPrecompiledR2RCode(PrepareCodeConfig* pConfig);
     PCODE GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0Jit);
     COR_ILMETHOD_DECODER* GetAndVerifyILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyMetadataILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyNoMetadataILHeader();
-    PCODE JitCompileCode(PrepareCodeConfig* pConfig);
-    PCODE JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry);
-    PCODE JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pLockEntry, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags);
 #endif // DACCESS_COMPILE
 
 #ifdef HAVE_GCCOVER

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2144,10 +2144,12 @@ public:
         return m_shouldCountCalls;
     }
 
-    void SetShouldCountCalls(bool value = true)
+    void SetShouldCountCalls()
     {
         WRAPPER_NO_CONTRACT;
-        m_shouldCountCalls = value;
+        _ASSERTE(!m_shouldCountCalls);
+
+        m_shouldCountCalls = true;
     }
 #endif
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2137,12 +2137,10 @@ public:
         return m_shouldCountCalls;
     }
 
-    void SetShouldCountCalls()
+    void SetShouldCountCalls(bool value = true)
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(!m_shouldCountCalls);
-
-        m_shouldCountCalls = true;
+        m_shouldCountCalls = value;
     }
 #endif
 
@@ -3611,7 +3609,7 @@ public:
 #ifdef FEATURE_PREJIT
         if (HasNativeCodeSlot())
         {
-            size += (*dac_cast<PTR_TADDR>(GetAddrOfNativeCodeSlot()) & FIXUP_LIST_MASK) ? 
+            size += (*dac_cast<PTR_TADDR>(GetAddrOfNativeCodeSlot()) & FIXUP_LIST_MASK) ?
                 sizeof(FixupListSlot) : 0;
         }
 #endif

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -361,6 +361,19 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     STANDARD_VM_CONTRACT;
     PCODE pCode = NULL;
 
+#if defined(FEATURE_TIERED_COMPILATION)
+    bool shouldCountCalls = pConfig->GetMethodDesc()->IsEligibleForTieredCompilation();
+#if !defined(TARGET_X86)
+    if (shouldCountCalls
+        && (pConfig->GetCallerGCMode() == CallerGCMode::Preemptive
+            || (pConfig->GetCallerGCMode() == CallerGCMode::Unknown
+                && HasUnmanagedCallersOnlyAttribute())))
+    {
+        shouldCountCalls = false;
+    }
+#endif
+#endif
+
     if (pConfig->MayUsePrecompiledCode())
     {
 #ifdef FEATURE_READYTORUN
@@ -393,7 +406,13 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
 #endif // FEATURE_READYTORUN
 
         if (pCode == NULL)
+        {
+#ifdef FEATURE_TIERED_COMPILATION
+            pCode = GetPrecompiledCode(pConfig, shouldCountCalls);
+#else
             pCode = GetPrecompiledCode(pConfig);
+#endif
+        }
 
 #ifdef FEATURE_PERFMAP
         if (pCode != NULL)
@@ -405,23 +424,17 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     {
         LOG((LF_CLASSLOADER, LL_INFO1000000,
             "    In PrepareILBasedCode, calling JitCompileCode\n"));
-        pCode = JitCompileCode(pConfig);
+
+#ifdef FEATURE_TIERED_COMPILATION
+            pCode = JitCompileCode(pConfig, shouldCountCalls);
+#else
+            pCode = JitCompileCode(pConfig);
+#endif
     }
     else
     {
         DACNotifyCompilationFinished(this, pCode);
     }
-
-#if defined(FEATURE_TIERED_COMPILATION) && !defined(TARGET_X86)
-    if (pConfig->ShouldCountCalls()
-        && (pConfig->GetCallerGCMode() == CallerGCMode::Preemptive
-            || (pConfig->GetCallerGCMode() == CallerGCMode::Unknown
-                && HasUnmanagedCallersOnlyAttribute())))
-    {
-        // We can't count calls for UnmanagedCallersOnly methods due to GC mode issues.
-        pConfig->SetShouldCountCalls(false);
-    }
-#endif
 
     // Mark the code as hot in case the method ends up in the native image
     g_IBCLogger.LogMethodCodeAccess(this);
@@ -429,7 +442,11 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     return pCode;
 }
 
+#ifdef FEATURE_TIERED_COMPILATION
+PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldCountCalls)
+#else
 PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
+#endif
 {
     STANDARD_VM_CONTRACT;
     PCODE pCode = NULL;
@@ -452,37 +469,13 @@ PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
         {
             LOG_USING_R2R_CODE(this);
 
-#ifdef FEATURE_TIERED_COMPILATION
-            bool shouldTier = pConfig->GetMethodDesc()->IsEligibleForTieredCompilation();
-#if !defined(TARGET_X86)
-            CallerGCMode callerGcMode = pConfig->GetCallerGCMode();
-            // If the method is eligible for tiering but is being
-            // called from a Preemptive GC Mode thread or the method
-            // has the UnmanagedCallersOnlyAttribute then the Tiered Compilation
-            // should be disabled.
-            if (shouldTier
-                && (callerGcMode == CallerGCMode::Preemptive
-                    || (callerGcMode == CallerGCMode::Unknown
-                        && HasUnmanagedCallersOnlyAttribute())))
-            {
-                NativeCodeVersion codeVersion = pConfig->GetCodeVersion();
-                if (codeVersion.IsDefaultVersion())
-                {
-                    pConfig->GetMethodDesc()->GetLoaderAllocator()->GetCallCountingManager()->DisableCallCounting(codeVersion);
-                }
-                codeVersion.SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
-                shouldTier = false;
-            }
-#endif  // !TARGET_X86
-#endif // FEATURE_TIERED_COMPILATION
-
             if (pConfig->SetNativeCode(pCode, &pCode))
             {
 #ifdef FEATURE_CODE_VERSIONING
                 pConfig->SetGeneratedOrLoadedNewCode();
 #endif
 #ifdef FEATURE_TIERED_COMPILATION
-                if (shouldTier)
+                if (shouldCountCalls)
                 {
                     _ASSERTE(pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
                     pConfig->SetShouldCountCalls();
@@ -721,8 +714,11 @@ COR_ILMETHOD_DECODER* MethodDesc::GetAndVerifyILHeader(PrepareCodeConfig* pConfi
 //
 // This function creates a DeadlockAware list of methods being jitted
 // which prevents us from trying to JIT the same method more that once.
-
+#ifdef FEATURE_TIERED_COMPILATION
+PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig, bool shouldCountCalls)
+#else
 PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
+#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -815,7 +811,7 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
                 {
                 #ifdef FEATURE_TIERED_COMPILATION
                     // Finalize the optimization tier before SetNativeCode() is called
-                    bool shouldCountCalls = wasTier0Jit && pConfig->FinalizeOptimizationTierForTier0Jit();
+                    shouldCountCalls = wasTier0Jit && pConfig->FinalizeOptimizationTierForTier0Jit() && shouldCountCalls;
                 #endif
 
                     if (pConfig->SetNativeCode(pCode, &pCode))
@@ -835,12 +831,20 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
                 }
             }
 
+#ifdef FEATURE_TIERED_COMPILATION
+            return JitCompileCodeLockedEventWrapper(pConfig, pEntryLock, shouldCountCalls);
+#else
             return JitCompileCodeLockedEventWrapper(pConfig, pEntryLock);
+#endif
         }
     }
 }
 
+#ifdef FEATURE_TIERED_COMPILATION
+PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, bool shouldCountCalls)
+#else
 PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry)
+#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -895,7 +899,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
         TRACE_LEVEL_VERBOSE,
         CLR_JIT_KEYWORD))
     {
+#ifdef FEATURE_TIERED_COMPILATION
+        pCode = JitCompileCodeLocked(pConfig, pEntry, shouldCountCalls, &sizeOfCode, &flags);
+#else
         pCode = JitCompileCodeLocked(pConfig, pEntry, &sizeOfCode, &flags);
+#endif
     }
     else
     {
@@ -915,7 +923,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
             &methodSignature);
 #endif
 
+#ifdef FEATURE_TIERED_COMPILATION
+        pCode = JitCompileCodeLocked(pConfig, pEntry, shouldCountCalls, &sizeOfCode, &flags);
+#else
         pCode = JitCompileCodeLocked(pConfig, pEntry, &sizeOfCode, &flags);
+#endif
 
         // Interpretted methods skip this notification
 #ifdef FEATURE_INTERPRETER
@@ -1005,7 +1017,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
     return pCode;
 }
 
+#ifdef FEATURE_TIERED_COMPILATION
+PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, bool shouldCountCalls, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags)
+#else
 PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags)
+#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -1018,6 +1034,23 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     COR_ILMETHOD_DECODER ilDecoderTemp;
     COR_ILMETHOD_DECODER *pilHeader = GetAndVerifyILHeader(pConfig, &ilDecoderTemp);
     *pFlags = pConfig->GetJitCompilationFlags();
+
+#ifdef FEATURE_TIERED_COMPILATION
+    bool isTier0 = pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
+    // If we've already opted-out of call counting, for example in the UnmangedCallersOnly case,
+    // switch to optimized code.
+    if (!shouldCountCalls)
+    {
+        pFlags->Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
+        pFlags->Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER1);
+
+        if (pConfig->GetMethodDesc()->IsEligibleForTieredCompilation())
+        {
+            pConfig->SetJitSwitchedToOptimized();
+        }
+    }
+#endif
+
     PCODE pOtherCode = NULL;
 
     EX_TRY
@@ -1085,7 +1118,7 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
 
 #ifdef FEATURE_TIERED_COMPILATION
     // Finalize the optimization tier before SetNativeCode() is called
-    bool shouldCountCalls = pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0) && pConfig->FinalizeOptimizationTierForTier0Jit();
+    shouldCountCalls = isTier0 && pConfig->FinalizeOptimizationTierForTier0Jit() && shouldCountCalls;
 #endif
 
     // Aside from rejit, performing a SetNativeCodeInterlocked at this point

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -412,6 +412,17 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
         DACNotifyCompilationFinished(this, pCode);
     }
 
+#if defined(FEATURE_TIERED_COMPILATION) && !defined(TARGET_X86)
+    if (pConfig->ShouldCountCalls()
+        && (pConfig->GetCallerGCMode() == CallerGCMode::Preemptive
+            || (pConfig->GetCallerGCMode() == CallerGCMode::Unknown
+                && HasUnmanagedCallersOnlyAttribute())))
+    {
+        // We can't count calls for UnmanagedCallersOnly methods due to GC mode issues.
+        pConfig->SetShouldCountCalls(false);
+    }
+#endif
+
     // Mark the code as hot in case the method ends up in the native image
     g_IBCLogger.LogMethodCodeAccess(this);
 


### PR DESCRIPTION
Tiered compilation uses call counting and the call counting mechanism today is incompatible with UnmanagedCallersOnly. Disabled tiered compilation for UnmanagedCallersOnly methods.

Fixes #46512