### PR TITLE
[release/5.0] Fix data breakpoints

### DIFF
--- a/src/coreclr/src/debug/di/divalue.cpp
+++ b/src/coreclr/src/debug/di/divalue.cpp
@@ -4420,14 +4420,7 @@ HRESULT CordbHandleValue::Dispose()
                           m_appdomain->GetADToken());
 
     event.DisposeHandle.vmObjectHandle = vmObjHandle;
-    if (m_handleType == HANDLE_STRONG)
-    {
-        event.DisposeHandle.fStrong = TRUE;
-    }
-    else
-    {
-        event.DisposeHandle.fStrong = FALSE;
-    }
+    event.DisposeHandle.handleType = m_handleType;
 
     // Note: one-way event here...
     hr = process->SendIPCEvent(&event, sizeof(DebuggerIPCEvent));

--- a/src/coreclr/src/debug/di/module.cpp
+++ b/src/coreclr/src/debug/di/module.cpp
@@ -2758,6 +2758,7 @@ HRESULT CordbModule::GetJITCompilerFlags(DWORD *pdwFlags )
 
 HRESULT CordbModule::IsMappedLayout(BOOL *isMapped)
 {
+    PUBLIC_API_ENTRY(this);
     VALIDATE_POINTER_TO_OBJECT(isMapped, BOOL*);
     FAIL_IF_NEUTERED(this);
 
@@ -2765,11 +2766,12 @@ HRESULT CordbModule::IsMappedLayout(BOOL *isMapped)
     CordbProcess *pProcess = GetProcess();
 
     ATT_REQUIRE_STOPPED_MAY_FAIL(pProcess);
-    PUBLIC_API_BEGIN(pProcess);
+
+    EX_TRY
     {
         hr = pProcess->GetDAC()->IsModuleMapped(m_vmModule, isMapped);
     }
-    PUBLIC_API_END(hr);
+    EX_CATCH_HRESULT(hr);
 
     return hr;
 }

--- a/src/coreclr/src/debug/ee/controller.cpp
+++ b/src/coreclr/src/debug/ee/controller.cpp
@@ -2708,10 +2708,21 @@ DPOSS_ACTION DebuggerController::ScanForTriggers(CORDB_ADDRESS_TYPE *address,
 #ifdef FEATURE_DATABREAKPOINT
     if (stWhat & ST_SINGLE_STEP &&
         tpr != TPR_TRIGGER_ONLY_THIS &&
-        DebuggerDataBreakpoint::TriggerDataBreakpoint(thread, context))
+        DebuggerDataBreakpoint::IsDataBreakpoint(thread, context))
     {
-        DebuggerDataBreakpoint *pDataBreakpoint = new (interopsafe) DebuggerDataBreakpoint(thread);
-        pDcq->dcqEnqueue(pDataBreakpoint, FALSE);
+        if (g_pDebugger->m_isSuspendedForGarbageCollection)
+        {
+            // The debugger is not interested in Data Breakpoints during garbage collection
+            // We can safely ignore them since the Data Breakpoints are now on pinned objects
+            LOG((LF_CORDB, LL_INFO10000, "D:DDBP: Ignoring data breakpoint while suspended for GC \n"));
+
+            used = DPOSS_USED_WITH_NO_EVENT;
+        }
+        else if(DebuggerDataBreakpoint::TriggerDataBreakpoint(thread, context))
+        {
+            DebuggerDataBreakpoint *pDataBreakpoint = new (interopsafe) DebuggerDataBreakpoint(thread);
+            pDcq->dcqEnqueue(pDataBreakpoint, FALSE);
+        }
     }
 #endif
 
