### PR TITLE
Fix TestsManifestGeneration tests

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -55,6 +55,8 @@ namespace BasicEventSourceTests
 
                     tracesession.Flush();
 
+                    // Sleep after requesting flush to ensure that the manifest payload generated
+                    // is fully written to the etl file.
                     Thread.Sleep(TimeSpan.FromSeconds(5));
 
                     tracesession.DisableProvider("SimpleEventSource");
@@ -90,6 +92,8 @@ namespace BasicEventSourceTests
 
                     tracesession.Flush();
 
+                    // Sleep after requesting flush to ensure that the manifest payload generated
+                    // is fully written to the etl file.
                     Thread.Sleep(TimeSpan.FromSeconds(5));
 
                     tracesession.SetFileName(rolloverFile);

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -54,6 +54,9 @@ namespace BasicEventSourceTests
                     Thread.Sleep(TimeSpan.FromSeconds(5));
 
                     tracesession.Flush();
+
+                    Thread.Sleep(TimeSpan.FromSeconds(5));
+
                     tracesession.DisableProvider("SimpleEventSource");
                     tracesession.Dispose();
 
@@ -86,6 +89,8 @@ namespace BasicEventSourceTests
                     Thread.Sleep(TimeSpan.FromSeconds(5));
 
                     tracesession.Flush();
+
+                    Thread.Sleep(TimeSpan.FromSeconds(5));
 
                     tracesession.SetFileName(rolloverFile);
 


### PR DESCRIPTION
Fix #46518 

These tests sometimes fail because the call to disable the provider or roll over the file happens almost instantly after TraceEventSession.Flush(), and the Manifest data may not have been fully written to the file before we check for its existence. This adds a sleep between flushing and disabling the provider so that there's plenty of leeway for the payload to be fully written to the trace file.
