### PR TITLE
Fix PostEvictionCallbacks bug 

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.CacheEntryTokens.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.CacheEntryTokens.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Caching.Memory
             internal List<IChangeToken> ExpirationTokens => _expirationTokens ??= new List<IChangeToken>();
             internal List<PostEvictionCallbackRegistration> PostEvictionCallbacks => _postEvictionCallbacks ??= new List<PostEvictionCallbackRegistration>();
 
-            internal void AttachTokens()
+            internal void AttachTokens(CacheEntry cacheEntry)
             {
                 if (_expirationTokens != null)
                 {
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Caching.Memory
                             if (expirationToken.ActiveChangeCallbacks)
                             {
                                 _expirationTokenRegistrations ??= new List<IDisposable>(1);
-                                IDisposable registration = expirationToken.RegisterChangeCallback(ExpirationCallback, this);
+                                IDisposable registration = expirationToken.RegisterChangeCallback(ExpirationCallback, cacheEntry);
                                 _expirationTokenRegistrations.Add(registration);
                             }
                         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
-        internal void AttachTokens() => _tokens?.AttachTokens();
+        internal void AttachTokens() => _tokens?.AttachTokens(this);
 
         private static void ExpirationTokensExpired(object obj)
         {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
@@ -6,11 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
-             Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Extensions.Caching.Memory.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection\src\Microsoft.Extensions.DependencyInjection.csproj" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
@@ -6,6 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
+             Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Extensions.Caching.Memory.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection\src\Microsoft.Extensions.DependencyInjection.csproj" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/TokenExpirationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/TokenExpirationTests.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Extensions.Caching.Memory
         [Fact]
         public async Task PostEvictionCallbacksGetInvokedWhenMemoryCacheEntriesExpireWithAnActiveChangeToken()
         {
-            var cache = new MemoryCache(new MemoryCacheOptions());
+            using var cache = new MemoryCache(new MemoryCacheOptions());
             var key = new object();
 
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
@@ -218,20 +218,16 @@ namespace Microsoft.Extensions.Caching.Memory
 
             cache.Set(key, new object(), new MemoryCacheEntryOptions
             {
-                ExpirationTokens = { new Microsoft.Extensions.Primitives.CancellationChangeToken(cts.Token) },
-                PostEvictionCallbacks = { new PostEvictionCallbackRegistration { EvictionCallback = OnEntryEvicted } },
+                ExpirationTokens = { new CancellationChangeToken(cts.Token) },
+                PostEvictionCallbacks = { new PostEvictionCallbackRegistration {
+                    EvictionCallback = (key, value, reason, state) => tcs.TrySetResult(new object()) } },
             });
 
             Assert.True(cache.TryGetValue(key, out _));
 
-            await Task.Run(() => tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(10)));
+            await tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(10));
 
             Assert.False(cache.TryGetValue(key, out _));
-
-            void OnEntryEvicted(object key, object value, EvictionReason reason, object state)
-            {
-                tcs.TrySetResult(new object());
-            }
         }
 
         internal class TestToken : IChangeToken


### PR DESCRIPTION
Explanation: after #45962 the `this` keyword was not referring to an instance of the `CacheEntry` type:

https://github.com/dotnet/runtime/blob/6b4c1ad8b2297bfa0da566f7097ec5ed38fc79a5/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.CacheEntryTokens.cs#L38

And it was causing a silent error after performing an invalid cast as a part of the scheduled task:

https://github.com/dotnet/runtime/blob/dfc70d174ff13894d9ca6added89601394c0ea2a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs#L207-L209

Fixes #46774