### PR TITLE
System.Text.Json: .NET 5.0 perf regression serializing Nullable<T>

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
@@ -70,5 +70,7 @@ namespace System.Text.Json.Serialization.Converters
                 _converter.WriteNumberWithCustomHandling(writer, value.Value, handling);
             }
         }
+
+        internal override bool IsNull(T? value) => !value.HasValue;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
@@ -71,6 +71,6 @@ namespace System.Text.Json.Serialization.Converters
             }
         }
 
-        internal override bool IsNull(T? value) => !value.HasValue;
+        internal override bool IsNull(in T? value) => !value.HasValue;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -294,7 +294,7 @@ namespace System.Text.Json.Serialization
             return success;
         }
 
-        internal virtual bool IsNull(T value) => value == null;
+        internal virtual bool IsNull(in T value) => value == null;
 
         internal bool TryWrite(Utf8JsonWriter writer, in T value, JsonSerializerOptions options, ref WriteStack state)
         {
@@ -344,7 +344,7 @@ namespace System.Text.Json.Serialization
                     }
                 }
             }
-            else if (IsNull(value) && !HandleNullOnWrite)
+            else if (CanBeNull && !HandleNullOnWrite && IsNull(value))
             {
                 // We do not pass null values to converters unless HandleNullOnWrite is true. Null values for properties were
                 // already handled in GetMemberAndWriteJson() so we don't need to check for IgnoreNullValues here.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -294,6 +294,8 @@ namespace System.Text.Json.Serialization
             return success;
         }
 
+        internal virtual bool IsNull(T value) => value == null;
+
         internal bool TryWrite(Utf8JsonWriter writer, in T value, JsonSerializerOptions options, ref WriteStack state)
         {
             if (writer.CurrentDepth >= options.EffectiveMaxDepth)
@@ -342,7 +344,7 @@ namespace System.Text.Json.Serialization
                     }
                 }
             }
