### PR TITLE
Use stackalloc in RSAPkcs1X509SignatureGenerator.BuildPublicKey

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSAPkcs1X509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/RSAPkcs1X509SignatureGenerator.cs
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.X509Certificates
                 //
                 // This is due to one version of the ASN.1 not including OPTIONAL, and that was
                 // the version that got predominately implemented for RSA. Now it's convention.
-                new AsnEncodedData(oid, new byte[] { 0x05, 0x00 }),
+                new AsnEncodedData(oid, stackalloc byte[] { 0x05, 0x00 }),
                 new AsnEncodedData(oid, rsa.ExportRSAPublicKey()));
         }
 


### PR DESCRIPTION
Just an unnecessary allocation.  The AsnEncodedData ctor makes a copy regardless of whether the input is a span or an array, so may as well avoid allocating another array on top of that.

Contributes to https://github.com/dotnet/runtime/issues/44598