### PR TITLE
Fix createdump fault in diagnostic tests

### DIFF
--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -542,9 +542,12 @@ HRESULT ClrDataAccess::DumpManagedExcepObject(CLRDataEnumMemoryFlags flags, OBJE
             PCODE addr = pMD->GetNativeCode();
             if (addr != NULL)
             {
-                IJitManager::MethodRegionInfo methodRegionInfo = { NULL, 0, NULL, 0 };
                 EECodeInfo codeInfo(addr);
-                codeInfo.GetMethodRegionInfo(&methodRegionInfo);
+                if (codeInfo.IsValid())
+                {
+                    IJitManager::MethodRegionInfo methodRegionInfo = { NULL, 0, NULL, 0 };
+                    codeInfo.GetMethodRegionInfo(&methodRegionInfo);
+                }
             }
         }
 


### PR DESCRIPTION
Createdump was faulting in the DAC memory enumeration API during the diagnostics repo tests. During the managed exception object enumeration there was an invalid EECodeInfo that was being created that caused this fault. Added a EECodeInfo::IsValid() check around the usage.