### PR TITLE
Fix inconistent minus sign with different culture

### DIFF
--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -807,50 +807,30 @@ namespace System.Xml.Linq
 
         internal static string GetStringValue(object value)
         {
-            string? s = value as string;
-            if (s != null)
-            {
-                return s;
-            }
-            else if (value is double)
-            {
-                s = XmlConvert.ToString((double)value);
-            }
-            else if (value is float)
-            {
-                s = XmlConvert.ToString((float)value);
-            }
-            else if (value is decimal)
-            {
-                s = XmlConvert.ToString((decimal)value);
-            }
-            else if (value is bool)
-            {
-                s = XmlConvert.ToString((bool)value);
-            }
-            else if (value is DateTime)
-            {
-                s = XmlConvert.ToString((DateTime) value, XmlDateTimeSerializationMode.RoundtripKind);
-            }
-            else if (value is DateTimeOffset)
-            {
-                s = XmlConvert.ToString((DateTimeOffset)value);
-            }
-            else if (value is TimeSpan)
-            {
-                s = XmlConvert.ToString((TimeSpan)value);
-            }
-            else if (value is XObject)
-            {
-                throw new ArgumentException(SR.Argument_XObjectValue);
-            }
-            else
-            {
-                s = value.ToString();
-            }
+            string? s = ConvertToString(value);
             if (s == null) throw new ArgumentException(SR.Argument_ConvertToString);
             return s;
         }
+
+        private static string? ConvertToString(object value) =>
+            value switch
+            {
+                string stringValue => stringValue,
+                int intValue => XmlConvert.ToString(intValue),
+                double doubleValue => XmlConvert.ToString(doubleValue),
+                long longValue => XmlConvert.ToString(longValue),
+                float floatValue => XmlConvert.ToString(floatValue),
+                decimal decimalValue => XmlConvert.ToString(decimalValue),
+                short shortValue => XmlConvert.ToString(shortValue),
+                sbyte sbyteValue => XmlConvert.ToString(sbyteValue),
+                bool boolValue => XmlConvert.ToString(boolValue),
+                DateTime dtValue => XmlConvert.ToString(dtValue, XmlDateTimeSerializationMode.RoundtripKind),
+                DateTimeOffset dtoValue => XmlConvert.ToString(dtoValue),
+                TimeSpan tsValue => XmlConvert.ToString(tsValue),
+                XObject => throw new ArgumentException(SR.Argument_XObjectValue),
+                _ => value.ToString()
+            };
+
 
         internal void ReadContentFrom(XmlReader r)
         {

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -807,13 +807,7 @@ namespace System.Xml.Linq
 
         internal static string GetStringValue(object value)
         {
-            string? s = ConvertToString(value);
-            if (s == null) throw new ArgumentException(SR.Argument_ConvertToString);
-            return s;
-        }
-
-        private static string? ConvertToString(object value) =>
-            value switch
+            string? s = value switch
             {
                 string stringValue => stringValue,
                 int intValue => XmlConvert.ToString(intValue),
@@ -831,6 +825,9 @@ namespace System.Xml.Linq
                 _ => value.ToString()
             };
 
+            if (s == null) throw new ArgumentException(SR.Argument_ConvertToString);
+            return s;
+        }
 
         internal void ReadContentFrom(XmlReader r)
         {

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Test.ModuleCore;
 using Xunit;
 
 namespace System.Xml.Linq.Tests
@@ -16,6 +13,57 @@ namespace System.Xml.Linq.Tests
         {
             // Ensure we are compatible with the .NET Framework
             Assert.Equal("CreatedTime=\"2018-01-01T12:13:14Z\"", new XAttribute("CreatedTime", new DateTime(2018, 1, 1, 12, 13, 14, DateTimeKind.Utc)).ToString());
+        }
+
+        public static IEnumerable<object[]> NumericValuesWithMinusSign()
+        {
+            yield return new object[] { -123 };
+            yield return new object[] { -123f };
+            yield return new object[] { -123L };
+            yield return new object[] { (short)-123 };
+            yield return new object[] { -12.3 };
+            yield return new object[] { -12.3m };
+            yield return new object[] { (sbyte)-123 };
+        }
+
+        [Theory]
+        [MemberData(nameof(NumericValuesWithMinusSign))]
+        public void MinusSignWithDifferentTypeSwedishCulture(object value)
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("SE-SW");
+
+            Assert.Equal('-', (new XAttribute("a", value)).Value[0]);
+        }
+
+        [Theory]
+        [MemberData(nameof(NumericValuesWithMinusSign))]
+        public void MinusSignWithDifferentTypeNoCulture(object value)
+        {
+            Assert.Equal('-', (new XAttribute("a", value)).Value[0]);
+        }
+
+        public static IEnumerable<object[]> NonNumericValues()
+        {
+            yield return new object[] { true, "true" };
+            yield return new object[] { new DateTimeOffset(2018, 1, 1, 12, 13, 14, TimeSpan.Zero), "2018-01-01T12:13:14Z" };
+            yield return new object[] { new TimeSpan(12, 13, 14), "PT12H13M14S" };
+            yield return new object[] { "-123\n", "-123\n" };
+        }
+
+        [Theory]
+        [MemberData(nameof(NonNumericValues))]
+        public void NonNumericTypeSwedishCulture(object value, string expected)
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("SE-SW");
+
+            Assert.Equal(expected, (new XAttribute("a", value)).Value);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonNumericValues))]
+        public void NonNumericTypesNoCulture(object value, string expected)
+        {
+            Assert.Equal(expected, (new XAttribute("a", value)).Value);
         }
     }
 }

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Tests;
 using Xunit;
 
 namespace System.Xml.Linq.Tests
