### PR TITLE
Methods  "readonly" annotation

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
@@ -130,7 +130,7 @@ internal static partial class Interop
             _rawErrno = -1;
         }
 
-        internal Error Error
+        internal readonly Error Error
         {
             get { return _error; }
         }

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssBuffer.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssBuffer.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             internal ulong _length;
             internal IntPtr _data;
 
-            internal int Copy(byte[] destination, int offset)
+            internal readonly int Copy(byte[] destination, int offset)
             {
                 Debug.Assert(destination != null, "target destination cannot be null");
                 Debug.Assert((offset >= 0 && offset < destination.Length) || destination.Length == 0, "invalid offset " + offset);
@@ -38,7 +38,7 @@ internal static partial class Interop
                 return sourceLength;
             }
 
-            internal byte[] ToByteArray()
+            internal readonly byte[] ToByteArray()
             {
                 if (_data == IntPtr.Zero || _length == 0)
                 {
@@ -51,7 +51,7 @@ internal static partial class Interop
                 return destination;
             }
 
-            internal unsafe ReadOnlySpan<byte> Span => (_data != IntPtr.Zero && _length != 0) ?
+            internal unsafe readonly ReadOnlySpan<byte> Span => (_data != IntPtr.Zero && _length != 0) ?
                 new ReadOnlySpan<byte>(_data.ToPointer(), checked((int)_length)) :
                 default;
 

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.PERF_INFO.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.PERF_INFO.cs
@@ -97,7 +97,7 @@ internal partial class Interop
             internal short wSecond;
             internal short wMilliseconds;
 
-            public override string ToString()
+            public override readonly string ToString()
             {
                 return "[SYSTEMTIME: "
                 + wDay.ToString(CultureInfo.CurrentCulture) + "/" + wMonth.ToString(CultureInfo.CurrentCulture) + "/" + wYear.ToString(CultureInfo.CurrentCulture)

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CRYPT_BIT_BLOB.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CRYPT_BIT_BLOB.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             internal IntPtr pbData;
             internal int cUnusedBits;
 
-            internal byte[] ToByteArray()
+            internal readonly byte[] ToByteArray()
             {
                 int numBytes = cbData;
                 byte[] data = new byte[numBytes];

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.FindOidInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.FindOidInfo.cs
@@ -21,7 +21,7 @@ internal static partial class Interop
             public int cbData;
             public IntPtr pbData;
 
-            public string? OID
+            public readonly string? OID
             {
                 get
                 {
@@ -29,7 +29,7 @@ internal static partial class Interop
                 }
             }
 
-            public string? Name
+            public readonly string? Name
             {
                 get
                 {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RECT.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RECT.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             public int right;
             public int bottom;
 
-            public Size Size => new Size(right - left, bottom - top);
+            public readonly Size Size => new Size(right - left, bottom - top);
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Interop.LongFileTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.LongFileTime.cs
@@ -22,6 +22,6 @@ internal partial class Interop
         internal long TicksSince1601;
 #pragma warning restore CS0649
 
-        internal DateTimeOffset ToDateTimeOffset() => new DateTimeOffset(DateTime.FromFileTimeUtc(TicksSince1601));
+        internal readonly DateTimeOffset ToDateTimeOffset() => new DateTimeOffset(DateTime.FromFileTimeUtc(TicksSince1601));
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
@@ -58,7 +58,7 @@ internal static partial class Interop
             internal IntPtr address;
             internal int addressLength;
 
-            internal IPAddress MarshalIPAddress()
+            internal readonly IPAddress MarshalIPAddress()
             {
                 // Determine the address family used to create the IPAddress.
                 AddressFamily family = (addressLength > Internals.SocketAddress.IPv4AddressSize)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FILE_TIME.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FILE_TIME.cs
@@ -18,9 +18,9 @@ internal static partial class Interop
                 dwHighDateTime = (uint)(fileTime >> 32);
             }
 
-            internal long ToTicks() => ((long)dwHighDateTime << 32) + dwLowDateTime;
-            internal DateTime ToDateTimeUtc() => DateTime.FromFileTimeUtc(ToTicks());
-            internal DateTimeOffset ToDateTimeOffset() => DateTimeOffset.FromFileTime(ToTicks());
+            internal readonly long ToTicks() => ((long)dwHighDateTime << 32) + dwLowDateTime;
+            internal readonly DateTime ToDateTimeUtc() => DateTime.FromFileTimeUtc(ToTicks());
+            internal readonly DateTimeOffset ToDateTimeOffset() => DateTimeOffset.FromFileTime(ToTicks());
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.TimeZone.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.TimeZone.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
             internal ushort Second;
             internal ushort Milliseconds;
 
-            internal bool Equals(in SYSTEMTIME other) =>
+            internal readonly bool Equals(in SYSTEMTIME other) =>
                     Year == other.Year &&
                     Month == other.Month &&
                     DayOfWeek == other.DayOfWeek &&
@@ -42,7 +42,7 @@ internal static partial class Interop
             internal fixed char TimeZoneKeyName[128];
             internal byte DynamicDaylightTimeDisabled;
 
-            internal string GetTimeZoneKeyName()
+            internal readonly string GetTimeZoneKeyName()
             {
                 fixed (char* p = TimeZoneKeyName)
                     return new string(p);
@@ -68,13 +68,13 @@ internal static partial class Interop
                     *pTo = *(TIME_ZONE_INFORMATION*)pFrom;
             }
 
-            internal string GetStandardName()
+            internal readonly string GetStandardName()
             {
                 fixed (char* p = StandardName)
                     return new string(p);
             }
 
-            internal string GetDaylightName()
+            internal readonly string GetDaylightName()
             {
                 fixed (char* p = DaylightName)
                     return new string(p);

--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_DIR_INFORMATION.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.FILE_FULL_DIR_INFORMATION.cs
@@ -54,7 +54,7 @@ internal partial class Interop
             public uint EaSize;
 
             private char _fileName;
-            public unsafe ReadOnlySpan<char> FileName { get { fixed (char* c = &_fileName) { return new ReadOnlySpan<char>(c, (int)FileNameLength / sizeof(char)); } } }
+            public unsafe readonly ReadOnlySpan<char> FileName { get { fixed (char* c = &_fileName) { return new ReadOnlySpan<char>(c, (int)FileNameLength / sizeof(char)); } } }
 
             /// <summary>
             /// Gets the next info pointer or null if there are no more.

--- a/src/libraries/Common/src/Interop/Windows/Ole32/Interop.STATSTG.cs
+++ b/src/libraries/Common/src/Interop/Windows/Ole32/Interop.STATSTG.cs
@@ -59,7 +59,7 @@ internal static partial class Interop
             public uint grfStateBits;
             public uint reserved;
 
-            public string? GetName() => Marshal.PtrToStringUni(pwcsName);
+            public readonly string? GetName() => Marshal.PtrToStringUni(pwcsName);
 
             /// <summary>
             /// Caller is responsible for freeing the name memory.

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -23,7 +23,7 @@ internal static partial class Interop
             private IntPtr dwLower;
             private IntPtr dwUpper;
 
-            public bool IsZero
+            public readonly bool IsZero
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
@@ -38,7 +38,7 @@ internal static partial class Interop
                 dwUpper = IntPtr.Zero;
             }
 
-            public override string ToString()
+            public override readonly string ToString()
             {
                 { return dwLower.ToString("x") + ":" + dwUpper.ToString("x"); }
             }

--- a/src/libraries/Common/src/System/MutableDecimal.cs
+++ b/src/libraries/Common/src/System/MutableDecimal.cs
@@ -23,13 +23,13 @@ namespace System
 
         public bool IsNegative
         {
-            get { return (Flags & SignMask) != 0; }
+            readonly get { return (Flags & SignMask) != 0; }
             set { Flags = (Flags & ~SignMask) | (value ? SignMask : 0); }
         }
 
         public int Scale
         {
-            get { return (byte)(Flags >> ScaleShift); }
+            readonly get { return (byte)(Flags >> ScaleShift); }
             set { Flags = (Flags & ~ScaleMask) | ((uint)value << ScaleShift); }
         }
 

--- a/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/Variant.cs
@@ -230,7 +230,7 @@ namespace System.Runtime.InteropServices
         /// Get the managed object representing the Variant.
         /// </summary>
         /// <returns></returns>
-        public object? ToObject()
+        public readonly object? ToObject()
         {
             // Check the simple case upfront
             if (IsEmpty)
@@ -316,13 +316,13 @@ namespace System.Runtime.InteropServices
 
         public VarEnum VariantType
         {
-            get => (VarEnum)_typeUnion._vt;
+            readonly get => (VarEnum)_typeUnion._vt;
             set => _typeUnion._vt = (ushort)value;
         }
 
-        public bool IsEmpty => _typeUnion._vt == ((ushort)VarEnum.VT_EMPTY);
+        public readonly bool IsEmpty => _typeUnion._vt == ((ushort)VarEnum.VT_EMPTY);
 
-        public bool IsByRef => (_typeUnion._vt & ((ushort)VarEnum.VT_BYREF)) != 0;
+        public readonly bool IsByRef => (_typeUnion._vt & ((ushort)VarEnum.VT_BYREF)) != 0;
 
         public void SetAsNULL()
         {
@@ -334,7 +334,7 @@ namespace System.Runtime.InteropServices
 
         public sbyte AsI1
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_I1);
                 return _typeUnion._unionTypes._i1;
@@ -351,7 +351,7 @@ namespace System.Runtime.InteropServices
 
         public short AsI2
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_I2);
                 return _typeUnion._unionTypes._i2;
@@ -368,7 +368,7 @@ namespace System.Runtime.InteropServices
 
         public int AsI4
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_I4);
                 return _typeUnion._unionTypes._i4;
@@ -385,7 +385,7 @@ namespace System.Runtime.InteropServices
 
         public long AsI8
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_I8);
                 return _typeUnion._unionTypes._i8;
@@ -402,7 +402,7 @@ namespace System.Runtime.InteropServices
 
         public byte AsUi1
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_UI1);
                 return _typeUnion._unionTypes._ui1;
@@ -419,7 +419,7 @@ namespace System.Runtime.InteropServices
 
         public ushort AsUi2
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_UI2);
                 return _typeUnion._unionTypes._ui2;
@@ -436,7 +436,7 @@ namespace System.Runtime.InteropServices
 
         public uint AsUi4
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_UI4);
                 return _typeUnion._unionTypes._ui4;
