### PR TITLE
add Memory<byte> support in SendPacketElements and SendPacketsAsync

### DIFF
--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -234,6 +234,8 @@ namespace System.Net.Sockets
         public SendPacketsElement(byte[] buffer) { }
         public SendPacketsElement(byte[] buffer, int offset, int count) { }
         public SendPacketsElement(byte[] buffer, int offset, int count, bool endOfPacket) { }
+        public SendPacketsElement(ReadOnlyMemory<byte> buffer) { }
+        public SendPacketsElement(ReadOnlyMemory<byte> buffer, bool endOfPacket) { }
         public SendPacketsElement(System.IO.FileStream fileStream) { }
         public SendPacketsElement(System.IO.FileStream fileStream, long offset, int count) { }
         public SendPacketsElement(System.IO.FileStream fileStream, long offset, int count, bool endOfPacket) { }
@@ -247,6 +249,7 @@ namespace System.Net.Sockets
         public bool EndOfPacket { get { throw null; } }
         public string? FilePath { get { throw null; } }
         public System.IO.FileStream? FileStream { get { throw null; } }
+        public ReadOnlyMemory<byte>? MemoryBuffer { get { throw null; } }
         public int Offset { get { throw null; } }
         public long OffsetLong { get { throw null; } }
     }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SendPacketsElement.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SendPacketsElement.cs
@@ -106,7 +106,7 @@ namespace System.Net.Sockets
         }
 
         public SendPacketsElement(ReadOnlyMemory<byte> buffer) :
-            this(buffer, false)
+            this(buffer, endOfPacket: false)
         { }
 
         public SendPacketsElement(ReadOnlyMemory<byte> buffer, bool endOfPacket)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SendPacketsElement.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SendPacketsElement.cs
@@ -42,7 +42,7 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
 
-            Initialize(filepath, null, null, offset, count, endOfPacket);
+            Initialize(filepath, null, null, null, offset, count, endOfPacket);
         }
 
         // Constructors for fileStream elements.
@@ -75,7 +75,7 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
 
-            Initialize(null, fileStream, null, offset, count, endOfPacket);
+            Initialize(null, fileStream, null, null, offset, count, endOfPacket);
         }
 
         // Constructors for buffer elements.
@@ -102,14 +102,24 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
 
-            Initialize(null, null, buffer, offset, count, endOfPacket);
+            Initialize(null, null, buffer, new ReadOnlyMemory<byte>(buffer, offset, count), offset, count, endOfPacket);
         }
 
