### PR TITLE
Update TraceEvent version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -126,7 +126,6 @@
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>
     <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
-    <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.49</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
     <MicrosoftDiagnosticsToolsRuntimeClientVersion>1.0.4-preview6.19326.1</MicrosoftDiagnosticsToolsRuntimeClientVersion>
     <MicrosoftDiagnosticsNETCoreClientVersion>0.2.61701</MicrosoftDiagnosticsNETCoreClientVersion>
     <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -147,7 +147,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>
-    <TraceEventVersion>2.0.5</TraceEventVersion>
+    <TraceEventVersion>2.0.64</TraceEventVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>

--- a/src/tests/Common/external/external.csproj
+++ b/src/tests/Common/external/external.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="xunit.performance.core" Version="$(XunitPerformanceApiPackageVersion)" />
     <PackageReference Include="xunit.performance.execution" Version="$(XunitPerformanceApiPackageVersion)" />
     <PackageReference Include="xunit.performance.metrics" Version="$(XunitPerformanceApiPackageVersion)" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventPackageVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />

--- a/src/tests/performance/Scenario/JitBench/JitBench.csproj
+++ b/src/tests/performance/Scenario/JitBench/JitBench.csproj
@@ -11,7 +11,7 @@
       <Version>$(CommandLineParserVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-      <Version>$(MicrosoftDiagnosticsTracingTraceEventPackageVersion)</Version>
+      <Version>$(TraceEventVersion)</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.api">
       <Version>$(XunitPerformanceApiPackageVersion)</Version>

--- a/src/tests/performance/Scenario/JitBench/unofficial_dotnet/JitBench.csproj
+++ b/src/tests/performance/Scenario/JitBench/unofficial_dotnet/JitBench.csproj
@@ -18,7 +18,7 @@
       <Version>$(CommandLineParserVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-      <Version>$(MicrosoftDiagnosticsTracingTraceEventPackageVersion)</Version>
+      <Version>$(TraceEventVersion)</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.api">
       <Version>$(XunitPerformanceApiPackageVersion)</Version>

--- a/src/tests/profiler/native/eventpipeprofiler/eventpipewritingprofiler.cpp
+++ b/src/tests/profiler/native/eventpipeprofiler/eventpipewritingprofiler.cpp
@@ -64,7 +64,7 @@ HRESULT EventPipeWritingProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
             0,                              // Keywords
             1,                              // Version
             COR_PRF_EVENTPIPE_LOGALWAYS,    // Level
-            12,                              // opcode
+            0,                              // opcode
             true,                           // Needs stack
             allTypesParamsCount,            // size of params
             allTypesParams,                 // Param descriptors


### PR DESCRIPTION
We're using 2.0.5 version of TraceEvent for tests in System.Diagnostics.Tracing which is from 2018.. This PR bumps up the version to the latest release (2.0.64). 