### PR TITLE
PGO: don't record info for collectible classes

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5254,7 +5254,15 @@ HCIMPL2(void, JIT_ClassProfile, Object *obj, void* tableAddress)
         return;
     }
 
-    CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE)objRef->GetMethodTable();
+    MethodTable* pMT = objRef->GetMethodTable();
+
+    // If the object class is collectible, record NULL
+    // for the class handle.
+    //
+    if (pMT->GetLoaderAllocator()->IsCollectible())
+    {
+        pMT = NULL;
+    }
 
 #ifdef _DEBUG
     PgoManager::VerifyAddress(classProfile);
@@ -5265,7 +5273,7 @@ HCIMPL2(void, JIT_ClassProfile, Object *obj, void* tableAddress)
     //
     if (count < S)
     {
-        classProfile->ClassTable[count] = clsHnd;
+        classProfile->ClassTable[count] = (CORINFO_CLASS_HANDLE)pMT;
     }
     else
     {
@@ -5297,7 +5305,7 @@ HCIMPL2(void, JIT_ClassProfile, Object *obj, void* tableAddress)
         if ((x % N) < S)
         {
             unsigned i = x % S;
-            classProfile->ClassTable[i] = clsHnd;
+            classProfile->ClassTable[i] = (CORINFO_CLASS_HANDLE)pMT;
         }
     }
 }


### PR DESCRIPTION
Map method tables for collectible classes to null so profile entries won't
hold onto pointers that can become invalid.

Record the nulls in the profiles so that collectible classes still impact the
profile stats.