### PR TITLE
Variable in build-runtime script correctly enclosed by percentages

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -677,7 +677,7 @@ if %__BuildNative% EQU 1 (
 
     set "__UCRTDir=%UniversalCRTSdkDir%Redist\%UCRTVersion%\ucrt\DLLs\%__BuildArch%\"
 
-    xcopy /Y/I/E/D/F "!__UCRTDir!*.dll" "%__BinDir%\Redist\ucrt\DLLs\%__BuildArch%"
+    xcopy /Y/I/E/D/F "%__UCRTDir%*.dll" "%__BinDir%\Redist\ucrt\DLLs\%__BuildArch%"
     if not !errorlevel! == 0 (
         set __exitCode=!errorlevel!
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to copy the Universal CRT to the artifacts directory.


### PR DESCRIPTION
Variable __UCRTDir was wrongly enclosed by exclamation marks instead of percentage signs.

Fixes #46918