### PR TITLE
Remove StartupHooks ILLink warning suppressions from shared file

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.StartupHookProvider.ProcessStartupHooks()</property>
+      <property name="Justification">This warning is left in the product so developers get an ILLink warning when trimming an app with System.StartupHookProvider.IsSupported=true.</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
@@ -21,12 +21,6 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.StartupHookProvider.ProcessStartupHooks()</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2050</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Runtime.InteropServices.Marshal.BindMoniker(System.Runtime.InteropServices.ComTypes.IMoniker,System.UInt32,System.Guid@,System.Object@)</property>
@@ -138,12 +132,6 @@
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Diagnostics.Tracing.ManifestBuilder.CreateManifestString</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.StartupHookProvider.CallStartupHook(System.StartupHookProvider.StartupHookNameOrPath)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -62,7 +62,6 @@
 
     <PropertyGroup>
       <ProjectILLinkSuppressionsFile>src\ILLink\ILLink.Suppressions</ProjectILLinkSuppressionsFile>
-      <CoreLibSharedILLinkSuppressionsFilesPrefix>$(CoreLibSharedDir)ILLink\ILLink.Suppressions.Shared</CoreLibSharedILLinkSuppressionsFilesPrefix>
     </PropertyGroup>
 
     <ItemGroup>
@@ -70,7 +69,8 @@
       <_SuppressionsXmls Include="$(ILLinkTrimAssemblySuppressionsXmlsDir)*.xml" />
 
       <!-- Collate CoreLib suppression XML files not bin-placed in earlier per-library linker run. CoreLib doesn't use bin-place logic. -->
-      <_SuppressionsXmls Include="$(CoreLibSharedILLinkSuppressionsFilesPrefix).xml" />
+      <_SuppressionsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.Shared.xml" />
+      <_SuppressionsXmls Condition="'$(RuntimeFlavor)' == 'CoreCLR'" Include="$(CoreClrProjectRoot)System.Private.CoreLib\$(ProjectILLinkSuppressionsFile).LibraryBuild.xml" />
 
       <!-- netstandard2.1-only System.ComponentModel.Annotations XML file is not bin-placed during -allConfigurations builds
            due to the linker not being run on the assembly (eng\illink.targets). Manually include it. -->


### PR DESCRIPTION
One suppression is needed going forward in order for developers to get a warning if they trim apps with StartupHookProvider.IsSupported=true.

Contributes to #45623