### PR TITLE
[browser][test] Re-Add make target to run the outerloop tests on browser

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -177,6 +177,9 @@ run-tests-%:
 run-browser-tests-%:
 	PATH="$(CHROMEDRIVER):$(PATH)" XHARNESS_COMMAND=test-browser $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
+run-browser-outerloop-tests-%:
+	PATH="$(CHROMEDRIVER):$(PATH)" XHARNESS_COMMAND=test-browser $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:OuterLoop=true $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
+
 run-debugger-tests:
 	if [ ! -z "$(TEST_FILTER)" ]; then \
 		export LC_ALL=en_US.UTF-8; \


### PR DESCRIPTION
- Seems to have been removed in other PR by mistake.
- See https://github.com/dotnet/runtime/pull/45465 for original PR