### PR TITLE
Update MicrosoftCodeAnalysisNetAnalyzersVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
     <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
   </ItemGroup>
   <PropertyGroup>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview1.20513.4</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview1.21054.10</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.8.0-4.20503.2</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <!-- Arcade dependencies -->
     <MicrosoftDotNetApiCompatVersion>6.0.0-beta.20630.2</MicrosoftDotNetApiCompatVersion>


### PR DESCRIPTION
Current build is a few months old (early October), so updating to a newer one (yesterday's).