### PR TITLE
Increase timeout for ProcessWaitingTests.WaitAsyncForSignal

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -449,7 +449,7 @@ namespace System.Diagnostics.Tests
         {
             const string expectedSignal = "Signal";
             const string successResponse = "Success";
-            const int timeout = 5 * 1000;
+            const int timeout = 30 * 1000; // 30 seconds, to allow for very slow machines
 
             using Process p = CreateProcessPortable(RemotelyInvokable.WriteLineReadLine);
             p.StartInfo.RedirectStandardInput = true;


### PR DESCRIPTION
This should fix this timeout
```
net6.0-Linux-Debug-x64-CoreCLR_release-Ubuntu.1804.Amd64.Open
System.Threading.Tasks.TaskCanceledException : A task was canceled.
Stack trace
   at System.Diagnostics.Process.WaitForExitAsync(CancellationToken cancellationToken) in /_/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs:line 1478
   at System.Diagnostics.Tests.ProcessWaitingTests.WaitAsyncForSignal() in /_/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs:line 490
--- End of stack trace from previous location ---
```

I notice I already made this exact change on the test above, but the change that added _this_ test probably started before that and finished after it so it never got the increased timeout.

All other timeouts in these tests seem reasonable.

And thus is demonstrated Dans First Law Of Running Tests In Helix -- never underestimate the possibility of hitting the longest tail of possibilities when you run tests sufficiently many times a day.