### PR TITLE
Enable COMPlus_JitDisasmWithGC with SuperPMI asm diffs

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1323,6 +1323,7 @@ class SuperPMIReplayAsmDiffs:
             "COMPlus_JitEnableNoWayAssert": "1",
             "COMPlus_JitNoForceFallback": "1",
             "COMPlus_JitRequired": "1",
+            "COMPlus_JitDisasmWithGC": "1",
             "COMPlus_TieredCompilation": "0" }
 
         if self.coreclr_args.gcinfo:


### PR DESCRIPTION
All SPMI asm diffs (generated using superpmi.py) will
display interleaved GC info.

Note that you can also pass the `--gcinfo` option
to get traditional end-of-code asm dump, but that also
requires adding per-instruction offset output, which can lead
to excessive textual diffs.