@@ -453,7 +453,7 @@ namespace System.Runtime.InteropServices
 
         public ulong AsUi8
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_UI8);
                 return _typeUnion._unionTypes._ui8;
@@ -470,7 +470,7 @@ namespace System.Runtime.InteropServices
 
         public int AsInt
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_INT);
                 return _typeUnion._unionTypes._int;
@@ -487,7 +487,7 @@ namespace System.Runtime.InteropServices
 
         public uint AsUint
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_UINT);
                 return _typeUnion._unionTypes._uint;
@@ -504,7 +504,7 @@ namespace System.Runtime.InteropServices
 
         public bool AsBool
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_BOOL);
                 return _typeUnion._unionTypes._bool != 0;
@@ -523,7 +523,7 @@ namespace System.Runtime.InteropServices
 
         public int AsError
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_ERROR);
                 return _typeUnion._unionTypes._error;
@@ -540,7 +540,7 @@ namespace System.Runtime.InteropServices
 
         public float AsR4
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_R4);
                 return _typeUnion._unionTypes._r4;
@@ -557,7 +557,7 @@ namespace System.Runtime.InteropServices
 
         public double AsR8
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_R8);
                 return _typeUnion._unionTypes._r8;
@@ -574,7 +574,7 @@ namespace System.Runtime.InteropServices
 
         public decimal AsDecimal
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_DECIMAL);
                 // The first byte of Decimal is unused, but usually set to 0
@@ -596,7 +596,7 @@ namespace System.Runtime.InteropServices
 
         public decimal AsCy
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_CY);
                 return decimal.FromOACurrency(_typeUnion._unionTypes._cy);
@@ -613,7 +613,7 @@ namespace System.Runtime.InteropServices
 
         public DateTime AsDate
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_DATE);
                 return DateTime.FromOADate(_typeUnion._unionTypes._date);
@@ -630,7 +630,7 @@ namespace System.Runtime.InteropServices
 
         public string AsBstr
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_BSTR);
                 return (string)Marshal.PtrToStringBSTR(this._typeUnion._unionTypes._bstr);
@@ -647,7 +647,7 @@ namespace System.Runtime.InteropServices
 
         public object? AsUnknown
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_UNKNOWN);
                 if (_typeUnion._unionTypes._unknown == IntPtr.Zero)