@@ -31,13 +32,18 @@ namespace System.Xml.Linq.Tests
         [MemberData(nameof(NumericValuesWithMinusSign))]
         public void MinusSignWithDifferentTypeSwedishCulture(object value)
         {
+            CultureInfo newCulture = null;
             try
             {
-                Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("SE-SW");
+                newCulture = new CultureInfo("SE-SW");
             }
             catch (CultureNotFoundException) { /* Do nothing */ }
 
-            Assert.Equal('-', (new XAttribute("a", value)).Value[0]);
+            using (new ThreadCultureChange(newCulture))
+            {
+
+                Assert.Equal('-', (new XAttribute("a", value)).Value[0]);
+            }
         }
 
         [Theory]
@@ -59,13 +65,17 @@ namespace System.Xml.Linq.Tests
         [MemberData(nameof(NonNumericValues))]
         public void NonNumericTypeSwedishCulture(object value, string expected)
         {
+            CultureInfo newCulture = null;
             try
             {
-                Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("SE-SW");
+                newCulture = new CultureInfo("SE-SW");
             }
             catch (CultureNotFoundException) { /* Do nothing */ }
 
-            Assert.Equal(expected, (new XAttribute("a", value)).Value);
+            using (new ThreadCultureChange(newCulture))
+            {
+                Assert.Equal(expected, (new XAttribute("a", value)).Value);
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Xunit;
 
 namespace System.Xml.Linq.Tests
@@ -30,7 +31,11 @@ namespace System.Xml.Linq.Tests
         [MemberData(nameof(NumericValuesWithMinusSign))]
         public void MinusSignWithDifferentTypeSwedishCulture(object value)
         {
-            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("SE-SW");
+            try
+            {
+                Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("SE-SW");
+            }
+            catch (CultureNotFoundException) { /* Do nothing */ }
 
             Assert.Equal('-', (new XAttribute("a", value)).Value[0]);
         }
@@ -54,7 +59,11 @@ namespace System.Xml.Linq.Tests
         [MemberData(nameof(NonNumericValues))]
         public void NonNumericTypeSwedishCulture(object value, string expected)
         {
-            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("SE-SW");
+            try
+            {
+                Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("SE-SW");
+            }
+            catch (CultureNotFoundException) { /* Do nothing */ }
 
             Assert.Equal(expected, (new XAttribute("a", value)).Value);
         }

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XAttribute.cs
@@ -35,13 +35,12 @@ namespace System.Xml.Linq.Tests
             CultureInfo newCulture = null;
             try
             {
-                newCulture = new CultureInfo("SE-SW");
+                newCulture = new CultureInfo("sv-SE");
             }
             catch (CultureNotFoundException) { /* Do nothing */ }
 
             using (new ThreadCultureChange(newCulture))
             {
-
                 Assert.Equal('-', (new XAttribute("a", value)).Value[0]);
             }
         }
@@ -68,7 +67,7 @@ namespace System.Xml.Linq.Tests
             CultureInfo newCulture = null;
             try
             {
-                newCulture = new CultureInfo("SE-SW");
+                newCulture = new CultureInfo("sv-SE");
             }
             catch (CultureNotFoundException) { /* Do nothing */ }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/45952

XContainer.cs using XmlConvert.ToString(...) overloads for converting some numeric types like float, double, decimal types which uses Invariant culture internally. For other numeral like int, long, short ets converted using Object.ToString() which converts the numbers with default culture which is causing the minus sign (-) converted differently for some cultures like Swedish, they all should converted by XmlConvert.ToString(...) which uses Invariant culture.