### PR TITLE
fix SslStreamCertificateContext.Create with partial chain

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -38,16 +38,22 @@ namespace System.Net.Security
                     NetEventSource.Error(null, $"Failed to build chain for {target.Subject}");
                 }
 
-                int count = chain.ChainElements.Count - (TrimRootCertificate ? 1 : 2);
-                foreach (X509ChainStatus status in chain.ChainStatus)
+                int count = chain.ChainElements.Count - 1;
+#pragma warning disable 0162 // Disable unreachable code warning. TrimRootCertificate is const bool = false on some platforms
+                if (TrimRootCertificate)
                 {
-                    if (status.Status.HasFlag(X509ChainStatusFlags.PartialChain))
+                    count--;
+                    foreach (X509ChainStatus status in chain.ChainStatus)
                     {
-                        // The last cert isn't a root cert
-                        count++;
-                        break;
+                        if (status.Status.HasFlag(X509ChainStatusFlags.PartialChain))
+                        {
+                            // The last cert isn't a root cert
+                            count++;
+                            break;
+                        }
                     }
                 }
+#pragma warning restore 0162
 
                 // Count can be zero for a self-signed certificate, or a cert issued directly from a root.
                 if (count > 0 && chain.ChainElements.Count > 1)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -107,8 +107,9 @@ namespace System.Net.Security.Tests
             catch { };
         }
 
-        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, [CallerMemberName] string? testName = null)
+        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, [CallerMemberName] string? testName = null, bool longChain = false)
         {
+            const int keySize = 2048;
             if (PlatformDetection.IsWindows && testName != null)
             {
                 CleanupCertificates(testName);
@@ -132,8 +133,42 @@ namespace System.Net.Security.Tests
                 out X509Certificate2 endEntity,
                 subjectName: targetName,
                 testName: testName,
-                keySize: 2048,
+                keySize: keySize,
                 extensions: extensions);
+
+            if (longChain)
+            {
+                using (RSA intermedKey2 = RSA.Create(keySize))
+                using (RSA intermedKey3 = RSA.Create(keySize))
+                {
+                    X509Certificate2 intermedPub2 = intermediate.CreateSubordinateCA(
+                        $"CN=\"A SSL Test CA 2\", O=\"testName\"",
+                        intermedKey2);
+
+                    X509Certificate2 intermedCert2 = intermedPub2.CopyWithPrivateKey(intermedKey2);
+                    intermedPub2.Dispose();
+                    CertificateAuthority intermediateAuthority2 = new CertificateAuthority(intermedCert2, null, null, null);
+
+                    X509Certificate2 intermedPub3 = intermediateAuthority2.CreateSubordinateCA(
+                        $"CN=\"A SSL Test CA 3\", O=\"testName\"",
+                        intermedKey3);
+
+                    X509Certificate2 intermedCert3 = intermedPub3.CopyWithPrivateKey(intermedKey3);
+                    intermedPub3.Dispose();
+                    CertificateAuthority intermediateAuthority3 = new CertificateAuthority(intermedCert3, null, null, null);
+
+                    RSA  eeKey = (RSA)endEntity.PrivateKey;
+                    endEntity = intermediateAuthority3.CreateEndEntity(
+                        $"CN=\"A SSL Test\", O=\"testName\"",
+                        eeKey,
+                        extensions);
+
+                    endEntity = endEntity.CopyWithPrivateKey(eeKey);
+
+                    chain.Add(intermedCert3);
+                    chain.Add(intermedCert2);
+                }
+            }
 
             chain.Add(intermediate.CloneIssuerCert());
             chain.Add(root.CloneIssuerCert());


### PR DESCRIPTION
With TrimRootCertificate=false, the old logic would incorrectly increase count when chain.Build() return partial chain. That would later cause ArgumentOutOfRangeException when iterating through the chain certificate collection.

Further more, the TrimRootCertificate is swapped. If we want to trim root we need to subtract 2 (e.g. root itself and leaf cert) This will cause wrong number of certificates sent on the wire on Unix. (on Windows all the logic is bolted to OS) 

To fix this, I refactor the code a little bit. There is no need to invoke the partial chain logic at all if we are going to give whole chain to OS (Windows)  

I added variant to SslStream_UntrustedCaWithCustomCallback_OK and verified it will expose the ArgumentOutOfRangeException without the fix.

fixes  #46654