@@ -675,7 +675,7 @@ namespace System.Runtime.InteropServices
 
         public object? AsDispatch
         {
-            get
+            readonly get
             {
                 Debug.Assert(VariantType == VarEnum.VT_DISPATCH);
                 if (_typeUnion._unionTypes._dispatch == IntPtr.Zero)
@@ -699,7 +699,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public IntPtr AsByRefVariant
+        public readonly IntPtr AsByRefVariant
         {
             get
             {

--- a/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
+++ b/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
@@ -30,7 +30,7 @@ namespace System.Text
 
         public int Length
         {
-            get => _pos;
+            readonly get => _pos;
             set
             {
                 Debug.Assert(value >= 0);
@@ -39,7 +39,7 @@ namespace System.Text
             }
         }
 
-        public int Capacity => _chars.Length;
+        public readonly int Capacity => _chars.Length;
 
         public void EnsureCapacity(int capacity)
         {
@@ -57,7 +57,7 @@ namespace System.Text
         /// This overload is pattern matched in the C# 7.3+ compiler so you can omit
         /// the explicit method call, and write eg "fixed (char* c = builder)"
         /// </summary>
-        public ref char GetPinnableReference()
+        public readonly ref char GetPinnableReference()
         {
             return ref MemoryMarshal.GetReference(_chars);
         }
@@ -76,7 +76,7 @@ namespace System.Text
             return ref MemoryMarshal.GetReference(_chars);
         }
 
-        public ref char this[int index]
+        public readonly ref char this[int index]
         {
             get
             {
@@ -93,7 +93,7 @@ namespace System.Text
         }
 
         /// <summary>Returns the underlying storage of the builder.</summary>
-        public Span<char> RawChars => _chars;
+        public readonly Span<char> RawChars => _chars;
 
         /// <summary>
         /// Returns a span around the contents of the builder.
@@ -109,9 +109,9 @@ namespace System.Text
             return _chars.Slice(0, _pos);
         }
 
-        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
-        public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
-        public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+        public readonly ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+        public readonly ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+        public readonly ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
 
         public bool TryCopyTo(Span<char> destination, out int charsWritten)
         {

--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/ref/Microsoft.Bcl.AsyncInterfaces.cs
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/ref/Microsoft.Bcl.AsyncInterfaces.cs
@@ -85,9 +85,9 @@ namespace System.Threading.Tasks.Sources
         private object _dummy;
         private int _dummyPrimitive;
         public bool RunContinuationsAsynchronously { readonly get { throw null; } set { } }
-        public short Version { get { throw null; } }
-        public TResult GetResult(short token) { throw null; }
-        public System.Threading.Tasks.Sources.ValueTaskSourceStatus GetStatus(short token) { throw null; }
+        public readonly short Version { get { throw null; } }
+        public readonly TResult GetResult(short token) { throw null; }
+        public readonly System.Threading.Tasks.Sources.ValueTaskSourceStatus GetStatus(short token) { throw null; }
         public void OnCompleted(System.Action<object> continuation, object state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public void Reset() { }
         public void SetException(System.Exception error) { }

--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/ref/Microsoft.Bcl.AsyncInterfaces.cs
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/ref/Microsoft.Bcl.AsyncInterfaces.cs
@@ -84,7 +84,7 @@ namespace System.Threading.Tasks.Sources
         private TResult _result;
         private object _dummy;
         private int _dummyPrimitive;
-        public bool RunContinuationsAsynchronously { readonly get { throw null; } set { } }
+        public bool RunContinuationsAsynchronously { get { throw null; } set { } }
         public readonly short Version { get { throw null; } }
         public readonly TResult GetResult(short token) { throw null; }
         public readonly System.Threading.Tasks.Sources.ValueTaskSourceStatus GetStatus(short token) { throw null; }

--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -47,7 +47,7 @@ namespace System.Threading.Tasks.Sources
 
         /// <summary>Gets or sets whether to force continuations to run asynchronously.</summary>
         /// <remarks>Continuations may run asynchronously if this is false, but they'll never run synchronously if this is true.</remarks>
-        public bool RunContinuationsAsynchronously { get; set; }
+        public bool RunContinuationsAsynchronously { readonly get; set; }
 
         /// <summary>Resets to prepare for the next operation.</summary>
         public void Reset()
@@ -80,11 +80,11 @@ namespace System.Threading.Tasks.Sources
         }
 
         /// <summary>Gets the operation version.</summary>
-        public short Version => _version;
+        public readonly short Version => _version;
 
         /// <summary>Gets the status of the operation.</summary>
         /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
-        public ValueTaskSourceStatus GetStatus(short token)
+        public readonly ValueTaskSourceStatus GetStatus(short token)
         {
             ValidateToken(token);
             return
@@ -96,7 +96,7 @@ namespace System.Threading.Tasks.Sources
 
         /// <summary>Gets the result of the operation.</summary>
         /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
-        public TResult GetResult(short token)
+        public readonly TResult GetResult(short token)
         {
             ValidateToken(token);
             if (!_completed)
@@ -189,7 +189,7 @@ namespace System.Threading.Tasks.Sources
 
         /// <summary>Ensures that the specified token matches the current version.</summary>
         /// <param name="token">The token supplied by <see cref="ValueTask"/>.</param>
-        private void ValidateToken(short token)
+        private readonly void ValidateToken(short token)
         {
             if (token != _version)
             {
@@ -227,7 +227,7 @@ namespace System.Threading.Tasks.Sources
         /// This assumes that if <see cref="_executionContext"/> is not null we're already
         /// running within that <see cref="ExecutionContext"/>.
         /// </summary>
-        private void InvokeContinuation()
+        private readonly void InvokeContinuation()
         {
             Debug.Assert(_continuation != null);
 

--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -47,7 +47,7 @@ namespace System.Threading.Tasks.Sources
 
         /// <summary>Gets or sets whether to force continuations to run asynchronously.</summary>
         /// <remarks>Continuations may run asynchronously if this is false, but they'll never run synchronously if this is true.</remarks>
-        public bool RunContinuationsAsynchronously { readonly get; set; }
+        public bool RunContinuationsAsynchronously { get; set; }
 
         /// <summary>Resets to prepare for the next operation.</summary>
         public void Reset()

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/CallSiteJsonFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/CallSiteJsonFormatter.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Extensions.DependencyInjection
             public int Offset { get; }
             public StringBuilder Builder { get; }
 
-            public bool ShouldFormat(ServiceCallSite serviceCallSite)
+            public readonly bool ShouldFormat(ServiceCallSite serviceCallSite)
             {
                 return _processedCallSites.Add(serviceCallSite);
             }
 
-            public CallSiteFormatterContext IncrementOffset()
+            public readonly CallSiteFormatterContext IncrementOffset()
             {
                 return new CallSiteFormatterContext(Builder, Offset + 4, _processedCallSites)
                 {
@@ -143,13 +143,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 };
             }
 
-            public CallSiteFormatterContext StartObject()
+            public readonly CallSiteFormatterContext StartObject()
             {
                 Builder.Append('{');
                 return IncrementOffset();
             }
 
-            public void EndObject()
+            public readonly void EndObject()
             {
                 Builder.Append('}');
             }
@@ -192,13 +192,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            public CallSiteFormatterContext StartArray()
+            public readonly CallSiteFormatterContext StartArray()
             {
                 Builder.Append('[');
                 return IncrementOffset();
             }
 
-            public void EndArray()
+            public readonly void EndArray()
             {
                 Builder.Append(']');
             }

--- a/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -247,16 +247,16 @@ namespace System.Collections.ObjectModel
                 _enumerator = _dictionary.GetEnumerator();
             }
 
-            public DictionaryEntry Entry
+            public readonly DictionaryEntry Entry
             {
                 get => new DictionaryEntry(_enumerator.Current.Key, _enumerator.Current.Value);
             }
 
-            public object Key => _enumerator.Current.Key;
+            public readonly object Key => _enumerator.Current.Key;
 
-            public object? Value => _enumerator.Current.Value;
+            public readonly object? Value => _enumerator.Current.Value;
 
-            public object Current => Entry;
+            public readonly object Current => Entry;
 
             public bool MoveNext() => _enumerator.MoveNext();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/DictionaryEntry.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/DictionaryEntry.cs
@@ -24,18 +24,18 @@ namespace System.Collections
 
         public object Key
         {
-            get => _key;
+            readonly get => _key;
             set => _key = value;
         }
 
         public object? Value
         {
-            get => _value;
+            readonly get => _value;
             set => _value = value;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Deconstruct(out object key, out object? value)
+        public readonly void Deconstruct(out object key, out object? value)
         {
             key = Key;
             value = Value;

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -13,15 +13,15 @@ namespace System
     public partial struct Decimal
     {
         // Low level accessors used by a DecCalc and formatting
-        internal uint High => _hi32;
-        internal uint Low => (uint)_lo64;
-        internal uint Mid => (uint)(_lo64 >> 32);
+        internal readonly uint High => _hi32;
+        internal readonly uint Low => (uint)_lo64;
+        internal readonly uint Mid => (uint)(_lo64 >> 32);
 
-        internal bool IsNegative => _flags < 0;
+        internal readonly bool IsNegative => _flags < 0;
 
-        internal int Scale => (byte)(_flags >> ScaleShift);
+        internal readonly int Scale => (byte)(_flags >> ScaleShift);
 
-        private ulong Low64 => _lo64;
+        private readonly ulong Low64 => _lo64;
 
         private static ref DecCalc AsMutable(ref decimal d) => ref Unsafe.As<decimal, DecCalc>(ref d);
 
@@ -65,29 +65,29 @@ namespace System
 
             private uint High
             {
-                get => uhi;
+                readonly get => uhi;
                 set => uhi = value;
             }
 
             private uint Low
             {
-                get => ulo;
+                readonly get => ulo;
                 set => ulo = value;
             }
 
             private uint Mid
             {
-                get => umid;
+                readonly get => umid;
                 set => umid = value;
             }
 
-            private bool IsNegative => (int)uflags < 0;
+            private readonly bool IsNegative => (int)uflags < 0;
 
-            private int Scale => (byte)(uflags >> ScaleShift);
+            private readonly int Scale => (byte)(uflags >> ScaleShift);
 
             private ulong Low64
             {
-                get => ulomid;
+                readonly get => ulomid;
                 set => ulomid = value;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -5243,7 +5243,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
         internal int Index;
 
         // The length of Value string.
-        internal int Length => Value.Length;
+        internal readonly int Length => Value.Length;
 
         // The current character to be looked at.
         internal char m_current;
@@ -5270,7 +5270,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             m_checkDigitToken = ((dtfi.FormatFlags & DateTimeFormatFlags.UseDigitPrefixInTokens) != 0);
         }
 
-        internal CompareInfo CompareInfo => m_info;
+        internal readonly CompareInfo CompareInfo => m_info;
 
         //
         // Advance the Index.
@@ -5292,7 +5292,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             return false;
         }
 
-        internal bool AtEnd()
+        internal readonly bool AtEnd()
         {
             return Index < Length ? false : true;
         }
@@ -5430,13 +5430,13 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool MatchSpecifiedWord(string target) =>
+        internal readonly bool MatchSpecifiedWord(string target) =>
             Index + target.Length <= Length &&
             m_info.Compare(Value.Slice(Index, target.Length), target, CompareOptions.IgnoreCase) == 0;
 
         private static readonly char[] WhiteSpaceChecks = new char[] { ' ', '\u00A0' };
 
-        internal bool MatchSpecifiedWords(string target, bool checkWordBoundary, ref int matchLength)
+        internal readonly bool MatchSpecifiedWords(string target, bool checkWordBoundary, ref int matchLength)
         {
             int valueRemaining = Value.Length - Index;
             matchLength = target.Length;
@@ -5622,7 +5622,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
         //
         // Get the current character.
         //
-        internal char GetChar()
+        internal readonly char GetChar()
         {
             Debug.Assert(Index >= 0 && Index < Length, "Index >= 0 && Index < len");
             return Value[Index];
@@ -5631,7 +5631,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
         //
         // Convert the current character to a digit, and return it.
         //
-        internal int GetDigit()
+        internal readonly int GetDigit()
         {
             Debug.Assert(Index >= 0 && Index < Length, "Index >= 0 && Index < len");
             Debug.Assert(DateTimeParse.IsDigit(Value[Index]), "IsDigit(Value[Index])");
@@ -5842,7 +5842,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
         internal DTSubStringType type;
         internal int value;
 
-        internal char this[int relativeIndex] => s[index + relativeIndex];
+        internal readonly char this[int relativeIndex] => s[index + relativeIndex];
     }
 
     //
@@ -5887,7 +5887,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             num[numCount++] = value;
         }
 
-        internal int GetNumber(int index)
+        internal readonly int GetNumber(int index)
         {
             return num[index];
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanFormat.cs
@@ -492,12 +492,12 @@ namespace System.Globalization
 
             private string[] _literals;
 
-            internal string Start => _literals[0];
-            internal string DayHourSep => _literals[1];
-            internal string HourMinuteSep => _literals[2];
-            internal string MinuteSecondSep => _literals[3];
-            internal string SecondFractionSep => _literals[4];
-            internal string End => _literals[5];
+            internal readonly string Start => _literals[0];
+            internal readonly string DayHourSep => _literals[1];
+            internal readonly string HourMinuteSep => _literals[2];
+            internal readonly string MinuteSecondSep => _literals[3];
+            internal readonly string SecondFractionSep => _literals[4];
+            internal readonly string End => _literals[5];
 
             /* factory method for static invariant FormatLiterals */
             internal static FormatLiterals InitInvariant(bool isNegative)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanParse.cs
@@ -239,7 +239,7 @@ namespace System.Globalization
                 return new TimeSpanToken(TTT.Sep, 0, 0, _value.Slice(pos, length));
             }
 
-            internal bool EOL => _pos >= (_value.Length - 1);
+            internal readonly bool EOL => _pos >= (_value.Length - 1);
 
             internal void BackOne()
             {
@@ -289,7 +289,7 @@ namespace System.Globalization
                 }
             }
 
-            internal bool FullAppCompatMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullAppCompatMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 5
                 && _numCount == 4
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -298,7 +298,7 @@ namespace System.Globalization
                 && _literals3.EqualsOrdinal(pattern.AppCompatLiteral)
                 && _literals4.EqualsOrdinal(pattern.End);
 
-            internal bool PartialAppCompatMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool PartialAppCompatMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 4
                 && _numCount == 3
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -307,7 +307,7 @@ namespace System.Globalization
                 && _literals3.EqualsOrdinal(pattern.End);
 
             /// <summary>DHMSF (all values matched)</summary>
-            internal bool FullMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == MaxLiteralTokens
                 && _numCount == MaxNumericTokens
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -318,14 +318,14 @@ namespace System.Globalization
                 && _literals5.EqualsOrdinal(pattern.End);
 
             /// <summary>D (no hours, minutes, seconds, or fractions)</summary>
-            internal bool FullDMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullDMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 2
                 && _numCount == 1
                 && _literals0.EqualsOrdinal(pattern.Start)
                 && _literals1.EqualsOrdinal(pattern.End);
 
             /// <summary>HM (no days, seconds, or fractions)</summary>
-            internal bool FullHMMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullHMMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 3
                 && _numCount == 2
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -333,7 +333,7 @@ namespace System.Globalization
                 && _literals2.EqualsOrdinal(pattern.End);
 
             /// <summary>DHM (no seconds or fraction)</summary>
-            internal bool FullDHMMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullDHMMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 4
                 && _numCount == 3
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -342,7 +342,7 @@ namespace System.Globalization
                 && _literals3.EqualsOrdinal(pattern.End);
 
             /// <summary>HMS (no days or fraction)</summary>
-            internal bool FullHMSMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullHMSMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 4
                 && _numCount == 3
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -351,7 +351,7 @@ namespace System.Globalization
                 && _literals3.EqualsOrdinal(pattern.End);
 
             /// <summary>DHMS (no fraction)</summary>
-            internal bool FullDHMSMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullDHMSMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 5
                 && _numCount == 4
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -361,7 +361,7 @@ namespace System.Globalization
                 && _literals4.EqualsOrdinal(pattern.End);
 
             /// <summary>HMSF (no days)</summary>
-            internal bool FullHMSFMatch(TimeSpanFormat.FormatLiterals pattern) =>
+            internal readonly bool FullHMSFMatch(TimeSpanFormat.FormatLiterals pattern) =>
                 _sepCount == 5
                 && _numCount == 4
                 && _literals0.EqualsOrdinal(pattern.Start)
@@ -1476,7 +1476,7 @@ namespace System.Globalization
                     (char)0;
             }
 
-            internal char NextNonDigit()
+            internal readonly char NextNonDigit()
             {
                 int i = _pos;
                 while (i < _len)

--- a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
@@ -355,7 +355,7 @@ namespace System
             }
         }
 
-        public int ToHashCode()
+        public readonly int ToHashCode()
         {
             // Storing the value of _length locally shaves of quite a few bytes
             // in the resulting machine code.

--- a/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
@@ -50,16 +50,16 @@ namespace System
         public readonly T GetValueOrDefault(T defaultValue) =>
             hasValue ? value : defaultValue;
 
-        public override bool Equals(object? other)
+        public override readonly bool Equals(object? other)
         {
             if (!hasValue) return other == null;
             if (other == null) return false;
             return value.Equals(other);
         }
 
-        public override int GetHashCode() => hasValue ? value.GetHashCode() : 0;
+        public override readonly int GetHashCode() => hasValue ? value.GetHashCode() : 0;
 
-        public override string? ToString() => hasValue ? value.ToString() : "";
+        public override readonly string? ToString() => hasValue ? value.ToString() : "";
 
         [NonVersionable]
         public static implicit operator Nullable<T>(T value) =>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncVoidMethodBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncVoidMethodBuilder.cs
@@ -148,7 +148,7 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>Lazily instantiate the Task in a non-thread-safe manner.</summary>
-        private Task Task => _builder.Task;
+        private readonly Task Task => _builder.Task;
 
         /// <summary>
         /// Gets an object that may be used to uniquely identify this builder to the debugger.
@@ -157,6 +157,6 @@ namespace System.Runtime.CompilerServices
         /// This property lazily instantiates the ID in a non-thread-safe manner.
         /// It must only be used by the debugger and AsyncCausalityTracer in a single-threaded manner.
         /// </remarks>
-        internal object ObjectIdForDebugger => _builder.ObjectIdForDebugger;
+        internal readonly object ObjectIdForDebugger => _builder.ObjectIdForDebugger;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
@@ -79,7 +79,7 @@ namespace System.Runtime.InteropServices
         // Target property - allows getting / updating of the handle's referent.
         public object? Target
         {
-            get
+            readonly get
             {
                 IntPtr handle = _handle;
                 ThrowIfInvalid(handle);
@@ -142,7 +142,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>Determine whether this handle has been allocated or not.</summary>
-        public bool IsAllocated => _handle != IntPtr.Zero;
+        public readonly bool IsAllocated => _handle != IntPtr.Zero;
 
         /// <summary>
         /// Used to create a GCHandle from an int.  This is intended to
@@ -161,9 +161,9 @@ namespace System.Runtime.InteropServices
 
         public static IntPtr ToIntPtr(GCHandle value) => value._handle;
 
-        public override int GetHashCode() => _handle.GetHashCode();
+        public override readonly int GetHashCode() => _handle.GetHashCode();
 
-        public override bool Equals([NotNullWhen(true)] object? o) => o is GCHandle && _handle == ((GCHandle)o)._handle;
+        public override readonly bool Equals([NotNullWhen(true)] object? o) => o is GCHandle && _handle == ((GCHandle)o)._handle;
 
         public static bool operator ==(GCHandle a, GCHandle b) => a._handle == b._handle;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/SpanRuneEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/SpanRuneEnumerator.cs
@@ -16,9 +16,9 @@ namespace System.Text
             _current = default;
         }
 
-        public Rune Current => _current;
+        public readonly Rune Current => _current;
 
-        public SpanRuneEnumerator GetEnumerator() => this;
+        public readonly SpanRuneEnumerator GetEnumerator() => this;
 
         public bool MoveNext()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -582,7 +582,7 @@ namespace System.Text
             /// Implement IEnumerable.GetEnumerator() to return  'this' as the IEnumerator
             /// </summary>
             [ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)] // Only here to make foreach work
-            public ChunkEnumerator GetEnumerator() { return this; }
+            public readonly ChunkEnumerator GetEnumerator() { return this; }
 
             /// <summary>
             /// Implements the IEnumerator pattern.
@@ -613,7 +613,7 @@ namespace System.Text
             /// <summary>
             /// Implements the IEnumerator pattern.
             /// </summary>
-            public ReadOnlyMemory<char> Current
+            public readonly ReadOnlyMemory<char> Current
             {
                 get
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringRuneEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringRuneEnumerator.cs
@@ -20,9 +20,9 @@ namespace System.Text
             _nextIndex = 0;
         }
 
-        public Rune Current => _current;
+        public readonly Rune Current => _current;
 
-        public StringRuneEnumerator GetEnumerator() => this;
+        public readonly StringRuneEnumerator GetEnumerator() => this;
 
         public bool MoveNext()
         {
@@ -56,9 +56,9 @@ namespace System.Text
             // no-op
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this;
+        readonly IEnumerator IEnumerable.GetEnumerator() => this;
 
-        IEnumerator<Rune> IEnumerable<Rune>.GetEnumerator() => this;
+        readonly IEnumerator<Rune> IEnumerable<Rune>.GetEnumerator() => this;
 
         void IEnumerator.Reset()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/TextSegmentationUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/TextSegmentationUtility.cs
@@ -202,13 +202,13 @@ namespace System.Text.Unicode
                 CurrentCodeUnitOffset = 0;
             }
 
-            public int CurrentCodeUnitOffset { get; private set; }
+            public int CurrentCodeUnitOffset { readonly get; private set; }
 
             /// <summary>
             /// Will be <see cref="GraphemeClusterBreakType.Other"/> if invalid data or EOF reached.
             /// Caller shouldn't need to special-case this since the normal rules will halt on this condition.
             /// </summary>
-            public GraphemeClusterBreakType CurrentType { get; private set; }
+            public GraphemeClusterBreakType CurrentType { readonly get; private set; }
 
             public void MoveNext()
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/TextSegmentationUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/TextSegmentationUtility.cs
@@ -202,13 +202,13 @@ namespace System.Text.Unicode
                 CurrentCodeUnitOffset = 0;
             }
 
-            public int CurrentCodeUnitOffset { readonly get; private set; }
+            public int CurrentCodeUnitOffset { get; private set; }
 
             /// <summary>
             /// Will be <see cref="GraphemeClusterBreakType.Other"/> if invalid data or EOF reached.
             /// Caller shouldn't need to special-case this since the normal rules will halt on this condition.
             /// </summary>
-            public GraphemeClusterBreakType CurrentType { readonly get; private set; }
+            public GraphemeClusterBreakType CurrentType { get; private set; }
 
             public void MoveNext()
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -39,7 +39,7 @@ namespace System.Threading.Tasks.Sources
 
         /// <summary>Gets or sets whether to force continuations to run asynchronously.</summary>
         /// <remarks>Continuations may run asynchronously if this is false, but they'll never run synchronously if this is true.</remarks>
-        public bool RunContinuationsAsynchronously { get; set; }
+        public bool RunContinuationsAsynchronously { readonly get; set; }
 
         /// <summary>Resets to prepare for the next operation.</summary>
         public void Reset()
@@ -72,11 +72,11 @@ namespace System.Threading.Tasks.Sources
         }
 
         /// <summary>Gets the operation version.</summary>
-        public short Version => _version;
+        public readonly short Version => _version;
 
         /// <summary>Gets the status of the operation.</summary>
         /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
-        public ValueTaskSourceStatus GetStatus(short token)
+        public readonly ValueTaskSourceStatus GetStatus(short token)
         {
             ValidateToken(token);
             return
@@ -89,7 +89,7 @@ namespace System.Threading.Tasks.Sources
         /// <summary>Gets the result of the operation.</summary>
         /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
         [StackTraceHidden]
-        public TResult GetResult(short token)
+        public readonly TResult GetResult(short token)
         {
             ValidateToken(token);
             if (!_completed)
@@ -189,7 +189,7 @@ namespace System.Threading.Tasks.Sources
 
         /// <summary>Ensures that the specified token matches the current version.</summary>
         /// <param name="token">The token supplied by <see cref="ValueTask"/>.</param>
-        private void ValidateToken(short token)
+        private readonly void ValidateToken(short token)
         {
             if (token != _version)
             {
@@ -235,7 +235,7 @@ namespace System.Threading.Tasks.Sources
             }
         }
 
-        private void InvokeContinuationWithContext()
+        private readonly void InvokeContinuationWithContext()
         {
             // This is in a helper as the error handling causes the generated asm
             // for the surrounding code to become less efficent (stack spills etc)
@@ -310,7 +310,7 @@ namespace System.Threading.Tasks.Sources
         /// This assumes that if <see cref="_continuation"/> is not null we're already
         /// running within that <see cref="ExecutionContext"/>.
         /// </summary>
-        private void InvokeSchedulerContinuation()
+        private readonly void InvokeSchedulerContinuation()
         {
             Debug.Assert(_capturedContext != null);
             Debug.Assert(_continuation != null);

--- a/src/libraries/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -39,7 +39,7 @@ namespace System
         /// </summary>
         /// <param name="obj">The object to compare with this instance.</param>
         /// <returns><see langword="true"/> if <paramref name="obj"/> is a <see cref="ValueTuple"/>.</returns>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple;
         }
@@ -47,17 +47,17 @@ namespace System
         /// <summary>Returns a value indicating whether this instance is equal to a specified value.</summary>
         /// <param name="other">An instance to compare to this instance.</param>
         /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
-        public bool Equals(ValueTuple other)
+        public readonly bool Equals(ValueTuple other)
         {
             return true;
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer)
         {
             return other is ValueTuple;
         }
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is null) return 1;
 
@@ -77,12 +77,12 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple other)
+        public readonly int CompareTo(ValueTuple other)
         {
             return 0;
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is null) return 1;
 
@@ -96,17 +96,17 @@ namespace System
 
         /// <summary>Returns the hash code for this instance.</summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return 0;
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return 0;
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return 0;
         }
@@ -118,12 +118,12 @@ namespace System
         /// <remarks>
         /// The string returned by this method takes the form <c>()</c>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "()";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return ")";
         }
@@ -136,7 +136,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index] => throw new IndexOutOfRangeException();
+        readonly object?ITuple.this[int index] => throw new IndexOutOfRangeException();
 
         /// <summary>Creates a new struct 0-tuple.</summary>
         /// <returns>A 0-tuple.</returns>
@@ -290,7 +290,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1> tuple && Equals(tuple);
         }
@@ -305,16 +305,16 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its field
         /// is equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1> other)
+        public readonly bool Equals(ValueTuple<T1> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1);
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1> vt &&
             comparer.Equals(Item1, vt.Item1);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -337,12 +337,12 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1> other)
+        public readonly int CompareTo(ValueTuple<T1> other)
         {
             return Comparer<T1>.Default.Compare(Item1, other.Item1);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -361,17 +361,17 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return Item1?.GetHashCode() ?? 0;
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return comparer.GetHashCode(Item1!);
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return comparer.GetHashCode(Item1!);
         }
@@ -385,12 +385,12 @@ namespace System
         /// where <c>Item1</c> represents the value of <see cref="Item1"/>. If the field is <see langword="null"/>,
         /// it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "(" + Item1?.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ")";
         }
@@ -403,7 +403,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index]
+        readonly object?ITuple.this[int index]
         {
             get
             {
@@ -462,7 +462,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1, T2> tuple && Equals(tuple);
         }
@@ -476,7 +476,7 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
         /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1, T2> other)
+        public readonly bool Equals(ValueTuple<T1, T2> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
                 && EqualityComparer<T2>.Default.Equals(Item2, other.Item2);
@@ -500,12 +500,12 @@ namespace System
         ///  <see cref="IEqualityComparer.Equals"/> implementation. If this method call returns <see langword="true"/>, the method is
         ///  called again and passed the <see cref="Item2"/> values of the two <see cref="ValueTuple{T1, T2}"/> instances.
         /// </remarks>
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1, T2> vt &&
             comparer.Equals(Item1, vt.Item1) &&
             comparer.Equals(Item2, vt.Item2);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -528,7 +528,7 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1, T2> other)
+        public readonly int CompareTo(ValueTuple<T1, T2> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
             if (c != 0) return c;
@@ -536,7 +536,7 @@ namespace System
             return Comparer<T2>.Default.Compare(Item2, other.Item2);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -558,24 +558,24 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1, T2}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                     Item2?.GetHashCode() ?? 0);
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
 
-        private int GetHashCodeCore(IEqualityComparer comparer)
+        private readonly int GetHashCodeCore(IEqualityComparer comparer)
         {
             return HashCode.Combine(comparer.GetHashCode(Item1!),
                                     comparer.GetHashCode(Item2!));
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -590,12 +590,12 @@ namespace System
         /// and <see cref="Item2"/> fields. If either field value is <see langword="null"/>,
         /// it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ")";
         }
@@ -608,7 +608,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index] =>
+        readonly object?ITuple.this[int index] =>
             index switch
             {
                 0 => Item1,
@@ -668,7 +668,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1, T2, T3> tuple && Equals(tuple);
         }
