### PR TITLE
Improve tiering disablement for `UnmanagedCallersOnly` methods

### DIFF
--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2023,23 +2023,16 @@ public:
 
 private:
     PCODE PrepareILBasedCode(PrepareCodeConfig* pConfig);
-#ifdef FEATURE_TIERED_COMPILATION
-    PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldCountCalls);
-    PCODE JitCompileCode(PrepareCodeConfig* pConfig, bool shouldCountCalls);
-    PCODE JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, bool shouldCountCalls);
-    PCODE JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pLockEntry, bool shouldCountCalls, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags);
-#else
-    PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig);
-    PCODE JitCompileCode(PrepareCodeConfig* pConfig);
-    PCODE JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry);
-    PCODE JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pLockEntry, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags);
-#endif
+    PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldTier);
     PCODE GetPrecompiledNgenCode(PrepareCodeConfig* pConfig);
     PCODE GetPrecompiledR2RCode(PrepareCodeConfig* pConfig);
     PCODE GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0Jit);
     COR_ILMETHOD_DECODER* GetAndVerifyILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyMetadataILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyNoMetadataILHeader();
+    PCODE JitCompileCode(PrepareCodeConfig* pConfig);
+    PCODE JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry);
+    PCODE JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pLockEntry, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags);
 #endif // DACCESS_COMPILE
 
 #ifdef HAVE_GCCOVER
@@ -2138,6 +2131,20 @@ public:
 
 #ifdef FEATURE_TIERED_COMPILATION
 public:
