### PR TITLE
Fixing docs link to maximum file path limitation removal

### DIFF
--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -10,7 +10,7 @@ You must install several components to build the dotnet/runtime repository. Thes
 
 ## Enable Long Paths
 
-The runtime repository requires long paths to be enabled. Follow [the instructions provided here](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later) to enable that feature.
+The runtime repository requires long paths to be enabled. Follow [the instructions provided here](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to enable that feature.
 
 If using Git for Windows you might need to also configure long paths there. Using an admin terminal simply type:
 ```cmd


### PR DESCRIPTION
The part of the docs we linked to [was refactored to a different page](https://github.com/MicrosoftDocs/win32/commit/855d8d3527f0179e802fd0395f7f50dd8e361524#diff-6898857dc889c6526a48f3fc82963c7934ae3ce54a68fd0babfb92357f6d6c3f).