@@ -683,20 +683,20 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
         /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1, T2, T3> other)
+        public readonly bool Equals(ValueTuple<T1, T2, T3> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
                 && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
                 && EqualityComparer<T3>.Default.Equals(Item3, other.Item3);
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1, T2, T3> vt &&
             comparer.Equals(Item1, vt.Item1) &&
             comparer.Equals(Item2, vt.Item2) &&
             comparer.Equals(Item3, vt.Item3);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -719,7 +719,7 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1, T2, T3> other)
+        public readonly int CompareTo(ValueTuple<T1, T2, T3> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
             if (c != 0) return c;
@@ -730,7 +730,7 @@ namespace System
             return Comparer<T3>.Default.Compare(Item3, other.Item3);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -755,26 +755,26 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                     Item2?.GetHashCode() ?? 0,
                                     Item3?.GetHashCode() ?? 0);
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
 
-        private int GetHashCodeCore(IEqualityComparer comparer)
+        private readonly int GetHashCodeCore(IEqualityComparer comparer)
         {
             return HashCode.Combine(comparer.GetHashCode(Item1!),
                                     comparer.GetHashCode(Item2!),
                                     comparer.GetHashCode(Item3!));
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -787,12 +787,12 @@ namespace System
         /// The string returned by this method takes the form <c>(Item1, Item2, Item3)</c>.
         /// If any field value is <see langword="null"/>, it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
         }