+    bool WasTieringDisabledBeforeJitting() const
+    {
+        WRAPPER_NO_CONTRACT;
+        return m_wasTieringDisabledBeforeJitting;
+    }
+
+    void SetWasTieringDisabledBeforeJitting()
+    {
+        WRAPPER_NO_CONTRACT;
+        _ASSERTE(GetMethodDesc()->IsEligibleForTieredCompilation());
+
+        m_wasTieringDisabledBeforeJitting = true;
+    }
+
     bool ShouldCountCalls() const
     {
         WRAPPER_NO_CONTRACT;
@@ -2245,6 +2252,7 @@ private:
 
 #ifdef FEATURE_TIERED_COMPILATION
 private:
+    bool m_wasTieringDisabledBeforeJitting;
     bool m_shouldCountCalls;
 #endif
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -361,18 +361,34 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     STANDARD_VM_CONTRACT;
     PCODE pCode = NULL;
 
+    bool shouldTier = false;
 #if defined(FEATURE_TIERED_COMPILATION)
-    bool shouldCountCalls = pConfig->GetMethodDesc()->IsEligibleForTieredCompilation();
+    shouldTier = pConfig->GetMethodDesc()->IsEligibleForTieredCompilation();
 #if !defined(TARGET_X86)
-    if (shouldCountCalls
+    // If the method is eligible for tiering but is being
+    // called from a Preemptive GC Mode thread or the method
+    // has the UnmanagedCallersOnlyAttribute then the Tiered Compilation
+    // should be disabled.
+    if (shouldTier
         && (pConfig->GetCallerGCMode() == CallerGCMode::Preemptive
             || (pConfig->GetCallerGCMode() == CallerGCMode::Unknown
                 && HasUnmanagedCallersOnlyAttribute())))
     {
-        shouldCountCalls = false;
+        NativeCodeVersion codeVersion = pConfig->GetCodeVersion();
+        if (codeVersion.IsDefaultVersion())
+        {
+            pConfig->GetMethodDesc()->GetLoaderAllocator()->GetCallCountingManager()->DisableCallCounting(codeVersion);
+            _ASSERTE(codeVersion.GetOptimizationTier() != NativeCodeVersion::OptimizationTier0);
+        }
+        else if (codeVersion.GetOptimizationTier() == NativeCodeVersion::OptimizationTier0)
+        {
+            codeVersion.SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
+        }
+        pConfig->SetWasTieringDisabledBeforeJitting();
+        shouldTier = false;
     }
-#endif
-#endif
+#endif // !TARGET_X86
+#endif // FEATURE_TIERED_COMPILATION
 
     if (pConfig->MayUsePrecompiledCode())
     {
@@ -407,11 +423,7 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
 
         if (pCode == NULL)
         {
-#ifdef FEATURE_TIERED_COMPILATION
-            pCode = GetPrecompiledCode(pConfig, shouldCountCalls);
-#else
-            pCode = GetPrecompiledCode(pConfig);
-#endif
+            pCode = GetPrecompiledCode(pConfig, shouldTier);
         }
 
 #ifdef FEATURE_PERFMAP
@@ -424,12 +436,7 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     {
         LOG((LF_CLASSLOADER, LL_INFO1000000,
             "    In PrepareILBasedCode, calling JitCompileCode\n"));
-
-#ifdef FEATURE_TIERED_COMPILATION
-            pCode = JitCompileCode(pConfig, shouldCountCalls);
-#else
-            pCode = JitCompileCode(pConfig);
-#endif
+        pCode = JitCompileCode(pConfig);
     }
     else
     {
@@ -442,11 +449,7 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     return pCode;
 }
 
-#ifdef FEATURE_TIERED_COMPILATION
-PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldCountCalls)
-#else
-PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
-#endif
+PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldTier)
 {
     STANDARD_VM_CONTRACT;
     PCODE pCode = NULL;
@@ -475,7 +478,7 @@ PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
                 pConfig->SetGeneratedOrLoadedNewCode();
 #endif
 #ifdef FEATURE_TIERED_COMPILATION
-                if (shouldCountCalls)
+                if (shouldTier)
                 {
                     _ASSERTE(pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
                     pConfig->SetShouldCountCalls();
@@ -714,11 +717,8 @@ COR_ILMETHOD_DECODER* MethodDesc::GetAndVerifyILHeader(PrepareCodeConfig* pConfi
 //
 // This function creates a DeadlockAware list of methods being jitted
 // which prevents us from trying to JIT the same method more that once.
-#ifdef FEATURE_TIERED_COMPILATION
-PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig, bool shouldCountCalls)
-#else
+
 PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
-#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -811,7 +811,7 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
                 {
                 #ifdef FEATURE_TIERED_COMPILATION
                     // Finalize the optimization tier before SetNativeCode() is called
-                    shouldCountCalls = wasTier0Jit && pConfig->FinalizeOptimizationTierForTier0Jit() && shouldCountCalls;
+                    bool shouldCountCalls = wasTier0Jit && pConfig->FinalizeOptimizationTierForTier0Jit();
                 #endif
 
                     if (pConfig->SetNativeCode(pCode, &pCode))
@@ -831,20 +831,12 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
                 }
             }
 
-#ifdef FEATURE_TIERED_COMPILATION
-            return JitCompileCodeLockedEventWrapper(pConfig, pEntryLock, shouldCountCalls);
-#else
             return JitCompileCodeLockedEventWrapper(pConfig, pEntryLock);
-#endif
         }
     }
 }
 
-#ifdef FEATURE_TIERED_COMPILATION
-PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, bool shouldCountCalls)
-#else
 PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry)
-#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -899,11 +891,7 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
         TRACE_LEVEL_VERBOSE,
         CLR_JIT_KEYWORD))
     {
-#ifdef FEATURE_TIERED_COMPILATION
-        pCode = JitCompileCodeLocked(pConfig, pEntry, shouldCountCalls, &sizeOfCode, &flags);
-#else
         pCode = JitCompileCodeLocked(pConfig, pEntry, &sizeOfCode, &flags);
-#endif
     }
     else
     {
@@ -923,11 +911,7 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
             &methodSignature);
 #endif
 
-#ifdef FEATURE_TIERED_COMPILATION
-        pCode = JitCompileCodeLocked(pConfig, pEntry, shouldCountCalls, &sizeOfCode, &flags);
-#else
         pCode = JitCompileCodeLocked(pConfig, pEntry, &sizeOfCode, &flags);
-#endif
 
         // Interpretted methods skip this notification
 #ifdef FEATURE_INTERPRETER
@@ -1017,11 +1001,7 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
     return pCode;
 }
 
-#ifdef FEATURE_TIERED_COMPILATION
-PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, bool shouldCountCalls, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags)
-#else
 PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEntry* pEntry, ULONG* pSizeOfCode, CORJIT_FLAGS* pFlags)
