### PR TITLE
Arm64 apple vm fixes for arg alignment.

### DIFF
--- a/src/coreclr/classlibnative/bcltype/varargsnative.cpp
+++ b/src/coreclr/classlibnative/bcltype/varargsnative.cpp
@@ -115,7 +115,8 @@ static void InitCommon(VARARGS *data, VASigCookie** cookie)
 
     // Always skip over the varargs_cookie.
     const bool isValueType = false;
-    data->ArgPtr += StackElemSize(sizeof(LPVOID), isValueType);
+    const bool isFloatHfa = false;
+    data->ArgPtr += StackElemSize(sizeof(LPVOID), isValueType, isFloatHfa);
 #endif
 }
 
@@ -142,7 +143,8 @@ void AdvanceArgPtr(VARARGS *data)
         TypeHandle thValueType;
         const unsigned cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule, &typeContext, &thValueType);
         const bool isValueType = (!thValueType.IsNull() && thValueType.IsValueType());
-        unsigned cbArg = StackElemSize(cbRaw, isValueType);
+        const bool isFloatHfa = false;
+        unsigned cbArg = StackElemSize(cbRaw, isValueType, isFloatHfa);
 #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
         if (ArgIterator::IsVarArgPassedByRef(cbRaw))
             cbArg = sizeof(void*);
@@ -268,7 +270,8 @@ VarArgsNative::Init2,
             TypeHandle thValueType;
             unsigned cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule,&typeContext, &thValueType);
             const bool isValueType = (!thValueType.IsNull() && thValueType.IsValueType());
-            unsigned cbArg = StackElemSize(cbRaw, isValueType);
+            const bool isFloatHfa = false;
+            unsigned cbArg = StackElemSize(cbRaw, isValueType, isFloatHfa);
 #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
             if (ArgIterator::IsVarArgPassedByRef(cbRaw))
                 cbArg = sizeof(void*);
@@ -425,7 +428,8 @@ FCIMPL3(void, VarArgsNative::GetNextArg2, VARARGS* _this, void * value, ReflectC
     {
         COMPlusThrow(kNotSupportedException, W("NotSupported_Type"));
     }
-    size = StackElemSize(size, isValueType);
+    const bool isFloatHfa = false;
+    size = StackElemSize(size, isValueType, isFloatHfa);
     AdjustArgPtrForAlignment(_this, size);
 
 #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
@@ -478,7 +482,8 @@ VarArgsNative::GetNextArgHelper(
     TypeHandle thValueType;
     const unsigned cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule,&typeContext, &thValueType);
     const bool isValueType = (!thValueType.IsNull() && thValueType.IsValueType());
-    unsigned cbArg = StackElemSize(cbRaw, isValueType);
+    const bool isFloatHfa = false;
+    unsigned cbArg = StackElemSize(cbRaw, isValueType, isFloatHfa);
     AdjustArgPtrForAlignment(data, cbArg);
 
     // Get a pointer to the beginning of the argument.

--- a/src/coreclr/classlibnative/bcltype/varargsnative.cpp
+++ b/src/coreclr/classlibnative/bcltype/varargsnative.cpp
@@ -138,9 +138,9 @@ void AdvanceArgPtr(VARARGS *data)
             break;
 
         SigTypeContext      typeContext; // This is an empty type context.  This is OK because the vararg methods may not be generic
-        SIZE_T cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule, &typeContext);
-        SIZE_T cbArg = StackElemSize(cbRaw);
-
+        TypeHandle thValueType;
+        unsigned cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule, &typeContext, &thValueType);
+        unsigned cbArg = StackElemSize(cbRaw);
 #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
         if (ArgIterator::IsVarArgPassedByRef(cbRaw))
             cbArg = sizeof(void*);
@@ -263,9 +263,9 @@ VarArgsNative::Init2,
             }
 
             SigTypeContext typeContext; // This is an empty type context.  This is OK because the vararg methods may not be generic
-            SIZE_T cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule,&typeContext);
-            SIZE_T cbArg = StackElemSize(cbRaw);
-
+            TypeHandle thValueType;
+            unsigned cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule,&typeContext, &thValueType);
+            unsigned cbArg = StackElemSize(cbRaw);
 #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
             if (ArgIterator::IsVarArgPassedByRef(cbRaw))
                 cbArg = sizeof(void*);
@@ -401,7 +401,7 @@ FCIMPL3(void, VarArgsNative::GetNextArg2, VARARGS* _this, void * value, ReflectC
     TypeHandle typehandle = refType->GetType();
 
     _ASSERTE(_this != NULL);
-    UINT size = 0;
+    unsigned size = 0;
 
     CorElementType typ = typehandle.GetInternalCorElementType();
     if (CorTypeInfo::IsPrimitiveType(typ))
@@ -472,9 +472,9 @@ VarArgsNative::GetNextArgHelper(
     _ASSERTE(data->RemainingArgs != 0);
 
     SigTypeContext typeContext; // This is an empty type context.  This is OK because the vararg methods may not be generic
-    SIZE_T cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule,&typeContext);
-    SIZE_T cbArg = StackElemSize(cbRaw);
-
+    TypeHandle thValueType;
+    unsigned cbRaw = data->SigPtr.SizeOf(data->ArgCookie->pModule,&typeContext, &thValueType);
+    unsigned cbArg = StackElemSize(cbRaw);
     AdjustArgPtrForAlignment(data, cbArg);
 
     // Get a pointer to the beginning of the argument.

--- a/src/coreclr/classlibnative/bcltype/varargsnative.cpp
+++ b/src/coreclr/classlibnative/bcltype/varargsnative.cpp
@@ -116,7 +116,7 @@ static void InitCommon(VARARGS *data, VASigCookie** cookie)
     // Always skip over the varargs_cookie.
     const bool isValueType = false;
     const bool isFloatHfa = false;
-    data->ArgPtr += StackElemSize(sizeof(LPVOID), isValueType, isFloatHfa);
+    data->ArgPtr += StackElemSize(TARGET_POINTER_SIZE, isValueType, isFloatHfa);
 #endif
 }
 

--- a/src/coreclr/gcinfo/gcinfoencoder.cpp
+++ b/src/coreclr/gcinfo/gcinfoencoder.cpp
@@ -577,8 +577,10 @@ GcSlotId GcInfoEncoder::GetStackSlotId( INT32 spOffset, GcSlotFlags flags, GcSta
 
     _ASSERTE( (flags & (GC_SLOT_IS_REGISTER | GC_SLOT_IS_DELETED)) == 0 );
 
+#if !defined(OSX_ARM64_ABI)
     // the spOffset for the stack slot is required to be pointer size aligned
     _ASSERTE((spOffset % TARGET_POINTER_SIZE) == 0);
+#endif
 
     m_SlotTable[ m_NumSlots ].Slot.Stack.SpOffset = spOffset;
     m_SlotTable[ m_NumSlots ].Slot.Stack.Base = spBase;

--- a/src/coreclr/inc/stdmacros.h
+++ b/src/coreclr/inc/stdmacros.h
@@ -185,17 +185,11 @@ inline size_t ALIGN_UP( size_t val, size_t alignment )
     _ASSERTE( result >= val );      // check for overflow
     return result;
 }
