### PR TITLE
Fix parsing of JIT-EE version GUID

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1857,7 +1857,7 @@ def determine_jit_ee_version(coreclr_args):
         # The string is near the beginning of the somewhat large file, so just read a line at a time when searching.
         with open(jiteeversionguid_h_path, 'r') as file_handle:
             for line in file_handle:
-                match_obj = re.search(r'JITEEVersionIdentifier *= *{ */\* *([^ ]*) *\*/', line)
+                match_obj = re.search(r'^constexpr GUID JITEEVersionIdentifier *= *{ */\* *([^ ]*) *\*/', line)
                 if match_obj is not None:
                     jiteeversionguid_h_jit_ee_version = match_obj.group(1)
                     logging.info("Using JIT/EE Version from jiteeversionguid.h: %s", jiteeversionguid_h_jit_ee_version)


### PR DESCRIPTION
With https://github.com/dotnet/runtime/pull/46116, a copy of the
actual first line of the GUID definition was added as a comment.
Unfortunately, the superpmi.py GUID parser was finding that one
instead of the actual GUID. Fix the parser to match from the
beginning of the line.