### PR TITLE
Fix GC fragmentation counter to not return NaN

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -73,7 +73,7 @@ namespace System.Diagnostics.Tracing
                 _timerCounter ??= new PollingCounter("active-timer-count", this, () => Timer.ActiveCount) { DisplayName = "Number of Active Timers" };
                 _fragmentationCounter ??= new PollingCounter("gc-fragmentation", this, () => {
                     var gcInfo = GC.GetGCMemoryInfo();
-                    return gcInfo.FragmentedBytes * 100d / gcInfo.HeapSizeBytes;
+                    return gcInfo.HeapSizeBytes != 0 ? gcInfo.FragmentedBytes * 100d / gcInfo.HeapSizeBytes : 0;
                  }) { DisplayName = "GC Fragmentation", DisplayUnits = "%" };
 #if !MONO
                 _exceptionCounter ??= new IncrementingPollingCounter("exception-count", this, () => Exception.GetExceptionCount()) { DisplayName = "Exception Count", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };

--- a/src/tests/tracing/eventcounter/regression-46938.cs
+++ b/src/tests/tracing/eventcounter/regression-46938.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace EventCounterRegressionTests
+{
+    public class SimpleEventListener : EventListener
+    {        
+        private readonly EventLevel _level = EventLevel.Verbose;
+
+        public bool SawNanFragmentation = false;
+
+        public SimpleEventListener()
+        {
+        }
+
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name.Equals("System.Runtime"))
+            {
+                Dictionary<string, string> refreshInterval = new Dictionary<string, string>();
+                refreshInterval.Add("EventCounterIntervalSec", "1");
+                EnableEvents(source, _level, (EventKeywords)(-1), refreshInterval);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            string fragmentationReported = "";
+            bool isGCFragmentationCounter = false;
+
+            for (int i = 0; i < eventData.Payload.Count; i++)
+            {
+                IDictionary<string, object> eventPayload = eventData.Payload[i] as IDictionary<string, object>;
+                if (eventPayload != null)
+                {
+                    foreach (KeyValuePair<string, object> payload in eventPayload)
+                    {
+                        if (payload.Key.Equals("Name") && payload.Value.ToString().Equals("gc-fragmentation"))
+                            isGCFragmentationCounter = true;
+                        if (payload.Key.Equals("Mean"))
+                        {
+                            fragmentationReported = payload.Value.ToString();
+                        }
+                    }
+                    if (isGCFragmentationCounter && fragmentationReported.Equals("NaN"))
+                    {
+                        SawNanFragmentation = true;
+                    }
+                }
+            }
+        }
+    }
+
+    public partial class TestEventCounter
+    {
+        public static int Main(string[] args)
+        {
+            // Create an EventListener.
+            using (SimpleEventListener myListener = new SimpleEventListener())
+            {
+                Thread.Sleep(3000); 
+                if (!myListener.SawNanFragmentation)
+                {
+                    Console.WriteLine("Test passed");
+                    return 100;
+                }
+                else
+                {
+                    Console.WriteLine($"Test Failed - GC fragmentation counter reported a NaN");
+                    return 1;
+                }
+            }
+        }
+    }
+}

--- a/src/tests/tracing/eventcounter/regression-46938.csproj
+++ b/src/tests/tracing/eventcounter/regression-46938.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- This test has a secondary thread with an infinite loop -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="regression-46938.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The fragmentation counter can return NaN before the first GC has occurred. This PR fixes it by checking for what GC.GetMemoryInfo returns and returns 0 instead of NaN if there hasn't been a GC yet.