-inline void* ALIGN_UP( void* val, size_t alignment )
+
+template <typename T> inline T ALIGN_UP(T val, size_t alignment)
 {
     WRAPPER_NO_CONTRACT;
-
-    return (void*) ALIGN_UP( (size_t)val, alignment );
-}
-inline uint8_t* ALIGN_UP( uint8_t* val, size_t alignment )
-{
-    WRAPPER_NO_CONTRACT;
-
-    return (uint8_t*) ALIGN_UP( (size_t)val, alignment );
+    return (T)ALIGN_UP((size_t)val, alignment);
 }
 
 inline size_t ALIGN_DOWN( size_t val, size_t alignment )

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -145,14 +145,13 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 // Parameter size
 //**********************************************************************
 
-typedef INT64 StackElemType;
-#define STACK_ELEM_SIZE sizeof(StackElemType)
-
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false)
 {
+    typedef INT64 StackElemType;
+    const unsigned stackSlotSize = sizeof(StackElemType);
     // The next expression assumes STACK_ELEM_SIZE is a power of 2.
-    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
-    return (parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1);
+    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 
 //**********************************************************************

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -148,8 +148,12 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 typedef INT64 StackElemType;
 #define STACK_ELEM_SIZE sizeof(StackElemType)
 
-// !! This expression assumes STACK_ELEM_SIZE is a power of 2.
-#define StackElemSize(parmSize) (((parmSize) + STACK_ELEM_SIZE - 1) & ~((ULONG)(STACK_ELEM_SIZE - 1)))
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false)
+{
+    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
+    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return (parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1);
+}
 
 //**********************************************************************
 // Frames

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -145,7 +145,7 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 // Parameter size
 //**********************************************************************
 
-inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false)
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
     typedef INT64 StackElemType;
     const unsigned stackSlotSize = sizeof(StackElemType);

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -150,7 +150,7 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
     const unsigned stackSlotSize = sizeof(void*);
-    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
+    return ALIGN_UP(parmSize, stackSlotSize);
 }
 
 //**********************************************************************

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -149,10 +149,7 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
-    typedef INT64 StackElemType;
-    const unsigned stackSlotSize = sizeof(StackElemType);
-    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
-    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    const unsigned stackSlotSize = sizeof(void*);
     return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -149,7 +149,7 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
-    const unsigned stackSlotSize = sizeof(void*);
+    const unsigned stackSlotSize = 8;
     return ALIGN_UP(parmSize, stackSlotSize);
 }
 

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -101,6 +101,8 @@ EXTERN_C void FastCallFinalizeWorker(Object *obj, PCODE funcPtr);
 #define X86RegFromAMD64Reg(extended_reg) \
             ((X86Reg)(((int)extended_reg) & X86_REGISTER_MASK))
 
+#define FLOAT_REGISTER_SIZE 16 // each register in FloatArgumentRegisters is 16 bytes.
+
 // Why is the return value ARG_SLOT? On 64-bit systems, that is 64-bits
 // and much bigger than necessary for R4, requiring explicit downcasts.
 inline

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -99,7 +99,7 @@ EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 // Parameter size
 //**********************************************************************
 
-inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false)
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
     typedef INT32 StackElemType;
     const unsigned stackSlotSize = sizeof(StackElemType);

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -99,14 +99,13 @@ EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 // Parameter size
 //**********************************************************************
 
-typedef INT32 StackElemType;
-#define STACK_ELEM_SIZE sizeof(StackElemType)
-
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false)
 {
+    typedef INT32 StackElemType;
+    const unsigned stackSlotSize = sizeof(StackElemType);
     // The next expression assumes STACK_ELEM_SIZE is a power of 2.
-    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
-    return (parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1);
+    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 
 //**********************************************************************

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -102,8 +102,12 @@ EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 typedef INT32 StackElemType;
 #define STACK_ELEM_SIZE sizeof(StackElemType)
 
-// !! This expression assumes STACK_ELEM_SIZE is a power of 2.
-#define StackElemSize(parmSize) (((parmSize) + STACK_ELEM_SIZE - 1) & ~((ULONG)(STACK_ELEM_SIZE - 1)))
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false)
+{
+    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
+    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return (parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1);
+}
 
 //**********************************************************************
 // Frames

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -104,7 +104,7 @@ EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
     const unsigned stackSlotSize = sizeof(void*);
-    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
+    return ALIGN_UP(parmSize, stackSlotSize);
 }
 
 //**********************************************************************

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -103,10 +103,7 @@ EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
-    typedef INT32 StackElemType;
-    const unsigned stackSlotSize = sizeof(StackElemType);
-    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
-    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    const unsigned stackSlotSize = sizeof(void*);
     return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -103,7 +103,7 @@ EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
-    const unsigned stackSlotSize = sizeof(void*);
+    const unsigned stackSlotSize = 4;
     return ALIGN_UP(parmSize, stackSlotSize);
 }
 

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -95,6 +95,8 @@ EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 // Offset of pc register
 #define PC_REG_RELATIVE_OFFSET 4
 
+#define FLOAT_REGISTER_SIZE 4 // each register in FloatArgumentRegisters is 4 bytes.
+
 //**********************************************************************
 // Parameter size
 //**********************************************************************

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -81,7 +81,7 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 // Parameter size
 //**********************************************************************
 
-inline unsigned StackElemSize(unsigned parmSize, bool isValueType)
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatHfa)
 {
     typedef INT64 StackElemType;
     const unsigned stackSlotSize = sizeof(StackElemType);

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -84,10 +84,12 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 typedef INT64 StackElemType;
 #define STACK_ELEM_SIZE sizeof(StackElemType)
 
-// The expression below assumes STACK_ELEM_SIZE is a power of 2, so check that.
-static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
-
-#define StackElemSize(parmSize) (((parmSize) + STACK_ELEM_SIZE - 1) & ~((ULONG)(STACK_ELEM_SIZE - 1)))
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType)
+{
+    // The expression below assumes STACK_ELEM_SIZE is a power of 2, so check that.
+    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return ((parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1));
+}
 
 //
 // JIT HELPERS.

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -81,14 +81,13 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 // Parameter size
 //**********************************************************************
 
-typedef INT64 StackElemType;
-#define STACK_ELEM_SIZE sizeof(StackElemType)
-
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType)
 {
-    // The expression below assumes STACK_ELEM_SIZE is a power of 2, so check that.
-    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
-    return ((parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1));
+    typedef INT64 StackElemType;
+    const unsigned stackSlotSize = sizeof(StackElemType);
+    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
+    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 
 //

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -83,6 +83,19 @@ void     R8ToFPSpill(void* pSpillSlot, SIZE_T  srcDoubleAsSIZE_T)
 
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatHfa)
 {
+#if defined(OSX_ARM64_ABI)
+    if (!isValueType)
+    {
+        // No padding/alignment for primitive types.
+        return parmSize;
+    }
+    if (isFloatHfa)
+    {
+        // float hfa is not considered a struct type and passed with 4-byte alignment.
+        return sizeof(float);
+    }
+#endif
+
     typedef INT64 StackElemType;
     const unsigned stackSlotSize = sizeof(StackElemType);
     // The next expression assumes STACK_ELEM_SIZE is a power of 2.

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -99,10 +99,7 @@ inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatH
     }
 #endif
 
