### PR TITLE
Use Math.DivRem instead of / % in BigInteger if dividend and divisor are trivial

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -743,8 +743,9 @@ namespace System.Numerics
 
             if (trivialDividend && trivialDivisor)
             {
-                remainder = dividend._sign % divisor._sign;
-                return dividend._sign / divisor._sign;
+                BigInteger quotient;
+                (quotient, remainder) = Math.DivRem(dividend._sign, divisor._sign);
+                return quotient;
             }
 
             if (trivialDividend)


### PR DESCRIPTION
#45230