### PR TITLE
Fix MS.NETCore.App.Bundle on osx-arm64

### DIFF
--- a/src/installer/pkg/sfx/bundle/Microsoft.NETCore.App.Bundle.bundleproj
+++ b/src/installer/pkg/sfx/bundle/Microsoft.NETCore.App.Bundle.bundleproj
@@ -10,10 +10,10 @@
     <BundleThemeDirectory>$(MSBuildProjectDirectory)</BundleThemeDirectory>
     <ArchiveName>dotnet-runtime</ArchiveName>
     <InstallerName>dotnet-runtime</InstallerName>
-    <InstallerRuntimeIdentifiers>win-x86;win-x64;win-arm64;osx-x64</InstallerRuntimeIdentifiers>
+    <InstallerRuntimeIdentifiers>win-x86;win-x64;win-arm64;osx-x64;osx-arm64</InstallerRuntimeIdentifiers>
     <BundleNameSuffix>Runtime</BundleNameSuffix>
     <MacOSBundleTemplate>$(MSBuildProjectDirectory)/shared-framework-distribution-template.xml</MacOSBundleTemplate>
-    <MacOSBundleIdentifierName>com.microsoft.dotnet.Microsoft.NETCore.App.$(ProductVersion).osx.x64</MacOSBundleIdentifierName>
+    <MacOSBundleIdentifierName>com.microsoft.dotnet.Microsoft.NETCore.App.$(ProductVersion).osx.$(TargetArchitecture)</MacOSBundleIdentifierName>
     <MacOSBundleResourcesPath>osx_resources</MacOSBundleResourcesPath>
   </PropertyGroup>
   


### PR DESCRIPTION
While I was looking at another issue, this looked wrong for the new osx-arm64 installer...

