### PR TITLE
Fix failure to dispose stream when exception occurs in Package.Open 

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -287,6 +287,11 @@ namespace System.IO.Packaging
                     zipArchive.Dispose();
                 }
 
+                if (_containerStream != null)
+                {
+                    _containerStream.Dispose();
+                }
+
                 throw;
             }
 

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -282,15 +282,8 @@ namespace System.IO.Packaging
             }
             catch
             {
-                if (zipArchive != null)
-                {
-                    zipArchive.Dispose();
-                }
-
-                if (_containerStream != null)
-                {
-                    _containerStream.Dispose();
-                }
+                zipArchive?.Dispose();
+                _containerStream?.Dispose();
 
                 throw;
             }

--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -198,7 +198,7 @@ namespace System.IO.Packaging.Tests
                 () => Package.Open(temp, FileMode.Open, FileAccess.Read, FileShare.Read));
 
             // Package should not have held a stream open on the file; if it did, this operation will
-            // throw IOException (unless the finalizer will run, and it will not do so deterministically)
+            // throw IOException (unless the finalizer runs first, and it will not do so deterministically)
             File.Move(temp, GetTestFilePath());
         }
 

--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -184,14 +184,13 @@ namespace System.IO.Packaging.Tests
         [Fact]
         public void PackageOpen_Open_InvalidContent_Throws()
         {
-            var temp = GetTempFileInfoWithExtension(".docx").FullName;
+            string temp = GetTempFileInfoWithExtension(".docx").FullName;
 
             using (FileStream fs = File.OpenWrite(temp))
             {
                 byte[] bytes = File.ReadAllBytes("plain.docx");
+                bytes.AsSpan(500, 500).Clear(); // garble it
                 fs.Write(bytes, 0, bytes.Length);
-                fs.Seek(500, SeekOrigin.Begin);
-                fs.Write(new byte[500], 0, 500); // garble it
             }
 
             AssertExtensions.ThrowsAny<InvalidDataException, ArgumentOutOfRangeException>(


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/46791

Note these tests run against .NET Framework as well, demonstrating indeed it is a regression. (On .NET Framework, the garbling produces ArgumentOutOfRangeException, but it does dispose the stream.)

This test will pass even with the bug if the finalizer thread is lucky, but in my tests it consistently fails without the fix.