@@ -805,7 +805,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index] =>
+        readonly object?ITuple.this[int index] =>
             index switch
             {
                 0 => Item1,
@@ -873,7 +873,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4> tuple && Equals(tuple);
         }
@@ -888,7 +888,7 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
         /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1, T2, T3, T4> other)
+        public readonly bool Equals(ValueTuple<T1, T2, T3, T4> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
                 && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
@@ -896,14 +896,14 @@ namespace System
                 && EqualityComparer<T4>.Default.Equals(Item4, other.Item4);
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1, T2, T3, T4> vt &&
             comparer.Equals(Item1, vt.Item1) &&
             comparer.Equals(Item2, vt.Item2) &&
             comparer.Equals(Item3, vt.Item3) &&
             comparer.Equals(Item4, vt.Item4);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -926,7 +926,7 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1, T2, T3, T4> other)
+        public readonly int CompareTo(ValueTuple<T1, T2, T3, T4> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
             if (c != 0) return c;
@@ -940,7 +940,7 @@ namespace System
             return Comparer<T4>.Default.Compare(Item4, other.Item4);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -968,7 +968,7 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                     Item2?.GetHashCode() ?? 0,
@@ -976,12 +976,12 @@ namespace System
                                     Item4?.GetHashCode() ?? 0);
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
 
