### PR TITLE
add shutdown guard to profiler tests

### DIFF
--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
@@ -27,80 +27,23 @@ shared_ptr<SlowPathELTProfiler> SlowPathELTProfiler::s_profiler;
 #define PROFILER_STUB EXTERN_C void STDMETHODCALLTYPE
 #endif // WIN32
 
-class ELTGuard
-{
-private:
-    static atomic<bool> s_preventHooks;
-    static atomic<int> s_hooksInProgress;
-
-public:
-    ELTGuard()
-    {
-        ++s_hooksInProgress;
-    }
-
-    ~ELTGuard()
-    {
-        --s_hooksInProgress;
-    }
-
-    static void Initialize()
-    {
-        s_preventHooks = false;
-        s_hooksInProgress = 0;
-    }
-
-    static bool HasShutdownStarted()
-    {
-        return s_preventHooks.load();
-    }
-
-    static void WaitForInProgressHooks()
-    {
-        s_preventHooks = true;
-
-        while (s_hooksInProgress.load() > 0)
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        }
-    }
-};
-
-atomic<bool> ELTGuard::s_preventHooks;
-atomic<int> ELTGuard::s_hooksInProgress;
-
 PROFILER_STUB EnterStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
 {
-    ELTGuard();
-
-    if (ELTGuard::HasShutdownStarted())
-    {
-        return;
-    }
+    SHUTDOWNGUARD_RETVOID();
 
     SlowPathELTProfiler::s_profiler->EnterCallback(functionId, eltInfo);
 }
 
 PROFILER_STUB LeaveStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
 {
-    ELTGuard();
-
-    if (ELTGuard::HasShutdownStarted())
-    {
-        return;
-    }
+    SHUTDOWNGUARD_RETVOID();
 
     SlowPathELTProfiler::s_profiler->LeaveCallback(functionId, eltInfo);
 }
 
 PROFILER_STUB TailcallStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo)
 {
-    ELTGuard();
-
-    if (ELTGuard::HasShutdownStarted())
-    {
-        return;
-    }
+    SHUTDOWNGUARD_RETVOID();
 
     SlowPathELTProfiler::s_profiler->TailcallCallback(functionId, eltInfo);
 }