-    typedef INT64 StackElemType;
-    const unsigned stackSlotSize = sizeof(StackElemType);
-    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
-    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    const unsigned stackSlotSize = sizeof(void*);
     return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -101,7 +101,7 @@ inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatH
     }
 #endif
 
-    const unsigned stackSlotSize = sizeof(void*);
+    const unsigned stackSlotSize = 8;
     return ALIGN_UP(parmSize, stackSlotSize);
 }
 

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -101,7 +101,7 @@ inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatH
 #endif
 
     const unsigned stackSlotSize = sizeof(void*);
-    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
+    return ALIGN_UP(parmSize, stackSlotSize);
 }
 
 //

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -95,8 +95,9 @@ inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatH
     }
     if (isFloatHfa)
     {
+        _ASSERTE((parmSize % 4) == 0);
         // float hfa is not considered a struct type and passed with 4-byte alignment.
-        return sizeof(float);
+        return parmSize;
     }
 #endif
 

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -88,8 +88,9 @@ inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatH
 #if defined(OSX_ARM64_ABI)
     if (!isValueType)
     {
+        // The primitive types' sizes are expected to be powers of 2.
+        _ASSERTE((parmSize & (parmSize - 1)) == 0);
         // No padding/alignment for primitive types.
-        _ASSERTE((((parmSize & (parmSize - 1)) == 0));
         return parmSize;
     }
     if (isFloatHfa)

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -58,6 +58,8 @@ extern PCODE GetPreStubEntryPoint();
 #define CALLDESCR_FPARGREGS                     1   // CallDescrWorker has FloatArgumentRegisters parameter
 #define CALLDESCR_RETBUFFARGREG                 1   // CallDescrWorker has RetBuffArg parameter that's separate from arg regs
 
+#define FLOAT_REGISTER_SIZE 16 // each register in FloatArgumentRegisters is 16 bytes.
+
 // Given a return address retrieved during stackwalk,
 // this is the offset by which it should be decremented to arrive at the callsite.
 #define STACKWALK_CONTROLPC_ADJUST_OFFSET 4
@@ -87,6 +89,7 @@ inline unsigned StackElemSize(unsigned parmSize, bool isValueType, bool isFloatH
     if (!isValueType)
     {
         // No padding/alignment for primitive types.
+        _ASSERTE((((parmSize & (parmSize - 1)) == 0));
         return parmSize;
     }
     if (isFloatHfa)

--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -517,7 +517,8 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
     CallDescrData callDescrData;
 
     callDescrData.pSrc = pTransitionBlock + sizeof(TransitionBlock);
-    callDescrData.numStackSlots = nStackBytes / STACK_ELEM_SIZE;
+    _ASSERTE((nStackBytes % TARGET_POINTER_SIZE) == 0);
+    callDescrData.numStackSlots = nStackBytes / TARGET_POINTER_SIZE;
 #ifdef CALLDESCR_ARGREGS
     callDescrData.pArgumentRegisters = (ArgumentRegisters*)(pTransitionBlock + TransitionBlock::GetOffsetOfArgumentRegisters());
 #endif

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -688,7 +688,8 @@ public:
         pLoc->Init();
 
         const bool isValueType = (m_argType == ELEMENT_TYPE_VALUETYPE);
-        unsigned byteArgSize = StackElemSize(GetArgSize(), isValueType);
+        unsigned byteArgSize = StackElemSize(GetArgSize(), isValueType, m_argTypeHandle.IsFloatHfa());
+
 
         if (TransitionBlock::IsFloatArgumentRegisterOffset(argOffset))
         {
@@ -1460,7 +1461,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
         break;
     }
     const bool isValueType = (argType == ELEMENT_TYPE_VALUETYPE);
-    const int cbArg = StackElemSize(argSize, isValueType);
+    const int cbArg = StackElemSize(argSize, isValueType, thValueType.IsFloatHfa());
     if (cFPRegs>0 && !this->IsVarArg())
     {
         if (cFPRegs + m_idxFPReg <= 8)
@@ -1767,8 +1768,11 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ForceSigWalk()
         stackElemSize = TARGET_POINTER_SIZE;
 #endif // UNIX_AMD64_ABI
 #else // TARGET_AMD64
-        const bool isValueType = (GetArgType() == ELEMENT_TYPE_VALUETYPE);
-        stackElemSize = StackElemSize(GetArgSize(), isValueType);
+
+        TypeHandle thValueType;
+        const CorElementType argType = GetArgType(&thValueType);
+        const bool isValueType = (argType == ELEMENT_TYPE_VALUETYPE);
+        stackElemSize = StackElemSize(GetArgSize(), isValueType, thValueType.IsFloatHfa());
 #if defined(ENREGISTERED_PARAMTYPE_MAXSIZE)
         if (IsArgPassedByRef())
             stackElemSize = TARGET_POINTER_SIZE;

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -764,7 +764,7 @@ public:
             pLoc->m_idxStack = TransitionBlock::GetStackArgumentIndexFromOffset(argOffset);
             int argOnStackSize;
             if (IsArgPassedByRef())
-                argOnStackSize = STACK_ELEM_SIZE;
+                argOnStackSize = TARGET_POINTER_SIZE;
             else
                 argOnStackSize = GetArgSize();
             pLoc->m_cStack = (argOnStackSize + STACK_ELEM_SIZE - 1) / STACK_ELEM_SIZE;
@@ -1198,9 +1198,9 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
 
     m_fArgInRegisters = false;
 
-    int argOfs = TransitionBlock::GetOffsetOfArgs() + m_idxStack * STACK_ELEM_SIZE;
+    int argOfs = TransitionBlock::GetOffsetOfArgs() + m_idxStack * TARGET_POINTER_SIZE;
 
-    int cArgSlots = cbArg / STACK_ELEM_SIZE;
+    int cArgSlots = cbArg / TARGET_POINTER_SIZE;
     m_idxStack += cArgSlots;
 
     return argOfs;

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -1789,6 +1789,9 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ForceSigWalk()
 
 #endif // TARGET_X86
 
+    // arg stack size is rounded to the pointer size on all platforms.
+    nSizeOfArgStack = (int)ALIGN_UP(nSizeOfArgStack, TARGET_POINTER_SIZE);
+
     // Cache the result
     m_nSizeOfArgStack = nSizeOfArgStack;
     m_dwFlags |= SIZE_OF_ARG_STACK_COMPUTED;

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -39,9 +39,6 @@ struct ArgLocDesc
     int     m_idxGenReg;          // First general register used (or -1)
     int     m_cGenReg;            // Count of general registers used (or 0)
 
-    int     m_idxStack;           // First stack slot used (or -1)
-    int     m_cStack;             // Count of stack slots used (or 0)
-
     int     m_byteStackIndex;     // Stack offset in bytes (or -1)
     int     m_byteStackSize;      // Stack size in bytes
 
@@ -88,8 +85,6 @@ struct ArgLocDesc
         m_cFloatReg = 0;
         m_idxGenReg = -1;
         m_cGenReg = 0;
-        m_idxStack = -1;
-        m_cStack = 0;
         m_byteStackIndex = -1;
         m_byteStackSize = 0;
 #if defined(TARGET_ARM)
@@ -621,11 +616,8 @@ public:
         }
         else
         {
-            pLoc->m_idxStack = TransitionBlock::GetStackArgumentIndexFromOffset(argOffset);
-            pLoc->m_cStack = cSlots;
             pLoc->m_byteStackSize = GetArgSize();
             pLoc->m_byteStackIndex = TransitionBlock::GetStackArgumentByteIndexFromOffset(argOffset);
-            _ASSERTE(pLoc->m_byteStackIndex / TARGET_POINTER_SIZE == pLoc->m_idxStack);
         }
     }
 #endif
@@ -661,20 +653,14 @@ public:
             else
             {
                 pLoc->m_cGenReg = 4 - pLoc->m_idxGenReg;
-                pLoc->m_cStack = cSlots - pLoc->m_cGenReg;
-                pLoc->m_idxStack = 0;
                 pLoc->m_byteStackIndex = 0;
                 pLoc->m_byteStackSize = byteArgSize - pLoc->m_cGenReg * TARGET_POINTER_SIZE;
             }
         }
         else
         {
-            pLoc->m_idxStack = TransitionBlock::GetStackArgumentIndexFromOffset(argOffset);
-            pLoc->m_cStack = cSlots;
-
             pLoc->m_byteStackIndex = TransitionBlock::GetStackArgumentByteIndexFromOffset(argOffset);
             pLoc->m_byteStackSize = byteArgSize;
-            _ASSERTE(pLoc->m_byteStackIndex / TARGET_POINTER_SIZE == pLoc->m_idxStack);
         }
     }
 #endif // TARGET_ARM
