### PR TITLE
Publish hostfxr static library

### DIFF
--- a/src/installer/corehost/cli/fxr/standalone/CMakeLists.txt
+++ b/src/installer/corehost/cli/fxr/standalone/CMakeLists.txt
@@ -28,6 +28,7 @@ else(CLR_CMAKE_TARGET_WIN32)
 endif(CLR_CMAKE_TARGET_WIN32)
 
 include(../../lib.cmake)
+include(../../lib_static.cmake)
 
 if(CLR_CMAKE_HOST_UNIX)
     add_custom_target(hostfxr_exports DEPENDS ${EXPORTS_FILE})
@@ -37,5 +38,21 @@ if(CLR_CMAKE_HOST_UNIX)
     set_property(TARGET hostfxr APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
 endif(CLR_CMAKE_HOST_UNIX)
 
+# Copy static lib PDB to the project output directory
+if (WIN32)
+    set_target_properties(libhostfxr PROPERTIES
+        COMPILE_PDB_NAME "libhostfxr"
+        COMPILE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
+    )
+endif(WIN32)
+
 install_with_stripped_symbols(hostfxr TARGETS corehost)
+
+# Only Windows creates a symbols file for static libs.
+if (WIN32)
+    install_with_stripped_symbols(libhostfxr TARGETS corehost)
+else()
+    install(TARGETS libhostfxr DESTINATION corehost)
+endif(WIN32)
+
 target_link_libraries(hostfxr libhostcommon)

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -22,6 +22,11 @@
         binaries that link against the static version. -->
     <NativeBinary Include="$(DotNetHostBinDir)/libnethost.lib" />
     <NativeBinary Include="$(DotNetHostBinDir)/PDB/libnethost.pdb" />
+    <NativeBinary Include="$(DotNetHostBinDir)/libhostfxr.lib" />
+    <NativeBinary Include="$(DotNetHostBinDir)/PDB/libhostfxr.pdb" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' != 'windows'">
+    <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(StaticLibSuffix)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">


### PR DESCRIPTION
I think there are two major use cases for a static `hostfxr` library:

1. A custom native host can link in only what it needs from `hostfxr` which helps reduce the size for self-contained deployments and simplifies the host so it doesn't have to locate `hostfxr`.
2. Native executables that need utility functions from `hostfxr` such as `hostfxr_get_available_sdks` or the proposed `hostfxr_get_dotnet_environment_info ` can be compiled as a single file with no external dependencies.