### PR TITLE
HTTP/3: Fix decoding trailing headers

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
@@ -167,14 +167,21 @@ namespace System.Net.Http.QPack
             }
         }
 
+        /// <summary>
+        /// Reset the decoder state back to its initial value. Resetting state is required when reusing a decoder with multiple
+        /// header frames. For example, decoding a response's headers and trailers.
+        /// </summary>
+        public void Reset()
+        {
+            _state = State.RequiredInsertCount;
+        }
+
         public void Decode(in ReadOnlySequence<byte> headerBlock, IHttpHeadersHandler handler)
         {
             foreach (ReadOnlyMemory<byte> segment in headerBlock)
             {
                 Decode(segment.Span, handler);
             }
-
-            _state = State.RequiredInsertCount;
         }
 
         public void Decode(ReadOnlySpan<byte> headerBlock, IHttpHeadersHandler handler)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -808,6 +808,9 @@ namespace System.Net.Http
                 _recvBuffer.Discard(processLength);
                 headersLength -= processLength;
             }
+
+            // Reset decoder state. Require because one decoder instance is reused to decode headers and trailers.
+            _headerDecoder.Reset();
         }
 
         private static ReadOnlySpan<byte> StatusHeaderNameBytes => new byte[] { (byte)'s', (byte)'t', (byte)'a', (byte)'t', (byte)'u', (byte)'s' };


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46263

HttpClient uses `void Decode(ReadOnlySpan<byte> headerBlock, IHttpHeadersHandler handler)`. Also need to reset decoder status there.