@@ -115,8 +58,6 @@ GUID SlowPathELTProfiler::GetClsid()
 HRESULT SlowPathELTProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
 {
     Profiler::Initialize(pICorProfilerInfoUnk);
-
-    ELTGuard::Initialize();
 
     HRESULT hr = S_OK;
     constexpr ULONG bufferSize = 1024;
@@ -177,8 +118,6 @@ HRESULT SlowPathELTProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
 
 HRESULT SlowPathELTProfiler::Shutdown()
 {
-    ELTGuard::WaitForInProgressHooks();
-
     Profiler::Shutdown();
 
     if (_testType == TestType::EnterHooks)
@@ -368,6 +307,8 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::LeaveCallback(FunctionIDOrClientI
 
 HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::TailcallCallback(FunctionIDOrClientID functionIdOrClientID, COR_PRF_ELT_INFO eltInfo)
 {
+    SHUTDOWNGUARD();
+
     COR_PRF_FRAME_INFO frameInfo;
     HRESULT hr = pCorProfilerInfo->GetFunctionTailcall3Info(functionIdOrClientID.functionID, eltInfo, &frameInfo);
     if (FAILED(hr))

--- a/src/tests/profiler/native/eventpipeprofiler/eventpipereadingprofiler.cpp
+++ b/src/tests/profiler/native/eventpipeprofiler/eventpipereadingprofiler.cpp
@@ -86,6 +86,8 @@ HRESULT EventPipeReadingProfiler::EventPipeEventDelivered(
     ULONG numStackFrames,
     UINT_PTR stackFrames[])
 {
+    SHUTDOWNGUARD();
+
     String name = GetOrAddProviderName(provider);
     wprintf(L"EventPipeReadingProfiler saw event %s\n", name.ToCStr());
 
@@ -112,6 +114,8 @@ HRESULT EventPipeReadingProfiler::EventPipeEventDelivered(
 
 HRESULT EventPipeReadingProfiler::EventPipeProviderCreated(EVENTPIPE_PROVIDER provider)
 {
+    SHUTDOWNGUARD();
+
     String name = GetOrAddProviderName(provider);
     wprintf(L"CorProfiler::EventPipeProviderCreated provider=%s\n", name.ToCStr());
 

--- a/src/tests/profiler/native/eventpipeprofiler/eventpipewritingprofiler.cpp
+++ b/src/tests/profiler/native/eventpipeprofiler/eventpipewritingprofiler.cpp
@@ -171,11 +171,15 @@ HRESULT EventPipeWritingProfiler::Shutdown()
 
 HRESULT EventPipeWritingProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     return FunctionSeen(functionId);
 }
 
 HRESULT STDMETHODCALLTYPE EventPipeWritingProfiler::JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result)
 {
+    SHUTDOWNGUARD();
+
     if (result == COR_PRF_CACHED_FUNCTION_FOUND)
     {
         return FunctionSeen(functionId);
@@ -187,6 +191,8 @@ HRESULT STDMETHODCALLTYPE EventPipeWritingProfiler::JITCachedFunctionSearchFinis
 
 HRESULT EventPipeWritingProfiler::FunctionSeen(FunctionID functionID)
 {
+    SHUTDOWNGUARD();
+
     String functionName = GetFunctionIDName(functionID);
     if (functionName == WCHAR("TriggerMethod"))
     {

--- a/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
+++ b/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
@@ -55,6 +55,8 @@ HRESULT GCBasicProfiler::Shutdown()
 
 HRESULT GCBasicProfiler::GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
 {
+    SHUTDOWNGUARD();
+
     _gcStarts++;
     if (_gcStarts - _gcFinishes > 2)
     {
@@ -125,6 +127,8 @@ HRESULT GCBasicProfiler::GarbageCollectionStarted(int cGenerations, BOOL generat
 
 HRESULT GCBasicProfiler::GarbageCollectionFinished()
 {
+    SHUTDOWNGUARD();
+
     _gcFinishes++;
     if (_gcStarts < _gcFinishes)
     {

--- a/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
+++ b/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
@@ -57,6 +57,8 @@ HRESULT GCProfiler::Shutdown()
 
 HRESULT GCProfiler::GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
 {
+    SHUTDOWNGUARD();
+
     _gcStarts++;
     if (_gcStarts - _gcFinishes > 2)
     {
@@ -69,6 +71,8 @@ HRESULT GCProfiler::GarbageCollectionStarted(int cGenerations, BOOL generationCo
 
 HRESULT GCProfiler::GarbageCollectionFinished()
 {
+    SHUTDOWNGUARD();
+
     _gcFinishes++;
     if (_gcStarts < _gcFinishes)
     {
@@ -84,6 +88,8 @@ HRESULT GCProfiler::GarbageCollectionFinished()
 
 HRESULT GCProfiler::ObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[])
 {
+    SHUTDOWNGUARD();
+
     HRESULT hr = S_OK;
     for (ULONG i = 0; i < cObjectRefs; ++i)
     {
@@ -98,7 +104,9 @@ HRESULT GCProfiler::ObjectReferences(ObjectID objectId, ClassID classId, ULONG c
 }
 
 HRESULT GCProfiler::RootReferences(ULONG cRootRefs, ObjectID rootRefIds[])
-{    
+{
+    SHUTDOWNGUARD();
+
     for (ULONG i = 0; i < cRootRefs; ++i)
     {
         ObjectID obj = rootRefIds[i];

--- a/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.cpp
+++ b/src/tests/profiler/native/getappdomainstaticaddress/getappdomainstaticaddress.cpp
@@ -124,6 +124,8 @@ HRESULT GetAppDomainStaticAddress::Shutdown()
 
 HRESULT GetAppDomainStaticAddress::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus)
 {
+    SHUTDOWNGUARD();
+
     constexpr size_t nameLen = 1024;
     WCHAR name[nameLen];
     HRESULT hr = pCorProfilerInfo->GetModuleInfo2(moduleId,
@@ -148,7 +150,9 @@ HRESULT GetAppDomainStaticAddress::ModuleLoadFinished(ModuleID moduleId, HRESULT
 }
 
 HRESULT GetAppDomainStaticAddress::ModuleUnloadStarted(ModuleID moduleId)
-{               
+{
+    SHUTDOWNGUARD();
+
     printf("Forcing GC due to module unload\n");
     gcWaitEvent.Signal();
 
@@ -247,6 +251,8 @@ HRESULT GetAppDomainStaticAddress::ModuleUnloadStarted(ModuleID moduleId)
 
 HRESULT GetAppDomainStaticAddress::ClassLoadFinished(ClassID classId, HRESULT hrStatus)
 {
+    SHUTDOWNGUARD();
+
     HRESULT hr = S_OK;
 
     ThreadID threadId = NULL;
@@ -313,6 +319,8 @@ HRESULT GetAppDomainStaticAddress::ClassLoadFinished(ClassID classId, HRESULT hr
 
 HRESULT GetAppDomainStaticAddress::ClassUnloadStarted(ClassID classId)
 {
+    SHUTDOWNGUARD();
+
     lock_guard<mutex> guard(classADMapLock);
 
     mdTypeDef unloadClassToken;
@@ -356,12 +364,16 @@ HRESULT GetAppDomainStaticAddress::ClassUnloadStarted(ClassID classId)
 
 HRESULT GetAppDomainStaticAddress::JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     ++jitEventCount;
     return S_OK;
 }
 
 HRESULT GetAppDomainStaticAddress::GarbageCollectionFinished()
 {
+    SHUTDOWNGUARD();
+
     HRESULT hr = S_OK;
     lock_guard<mutex> guard(classADMapLock);
 

--- a/src/tests/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
+++ b/src/tests/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
@@ -62,8 +62,6 @@ HRESULT MetaDataGetDispenser::Initialize(IUnknown* pICorProfilerInfoUnk)
         return hr;
     }
 
-
-
     return S_OK;
 }
 

--- a/src/tests/profiler/native/profiler.h
+++ b/src/tests/profiler/native/profiler.h
@@ -7,6 +7,8 @@
 
 #include <atomic>
 #include <cstdio>
+#include <thread>
+#include <chrono>
 #include "cor.h"
 #include "corprof.h"
 #include "holder.h"
@@ -22,6 +24,68 @@
 #define SHORT_LENGTH    32
 #define STRING_LENGTH  256
 #define LONG_LENGTH   1024
+
+class ShutdownGuard
+{
+private:
+    static std::atomic<bool> s_preventHooks;
+    static std::atomic<int> s_hooksInProgress;
+
+public:
+    ShutdownGuard()
+    {
+        ++s_hooksInProgress;
+    }
+
+    ~ShutdownGuard()
+    {
+        --s_hooksInProgress;
+    }
+
+    static void Initialize()
+    {
+        s_preventHooks = false;
+        s_hooksInProgress = 0;
+    }
+
+    static bool HasShutdownStarted()
+    {
+        return s_preventHooks.load();
+    }
+
+    static void WaitForInProgressHooks()
+    {
+        s_preventHooks = true;
+
+        while (s_hooksInProgress.load() > 0)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+};
+
+// Managed code can keep running after Shutdown() is called, and things like
+// ELT hooks will continue to be called. We would AV if we tried to call
+// in to freed resources.
+#define SHUTDOWNGUARD()                             \
+    do                                              \
+    {                                               \
+        ShutdownGuard();                            \
+        if (ShutdownGuard::HasShutdownStarted())    \
+        {                                           \
+            return S_OK;                            \
+        }                                           \
+    } while(0) 
+
+#define SHUTDOWNGUARD_RETVOID()                     \
+    do                                              \
+    {                                               \
+        ShutdownGuard();                            \
+        if (ShutdownGuard::HasShutdownStarted())    \
+        {                                           \
+            return;                                 \
+        }                                           \
+    } while(0)
 
 class Profiler : public ICorProfilerCallback10
 {

--- a/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -120,6 +120,8 @@ HRESULT ReJITProfiler::Shutdown()
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     return S_OK;
 }
 
@@ -235,12 +237,16 @@ bool ReJITProfiler::FunctionSeen(FunctionID functionId)
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     FunctionSeen(functionId);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::JITInlining(FunctionID callerId, FunctionID calleeId, BOOL* pfShouldInline)
 {
+    SHUTDOWNGUARD();
+
     AddInlining(callerId, calleeId);
     *pfShouldInline = TRUE;
 
@@ -250,6 +256,8 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::JITInlining(FunctionID callerId, Functi
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result)
 {
+    SHUTDOWNGUARD();
+
     if (result == COR_PRF_CACHED_FUNCTION_FOUND)
     {
         // FunctionSeen will return true if it's a method we're tracking, and false otherwise
@@ -294,6 +302,8 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCachedFunctionSearchFinished(Functio
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     INFO(L"Saw a ReJIT for function " << GetFunctionIDName(functionId));
     _rejits++;
     return S_OK;
@@ -301,6 +311,8 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITCompilationStarted(FunctionID func
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::GetReJITParameters(ModuleID moduleId, mdMethodDef methodId, ICorProfilerFunctionControl* pFunctionControl)
 {
+    SHUTDOWNGUARD();
+
     INFO(L"Starting to build IL for method " << GetFunctionIDName(GetFunctionIDFromToken(moduleId, methodId)));
     COMPtrHolder<IUnknown> pUnk;
     HRESULT hr = _profInfo10->GetModuleMetaData(moduleId, ofWrite, IID_IMetaDataEmit2, &pUnk);
@@ -373,6 +385,8 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::GetReJITParameters(ModuleID moduleId, m
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     ULONG rejitIDsCount;
     HRESULT hr = pCorProfilerInfo->GetReJITIDs(functionId, 0, &rejitIDsCount, NULL);
     if (FAILED(hr))
@@ -394,6 +408,8 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITCompilationFinished(FunctionID fun
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId, HRESULT hrStatus)
 {
+    SHUTDOWNGUARD();
+
     _failures++;
 
     FAIL(L"ReJIT error reported hr=" << std::hex << hrStatus);

--- a/src/tests/profiler/native/releaseondetach/releaseondetach.cpp
+++ b/src/tests/profiler/native/releaseondetach/releaseondetach.cpp
@@ -97,6 +97,8 @@ HRESULT ReleaseOnDetach::Shutdown()
 
 HRESULT ReleaseOnDetach::ProfilerAttachComplete()
 {
+    SHUTDOWNGUARD();
+
     HRESULT hr = pCorProfilerInfo->RequestProfilerDetach(0);
     if (FAILED(hr))
     {
@@ -113,6 +115,8 @@ HRESULT ReleaseOnDetach::ProfilerAttachComplete()
 
 HRESULT STDMETHODCALLTYPE ReleaseOnDetach::ProfilerDetachSucceeded()
 {
+    SHUTDOWNGUARD();
+
     printf("Profiler detach succeeded\n");
     _detachSucceeded = true;
     return S_OK;

--- a/src/tests/profiler/native/transitions/transitions.cpp
+++ b/src/tests/profiler/native/transitions/transitions.cpp
@@ -60,6 +60,8 @@ extern "C" EXPORT void STDMETHODCALLTYPE DoPInvoke(int i)
 
 HRESULT Transitions::UnmanagedToManagedTransition(FunctionID functionID, COR_PRF_TRANSITION_REASON reason)
 {
+    SHUTDOWNGUARD();
+
     if (FunctionIsTargetFunction(functionID))
     {
         _sawEnter = true;
@@ -70,6 +72,8 @@ HRESULT Transitions::UnmanagedToManagedTransition(FunctionID functionID, COR_PRF
 
 HRESULT Transitions::ManagedToUnmanagedTransition(FunctionID functionID, COR_PRF_TRANSITION_REASON reason)
 {
+    SHUTDOWNGUARD();
+
     if (FunctionIsTargetFunction(functionID))
     {
         _sawLeave = true;


### PR DESCRIPTION
It's always been possible for managed code to continue running on background threads after EE shutdown, but the profiler tests have never needed to deal with it before because all the profilees were single threaded. That means that when the main method returned no more managed code would run.

Now that the managed thread pool is in place there can be background threads running managed code during shutdown. If something happens that triggers a call in to a profiler (ELT hook, JIT notification, etc) after shutdown, the test profiler will AV and fail the test due to trying to use a null ICorProfilerInfo*.

This adds synchronization so that the profile will block at shutdown if any runtime calls in the to profiler in progress, and then block future calls from doing anything.