### PR TITLE
[release/5.0] Change FeedbackSize on Rijndael wrappers to delegate to implementation.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RijndaelImplementation.cs
@@ -23,6 +23,7 @@ namespace Internal.Cryptography
 
             // This class wraps Aes
             _impl = Aes.Create();
+            _impl.FeedbackSize = 128;
         }
 
         public override int BlockSize
@@ -40,6 +41,12 @@ namespace Internal.Cryptography
                 if (value != 128)
                     throw new CryptographicException(SR.Cryptography_Rijndael_BlockSize);
             }
+        }
+
+        public override int FeedbackSize
+        {
+            get => _impl.FeedbackSize;
+            set => _impl.FeedbackSize = value;
         }
 
         public override byte[] IV

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RijndaelManaged.cs
@@ -19,6 +19,7 @@ namespace System.Security.Cryptography
 
             // This class wraps Aes
             _impl = Aes.Create();
+            _impl.FeedbackSize = 128;
         }
 
         public override int BlockSize
@@ -36,6 +37,12 @@ namespace System.Security.Cryptography
                 if (value != 128)
                     throw new CryptographicException(SR.Cryptography_Rijndael_BlockSize);
             }
+        }
+
+        public override int FeedbackSize
+        {
+            get => _impl.FeedbackSize;
+            set => _impl.FeedbackSize = value;
         }
 
         public override byte[] IV

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
@@ -25,6 +25,7 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
                 Assert.Equal(128, alg.LegalBlockSizes[0].MinSize);
                 Assert.Equal(128, alg.LegalBlockSizes[0].MaxSize);
                 Assert.Equal(128, alg.BlockSize);
+                Assert.Equal(128, alg.FeedbackSize);
 
                 // Different exception since we have different supported BlockSizes than desktop
                 Assert.Throws<PlatformNotSupportedException>(() => alg.BlockSize = 192);
@@ -32,6 +33,7 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
 
                 // Normal exception for rest
                 Assert.Throws<CryptographicException>(() => alg.BlockSize = 111);
+                Assert.Throws<CryptographicException>(() => alg.FeedbackSize = 15);
 
                 Assert.Equal(CipherMode.CBC, alg.Mode);
                 Assert.Equal(PaddingMode.PKCS7, alg.Padding);
@@ -169,6 +171,9 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
 
                 alg.Padding = PaddingMode.PKCS7;
                 Assert.Equal(PaddingMode.PKCS7, alg.Padding);
+
+                alg.FeedbackSize = 8;
+                Assert.Equal(8, alg.FeedbackSize);
             }
 
             using (var alg = Rijndael.Create())
@@ -289,6 +294,47 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
 
             string decrypted = Encoding.ASCII.GetString(outputBytes, 0, outputOffset);
             Assert.Equal(ExpectedOutput, decrypted);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [InlineData(128)]
+        [InlineData(8)]
+        [InlineData(null)]
+        public static void CfbFeedbackSizeIsRespected(int? feedbackSize)
+        {
+            void Test(Rijndael alg)
+            {
+                alg.Mode = CipherMode.CFB;
+
+                if (feedbackSize == null)
+                {
+                    feedbackSize = alg.FeedbackSize;
+                }
+                else
+                {
+                    alg.FeedbackSize = feedbackSize.Value;
+                }
+
+                int feedbackSizeBytes = feedbackSize.Value / 8;
+                byte[] input = new byte[feedbackSizeBytes + 1];
+
+                using ICryptoTransform transform = alg.CreateEncryptor();
+
+                byte[] output = transform.TransformFinalBlock(input, 0, input.Length);
+                int expectedOutputSize = (input.Length / feedbackSizeBytes) * feedbackSizeBytes + feedbackSizeBytes;
+
+                Assert.Equal(expectedOutputSize, output.Length);
+            }
+
+            using (Rijndael alg = new RijndaelManaged())
+            {
+                Test(alg);
+            }
+
+            using (Rijndael alg = Rijndael.Create())
+            {
+                Test(alg);
+            }
         }
 
         private class RijndaelLegalSizesBreaker : RijndaelMinimal


### PR DESCRIPTION
Manual back port of #46686 for issue https://github.com/dotnet/runtime/issues/46672

## Customer Impact

Customer reported. Blocks migration from .NET Framework for those using this API.

A new mode of symmetric encryption was introduced in .NET 5, CFB. The new mode did not correctly set or retrieve the `FeedbackSize` value from `Rijndael` instances created either from `RijndaelManaged` or `Rijndael.Create()`. The inability to properly set the `FeedbackSize` would lead to it being ignored by the actual encryption or decryption. CFB8 would always be used, even if the developer specifically asked for CFB128 by setting the `FeedbackSize` to 128.

This also changes the default `FeedbackSize` from 8 to 128 for `Rijndael` and derived types to be consistent with the default value in the .NET Framework. These types exist in .NET 5 specifically for compatibility - so they are kept compatible with the .NET Framework.

## Testing

Unit tests to prevent regressions, manual validation against .NET Framework to verify the `FeedbackSize` for `Rijndael` are derived types is consistent.

## Risk

This changes the default behavior of `FeedbackSize` on `RijndaelManaged` and `Rijndael.Create()`. In .NET 5, the actual behavior observed was a `FeedbackSize` of 8. This will change it to 128 to be consistent with the compatibility types. Thus this is a breaking change in the CFB behavior that was introduced in .NET 5. However these types exist for compatibility purposes, it is not expected that new .NET 5 code uses Rijndael, rather `Aes` should be used.

Developers that are affected by the breaking change can preserve the old behavior by setting the `FeedbackSize` back to 8 in their application code.