### PR TITLE
Fix sync issue in profiler tests

### DIFF
--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
@@ -307,8 +307,6 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::LeaveCallback(FunctionIDOrClientI
 
 HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::TailcallCallback(FunctionIDOrClientID functionIdOrClientID, COR_PRF_ELT_INFO eltInfo)
 {
-    SHUTDOWNGUARD();
-
     COR_PRF_FRAME_INFO frameInfo;
     HRESULT hr = pCorProfilerInfo->GetFunctionTailcall3Info(functionIdOrClientID.functionID, eltInfo, &frameInfo);
     if (FAILED(hr))

--- a/src/tests/profiler/native/profiler.h
+++ b/src/tests/profiler/native/profiler.h
@@ -67,25 +67,19 @@ public:
 // Managed code can keep running after Shutdown() is called, and things like
 // ELT hooks will continue to be called. We would AV if we tried to call
 // in to freed resources.
-#define SHUTDOWNGUARD()                             \
-    do                                              \
-    {                                               \
-        ShutdownGuard();                            \
-        if (ShutdownGuard::HasShutdownStarted())    \
-        {                                           \
-            return S_OK;                            \
-        }                                           \
-    } while(0) 
+#define SHUTDOWNGUARD()                         \
+    ShutdownGuard();                            \
+    if (ShutdownGuard::HasShutdownStarted())    \
+    {                                           \
+        return S_OK;                            \
+    }
 
-#define SHUTDOWNGUARD_RETVOID()                     \
-    do                                              \
-    {                                               \
-        ShutdownGuard();                            \
-        if (ShutdownGuard::HasShutdownStarted())    \
-        {                                           \
-            return;                                 \
-        }                                           \
-    } while(0)
+#define SHUTDOWNGUARD_RETVOID()                 \
+    ShutdownGuard();                            \
+    if (ShutdownGuard::HasShutdownStarted())    \
+    {                                           \
+        return;                                 \
+    }
 
 class Profiler : public ICorProfilerCallback10
 {


### PR DESCRIPTION
Fixes #46844

The macros introduced with #46739 had a bug. Because I was on autopilot and used `do{...} while(0)` in the macros, it introduced a new scope and the ShutdownGuard class would not be held for the duration of the call. I did test it, since it prevented new calls from entering the profiler code it drastically reduced the hit rate but there still was a race condition.