### PR TITLE
Fix Mono Windows x64 SIMD support.

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -224,10 +224,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(HOST_NO_SYMLINKS 1)
   set(MONO_KEYWORD_THREAD "__declspec (thread)")
   set(MONO_ZERO_LEN_ARRAY 1)
-
-  # FIXME: disable SIMD support for Windows, see https://github.com/dotnet/runtime/issues/1933
-  set(DISABLE_SIMD 1)
-
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>") # statically link VC runtime library
   add_compile_options(/W3)   # set warning level 3
   add_compile_options(/EHsc) # set exception handling behavior

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2994,7 +2994,6 @@ MonoCPUFeatures mono_arch_get_cpu_features (void);
 #ifdef MONO_ARCH_SIMD_INTRINSICS
 void        mono_simd_simplify_indirection (MonoCompile *cfg);
 void        mono_simd_decompose_intrinsic (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins);
-void        mono_simd_decompose_intrinsics (MonoCompile *cfg);
 MonoInst*   mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoInst*   mono_emit_simd_field_load (MonoCompile *cfg, MonoClassField *field, MonoInst *addr);
 void        mono_simd_intrinsics_init (void);

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -877,27 +877,9 @@ mono_simd_decompose_intrinsic (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *i
 		}
 	}
 }
-
-void
-mono_simd_decompose_intrinsics (MonoCompile *cfg)
-{
-	MonoBasicBlock *bb;
-	MonoInst *ins;
-
-	for (bb = cfg->bb_entry; bb; bb = bb->next_bb) {
-		for (ins = bb->code; ins; ins = ins->next) {
-			mono_simd_decompose_intrinsic (cfg, bb, ins);
-		}
-	}
-}
 #else
 void
 mono_simd_decompose_intrinsic (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins)
-{
-}
-
-void
-mono_simd_decompose_intrinsics (MonoCompile *cfg)
 {
 }
 #endif /*defined(TARGET_WIN32) && defined(TARGET_AMD64)*/


### PR DESCRIPTION
Mono Windows x64 SIMD support was not fully implemented on netcore causing issues reported in https://github.com/dotnet/runtime/issues/1933. PR integrate logic from Mono Windows x64 SIMD implementation into Mono netcore SIMD implementation needed to correctly handle Windows x64 value type ABI together with SIMD intrinsics.

PR also re-enables SIMD optimization on Windows x64.