-        private int GetHashCodeCore(IEqualityComparer comparer)
+        private readonly int GetHashCodeCore(IEqualityComparer comparer)
         {
             return HashCode.Combine(comparer.GetHashCode(Item1!),
                                     comparer.GetHashCode(Item2!),
@@ -989,7 +989,7 @@ namespace System
                                     comparer.GetHashCode(Item4!));
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -1002,12 +1002,12 @@ namespace System
         /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4)</c>.
         /// If any field value is <see langword="null"/>, it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
         }
@@ -1020,7 +1020,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index] =>
+        readonly object?ITuple.this[int index] =>
             index switch
             {
                 0 => Item1,
@@ -1096,7 +1096,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5> tuple && Equals(tuple);
         }
@@ -1111,7 +1111,7 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
         /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5> other)
+        public readonly bool Equals(ValueTuple<T1, T2, T3, T4, T5> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
                 && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
@@ -1120,14 +1120,14 @@ namespace System
                 && EqualityComparer<T5>.Default.Equals(Item5, other.Item5);
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1, T2, T3, T4, T5> vt &&
             comparer.Equals(Item1, vt.Item1) &&
             comparer.Equals(Item2, vt.Item2) &&
             comparer.Equals(Item3, vt.Item3) &&
             comparer.Equals(Item5, vt.Item5);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -1150,7 +1150,7 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other)
+        public readonly int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
             if (c != 0) return c;
@@ -1167,7 +1167,7 @@ namespace System
             return Comparer<T5>.Default.Compare(Item5, other.Item5);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -1198,7 +1198,7 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                     Item2?.GetHashCode() ?? 0,
@@ -1207,12 +1207,12 @@ namespace System
                                     Item5?.GetHashCode() ?? 0);
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
 
-        private int GetHashCodeCore(IEqualityComparer comparer)
+        private readonly int GetHashCodeCore(IEqualityComparer comparer)
         {
             return HashCode.Combine(comparer.GetHashCode(Item1!),
                                     comparer.GetHashCode(Item2!),
@@ -1221,7 +1221,7 @@ namespace System
                                     comparer.GetHashCode(Item5!));
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -1234,12 +1234,12 @@ namespace System
         /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5)</c>.
         /// If any field value is <see langword="null"/>, it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
         }
@@ -1252,7 +1252,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index] =>
+        readonly object?ITuple.this[int index] =>
             index switch
             {
                 0 => Item1,
@@ -1336,7 +1336,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5, T6> tuple && Equals(tuple);
         }
@@ -1351,7 +1351,7 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
         /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        public readonly bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
                 && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
@@ -1361,7 +1361,7 @@ namespace System
                 && EqualityComparer<T6>.Default.Equals(Item6, other.Item6);
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1, T2, T3, T4, T5, T6> vt &&
             comparer.Equals(Item1, vt.Item1) &&
             comparer.Equals(Item2, vt.Item2) &&
@@ -1369,7 +1369,7 @@ namespace System
             comparer.Equals(Item5, vt.Item5) &&
             comparer.Equals(Item6, vt.Item6);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -1392,7 +1392,7 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        public readonly int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
             if (c != 0) return c;
@@ -1412,7 +1412,7 @@ namespace System
             return Comparer<T6>.Default.Compare(Item6, other.Item6);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -1446,7 +1446,7 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                     Item2?.GetHashCode() ?? 0,
@@ -1456,12 +1456,12 @@ namespace System
                                     Item6?.GetHashCode() ?? 0);
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
 
-        private int GetHashCodeCore(IEqualityComparer comparer)
+        private readonly int GetHashCodeCore(IEqualityComparer comparer)
         {
             return HashCode.Combine(comparer.GetHashCode(Item1!),
                                     comparer.GetHashCode(Item2!),
@@ -1471,7 +1471,7 @@ namespace System
                                     comparer.GetHashCode(Item6!));
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -1484,12 +1484,12 @@ namespace System
         /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6)</c>.
         /// If any field value is <see langword="null"/>, it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
         }
@@ -1502,7 +1502,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index] =>
+        readonly object?ITuple.this[int index] =>
             index switch
             {
                 0 => Item1,
@@ -1594,7 +1594,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7> tuple && Equals(tuple);
         }
@@ -1609,7 +1609,7 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
         /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        public readonly bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
                 && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
@@ -1620,7 +1620,7 @@ namespace System
                 && EqualityComparer<T7>.Default.Equals(Item7, other.Item7);
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1, T2, T3, T4, T5, T6, T7> vt &&
             comparer.Equals(Item1, vt.Item1) &&
             comparer.Equals(Item2, vt.Item2) &&
@@ -1629,7 +1629,7 @@ namespace System
             comparer.Equals(Item6, vt.Item6) &&
             comparer.Equals(Item7, vt.Item7);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -1652,7 +1652,7 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        public readonly int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
             if (c != 0) return c;
@@ -1675,7 +1675,7 @@ namespace System
             return Comparer<T7>.Default.Compare(Item7, other.Item7);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -1712,7 +1712,7 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                     Item2?.GetHashCode() ?? 0,
@@ -1723,12 +1723,12 @@ namespace System
                                     Item7?.GetHashCode() ?? 0);
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
 
-        private int GetHashCodeCore(IEqualityComparer comparer)
+        private readonly int GetHashCodeCore(IEqualityComparer comparer)
         {
             return HashCode.Combine(comparer.GetHashCode(Item1!),
                                     comparer.GetHashCode(Item2!),
@@ -1739,7 +1739,7 @@ namespace System
                                     comparer.GetHashCode(Item7!));
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -1752,12 +1752,12 @@ namespace System
         /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7)</c>.
         /// If any field value is <see langword="null"/>, it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
         }
@@ -1770,7 +1770,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index] =>
+        readonly object?ITuple.this[int index] =>
             index switch
             {
                 0 => Item1,
@@ -1876,7 +1876,7 @@ namespace System
         ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
         /// </list>
         /// </remarks>
-        public override bool Equals([NotNullWhen(true)] object? obj)
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> tuple && Equals(tuple);
         }
@@ -1891,7 +1891,7 @@ namespace System
         /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
         /// are equal to that of the current instance, using the default comparer for that field's type.
         /// </remarks>
-        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        public readonly bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
         {
             return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
                 && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
@@ -1903,7 +1903,7 @@ namespace System
                 && EqualityComparer<TRest>.Default.Equals(Rest, other.Rest);
         }
 
-        bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
+        readonly bool IStructuralEquatable.Equals(object? other, IEqualityComparer comparer) =>
             other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> vt &&
             comparer.Equals(Item1, vt.Item1) &&
             comparer.Equals(Item2, vt.Item2) &&
