### PR TITLE
[Wasm] Set WasmBuildDir so that AOT tests can properly run

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -182,7 +182,7 @@
   <Target Condition="'$(TargetOS)' == 'Browser'" Name="PrepareForWasmBuildApp">
     <PropertyGroup>
       <WasmAppDir>$(BundleDir)</WasmAppDir>
-      <WasmAotDir>$(PublishDir)</WasmAotDir>
+      <WasmBuildDir>$(PublishDir)</WasmBuildDir>
       <WasmMainAssemblyPath>$(PublishDir)WasmTestRunner.dll</WasmMainAssemblyPath>
       <WasmMainJSPath>$(MonoProjectRoot)\wasm\runtime-test.js</WasmMainJSPath>
       <WasmInvariantGlobalization>$(InvariantGlobalization)</WasmInvariantGlobalization>


### PR DESCRIPTION
We recently changed names from WasmAOTDir to WasmBuildDir and the new name was missing from test.mobile.targets.