### PR TITLE
Add recursion / thread interaction guard in LogInfoForFatalError

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -348,6 +348,14 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
 {
     WRAPPER_NO_CONTRACT;
 
+    static volatile LONG s_recursionGuard = 0;
+
+    if (::InterlockedCompareExchange(&s_recursionGuard, 1, 0) != 0)
+    {
+        PrintToStdErrA("Repeated call to LogInfoForFatalError skipped to avoid infinite recursion and interaction between crashing threads.");
+        return;
+    }
+
     Thread *pThread = GetThread();
     EX_TRY
     {

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -348,26 +348,28 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
 {
     WRAPPER_NO_CONTRACT;
 
-    static volatile LONG s_crashingThreadId = 0;
+    static Thread *const FatalErrorNotSeenYet = nullptr;
+    static Thread *const FatalErrorLoggingFinished = reinterpret_cast<Thread *>(1);
 
-    LONG currentThread = GetCurrentThreadId();
-    LONG previousThread = ::InterlockedCompareExchange(&s_crashingThreadId, currentThread, 0);
-
-    if (previousThread == currentThread)
-    {
-        PrintToStdErrA("Repeated fatal crash ignored to avoid infinite recursion.\n");
-        return;
-    }
-    else if (previousThread != 0)
-    {
-        PrintToStdErrA("Fatal crash detected on another thread, waiting for termination...\n");
-        for (;;)
-        {
-            ClrSleepEx(1000, /*bAlertable*/ FALSE);
-        }
-    }
+    static Thread *volatile s_pCrashingThread = FatalErrorNotSeenYet;
 
     Thread *pThread = GetThread();
+    Thread *pPreviousThread = InterlockedCompareExchangeT<Thread *>(&s_pCrashingThread, pThread, FatalErrorNotSeenYet);
+
+    if (pPreviousThread == pThread)
+    {
+        PrintToStdErrA("Fatal error while logging another fatal error.\n");
+        return;
+    }
+    else if (pPreviousThread != nullptr)
+    {
+        while (s_pCrashingThread != FatalErrorLoggingFinished)
+        {
+            ClrSleepEx(50, /*bAlertable*/ FALSE);
+        }
+        return;
+    }
+
     EX_TRY
     {
         if (exitCode == (UINT)COR_E_FAILFAST)
@@ -412,6 +414,8 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     {
     }
     EX_END_CATCH(SwallowAllExceptions)
+    
+    InterlockedCompareExchangeT<Thread *>(&s_pCrashingThread, FatalErrorLoggingFinished, pThread);
 }
 
 //This starts FALSE and then converts to true if HandleFatalError has ever been called by a GC thread

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -352,7 +352,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
 
     if (::InterlockedCompareExchange(&s_recursionGuard, 1, 0) != 0)
     {
-        PrintToStdErrA("Repeated call to LogInfoForFatalError skipped to avoid infinite recursion and interaction between crashing threads.");
+        PrintToStdErrA("Repeated fatal crash skipped to avoid infinite recursion and interaction between crashing threads.");
         return;
     }
 

--- a/src/tests/baseservices/exceptions/simple/ParallelCrash.cs
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrash.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+// Runtime stability in the presence of concurrent fatal errors
+
+public class ParallelCrash
+{
+    private const int ThreadCount = 10;
+
+    private volatile static int _runningThreads;
+
+    public static int Main()
+    {
+        Thread[] threadMap = new Thread[ThreadCount];
+        for (int threadIndex = 0; threadIndex < ThreadCount; threadIndex++)
+        {
+            Thread thread = new Thread(new ThreadStart(CrashInParallel));
+            threadMap[threadIndex] = thread;
+            thread.Start();
+        }
+        for (;;)
+        {
+            Thread.Sleep(1000);
+        }
+        return 0;
+    }
+
+    private static void CrashInParallel()
+    {
+        int threadIndex = ++_runningThreads;
+        string failFastMessage = string.Format("Parallel crash in thread {0}!\n", threadIndex);
+        while (_runningThreads != ThreadCount)
+        {
+        }
+        // Now all the worker threads should be running, fire!
+        Environment.FailFast(failFastMessage);
+    }
+}

--- a/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestExitCode>-2146232797</CLRTestExitCode>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ParallelCrash.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
@@ -3,7 +3,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestExitCode>-2146232797</CLRTestExitCode>
+    <CLRTestExitCode>134</CLRTestExitCode>
+    <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146232797</CLRTestExitCode>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ParallelCrash.cs" />

--- a/src/tests/baseservices/exceptions/simple/ParallelCrashMainThread.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashMainThread.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestKind>RunOnly</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestProjectToRun>ParallelCrash.csproj</CLRTestProjectToRun>
+    <CLRTestExecutionArguments>1</CLRTestExecutionArguments>
     <CLRTestExitCode>-2146232797</CLRTestExitCode>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="ParallelCrash.cs" />
-  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/simple/ParallelCrashMainThread.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashMainThread.csproj
@@ -4,6 +4,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ParallelCrash.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>1</CLRTestExecutionArguments>
-    <CLRTestExitCode>-2146232797</CLRTestExitCode>
+    <CLRTestExitCode>134</CLRTestExitCode>
+    <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146232797</CLRTestExitCode>
   </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/simple/ParallelCrashWorkerThreads.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashWorkerThreads.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestKind>RunOnly</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestProjectToRun>ParallelCrash.csproj</CLRTestProjectToRun>
+    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
     <CLRTestExitCode>-2146232797</CLRTestExitCode>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="ParallelCrash.cs" />
-  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/simple/ParallelCrashWorkerThreads.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashWorkerThreads.csproj
@@ -4,6 +4,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ParallelCrash.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
-    <CLRTestExitCode>-2146232797</CLRTestExitCode>
+    <CLRTestExitCode>134</CLRTestExitCode>
+    <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146232797</CLRTestExitCode>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Based on local instrumentation I introduced while investigating
issues related to the switch-over to compile System.Private.CoreLib
using Crossgen2 I'm proposing to harden fatal exception handling
against nested and concurrent fatal error occurrences.

Thanks

Tomas