### PR TITLE
Disable Speech Tests on Mono.

### DIFF
--- a/src/libraries/System.Speech/tests/GrammarTests.cs
+++ b/src/libraries/System.Speech/tests/GrammarTests.cs
@@ -100,6 +100,7 @@ namespace SampleSynthesisTests
         }
 
         [ConditionalFact(typeof(SynthesizeRecognizeTests), nameof(SynthesizeRecognizeTests.HasInstalledRecognizers))]
+        [SkipOnMono("No SAPI on Mono")]
         public void GrammarBuilder()
         {
             Choices colorChoice = new Choices(new string[] { "red", "green", "blue" });

--- a/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
+++ b/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
@@ -18,10 +18,12 @@ using Xunit;
 namespace SampleSynthesisTests
 {
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // No SAPI on Nano or Server Core
+    [SkipOnMono("No SAPI on Mono")]
     public class SynthesizeRecognizeTests : FileCleanupTestBase
     {
         // Our Windows 7 and Windows 8.1 queues seem to have no recognizers installed
-        public static bool HasInstalledRecognizers => PlatformDetection.IsNotWindowsNanoNorServerCore &&
+        public static bool HasInstalledRecognizers => PlatformDetection.IsNotMonoRuntime &&
+                                                      PlatformDetection.IsNotWindowsNanoNorServerCore &&
                                                       SpeechRecognitionEngine.InstalledRecognizers().Count > 0;
 
         [ConditionalFact(nameof(HasInstalledRecognizers))]


### PR DESCRIPTION
Mono on netcore doesn't support COM wrappers that System.Speech depends on. Disable System.Speech.Tests on Mono.