### PR TITLE
HTTP/3: Header encoding and decoding fixes

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
@@ -173,6 +173,8 @@ namespace System.Net.Http.QPack
             {
                 Decode(segment.Span, handler);
             }
+
+            _state = State.RequiredInsertCount;
         }
 
         public void Decode(ReadOnlySpan<byte> headerBlock, IHttpHeadersHandler handler)

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
@@ -477,9 +477,8 @@ namespace System.Net.Http.QPack
                 case 400:
                 case 404:
                 case 500:
-                    // TODO this isn't safe, some index can be larger than 64. Encoded here!
-                    buffer[0] = (byte)(0xC0 | H3StaticTable.StatusIndex[statusCode]);
-                    return 1;
+                    EncodeStaticIndexedHeaderField(H3StaticTable.StatusIndex[statusCode], buffer, out var bytesWritten);
+                    return bytesWritten;
                 default:
                     // Send as Literal Header Field Without Indexing - Indexed Name
                     buffer[0] = 0x08;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46263

Also, encoding status code 500 was failing in Kestrel.

Tests that verify are part of https://github.com/dotnet/aspnetcore/pull/28763 and https://github.com/dotnet/aspnetcore/pull/28940