@@ -8995,12 +9006,9 @@ bool DebuggerContinuableExceptionBreakpoint::SendEvent(Thread *thread, bool fIpC
 
 #ifdef FEATURE_DATABREAKPOINT
 
-/* static */ bool DebuggerDataBreakpoint::TriggerDataBreakpoint(Thread *thread, CONTEXT * pContext)
+/* static */ bool DebuggerDataBreakpoint::IsDataBreakpoint(Thread *thread, CONTEXT * pContext)
 {
-    LOG((LF_CORDB, LL_INFO10000, "D::DDBP: Doing TriggerDataBreakpoint...\n"));
-
     bool hitDataBp = false;
-    bool result = false;
 #ifdef TARGET_UNIX
     #error Not supported
 #endif // TARGET_UNIX
@@ -9014,6 +9022,15 @@ bool DebuggerContinuableExceptionBreakpoint::SendEvent(Thread *thread, bool fIpC
 #else // defined(TARGET_X86) || defined(TARGET_AMD64)
     #error Not supported
 #endif // defined(TARGET_X86) || defined(TARGET_AMD64)
+    return hitDataBp;
+}
+
+/* static */ bool DebuggerDataBreakpoint::TriggerDataBreakpoint(Thread *thread, CONTEXT * pContext)
+{
+    LOG((LF_CORDB, LL_INFO10000, "D::DDBP: Doing TriggerDataBreakpoint...\n"));
+
+    bool hitDataBp = IsDataBreakpoint(thread, pContext);
+    bool result = false;
     if (hitDataBp)
     {
         if (g_pDebugger->IsThreadAtSafePlace(thread))
@@ -9071,23 +9088,6 @@ bool DebuggerDataBreakpoint::TriggerSingleStep(Thread *thread, const BYTE *ip)
         LOG((LF_CORDB, LL_INFO10000, "D:DDBP: Finally safe for stopping, stop stepping\n"));
         this->DisableSingleStep();
         return true;
-    }
-    else if (g_pDebugger->m_isSuspendedForGarbageCollection)
-    {
-        // The debugger is not interested in Data Breakpoints during garbage collection
-        // We can safely ignore them since the Data Breakpoints are now on pinned objects
-        LOG((LF_CORDB, LL_INFO10000, "D:DDBP: Ignoring data breakpoint while in SuspendEE() for GC \n"));
-
-        // We enabled single step in TriggerDataBreakpoint so that the ScanForTriggers
-        // would return DPOSS_USED_WITH_NO_EVENT effectively treating the data breakpoint
-        // as a debugger exception which is intended to be ignored
-        this->DisableSingleStep();
-
-        // We are done with this controller
-        Delete();
-
-        // Don't queue this object to send an event
-        return false;
     }
     else
     {

--- a/src/coreclr/src/debug/ee/controller.cpp
+++ b/src/coreclr/src/debug/ee/controller.cpp
@@ -9072,6 +9072,23 @@ bool DebuggerDataBreakpoint::TriggerSingleStep(Thread *thread, const BYTE *ip)
         this->DisableSingleStep();
         return true;
     }
+    else if (g_pDebugger->m_isSuspendedForGarbageCollection)
+    {
+        // The debugger is not interested in Data Breakpoints during garbage collection
+        // We can safely ignore them since the Data Breakpoints are now on pinned objects
+        LOG((LF_CORDB, LL_INFO10000, "D:DDBP: Ignoring data breakpoint while in SuspendEE() for GC \n"));
+
+        // We enabled single step in TriggerDataBreakpoint so that the ScanForTriggers
+        // would return DPOSS_USED_WITH_NO_EVENT effectively treating the data breakpoint
+        // as a debugger exception which is intended to be ignored
+        this->DisableSingleStep();
+
+        // We are done with this controller
+        Delete();
+
+        // Don't queue this object to send an event
+        return false;
+    }
     else
     {
         LOG((LF_CORDB, LL_INFO10000, "D:DDBP: Still not safe for stopping, continue stepping\n"));

--- a/src/coreclr/src/debug/ee/controller.h
+++ b/src/coreclr/src/debug/ee/controller.h
@@ -1811,6 +1811,7 @@ public:
         return true;
     }
 
+    static bool IsDataBreakpoint(Thread *thread, CONTEXT * pContext);
     static bool TriggerDataBreakpoint(Thread *thread, CONTEXT * pContext);
 };
 

--- a/src/coreclr/src/debug/ee/debugger.cpp
+++ b/src/coreclr/src/debug/ee/debugger.cpp
@@ -935,6 +935,7 @@ Debugger::Debugger()
     m_forceNonInterceptable(FALSE),
     m_pLazyData(NULL),
     m_defines(_defines),
+    m_isSuspendedForGarbageCollection(FALSE),
     m_isBlockedOnGarbageCollectionEvent(FALSE),
     m_willBlockOnGarbageCollectionEvent(FALSE),
     m_isGarbageCollectionEventsEnabled(FALSE),
@@ -6001,6 +6002,7 @@ void Debugger::SuspendForGarbageCollectionCompleted()
     }
     CONTRACTL_END;
 
+    this->m_isSuspendedForGarbageCollection = TRUE;
     if (!CORDebuggerAttached() || !this->m_isGarbageCollectionEventsEnabledLatch)
     {
         return;
@@ -6037,6 +6039,8 @@ void Debugger::ResumeForGarbageCollectionStarted()
         GC_NOTRIGGER;
     }
     CONTRACTL_END;
+
+    this->m_isSuspendedForGarbageCollection = FALSE;
 
     if (!CORDebuggerAttached() || !this->m_isGarbageCollectionEventsEnabledLatch)
     {

--- a/src/coreclr/src/debug/ee/debugger.cpp
+++ b/src/coreclr/src/debug/ee/debugger.cpp
@@ -11421,14 +11421,21 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
         {
             // DISPOSE an object handle
             OBJECTHANDLE objectHandle = pEvent->DisposeHandle.vmObjectHandle.GetRawPtr();
+            CorDebugHandleType handleType = pEvent->DisposeHandle.handleType;
 
-            if (pEvent->DisposeHandle.fStrong == TRUE)
+            switch (handleType)
             {
+            case HANDLE_STRONG:
                 DestroyStrongHandle(objectHandle);
-            }
-            else
-            {
+                break;
+            case HANDLE_WEAK_TRACK_RESURRECTION:
                 DestroyLongWeakHandle(objectHandle);
+                break;
+            case HANDLE_PINNED:
+                DestroyPinningHandle(objectHandle);
+                break;
+            default:
+                pEvent->hr = E_INVALIDARG;
             }
             break;
         }

--- a/src/coreclr/src/debug/ee/debugger.h
+++ b/src/coreclr/src/debug/ee/debugger.h
@@ -2919,6 +2919,7 @@ public:
     virtual void SuspendForGarbageCollectionCompleted();
     virtual void ResumeForGarbageCollectionStarted();
 #endif
+    BOOL m_isSuspendedForGarbageCollection;
     BOOL m_isBlockedOnGarbageCollectionEvent;
     BOOL m_willBlockOnGarbageCollectionEvent;
     BOOL m_isGarbageCollectionEventsEnabled;

--- a/src/coreclr/src/debug/inc/dbgipcevents.h
+++ b/src/coreclr/src/debug/inc/dbgipcevents.h
@@ -2310,7 +2310,7 @@ struct MSLAYOUT DebuggerIPCEvent
         struct MSLAYOUT
         {
             VMPTR_OBJECTHANDLE vmObjectHandle;
-            BOOL            fStrong;
+            CorDebugHandleType handleType;
         } DisposeHandle;
 
         struct MSLAYOUT


### PR DESCRIPTION
Backport of #46763 to release/5.0

The initial attempt to fix data breakpoints in #44563 was incomplete.

We initially thought the fix was a complete fix, however the VS feature wasn't fully implemented.  We were in a hurry to fix the deadlock issue in #44563, so we accepted less than complete coverage.

When re-implementing the VS data break point feature for .NET 5, the developer found a few issues

- When setting a data breakpoint on a field containing a reference to an pinned object. The GC updates the object reference during a GC heap compaction. This caused an unexpected data breakpoint event during a GC. 
 This was what #44563 was expected to prevent. The data break point event caused the debugger to enter single stepping mode (major perf issue) until returning to managed code. Eventually this led to a catastrophic  stack overflow which terminated the process.
- When removing a data breakpoint in the VS UI, destroying the handle to the pinned object failed with an assertion
- When using a debug or checked runtime build, the debugger threw an assert during a call to `CordbModule::IsMappedLayout()`.  

## Customer Impact

- W/O this fix VS will not be able to fully re-enable the data breakpoints which were disabled by #44563.  This will represent a diagnostic feature regression over .NET 3.1.  
  - Data breakpoints won't be able to be set on object reference fields.  (Only value fields)
  - Data breakpoints enable by pinning will never be able to be unpinned.  This will cause data leaks during diagnostic sessions

### VS dev impact

- W/O the `CordbModule::IsMappedLayout()` fix any debugging of a debug/checked build of the .NET 5 runtime will cause VS crash.  This crash is difficult to diagnose and will consume dev time.

## Regression?

- Yes, from 3.1, which used a different solution for data break points
- This is newly implemented and tested functionality for the VS re-implemented data breakpoint .NET 5 solution

## Testing

- All VS data breakpoint scenarios have been implemented and tested 
  - Two failing scenarios uncovered during VS data breakpoint enablement were hand tested to resolve the fix
- VS debugger test suite was run and passed
- Final testing was performed with this complete patch set applied to v5.0.1

## Risk

This is a minimal risk patch.  
- The patch ignores data breakpoints trigger during suspend for GC
- The patch implements debugger destroy pinned handle support
- The patch fixes a debugger assert

CC @tommcdon @noahfalk @kouvel @chuckries @jeffschwMSFT @hoyosjs 