@@ -733,11 +719,8 @@ public:
         }
         else
         {
-            pLoc->m_idxStack = TransitionBlock::GetStackArgumentIndexFromOffset(argOffset);
-            pLoc->m_cStack = cSlots;
             pLoc->m_byteStackIndex = TransitionBlock::GetStackArgumentByteIndexFromOffset(argOffset);
             pLoc->m_byteStackSize = byteArgSize;
-            _ASSERTE(pLoc->m_byteStackIndex / TARGET_POINTER_SIZE == pLoc->m_idxStack);
         }
     }
 #endif // TARGET_ARM64
@@ -793,16 +776,13 @@ public:
         }
         else
         {
-            pLoc->m_idxStack = TransitionBlock::GetStackArgumentIndexFromOffset(argOffset);
             pLoc->m_byteStackIndex = TransitionBlock::GetStackArgumentByteIndexFromOffset(argOffset);
             int argSizeInBytes;
             if (IsArgPassedByRef())
                 argSizeInBytes = TARGET_POINTER_SIZE;
             else
                 argSizeInBytes = GetArgSize();
-            pLoc->m_cStack = (argSizeInBytes + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE;
             pLoc->m_byteStackSize = argSizeInBytes;
-            _ASSERTE(pLoc->m_byteStackIndex / TARGET_POINTER_SIZE == pLoc->m_idxStack);
         }
     }
 #endif // TARGET_AMD64

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -1764,14 +1764,14 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ForceSigWalk()
 #else // UNIX_AMD64_ABI
         // All stack arguments take just one stack slot on AMD64 because of arguments bigger
         // than a stack slot are passed by reference.
-        stackElemSize = STACK_ELEM_SIZE;
+        stackElemSize = TARGET_POINTER_SIZE;
 #endif // UNIX_AMD64_ABI
 #else // TARGET_AMD64
         const bool isValueType = (GetArgType() == ELEMENT_TYPE_VALUETYPE);
         stackElemSize = StackElemSize(GetArgSize(), isValueType);
 #if defined(ENREGISTERED_PARAMTYPE_MAXSIZE)
         if (IsArgPassedByRef())
