### PR TITLE
Improve OidLookup.ToOid perf, in particular for X509Certificate2.Extensions

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
@@ -14,8 +14,8 @@ namespace Internal.Cryptography
         private static readonly ConcurrentDictionary<string, string> s_lateBoundOidToFriendlyName =
             new ConcurrentDictionary<string, string>();
 
-        private static readonly ConcurrentDictionary<string, string> s_lateBoundFriendlyNameToOid =
-            new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, string?> s_lateBoundFriendlyNameToOid =
+            new ConcurrentDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
         //
         // Attempts to map a friendly name to an OID. Returns null if not a known name.
@@ -80,13 +80,19 @@ namespace Internal.Cryptography
 
             mappedOid = NativeFriendlyNameToOid(friendlyName, oidGroup, fallBackToAllGroups);
 
-            if (shouldUseCache && mappedOid != null)
+            if (shouldUseCache)
             {
                 s_lateBoundFriendlyNameToOid.TryAdd(friendlyName, mappedOid);
 
                 // Don't add the reverse here.  Friendly Name => OID is a case insensitive search,
                 // so the casing provided as input here may not be the 'correct' one.  Just let
                 // ToFriendlyName capture the response and cache it itself.
+
+                // Also, mappedOid could be null here if the lookup failed.  Allowing storing null
+                // means we're able to cache that a lookup failed so we don't repeat it.  It's
+                // theoretically possible, however, the failure could have been intermittent, e.g.
+                // if the call was forced to follow an AD fallback path and the relevant servers
+                // were offline.
             }
 
             return mappedOid;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -377,7 +377,7 @@ namespace Internal.Cryptography.Pal
                     {
                         CERT_EXTENSION* pCertExtension = pCertInfo->rgExtension + i;
                         string oidValue = Marshal.PtrToStringAnsi(pCertExtension->pszObjId)!;
-                        Oid oid = new Oid(oidValue);
+                        Oid oid = new Oid(oidValue, friendlyName: null);
                         bool critical = pCertExtension->fCritical != 0;
                         byte[] rawData = pCertExtension->Value.ToByteArray();
 


### PR DESCRIPTION
See commit descriptions.

This halves the time it takes to execute `CertificateManager.Instance.EnsureAspNetCoreHttpsDevelopmentCertificate` (https://github.com/dotnet/aspnetcore/blob/b3aa128ae4d124701f7bb2c636f20c057eb3aa46/src/Shared/CertificateGeneration/CertificateManager.cs#L166) when there's already a certificate installed.

cc: @bartonjs, @brianrob, @DamianEdwards 

Contributes to https://github.com/dotnet/runtime/issues/44598