-        private void Initialize(string? filePath, FileStream? fileStream, byte[]? buffer, long offset, int count, bool endOfPacket)
+        public SendPacketsElement(ReadOnlyMemory<byte> buffer) :
+            this(buffer, false)
+        { }
+
+        public SendPacketsElement(ReadOnlyMemory<byte> buffer, bool endOfPacket)
+        {
+            Initialize(null, null, null, buffer, 0, buffer.Length, endOfPacket);
+        }
+
+        private void Initialize(string? filePath, FileStream? fileStream, byte[]? buffer, ReadOnlyMemory<byte>? memoryBuffer, long offset, int count, bool endOfPacket)
         {
             FilePath = filePath;
             FileStream = fileStream;
             Buffer = buffer;
+            MemoryBuffer = memoryBuffer;
             OffsetLong = offset;
             Count = count;
             EndOfPacket = endOfPacket;
@@ -122,6 +132,8 @@ namespace System.Net.Sockets
         public byte[]? Buffer { get; private set; }
 
         public int Count { get; private set; }
+
+        public ReadOnlyMemory<byte>? MemoryBuffer { get; private set; }
 
         public int Offset => checked((int)OffsetLong);
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1797,9 +1797,9 @@ namespace System.Net.Sockets
                     SendPacketsElement e = elements[i];
                     if (e != null)
                     {
-                        if (e.Buffer != null)
+                        if (e.MemoryBuffer != null)
                         {
-                            bytesTransferred += await socket.SendAsync(new ArraySegment<byte>(e.Buffer, e.Offset, e.Count), SocketFlags.None).ConfigureAwait(false);
+                            bytesTransferred += await socket.SendAsync(e.MemoryBuffer.Value, SocketFlags.None).ConfigureAwait(false);
                         }
                         else
                         {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -52,13 +52,11 @@ namespace System.Net.Sockets.Tests
 
         #region Basic Arguments
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void Disposed_Throw(SocketImplementationType type)
+        [Fact]
+        public void Disposed_Throw()
         {
             int port;
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out port))
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, _serverAddress, out port))
             {
                 using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -73,13 +71,11 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void NullArgs_Throw(SocketImplementationType type)
+        [Fact]
+        public void NullArgs_Throw()
         {
             int port;
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out port))
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, _serverAddress, out port))
             {
                 using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -102,28 +98,22 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void NullList_Throws(SocketImplementationType type)
+        [Fact]
+        public void NullList_Throws()
         {
-            AssertExtensions.Throws<ArgumentException>("e", () => SendPackets(type, (SendPacketsElement[])null, SocketError.Success, 0));
+            AssertExtensions.Throws<ArgumentException>("e", () => SendPackets((SendPacketsElement[])null, SocketError.Success, 0));
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void NullElement_Ignored(SocketImplementationType type)
+        [Fact]
+        public void NullElement_Ignored()
         {
-            SendPackets(type, (SendPacketsElement)null, 0);
+            SendPackets((SendPacketsElement)null, 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void EmptyList_Ignored(SocketImplementationType type)
+        [Fact]
+        public void EmptyList_Ignored()
         {
-            SendPackets(type, new SendPacketsElement[0], SocketError.Success, 0);
+            SendPackets(new SendPacketsElement[0], SocketError.Success, 0);
         }
 
         [Fact]
@@ -137,42 +127,32 @@ namespace System.Net.Sockets.Tests
 
         #region Buffers
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void NormalBuffer_Success(SocketImplementationType type)
+        [Fact]
+        public void NormalBuffer_Success()
         {
-            SendPackets(type, new SendPacketsElement(new byte[10]), 10);
+            SendPackets(new SendPacketsElement(new byte[10]), 10);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void NormalBufferRange_Success(SocketImplementationType type)
+        [Fact]
+        public void NormalBufferRange_Success()
         {
-            SendPackets(type, new SendPacketsElement(new byte[10], 5, 5), 5);
+            SendPackets(new SendPacketsElement(new byte[10], 5, 5), 5);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void EmptyBuffer_Ignored(SocketImplementationType type)
+        [Fact]
+        public void EmptyBuffer_Ignored()
         {
-            SendPackets(type, new SendPacketsElement(new byte[0]), 0);
+            SendPackets(new SendPacketsElement(new byte[0]), 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void BufferZeroCount_Ignored(SocketImplementationType type)
+        [Fact]
+        public void BufferZeroCount_Ignored()
         {
-            SendPackets(type, new SendPacketsElement(new byte[10], 4, 0), 0);
+            SendPackets(new SendPacketsElement(new byte[10], 4, 0), 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void BufferMixedBuffers_ZeroCountBufferIgnored(SocketImplementationType type)
+        [Fact]
+        public void BufferMixedBuffers_ZeroCountBufferIgnored()
         {
             SendPacketsElement[] elements = new SendPacketsElement[]
             {
@@ -180,20 +160,18 @@ namespace System.Net.Sockets.Tests
                 new SendPacketsElement(new byte[10], 4, 4),
                 new SendPacketsElement(new byte[10], 0, 4)
             };
-            SendPackets(type, elements, SocketError.Success, 8);
+            SendPackets(elements, SocketError.Success, 8);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void BufferZeroCountThenNormal_ZeroCountIgnored(SocketImplementationType type)
+        [Fact]
+        public void BufferZeroCountThenNormal_ZeroCountIgnored()
         {
             Assert.True(Capability.IPv6Support());
 
             EventWaitHandle completed = new ManualResetEvent(false);
 
             int port;
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out port))
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, _serverAddress, out port))
             {
                 using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -238,42 +216,32 @@ namespace System.Net.Sockets.Tests
 
         #region Memory
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void NormalMemory_Success(SocketImplementationType type)
+        [Fact]
+        public void NormalMemory_Success()
         {
-            SendPackets(type, new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10])), 10);
+            SendPackets(new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10])), 10);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void NormalMemoryRange_Success(SocketImplementationType type)
+        [Fact]
+        public void NormalMemoryRange_Success()
         {
-            SendPackets(type, new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 5, 5)), 5);
+            SendPackets(new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 5, 5)), 5);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void EmptyMemory_Ignored(SocketImplementationType type)
+        [Fact]
+        public void EmptyMemory_Ignored()
         {
-            SendPackets(type, new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[0])), 0);
+            SendPackets(new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[0])), 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void MemoryZeroCount_Ignored(SocketImplementationType type)
+        [Fact]
+        public void MemoryZeroCount_Ignored()
         {
-            SendPackets(type, new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 4, 0)), 0);
+            SendPackets(new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 4, 0)), 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void MemoryMixedBuffers_ZeroCountMemoryIgnored(SocketImplementationType type)
+        [Fact]
+        public void MemoryMixedBuffers_ZeroCountMemoryIgnored()
         {
             SendPacketsElement[] elements = new SendPacketsElement[]
             {
@@ -281,20 +249,18 @@ namespace System.Net.Sockets.Tests
                 new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 4, 4)),
                 new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 0, 4))
             };