@@ -1913,7 +1913,7 @@ namespace System
             comparer.Equals(Item7, vt.Item7) &&
             comparer.Equals(Rest, vt.Rest);
 
-        int IComparable.CompareTo(object? other)
+        readonly int IComparable.CompareTo(object? other)
         {
             if (other is not null)
             {
@@ -1936,7 +1936,7 @@ namespace System
         /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater
         /// than <paramref name="other"/>.
         /// </returns>
-        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        public readonly int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
         {
             int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
             if (c != 0) return c;
@@ -1962,7 +1962,7 @@ namespace System
             return Comparer<TRest>.Default.Compare(Rest, other.Rest);
         }
 
-        int IStructuralComparable.CompareTo(object? other, IComparer comparer)
+        readonly int IStructuralComparable.CompareTo(object? other, IComparer comparer)
         {
             if (other is not null)
             {
@@ -2002,7 +2002,7 @@ namespace System
         /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             // We want to have a limited hash in this case. We'll use the first 7 elements of the tuple
             if (Rest is not IValueTupleInternal)
@@ -2076,12 +2076,12 @@ namespace System
             return -1;
         }
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        readonly int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
 
-        private int GetHashCodeCore(IEqualityComparer comparer)
+        private readonly int GetHashCodeCore(IEqualityComparer comparer)
         {
             // We want to have a limited hash in this case. We'll use the first 7 elements of the tuple
             if (Rest is not IValueTupleInternal rest)
@@ -2151,7 +2151,7 @@ namespace System
             return -1;
         }
 
-        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
+        readonly int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -2164,7 +2164,7 @@ namespace System
         /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7, Rest)</c>.
         /// If any field value is <see langword="null"/>, it is represented as <see cref="string.Empty"/>.
         /// </remarks>
-        public override string ToString()
+        public override readonly string ToString()
         {
             if (Rest is IValueTupleInternal)
             {
@@ -2174,7 +2174,7 @@ namespace System
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
         }
 
-        string IValueTupleInternal.ToStringEnd()
+        readonly string IValueTupleInternal.ToStringEnd()
         {
             if (Rest is IValueTupleInternal)
             {
@@ -2192,7 +2192,7 @@ namespace System
         /// <summary>
         /// Get the element at position <param name="index"/>.
         /// </summary>
-        object? ITuple.this[int index]
+        readonly object?ITuple.this[int index]
         {
             get
             {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -86,26 +86,26 @@ namespace System.Runtime.Serialization
         [DataMember(IsRequired = true)]
         public K Key
         {
-            get { return _key; }
+            readonly get { return _key; }
             set { _key = value; }
         }
 
         [DataMember(IsRequired = true)]
         public V Value
         {
-            get { return _value; }
+            readonly get { return _value; }
             set { _value = value; }
         }
 
         object? IKeyValue.Key
         {
-            get { return _key; }
+            readonly get { return _key; }
             set { _key = (K)value!; }
         }
 
         object? IKeyValue.Value
         {
-            get { return _value; }
+            readonly get { return _value; }
             set { _value = (V)value!; }
         }
     }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
@@ -24,14 +24,14 @@ namespace System.Runtime.Serialization
         [DataMember(Name = "DateTime", IsRequired = true)]
         public DateTime UtcDateTime
         {
-            get { return _utcDateTime; }
+            readonly get { return _utcDateTime; }
             set { _utcDateTime = value; }
         }
 
         [DataMember(Name = "OffsetMinutes", IsRequired = true)]
         public short OffsetMinutes
         {
-            get { return _offsetMinutes; }
+            readonly get { return _offsetMinutes; }
             set { _offsetMinutes = value; }
         }
 
@@ -64,7 +64,7 @@ namespace System.Runtime.Serialization
             return new DateTimeOffsetAdapter(value.UtcDateTime, (short)value.Offset.TotalMinutes);
         }
 
-        public string ToString(IFormatProvider provider)
+        public readonly string ToString(IFormatProvider provider)
         {
             return "DateTime: " + this.UtcDateTime + ", Offset: " + this.OffsetMinutes;
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectReferenceStack.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectReferenceStack.cs
@@ -84,7 +84,7 @@ namespace System.Runtime.Serialization
             _count--;
         }
 
-        internal bool Contains(object obj)
+        internal readonly bool Contains(object obj)
         {
             int currentCount = _count;
             if (currentCount > MaximumArraySize)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ScopedKnownTypes.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ScopedKnownTypes.cs
@@ -25,7 +25,7 @@ namespace System.Runtime.Serialization
             _count--;
         }
 
-        internal DataContract? GetDataContract(XmlQualifiedName qname)
+        internal readonly DataContract? GetDataContract(XmlQualifiedName qname)
         {
             for (int i = (_count - 1); i >= 0; i--)
             {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Text/SurrogateChar.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Text/SurrogateChar.cs
@@ -43,10 +43,10 @@ namespace System.Text
             _highChar = highChar;
         }
 
-        public char LowChar { get { return _lowChar; } }
-        public char HighChar { get { return _highChar; } }
+        public readonly char LowChar { get { return _lowChar; } }
+        public readonly char HighChar { get { return _highChar; } }
 
-        public int Char
+        public readonly int Char
         {
             get
             {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.Enumerator.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.Enumerator.cs
@@ -30,7 +30,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                 return false;
             }
 
-            public M Current
+            public readonly M Current
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             _queriedMembers = queriedMembers;
         }
 
-        public QueryResultEnumerator GetEnumerator() => new QueryResultEnumerator(this);
+        public readonly QueryResultEnumerator GetEnumerator() => new QueryResultEnumerator(this);
 
         /// <summary>
         /// Returns the number of matching results.
@@ -92,7 +92,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
         /// <summary>
         /// Returns a single member, null or throws AmbigousMatchException, for the Type.Get*(string name,...) family of apis.
         /// </summary>
-        public M? Disambiguate()
+        public readonly M? Disambiguate()
         {
             if (_queriedMembers == null)
                 return null; // This is an uninitialized QueryResult<M>, which is supported and represents a 0-length list of matches.
@@ -127,7 +127,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             return match;
         }
 
-        private int UnfilteredCount => ((_bindingAttr & BindingFlags.DeclaredOnly) != 0) ? _queriedMembers!.DeclaredOnlyCount : _queriedMembers!.TotalCount;
+        private readonly int UnfilteredCount => ((_bindingAttr & BindingFlags.DeclaredOnly) != 0) ? _queriedMembers!.DeclaredOnlyCount : _queriedMembers!.TotalCount;
 
         private readonly BindingFlags _bindingAttr;
         private int _lazyCount; // Intentionally not marking as volatile. QueryResult is for short-term use within a single method call - no aspiration to be thread-safe.

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/General/ListBuilder.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/General/ListBuilder.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Runtime.General
 #endif // DEBUG
         }
 
-        public T this[int index]
+        public readonly T this[int index]
         {
             get
             {
@@ -65,7 +65,7 @@ namespace System.Reflection.Runtime.General
             Array.Copy(_items!, 0, array, index, _count);
         }
 
-        public int Count
+        public readonly int Count
         {
             get
             {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2285,7 +2285,7 @@ namespace System
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", true)]
         public override int GetHashCode() { throw null; }
-        public int ToHashCode() { throw null; }
+        public readonly int ToHashCode() { throw null; }
     }
     public partial class HttpStyleUriParser : System.UriParser
     {
@@ -3037,13 +3037,13 @@ namespace System
         public Nullable(T value) { throw null; }
         public readonly bool HasValue { get { throw null; } }
         public readonly T Value { get { throw null; } }
-        public override bool Equals(object? other) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly bool Equals(object? other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public readonly T GetValueOrDefault() { throw null; }
         public readonly T GetValueOrDefault(T defaultValue) { throw null; }
         public static explicit operator T (T? value) { throw null; }
         public static implicit operator T? (T value) { throw null; }
-        public override string? ToString() { throw null; }
+        public override readonly string? ToString() { throw null; }
     }
     public partial class NullReferenceException : System.SystemException
     {
@@ -4880,9 +4880,9 @@ namespace System
     }
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo(System.ValueTuple other) { throw null; }
+        public readonly int CompareTo(System.ValueTuple other) { throw null; }
         public static System.ValueTuple Create() { throw null; }
         public static System.ValueTuple<T1> Create<T1>(T1 item1) { throw null; }
         public static (T1, T2) Create<T1, T2>(T1 item1, T2 item2) { throw null; }
@@ -4892,47 +4892,47 @@ namespace System
         public static (T1, T2, T3, T4, T5, T6) Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null; }
         public static (T1, T2, T3, T4, T5, T6, T7) Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null; }
         public static (T1, T2, T3, T4, T5, T6, T7, T8) Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals(System.ValueTuple other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals(System.ValueTuple other) { throw null; }
+        public readonly override int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1>>, System.IEquatable<System.ValueTuple<T1>>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public ValueTuple(T1 item1) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo(System.ValueTuple<T1> other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals(System.ValueTuple<T1> other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo(System.ValueTuple<T1> other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals(System.ValueTuple<T1> other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1, T2> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<(T1, T2)>, System.IEquatable<(T1, T2)>, System.Runtime.CompilerServices.ITuple
     {
         public T1 Item1;
         public T2 Item2;
         public ValueTuple(T1 item1, T2 item2) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo((T1, T2) other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals((T1, T2) other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo((T1, T2) other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals((T1, T2) other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1, T2, T3> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<(T1, T2, T3)>, System.IEquatable<(T1, T2, T3)>, System.Runtime.CompilerServices.ITuple
     {
@@ -4940,17 +4940,17 @@ namespace System
         public T2 Item2;
         public T3 Item3;
         public ValueTuple(T1 item1, T2 item2, T3 item3) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo((T1, T2, T3) other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals((T1, T2, T3) other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo((T1, T2, T3) other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals((T1, T2, T3) other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1, T2, T3, T4> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<(T1, T2, T3, T4)>, System.IEquatable<(T1, T2, T3, T4)>, System.Runtime.CompilerServices.ITuple
     {
@@ -4959,17 +4959,17 @@ namespace System
         public T3 Item3;
         public T4 Item4;
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo((T1, T2, T3, T4) other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals((T1, T2, T3, T4) other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo((T1, T2, T3, T4) other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals((T1, T2, T3, T4) other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1, T2, T3, T4, T5> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<(T1, T2, T3, T4, T5)>, System.IEquatable<(T1, T2, T3, T4, T5)>, System.Runtime.CompilerServices.ITuple
     {
@@ -4979,17 +4979,17 @@ namespace System
         public T4 Item4;
         public T5 Item5;
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo((T1, T2, T3, T4, T5) other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals((T1, T2, T3, T4, T5) other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo((T1, T2, T3, T4, T5) other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals((T1, T2, T3, T4, T5) other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1, T2, T3, T4, T5, T6> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<(T1, T2, T3, T4, T5, T6)>, System.IEquatable<(T1, T2, T3, T4, T5, T6)>, System.Runtime.CompilerServices.ITuple
     {
@@ -5000,17 +5000,17 @@ namespace System
         public T5 Item5;
         public T6 Item6;
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo((T1, T2, T3, T4, T5, T6) other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals((T1, T2, T3, T4, T5, T6) other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo((T1, T2, T3, T4, T5, T6) other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals((T1, T2, T3, T4, T5, T6) other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1, T2, T3, T4, T5, T6, T7> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<(T1, T2, T3, T4, T5, T6, T7)>, System.IEquatable<(T1, T2, T3, T4, T5, T6, T7)>, System.Runtime.CompilerServices.ITuple
     {
@@ -5022,17 +5022,17 @@ namespace System
         public T6 Item6;
         public T7 Item7;
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo((T1, T2, T3, T4, T5, T6, T7) other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals((T1, T2, T3, T4, T5, T6, T7) other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo((T1, T2, T3, T4, T5, T6, T7) other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals((T1, T2, T3, T4, T5, T6, T7) other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public partial struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, System.IEquatable<System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, System.Runtime.CompilerServices.ITuple where TRest : struct
     {
@@ -5045,17 +5045,17 @@ namespace System
         public T7 Item7;
         public TRest Rest;
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { throw null; }
-        object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
+        readonly object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }
         int System.Runtime.CompilerServices.ITuple.Length { get { throw null; } }
-        public int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
-        public bool Equals(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
-        public override int GetHashCode() { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.IComparable.CompareTo(object? other) { throw null; }
-        public override string ToString() { throw null; }
+        public readonly int CompareTo(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public readonly bool Equals(System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        readonly int System.Collections.IStructuralComparable.CompareTo(object? other, System.Collections.IComparer comparer) { throw null; }
+        readonly bool System.Collections.IStructuralEquatable.Equals(object? other, System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
+        readonly int System.IComparable.CompareTo(object? other) { throw null; }
+        public override readonly string ToString() { throw null; }
     }
     public abstract partial class ValueType
     {
@@ -5314,10 +5314,10 @@ namespace System.Collections
         private object _dummy;
         private int _dummyPrimitive;
         public DictionaryEntry(object key, object? value) { throw null; }
-        public object Key { get { throw null; } set { } }
-        public object? Value { get { throw null; } set { } }
+        public object Key { readonly get { throw null; } set { } }
+        public object? Value { readonly get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public void Deconstruct(out object key, out object? value) { throw null; }
+        public readonly void Deconstruct(out object key, out object? value) { throw null; }
     }
     public partial class Hashtable : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.ICloneable, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
     {
@@ -9811,15 +9811,15 @@ namespace System.Runtime.InteropServices
     public partial struct GCHandle
     {
         private int _dummyPrimitive;
-        public bool IsAllocated { get { throw null; } }
-        public object? Target { get { throw null; } set { } }
+        public readonly bool IsAllocated { get { throw null; } }
+        public object? Target { readonly get { throw null; } set { } }
         public System.IntPtr AddrOfPinnedObject() { throw null; }
         public static System.Runtime.InteropServices.GCHandle Alloc(object? value) { throw null; }
         public static System.Runtime.InteropServices.GCHandle Alloc(object? value, System.Runtime.InteropServices.GCHandleType type) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? o) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? o) { throw null; }
         public void Free() { }
         public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
         public static explicit operator System.Runtime.InteropServices.GCHandle (System.IntPtr value) { throw null; }
         public static explicit operator System.IntPtr (System.Runtime.InteropServices.GCHandle value) { throw null; }
@@ -10931,9 +10931,9 @@ namespace System.Text
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.ReadOnlyMemory<char> Current { get { throw null; } }
+            public readonly System.ReadOnlyMemory<char> Current { get { throw null; } }
             [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-            public System.Text.StringBuilder.ChunkEnumerator GetEnumerator() { throw null; }
+            public readonly System.Text.StringBuilder.ChunkEnumerator GetEnumerator() { throw null; }
             public bool MoveNext() { throw null; }
         }
     }
@@ -10941,12 +10941,12 @@ namespace System.Text
     {
         private object _dummy;
         private int _dummyPrimitive;
-        public System.Text.Rune Current { get { throw null; } }
+        public readonly System.Text.Rune Current { get { throw null; } }
         object? System.Collections.IEnumerator.Current { get { throw null; } }
-        public System.Text.StringRuneEnumerator GetEnumerator() { throw null; }
+        public readonly System.Text.StringRuneEnumerator GetEnumerator() { throw null; }
         public bool MoveNext() { throw null; }
-        System.Collections.Generic.IEnumerator<System.Text.Rune> System.Collections.Generic.IEnumerable<System.Text.Rune>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        readonly System.Collections.Generic.IEnumerator<System.Text.Rune> System.Collections.Generic.IEnumerable<System.Text.Rune>.GetEnumerator() { throw null; }
+        readonly System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         void System.Collections.IEnumerator.Reset() { }
         void System.IDisposable.Dispose() { }
     }
@@ -11561,9 +11561,9 @@ namespace System.Threading.Tasks.Sources
         private object _dummy;
         private int _dummyPrimitive;
         public bool RunContinuationsAsynchronously { readonly get { throw null; } set { } }
-        public short Version { get { throw null; } }
-        public TResult GetResult(short token) { throw null; }
-        public System.Threading.Tasks.Sources.ValueTaskSourceStatus GetStatus(short token) { throw null; }
+        public readonly short Version { get { throw null; } }
+        public readonly TResult GetResult(short token) { throw null; }
+        public readonly System.Threading.Tasks.Sources.ValueTaskSourceStatus GetStatus(short token) { throw null; }
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public void Reset() { }
         public void SetException(System.Exception error) { }


### PR DESCRIPTION
Close #1718
I wrote a little Roslyn-based program that automate most of the work (I'm only rechecking changes in git diff) and pushed one file to init. But I'm ready to mark all methods (and properties) in src\libraries\ in **NOT** `readonly struct` with `readonly` keyword.
But I'm not sure should I mark method/property as `readonly` or not if it is a explicit interface implementation

Also how it would be better to commit changes if it's important? Commit per file or one huge commit? 
As I see now, there will be at least 1300 methods in 307 files (without tests directories)