### PR TITLE
No need to handle COR_E_STACKOVERFLOW when waiting for GC.

### DIFF
--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1931,9 +1931,6 @@ FAILURE:
             END_PIN_PROFILER();
         }
 #endif // PROFILING_SUPPORTED
-
-        // CoreCLR does not support user-requested thread suspension
-        _ASSERTE(!(m_State & TS_SuspendUnstarted));
     }
 
     return res;

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1137,7 +1137,7 @@ public:
         TS_StackCrawlNeeded       = 0x00200000,    // A stackcrawl is needed on this thread, such as for thread abort
                                                    // See comment for s_pWaitForStackCrawlEvent for reason.
 
-        TS_SuspendUnstarted       = 0x00400000,    // latch a user suspension on an unstarted thread
+        // unused                 = 0x00400000,
 
         // unused                 = 0x00800000,    
         TS_TPWorkerThread         = 0x01000000,    // is this a threadpool worker thread?

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1112,9 +1112,7 @@ public:
         TS_Hijacked               = 0x00000080,    // Return address has been hijacked
 #endif // FEATURE_HIJACK
 
-        TS_BlockGCForSO           = 0x00000100,    // If a thread does not have enough stack, WaitUntilGCComplete may fail.
-                                                   // Either GC suspension will wait until the thread has cleared this bit,
-                                                   // Or the current thread is going to spin if GC has suspended all threads.
+        // unused                 = 0x00000100,
         TS_Background             = 0x00000200,    // Thread is a background thread
         TS_Unstarted              = 0x00000400,    // Thread has never been started
         TS_Dead                   = 0x00000800,    // Thread is dead

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1188,8 +1188,7 @@ public:
         // unused                       = 0x00000002,
         TSNC_DebuggerIsStepping         = 0x00000004, // debugger is stepping this thread
         TSNC_DebuggerIsManagedException = 0x00000008, // EH is re-raising a managed exception.
-        TSNC_WaitUntilGCFinished        = 0x00000010, // The current thread is waiting for GC.  If host returns
-                                                      // SO during wait, we will either spin or make GC wait.
+        // unused                       = 0x00000010,
         TSNC_BlockedForShutdown         = 0x00000020, // Thread is blocked in WaitForEndOfShutdown.  We should not hit WaitForEndOfShutdown again.
         // unused                       = 0x00000040,
         TSNC_CLRCreatedThread           = 0x00000080, // The thread was created through Thread::CreateNewThread

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2110,9 +2110,7 @@ void Thread::RareDisablePreemptiveGC()
 #endif // PROFILING_SUPPORTED
 
                 DWORD status = S_OK;
-                SetThreadStateNC(TSNC_WaitUntilGCFinished);
                 status = GCHeapUtilities::GetGCHeap()->WaitUntilGCComplete();
-                ResetThreadStateNC(TSNC_WaitUntilGCFinished);
 
                 if (status == (DWORD)COR_E_STACKOVERFLOW)
                 {
@@ -2137,13 +2135,12 @@ void Thread::RareDisablePreemptiveGC()
                         break;
                     }
                 }
+
                 if (!GCHeapUtilities::IsGCInProgress())
                 {
                     if (HasThreadState(TS_StackCrawlNeeded))
                     {
-                        SetThreadStateNC(TSNC_WaitUntilGCFinished);
                         ThreadStore::WaitForStackCrawlEvent();
-                        ResetThreadStateNC(TSNC_WaitUntilGCFinished);
                     }
                 }
 

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2109,31 +2109,10 @@ void Thread::RareDisablePreemptiveGC()
                 }
 #endif // PROFILING_SUPPORTED
 
-                DWORD status = S_OK;
-                status = GCHeapUtilities::GetGCHeap()->WaitUntilGCComplete();
-
-                if (status == (DWORD)COR_E_STACKOVERFLOW)
+                DWORD status = GCHeapUtilities::GetGCHeap()->WaitUntilGCComplete();
+                if (status != S_OK)
                 {
-                    // One of two things can happen here:
-                    // 1. Spin until EE restarts.
-                    // 2. Suspending thread lets us to cooperative mode and waits until we suspend.
-                    SetThreadState(TS_BlockGCForSO);
-                    while (GCHeapUtilities::IsGCInProgress() && m_fPreemptiveGCDisabled.Load() == 0)
-                    {
-                        // We can not go to a host for blocking operation due ot lack of stack.
-                        // Instead we will spin here until
-                        // 1. GC is finished; Or
-                        // 2. GC lets this thread to run and will wait for it
-#undef Sleep
-                        Sleep(10);
-#define Sleep(a) Dont_Use_Sleep(a)
-                    }
-                    ResetThreadState(TS_BlockGCForSO);
-                    if (m_fPreemptiveGCDisabled.Load() == 1)
-                    {
-                        // GC suspension has allowed this thread to switch back to cooperative mode.
-                        break;
-                    }
+                    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("Waiting for GC completion failed"));
                 }
 
                 if (!GCHeapUtilities::IsGCInProgress())
@@ -3379,25 +3358,6 @@ HRESULT ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
                     countThreads++;
                     thread->SetThreadState(Thread::TS_GCSuspendPending);
                 }
-            }
-
-            if (thread->HasThreadState(Thread::TS_BlockGCForSO))
-            {
-                // The thread has seen the trap while going to cooperative but does not have enough stack to block.
-                // It can't continue to cooperative mode either - per contract with us, so it does Sleep(10)
-                // in a loop until EE restarts.
-                // If we happen to catch a thread in such state, we can try unwedge it earlier than that.
-                if (thread->m_fPreemptiveGCDisabled.Load() == 0)
-                {
-                    if (!thread->HasThreadState(Thread::TS_GCSuspendPending))
-                    {
-                        thread->SetThreadState(Thread::TS_GCSuspendPending);
-                        countThreads ++;
-                    }
-                    thread->ResetThreadState(Thread::TS_BlockGCForSO);
-                    FastInterlockOr (&thread->m_fPreemptiveGCDisabled, 1);
-                }
-                continue;
             }
 
             if (!thread->HasThreadStateOpportunistic(Thread::TS_GCSuspendPending))


### PR DESCRIPTION
Resolves:https://github.com/dotnet/runtime/issues/44001

It does not look like `COR_E_STACKOVERFLOW` can happen when waiting on GC completion. 

Likely the scenario came from the times of SQL hosting, when locking was handled in the host. I guess the blocking wait in SQL host could return `COR_E_STACKOVERFLOW` and perhaps often, since stacks were intentionally limited, so this was important.

Now we just do non-alertable `WaitForSingleObjectEx`, after a few indirections. 
We can only get `S_OK` or `WAIT_FAILED` from that and the latter should be fatal. The failure is highly unlikely, but then the possible reasons are many. We can get more info from `GetLastError` but good chances it is unrecoverable anyways.

This makes `COR_E_STACKOVERFLOW` not a real scenario. Even if it was, attempt to handle it by calling `Sleep(10)` could just cause another SO.

Also removed couple thread states that appear to have no effect.