### PR TITLE
Add RequiresAssemblyFilesAttribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -226,6 +226,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Decimal.DecCalc.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DefaultBinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Delegate.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\RequiresAssemblyFilesAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttribute.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the specified member requires assembly files to be on disk.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor |
+                    AttributeTargets.Event |
+                    AttributeTargets.Method |
+                    AttributeTargets.Property,
+                    Inherited = false,
+                    AllowMultiple = false)]
+    public sealed class RequiresAssemblyFilesAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequiresAssemblyFilesAttribute"/> class.
+        /// </summary>
+        public RequiresAssemblyFilesAttribute() { }
+
+        /// <summary>
+        /// Gets or sets an optional message that contains information about the need for
+        /// assembly files to be on disk.
+        /// </summary>
+        public string? Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the member,
+        /// why it requires assembly files to be on disk, and what options a consumer has
+        /// to deal with it.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+}

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5932,6 +5932,13 @@ namespace System.Diagnostics.CodeAnalysis
         public NotNullWhenAttribute(bool returnValue) { }
         public bool ReturnValue { get { throw null; } }
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    public sealed partial class RequiresAssemblyFilesAttribute : System.Attribute
+    {
+        public RequiresAssemblyFilesAttribute() { }
+        public string? Message { get { throw null; } set { } }
+        public string? Url { get { throw null; } set { } }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Constructor | System.AttributeTargets.Method, Inherited=false)]
     public sealed partial class RequiresUnreferencedCodeAttribute : System.Attribute
     {

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttributeTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Diagnostics.CodeAnalysis.Tests
+{
+    public class RequiresAssemblyFilesAttributeTests
+    {
+        [Fact]
+        public void TestConstructor()
+        {
+            var attr = new RequiresAssemblyFilesAttribute();
+
+            Assert.Null(attr.Message);
+            Assert.Null(attr.Url);
+        }
+
+        [Theory]
+        [InlineData("Message")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TestSetMessage(string message)
+        {
+            var attr = new RequiresAssemblyFilesAttribute(Message = message);
+
+            Assert.Equal(message, attr.Message);
+            Assert.Null(attr.Url);
+        }
+
+        [Theory]
+        [InlineData("https://dot.net")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TestSetUrl(string url)
+        {
+            var attr = new RequiresAssemblyFilesAttribute(Url = url);
+
+            Assert.Null(attr.Message);
+            Assert.Equal()
+        }
+
+        [Theory]
+        [InlineData("Message", "https://dot.net")]
+        [InlineData("Message", "")]
+        [InlineData("Message", null)]
+        [InlineData("", "https://dot.net")]
+        [InlineData("", "")]
+        [InlineData("", null)]
+        [InlineData(null, "https://dot.net")]
+        [InlineData(null, "")]
+        [InlineData(null, null)]
+        public void TestSetMessageAndUrl(string message, string url)
+        {
+            var attr = new RequiresAssemblyFilesAttribute(Message = message, Url = url);
+
+            Assert.Equal(attr.Message = message);
+            Assert.Equal(attr.Url = url);
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttributeTests.cs
@@ -37,7 +37,7 @@ namespace System.Diagnostics.CodeAnalysis.Tests
             var attr = new RequiresAssemblyFilesAttribute(Url = url);
 
             Assert.Null(attr.Message);
-            Assert.Equal()
+            Assert.Equal(url, attr.Url);
         }
 
         [Theory]
@@ -54,8 +54,8 @@ namespace System.Diagnostics.CodeAnalysis.Tests
         {
             var attr = new RequiresAssemblyFilesAttribute(Message = message, Url = url);
 
-            Assert.Equal(attr.Message = message);
-            Assert.Equal(attr.Url = url);
+            Assert.Equal(message, attr.Message);
+            Assert.Equal(ur, attr.Url);
         }
     }
 }


### PR DESCRIPTION
The new attribute will be used by the ILLink analyzer to know which members are unsafe in the presence of a single-file application and help us produce diagnostics.