### PR TITLE
Enable host tests on OSX

### DIFF
--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -401,7 +401,7 @@ jobs:
             path: $(Build.SourcesDirectory)/artifacts/bin/osx-${{ parameters.archType }}.$(_BuildConfig)/corehost
             entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
 
-    - script: $(BaseJobBuildCommand) -subset host.pkg+host.tools+packs
+    - script: $(BaseJobBuildCommand) -subset host.pkg+host.tools+host.tests+packs
       displayName: Build and Package
       continueOnError: ${{ and(eq(variables.SkipTests, false), eq(parameters.shouldContinueOnError, true)) }}
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
@@ -19,6 +19,14 @@ internal static partial class Interop
         }
     }
 
+    internal static partial class OpenSsl
+    {
+        static OpenSsl()
+        {
+            CryptoInitializer.Initialize();
+        }
+    }
+
     internal static class CryptoInitializer
     {
         static CryptoInitializer()

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -56,6 +56,8 @@
   </ItemGroup>
   <!-- Unix imports -->
   <ItemGroup>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs"
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslGetProtocolSupport.cs"

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -7,6 +7,10 @@
 #include "pal_safecrt.h"
 #include "openssl.h"
 
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+#include "opensslshim.h"
+#endif
+
 #include <assert.h>
 #include <limits.h>
 #include <pthread.h>
@@ -1311,6 +1315,8 @@ int32_t CryptoNative_EnsureOpenSslInitialized()
     // If 1.0, call the 1.0 one.
     // Otherwise call the 1.1 one.
 #ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+    InitializeOpenSSLShim();
+
     if (API_EXISTS(SSL_state))
     {
         return EnsureOpenSsl10Initialized();

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -116,8 +116,7 @@ static bool OpenLibrary()
     return libssl != NULL;
 }
 
-__attribute__((constructor))
-static void InitializeOpenSSLShim()
+void InitializeOpenSSLShim(void)
 {
     if (!OpenLibrary())
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "opensslshim.h"
+#include "pal_atomic.h"
 
 // Define pointers to all the used OpenSSL functions
 #define REQUIRED_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
@@ -28,7 +29,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 // x.x.x, considering the max number of decimal digits for each component
 #define MaxVersionStringLength 32
 
-static void* libssl = NULL;
+ static void* volatile libssl = NULL;
 
 #ifdef __APPLE__
 #define DYLIBNAME_PREFIX "libssl."
@@ -41,8 +42,13 @@ static void* libssl = NULL;
 
 static void DlOpen(const char* libraryName)
 {
-    assert(libssl == NULL);
-    libssl = dlopen(libraryName, RTLD_LAZY);
+    void* libsslNew = dlopen(libraryName, RTLD_LAZY);
+
+    // check is someone else has opened and published libssl already
+    if (!pal_atomic_cas_ptr(&libssl, libsslNew, NULL))
+    {
+        dlclose(libsslNew);
+    }
 }
 
 static bool OpenLibrary()

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -73,6 +73,8 @@
 #define NEED_OPENSSL_1_0 true
 #define NEED_OPENSSL_1_1 true
 
+void InitializeOpenSSLShim(void);
+
 #if !HAVE_OPENSSL_EC2M
 // In portable build, we need to support the following functions even if they were not present
 // on the build OS. The shim will detect their presence at runtime.

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -103,6 +103,8 @@
     <Compile Include="DefaultECDsaProvider.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'">
     <Compile Include="DefaultECDiffieHellmanProvider.Unix.cs" />

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
@@ -302,7 +302,7 @@ namespace System.Security.Cryptography.EcDsa.OpenSsl.Tests
 
 internal static partial class Interop
 {
-    internal static class Crypto
+    internal static partial class Crypto
     {
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByOid")]
         internal static extern IntPtr EcKeyCreateByOid(string oid);

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -125,6 +125,8 @@
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs" />
     <Compile Include="SafeEvpPKeyHandleTests.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Cryptography.Cng\src\System.Security.Cryptography.Cng.csproj" />


### PR DESCRIPTION
Also need to make initialization of OpenSsl shim on-demand. 
(see:  https://github.com/dotnet/runtime/issues/46771 and https://github.com/dotnet/sdk/issues/15229). 
Otherwise any singlefile app on macOS tries to initialize the shim and aborts if OpenSsl is not available, which is the default situation.