### PR TITLE
WinHttpHandler: Read HTTP/2 trailing headers

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -69,6 +69,7 @@ internal partial class Interop
         public const uint WINHTTP_QUERY_STATUS_TEXT = 20;
         public const uint WINHTTP_QUERY_RAW_HEADERS = 21;
         public const uint WINHTTP_QUERY_RAW_HEADERS_CRLF = 22;
+        public const uint WINHTTP_QUERY_FLAG_TRAILERS = 0x02000000;
         public const uint WINHTTP_QUERY_CONTENT_ENCODING = 29;
         public const uint WINHTTP_QUERY_SET_COOKIE = 43;
         public const uint WINHTTP_QUERY_CUSTOM = 65535;

--- a/src/libraries/Common/src/System/Net/SecurityProtocol.cs
+++ b/src/libraries/Common/src/System/Net/SecurityProtocol.cs
@@ -8,7 +8,7 @@ namespace System.Net
     internal static class SecurityProtocol
     {
         public const SslProtocols DefaultSecurityProtocols =
-#if !NETSTANDARD2_0 && !NETFRAMEWORK
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1 && !NETFRAMEWORK
             SslProtocols.Tls13 |
 #endif
             SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <TargetFrameworks>netstandard2.0-windows;netstandard2.0;net461-windows</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0-windows;netstandard2.0;netstandard2.1-windows;netstandard2.1;net461-windows</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -14,11 +14,11 @@
     <Compile Include="BaseCertificateTest.cs" />
     <Compile Include="ServerCertificateTest.cs" />
     <Compile Include="WinHttpHandlerTest.cs" />
-    <Compile Include="XunitTestAssemblyAtrributes.cs" /> 
+    <Compile Include="XunitTestAssemblyAtrributes.cs" />
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs"
              Link="Common\System\Net\Http\HttpHandlerDefaults.cs" />
     <Compile Include="$(CommonTestPath)System\IO\DelegateStream.cs"
-             Link="Common\System\IO\DelegateStream.cs" />    
+             Link="Common\System\IO\DelegateStream.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs"
              Link="Common\System\Net\Configuration.Certificates.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs"
@@ -126,7 +126,7 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\RepeatedFlushContent.cs"
              Link="Common\System\Net\Http\RepeatedFlushContent.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\ResponseStreamTest.cs"
-             Link="Common\System\Net\Http\ResponseStreamTest.cs" />    
+             Link="Common\System\Net\Http\ResponseStreamTest.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\SchSendAuxRecordHttpTest.cs"
              Link="Common\System\Net\Http\SchSendAuxRecordHttpTest.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\SyncBlockingContent.cs"
@@ -141,6 +141,7 @@
     <Compile Include="WinHttpClientHandler.cs" />
     <Compile Include="PlatformHandlerTest.cs" />
     <Compile Include="ClientCertificateTest.cs" />
+    <Compile Include="TrailingHeadersTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/TrailingHeadersTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/TrailingHeadersTest.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http.Functional.Tests;
+using System.Net.Http.Headers;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.WinHttpHandlerFunctional.Tests
+{
+    public class TrailingHeadersTest : HttpClientHandlerTestBase
+    {
+        public TrailingHeadersTest(ITestOutputHelper output) : base(output)
+        { }
+
+        protected override Version UseVersion => new Version(2, 0);
+
+        protected static byte[] DataBytes = Encoding.ASCII.GetBytes("data");
+
+        protected static readonly IList<HttpHeaderData> TrailingHeaders = new HttpHeaderData[] {
+            new HttpHeaderData("MyCoolTrailerHeader", "amazingtrailer"),
+            new HttpHeaderData("EmptyHeader", ""),
+            new HttpHeaderData("Accept-Encoding", "identity,gzip"),
+            new HttpHeaderData("Hello", "World") };
+
+        protected static Frame MakeDataFrame(int streamId, byte[] data, bool endStream = false) =>
+            new DataFrame(data, (endStream ? FrameFlags.EndStream : FrameFlags.None), 0, streamId);
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+        public async Task Http2GetAsync_NoTrailingHeaders_EmptyCollection()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                int streamId = await connection.ReadRequestHeaderAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Response data.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes, endStream: true));
+
+                // Server doesn't send trailing header frame.
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var trailingHeaders = GetTrailingHeaders(response);
+                Assert.NotNull(trailingHeaders);
+                Assert.Equal(0, trailingHeaders.Count());
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+        public async Task Http2GetAsync_MissingTrailer_TrailingHeadersAccepted()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                int streamId = await connection.ReadRequestHeaderAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Response data, missing Trailers.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes));
+
+                // Additional trailing header frame.
+                await connection.SendResponseHeadersAsync(streamId, isTrailingHeader: true, headers: TrailingHeaders, endStream: true);
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var trailingHeaders = GetTrailingHeaders(response);
+                Assert.Equal(TrailingHeaders.Count, trailingHeaders.Count());
+                Assert.Contains("amazingtrailer", trailingHeaders.GetValues("MyCoolTrailerHeader"));
+                Assert.Contains("World", trailingHeaders.GetValues("Hello"));
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+        public async Task Http2GetAsyncResponseHeadersReadOption_TrailingHeaders_Available()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address, HttpCompletionOption.ResponseHeadersRead);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                int streamId = await connection.ReadRequestHeaderAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Response data, missing Trailers.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes));
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                // Pending read on the response content.
+                var trailingHeaders = GetTrailingHeaders(response);
+                Assert.True(trailingHeaders == null || trailingHeaders.Count() == 0);
+
+                Stream stream = await response.Content.ReadAsStreamAsync(TestAsync);
+                Byte[] data = new Byte[100];
+                await stream.ReadAsync(data, 0, data.Length);
+
+                // Intermediate test - haven't reached stream EOF yet.
+                trailingHeaders = GetTrailingHeaders(response);
+                Assert.True(trailingHeaders == null || trailingHeaders.Count() == 0);
+
+                // Finish data stream and write out trailing headers.
+                await connection.WriteFrameAsync(MakeDataFrame(streamId, DataBytes));
+                await connection.SendResponseHeadersAsync(streamId, endStream: true, isTrailingHeader: true, headers: TrailingHeaders);
+
+                // Read data until EOF is reached
+                while (stream.Read(data, 0, data.Length) != 0) ;
+
+                trailingHeaders = GetTrailingHeaders(response);
+                Assert.Equal(TrailingHeaders.Count, trailingHeaders.Count());
+                Assert.Contains("amazingtrailer", trailingHeaders.GetValues("MyCoolTrailerHeader"));
+                Assert.Contains("World", trailingHeaders.GetValues("Hello"));
+
+                // Read when already zero. Trailers shouldn't be changed.
+                stream.Read(data, 0, data.Length);
+
+                trailingHeaders = GetTrailingHeaders(response);
+                Assert.Equal(TrailingHeaders.Count, trailingHeaders.Count());
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+        public async Task Http2GetAsync_TrailerHeaders_TrailingHeaderNoBody()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                int streamId = await connection.ReadRequestHeaderAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+                await connection.SendResponseHeadersAsync(streamId, endStream: true, isTrailingHeader: true, headers: TrailingHeaders);
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var trailingHeaders = GetTrailingHeaders(response);
+                Assert.Equal(TrailingHeaders.Count, trailingHeaders.Count());
+                Assert.Contains("amazingtrailer", trailingHeaders.GetValues("MyCoolTrailerHeader"));
+                Assert.Contains("World", trailingHeaders.GetValues("Hello"));
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+        public async Task Http2GetAsync_TrailingHeaders_NoData_EmptyResponseObserved()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                int streamId = await connection.ReadRequestHeaderAsync();
+
+                // Response header.
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // No data.
+
+                // Response trailing headers
+                await connection.SendResponseHeadersAsync(streamId, isTrailingHeader: true, headers: TrailingHeaders);
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal<byte>(Array.Empty<byte>(), await response.Content.ReadAsByteArrayAsync());
+
+                var trailingHeaders = GetTrailingHeaders(response);
+                Assert.Contains("amazingtrailer", trailingHeaders.GetValues("MyCoolTrailerHeader"));
+                Assert.Contains("World", trailingHeaders.GetValues("Hello"));
+            }
+        }
+
+        private HttpHeaders GetTrailingHeaders(HttpResponseMessage responseMessage)
+        {
+#if !NET48
+            return responseMessage.TrailingHeaders;
+#else
+#pragma warning disable CS0618 // Type or member is obsolete
+            responseMessage.RequestMessage.Properties.TryGetValue("__ResponseTrailers", out object trailers);
+#pragma warning restore CS0618 // Type or member is obsolete
+            return (HttpHeaders)trailers;
+#endif
+        }
+    }
+}

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -376,7 +376,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             handle.Context = state.ToIntPtr();
             state.RequestHandle = handle;
 
-            return new WinHttpResponseStream(handle, state);
+            return new WinHttpResponseStream(handle, state, new HttpResponseMessage());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44778

Read HTTP/2 trailing headers when using WinHttpHandler.

Notes:

* Adds netstandard2.1 target.
* Loads trailers into `HttpResponseMessage.TrailingHeaders` in netstandard2.1. With older targets the trailers are stashed in `HttpRequestMessage.Properties`.
* Requires modern version of Windows. Should the OS version be checked to avoid using new option on older Windows versions?