### PR TITLE
Classify type with empty base as non-blittable

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
@@ -161,14 +161,23 @@ namespace Internal.TypeSystem
             }
         }
 
-        public bool IsZeroSized
+        public bool IsZeroSizedReferenceType
         {
             get
             {
+                if (Category != TypeFlags.Class)
+                {
+                    throw new InvalidOperationException("Only reference types are allowed.");
+                }
+
                 if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedInstanceTypeLayout))
                 {
                     ComputeInstanceLayout(InstanceLayoutKind.TypeOnly);
                 }
+
+                // test that size without padding is zero:
+                //   _instanceByteCountUnaligned - _instanceByteAlignment == LayoutInt.Zero
+                // simplified to:
                 return _instanceByteCountUnaligned == _instanceByteAlignment;
             }
         }

--- a/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
@@ -161,6 +161,18 @@ namespace Internal.TypeSystem
             }
         }
 
+        public bool IsZeroSized
+        {
+            get
+            {
+                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedInstanceTypeLayout))
+                {
+                    ComputeInstanceLayout(InstanceLayoutKind.TypeOnly);
+                }
+                return _instanceByteCountUnaligned == _instanceByteAlignment;
+            }
+        }
+
         /// <summary>
         /// The type has stable Abi layout
         /// </summary>

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -24,7 +24,7 @@ namespace Internal.TypeSystem.Interop
                 && !baseType.IsWellKnownType(WellKnownType.ValueType);
 
             // Type is blittable only if parent is also blittable and is not empty.
-            if (hasNonTrivialParent && (!IsBlittableType(baseType) || baseType.IsZeroSized))
+            if (hasNonTrivialParent && (!IsBlittableType(baseType) || baseType.IsZeroSizedReferenceType))
             {
                 return false;
             }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -18,12 +18,13 @@ namespace Internal.TypeSystem.Interop
                 return false;
             }
 
-            TypeDesc baseType = type.BaseType;
+            DefType baseType = type.BaseType;
             bool hasNonTrivialParent = baseType != null
                 && !baseType.IsWellKnownType(WellKnownType.Object)
                 && !baseType.IsWellKnownType(WellKnownType.ValueType);
 
