### PR TITLE
Specify a GUID for the IL SDK and expose it to slngen

### DIFF
--- a/eng/slngen.targets
+++ b/eng/slngen.targets
@@ -10,4 +10,7 @@
     <!-- Include CompilerServices.Unsafe as it's a transitive test dependency. -->
     <IncludeInSolutionFile Condition="'$(IsNETCoreAppRef)' == 'true' and '$(MSBuildProjectName)' == 'System.Runtime.CompilerServices.Unsafe'">true</IncludeInSolutionFile>
   </PropertyGroup>
+  <ItemGroup>
+    <SlnGenCustomProjectTypeGuid Include=".ilproj" ProjectTypeGuid="{F571AB99-FB84-49F4-A0DF-F27AA55F3F3F}" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
@@ -16,7 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultLanguageSourceExtension>.il</DefaultLanguageSourceExtension>
     <Language>IL</Language>
     <TargetRuntime>Managed</TargetRuntime>
-    <DefaultProjectTypeGuid>{F571AB99-FB84-49F4-A0DF-F27AA55F3F3F}</DefaultProjectTypeGuid>
+    <DefaultProjectTypeGuid Condition="'$(DefaultProjectTypeGuid)' == ''">{F571AB99-FB84-49F4-A0DF-F27AA55F3F3F}</DefaultProjectTypeGuid>
     <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     <AlwaysUseNumericalSuffixInItemNames>true</AlwaysUseNumericalSuffixInItemNames>
   </PropertyGroup>

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
@@ -16,7 +16,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultLanguageSourceExtension>.il</DefaultLanguageSourceExtension>
     <Language>IL</Language>
     <TargetRuntime>Managed</TargetRuntime>
+    <DefaultProjectTypeGuid>{F571AB99-FB84-49F4-A0DF-F27AA55F3F3F}</DefaultProjectTypeGuid>
+    <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
+    <AlwaysUseNumericalSuffixInItemNames>true</AlwaysUseNumericalSuffixInItemNames>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="Managed" />
+    <ProjectCapability Include="ReferencesFolder" />
+  </ItemGroup>
 
   <PropertyGroup>
     <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('windows'))">win</_OSPlatform>


### PR DESCRIPTION
Currently we use the C# GUID for ilproj and VS solution files are irritated by that and update the GUID. Therefore specifying a default language GUID for the IL SDK and setting the slngen item to handle the GUID when generating the solution files.

Also setting a few other properties that the C# language targets set.

Unrelated, but the ilproj doesn't show any compile items inside VS for which I opened https://github.com/dotnet/project-system/issues/6831.
