### PR TITLE
Don't consider types with empty base classes blittable. They have a different managed and native size.

### DIFF
--- a/src/coreclr/vm/classlayoutinfo.cpp
+++ b/src/coreclr/vm/classlayoutinfo.cpp
@@ -654,8 +654,11 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
         );
 
     // Type is blittable only if parent is also blittable and is not empty.
-    isBlittable = isBlittable && (fHasNonTrivialParent
-        ? pParentMT->IsBlittable() && (!pParentLayoutInfo || !pParentLayoutInfo->IsZeroSized()) : TRUE);
+    if (isBlittable && fHasNonTrivialParent)
+    {
+        isBlittable = pParentMT->IsBlittable()  // Check parent
+            && (!pParentLayoutInfo || !pParentLayoutInfo->IsZeroSized()); // Ensure non-zero size
+    }
     pEEClassLayoutInfoOut->SetIsBlittable(isBlittable);
 
     S_UINT32 cbSortArraySize = S_UINT32(cTotalFields) * S_UINT32(sizeof(LayoutRawFieldInfo*));

--- a/src/coreclr/vm/classlayoutinfo.cpp
+++ b/src/coreclr/vm/classlayoutinfo.cpp
@@ -653,8 +653,9 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
         DEBUGARG(szName)
         );
 
-    // Type is blittable only if parent is also blittable
-    isBlittable = isBlittable && (fHasNonTrivialParent ? pParentMT->IsBlittable() : TRUE);
+    // Type is blittable only if parent is also blittable and is not empty.
+    isBlittable = isBlittable && (fHasNonTrivialParent
+        ? pParentMT->IsBlittable() && (!pParentLayoutInfo || !pParentLayoutInfo->IsZeroSized()) : TRUE);
     pEEClassLayoutInfoOut->SetIsBlittable(isBlittable);
 
     S_UINT32 cbSortArraySize = S_UINT32(cTotalFields) * S_UINT32(sizeof(LayoutRawFieldInfo*));

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
@@ -59,6 +59,12 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(8, Marshal.SizeOf<TestStructWithVector64>());
         }
 
+        [Fact]
+        public void SizeOf_TypeWithEmptyBase_ReturnsExpected()
+        {
+            Assert.Equal(4, Marshal.SizeOf<DerivedClass>());
+        }
+
         public static IEnumerable<object[]> SizeOf_InvalidType_TestData()
         {
             yield return new object[] { typeof(int).MakeByRefType(), null };
@@ -135,6 +141,17 @@ namespace System.Runtime.InteropServices.Tests
         public struct TestStructWithVector64
         {
             public System.Runtime.Intrinsics.Vector64<double> v;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class EmptyClass
+        {
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class DerivedClass : EmptyClass
+        {
+            public int i;
         }
     }
 }


### PR DESCRIPTION
With the refactoring of native type layout information loading to be lazy, we made an assumption that if a type is blittable, the managed size, alignment, and field layout are all equal to the native size, alignment, and field layout. However, our calculation of blittability didn't account for the case of a type with blittable fields having an empty base class. As a result, we were considering these types blittable when they weren't.

Fixes #46643