### PR TITLE
Fix TestsManifestGeneration test again

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -58,7 +58,8 @@ namespace BasicEventSourceTests
                     tracesession.DisableProvider("SimpleEventSource");
                     tracesession.Dispose();
 
-                    manifestExists = false;
+                    var manifestExists = false;
+                    var max_retries = 50;
 
                     for (int i = 0; i < max_retries; i++)
                     {
@@ -100,7 +101,7 @@ namespace BasicEventSourceTests
 
                     tracesession.Flush();
 
-                    tracesession.SetFileName(rolloverFile);
+                    tracesession.SetFileName(rolloverFileName);
 
                     Thread.Sleep(TimeSpan.FromSeconds(5));
 

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -102,6 +102,10 @@ namespace BasicEventSourceTests
 
                     tracesession.Flush();
 
+                    // Sleep after requesting flush to ensure that the manifest payload generated
+                    // is fully written to the etl file.
+                    Thread.Sleep(TimeSpan.FromSeconds(5));
+
                     tracesession.DisableProvider("SimpleEventSource");
                     tracesession.Dispose();
 


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/41954

I already fixed this test in https://github.com/dotnet/runtime/pull/46658 -- the issue is that requesting flush to ETW session does not guarantee the file to be fully written before we check for the existence of the event. In order to prevent the race, I added sleep between when we request ETW flush and when the trace is parsed in #46658, but missed one of the calls to flush. This adds it to the missing call.