### PR TITLE
[release/5.0] fix SslStreamCertificateContext.Create with partial certificate chain

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -38,16 +38,22 @@ namespace System.Net.Security
                     NetEventSource.Error(null, $"Failed to build chain for {target.Subject}");
                 }
 
-                int count = chain.ChainElements.Count - (TrimRootCertificate ? 1 : 2);
-                foreach (X509ChainStatus status in chain.ChainStatus)
+                int count = chain.ChainElements.Count - 1;
+#pragma warning disable 0162 // Disable unreachable code warning. TrimRootCertificate is const bool = false on some platforms
+                if (TrimRootCertificate)
                 {
-                    if (status.Status.HasFlag(X509ChainStatusFlags.PartialChain))
+                    count--;
+                    foreach (X509ChainStatus status in chain.ChainStatus)
                     {
-                        // The last cert isn't a root cert
-                        count++;
-                        break;
+                        if (status.Status.HasFlag(X509ChainStatusFlags.PartialChain))
+                        {
+                            // The last cert isn't a root cert
+                            count++;
+                            break;
+                        }
                     }
                 }
+#pragma warning restore 0162
 
                 // Count can be zero for a self-signed certificate, or a cert issued directly from a root.
                 if (count > 0 && chain.ChainElements.Count > 1)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -274,15 +274,30 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
-        public async Task SslStream_UntrustedCaWithCustomCallback_OK()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SslStream_UntrustedCaWithCustomCallback_OK(bool usePartialChain)
         {
+            var rnd = new Random();
+            int split = rnd.Next(0, _serverChain.Count - 1);
+
             var clientOptions = new  SslClientAuthenticationOptions() { TargetHost = "localhost" };
             clientOptions.RemoteCertificateValidationCallback =
                 (sender, certificate, chain, sslPolicyErrors) =>
                 {
-                    chain.ChainPolicy.CustomTrustStore.Add(_serverChain[_serverChain.Count -1]);
+                    // add our custom root CA
+                    chain.ChainPolicy.CustomTrustStore.Add(_serverChain[_serverChain.Count - 1]);
                     chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                    // Add only one CA to verify that peer did send intermediate CA cert.
+                    // In case of partial chain, we need to make missing certs available.
+                    if (usePartialChain)
+                    {
+                        for (int i = split; i < _serverChain.Count - 1; i++)
+                        {
+                            chain.ChainPolicy.ExtraStore.Add(_serverChain[i]);
+                        }
+                    }
 
                     bool result = chain.Build((X509Certificate2)certificate);
                     Assert.True(result);
@@ -291,7 +306,22 @@ namespace System.Net.Security.Tests
                 };
 
             var serverOptions = new SslServerAuthenticationOptions();
-            serverOptions.ServerCertificateContext = SslStreamCertificateContext.Create(_serverCert, _serverChain);
+            X509Certificate2Collection serverChain;
+            if (usePartialChain)
+            {
+                // give first few certificates without root CA
+                serverChain = new X509Certificate2Collection();
+                for (int i = 0; i < split; i++)
+                {
+                    serverChain.Add(_serverChain[i]);
+                }
+            }
+            else
+            {
+                serverChain = _serverChain;
+            }
+
+            serverOptions.ServerCertificateContext = SslStreamCertificateContext.Create(_serverCert, serverChain);
 
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
             using (clientStream)
@@ -319,6 +349,7 @@ namespace System.Net.Security.Tests
                 clientOptions.RemoteCertificateValidationCallback =
                     (sender, certificate, chain, sslPolicyErrors) =>
                     {
+                        // Add only root CA to verify that peer did send intermediate CA cert.
                         chain.ChainPolicy.CustomTrustStore.Add(_serverChain[_serverChain.Count -1]);
                         chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
                         // This should work and we should be able to trust the chain.
@@ -331,7 +362,8 @@ namespace System.Net.Security.Tests
             }
             else
             {
-                errorMessage = "UntrustedRoot";
+                // On Windows we hand whole chain to OS so they can always see the root CA.
+                errorMessage = PlatformDetection.IsWindows ? "UntrustedRoot" : "PartialChain";
             }
 
             var serverOptions = new SslServerAuthenticationOptions();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -107,8 +107,10 @@ namespace System.Net.Security.Tests
             }
             catch { };
         }
-        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, string? testName = null)
+        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, string? testName = null, bool longChain = false)
         {
+            const int keySize = 2048;
+
             if (PlatformDetection.IsWindows && testName != null)
             {
                 CleanupCertificates(testName);
@@ -132,8 +134,42 @@ namespace System.Net.Security.Tests
                 out X509Certificate2 endEntity,
                 subjectName: targetName,
                 testName: testName,
-                keySize: 2048,
+                keySize: keySize,
                 extensions: extensions);
+
+            if (longChain)
+            {
+                using (RSA intermedKey2 = RSA.Create(keySize))
+                using (RSA intermedKey3 = RSA.Create(keySize))
+                {
+                    X509Certificate2 intermedPub2 = intermediate.CreateSubordinateCA(
+                        $"CN=\"A SSL Test CA 2\", O=\"testName\"",
+                        intermedKey2);
+
+                    X509Certificate2 intermedCert2 = intermedPub2.CopyWithPrivateKey(intermedKey2);
+                    intermedPub2.Dispose();
+                    CertificateAuthority intermediateAuthority2 = new CertificateAuthority(intermedCert2, null, null, null);
+
+                    X509Certificate2 intermedPub3 = intermediateAuthority2.CreateSubordinateCA(
+                        $"CN=\"A SSL Test CA 3\", O=\"testName\"",
+                        intermedKey3);
+
+                    X509Certificate2 intermedCert3 = intermedPub3.CopyWithPrivateKey(intermedKey3);
+                    intermedPub3.Dispose();
+                    CertificateAuthority intermediateAuthority3 = new CertificateAuthority(intermedCert3, null, null, null);
+
+                    RSA  eeKey = (RSA)endEntity.PrivateKey;
+                    endEntity = intermediateAuthority3.CreateEndEntity(
+                        $"CN=\"A SSL Test\", O=\"testName\"",
+                        eeKey,
+                        extensions);
+
+                    endEntity = endEntity.CopyWithPrivateKey(eeKey);
+
+                    chain.Add(intermedCert3);
+                    chain.Add(intermedCert2);
+                }
+            }
 
             chain.Add(intermediate.CloneIssuerCert());
             chain.Add(root.CloneIssuerCert());


### PR DESCRIPTION
this is port of #46664 to 5.0 branch
Fixes #46654
reported by customer originally in https://github.com/dotnet/aspnetcore/issues/28584

## Customer Impact
Kestrel server cannot be started if the machine is somehow missing the cert forming the root of the certificate chain being used.
This is caused by an out of bound array iteration in runtime code. 

## Regression? 
Users who were previously able to start Kestrel no longer can. (Our API is new in 5.0, but Kestrel now uses it.)

## Testing
new test case was added for partial certificate chain.

## Risk
Low. The fix corrects how we iterate over the array representing the certificate chain so that we don't try to read beyond the array, nor send the wrong certificates.

Details:
With TrimRootCertificate=false, the old logic would incorrectly increase count when chain.Build() return partial chain. That would later cause ArgumentOutOfRangeException when iterating through the chain certificate collection. Further more, the TrimRootCertificate is swapped. If we want to trim root we need to subtract 2 (e.g. root itself and leaf cert) This will cause wrong number of certificates sent on the wire on Unix. 