### PR TITLE
Do a JIT rolling build if the JIT-EE GUID changes

### DIFF
--- a/eng/pipelines/coreclr/jitrollingbuild.yml
+++ b/eng/pipelines/coreclr/jitrollingbuild.yml
@@ -6,6 +6,7 @@ trigger:
   paths:
     include:
     - src/coreclr/jit/*
+    - src/coreclr/inc/jiteeversionguid.h
 
 # This pipeline is supposed to be run only on merged changes
 # and should not be triggerable from a PR. 


### PR DESCRIPTION
Normally, any JIT-EE GUID change would be accompanied by
a change in the JIT source code, so a JIT build would be
kicked off. But in some cases, such as a change in the
SuperPMI data format to cause an incompatible format, with
a manual change of the GUID to compensate, should also
kick off a JIT build so asmdiff baselines have a JIT
with an appropriate GUID.