### PR TITLE
x86: support Return SIMD8.

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1192,14 +1192,14 @@ void CodeGen::genSIMDSplitReturn(GenTree* src, ReturnTypeDesc* retTypeDesc)
     // reg0 = opReg[31:0]
     inst_RV_RV(ins_Copy(opReg, TYP_INT), reg0, opReg, TYP_INT);
     // reg1 = opRef[61:32]
-    if (compiler->compExactlyDependsOn(InstructionSet_SSE41))
+    if (compiler->compOpportunisticallyDependsOn(InstructionSet_SSE41))
     {
-        inst_RV_RV_IV(INS_pextrd, EA_4BYTE, reg1, opReg, 1);
+        inst_RV_TT_IV(INS_pextrd, EA_4BYTE, reg1, src, 1);
     }
     else
     {
         int8_t shuffleMask = 1; // we only need [61:32]->[31:0], the rest is not read.
-        GetEmitter()->emitIns_R_R_I(INS_pshufd, EA_8BYTE, opReg, opReg, shuffleMask);
+        inst_RV_TT_IV(INS_pshufd, EA_8BYTE, opReg, src, shuffleMask);
         inst_RV_RV(ins_Copy(opReg, TYP_INT), reg1, opReg, TYP_INT);
     }
 #endif // TARGET_X86

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1198,7 +1198,7 @@ void CodeGen::genSIMDSplitReturn(GenTree* src, ReturnTypeDesc* retTypeDesc)
     }
     else
     {
-        int8_t shuffleMask = 1; //we only need [61:32]->[31:0], the rest is not read.
+        int8_t shuffleMask = 1; // we only need [61:32]->[31:0], the rest is not read.
         GetEmitter()->emitIns_R_R_I(INS_pshufd, EA_8BYTE, opReg, opReg, shuffleMask);
         inst_RV_RV(ins_Copy(opReg, TYP_INT), reg1, opReg, TYP_INT);
     }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8821,7 +8821,7 @@ void emitter::emitDispIns(
             }
             else if (ins == INS_mov_xmm2i)
             {
-                printf("%s, %s", emitRegName(id->idReg2(), attr), emitRegName(id->idReg1(), EA_16BYTE));
+                printf("%s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), EA_16BYTE));
             }
             else if (ins == INS_pmovmskb)
             {

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -945,7 +945,7 @@ void CodeGen::inst_RV_RV_IV(instruction ins, emitAttr size, regNumber reg1, regN
 {
     assert(ins == INS_shld || ins == INS_shrd || ins == INS_shufps || ins == INS_shufpd || ins == INS_pshufd ||
            ins == INS_cmpps || ins == INS_cmppd || ins == INS_dppd || ins == INS_dpps || ins == INS_insertps ||
-           ins == INS_roundps || ins == INS_roundss || ins == INS_roundpd || ins == INS_roundsd || ins == INS_pextrd);
+           ins == INS_roundps || ins == INS_roundss || ins == INS_roundpd || ins == INS_roundsd);
 
     GetEmitter()->emitIns_R_R_I(ins, size, reg1, reg2, ival);
 }

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -945,7 +945,7 @@ void CodeGen::inst_RV_RV_IV(instruction ins, emitAttr size, regNumber reg1, regN
 {
     assert(ins == INS_shld || ins == INS_shrd || ins == INS_shufps || ins == INS_shufpd || ins == INS_pshufd ||
            ins == INS_cmpps || ins == INS_cmppd || ins == INS_dppd || ins == INS_dpps || ins == INS_insertps ||
-           ins == INS_roundps || ins == INS_roundss || ins == INS_roundpd || ins == INS_roundsd);
+           ins == INS_roundps || ins == INS_roundss || ins == INS_roundpd || ins == INS_roundsd || ins == INS_pextrd);
 
     GetEmitter()->emitIns_R_R_I(ins, size, reg1, reg2, ival);
 }


### PR DESCRIPTION
Support trees like:
```
N002 (  4,  3) [000055] ------------              *  RETURN    simd8  $304
N001 (  3,  2) [000054] -------N----              \--*  LCL_VAR   simd8 <System.Numerics.Vector2> V09 tmp3         u:1 (last use) $302
```
that we return in `EAX/EDX`.

Also, fix a few non-functional bugs like wrong printing or wrong instruction attributes that are not read.
Unblocks https://github.com/dotnet/runtime/pull/46238