### PR TITLE
Cleanup, and little improvement for aggressive trimming

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -157,10 +157,15 @@
       <!-- Mark all the assemblies for link. We will explicitly mark the non-trimmable ones -->
       <ResolvedFileToPublish TrimMode="link" />
 
-      <!-- Don't trim the test runner, and main assembly.
+      <!-- Don't trim the main assembly.
            TrimMode="" is needed so the root assemblies are correctly identified -->
       <ResolvedFileToPublish TrimMode="" Condition="'%(FileName)' == '$(AssemblyName)'" />
-      <ResolvedFileToPublish TrimMode="" Condition="$([System.String]::Copy('%(FileName)%(Extension)').EndsWith('TestRunner.dll'))" />
+
+      <!-- Even though we are trimming the test runner assembly, we want it to be treated
+           as a root -->
+      <TrimmerRootAssembly
+          Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('TestRunner.dll'))"
+          Include="%(ResolvedFileToPublish.FileName)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -158,8 +158,8 @@
       <ResolvedFileToPublish TrimMode="link" />
 
       <!-- Don't trim the test runner, and main assembly.
-           TrimMode="" is needed to the root assemblies are correctly identified -->
-      <ResolvedFileToPublish TrimMode="" Condition="'%(ResolvedFileToPublish.FileName)' == '$(AssemblyName)'" />
+           TrimMode="" is needed so the root assemblies are correctly identified -->
+      <ResolvedFileToPublish TrimMode="" Condition="'%(FileName)' == '$(AssemblyName)'" />
       <ResolvedFileToPublish TrimMode="" Condition="$([System.String]::Copy('%(FileName)%(Extension)').EndsWith('TestRunner.dll'))" />
     </ItemGroup>
 

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -148,26 +148,22 @@
 
   </Target>
 
-  <Target Name="ConfigureTrimming" Condition="'$(EnableAggressiveTrimming)' == 'true'" BeforeTargets="PrepareForILLink">
+  <Target Name="ConfigureTrimming" Condition="'$(EnableAggressiveTrimming)' == 'true'" AfterTargets="AddTestRunnersToPublishedFiles">
     <PropertyGroup>
       <TrimMode>link</TrimMode>
     </PropertyGroup>
 
     <ItemGroup>
-      <ManagedAssemblyToLink Include="$(OutDir)\*xunit*">
-        <IsTrimmable>true</IsTrimmable>
-        <TrimMode>link</TrimMode>
-      </ManagedAssemblyToLink>
-      <ManagedAssemblyToLink Condition="('%(ManagedAssemblyToLink.FileName).dll' != '$(MSBuildProjectName).dll')" >
-        <TrimMode>link</TrimMode>
-      </ManagedAssemblyToLink>
-      <ManagedAssemblyToLink Condition="('%(ManagedAssemblyToLink.FileName).dll' == '$(AssemblyName).dll')" >
-        <TrimMode>copy</TrimMode>
-      </ManagedAssemblyToLink>
-      <TrimmerRootAssembly Condition="'$(TargetOS)' == 'Android'" Include="AndroidTestRunner"/>
-      <TrimmerRootAssembly Condition="'$(TargetOS)' == 'Browser'" Include="WasmTestRunner"/>
-      <TrimmerRootAssembly Condition="'$(TargetOS)' == 'iOS'" Include="AppleTestRunner"/>
-      <TrimmerRootAssembly Include="$(AssemblyName)"/>
+      <!-- Mark all the assemblies for link. We will explicitly mark the non-trimmable ones -->
+      <ResolvedFileToPublish TrimMode="link" />
+
+      <!-- Don't trim the test runner, and main assembly.
+           TrimMode="" is needed to the root assemblies are correctly identified -->
+      <ResolvedFileToPublish TrimMode="" Condition="'%(ResolvedFileToPublish.FileName)' == '$(AssemblyName)'" />
+      <ResolvedFileToPublish TrimMode="" Condition="$([System.String]::Copy('%(FileName)%(Extension)').EndsWith('TestRunner.dll'))" />
+    </ItemGroup>
+
+    <ItemGroup>
       <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptor.xunit.xml" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
- The `ConfigureTrimming` target adds xunit assemblies explicitly, and
  sets `TriggerRootAssembly` too.

- Looking at the files being linked, some issues noticed:
    - Multiple copies of xunit assemblies, from various locations are
      included. Eg. from `System.Buffer.Tests`, `WasmTestRunner`, and
      from the nuget
    - `WasmTestRunner` is explicitly added as `TriggerRootAssembly`, but
      it is also passed as an arg for linking, `-p link ...`
    - `xunit.runner.json` is incorrectly added to the files to be linked

- Instead:
    - all the files to be published are already in
      `ResolvedFileToPublish` after `AddTestRunnersToPublishedFiles` target
    - so, we mark everything for linking,
    - *except* the main test assembly
    - Also, we use the test runner as a root

    - This way we are explicitly specifying which assemblies to link,
      and which ones to `copy`

- This reduces the size:
    - 3.1M to 2.6M `artifacts/bin/System.Buffers.Tests/net6.0-Release/browser-wasm/AppBundle/managed/`
    - 46M to 31M `artifacts/bin/System.Buffers.Tests/net6.0-Release/browser-wasm/AppBundle/publish/`