### PR TITLE
set BuildingAnOfficialBuildLeg in the root directory.build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,10 @@
     <!-- For non-SDK projects that import this file and then import Microsoft.Common.props,
          tell Microsoft.Common.props not to import Directory.Build.props again. -->
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <!-- Used to determine if we should build some packages only once across multiple official build legs.
+         For offline builds we still set OfficialBuildId but we need to build all the packages for a single
+         leg only, so we also take DotNetBuildFromSource  into account. -->
+    <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' and '$(OfficialBuildId)' != '' and '$(DotNetBuildFromSource)' != 'true'">true</BuildingAnOfficialBuildLeg>
   </PropertyGroup>
 
   <PropertyGroup Label="CalculateTargetOS">

--- a/src/coreclr/.nuget/builds.targets
+++ b/src/coreclr/.nuget/builds.targets
@@ -2,11 +2,6 @@
   <PropertyGroup Condition="'$(BuildIdentityPackage)' == ''">
     <BuildIdentityPackage>true</BuildIdentityPackage>
 
-    <!-- Used to determine if we should build some packages only once across multiple official build legs.
-         For offline builds we still set OfficialBuildId but we need to build all the packages for a single
-         leg only, so we also take DotNetBuildFromSource into account. -->
-    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildFromSource)' != 'true'">true</BuildingAnOfficialBuildLeg>
-
     <!-- During an official build, only build identity packages on windows x64 legs -->
     <BuildIdentityPackage Condition="'$(BuildingAnOfficialBuildLeg)' == 'true' AND ('$(OS)' != 'Windows_NT' OR '$(TargetArchitecture)' != 'x64')">false</BuildIdentityPackage>
   </PropertyGroup>

--- a/src/libraries/pkg/Directory.Build.props
+++ b/src/libraries/pkg/Directory.Build.props
@@ -6,10 +6,6 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- Used to determine if we should build some packages only once across multiple official build legs.
-         For offline builds we still set OfficialBuildId but we need to build all the packages for a single
-         leg only, so we also take DotNetBuildFromSource  into account. -->
-    <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' and '$(OfficialBuildId)' != '' and '$(DotNetBuildFromSource)' != 'true'">true</BuildingAnOfficialBuildLeg>
     <HarvestStablePackage>false</HarvestStablePackage>
   </PropertyGroup>
 


### PR DESCRIPTION
BuildingAnOfficialBuildLeg was not being set at the proper place so it lead to building Microsoft.NetCore.Platforms and targets to be produced in multiple legs which caused failures in publishing

Failure Build https://dev.azure.com/dnceng/internal/_build/results?buildId=939209&view=results
Build queued for this change https://dev.azure.com/dnceng/internal/_build/results?buildId=939685&view=results