### PR TITLE
Fix `assert(isByteReg(ireg))`.

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3273,11 +3273,20 @@ int LinearScan::BuildMultiRegStoreLoc(GenTreeLclVar* storeLoc)
     //
     for (unsigned int i = 0; i < dstCount; ++i)
     {
+        LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(varDsc->lvFieldLclStart + i);
+
         if (isMultiRegSrc)
         {
-            BuildUse(op1, RBM_NONE, i);
+            regMaskTP srcCandidates = RBM_NONE;
+#ifdef TARGET_X86
+            var_types type = fieldVarDsc->TypeGet();
+            if (varTypeIsByte(type))
+            {
+                srcCandidates = allByteRegs();
+            }
+#endif // TARGET_X86
+            BuildUse(op1, srcCandidates, i);
         }
-        LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(varDsc->lvFieldLclStart + i);
         assert(isCandidateVar(fieldVarDsc));
         BuildStoreLocDef(storeLoc, fieldVarDsc, nullptr, i);
         if (isMultiRegSrc && (i < (dstCount - 1)))


### PR DESCRIPTION
We had a similar code in the non-multi reg case:
https://github.com/dotnet/runtime/blob/867ba801d1a609f4cbb6e5847a3ec030adb2d8f4/src/coreclr/jit/lsrabuild.cpp#L3380-L3386
so repeat the logic for MultiReg.

When we do a call we then copy the arguments to the temp location and we should choose registers that can be used in byte instructions on x86. 

Fixes #46277.

No diffs.