### PR TITLE
R2RDump improvements

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -481,12 +481,21 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private bool TryLocateNativeReadyToRunHeader()
         {
-            PEExportTable exportTable = CompositeReader.GetExportTable();
-            if (exportTable.TryGetValue("RTR_HEADER", out _readyToRunHeaderRVA))
+            try
             {
-                _composite = true;
-                return true;
+                PEExportTable exportTable = CompositeReader.GetExportTable();
+                if (exportTable.TryGetValue("RTR_HEADER", out _readyToRunHeaderRVA))
+                {
+                    _composite = true;
+                    return true;
+                }
             }
+            catch (BadImageFormatException)
+            {
+                // MSIL assemblies with no ready-to-run payload typically have no export table
+                return false;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
* Fix handling of module override token in signature parser. When the override is present, a new SignatureDecoder is created and used as the decoder for the final signature with the fixup kind (and module override flag which is stored in the upper bit of the fixup kind byte) already parsed. This causes the remainder of the signature to be parsed as a full R2R signature which is now missing the fixup type. This fixes https://github.com/dotnet/runtime/issues/46210.
* Instead of creating a new decoder when a module override is present, set up the initial decoder's metadata reader in the constructor by detecting the module override up front.
* Fix `TryLocateNativeReadyToRunHeader` to swallow `BadImageFormatException` and return true / false whether the image has a native R2R header (for composite images).
* Running R2RDump on IL assemblies with no R2R now emits an error message that the assembly is not R2R instead of an unhelpful error about some RVA offset conversion failing.