### PR TITLE
[release/5.0] Ensure console is initialized before writing to stdout (#46852)

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1235,6 +1235,11 @@ namespace System
         /// <param name="mayChangeCursorPosition">Writing this buffer may change the cursor position.</param>
         private static unsafe void Write(SafeFileHandle fd, byte[] buffer, int offset, int count, bool mayChangeCursorPosition = true)
         {
+            // Console initialization might emit data to stdout.
+            // In order to avoid splitting user data we need to
+            // complete it before any writes are performed.
+            EnsureConsoleInitialized();
+
             fixed (byte* bufPtr = buffer)
             {
                 Write(fd, bufPtr + offset, count, mayChangeCursorPosition);


### PR DESCRIPTION
Backport of #46852 to release/5.0, fixing #46165.

## Customer Impact

Customer reported regression introduced in .NET 5 impacting Unix console applications: if the first string written to stdout is large enough (over 256 characters) and contains ANSI escape sequences, it is possible that some of this output might get garbled. This is caused by the fact that the one-time console initialization procedure might happen _after_ the first chunk of data is written to stdout. The bug can be worked around by breaking up the initial output into smaller strings.

## Testing

The fix was verified manually on Linux and mac terminals. Due to the nature of the bug it cannot be verified with unit testing.

## Risk

Low. The fix simply ensures that the one-time console initialization procedure is performed _before_ any data chunks are written to stdout. While it is possible that side-effects from an early console initialization might result in unforeseen issues, it is done lazily once the user starts writing to stdout. This is the initialization we already perform in another overload of this method - it was missed from this one.