### PR TITLE
Free the second half of double register

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -4937,11 +4937,15 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
 
                 // If this is a TYP_FLOAT interval, and the assigned interval was TYP_DOUBLE, we also
                 // need to update the liveRegs to specify that the other half is not live anymore.
+                // As mentioned above, for TYP_DOUBLE, the other half will be unassigned further below.
                 if ((interval->registerType == TYP_FLOAT) &&
                     ((targetRegRecord->assignedInterval != nullptr) &&
                      (targetRegRecord->assignedInterval->registerType == TYP_DOUBLE)))
                 {
-                    liveRegs &= ~getRegMask(getSecondHalfRegRec(targetRegRecord)->regNum, TYP_DOUBLE);
+                    RegRecord* anotherHalfRegRec = findAnotherHalfRegRec(targetRegRecord);
+
+                    // Use TYP_FLOAT to get the regmask of just the half reg.
+                    liveRegs &= ~getRegMask(anotherHalfRegRec->regNum, TYP_FLOAT);
                 }
 
 #endif // TARGET_ARM

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -4923,8 +4923,7 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
             {
 #ifdef TARGET_ARM
                 // If this is a TYP_DOUBLE interval, and the assigned interval is either null or is TYP_FLOAT,
-                // we also need to unassign the other half of the register so it is free to get assigned to
-                // this interval.
+                // we also need to unassign the other half of the register.
                 // Note that if the assigned interval is TYP_DOUBLE, it will be unassigned below.
                 if ((interval->registerType == TYP_DOUBLE) &&
                     ((targetRegRecord->assignedInterval == nullptr) ||


### PR DESCRIPTION
As pointed out in my analysis in https://github.com/dotnet/runtime/issues/46085#issuecomment-759133065, after #45135, we added a `DEBUG` only validation that checks if a `RegRecord` doesn't have an assigned interval, it should be free and its entry should be present in `m_AvailableRegs` mask. However, for ARM, that invariant was not maintained.

In Arm, a pair of registers are used to store value of `TYP_DOUBLE`. However, if a register pair was previously assigned to an interval that has `TYP_DOUBLE` value and we are currently trying to assign a register to an interval that has `TYP_FLOAT` value, we unassign both registers and  re-assign one of the register of the pair to the current interval. However, we were not marking the other half register as free. This is done in `liveRegs` that tracks the live variables. The fix was that whenever we see this happening, remove the other half register from the `liveRegs` mask, so it is considered as free.

[JitStressregs](https://dev.azure.com/dnceng/public/_build/results?buildId=950026&view=results) is green. The failures in [JitStress2-JitStressRegs](https://dev.azure.com/dnceng/public/_build/results?buildId=950027&view=results) are unrelated and are because of the following issues:

- https://github.com/dotnet/runtime/issues/41954
- https://github.com/dotnet/runtime/issues/2352
- https://github.com/dotnet/runtime/issues/46086
- https://github.com/dotnet/runtime/search?q=GetComponentSize&type=issues

Fixes: https://github.com/dotnet/runtime/issues/46085