### PR TITLE
[browser][make] Add make target to run the `mono.wasmruntime` build

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -152,6 +152,9 @@ build-all:
 runtime:
 	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono.runtime+mono.wasmruntime+libs.native+libs.pretest -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true $(MSBUILD_ARGS)
 
+wasmruntime:
+	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono.wasmruntime -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true $(MSBUILD_ARGS)
+
 corlib:
 	EMSDK_PATH=$(EMSDK_PATH) $(TOP)/build.sh mono.corelib+mono.wasmruntime+libs.pretest -os Browser -c $(CONFIG) /p:ContinueOnError=false /p:StopOnFirstFailure=true $(MSBUILD_ARGS)
 


### PR DESCRIPTION
- target `wasmruntime`
- Sometimes you just don't need all the fluff of building everything.
- Just builds and packages the java script runtime files.