### PR TITLE
Ensure console is initialized before writing to stdout

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1229,6 +1229,11 @@ namespace System
         /// <param name="mayChangeCursorPosition">Writing this buffer may change the cursor position.</param>
         internal static unsafe void Write(SafeFileHandle fd, ReadOnlySpan<byte> buffer, bool mayChangeCursorPosition = true)
         {
+            // Console initialization might emit data to stdout.
+            // In order to avoid splitting user data we need to
+            // complete it before any writes are performed.
+            EnsureConsoleInitialized();
+
             fixed (byte* p = buffer)
             {
                 byte* bufPtr = p;


### PR DESCRIPTION
Fixes #46165.

@tmds note that I did not revert #41317 since it is likely this could be called without needing to write to `Console.Out`.