-            stackElemSize = STACK_ELEM_SIZE;
+            stackElemSize = TARGET_POINTER_SIZE;
 #endif
 #endif // TARGET_AMD64
 

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -648,7 +648,7 @@ public:
 
             if ((int)byteArgSize <= (4 - pLoc->m_idxGenReg) * TARGET_POINTER_SIZE)
             {
-                pLoc->m_cGenReg = (byteArgSize + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE;
+                pLoc->m_cGenReg = ALIGN_UP(byteArgSize, TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;
             }
             else
             {
@@ -696,7 +696,7 @@ public:
         }
 
 
-        unsigned cSlots = (byteArgSize + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE;
+        unsigned cSlots = ALIGN_UP(byteArgSize, TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;
 
         // Question: why do not arm and x86 have similar checks?
         // Composites greater than 16 bytes are passed by reference
@@ -714,7 +714,7 @@ public:
         if (!TransitionBlock::IsStackArgumentOffset(argOffset))
         {
             pLoc->m_idxGenReg = TransitionBlock::GetArgumentIndexFromOffset(argOffset);
-            pLoc->m_cGenReg = (byteArgSize + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE;;
+            pLoc->m_cGenReg = ALIGN_UP(byteArgSize, TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;;
         }
         else
         {
@@ -1354,7 +1354,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
         if (cbArg <= cRemainingRegs * TARGET_POINTER_SIZE)
         {
             // Mark the registers just allocated as used.
-            m_idxGenReg += (cbArg + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE;
+            m_idxGenReg += ALIGN_UP(cbArg, TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;
             return argOfs;
         }
 
@@ -1459,7 +1459,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
 #if !defined(OSX_ARM64_ABI)
         _ASSERTE((cbArg% TARGET_POINTER_SIZE) == 0);
 #endif
-        const int regSlots = (cbArg + TARGET_POINTER_SIZE - 1) / TARGET_POINTER_SIZE;
+        const int regSlots = ALIGN_UP(cbArg, TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;
         // Only x0-x7 are valid argument registers (x8 is always the return buffer)
         if (m_idxGenReg + regSlots <= 8)
         {

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -636,9 +636,9 @@ public:
         int cSlots = (GetArgSize() + 3) / 4;
         if (TransitionBlock::IsFloatArgumentRegisterOffset(argOffset))
         {
-            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / TARGET_POINTER_SIZE;
-            _ASSERTE(byteArgSize / TARGET_POINTER_SIZE == cSlots);
-            pLoc->m_cFloatReg = byteArgSize / TARGET_POINTER_SIZE;
+            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / FLOAT_REGISTER_SIZE;
+            _ASSERTE(byteArgSize / FLOAT_REGISTER_SIZE == cSlots);
+            pLoc->m_cFloatReg = byteArgSize / FLOAT_REGISTER_SIZE;
             return;
         }
 
@@ -679,8 +679,7 @@ public:
 
         if (TransitionBlock::IsFloatArgumentRegisterOffset(argOffset))
         {
-            // Dividing by 16 as size of each register in FloatArgumentRegisters is 16 bytes.
-            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / 16;
+            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / FLOAT_REGISTER_SIZE;
 
             if (!m_argTypeHandle.IsNull() && m_argTypeHandle.IsHFA())
             {
@@ -752,8 +751,7 @@ public:
 #if defined(UNIX_AMD64_ABI)
         if (TransitionBlock::IsFloatArgumentRegisterOffset(argOffset))
         {
-            // Dividing by 16 as size of each register in FloatArgumentRegisters is 16 bytes.
-            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / 16;
+            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / FLOAT_REGISTER_SIZE;
             pLoc->m_cFloatReg = 1;
         }
         else 

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -685,7 +685,7 @@ public:
             {
                 CorInfoHFAElemType type = m_argTypeHandle.GetHFAType();
                 pLoc->setHFAFieldSize(type);
-                pLoc->m_cFloatReg = byteArgSize / pLoc->m_hfaFieldSize;
+                pLoc->m_cFloatReg = GetArgSize() / pLoc->m_hfaFieldSize;
 
             }
             else
@@ -780,7 +780,7 @@ public:
                 argSizeInBytes = TARGET_POINTER_SIZE;
             else
                 argSizeInBytes = GetArgSize();
-            pLoc->m_byteStackSize = argSizeInBytes;
+            pLoc->m_byteStackSize = StackElemSize(argSizeInBytes);
         }
     }
 #endif // TARGET_AMD64

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -634,7 +634,7 @@ public:
         {
             const int floatRegOfsInBytes = argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters();
             _ASSERTE((floatRegOfsInBytes % FLOAT_REGISTER_SIZE) == 0);
-            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / FLOAT_REGISTER_SIZE;
+            pLoc->m_idxFloatReg = floatRegOfsInBytes / FLOAT_REGISTER_SIZE;
             pLoc->m_cFloatReg = ALIGN_UP(byteArgSize, FLOAT_REGISTER_SIZE) / FLOAT_REGISTER_SIZE;
             return;
         }
@@ -673,7 +673,9 @@ public:
 
         if (TransitionBlock::IsFloatArgumentRegisterOffset(argOffset))
         {
-            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / FLOAT_REGISTER_SIZE;
+            const int floatRegOfsInBytes = argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters();
+            _ASSERTE((floatRegOfsInBytes % FLOAT_REGISTER_SIZE) == 0);
+            pLoc->m_idxFloatReg = floatRegOfsInBytes / FLOAT_REGISTER_SIZE;
 
             if (!m_argTypeHandle.IsNull() && m_argTypeHandle.IsHFA())
             {
@@ -745,7 +747,9 @@ public:
 #if defined(UNIX_AMD64_ABI)
         if (TransitionBlock::IsFloatArgumentRegisterOffset(argOffset))
         {
-            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / FLOAT_REGISTER_SIZE;
+            const int floatRegOfsInBytes = argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters();
+            _ASSERTE((floatRegOfsInBytes % FLOAT_REGISTER_SIZE) == 0);
+            pLoc->m_idxFloatReg = floatRegOfsInBytes / FLOAT_REGISTER_SIZE;
             pLoc->m_cFloatReg = 1;
         }
         else 

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -1274,7 +1274,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
     m_fRequires64BitAlignment = fRequiresAlign64Bit;
 
     int cbArg = StackElemSize(argSize);
-    assert((cbArg % TARGET_POINTER_SIZE) == 0);
+    _ASSERTE((cbArg % TARGET_POINTER_SIZE) == 0);
 
     // Ignore floating point argument placement in registers if we're dealing with a vararg function (the ABI
     // specifies this so that vararg processing on the callee side is simplified).

--- a/src/coreclr/vm/clrvarargs.cpp
+++ b/src/coreclr/vm/clrvarargs.cpp
@@ -76,7 +76,8 @@ VARARGS::MarshalToUnmanagedVaList(
             case ELEMENT_TYPE_U:
             case ELEMENT_TYPE_PTR:
                 {
-                    DWORD cbSize = StackElemSize(CorTypeInfo::Size(elemType));
+                    const bool isValueType = false;
+                    DWORD cbSize = StackElemSize(CorTypeInfo::Size(elemType), isValueType);
 
                     #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
                     if (cbSize > ENREGISTERED_PARAMTYPE_MAXSIZE)

--- a/src/coreclr/vm/clrvarargs.cpp
+++ b/src/coreclr/vm/clrvarargs.cpp
@@ -77,7 +77,8 @@ VARARGS::MarshalToUnmanagedVaList(
             case ELEMENT_TYPE_PTR:
                 {
                     const bool isValueType = false;
-                    DWORD cbSize = StackElemSize(CorTypeInfo::Size(elemType), isValueType);
+                    const bool isFloatHfa = false;
+                    DWORD cbSize = StackElemSize(CorTypeInfo::Size(elemType), isValueType, isFloatHfa);
 
                     #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
                     if (cbSize > ENREGISTERED_PARAMTYPE_MAXSIZE)

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -194,7 +194,7 @@ public:
             index = byteIndex / TARGET_POINTER_SIZE;
             _ASSERTE((m_argLocDesc->m_idxStack + m_currentStackSlotIndex) == index);
             m_currentStackSlotIndex++;
-            m_currentByteStackIndex += m_argLocDesc->m_byteStackSize;
+            m_currentByteStackIndex += TARGET_POINTER_SIZE;
 
             // Delegates cannot handle overly large argument stacks due to shuffle entry encoding limitations.
             if (index >= ShuffleEntry::REGMASK)

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -605,13 +605,13 @@ VOID GenerateShuffleArray(MethodDesc* pInvoke, MethodDesc *pTargetMeth, SArray<S
             entry.srcofs = ShuffleOfs(ofsSrc);
             entry.dstofs = ShuffleOfs(ofsDst, stackSizeDelta);
 
-            ofsSrc += STACK_ELEM_SIZE;
-            ofsDst += STACK_ELEM_SIZE;
+            ofsSrc += TARGET_POINTER_SIZE;
+            ofsDst += TARGET_POINTER_SIZE;
 
             if (entry.srcofs != entry.dstofs)
                 pShuffleEntryArray->Append(entry);
 
-            cbSize -= STACK_ELEM_SIZE;
+            cbSize -= TARGET_POINTER_SIZE;
         }
         while (cbSize > 0);
     }

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -77,8 +77,6 @@ class ShuffleIterator
     int m_currentFloatRegIndex;
     // Current byte stack index (relative to the ArgLocDesc::m_byteStackIndex)
     int m_currentByteStackIndex;
-    // Current stack slot index (relative to the ArgLocDesc::m_idxStack)
-    int m_currentStackSlotIndex;
 
 #if defined(UNIX_AMD64_ABI)
     // Get next shuffle offset for struct passed in registers. There has to be at least one offset left.
@@ -136,15 +134,13 @@ public:
 #endif
         m_currentGenRegIndex(0),
         m_currentFloatRegIndex(0),
-        m_currentByteStackIndex(0),
-        m_currentStackSlotIndex(0)
+        m_currentByteStackIndex(0)
     {
     }
 
     // Check if there are more offsets to shuffle
     bool HasNextOfs()
     {
-        _ASSERTE((m_currentStackSlotIndex < m_argLocDesc->m_cStack) == (m_currentByteStackIndex < m_argLocDesc->m_byteStackSize));
         return (m_currentGenRegIndex < m_argLocDesc->m_cGenReg) ||
                (m_currentFloatRegIndex < m_argLocDesc->m_cFloatReg) ||
                (m_currentByteStackIndex < m_argLocDesc->m_byteStackSize);
@@ -186,14 +182,11 @@ public:
 
         // If we get here we must have at least one stack slot left to shuffle (this method should only be called
         // when AnythingToShuffle(pArg) == true).
-        _ASSERTE((m_currentByteStackIndex < m_argLocDesc->m_byteStackSize) == (m_currentStackSlotIndex < m_argLocDesc->m_cStack));
         if (m_currentByteStackIndex < m_argLocDesc->m_byteStackSize)
         {            
             const unsigned byteIndex = m_argLocDesc->m_byteStackIndex + m_currentByteStackIndex;
             _ASSERTE((byteIndex % TARGET_POINTER_SIZE) == 0);
             index = byteIndex / TARGET_POINTER_SIZE;
-            _ASSERTE((m_argLocDesc->m_idxStack + m_currentStackSlotIndex) == index);
-            m_currentStackSlotIndex++;
             m_currentByteStackIndex += TARGET_POINTER_SIZE;
 
             // Delegates cannot handle overly large argument stacks due to shuffle entry encoding limitations.

--- a/src/coreclr/vm/comtoclrcall.cpp
+++ b/src/coreclr/vm/comtoclrcall.cpp
@@ -226,7 +226,7 @@ inline static void InvokeStub(ComCallMethodDesc *pCMD, PCODE pManagedTarget, OBJ
     INT_PTR dangerousThis;
     *(OBJECTREF *)&dangerousThis = orThis;
 
-    DWORD dwStackSlots = pCMD->GetNumStackBytes() / STACK_ELEM_SIZE;
+    DWORD dwStackSlots = pCMD->GetNumStackBytes() / TARGET_POINTER_SIZE;
 
     // Managed code is generally "THROWS" and we have no exception handler here that the contract system can
     // see.  We ensure that we don't get exceptions here by generating a try/catch in the IL stub that covers
@@ -827,7 +827,7 @@ void ComCallMethodDesc::InitRuntimeNativeInfo(MethodDesc *pStubMD)
     NewArrayHolder<UINT16> pwStubStackSlotOffsets;
     UINT16 *pOutputStack = NULL;
 
-    UINT16 wStubStackSlotCount = static_cast<UINT16>(dwArgStack) / STACK_ELEM_SIZE;
+    UINT16 wStubStackSlotCount = static_cast<UINT16>(dwArgStack) / TARGET_POINTER_SIZE;
     if (wStubStackSlotCount > 0)
     {
         pwStubStackSlotOffsets = new UINT16[wStubStackSlotCount];
@@ -843,15 +843,15 @@ void ComCallMethodDesc::InitRuntimeNativeInfo(MethodDesc *pStubMD)
     if (!pStubMD->IsStatic())
     {
         numRegistersUsed++;
-        wInputStack += STACK_ELEM_SIZE;
+        wInputStack += TARGET_POINTER_SIZE;
     }
 
     // process the return buffer parameter
     if (argit.HasRetBuffArg())
     {
         numRegistersUsed++;
-        wSourceSlotEDX = wInputStack / STACK_ELEM_SIZE;
-        wInputStack += STACK_ELEM_SIZE;
+        wSourceSlotEDX = wInputStack / TARGET_POINTER_SIZE;
+        wInputStack += TARGET_POINTER_SIZE;
     }
 
     // process ordinary parameters
@@ -864,17 +864,18 @@ void ComCallMethodDesc::InitRuntimeNativeInfo(MethodDesc *pStubMD)
 
         if (ArgIterator::IsArgumentInRegister(&numRegistersUsed, type, thValueType))
         {
-            wSourceSlotEDX = wInputStack / STACK_ELEM_SIZE;
-            wInputStack += STACK_ELEM_SIZE;
+            wSourceSlotEDX = wInputStack / TARGET_POINTER_SIZE;
+            wInputStack += TARGET_POINTER_SIZE;
         }
         else
         {
             // we may need more stack slots for larger parameters
-            pOutputStack -= StackElemSize(cbSize) / STACK_ELEM_SIZE;
-            for (UINT slot = 0; slot < (StackElemSize(cbSize) / STACK_ELEM_SIZE); slot++)
+            UINT slotsCount = StackElemSize(cbSize) / TARGET_POINTER_SIZE;
+            pOutputStack -= slotsCount;
+            for (UINT slot = 0; slot < slotsCount; slot++)
             {
                 pOutputStack[slot] = wInputStack;
-                wInputStack += STACK_ELEM_SIZE;
+                wInputStack += TARGET_POINTER_SIZE;
             }
         }
     }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -3230,7 +3230,8 @@ BOOL NDirect::MarshalingRequired(
 #endif
                 if (i > 0)
                 {
-                    dwStackSize += StackElemSize(hndArgType.GetSize());
+                    const bool isValueType = true;
+                    dwStackSize += StackElemSize(hndArgType.GetSize(), isValueType);
                 }
                 break;
             }
@@ -3247,7 +3248,12 @@ BOOL NDirect::MarshalingRequired(
             {
                 if (CorTypeInfo::IsPrimitiveType(type) || type == ELEMENT_TYPE_FNPTR)
                 {
-                    if (i > 0) dwStackSize += StackElemSize(CorTypeInfo::Size(type));
+
+                    if (i > 0)
+                    {
+                        const bool isValueType = false;
+                        dwStackSize += StackElemSize(CorTypeInfo::Size(type), isValueType);
+                    }
                 }
                 else
                 {

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -3231,7 +3231,7 @@ BOOL NDirect::MarshalingRequired(
                 if (i > 0)
                 {
                     const bool isValueType = true;
-                    dwStackSize += StackElemSize(hndArgType.GetSize(), isValueType);
+                    dwStackSize += StackElemSize(hndArgType.GetSize(), isValueType, hndArgType.IsFloatHfa());
                 }
                 break;
             }
@@ -3252,7 +3252,8 @@ BOOL NDirect::MarshalingRequired(
                     if (i > 0)
                     {
                         const bool isValueType = false;
-                        dwStackSize += StackElemSize(CorTypeInfo::Size(type), isValueType);
+                        const bool isFloatHfa = false;
+                        dwStackSize += StackElemSize(CorTypeInfo::Size(type), isValueType, isFloatHfa);
                     }
                 }
                 else

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -105,15 +105,14 @@ EXTERN_C void SinglecastDelegateInvokeStub();
 typedef INT32 StackElemType;
 #define STACK_ELEM_SIZE sizeof(StackElemType)
 
-
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false  /* unused */)
+{
+    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
+    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return (parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1);
+}
 
 #include "stublinkerx86.h"
-
-
-
-// !! This expression assumes STACK_ELEM_SIZE is a power of 2.
-#define StackElemSize(parmSize) (((parmSize) + STACK_ELEM_SIZE - 1) & ~((ULONG)(STACK_ELEM_SIZE - 1)))
-
 
 //**********************************************************************
 // Frames

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -102,7 +102,7 @@ EXTERN_C void SinglecastDelegateInvokeStub();
 // Parameter size
 //**********************************************************************
 
-inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false  /* unused */)
+inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
     typedef INT32 StackElemType;
     const unsigned stackSlotSize = sizeof(StackElemType);

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -102,14 +102,13 @@ EXTERN_C void SinglecastDelegateInvokeStub();
 // Parameter size
 //**********************************************************************
 
-typedef INT32 StackElemType;
-#define STACK_ELEM_SIZE sizeof(StackElemType)
-
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false  /* unused */)
 {
+    typedef INT32 StackElemType;
+    const unsigned stackSlotSize = sizeof(StackElemType);
     // The next expression assumes STACK_ELEM_SIZE is a power of 2.
-    static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
-    return (parmSize + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1);
+    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 
 #include "stublinkerx86.h"

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -104,7 +104,7 @@ EXTERN_C void SinglecastDelegateInvokeStub();
 
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
-    const unsigned stackSlotSize = sizeof(void*);
+    const unsigned stackSlotSize = 4;
     return ALIGN_UP(parmSize, stackSlotSize);
 }
 

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -105,7 +105,7 @@ EXTERN_C void SinglecastDelegateInvokeStub();
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
     const unsigned stackSlotSize = sizeof(void*);
-    return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
+    return ALIGN_UP(parmSize, stackSlotSize);
 }
 
 #include "stublinkerx86.h"

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -104,10 +104,7 @@ EXTERN_C void SinglecastDelegateInvokeStub();
 
 inline unsigned StackElemSize(unsigned parmSize, bool isValueType = false /* unused */, bool isFloatHfa = false /* unused */)
 {
-    typedef INT32 StackElemType;
-    const unsigned stackSlotSize = sizeof(StackElemType);
-    // The next expression assumes STACK_ELEM_SIZE is a power of 2.
-    static_assert(((stackSlotSize & (stackSlotSize-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+    const unsigned stackSlotSize = sizeof(void*);
     return (parmSize + stackSlotSize - 1) & ~(stackSlotSize - 1);
 }
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2758,7 +2758,10 @@ public:
     void SetNativeStackArgSize(WORD cbArgSize)
     {
         LIMITED_METHOD_CONTRACT;
-        _ASSERTE(IsILStub() && (cbArgSize % TARGET_POINTER_SIZE) == 0);
+        _ASSERTE(IsILStub());
+#if !defined(OSX_ARM64_ABI)
+        _ASSERTE((cbArgSize % TARGET_POINTER_SIZE) == 0);
+#endif
         m_dwExtendedFlags = (m_dwExtendedFlags & ~nomdStackArgSize) | ((DWORD)cbArgSize << 16);
     }
 

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -2909,16 +2909,8 @@ UINT16 MarshalInfo::GetNativeSize(MarshalType mtype)
 
     if (nativeSize == VARIABLESIZE)
     {
-        switch (mtype)
-        {
-            case MARSHAL_TYPE_BLITTABLEVALUECLASS:
-            case MARSHAL_TYPE_VALUECLASS:
-            case MARSHAL_TYPE_BLITTABLEVALUECLASSWITHCOPYCTOR:
-                return (UINT16) m_pMT->GetNativeSize();
-
-            default:
-                _ASSERTE(0);
-        }
+        _ASSERTE(IsValueClass(mtype));
+        return (UINT16) m_pMT->GetNativeSize();
     }
 
     return nativeSize;
@@ -2943,6 +2935,20 @@ bool MarshalInfo::IsInOnly(MarshalType mtype)
     };
 
     return ILMarshalerIsInOnly[mtype];
+}
+
+bool MarshalInfo::IsValueClass(MarshalType mtype)
+{
+    switch (mtype)
+    {
+    case MARSHAL_TYPE_BLITTABLEVALUECLASS:
+    case MARSHAL_TYPE_VALUECLASS:
+    case MARSHAL_TYPE_BLITTABLEVALUECLASSWITHCOPYCTOR:
+        return true;
+
+    default:
+        return false;
+    }
 }
 
 OVERRIDEPROC MarshalInfo::GetArgumentOverrideProc(MarshalType mtype)

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -2875,7 +2875,8 @@ void MarshalInfo::SetupArgumentSizes()
 
     const unsigned targetPointerSize = TARGET_POINTER_SIZE;
     const bool pointerIsValueType = false;
-    _ASSERTE(targetPointerSize == StackElemSize(TARGET_POINTER_SIZE, pointerIsValueType));
+    const bool pointerIsFloatHfa = false;
+    _ASSERTE(targetPointerSize == StackElemSize(TARGET_POINTER_SIZE, pointerIsValueType, pointerIsFloatHfa));
 
     if (m_byref)
     {
@@ -2883,7 +2884,9 @@ void MarshalInfo::SetupArgumentSizes()
     }
     else
     {
-        m_nativeArgSize = StackElemSize(GetNativeSize(m_type), IsValueClass(m_type));
+        const bool isValueType = IsValueClass(m_type);
+        const bool isFloatHfa = isValueType && (m_pMT->GetHFAType() == CORINFO_HFA_ELEM_FLOAT);
+        m_nativeArgSize = StackElemSize(GetNativeSize(m_type), isValueType, isFloatHfa);
     }
 
 #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -2873,18 +2873,24 @@ void MarshalInfo::SetupArgumentSizes()
     }
     CONTRACTL_END;
 
+    const unsigned targetPointerSize = TARGET_POINTER_SIZE;
+    const bool pointerIsValueType = false;
+    _ASSERTE(targetPointerSize == StackElemSize(TARGET_POINTER_SIZE, pointerIsValueType));
+
     if (m_byref)
     {
-        m_nativeArgSize = StackElemSize(TARGET_POINTER_SIZE);
+        m_nativeArgSize = targetPointerSize;
     }
     else
     {
-        m_nativeArgSize = StackElemSize(GetNativeSize(m_type));
+        m_nativeArgSize = StackElemSize(GetNativeSize(m_type), IsValueClass(m_type));
     }
 
 #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
     if (m_nativeArgSize > ENREGISTERED_PARAMTYPE_MAXSIZE)
-        m_nativeArgSize = StackElemSize(TARGET_POINTER_SIZE);
+    {
+        m_nativeArgSize = targetPointerSize;
+    }
 #endif // ENREGISTERED_PARAMTYPE_MAXSIZE
 }
 

--- a/src/coreclr/vm/mlinfo.h
+++ b/src/coreclr/vm/mlinfo.h
@@ -490,6 +490,7 @@ private:
 
     UINT16                      GetNativeSize(MarshalType mtype);
     static bool                 IsInOnly(MarshalType mtype);
+    static bool                 IsValueClass(MarshalType mtype);
 
     static OVERRIDEPROC         GetArgumentOverrideProc(MarshalType mtype);
     static RETURNOVERRIDEPROC   GetReturnOverrideProc(MarshalType mtype);

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -828,7 +828,8 @@ FCIMPL5(Object*, RuntimeMethodHandle::InvokeMethod,
     CallDescrData callDescrData;
 
     callDescrData.pSrc = pTransitionBlock + sizeof(TransitionBlock);
-    callDescrData.numStackSlots = nStackBytes / STACK_ELEM_SIZE;
+    _ASSERTE((nStackBytes % TARGET_POINTER_SIZE) == 0);
+    callDescrData.numStackSlots = nStackBytes / TARGET_POINTER_SIZE;
 #ifdef CALLDESCR_ARGREGS
     callDescrData.pArgumentRegisters = (ArgumentRegisters*)(pTransitionBlock + TransitionBlock::GetOffsetOfArgumentRegisters());
 #endif

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -2598,7 +2598,7 @@ UINT MetaSig::GetElemSize(CorElementType etype, TypeHandle thValueType)
 // Returns size of that element in bytes. This is the minimum size that a
 // field of this type would occupy inside an object.
 //
-UINT SigPointer::SizeOf(Module* pModule, const SigTypeContext *pTypeContext) const
+UINT SigPointer::SizeOf(Module* pModule, const SigTypeContext *pTypeContext, TypeHandle* pTypeHandle) const
 {
     CONTRACTL
     {
@@ -2613,9 +2613,8 @@ UINT SigPointer::SizeOf(Module* pModule, const SigTypeContext *pTypeContext) con
     }
     CONTRACTL_END
 
-    TypeHandle thValueType;
-    CorElementType etype = PeekElemTypeNormalized(pModule, pTypeContext, &thValueType);
-    return MetaSig::GetElemSize(etype, thValueType);
+    CorElementType etype = PeekElemTypeNormalized(pModule, pTypeContext, pTypeHandle);
+    return MetaSig::GetElemSize(etype, *pTypeHandle);
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -197,7 +197,7 @@ public:
         // Returns size of that element in bytes. This is the minimum size that a
         // field of this type would occupy inside an object.
         //------------------------------------------------------------------------
-        UINT SizeOf(Module* pModule, const SigTypeContext *pTypeContext) const;
+        UINT SizeOf(Module* pModule, const SigTypeContext *pTypeContext, TypeHandle* pTypeHandle) const;
 
 private:
 
@@ -856,7 +856,8 @@ class MetaSig
         {
             WRAPPER_NO_CONTRACT;
             SUPPORTS_DAC;
-            return m_pRetType.SizeOf(m_pModule, &m_typeContext);
+            TypeHandle thValueType;
+            return m_pRetType.SizeOf(m_pModule, &m_typeContext, &thValueType);
         }
 
         //------------------------------------------------------------------

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -434,6 +434,16 @@ CorInfoHFAElemType TypeHandle::GetHFAType() const
     return CORINFO_HFA_ELEM_NONE;
 }
 
+bool TypeHandle::IsFloatHfa() const
+{
+    WRAPPER_NO_CONTRACT;
+    if (IsNull() || !IsHFA())
+    {
+        return false;
+    }
+    return (GetHFAType() == CORINFO_HFA_ELEM_FLOAT);
+}
+
 
 #ifdef FEATURE_64BIT_ALIGNMENT
 bool TypeHandle::RequiresAlign8() const

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -388,6 +388,7 @@ Instantiation TypeHandle::GetInstantiation() const
 BOOL TypeHandle::IsValueType()  const
 {
     LIMITED_METHOD_DAC_CONTRACT;
+    _ASSERTE(!IsNull());
 
     if (!IsTypeDesc()) return AsMethodTable()->IsValueType();
     else return AsTypeDesc()->IsNativeValueType();

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -373,6 +373,8 @@ public:
     bool IsHFA() const;
     CorInfoHFAElemType GetHFAType() const;
 
+    bool IsFloatHfa() const;
+
 #ifdef FEATURE_64BIT_ALIGNMENT
     bool RequiresAlign8() const;
 #endif // FEATURE_64BIT_ALIGNMENT

--- a/src/tests/reflection/regression/manyStackArgs/manyStackArgs.cs
+++ b/src/tests/reflection/regression/manyStackArgs/manyStackArgs.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+public class TestSmallStackArgsClass
+{
+    public TestSmallStackArgsClass()
+    { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int TestSmallStackArgsMethod(short s1, short s2, short s3, short s4, short s5, short s6, short s7, short s8, short s9, short s10, short s11, short s12)
+    {
+        if (s1 != 1 || s2 != 2 || s3 != 3 || s4 != 4 || s5 != 5 || s6 != 6 || s7 != 7 || s8 != 8 || s9 != 9 || s10 != 10 || s11 != 11 || s12 != 12)
+        {
+            Console.WriteLine("small stack arguments do not match.");
+            Console.WriteLine("Expected: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12");
+            Console.WriteLine("Actual: " + s1 + ", " + s2 + ", " + s3 + ", " + s4 + ", " + s5 + ", " + s6 + ", " + s7 + ", " + s8 + ", " + s9 + ", " + s10 + ", " + s11 + ", " + s12);
+            return 101;
+        }
+        return 100;
+    }
+}
+
+public class TestMethodInfo
+{
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int InvokeReflection(object testClassObject, MethodInfo testMethod, object[] args)
+    {
+
+        object retValue = testMethod.Invoke(testClassObject, args);
+        int r = Convert.ToInt32(retValue);
+        return r;
+    }
+
+
+    public static int Main()
+    {
+        Type testClass = Type.GetType("TestSmallStackArgsClass");
+        ConstructorInfo testConstructor = testClass.GetConstructor(Type.EmptyTypes);
+        object testClassObject = testConstructor.Invoke(new object[] { });
+
+        MethodInfo testMethod = testClass.GetMethod("TestSmallStackArgsMethod");
+        var args = new object[12];
+        for (short i = 0; i < 12; ++i)
+        {
+            args[i] = (short)(i + 1);
+        }
+
+        int r = InvokeReflection(testClassObject, testMethod, args);
+
+        if (r != 100)
+        {
+            Console.WriteLine("The test failed");
+            return 101;
+        }
+        Console.WriteLine("The test passed");
+        return 100;
+    }
+}

--- a/src/tests/reflection/regression/manyStackArgs/manyStackArgs.csproj
+++ b/src/tests/reflection/regression/manyStackArgs/manyStackArgs.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Contributes to #46456.

Move to byte sizes/offsets in VM so it works correctly with arguments that do not occupy TARGET_POINTER_SIZE stack slots on arm64.

It also unifies some platforms, for example, before `ArgIteratorBase` was using byte offsets for some and stack slot index for the others, now it uses byte offset for all.

Use `TARGET_POINTER_SIZE` instead of `STACK_ELEM_SIZE` because:
1. there were many places where `TARGET_POINTER_SIZE` was already used in such context;
2. it is confusing for arm64 apple to have `STACK_ELEM_SIZE` and I did not come up with a better name;
