### PR TITLE
[Android] Load System's OpenSSL

### DIFF
--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -238,10 +238,7 @@ elseif(CLR_CMAKE_TARGET_TVOS)
     # it is only used for interacting with OpenSSL which isn't useful there
 elseif(CLR_CMAKE_TARGET_ANDROID AND NOT CROSS_ROOTFS)
     #add_subdirectory(System.Net.Security.Native) # TODO: reenable
-    if (NOT "$ENV{ANDROID_OPENSSL_AAR}" STREQUAL "")
-        set(PREFER_OPENSSL_ANDROID 1)
-        add_subdirectory(System.Security.Cryptography.Native)
-    endif()
+    add_subdirectory(System.Security.Cryptography.Native)
 else()
     add_subdirectory(System.Globalization.Native)
     add_subdirectory(System.Net.Security.Native)
@@ -250,9 +247,4 @@ endif()
 
 if(CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     add_subdirectory(System.Security.Cryptography.Native.Apple)
-endif()
-
-# if ANDROID_OPENSSL_AAR is not set - use Android Native Crypto (it's going to replace openssl eventually)
-if(CLR_CMAKE_TARGET_ANDROID AND NOT PREFER_OPENSSL_ANDROID)
-    add_subdirectory(System.Security.Cryptography.Native.Android)
 endif()

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -47,18 +47,27 @@ set(NATIVECRYPTO_SOURCES
 # Always build portable on macOS because OpenSSL is not a system component
 # and our prebuilts should not assume a specific ABI version for the types
 # that use OpenSSL at runtime.
-if (CLR_CMAKE_TARGET_OSX)
+if (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_ANDROID)
     set(FEATURE_DISTRO_AGNOSTIC_SSL True)
 
     # by default uninitialized variables like the shim _ptr functions, will turn into common symbols
     # and on OSX those have linking problems in libraries (ELF vs. Mach-O difference)
     add_compile_options(-fno-common)
+
+    # Needed for LOG_XX macros on Android
+    add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
 endif()
 
 if (FEATURE_DISTRO_AGNOSTIC_SSL)
-    list(APPEND NATIVECRYPTO_SOURCES
-        opensslshim.c
-    )
+    if (CLR_CMAKE_TARGET_ANDROID)
+        list(APPEND NATIVECRYPTO_SOURCES
+            opensslshim_android.c
+        )
+    else()
+        list(APPEND NATIVECRYPTO_SOURCES
+            opensslshim.c
+        )
+    endif()
     add_definitions(-DFEATURE_DISTRO_AGNOSTIC_SSL)
 endif()
 
@@ -86,7 +95,7 @@ if (GEN_SHARED_LIB)
         #
         # on Linux, the build will succeed with undefined symbols, then the script reports them
         # and fails the build for us.
-        if (NOT APPLE)
+        if (NOT APPLE AND NOT CLR_CMAKE_TARGET_ANDROID)
             add_custom_command(TARGET System.Security.Cryptography.Native.OpenSsl POST_BUILD
                 COMMENT "Verifying System.Security.Cryptography.Native.OpenSsl.so dependencies"
                 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../verify-so.sh
@@ -111,6 +120,12 @@ if (GEN_SHARED_LIB)
     target_link_libraries(System.Security.Cryptography.Native.OpenSsl
         ${NATIVE_LIBS_EXTRA}
     )
+
+    if (CLR_CMAKE_TARGET_ANDROID)
+        target_link_libraries(System.Security.Cryptography.Native.OpenSsl
+            -llog
+        )
+    endif()
 endif()
 
 include(configure.cmake)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim_android.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim_android.c
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <android/log.h>
+
+#include "opensslshim.h"
+
+#define LOG_INFO(fmt, ...) ((void)__android_log_print(ANDROID_LOG_INFO, "DOTNET", "%s: " fmt, __FUNCTION__, ## __VA_ARGS__))
+#define LOG_ERROR(fmt, ...) ((void)__android_log_print(ANDROID_LOG_ERROR, "DOTNET", "%s: " fmt, __FUNCTION__, ## __VA_ARGS__))
+
+// Define pointers to all the used OpenSSL functions
+#define REQUIRED_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define NEW_REQUIRED_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define LIGHTUP_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define FALLBACK_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define RENAMED_FUNCTION(fn,oldfn) TYPEOF(fn) fn##_ptr;
+#define LEGACY_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+FOR_ALL_OPENSSL_FUNCTIONS
+#undef LEGACY_FUNCTION
+#undef RENAMED_FUNCTION
+#undef FALLBACK_FUNCTION
+#undef LIGHTUP_FUNCTION
+#undef NEW_REQUIRED_FUNCTION
+#undef REQUIRED_FUNCTION
+
+static void* libssl = NULL;
+
+static bool OpenLibrary()
+{
+    // Open itself, system OpenSSL should already exist in the current process.
+    libssl = dlopen(NULL, RTLD_NOW);
+    return libssl != NULL;
+}
+
+__attribute__((constructor))
+static void InitializeOpenSSLShim()
+{
+    LOG_INFO("InitializeOpenSSLShim");
+
+    if (!OpenLibrary())
+    {
+        LOG_ERROR("No usable version of libssl was found\n");
+        abort();
+    }
+
+    // A function defined in libcrypto.so.1.0.0/libssl.so.1.0.0 that is not defined in
+    // libcrypto.so.1.1.0/libssl.so.1.1.0
+    const void* v1_0_sentinel = dlsym(libssl, "SSL_state");
+
+    // Get pointers to all the functions that are needed
+#define REQUIRED_FUNCTION(fn) \
+    if (!(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { LOG_ERROR("Cannot get required symbol " #fn " from libssl\n"); }
+
+#define NEW_REQUIRED_FUNCTION(fn) \
+    if (!v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { LOG_ERROR("Cannot get required symbol " #fn " from libssl\n"); }
+
+#define LIGHTUP_FUNCTION(fn) \
+    fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn));
+
+#define FALLBACK_FUNCTION(fn) \
+    if (!(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fn##_ptr = (TYPEOF(fn))local_##fn; }
+
+#define RENAMED_FUNCTION(fn,oldfn) \
+    if (!v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { LOG_ERROR("Cannot get required symbol " #fn " from libssl\n"); } \
+    if (v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #oldfn)))) { LOG_ERROR("Cannot get required symbol " #oldfn " from libssl\n"); }
+
+#define LEGACY_FUNCTION(fn) \
+    if (v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { LOG_ERROR("Cannot get required symbol " #fn " from libssl\n"); }
+
+    FOR_ALL_OPENSSL_FUNCTIONS
+#undef LEGACY_FUNCTION
+#undef RENAMED_FUNCTION
+#undef FALLBACK_FUNCTION
+#undef LIGHTUP_FUNCTION
+#undef NEW_REQUIRED_FUNCTION
+#undef REQUIRED_FUNCTION
+
+    LOG_INFO("InitializeOpenSSLShim finished.");
+}

--- a/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -29,15 +29,6 @@ import java.util.zip.ZipInputStream;
 public class MonoRunner extends Instrumentation
 {
     static {
-        // loadLibrary triggers JNI_OnLoad in these libs
-        try
-        {
-            // loadLibrary can throw an error here if OpenSSL bits aren't around. 
-            // We'll delete OpenSSL impl once we finish the transition to Android Crypto.
-            System.loadLibrary("System.Security.Cryptography.Native.OpenSsl");
-        } catch (java.lang.UnsatisfiedLinkError e) {
-            Log.e("DOTNET", e.getLocalizedMessage());
-        }
         System.loadLibrary("monodroid");
     }
 


### PR DESCRIPTION
We can't use `dlopen` for system libs (AFAIK since some more or less recent API level) e.g. for system OpenSSL, but it turns out it's still always loaded into the current process (it's loaded in Zygote and Android just forks it every time) because most of the Android Security still relies on OpenSSL(BoringSSL) so we actually can just `dsym` it for `dlopen(NULL, RTLD_NOW) /*open self*/` as far as I understand (if `dlopen(NULL)` works reliably). It doesn't look like it's permitted (but makes sense to try to submit a simple app into the Google Play Store for tests - it should validate an apk for internal/prohibited APIs usages). I tried locally and managed to run simple hash functions just fine without any external OpenSSL bits. The only problem - among 348 symbols used by .NET there are 46 missing in the BoringSSL:
```
CRYPTO_add_lock **** (see https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md#reference-counts-and-opaque-types)
d2i_OCSP_RESPONSE
DSA_OpenSSL
EC_GFp_mont_method
EC_GFp_simple_method
EC_GROUP_check
EC_GROUP_get0_seed
EC_GROUP_get_seed_len
EC_GROUP_new
EC_GROUP_set_curve_GFp
EC_GROUP_set_seed
EVP_aes_128_ccm
EVP_aes_128_cfb128
EVP_aes_128_cfb8
EVP_aes_192_ccm
EVP_aes_192_cfb128
EVP_aes_192_cfb8
EVP_aes_256_ccm
EVP_aes_256_cfb128
EVP_aes_256_cfb8
EVP_des_cfb8
EVP_des_ede3_cfb8
EVP_des_ede3_cfb64
EVP_rc2_ecb
i2d_OCSP_REQUEST
i2d_OCSP_RESPONSE
OCSP_BASICRESP_free
OCSP_basic_verify
OCSP_CERTID_free
OCSP_cert_to_id
OCSP_check_nonce
OCSP_request_add0_id
OCSP_request_add1_nonce
OCSP_REQUEST_free
OCSP_REQUEST_new
OCSP_resp_find_status
OCSP_response_get1_basic
OCSP_RESPONSE_free
OCSP_RESPONSE_new
RSA_get_method
RSA_PKCS1_SSLeay
RSA_set_method
SSL_ctrl
SSL_CTX_ctrl
```
(see https://github.com/google/conscrypt/blob/master/common/src/jni/main/cpp/conscrypt/native_crypto.cc)


I believe these can be workaround-ed but I am not a System.Cryptography expert. The question is - can we rely on it?

/cc @marek-safar @akoeplinger @steveisok  @jonpryor also 'System.Security' label guys.