-            SendPackets(type, elements, SocketError.Success, 8);
+            SendPackets(elements, SocketError.Success, 8);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void MemoryZeroCountThenNormal_ZeroCountIgnored(SocketImplementationType type)
+        [Fact]
+        public void MemoryZeroCountThenNormal_ZeroCountIgnored()
         {
             Assert.True(Capability.IPv6Support());
 
             EventWaitHandle completed = new ManualResetEvent(false);
 
             int port;
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out port))
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, _serverAddress, out port))
             {
                 using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -338,115 +304,94 @@ namespace System.Net.Sockets.Tests
         #endregion Memory
 
         #region TransmitFileOptions
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SocketDisconnected_TransmitFileOptionDisconnect(SocketImplementationType type)
+
+        [Fact]
+        public void SocketDisconnected_TransmitFileOptionDisconnect()
         {
-            SendPackets(type, new SendPacketsElement(new byte[10], 4, 4), TransmitFileOptions.Disconnect, 4);
+            SendPackets(new SendPacketsElement(new byte[10], 4, 4), TransmitFileOptions.Disconnect, 4);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SocketDisconnectedAndReusable_TransmitFileOptionReuseSocket(SocketImplementationType type)
+        [Fact]
+        public void SocketDisconnectedAndReusable_TransmitFileOptionReuseSocket()
         {
-            SendPackets(type, new SendPacketsElement(new byte[10], 4, 4), TransmitFileOptions.Disconnect | TransmitFileOptions.ReuseSocket, 4);
+            SendPackets(new SendPacketsElement(new byte[10], 4, 4), TransmitFileOptions.Disconnect | TransmitFileOptions.ReuseSocket, 4);
         }
         #endregion
 
         #region Files
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_EmptyFileName_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_EmptyFileName_Throws()
         {
             AssertExtensions.Throws<ArgumentException>("path", null, () =>
             {
-                SendPackets(type, new SendPacketsElement(string.Empty), 0);
+                SendPackets(new SendPacketsElement(string.Empty), 0);
             });
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // whitespace-only is a valid name on Unix
-        public void SendPacketsElement_BlankFileName_Throws(SocketImplementationType type)
+        public void SendPacketsElement_BlankFileName_Throws()
         {
             AssertExtensions.Throws<ArgumentException>("path", null, () =>
             {
                 // Existence is validated on send
-                SendPackets(type, new SendPacketsElement("   "), 0);
+                SendPackets(new SendPacketsElement("   "), 0);
             });
         }
 
-        [Theory]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/25099")]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
         [PlatformSpecific(TestPlatforms.Windows)] // valid filename chars on Unix
-        public void SendPacketsElement_BadCharactersFileName_Throws(SocketImplementationType type)
+        public void SendPacketsElement_BadCharactersFileName_Throws()
         {
             AssertExtensions.Throws<ArgumentException>("path", null, () =>
             {
                 // Existence is validated on send
-                SendPackets(type, new SendPacketsElement("blarkd@dfa?/sqersf"), 0);
+                SendPackets(new SendPacketsElement("blarkd@dfa?/sqersf"), 0);
             });
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_MissingDirectoryName_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_MissingDirectoryName_Throws()
         {
             Assert.Throws<DirectoryNotFoundException>(() =>
             {
                 // Existence is validated on send
-                SendPackets(type, new SendPacketsElement(Path.Combine("nodir", "nofile")), 0);
+                SendPackets(new SendPacketsElement(Path.Combine("nodir", "nofile")), 0);
             });
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_MissingFile_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_MissingFile_Throws()
         {
             Assert.Throws<FileNotFoundException>(() =>
             {
                 // Existence is validated on send
-                SendPackets(type, new SendPacketsElement("DoesntExit"), 0);
+                SendPackets(new SendPacketsElement("DoesntExit"), 0);
             });
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_File_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_File_Success()
         {
-            SendPackets(type, new SendPacketsElement(TestFileName), s_testFileSize); // Whole File
+            SendPackets(new SendPacketsElement(TestFileName), s_testFileSize); // Whole File
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileZeroCount_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileZeroCount_Success()
         {
-            SendPackets(type, new SendPacketsElement(TestFileName, 0, 0), s_testFileSize);  // Whole File
+            SendPackets(new SendPacketsElement(TestFileName, 0, 0), s_testFileSize);  // Whole File
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FilePart_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FilePart_Success()
         {
-            SendPackets(type, new SendPacketsElement(TestFileName, 10, 20), 20);
+            SendPackets(new SendPacketsElement(TestFileName, 10, 20), 20);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileMultiPart_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileMultiPart_Success()
         {
             var elements = new[]
             {
@@ -454,31 +399,25 @@ namespace System.Net.Sockets.Tests
                 new SendPacketsElement(TestFileName, 30, 10),
                 new SendPacketsElement(TestFileName, 0, 10),
             };
-            SendPackets(type, elements, SocketError.Success, 40);
+            SendPackets(elements, SocketError.Success, 40);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileLargeOffset_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileLargeOffset_Throws()
         {
             // Length is validated on Send
-            SendPackets(type, new SendPacketsElement(TestFileName, 11000, 1), SocketError.InvalidArgument, 0);
+            SendPackets(new SendPacketsElement(TestFileName, 11000, 1), SocketError.InvalidArgument, 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileLargeCount_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileLargeCount_Throws()
         {
             // Length is validated on Send
-            SendPackets(type, new SendPacketsElement(TestFileName, 5, 10000), SocketError.InvalidArgument, 0);
+            SendPackets(new SendPacketsElement(TestFileName, 5, 10000), SocketError.InvalidArgument, 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamIsReleasedOnError(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStreamIsReleasedOnError()
         {
             // this test checks that FileStreams opened by the implementation of SendPacketsAsync
             // are properly disposed of when the SendPacketsAsync operation fails asynchronously.
@@ -490,7 +429,7 @@ namespace System.Net.Sockets.Tests
             EventWaitHandle completed1 = new ManualResetEvent(false);
             EventWaitHandle completed2 = new ManualResetEvent(false);
 
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out int port))
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, _serverAddress, out int port))
             {
                 using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -531,28 +470,22 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileZeroCount_OffsetLong_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileZeroCount_OffsetLong_Success()
         {
             var element = new SendPacketsElement(TestFileName, 0L, 0);
-            SendPackets(type, element, s_testFileSize, GetExpectedContent(element));  // Whole File
+            SendPackets(element, s_testFileSize, GetExpectedContent(element));  // Whole File
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FilePart_OffsetLong_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FilePart_OffsetLong_Success()
         {
             var element = new SendPacketsElement(TestFileName, 10L, 20);
-            SendPackets(type, element, 20, GetExpectedContent(element));
+            SendPackets(element, 20, GetExpectedContent(element));
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileMultiPart_OffsetLong_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileMultiPart_OffsetLong_Success()
         {
             var elements = new[]
             {
@@ -560,102 +493,88 @@ namespace System.Net.Sockets.Tests
                 new SendPacketsElement(TestFileName, 30L, 10),
                 new SendPacketsElement(TestFileName, 0L, 10),
             };
-            SendPackets(type, elements, SocketError.Success, 40, GetExpectedContent(elements));
+            SendPackets(elements, SocketError.Success, 40, GetExpectedContent(elements));
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileLargeOffset_OffsetLong_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileLargeOffset_OffsetLong_Throws()
         {
             // Length is validated on Send
-            SendPackets(type, new SendPacketsElement(TestFileName, (long)uint.MaxValue + 11000, 1), SocketError.InvalidArgument, 0);
+            SendPackets(new SendPacketsElement(TestFileName, (long)uint.MaxValue + 11000, 1), SocketError.InvalidArgument, 0);
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileLargeCount_OffsetLong_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileLargeCount_OffsetLong_Throws()
         {
             // Length is validated on Send
-            SendPackets(type, new SendPacketsElement(TestFileName, 5L, 10000), SocketError.InvalidArgument, 0);
+            SendPackets(new SendPacketsElement(TestFileName, 5L, 10000), SocketError.InvalidArgument, 0);
         }
 
         #endregion Files
 
         #region FileStreams
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStream_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStream_Success()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
             {
                 stream.Seek(s_testFileSize / 2, SeekOrigin.Begin);
-                SendPackets(type, new SendPacketsElement(stream), s_testFileSize); // Whole File
+                SendPackets(new SendPacketsElement(stream), s_testFileSize); // Whole File
                 Assert.Equal(s_testFileSize / 2, stream.Position);
 
-                SendPackets(type, new SendPacketsElement(stream), s_testFileSize); // Whole File
+                SendPackets(new SendPacketsElement(stream), s_testFileSize); // Whole File
                 Assert.Equal(s_testFileSize / 2, stream.Position);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamZeroCount_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStreamZeroCount_Success()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
             {
                 stream.Seek(s_testFileSize / 2, SeekOrigin.Begin);
-                SendPackets(type, new SendPacketsElement(stream, 0, 0), s_testFileSize); // Whole File
+                SendPackets(new SendPacketsElement(stream, 0, 0), s_testFileSize); // Whole File
                 Assert.Equal(s_testFileSize / 2, stream.Position);
 
-                SendPackets(type, new SendPacketsElement(stream, 0, 0), s_testFileSize); // Whole File
+                SendPackets(new SendPacketsElement(stream, 0, 0), s_testFileSize); // Whole File
                 Assert.Equal(s_testFileSize / 2, stream.Position);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamSizeCount_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStreamSizeCount_Success()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
             {
                 stream.Seek(s_testFileSize / 2, SeekOrigin.Begin);
-                SendPackets(type, new SendPacketsElement(stream, 0, s_testFileSize), s_testFileSize); // Whole File
+                SendPackets(new SendPacketsElement(stream, 0, s_testFileSize), s_testFileSize); // Whole File
                 Assert.Equal(s_testFileSize / 2, stream.Position);
 
-                SendPackets(type, new SendPacketsElement(stream, 0, s_testFileSize), s_testFileSize); // Whole File
+                SendPackets(new SendPacketsElement(stream, 0, s_testFileSize), s_testFileSize); // Whole File
                 Assert.Equal(s_testFileSize / 2, stream.Position);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamPart_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStreamPart_Success()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
             {
                 stream.Seek(s_testFileSize - 10, SeekOrigin.Begin);
-                SendPackets(type, new SendPacketsElement(stream, 0, 20), 20);
+                SendPackets(new SendPacketsElement(stream, 0, 20), 20);
                 Assert.Equal(s_testFileSize - 10, stream.Position);
 
-                SendPackets(type, new SendPacketsElement(stream, 10, 20), 20);
+                SendPackets(new SendPacketsElement(stream, 10, 20), 20);
                 Assert.Equal(s_testFileSize - 10, stream.Position);
 
-                SendPackets(type, new SendPacketsElement(stream, s_testFileSize - 20, 20), 20);
+                SendPackets(new SendPacketsElement(stream, s_testFileSize - 20, 20), 20);
                 Assert.Equal(s_testFileSize - 10, stream.Position);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamMultiPart_Success(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStreamMultiPart_Success()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous))
             {
@@ -668,48 +587,42 @@ namespace System.Net.Sockets.Tests
                     new SendPacketsElement(stream, 30, 10),
                 };
                 stream.Seek(s_testFileSize - 10, SeekOrigin.Begin);
-                SendPackets(type, elements, SocketError.Success, 70, GetExpectedContent(elements));
+                SendPackets(elements, SocketError.Success, 70, GetExpectedContent(elements));
                 Assert.Equal(s_testFileSize - 10, stream.Position);
 
-                SendPackets(type, elements, SocketError.Success, 70, GetExpectedContent(elements));
+                SendPackets(elements, SocketError.Success, 70, GetExpectedContent(elements));
                 Assert.Equal(s_testFileSize - 10, stream.Position);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamLargeOffset_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStreamLargeOffset_Throws()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
             {
                 stream.Seek(s_testFileSize / 2, SeekOrigin.Begin);
                 // Length is validated on Send
-                SendPackets(type, new SendPacketsElement(stream, (long)uint.MaxValue + 11000, 1), SocketError.InvalidArgument, 0);
+                SendPackets(new SendPacketsElement(stream, (long)uint.MaxValue + 11000, 1), SocketError.InvalidArgument, 0);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamLargeCount_Throws(SocketImplementationType type)
+        [Fact]
+        public void SendPacketsElement_FileStreamLargeCount_Throws()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
             {
                 stream.Seek(s_testFileSize / 2, SeekOrigin.Begin);
                 // Length is validated on Send
-                SendPackets(type, new SendPacketsElement(stream, 5, 10000),
-                    SocketError.InvalidArgument, 0);
+                SendPackets(new SendPacketsElement(stream, 5, 10000), SocketError.InvalidArgument,
+                    0);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamWithOptions_Success(SocketImplementationType type) {
+        [Fact]
+        public void SendPacketsElement_FileStreamWithOptions_Success() {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 var element = new SendPacketsElement(stream, 0, s_testFileSize);
-                SendPackets(type, element, s_testFileSize, GetExpectedContent(element));
+                SendPackets(element, s_testFileSize, GetExpectedContent(element));
             }
         }
 
@@ -717,10 +630,8 @@ namespace System.Net.Sockets.Tests
 
         #region Mixed Buffer, FilePath, FileStream tests
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamMultiPartMixed_Success(SocketImplementationType type) {
+        [Fact]
+        public void SendPacketsElement_FileStreamMultiPartMixed_Success() {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous)) {
                 var elements = new[]
                 {
@@ -734,14 +645,12 @@ namespace System.Net.Sockets.Tests
                     new SendPacketsElement(new byte[] { 8, 9, 10 }, 0, 3),
                 };
                 byte[] expected = GetExpectedContent(elements);
-                SendPackets(type, elements, SocketError.Success, expected.Length, expected);
+                SendPackets(elements, SocketError.Success, expected.Length, expected);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamMultiPartMixed_MultipleFileStreams_Success(SocketImplementationType type) {
+        [Fact]
+        public void SendPacketsElement_FileStreamMultiPartMixed_MultipleFileStreams_Success() {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous))
             using (var stream2 = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous)) {
                 var elements = new[]
@@ -756,14 +665,12 @@ namespace System.Net.Sockets.Tests
                     new SendPacketsElement(TestFileName, 30, 10),
                 };
                 byte[] expected = GetExpectedContent(elements);
-                SendPackets(type, elements, SocketError.Success, expected.Length, expected);
+                SendPackets(elements, SocketError.Success, expected.Length, expected);
             }
         }
 
-        [Theory]
-        [InlineData(SocketImplementationType.APM)]
-        [InlineData(SocketImplementationType.Async)]
-        public void SendPacketsElement_FileStreamMultiPartMixed_MultipleWholeFiles_Success(SocketImplementationType type) {
+        [Fact]
+        public void SendPacketsElement_FileStreamMultiPartMixed_MultipleWholeFiles_Success() {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous)) {
                 var elements = new[]
                 {
@@ -773,21 +680,22 @@ namespace System.Net.Sockets.Tests
                     new SendPacketsElement(TestFileName, 0L, 10),
                 };
                 byte[] expected = GetExpectedContent(elements);
-                SendPackets(type, elements, SocketError.Success, expected.Length, expected);
+                SendPackets(elements, SocketError.Success, expected.Length, expected);
             }
         }
 
         #endregion
         
         #region Helpers
-        private void SendPackets(SocketImplementationType type, SendPacketsElement element, TransmitFileOptions flags, int bytesExpected)
+
+        private void SendPackets(SendPacketsElement element, TransmitFileOptions flags, int bytesExpected)
         {
             Assert.True(Capability.IPv6Support());
 
             EventWaitHandle completed = new ManualResetEvent(false);
 
             int port;
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out port))
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, _serverAddress, out port))
             {
                 using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
@@ -822,24 +730,24 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        private void SendPackets(SocketImplementationType type, SendPacketsElement element, int bytesExpected, byte[] contentExpected = null)
+        private void SendPackets(SendPacketsElement element, int bytesExpected, byte[] contentExpected = null)
         {
-            SendPackets(type, new[] {element}, SocketError.Success, bytesExpected, contentExpected);
+            SendPackets(new[] { element }, SocketError.Success, bytesExpected, contentExpected);
         }
 
-        private void SendPackets(SocketImplementationType type, SendPacketsElement element, SocketError expectedResult, int bytesExpected)
+        private void SendPackets(SendPacketsElement element, SocketError expectedResult, int bytesExpected)
         {
-            SendPackets(type, new[] {element}, expectedResult, bytesExpected);
+            SendPackets(new[] { element }, expectedResult, bytesExpected);
         }
 
-        private void SendPackets(SocketImplementationType type, SendPacketsElement[] elements, SocketError expectedResult, int bytesExpected, byte[] contentExpected = null)
+        private void SendPackets(SendPacketsElement[] elements, SocketError expectedResult, int bytesExpected, byte[] contentExpected = null)
         {
             Assert.True(Capability.IPv6Support());
 
             EventWaitHandle completed = new ManualResetEvent(false);
 
             int port;
-            using (SocketTestServer.SocketTestServerFactory(type, _serverAddress, out port))
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, _serverAddress, out port))
             {
                 using (Socket sock = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -52,7 +52,6 @@ namespace System.Net.Sockets.Tests
 
         #region Basic Arguments
 
-        [OuterLoop]
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -74,7 +73,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [OuterLoop]
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -104,7 +102,6 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [OuterLoop]
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -113,7 +110,6 @@ namespace System.Net.Sockets.Tests
             AssertExtensions.Throws<ArgumentException>("e", () => SendPackets(type, (SendPacketsElement[])null, SocketError.Success, 0));
         }
 
-        [OuterLoop]
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -122,7 +118,6 @@ namespace System.Net.Sockets.Tests
             SendPackets(type, (SendPacketsElement)null, 0);
         }
 
-        [OuterLoop]
         [Theory]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
@@ -131,7 +126,6 @@ namespace System.Net.Sockets.Tests
             SendPackets(type, new SendPacketsElement[0], SocketError.Success, 0);
         }
 
-        [OuterLoop]
         [Fact]
         public void SocketAsyncEventArgs_DefaultSendSize_0()
         {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsElementTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsElementTest.cs
@@ -47,6 +47,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(0, element.Buffer.Length);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(0, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
         }
@@ -59,6 +61,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(10, element.Buffer.Length);
             Assert.Equal(0, element.Offset);
             Assert.Equal(10, element.Count);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
         }
@@ -107,6 +111,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(10, element.Buffer.Length);
             Assert.Equal(2, element.Offset);
             Assert.Equal(8, element.Count);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.True(element.EndOfPacket);
             Assert.Null(element.FilePath);
         }
@@ -119,6 +125,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(10, element.Buffer.Length);
             Assert.Equal(6, element.Offset);
             Assert.Equal(4, element.Count);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
         }
@@ -132,6 +140,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(0, element.Buffer.Length);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
         }
@@ -146,6 +156,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.Equal(0, element.OffsetLong);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
             Assert.Null(element.FileStream);
@@ -160,6 +172,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(0, element.Offset);
             Assert.Equal(10, element.Count);
             Assert.Equal(0, element.OffsetLong);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
             Assert.Null(element.FileStream);
@@ -174,6 +188,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(2, element.Offset);
             Assert.Equal(8, element.Count);
             Assert.Equal(2, element.OffsetLong);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.True(element.EndOfPacket);
             Assert.Null(element.FilePath);
             Assert.Null(element.FileStream);
@@ -188,6 +204,8 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(6, element.Offset);
             Assert.Equal(4, element.Count);
             Assert.Equal(6, element.OffsetLong);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
             Assert.Null(element.FileStream);
@@ -203,12 +221,89 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.Equal(0, element.OffsetLong);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(element.Count, element.MemoryBuffer.Value.Length);
             Assert.False(element.EndOfPacket);
             Assert.Null(element.FilePath);
             Assert.Null(element.FileStream);
         }
 
         #endregion Buffer
+
+        #region Memory
+
+        [Fact]
+        public void EmptyMemoryCtor_Success()
+        {
+            SendPacketsElement element = new SendPacketsElement(default(ReadOnlyMemory<byte>));
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(0, element.MemoryBuffer.Value.Length);
+            Assert.Null(element.Buffer);
+            Assert.Equal(0, element.Offset);
+            Assert.Equal(element.MemoryBuffer.Value.Length, element.Count);
+            Assert.False(element.EndOfPacket);
+            Assert.Null(element.FilePath);
+            Assert.Null(element.FileStream);
+        }
+
+        [Fact]
+        public void MemoryCtorNormal_Success()
+        {
+            SendPacketsElement element = new SendPacketsElement(new byte[10].AsMemory());
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(10, element.MemoryBuffer.Value.Length);
+            Assert.Null(element.Buffer);
+            Assert.Equal(0, element.Offset);
+            Assert.Equal(element.MemoryBuffer.Value.Length, element.Count);
+            Assert.False(element.EndOfPacket);
+            Assert.Null(element.FilePath);
+            Assert.Null(element.FileStream);
+        }
+
+        [Fact]
+        public void MemoryCtorEndOfPacketTrue_Success()
+        {
+            SendPacketsElement element = new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 2, 8), true);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(8, element.MemoryBuffer.Value.Length);
+            Assert.Null(element.Buffer);
+            Assert.Equal(0, element.Offset);
+            Assert.Equal(element.MemoryBuffer.Value.Length, element.Count);
+            Assert.True(element.EndOfPacket);
+            Assert.Null(element.FilePath);
+            Assert.Null(element.FileStream);
+        }
+
+        [Fact]
+        public void memoryCtorEndOfPacketFalse_Success()
+        {
+            SendPacketsElement element = new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[10], 6, 4), false);
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(4, element.MemoryBuffer.Value.Length);
+            Assert.Null(element.Buffer);
+            Assert.Equal(0, element.Offset);
+            Assert.Equal(element.MemoryBuffer.Value.Length, element.Count);
+            Assert.False(element.EndOfPacket);
+            Assert.Null(element.FilePath);
+            Assert.Null(element.FileStream);
+        }
+
+        [Fact]
+        public void MemoryCtorZeroCount_Success()
+        {
+            // Elements with empty Buffers are ignored on Send
+            SendPacketsElement element = new SendPacketsElement(new ReadOnlyMemory<byte>(new byte[0], 0, 0));
+            Assert.NotNull(element.MemoryBuffer);
+            Assert.Equal(0, element.MemoryBuffer.Value.Length);
+            Assert.Null(element.Buffer);
+            Assert.Equal(0, element.Offset);
+            Assert.Equal(element.MemoryBuffer.Value.Length, element.Count);
+            Assert.False(element.EndOfPacket);
+            Assert.Null(element.FilePath);
+            Assert.Null(element.FileStream);
+        }
+
+        #endregion Memory
 
         #region File
 
@@ -235,6 +330,7 @@ namespace System.Net.Sockets.Tests
             // An exception will happen on send if this file doesn't exist
             SendPacketsElement element = new SendPacketsElement(string.Empty);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.False(element.EndOfPacket);
@@ -247,6 +343,7 @@ namespace System.Net.Sockets.Tests
             // An exception will happen on send if this file doesn't exist
             SendPacketsElement element = new SendPacketsElement("   \t ");
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.False(element.EndOfPacket);
@@ -259,6 +356,7 @@ namespace System.Net.Sockets.Tests
             // An exception will happen on send if this file doesn't exist
             SendPacketsElement element = new SendPacketsElement("SomeFileName"); // Send whole file
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.False(element.EndOfPacket);
@@ -271,6 +369,7 @@ namespace System.Net.Sockets.Tests
             // An exception will happen on send if this file doesn't exist
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 0, 0); // Send whole file
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.False(element.EndOfPacket);
@@ -310,6 +409,7 @@ namespace System.Net.Sockets.Tests
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 2, 8, true);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(2, element.Offset);
             Assert.Equal(8, element.Count);
             Assert.True(element.EndOfPacket);
@@ -321,6 +421,7 @@ namespace System.Net.Sockets.Tests
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 6, 4, false);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(6, element.Offset);
             Assert.Equal(4, element.Count);
             Assert.False(element.EndOfPacket);
@@ -346,6 +447,7 @@ namespace System.Net.Sockets.Tests
             // An exception will happen on send if this file doesn't exist
             SendPacketsElement element = new SendPacketsElement(string.Empty);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.Equal(0, element.OffsetLong);
@@ -360,6 +462,7 @@ namespace System.Net.Sockets.Tests
             SendPacketsElement element = new SendPacketsElement("SomeFileName"); // Send whole file
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.Equal(0, element.OffsetLong);
@@ -374,6 +477,7 @@ namespace System.Net.Sockets.Tests
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 0, 0); // Send whole file
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.Equal(0, element.OffsetLong);
@@ -384,6 +488,7 @@ namespace System.Net.Sockets.Tests
             element = new SendPacketsElement("SomeFileName", 0L, 0); // Send whole file
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(0, element.Offset);
             Assert.Equal(0, element.Count);
             Assert.Equal(0, element.OffsetLong);
@@ -423,6 +528,7 @@ namespace System.Net.Sockets.Tests
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 2, 8, true);
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(2, element.Offset);
             Assert.Equal(8, element.Count);
             Assert.Equal(2, element.OffsetLong);
@@ -432,6 +538,7 @@ namespace System.Net.Sockets.Tests
             element = new SendPacketsElement("SomeFileName", 2L, 8, true);
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(2, element.Offset);
             Assert.Equal(8, element.Count);
             Assert.Equal(2, element.OffsetLong);
@@ -441,6 +548,7 @@ namespace System.Net.Sockets.Tests
             element = new SendPacketsElement("SomeFileName", (long)int.MaxValue + 2, 8, true);
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Throws<OverflowException>(() =>
             {
                 var ofset = element.Offset;
@@ -457,6 +565,7 @@ namespace System.Net.Sockets.Tests
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 6, 4, false);
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(6, element.Offset);
             Assert.Equal(4, element.Count);
             Assert.Equal(6, element.OffsetLong);
@@ -466,6 +575,7 @@ namespace System.Net.Sockets.Tests
             element = new SendPacketsElement("SomeFileName", 6L, 4, false);
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Equal(6, element.Offset);
             Assert.Equal(4, element.Count);
             Assert.Equal(6, element.OffsetLong);
@@ -475,6 +585,7 @@ namespace System.Net.Sockets.Tests
             element = new SendPacketsElement("SomeFileName", (long)int.MaxValue + 6, 4, false);
             Assert.Null(element.FileStream);
             Assert.Null(element.Buffer);
+            Assert.Null(element.MemoryBuffer);
             Assert.Throws<OverflowException>(() =>
             {
                 var ofset = element.Offset;
@@ -485,9 +596,9 @@ namespace System.Net.Sockets.Tests
             Assert.Equal("SomeFileName", element.FilePath);
         }
 
-        #endregion File
+#endregion File
 
-        #region FileStream
+#region FileStream
 
         [Fact]
         public void FileStreamCtorNull_Throws()
@@ -515,6 +626,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Equal(0, element.Offset);
                 Assert.Equal(0, element.Count);
                 Assert.Equal(0, element.OffsetLong);
@@ -531,6 +643,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Equal(0, element.Offset);
                 Assert.Equal(0, element.Count);
                 Assert.Equal(0, element.OffsetLong);
@@ -540,6 +653,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Equal(0, element.Offset);
                 Assert.Equal(0, element.Count);
                 Assert.Equal(0, element.OffsetLong);
@@ -618,6 +732,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Equal(2, element.Offset);
                 Assert.Equal(8, element.Count);
                 Assert.Equal(2, element.OffsetLong);
@@ -627,6 +742,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Equal(2, element.Offset);
                 Assert.Equal(8, element.Count);
                 Assert.Equal(2, element.OffsetLong);
@@ -636,6 +752,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Throws<OverflowException>(() =>
                 {
                     var ofset = element.Offset;
@@ -655,6 +772,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Equal(6, element.Offset);
                 Assert.Equal(4, element.Count);
                 Assert.Equal(6, element.OffsetLong);
@@ -664,6 +782,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Equal(6, element.Offset);
                 Assert.Equal(4, element.Count);
                 Assert.Equal(6, element.OffsetLong);
@@ -673,6 +792,7 @@ namespace System.Net.Sockets.Tests
                 Assert.Null(element.FilePath);
                 Assert.Equal(element.FileStream, stream);
                 Assert.Null(element.Buffer);
+                Assert.Null(element.MemoryBuffer);
                 Assert.Throws<OverflowException>(() =>
                 {
                     var ofset = element.Offset;
@@ -683,6 +803,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        #endregion FileStream
+#endregion FileStream
     }
 }


### PR DESCRIPTION
Fixes #45267

@antonfirsov @stephentoub @dotnet/ncl 