-#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -1034,23 +1014,6 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     COR_ILMETHOD_DECODER ilDecoderTemp;
     COR_ILMETHOD_DECODER *pilHeader = GetAndVerifyILHeader(pConfig, &ilDecoderTemp);
     *pFlags = pConfig->GetJitCompilationFlags();
-
-#ifdef FEATURE_TIERED_COMPILATION
-    bool isTier0 = pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
-    // If we've already opted-out of call counting, for example in the UnmangedCallersOnly case,
-    // switch to optimized code.
-    if (!shouldCountCalls)
-    {
-        pFlags->Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
-        pFlags->Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER1);
-
-        if (pConfig->GetMethodDesc()->IsEligibleForTieredCompilation())
-        {
-            pConfig->SetJitSwitchedToOptimized();
-        }
-    }
-#endif
-
     PCODE pOtherCode = NULL;
 
     EX_TRY
@@ -1118,7 +1081,7 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
 
 #ifdef FEATURE_TIERED_COMPILATION
     // Finalize the optimization tier before SetNativeCode() is called
-    shouldCountCalls = isTier0 && pConfig->FinalizeOptimizationTierForTier0Jit() && shouldCountCalls;
+    bool shouldCountCalls = pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0) && pConfig->FinalizeOptimizationTierForTier0Jit();
 #endif
 
     // Aside from rejit, performing a SetNativeCodeInterlocked at this point
@@ -1197,6 +1160,7 @@ PrepareCodeConfig::PrepareCodeConfig(NativeCodeVersion codeVersion, BOOL needsMu
     m_generatedOrLoadedNewCode(false),
 #endif
 #ifdef FEATURE_TIERED_COMPILATION
+    m_wasTieringDisabledBeforeJitting(false),
     m_shouldCountCalls(false),
 #endif
     m_jitSwitchedToMinOpt(false),
@@ -1284,7 +1248,7 @@ CORJIT_FLAGS PrepareCodeConfig::GetJitCompilationFlags()
         flags = pResolver->GetJitFlags();
     }
 #ifdef FEATURE_TIERED_COMPILATION
-    flags.Add(TieredCompilationManager::GetJitFlags(m_nativeCodeVersion));
+    flags.Add(TieredCompilationManager::GetJitFlags(this));
 #endif
     return flags;
 }
@@ -1462,7 +1426,7 @@ CORJIT_FLAGS VersionedPrepareCodeConfig::GetJitCompilationFlags()
 #endif
 
 #ifdef FEATURE_TIERED_COMPILATION
-    flags.Add(TieredCompilationManager::GetJitFlags(m_nativeCodeVersion));
+    flags.Add(TieredCompilationManager::GetJitFlags(this));
 #endif
 
     return flags;

--- a/src/coreclr/vm/tieredcompilation.h
+++ b/src/coreclr/vm/tieredcompilation.h
@@ -43,7 +43,7 @@ public:
     void HandleCallCountingForFirstCall(MethodDesc* pMethodDesc);
     bool TrySetCodeEntryPointAndRecordMethodForCallCounting(MethodDesc* pMethodDesc, PCODE codeEntryPoint);
     void AsyncPromoteToTier1(NativeCodeVersion tier0NativeCodeVersion, bool *scheduleTieringBackgroundWorkRef);
-    static CORJIT_FLAGS GetJitFlags(NativeCodeVersion nativeCodeVersion);
+    static CORJIT_FLAGS GetJitFlags(PrepareCodeConfig *config);
 
 private:
     bool IsTieringDelayActive();


### PR DESCRIPTION
- Simplifies https://github.com/dotnet/runtime/pull/46550 and fixes some issues
- Disables call counting and adjusts the tier appropriately for `UnmanagedCallersOnly` methods
- Fixes optimization flags sent to the JIT for the default code version when call counting is disabled, including when an `UnmanagedCallersOnly` method is attributed with `AggressiveOptimization`. On the default code version path previously it wasn't checking if call counting was disabled, and since that's an expensive check to add on that path, added a flag to `PrepareCodeConfig`.
- Fixes some miscellaneous inconsistencies between call counting enablement, optimization tier, and jit flags