### PR TITLE
[release/5.0] Don't rev the platforms package unless we ship it

### DIFF
--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -23,7 +23,7 @@
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
     <!-- major.minor.release version of the platforms package we're currently building
          Pre-release will be appended during build -->
-    <PlatformPackageVersion>$(ProductVersion)</PlatformPackageVersion>
+    <PlatformPackageVersion>5.0.0</PlatformPackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>


### PR DESCRIPTION
We should technically pin more here, similar to https://github.com/dotnet/runtime/pull/46447, but just doing the minimal in servicing to unblock https://github.com/dotnet/runtime/pull/46598 and https://github.com/dotnet/runtime/pull/46590

This is infra only change so should be mergeable on review.