### PR TITLE
Glob include files based on project extension (VS)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,16 +27,10 @@
   
   <!-- The Default behavior in VS is to show files for the first target framework in TargetFrameworks property.
        This is required to show all the files corresponding to all target frameworks in VS. -->
-  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(DesignTimeBuild)' == 'true'">
-    <None Include="$(MSBuildProjectDirectory)\**\*.cs"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
-          Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
-    <None Include="$(MSBuildProjectDirectory)\**\*.vb"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
-          Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
-    <None Include="$(MSBuildProjectDirectory)\**\*.fs"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
-          Condition="'$(MSBuildProjectExtension)' == '.fsproj'" />
+  <ItemGroup Condition="'$(DefaultLanguageSourceExtension)' != '' and
+                        ('$(BuildingInsideVisualStudio)' == 'true' or '$(DesignTimeBuild)' == 'true')">
+    <None Include="$(MSBuildProjectDirectory)\**\*$(DefaultLanguageSourceExtension)"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)" />
   </ItemGroup>
 
   <!-- Packaging -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,6 +24,20 @@
     <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(VersionSuffix)' == ''">$(ProductVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(VersionSuffix)' != ''">$(ProductVersion)-$(VersionSuffix)</InformationalVersion>
   </PropertyGroup>
+  
+  <!-- The Default behavior in VS is to show files for the first target framework in TargetFrameworks property.
+       This is required to show all the files corresponding to all target frameworks in VS. -->
+  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(DesignTimeBuild)' == 'true'">
+    <None Include="$(MSBuildProjectDirectory)\**\*.cs"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
+          Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
+    <None Include="$(MSBuildProjectDirectory)\**\*.vb"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
+          Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
+    <None Include="$(MSBuildProjectDirectory)\**\*.fs"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
+          Condition="'$(MSBuildProjectExtension)' == '.fsproj'" />
+  </ItemGroup>
 
   <!-- Packaging -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -257,10 +257,17 @@
   </Choose>
 
   <!-- The Default behavior in VS is to show files for the first target framework in TargetFrameworks property.
-        This is required to show all the files corresponding to all target frameworks in VS. -->
+       This is required to show all the files corresponding to all target frameworks in VS. -->
   <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(DesignTimeBuild)' == 'true'">
     <None Include="$(MSBuildProjectDirectory)\**\*.cs"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)" />
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
+          Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
+    <None Include="$(MSBuildProjectDirectory)\**\*.vb"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
+          Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
+    <None Include="$(MSBuildProjectDirectory)\**\*.fs"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
+          Condition="'$(MSBuildProjectExtension)' == '.fsproj'" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -256,20 +256,6 @@
     </When>
   </Choose>
 
-  <!-- The Default behavior in VS is to show files for the first target framework in TargetFrameworks property.
-       This is required to show all the files corresponding to all target frameworks in VS. -->
-  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(DesignTimeBuild)' == 'true'">
-    <None Include="$(MSBuildProjectDirectory)\**\*.cs"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
-          Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
-    <None Include="$(MSBuildProjectDirectory)\**\*.vb"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
-          Condition="'$(MSBuildProjectExtension)' == '.vbproj'" />
-    <None Include="$(MSBuildProjectDirectory)\**\*.fs"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)"
-          Condition="'$(MSBuildProjectExtension)' == '.fsproj'" />
-  </ItemGroup>
-
   <PropertyGroup>
     <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and ($([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')))">true</SkipLocalsInit>
   </PropertyGroup>


### PR DESCRIPTION
Wasn't reported but something that I just noticed while scanning code. Extracting into the root Directory.Build.targets, as this is the behavior that we want to see throughout the repo.