### PR TITLE
Make const variables internal to be used by other classes

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -32,9 +32,9 @@ namespace System.Net.Http
         private const ulong EightByteLengthMask = 0xC000000000000000;
 
         public const uint OneByteLimit = (1U << 6) - 1;
-        private const uint TwoByteLimit = (1U << 16) - 1;
-        private const uint FourByteLimit = (1U << 30) - 1;
-        private const long EightByteLimit = (1L << 62) - 1;
+        public const uint TwoByteLimit = (1U << 16) - 1;
+        public const uint FourByteLimit = (1U << 30) - 1;
+        public const long EightByteLimit = (1L << 62) - 1;
 
         public static bool TryRead(ReadOnlySpan<byte> buffer, out long value, out int bytesRead)
         {

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -31,6 +31,7 @@ namespace System.Net.Http
         private const uint FourByteLengthMask = 0x80000000;
         private const ulong EightByteLengthMask = 0xC000000000000000;
 
+        // public for internal use in aspnetcore 
         public const uint OneByteLimit = (1U << 6) - 1;
         public const uint TwoByteLimit = (1U << 16) - 1;
         public const uint FourByteLimit = (1U << 30) - 1;

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -31,7 +31,7 @@ namespace System.Net.Http
         private const uint FourByteLengthMask = 0x80000000;
         private const ulong EightByteLengthMask = 0xC000000000000000;
 
-        // public for internal use in aspnetcore 
+        // public for internal use in aspnetcore
         public const uint OneByteLimit = (1U << 6) - 1;
         public const uint TwoByteLimit = (1U << 16) - 1;
         public const uint FourByteLimit = (1U << 30) - 1;


### PR DESCRIPTION
We used some of these const values in aspnetcore outside of the VariableLengthIntegerHelper, so making them internal (this syncs code with aspnetcore).