### PR TITLE
Rewrite ARM64 IJW bootstrap thunk assembly.

### DIFF
--- a/src/installer/corehost/cli/ijwhost/arm64/bootstrap_thunk.h
+++ b/src/installer/corehost/cli/ijwhost/arm64/bootstrap_thunk.h
@@ -18,7 +18,7 @@ extern "C" void start_runtime_thunk_stub();
 class bootstrap_thunk
 {
 private:
-    DWORD           m_rgCode[4];
+    std::uint32_t          m_rgCode[4];
     std::uintptr_t        m_pBootstrapCode;
 
     pal::dll_t       m_dll;            // pal::dll_t of this module

--- a/src/installer/corehost/cli/ijwhost/arm64/bootstrap_thunk.h
+++ b/src/installer/corehost/cli/ijwhost/arm64/bootstrap_thunk.h
@@ -18,7 +18,7 @@ extern "C" void start_runtime_thunk_stub();
 class bootstrap_thunk
 {
 private:
-    std::uint32_t          m_rgCode[4];
+    std::uint32_t         m_rgCode[4];
     std::uintptr_t        m_pBootstrapCode;
 
     pal::dll_t       m_dll;            // pal::dll_t of this module


### PR DESCRIPTION
Rewrite the inline assembly used in the ARM64 IJW bootstrapping thunks.

The original assembly here was a copy of the ARM32 thunks as the original source of this code had a copy-paste bug.

This PR enables native code to call into a C++/CLI assembly via a native export on ARM64 (this scenario before was completely broken).

The fix has been validated offline by the people who reported the issue.

Fixes #46894 