### PR TITLE
Fix lots of uint[] allocation in BigInteger

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/NumericsHelpers.cs
@@ -106,7 +106,7 @@ namespace System.Numerics
 
         // Do an in-place two's complement. "Dangerous" because it causes
         // a mutation and needs to be used with care for immutable types.
-        public static void DangerousMakeTwosComplement(uint[] d)
+        public static void DangerousMakeTwosComplement(Span<uint> d)
         {
             if (d != null && d.Length > 0)
             {


### PR DESCRIPTION
- Lots of temporary uint[]s are being created and fed into BigInteger's ctor, which then creates a new one.  This enables using the input in most cases.
- GetPartsForBitManipulation is creating uint[]s for small values, after which it generally gets thrown away.  Stop doing that.
- Stack allocation can be used for smaller values in many cases.

Contributes to https://github.com/dotnet/runtime/issues/44598
Contributes to https://github.com/dotnet/runtime/issues/22609

Results from the dotnet/performance perf tests...

|                Method |           Toolchain |        numberString |           arguments |             Mean | Ratio | Allocated |
|---------------------- |-------------------- |-------------------- |-------------------- |-----------------:|------:|----------:|
|                   Add | \master\corerun.exe |                   ? |      1024,1024 bits |        65.677 ns |  1.00 |     320 B |
|                   Add |     \pr\corerun.exe |                   ? |      1024,1024 bits |        49.090 ns |  0.75 |     160 B |
|                       |                     |                     |                     |                  |       |           |
|              Subtract | \master\corerun.exe |                   ? |      1024,1024 bits |        65.071 ns |  1.00 |     304 B |
|              Subtract |     \pr\corerun.exe |                   ? |      1024,1024 bits |        49.934 ns |  0.77 |     152 B |
|                       |                     |                     |                     |                  |       |           |
|              Multiply | \master\corerun.exe |                   ? |      1024,1024 bits |       849.487 ns |  1.00 |     560 B |
|              Multiply |     \pr\corerun.exe |                   ? |      1024,1024 bits |       828.572 ns |  0.98 |     280 B |
|                       |                     |                     |                     |                  |       |           |
| GreatestCommonDivisor | \master\corerun.exe |                   ? |      1024,1024 bits |     8,411.785 ns |  1.00 |     304 B |
| GreatestCommonDivisor |     \pr\corerun.exe |                   ? |      1024,1024 bits |     8,388.163 ns |  1.00 |     304 B |
|                       |                     |                     |                     |                  |       |           |
|                ModPow | \master\corerun.exe |                   ? |   1024,1024,64 bits |   129,964.288 ns |  1.00 |     304 B |
|                ModPow |     \pr\corerun.exe |                   ? |   1024,1024,64 bits |   131,508.269 ns |  1.01 |     304 B |
|                       |                     |                     |                     |                  |       |           |
|                Divide | \master\corerun.exe |                   ? |       1024,512 bits |       516.967 ns |  1.00 |     344 B |
|                Divide |     \pr\corerun.exe |                   ? |       1024,512 bits |       503.786 ns |  0.97 |      96 B |
|                       |                     |                     |                     |                  |       |           |
|             Remainder | \master\corerun.exe |                   ? |       1024,512 bits |       522.524 ns |  1.00 |     240 B |
|             Remainder |     \pr\corerun.exe |                   ? |       1024,512 bits |       500.804 ns |  0.96 |     240 B |
|                       |                     |                     |                     |                  |       |           |
|        Ctor_ByteArray | \master\corerun.exe |                 123 |                   ? |         8.754 ns |  1.00 |         - |
|        Ctor_ByteArray |     \pr\corerun.exe |                 123 |                   ? |         7.835 ns |  0.90 |         - |
|                       |                     |                     |                     |                  |       |           |
|           ToByteArray | \master\corerun.exe |                 123 |                   ? |        12.279 ns |  1.00 |      32 B |
|           ToByteArray |     \pr\corerun.exe |                 123 |                   ? |        12.302 ns |  1.00 |      32 B |
|                       |                     |                     |                     |                  |       |           |
|                 Parse | \master\corerun.exe |                 123 |                   ? |       151.144 ns |  1.00 |     104 B |
|                 Parse |     \pr\corerun.exe |                 123 |                   ? |       154.544 ns |  1.02 |     104 B |
|                       |                     |                     |                     |                  |       |           |
|             ToStringX | \master\corerun.exe |                 123 |                   ? |        60.100 ns |  1.00 |      32 B |
|             ToStringX |     \pr\corerun.exe |                 123 |                   ? |        54.792 ns |  0.91 |      32 B |
|                       |                     |                     |                     |                  |       |           |
|             ToStringD | \master\corerun.exe |                 123 |                   ? |        36.857 ns |  1.00 |      32 B |
|             ToStringD |     \pr\corerun.exe |                 123 |                   ? |        37.005 ns |  1.01 |      32 B |
|                       |                     |                     |                     |                  |       |           |
|            ShiftRight | \master\corerun.exe |                 123 |                   ? |        22.814 ns |  1.00 |      64 B |
|            ShiftRight |     \pr\corerun.exe |                 123 |                   ? |        17.989 ns |  0.79 |         - |
|                       |                     |                     |                     |                  |       |           |
|             ShiftLeft | \master\corerun.exe |                 123 |                   ? |        20.007 ns |  1.00 |      64 B |
|             ShiftLeft |     \pr\corerun.exe |                 123 |                   ? |        15.200 ns |  0.76 |         - |
|                       |                     |                     |                     |                  |       |           |
|        Ctor_ByteArray | \master\corerun.exe | 1234(...)7890 [200] |                   ? |       105.972 ns |  1.00 |     112 B |
|        Ctor_ByteArray |     \pr\corerun.exe | 1234(...)7890 [200] |                   ? |       103.124 ns |  0.97 |     112 B |
|                       |                     |                     |                     |                  |       |           |
|           ToByteArray | \master\corerun.exe | 1234(...)7890 [200] |                   ? |        56.502 ns |  1.00 |     112 B |
|           ToByteArray |     \pr\corerun.exe | 1234(...)7890 [200] |                   ? |        55.041 ns |  0.97 |     112 B |
|                       |                     |                     |                     |                  |       |           |
|                 Parse | \master\corerun.exe | 1234(...)7890 [200] |                   ? |    16,713.332 ns |  1.00 |   56584 B |
|                 Parse |     \pr\corerun.exe | 1234(...)7890 [200] |                   ? |    16,469.686 ns |  0.99 |   55176 B |
|                       |                     |                     |                     |                  |       |           |
|             ToStringX | \master\corerun.exe | 1234(...)7890 [200] |                   ? |       405.306 ns |  1.00 |     360 B |
|             ToStringX |     \pr\corerun.exe | 1234(...)7890 [200] |                   ? |       389.472 ns |  0.96 |     360 B |
|                       |                     |                     |                     |                  |       |           |
|             ToStringD | \master\corerun.exe | 1234(...)7890 [200] |                   ? |     1,259.218 ns |  1.00 |     992 B |
|             ToStringD |     \pr\corerun.exe | 1234(...)7890 [200] |                   ? |     1,271.013 ns |  1.00 |     992 B |
|                       |                     |                     |                     |                  |       |           |
|            ShiftRight | \master\corerun.exe | 1234(...)7890 [200] |                   ? |        78.992 ns |  1.00 |     224 B |
|            ShiftRight |     \pr\corerun.exe | 1234(...)7890 [200] |                   ? |        67.366 ns |  0.85 |     112 B |
|                       |                     |                     |                     |                  |       |           |
|             ShiftLeft | \master\corerun.exe | 1234(...)7890 [200] |                   ? |        60.013 ns |  1.00 |     224 B |
|             ShiftLeft |     \pr\corerun.exe | 1234(...)7890 [200] |                   ? |        54.374 ns |  0.91 |     112 B |
|                       |                     |                     |                     |                  |       |           |
|                   Add | \master\corerun.exe |                   ? |          16,16 bits |         7.351 ns |  1.00 |         - |
|                   Add |     \pr\corerun.exe |                   ? |          16,16 bits |         6.254 ns |  0.85 |         - |
|                       |                     |                     |                     |                  |       |           |
|              Subtract | \master\corerun.exe |                   ? |          16,16 bits |         7.110 ns |  1.00 |         - |
|              Subtract |     \pr\corerun.exe |                   ? |          16,16 bits |         6.395 ns |  0.90 |         - |
|                       |                     |                     |                     |                  |       |           |
|              Multiply | \master\corerun.exe |                   ? |          16,16 bits |         6.108 ns |  1.00 |         - |
|              Multiply |     \pr\corerun.exe |                   ? |          16,16 bits |         6.212 ns |  1.02 |         - |
|                       |                     |                     |                     |                  |       |           |
| GreatestCommonDivisor | \master\corerun.exe |                   ? |          16,16 bits |        66.017 ns |  1.00 |         - |
| GreatestCommonDivisor |     \pr\corerun.exe |                   ? |          16,16 bits |        66.316 ns |  1.00 |         - |
|                       |                     |                     |                     |                  |       |           |
|                ModPow | \master\corerun.exe |                   ? |       16,16,16 bits |       142.000 ns |  1.00 |         - |
|                ModPow |     \pr\corerun.exe |                   ? |       16,16,16 bits |       142.069 ns |  1.00 |         - |
|                       |                     |                     |                     |                  |       |           |
|                Divide | \master\corerun.exe |                   ? |           16,8 bits |         7.470 ns |  1.00 |         - |
|                Divide |     \pr\corerun.exe |                   ? |           16,8 bits |         7.864 ns |  1.05 |         - |
|                       |                     |                     |                     |                  |       |           |
|             Remainder | \master\corerun.exe |                   ? |           16,8 bits |         7.333 ns |  1.00 |         - |
|             Remainder |     \pr\corerun.exe |                   ? |           16,8 bits |         6.307 ns |  0.86 |         - |
|                       |                     |                     |                     |                  |       |           |
|                ModPow | \master\corerun.exe |                   ? | 16384,16384,64 bits | 2,226,627.204 ns |  1.00 |    2224 B |
|                ModPow |     \pr\corerun.exe |                   ? | 16384,16384,64 bits | 2,196,583.036 ns |  0.99 |    2224 B |
|                       |                     |                     |                     |                  |       |           |
|                Divide | \master\corerun.exe |                   ? |    65536,32768 bits | 4,155,074.038 ns |  1.00 |   16473 B |
|                Divide |     \pr\corerun.exe |                   ? |    65536,32768 bits | 4,158,249.099 ns |  1.00 |   12345 B |
|                       |                     |                     |                     |                  |       |           |
|             Remainder | \master\corerun.exe |                   ? |    65536,32768 bits | 4,118,120.536 ns |  1.00 |   12337 B |
|             Remainder |     \pr\corerun.exe |                   ? |    65536,32768 bits | 4,116,774.665 ns |  1.00 |   12337 B |
|                       |                     |                     |                     |                  |       |           |
|                   Add | \master\corerun.exe |                   ? |    65536,65536 bits |     2,470.807 ns |  1.00 |   16448 B |
|                   Add |     \pr\corerun.exe |                   ? |    65536,65536 bits |     1,888.586 ns |  0.76 |    8224 B |
|                       |                     |                     |                     |                  |       |           |
|              Subtract | \master\corerun.exe |                   ? |    65536,65536 bits |     2,418.995 ns |  1.00 |   16432 B |
|              Subtract |     \pr\corerun.exe |                   ? |    65536,65536 bits |     1,881.856 ns |  0.78 |    8216 B |
|                       |                     |                     |                     |                  |       |           |
|              Multiply | \master\corerun.exe |                   ? |    65536,65536 bits |   738,517.936 ns |  1.00 |  169928 B |
|              Multiply |     \pr\corerun.exe |                   ? |    65536,65536 bits |   732,919.727 ns |  0.99 |  153520 B |
|                       |                     |                     |                     |                  |       |           |
| GreatestCommonDivisor | \master\corerun.exe |                   ? |    65536,65536 bits | 4,568,181.194 ns |  1.00 |   16433 B |
| GreatestCommonDivisor |     \pr\corerun.exe |                   ? |    65536,65536 bits | 4,563,006.010 ns |  1.00 |   16433 B |
|                       |                     |                     |                     |                  |       |           |
|        Ctor_ByteArray | \master\corerun.exe |         -2147483648 |                   ? |        11.586 ns |  1.00 |         - |
|        Ctor_ByteArray |     \pr\corerun.exe |         -2147483648 |                   ? |        12.109 ns |  1.05 |         - |
|                       |                     |                     |                     |                  |       |           |
|           ToByteArray | \master\corerun.exe |         -2147483648 |                   ? |        13.592 ns |  1.00 |      32 B |
|           ToByteArray |     \pr\corerun.exe |         -2147483648 |                   ? |        13.372 ns |  0.98 |      32 B |
|                       |                     |                     |                     |                  |       |           |
|                 Parse | \master\corerun.exe |         -2147483648 |                   ? |       360.580 ns |  1.00 |     136 B |
|                 Parse |     \pr\corerun.exe |         -2147483648 |                   ? |       349.208 ns |  0.97 |     136 B |
|                       |                     |                     |                     |                  |       |           |
|             ToStringX | \master\corerun.exe |         -2147483648 |                   ? |        66.486 ns |  1.00 |      40 B |
|             ToStringX |     \pr\corerun.exe |         -2147483648 |                   ? |        64.597 ns |  0.97 |      40 B |
|                       |                     |                     |                     |                  |       |           |
|             ToStringD | \master\corerun.exe |         -2147483648 |                   ? |        72.916 ns |  1.00 |     152 B |
|             ToStringD |     \pr\corerun.exe |         -2147483648 |                   ? |        69.305 ns |  0.95 |     152 B |
|                       |                     |                     |                     |                  |       |           |
|            ShiftRight | \master\corerun.exe |         -2147483648 |                   ? |        31.831 ns |  1.00 |      64 B |
|            ShiftRight |     \pr\corerun.exe |         -2147483648 |                   ? |        25.519 ns |  0.80 |         - |
|                       |                     |                     |                     |                  |       |           |
|             ShiftLeft | \master\corerun.exe |         -2147483648 |                   ? |        24.839 ns |  1.00 |      64 B |
|             ShiftLeft |     \pr\corerun.exe |         -2147483648 |                   ? |        22.049 ns |  0.89 |      32 B |
|                       |                     |                     |                     |                  |       |           |