### PR TITLE
Disable System.ComponentModel.Composition on Mono

### DIFF
--- a/src/libraries/System.ComponentModel.Composition/tests/AssemblyInfo.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/AssemblyInfo.cs
@@ -3,3 +3,4 @@
 
 using Xunit;
 
+[assembly: ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)] // flaky tests


### PR DESCRIPTION
Active issue is https://github.com/mono/mono/issues/16417

There seems to be some kind of System.Reflection.Emit concurrency problem here