-            if (hasNonTrivialParent && !IsBlittableType(baseType))
+            // Type is blittable only if parent is also blittable and is not empty.
+            if (hasNonTrivialParent && (!IsBlittableType(baseType) || baseType.IsZeroSized))
             {
                 return false;
             }

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/CoreTestAssembly/Marshalling.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/CoreTestAssembly/Marshalling.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Marshalling
+{
+    [StructLayout(LayoutKind.Explicit)]
+    public class ExplicitEmptyBase
+    {
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ClassWithExplicitEmptyBase : ExplicitEmptyBase
+    {
+        [FieldOffset(0)]
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0)]
+    public class ExplicitEmptySizeZeroBase
+    {
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ClassWithExplicitSizeZeroEmptyBase : ExplicitEmptySizeZeroBase
+    {
+        [FieldOffset(0)]
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ExplicitByteBase
+    {
+        [FieldOffset(0)]
+        public byte x;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ClassWithExplicitByteBase : ExplicitByteBase
+    {
+        [FieldOffset(1)]
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ExplicitInt16Base
+    {
+        [FieldOffset(0)]
+        public short x;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ClassWithExplicitInt16Base : ExplicitInt16Base
+    {
+        [FieldOffset(1)]
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ExplicitInt32Base
+    {
+        [FieldOffset(0)]
+        public int x;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ClassWithExplicitInt32Base : ExplicitInt32Base
+    {
+        [FieldOffset(1)]
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ExplicitInt64Base
+    {
+        [FieldOffset(0)]
+        public long x;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class ClassWithExplicitInt64Base : ExplicitInt64Base
+    {
+        [FieldOffset(1)]
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class SequentialEmptyBase
+    {
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class ClassWithSequentialEmptyBase : SequentialEmptyBase
+    {
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class SequentialByteBase
+    {
+        public byte x;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class ClassWithSequentialByteBase : SequentialByteBase
+    {
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class SequentialInt16Base
+    {
+        public short x;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class ClassWithSequentialInt16Base : SequentialInt16Base
+    {
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class SequentialInt32Base
+    {
+        public int x;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class ClassWithSequentialInt32Base : SequentialInt32Base
+    {
+        public int i;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class SequentialInt64Base
+    {
+        public long x;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class ClassWithSequentialInt64Base : SequentialInt64Base
+    {
+        public int i;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/CoreTestAssembly/Marshalling.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/CoreTestAssembly/Marshalling.cs
@@ -5,6 +5,37 @@ using System.Runtime.InteropServices;
 
 namespace Marshalling
 {
+
+    #region Simple classes
+
+    public class SimpleEmptyClass
+    {
+    }
+
+    public class SimpleByteClass
+    {
+        public byte x;
+    }
+
+    public class SimpleInt16Class
+    {
+        public short x;
+    }
+
+    public class SimpleInt32Class
+    {
+        public int x;
+    }
+
+    public class SimpleInt64Class
+    {
+        public long x;
+    }
+
+    #endregion
+
+    #region LayoutKind.Explicit classes
+
     [StructLayout(LayoutKind.Explicit)]
     public class ExplicitEmptyBase
     {
@@ -23,7 +54,7 @@ namespace Marshalling
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    public class ClassWithExplicitSizeZeroEmptyBase : ExplicitEmptySizeZeroBase
+    public class ClassWithExplicitEmptySizeZeroBase : ExplicitEmptySizeZeroBase
     {
         [FieldOffset(0)]
         public int i;
@@ -90,6 +121,10 @@ namespace Marshalling
     {
     }
 
+    #endregion
+
+    #region LayoutKind.Sequential classes
+
     [StructLayout(LayoutKind.Sequential)]
     public class ClassWithSequentialEmptyBase : SequentialEmptyBase
     {
@@ -143,4 +178,6 @@ namespace Marshalling
     {
         public int i;
     }
+
+    #endregion
 }

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/DefType.FieldLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/DefType.FieldLayoutTests.cs
@@ -36,8 +36,8 @@ namespace TypeSystemTests
         [InlineData("SequentialInt64Base")]
         public void IsZeroSizedReferenceType_NonEmptyType_ReturnsFalse(string className)
         {
-            DefType classWithSequentialBase = _testModule.GetType("Marshalling", className);
-            Assert.False(classWithSequentialBase.IsZeroSizedReferenceType);
+            DefType nonEmptyClass = _testModule.GetType("Marshalling", className);
+            Assert.False(nonEmptyClass.IsZeroSizedReferenceType);
         }
 
         [Theory]
@@ -47,8 +47,8 @@ namespace TypeSystemTests
         [InlineData("SequentialEmptyBase")]
         public void IsZeroSizedReferenceType_EmptyType_ReturnsTrue(string className)
         {
-            DefType classWithEmptyBase = _testModule.GetType("Marshalling", className);
-            Assert.True(classWithEmptyBase.IsZeroSizedReferenceType);
+            DefType emptyClass = _testModule.GetType("Marshalling", className);
+            Assert.True(emptyClass.IsZeroSizedReferenceType);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/DefType.FieldLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/DefType.FieldLayoutTests.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Interop;
+
+using Xunit;
+
+namespace TypeSystemTests
+{
+    public partial class DefTypeTests
+    {
+        private ModuleDesc _testModule;
+
+        public DefTypeTests()
+        {
+            var context = new TestTypeSystemContext(TargetArchitecture.X64);
+            var systemModule = context.CreateModuleForSimpleName("CoreTestAssembly");
+            context.SetSystemModule(systemModule);
+
+            _testModule = systemModule;
+        }
+
+        [Theory]
+        [InlineData("SimpleByteClass")]
+        [InlineData("SimpleInt16Class")]
+        [InlineData("SimpleInt32Class")]
+        [InlineData("SimpleInt64Class")]
+        [InlineData("ExplicitByteBase")]
+        [InlineData("ExplicitInt16Base")]
+        [InlineData("ExplicitInt32Base")]
+        [InlineData("ExplicitInt64Base")]
+        [InlineData("SequentialByteBase")]
+        [InlineData("SequentialInt16Base")]
+        [InlineData("SequentialInt32Base")]
+        [InlineData("SequentialInt64Base")]
+        public void IsZeroSizedReferenceType_NonEmptyType_ReturnsFalse(string className)
+        {
+            DefType classWithSequentialBase = _testModule.GetType("Marshalling", className);
+            Assert.False(classWithSequentialBase.IsZeroSizedReferenceType);
+        }
+
+        [Theory]
+        [InlineData("SimpleEmptyClass")]
+        [InlineData("ExplicitEmptyBase")]
+        [InlineData("ExplicitEmptySizeZeroBase")]
+        [InlineData("SequentialEmptyBase")]
+        public void IsZeroSizedReferenceType_EmptyType_ReturnsTrue(string className)
+        {
+            DefType classWithEmptyBase = _testModule.GetType("Marshalling", className);
+            Assert.True(classWithEmptyBase.IsZeroSizedReferenceType);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="GCPointerMapTests.cs" />
     <Compile Include="GenericTypeAndMethodTests.cs" />
     <Compile Include="CastingTests.cs" />
+    <Compile Include="DefType.FieldLayoutTests.cs" />
     <Compile Include="HashcodeTests.cs" />
     <Compile Include="ILDisassemblerTests.cs" />
     <Compile Include="InterfacesTests.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ILCompiler.ReadyToRun\ILCompiler.ReadyToRun.csproj" />
     <ProjectReference Include="..\ILCompiler.TypeSystem.ReadyToRun\ILCompiler.TypeSystem.ReadyToRun.csproj" />
     <!-- Make sure the test data gets built -->
     <ProjectReference Include="CoreTestAssembly\CoreTestAssembly.csproj">
@@ -58,5 +59,6 @@
     <Compile Include="TestTypeSystemContext.cs" />
     <Compile Include="WellKnownTypeTests.cs" />
     <Compile Include="ExceptionStringTests.cs" />
+    <Compile Include="MarshalUtilsTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/MarshalUtilsTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/MarshalUtilsTests.cs
@@ -72,7 +72,7 @@ namespace TypeSystemTests
 
         [Theory]
         [InlineData("ClassWithExplicitEmptyBase")]
-        [InlineData("ClassWithExplicitSizeZeroEmptyBase")]
+        [InlineData("ClassWithExplicitEmptySizeZeroBase")]
         [InlineData("ClassWithSequentialEmptyBase")]
         public void IsBlittableType_TypeWithEmptyBase_ReturnsFalse(string className)
         {

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/MarshalUtilsTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/MarshalUtilsTests.cs
@@ -66,8 +66,8 @@ namespace TypeSystemTests
         [InlineData("ClassWithSequentialInt64Base")]
         public void IsBlittableType_TypeWithBlittableBase_ReturnsTrue(string className)
         {
-            TypeDesc classWithSequentialBase = _testModule.GetType("Marshalling", className);
-            Assert.True(MarshalUtils.IsBlittableType(classWithSequentialBase));
+            TypeDesc classWithBlittableBase = _testModule.GetType("Marshalling", className);
+            Assert.True(MarshalUtils.IsBlittableType(classWithBlittableBase));
         }
 
         [Theory]

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/MarshalUtilsTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/MarshalUtilsTests.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Interop;
+
+using Xunit;
+
+namespace TypeSystemTests
+{
+    public class MarshalUtilsTests
+    {
+        private TestTypeSystemContext _context;
+        private ModuleDesc _testModule;
+
+        public MarshalUtilsTests()
+        {
+            _context = new TestTypeSystemContext(TargetArchitecture.X64);
+            var systemModule = _context.CreateModuleForSimpleName("CoreTestAssembly");
+            _context.SetSystemModule(systemModule);
+
+            _testModule = systemModule;
+        }
+
+        [Theory]
+        [InlineData(WellKnownType.Void)]
+        [InlineData(WellKnownType.Boolean)]
+        [InlineData(WellKnownType.Char)]
+        [InlineData(WellKnownType.SByte)]
+        [InlineData(WellKnownType.Byte)]
+        [InlineData(WellKnownType.Int16)]
+        [InlineData(WellKnownType.UInt16)]
+        [InlineData(WellKnownType.Int32)]
+        [InlineData(WellKnownType.UInt32)]
+        [InlineData(WellKnownType.Int64)]
+        [InlineData(WellKnownType.UInt64)]
+        [InlineData(WellKnownType.IntPtr)]
+        [InlineData(WellKnownType.UIntPtr)]
+        [InlineData(WellKnownType.Single)]
+        [InlineData(WellKnownType.Double)]
+        [InlineData(WellKnownType.RuntimeFieldHandle)]
+        [InlineData(WellKnownType.RuntimeTypeHandle)]
+        [InlineData(WellKnownType.RuntimeMethodHandle)]
+        public void IsBlittableType_BilittableWellKnownTypes_ReturnsTrue(WellKnownType type) =>
+            Assert.True(MarshalUtils.IsBlittableType(_context.GetWellKnownType(type)));
+
+        [Theory]
+        [InlineData(WellKnownType.String)]
+        [InlineData(WellKnownType.ValueType)]
+        [InlineData(WellKnownType.Enum)]
+        [InlineData(WellKnownType.Array)]
+        [InlineData(WellKnownType.MulticastDelegate)]
+        [InlineData(WellKnownType.Exception)]
+        [InlineData(WellKnownType.Object)]
+        public void IsBlittableType_NonBilittableWellKnownTypes_ReturnsFalse(WellKnownType type) =>
+            Assert.False(MarshalUtils.IsBlittableType(_context.GetWellKnownType(type)));
+
+        [Theory]
+        [InlineData("ClassWithExplicitByteBase")]
+        [InlineData("ClassWithExplicitInt16Base")]
+        [InlineData("ClassWithExplicitInt32Base")]
+        [InlineData("ClassWithExplicitInt64Base")]
+        [InlineData("ClassWithSequentialByteBase")]
+        [InlineData("ClassWithSequentialInt16Base")]
+        [InlineData("ClassWithSequentialInt32Base")]
+        [InlineData("ClassWithSequentialInt64Base")]
+        public void IsBlittableType_TypeWithBlittableBase_ReturnsTrue(string className)
+        {
+            TypeDesc classWithSequentialBase = _testModule.GetType("Marshalling", className);
+            Assert.True(MarshalUtils.IsBlittableType(classWithSequentialBase));
+        }
+
+        [Theory]
+        [InlineData("ClassWithExplicitEmptyBase")]
+        [InlineData("ClassWithExplicitSizeZeroEmptyBase")]
+        [InlineData("ClassWithSequentialEmptyBase")]
+        public void IsBlittableType_TypeWithEmptyBase_ReturnsFalse(string className)
+        {
+            TypeDesc classWithEmptyBase = _testModule.GetType("Marshalling", className);
+            Assert.False(MarshalUtils.IsBlittableType(classWithEmptyBase));
+        }
+    }
+}


### PR DESCRIPTION
Attempt to fix #46738.