### PR TITLE
[wasm] Disable `System.Diagnostics.Tests.ActivityTests.IdGenerationIn…

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/ActivityTests.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics.Tests
             Assert.DoesNotContain('#', activity.Id);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void IdGenerationInternalParent()
         {
             var parent = new Activity("parent");


### PR DESCRIPTION
…ternalParent`

throws `System.PlatformNotSupportedException : Cannot wait on monitors on this runtime.`

Partially fixes https://github.com/dotnet/runtime/issues/46768