-            else if (value == null && !HandleNullOnWrite)
+            else if (IsNull(value) && !HandleNullOnWrite)
             {
                 // We do not pass null values to converters unless HandleNullOnWrite is true. Null values for properties were
                 // already handled in GetMemberAndWriteJson() so we don't need to check for IgnoreNullValues here.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json
             Debug.Assert(writer != null);
 
             //  We treat typeof(object) special and allow polymorphic behavior.
-            if (value != null && inputType == JsonClassInfo.ObjectType)
+            if (inputType == JsonClassInfo.ObjectType && value != null)
             {
                 inputType = value!.GetType();
             }


### PR DESCRIPTION
I ran into these perf testing some other stuff.

## Nullable Property

```csharp
		public static void Main()
		{
			for (int i = 0; i < 100000; i++)
			{
				JsonSerializer.Serialize(new TestClass { Timestamp = DateTime.UtcNow });
			}
		}

		public class TestClass
		{
			public DateTime? Timestamp { get; set; }
		}
```

That code running on .NET 5 allocates a whole bunch of DateTimes:

![image](https://user-images.githubusercontent.com/28367120/104113925-6e6a0e80-52b3-11eb-9688-d0c713ee51c8.png)

Same code running on .NET 3.1 doesn't allocate any.

I tracked it down to this:
https://github.com/dotnet/runtime/blob/9c12a1f7a108ee0753faf486baf96f8fe685d829/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs#L345

That null check boxes the DateTime. Interestingly it works fine for `DateTime` but not `Nullable<DateTime>`. A quirk of the cast operation on `Nullable<T>` maybe? This PR has a fix (`virtual bool IsNull`), but there might be a better way to do it.

Benchmarks showing the regression:
|                  Method |        Job |       Runtime |     Toolchain |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----------- |-------------- |-------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|       SerializeToString | Job-TTOALK |      .NET 6.0 |        net6.0 | 451.9 ns |  7.66 ns |  6.40 ns | 450.7 ns | 440.2 ns | 463.4 ns |  0.94 |    0.03 | 0.0457 |     - |     - |     392 B |
|       SerializeToString | Job-WBBMJH | .NET Core 3.1 | netcoreapp3.1 | 480.2 ns | 14.02 ns | 15.00 ns | 476.7 ns | 464.3 ns | 516.8 ns |  1.00 |    0.00 | 0.0430 |     - |     - |     368 B |
|                         |            |               |               |          |          |          |          |          |          |       |         |        |       |       |           |
|    SerializeToUtf8Bytes | Job-TTOALK |      .NET 6.0 |        net6.0 | 410.8 ns |  8.85 ns |  9.84 ns | 409.5 ns | 393.8 ns | 427.5 ns |  0.97 |    0.03 | 0.0352 |     - |     - |     296 B |
|    SerializeToUtf8Bytes | Job-WBBMJH | .NET Core 3.1 | netcoreapp3.1 | 425.0 ns |  8.09 ns |  7.57 ns | 423.2 ns | 415.1 ns | 440.6 ns |  1.00 |    0.00 | 0.0322 |     - |     - |     272 B |
|                         |            |               |               |          |          |          |          |          |          |       |         |        |       |       |           |
|       SerializeToStream | Job-TTOALK |      .NET 6.0 |        net6.0 | 510.3 ns |  6.03 ns |  5.64 ns | 511.2 ns | 500.6 ns | 517.0 ns |  1.02 |    0.02 | 0.0208 |     - |     - |     176 B |
|       SerializeToStream | Job-WBBMJH | .NET Core 3.1 | netcoreapp3.1 | 500.4 ns |  8.61 ns |  7.64 ns | 501.2 ns | 491.3 ns | 516.3 ns |  1.00 |    0.00 | 0.0179 |     - |     - |     152 B |
|                         |            |               |               |          |          |          |          |          |          |       |         |        |       |       |           |
| SerializeObjectProperty | Job-TTOALK |      .NET 6.0 |        net6.0 | 675.2 ns | 11.48 ns | 10.18 ns | 674.2 ns | 657.8 ns | 694.5 ns |  1.01 |    0.02 | 0.0844 |     - |     - |     720 B |
| SerializeObjectProperty | Job-WBBMJH | .NET Core 3.1 | netcoreapp3.1 | 665.9 ns |  8.81 ns |  7.81 ns | 665.6 ns | 654.5 ns | 677.2 ns |  1.00 |    0.00 | 0.0788 |     - |     - |     664 B |

Benchmarks with fix:
|                  Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|       SerializeToString | 395.9 ns |  7.42 ns |  6.94 ns | 394.6 ns | 383.6 ns | 411.4 ns | 0.0440 |     - |     - |     368 B |
|    SerializeToUtf8Bytes | 351.0 ns |  6.26 ns |  5.86 ns | 351.2 ns | 342.1 ns | 363.7 ns | 0.0317 |     - |     - |     272 B |
|       SerializeToStream | 462.9 ns | 11.29 ns | 12.08 ns | 459.6 ns | 448.0 ns | 490.5 ns | 0.0179 |     - |     - |     152 B |
| SerializeObjectProperty | 631.9 ns |  7.32 ns |  6.85 ns | 630.4 ns | 619.8 ns | 646.9 ns | 0.0810 |     - |     - |     696 B |

## Nullable Root

```csharp
		public static void Main()
		{
			for (int i = 0; i < 100000; i++)
			{
				JsonSerializer.Serialize((DateTime?)DateTime.UtcNow);
			}
		}
```

This code allocates on both .NET 3.1 & .NET 5.

I tracked it down to this:
https://github.com/dotnet/runtime/blob/9c12a1f7a108ee0753faf486baf96f8fe685d829/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs#L24

Same idea here, null check is causing a box op. Easy enough to fix just reversing the clauses, included on this PR.

Benchmarks of existing perf:
|                  Method |        Job |       Runtime |     Toolchain |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----------- |-------------- |-------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|       SerializeToString | Job-MMTVPI |      .NET 6.0 |        net6.0 | 339.8 ns | 18.53 ns | 20.59 ns | 335.9 ns | 317.4 ns | 391.3 ns |  0.90 |    0.06 | 0.0334 |     - |     - |     280 B |
|       SerializeToString | Job-IMRGBN | .NET Core 3.1 | netcoreapp3.1 | 375.2 ns | 14.27 ns | 16.44 ns | 373.3 ns | 357.3 ns | 410.9 ns |  1.00 |    0.00 | 0.0310 |     - |     - |     264 B |
|                         |            |               |               |          |          |          |          |          |          |       |         |        |       |       |           |
|    SerializeToUtf8Bytes | Job-MMTVPI |      .NET 6.0 |        net6.0 | 297.5 ns |  1.99 ns |  1.77 ns | 297.6 ns | 294.0 ns | 300.4 ns |  0.88 |    0.03 | 0.0297 |     - |     - |     256 B |
|    SerializeToUtf8Bytes | Job-IMRGBN | .NET Core 3.1 | netcoreapp3.1 | 340.4 ns |  9.70 ns | 10.37 ns | 338.9 ns | 323.8 ns | 363.1 ns |  1.00 |    0.00 | 0.0277 |     - |     - |     232 B |
|                         |            |               |               |          |          |          |          |          |          |       |         |        |       |       |           |
|       SerializeToStream | Job-MMTVPI |      .NET 6.0 |        net6.0 | 329.8 ns |  5.68 ns |  5.31 ns | 331.4 ns | 316.6 ns | 334.8 ns |  0.83 |    0.01 | 0.0200 |     - |     - |     176 B |
|       SerializeToStream | Job-IMRGBN | .NET Core 3.1 | netcoreapp3.1 | 400.7 ns |  7.06 ns |  5.51 ns | 400.5 ns | 392.7 ns | 409.6 ns |  1.00 |    0.00 | 0.0210 |     - |     - |     176 B |
|                         |            |               |               |          |          |          |          |          |          |       |         |        |       |       |           |
| SerializeObjectProperty | Job-MMTVPI |      .NET 6.0 |        net6.0 | 353.3 ns |  6.87 ns |  6.43 ns | 352.8 ns | 344.0 ns | 365.7 ns |  0.88 |    0.02 | 0.0295 |     - |     - |     256 B |
| SerializeObjectProperty | Job-IMRGBN | .NET Core 3.1 | netcoreapp3.1 | 402.3 ns |  6.81 ns |  6.37 ns | 401.2 ns | 394.2 ns | 412.0 ns |  1.00 |    0.00 | 0.0305 |     - |     - |     256 B |

Benchmarks with tweak:
|                  Method |     Mean |   Error |  StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |---------:|--------:|--------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|       SerializeToString | 224.6 ns | 3.67 ns | 3.25 ns | 223.8 ns | 220.0 ns | 230.4 ns | 0.0286 |     - |     - |     240 B |
|    SerializeToUtf8Bytes | 199.6 ns | 3.94 ns | 3.87 ns | 198.7 ns | 195.1 ns | 205.9 ns | 0.0244 |     - |     - |     208 B |
|       SerializeToStream | 280.0 ns | 5.11 ns | 4.26 ns | 280.9 ns | 273.7 ns | 287.2 ns | 0.0179 |     - |     - |     152 B |
| SerializeObjectProperty | 352.8 ns | 4.30 ns | 4.02 ns | 353.2 ns | 344.9 ns | 359.9 ns | 0.0294 |     - |     - |     256 B |

## Micro Benchmarks

If this PR merges I will open a PR with these new cases in perf repo:

```csharp
    [GenericTypeArguments(typeof(DateTime?))]
    [GenericTypeArguments(typeof(ClassWithValueTypes))]
    public class WriteJson<T>

    public class ClassWithValueTypes
    {
        public DateTime Timestamp { get; set; }

        public DateTime? NullableTimestamp { get; set; }
    }
```

That is what I used for the above.