### PR TITLE
Add all public types into EventPipe C runtime  shim API that should be redefined by implementation.

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -54,15 +54,19 @@
 #undef DS_EXIT_BLOCKING_PAL_SECTION
 #define DS_EXIT_BLOCKING_PAL_SECTION
 
+#undef DS_RT_DEFINE_ARRAY
 #define DS_RT_DEFINE_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#undef DS_RT_DEFINE_LOCAL_ARRAY
 #define DS_RT_DEFINE_LOCAL_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_LOCAL_ARRAY_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#undef DS_RT_DEFINE_ARRAY_ITERATOR
 #define DS_RT_DEFINE_ARRAY_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_ITERATOR_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#undef DS_RT_DEFINE_ARRAY_REVERSE_ITERATOR
 #define DS_RT_DEFINE_ARRAY_REVERSE_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_REVERSE_ITERATOR_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-types-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-types-coreclr.h
@@ -7,15 +7,34 @@
 #ifdef ENABLE_PERFTRACING
 #include "ep-rt-types-coreclr.h"
 
+/*
+ * DiagnosticsIpcPollHandle.
+ */
+
+#undef ds_rt_ipc_poll_handle_array_t
+typedef struct _rt_coreclr_array_internal_t<DiagnosticsIpcPollHandle> ds_rt_ipc_poll_handle_array_t;
+
+#undef ds_rt_ipc_poll_handle_array_iterator_t
+typedef struct _rt_coreclr_array_iterator_internal_t<DiagnosticsIpcPollHandle> ds_rt_ipc_poll_handle_array_iterator_t;
+
+/*
+ * DiagnosticsPort.
+ */
+
+#undef ds_rt_port_array_t
 typedef struct _rt_coreclr_array_internal_t<DiagnosticsPort *> ds_rt_port_array_t;
+
+#undef ds_rt_port_array_iterator_t
 typedef struct _rt_coreclr_array_iterator_internal_t<DiagnosticsPort *> ds_rt_port_array_iterator_t;
 
+#undef ds_rt_port_config_array_t
 typedef struct _rt_coreclr_array_internal_t<ep_char8_t *> ds_rt_port_config_array_t;
-typedef struct _rt_coreclr_array_iterator_internal_t<ep_char8_t *> ds_rt_port_config_array_iterator_t;
-typedef struct _rt_coreclr_array_iterator_internal_t<ep_char8_t *> ds_rt_port_config_array_reverse_iterator_t;
 
-typedef struct _rt_coreclr_array_internal_t<DiagnosticsIpcPollHandle> ds_rt_ipc_poll_handle_array_t;
-typedef struct _rt_coreclr_array_iterator_internal_t<DiagnosticsIpcPollHandle> ds_rt_ipc_poll_handle_array_iterator_t;
+#undef ds_rt_port_config_array_iterator_t
+typedef struct _rt_coreclr_array_iterator_internal_t<ep_char8_t *> ds_rt_port_config_array_iterator_t;
+
+#undef ds_rt_port_config_array_reverse_iterator_t
+typedef struct _rt_coreclr_array_iterator_internal_t<ep_char8_t *> ds_rt_port_config_array_reverse_iterator_t;
 
 #endif /* ENABLE_PERFTRACING */
 #endif /* __DIAGNOSTICS_RT_TYPES_CORECLR_H__ */

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -824,6 +824,7 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 		return _rt_coreclr_list_is_valid<list_type>(list); \
 	}
 
+#undef EP_RT_DEFINE_LIST
 #define EP_RT_DEFINE_LIST(list_name, list_type, item_type) \
 	EP_RT_DEFINE_LIST_PREFIX(ep, list_name, list_type, item_type)
 
@@ -849,6 +850,7 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 		return _rt_coreclr_list_iterator_value<iterator_type, item_type>(iterator); \
 	}
 
+#undef EP_RT_DEFINE_LIST_ITERATOR
 #define EP_RT_DEFINE_LIST_ITERATOR(list_name, list_type, iterator_type, item_type) \
 	EP_RT_DEFINE_LIST_ITERATOR_PREFIX(ep, list_name, list_type, iterator_type, item_type)
 
@@ -889,6 +891,7 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 		return _rt_coreclr_queue_is_valid<queue_type>(queue); \
 	}
 
+#undef EP_RT_DEFINE_QUEUE
 #define EP_RT_DEFINE_QUEUE(queue_name, queue_type, item_type) \
 	EP_RT_DEFINE_QUEUE_PREFIX(ep, queue_name, queue_type, item_type)
 
@@ -946,9 +949,11 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 		STATIC_CONTRACT_NOTHROW; \
 	}
 
+#undef EP_RT_DEFINE_ARRAY
 #define EP_RT_DEFINE_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_PREFIX(ep, array_name, array_type, iterator_type, item_type)
 
+#undef EP_RT_DEFINE_LOCAL_ARRAY
 #define EP_RT_DEFINE_LOCAL_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_LOCAL_ARRAY_PREFIX(ep, array_name, array_type, iterator_type, item_type)
 
@@ -1001,9 +1006,11 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 		return _rt_coreclr_array_reverse_iterator_value<iterator_type, item_type> (iterator); \
 	}
 
+#undef EP_RT_DEFINE_ARRAY_ITERATOR
 #define EP_RT_DEFINE_ARRAY_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_ITERATOR_PREFIX(ep, array_name, array_type, iterator_type, item_type)
 
+#undef EP_RT_DEFINE_ARRAY_REVERSE_ITERATOR
 #define EP_RT_DEFINE_ARRAY_REVERSE_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_REVERSE_ITERATOR_PREFIX(ep, array_name, array_type, iterator_type, item_type)
 
@@ -1060,9 +1067,11 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 		_rt_coreclr_hash_map_remove<hash_map_type, key_type>(hash_map, key); \
 	}
 
+#undef EP_RT_DEFINE_HASH_MAP
 #define EP_RT_DEFINE_HASH_MAP(hash_map_name, hash_map_type, key_type, value_type) \
 	EP_RT_DEFINE_HASH_MAP_PREFIX(ep, hash_map_name, hash_map_type, key_type, value_type)
 
+#undef EP_RT_DEFINE_HASH_MAP_REMOVE
 #define EP_RT_DEFINE_HASH_MAP_REMOVE(hash_map_name, hash_map_type, key_type, value_type) \
 	EP_RT_DEFINE_HASH_MAP_REMOVE_PREFIX(ep, hash_map_name, hash_map_type, key_type, value_type)
 
@@ -1093,15 +1102,9 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 		return _rt_coreclr_hash_map_iterator_value<hash_map_type, iterator_type, value_type>(iterator); \
 	}
 
+#undef EP_RT_DEFINE_HASH_MAP_ITERATOR
 #define EP_RT_DEFINE_HASH_MAP_ITERATOR(hash_map_name, hash_map_type, iterator_type, key_type, value_type) \
 	EP_RT_DEFINE_HASH_MAP_ITERATOR_PREFIX(ep, hash_map_name, hash_map_type, iterator_type, key_type, value_type)
-
-//TODO: Move types into type API.
-typedef DWORD (WINAPI *ep_rt_thread_start_func)(LPVOID lpThreadParameter);
-typedef DWORD ep_rt_thread_start_func_return_t;
-
-//TODO: Should be a redefinable define.
-#define EP_RT_DEFINE_THREAD_FUNC(name) static ep_rt_thread_start_func_return_t WINAPI name (LPVOID data)
 
 static
 inline
@@ -1624,6 +1627,29 @@ ep_rt_notify_profiler_provider_created (EventPipeProvider *provider)
 EP_RT_DEFINE_LIST (session_provider_list, ep_rt_session_provider_list_t, EventPipeSessionProvider *)
 EP_RT_DEFINE_LIST_ITERATOR (session_provider_list, ep_rt_session_provider_list_t, ep_rt_session_provider_list_iterator_t, EventPipeSessionProvider *)
 
+static
+EventPipeSessionProvider *
+ep_rt_session_provider_list_find_by_name (
+	const ep_rt_session_provider_list_t *list,
+	const ep_char8_t *name)
+{
+	STATIC_CONTRACT_NOTHROW;
+
+	SList<SListElem<EventPipeSessionProvider *>> *provider_list = list->list;
+	EventPipeSessionProvider *session_provider = NULL;
+	SListElem<EventPipeSessionProvider *> *element = provider_list->GetHead ();
+	while (element) {
+		EventPipeSessionProvider *candidate = element->GetValue ();
+		if (ep_rt_utf8_string_compare (ep_session_provider_get_provider_name (candidate), name) == 0) {
+			session_provider = candidate;
+			break;
+		}
+		element = provider_list->GetNext (element);
+	}
+
+	return session_provider;
+}
+
 /*
  * EventPipeSequencePoint.
  */
@@ -1660,29 +1686,6 @@ EP_RT_DEFINE_ARRAY_ITERATOR (thread_session_state_array, ep_rt_thread_session_st
 #undef EP_RT_DECLARE_LOCAL_THREAD_SESSION_STATE_ARRAY
 #define EP_RT_DECLARE_LOCAL_THREAD_SESSION_STATE_ARRAY(var_name) \
 	EP_RT_DECLARE_LOCAL_ARRAY_VARIABLE(var_name, ep_rt_thread_session_state_array_t)
-
-static
-EventPipeSessionProvider *
-ep_rt_session_provider_list_find_by_name (
-	const ep_rt_session_provider_list_t *list,
-	const ep_char8_t *name)
-{
-	STATIC_CONTRACT_NOTHROW;
-
-	SList<SListElem<EventPipeSessionProvider *>> *provider_list = list->list;
-	EventPipeSessionProvider *session_provider = NULL;
-	SListElem<EventPipeSessionProvider *> *element = provider_list->GetHead ();
-	while (element) {
-		EventPipeSessionProvider *candidate = element->GetValue ();
-		if (ep_rt_utf8_string_compare (ep_session_provider_get_provider_name (candidate), name) == 0) {
-			session_provider = candidate;
-			break;
-		}
-		element = provider_list->GetNext (element);
-	}
-
-	return session_provider;
-}
 
 /*
  * Arrays.
@@ -1902,24 +1905,18 @@ ep_rt_execute_rundown (void)
  * PAL.
  */
 
-typedef struct ep_rt_thread_params_t {
-	ep_rt_thread_handle_t thread;
-	EventPipeThreadType thread_type;
-	ep_rt_thread_start_func thread_func;
-	void *thread_params;
-} ep_rt_thread_params_t;
-
 typedef struct _rt_coreclr_thread_params_internal_t {
 	ep_rt_thread_params_t thread_params;
 } rt_coreclr_thread_params_internal_t;
 
-static
-DWORD WINAPI
-ep_rt_thread_coreclr_start_func (LPVOID params)
+#undef EP_RT_DEFINE_THREAD_FUNC
+#define EP_RT_DEFINE_THREAD_FUNC(name) static ep_rt_thread_start_func_return_t WINAPI name (LPVOID data)
+
+EP_RT_DEFINE_THREAD_FUNC (ep_rt_thread_coreclr_start_func)
 {
 	STATIC_CONTRACT_NOTHROW;
 
-	rt_coreclr_thread_params_internal_t *thread_params = reinterpret_cast<rt_coreclr_thread_params_internal_t *>(params);
+	rt_coreclr_thread_params_internal_t *thread_params = reinterpret_cast<rt_coreclr_thread_params_internal_t *>(data);
 	DWORD result = thread_params->thread_params.thread_func (thread_params);
 	if (thread_params->thread_params.thread)
 		::DestroyThread (thread_params->thread_params.thread);
@@ -2441,38 +2438,6 @@ ep_rt_utf8_string_is_null_or_empty (const ep_char8_t *str)
 }
 
 static
-ep_char16_t *
-ep_rt_utf8_to_utf16_string (
-	const ep_char8_t *str,
-	size_t len)
-{
-	STATIC_CONTRACT_NOTHROW;
-
-	if (!str)
-		return NULL;
-
-	COUNT_T len_utf16 = WszMultiByteToWideChar (CP_UTF8, 0, str, static_cast<int>(len), 0, 0);
-	if (len_utf16 == 0)
-		return NULL;
-
-	if (static_cast<int>(len) != -1)
-		len_utf16 += 1;
-
-	ep_char16_t *str_utf16 = reinterpret_cast<ep_char16_t *>(malloc (len_utf16 * sizeof (ep_char16_t)));
-	if (!str_utf16)
-		return NULL;
-
-	len_utf16 = WszMultiByteToWideChar (CP_UTF8, 0, str, static_cast<int>(len), reinterpret_cast<LPWSTR>(str_utf16), len_utf16);
-	if (len_utf16 == 0) {
-		free (str_utf16);
-		return NULL;
-	}
-
-	str_utf16 [len_utf16 - 1] = 0;
-	return str_utf16;
-}
-
-static
 inline
 ep_char8_t *
 ep_rt_utf8_string_dup (const ep_char8_t *str)
@@ -2504,6 +2469,38 @@ ep_rt_utf8_string_strtok (
 	str_len, \
 	format, ...) \
 sprintf_s (reinterpret_cast<char *>(str), static_cast<size_t>(str_len), reinterpret_cast<const char *>(format), __VA_ARGS__)
+
+static
+ep_char16_t *
+ep_rt_utf8_to_utf16_string (
+	const ep_char8_t *str,
+	size_t len)
+{
+	STATIC_CONTRACT_NOTHROW;
+
+	if (!str)
+		return NULL;
+
+	COUNT_T len_utf16 = WszMultiByteToWideChar (CP_UTF8, 0, str, static_cast<int>(len), 0, 0);
+	if (len_utf16 == 0)
+		return NULL;
+
+	if (static_cast<int>(len) != -1)
+		len_utf16 += 1;
+
+	ep_char16_t *str_utf16 = reinterpret_cast<ep_char16_t *>(malloc (len_utf16 * sizeof (ep_char16_t)));
+	if (!str_utf16)
+		return NULL;
+
+	len_utf16 = WszMultiByteToWideChar (CP_UTF8, 0, str, static_cast<int>(len), reinterpret_cast<LPWSTR>(str_utf16), len_utf16);
+	if (len_utf16 == 0) {
+		free (str_utf16);
+		return NULL;
+	}
+
+	str_utf16 [len_utf16 - 1] = 0;
+	return str_utf16;
+}
 
 static
 inline

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-types-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-types-coreclr.h
@@ -133,75 +133,202 @@ struct _rt_coreclr_spin_lock_internal_t {
 	SpinLock *lock;
 };
 
-typedef struct _rt_coreclr_list_internal_t<EventPipeProvider *> ep_rt_provider_list_t;
-typedef class _rt_coreclr_list_internal_t<EventPipeProvider *>::list_type_t::Iterator ep_rt_provider_list_iterator_t;
+/*
+ * EventPipeBuffer.
+ */
 
-typedef struct _rt_coreclr_list_internal_t<EventPipeEvent *> ep_rt_event_list_t;
-typedef class _rt_coreclr_list_internal_t<EventPipeEvent *>::list_type_t::Iterator ep_rt_event_list_iterator_t;
-
-typedef struct _rt_coreclr_list_internal_t<EventPipeSessionProvider *> ep_rt_session_provider_list_t;
-typedef class _rt_coreclr_list_internal_t<EventPipeSessionProvider *>::list_type_t::Iterator ep_rt_session_provider_list_iterator_t;
-
-typedef struct _rt_coreclr_list_internal_t<EventPipeThreadSessionState *> ep_rt_thread_session_state_list_t;
-typedef class _rt_coreclr_list_internal_t<EventPipeThreadSessionState *>::list_type_t::Iterator ep_rt_thread_session_state_list_iterator_t;
-
-typedef struct _rt_coreclr_list_internal_t<EventPipeSequencePoint *> ep_rt_sequence_point_list_t;
-typedef class _rt_coreclr_list_internal_t<EventPipeSequencePoint *>::list_type_t::Iterator ep_rt_sequence_point_list_iterator_t;
-
-typedef struct _rt_coreclr_list_internal_t<EventPipeThread *> ep_rt_thread_list_t;
-typedef class _rt_coreclr_list_internal_t<EventPipeThread *>::list_type_t::Iterator ep_rt_thread_list_iterator_t;
-
-typedef struct _rt_coreclr_queue_internal_t<EventPipeProviderCallbackData *> ep_rt_provider_callback_data_queue_t;
-
-typedef struct _rt_coreclr_table_remove_internal_t<EventPipeEvent *, uint32_t> ep_rt_metadata_labels_hash_map_t;
-typedef class _rt_coreclr_table_remove_internal_t<EventPipeEvent *, uint32_t>::table_type_t::Iterator ep_rt_metadata_labels_hash_map_iterator_t;
-
-typedef struct _rt_coreclr_table_custom_internal_t<EventPipeCoreCLRStackHashTraits> ep_rt_stack_hash_map_t;
-typedef class _rt_coreclr_table_custom_internal_t<EventPipeCoreCLRStackHashTraits>::table_type_t::Iterator ep_rt_stack_hash_map_iterator_t;
-
-typedef struct _rt_coreclr_table_default_internal_t<EventPipeThreadSessionState *, uint32_t> ep_rt_thread_sequence_number_hash_map_t;
-typedef class _rt_coreclr_table_default_internal_t<EventPipeThreadSessionState *, uint32_t>::table_type_t::Iterator ep_rt_thread_sequence_number_hash_map_iterator_t;
-
+#undef ep_rt_buffer_array_t
 typedef struct _rt_coreclr_array_internal_t<EventPipeBuffer *> ep_rt_buffer_array_t;
+
+#undef ep_rt_buffer_array_iterator_t
 typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeBuffer *> ep_rt_buffer_array_iterator_t;
 
+/*
+ * EventPipeBufferList.
+ */
+
+#undef ep_rt_buffer_list_array_t
 typedef struct _rt_coreclr_array_internal_t<EventPipeBufferList *> ep_rt_buffer_list_array_t;
+
+#undef ep_rt_buffer_list_array_iterator_t
 typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeBufferList *> ep_rt_buffer_list_array_iterator_t;
 
-typedef struct _rt_coreclr_array_internal_t<EventPipeThread *> ep_rt_thread_array_t;
-typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeThread *> ep_rt_thread_array_iterator_t;
+/*
+ * EventPipeEvent.
+ */
 
-typedef struct _rt_coreclr_array_internal_t<EventPipeSessionID> ep_rt_session_id_array_t;
-typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeSessionID> ep_rt_session_id_array_iterator_t;
+#undef ep_rt_event_list_t
+typedef struct _rt_coreclr_list_internal_t<EventPipeEvent *> ep_rt_event_list_t;
 
+#undef ep_rt_event_list_iterator_t
+typedef class _rt_coreclr_list_internal_t<EventPipeEvent *>::list_type_t::Iterator ep_rt_event_list_iterator_t;
+
+/*
+ * EventPipeFile.
+ */
+
+#undef ep_rt_metadata_labels_hash_map_t
+typedef struct _rt_coreclr_table_remove_internal_t<EventPipeEvent *, uint32_t> ep_rt_metadata_labels_hash_map_t;
+
+#undef ep_rt_metadata_labels_hash_map_iterator_t
+typedef class _rt_coreclr_table_remove_internal_t<EventPipeEvent *, uint32_t>::table_type_t::Iterator ep_rt_metadata_labels_hash_map_iterator_t;
+
+#undef ep_rt_stack_hash_map_t
+typedef struct _rt_coreclr_table_custom_internal_t<EventPipeCoreCLRStackHashTraits> ep_rt_stack_hash_map_t;
+
+#undef ep_rt_stack_hash_map_iterator_t
+typedef class _rt_coreclr_table_custom_internal_t<EventPipeCoreCLRStackHashTraits>::table_type_t::Iterator ep_rt_stack_hash_map_iterator_t;
+
+/*
+ * EventPipeProvider.
+ */
+
+#undef ep_rt_provider_list_t
+typedef struct _rt_coreclr_list_internal_t<EventPipeProvider *> ep_rt_provider_list_t;
+
+#undef ep_rt_provider_list_iterator_t
+typedef class _rt_coreclr_list_internal_t<EventPipeProvider *>::list_type_t::Iterator ep_rt_provider_list_iterator_t;
+
+#undef ep_rt_provider_callback_data_queue_t
+typedef struct _rt_coreclr_queue_internal_t<EventPipeProviderCallbackData *> ep_rt_provider_callback_data_queue_t;
+
+/*
+ * EventPipeProviderConfiguration.
+ */
+
+#undef ep_rt_provider_config_array_t
 typedef struct _rt_coreclr_array_internal_t<EventPipeProviderConfiguration> ep_rt_provider_config_array_t;
+
+#undef ep_rt_provider_config_array_iterator_t
 typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeProviderConfiguration> ep_rt_provider_config_array_iterator_t;
 
+/*
+ * EventPipeSessionProvider.
+ */
+
+#undef ep_rt_session_provider_list_t
+typedef struct _rt_coreclr_list_internal_t<EventPipeSessionProvider *> ep_rt_session_provider_list_t;
+
+#undef ep_rt_session_provider_list_iterator_t
+typedef class _rt_coreclr_list_internal_t<EventPipeSessionProvider *>::list_type_t::Iterator ep_rt_session_provider_list_iterator_t;
+
+/*
+ * EventPipeSequencePoint.
+ */
+
+#undef ep_rt_sequence_point_list_t
+typedef struct _rt_coreclr_list_internal_t<EventPipeSequencePoint *> ep_rt_sequence_point_list_t;
+
+#undef ep_rt_sequence_point_list_iterator_t
+typedef class _rt_coreclr_list_internal_t<EventPipeSequencePoint *>::list_type_t::Iterator ep_rt_sequence_point_list_iterator_t;
+
+/*
+ * EventPipeThread.
+ */
+
+#undef ep_rt_thread_list_t
+typedef struct _rt_coreclr_list_internal_t<EventPipeThread *> ep_rt_thread_list_t;
+
+#undef ep_rt_thread_list_iterator_t
+typedef class _rt_coreclr_list_internal_t<EventPipeThread *>::list_type_t::Iterator ep_rt_thread_list_iterator_t;
+
+#undef ep_rt_thread_array_t
+typedef struct _rt_coreclr_array_internal_t<EventPipeThread *> ep_rt_thread_array_t;
+
+#undef ep_rt_thread_array_iterator_t
+typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeThread *> ep_rt_thread_array_iterator_t;
+
+/*
+ * EventPipeThreadSessionState.
+ */
+
+#undef ep_rt_thread_session_state_list_t
+typedef struct _rt_coreclr_list_internal_t<EventPipeThreadSessionState *> ep_rt_thread_session_state_list_t;
+
+#undef ep_rt_thread_session_state_list_iterator_t
+typedef class _rt_coreclr_list_internal_t<EventPipeThreadSessionState *>::list_type_t::Iterator ep_rt_thread_session_state_list_iterator_t;
+
+#undef ep_rt_thread_session_state_array_t
 typedef struct _rt_coreclr_array_internal_t<EventPipeThreadSessionState *> ep_rt_thread_session_state_array_t;
+
+#undef ep_rt_thread_session_state_array_iterator_t
 typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeThreadSessionState *> ep_rt_thread_session_state_array_iterator_t;
 
-typedef struct _rt_coreclr_array_internal_t<ep_char16_t *> ep_rt_env_array_utf16_t;
-typedef struct _rt_coreclr_array_iterator_internal_t<ep_char16_t *> ep_rt_env_array_utf16_iterator_t;
+/*
+ * EventPipe.
+ */
 
-typedef class Thread * ep_rt_thread_handle_t;
+#undef ep_rt_session_id_array_t
+typedef struct _rt_coreclr_array_internal_t<EventPipeSessionID> ep_rt_session_id_array_t;
 
-typedef class Thread * ep_rt_thread_activity_id_handle_t;
+#undef ep_rt_session_id_array_iterator_t
+typedef struct _rt_coreclr_array_iterator_internal_t<EventPipeSessionID> ep_rt_session_id_array_iterator_t;
 
-typedef class CFileStream * ep_rt_file_handle_t;
-
+#undef ep_rt_method_desc_t
 typedef class MethodDesc ep_rt_method_desc_t;
 
+/*
+ * PAL.
+ */
+
+#undef ep_rt_env_array_utf16_t
+typedef struct _rt_coreclr_array_internal_t<ep_char16_t *> ep_rt_env_array_utf16_t;
+
+#undef ep_rt_env_array_utf16_iterator_t
+typedef struct _rt_coreclr_array_iterator_internal_t<ep_char16_t *> ep_rt_env_array_utf16_iterator_t;
+
+#undef ep_rt_file_handle_t
+typedef class CFileStream * ep_rt_file_handle_t;
+
+#undef ep_rt_wait_event_handle_t
 typedef struct _rt_coreclr_event_internal_t ep_rt_wait_event_handle_t;
 
+#undef ep_rt_lock_handle_t
 typedef struct _rt_coreclr_lock_internal_t ep_rt_lock_handle_t;
 
+#undef ep_rt_spin_lock_handle_t
 typedef _rt_coreclr_spin_lock_internal_t ep_rt_spin_lock_handle_t;
 
+/*
+ * Thread.
+ */
+
+#undef ep_rt_thread_handle_t
+typedef class Thread * ep_rt_thread_handle_t;
+
+#undef ep_rt_thread_activity_id_handle_t
+typedef class Thread * ep_rt_thread_activity_id_handle_t;
+
+#undef ep_rt_thread_id_t
 #ifndef TARGET_UNIX
 typedef DWORD ep_rt_thread_id_t;
 #else
 typedef size_t ep_rt_thread_id_t;
 #endif
+
+#undef ep_rt_thread_start_func
+typedef DWORD (WINAPI *ep_rt_thread_start_func)(LPVOID lpThreadParameter);
+
+#undef ep_rt_thread_start_func_return_t
+typedef DWORD ep_rt_thread_start_func_return_t;
+
+#undef ep_rt_thread_params_t
+typedef struct _rt_coreclr_thread_params_t {
+	ep_rt_thread_handle_t thread;
+	EventPipeThreadType thread_type;
+	ep_rt_thread_start_func thread_func;
+	void *thread_params;
+} ep_rt_thread_params_t;
+
+/*
+ * ThreadSequenceNumberMap.
+ */
+
+#undef ep_rt_thread_sequence_number_hash_map_t
+typedef struct _rt_coreclr_table_default_internal_t<EventPipeThreadSessionState *, uint32_t> ep_rt_thread_sequence_number_hash_map_t;
+
+#undef ep_rt_thread_sequence_number_hash_map_iterator_t
+typedef class _rt_coreclr_table_default_internal_t<EventPipeThreadSessionState *, uint32_t>::table_type_t::Iterator ep_rt_thread_sequence_number_hash_map_iterator_t;
 
 #endif /* ENABLE_PERFTRACING */
 #endif /* __EVENTPIPE_RT_TYPES_CORECLR_H__ */

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -57,15 +57,19 @@
 	MONO_EXIT_GC_SAFE \
 	MONO_REQ_GC_UNSAFE_MODE
 
+#undef DS_RT_DEFINE_ARRAY
 #define DS_RT_DEFINE_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#undef DS_RT_DEFINE_LOCAL_ARRAY
 #define DS_RT_DEFINE_LOCAL_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_LOCAL_ARRAY_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#undef DS_RT_DEFINE_ARRAY_ITERATOR
 #define DS_RT_DEFINE_ARRAY_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_ITERATOR_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#undef DS_RT_DEFINE_ARRAY_REVERSE_ITERATOR
 #define DS_RT_DEFINE_ARRAY_REVERSE_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DEFINE_ARRAY_REVERSE_ITERATOR_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 

--- a/src/mono/mono/eventpipe/ds-rt-types-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-types-mono.h
@@ -8,15 +8,34 @@
 #include <eventpipe/ds-rt-config.h>
 #include "ep-rt-types-mono.h"
 
+/*
+ * DiagnosticsIpcPollHandle.
+ */
+
+#undef ds_rt_ipc_poll_handle_array_t
+typedef struct _rt_mono_array_internal_t ds_rt_ipc_poll_handle_array_t;
+
+#undef ds_rt_ipc_poll_handle_array_iterator_t
+typedef struct _rt_mono_array_iterator_internal_t ds_rt_ipc_poll_handle_array_iterator_t;
+
+/*
+ * DiagnosticsPort.
+ */
+
+#undef ds_rt_port_array_t
 typedef struct _rt_mono_array_internal_t ds_rt_port_array_t;
+
+#undef ds_rt_port_array_iterator_t
 typedef struct _rt_mono_array_iterator_internal_t ds_rt_port_array_iterator_t;
 
+#undef ds_rt_port_config_array_t
 typedef struct _rt_mono_array_internal_t ds_rt_port_config_array_t;
-typedef struct _rt_mono_array_iterator_internal_t ds_rt_port_config_array_iterator_t;
-typedef struct _rt_mono_array_iterator_internal_t ds_rt_port_config_array_reverse_iterator_t;
 
-typedef struct _rt_mono_array_internal_t ds_rt_ipc_poll_handle_array_t;
-typedef struct _rt_mono_array_iterator_internal_t ds_rt_ipc_poll_handle_array_iterator_t;
+#undef ds_rt_port_config_array_iterator_t
+typedef struct _rt_mono_array_iterator_internal_t ds_rt_port_config_array_iterator_t;
+
+#undef ds_rt_port_config_array_reverse_iterator_t
+typedef struct _rt_mono_array_iterator_internal_t ds_rt_port_config_array_reverse_iterator_t;
 
 #endif /* ENABLE_PERFTRACING */
 #endif /* __DIAGNOSTICS_RT_TYPES_MONO_H__ */

--- a/src/mono/mono/eventpipe/ep-rt-types-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-types-mono.h
@@ -73,70 +73,198 @@ struct _rt_mono_lock_internal_t {
 #endif
 };
 
-typedef struct _rt_mono_list_internal_t ep_rt_provider_list_t;
-typedef struct _rt_mono_list_iterator_internal_t ep_rt_provider_list_iterator_t;
+/*
+ * EventPipeBuffer.
+ */
 
-typedef struct _rt_mono_list_internal_t ep_rt_event_list_t;
-typedef struct _rt_mono_list_iterator_internal_t ep_rt_event_list_iterator_t;
-
-typedef struct _rt_mono_list_internal_t ep_rt_session_provider_list_t;
-typedef struct _rt_mono_list_iterator_internal_t ep_rt_session_provider_list_iterator_t;
-
-typedef struct _rt_mono_list_internal_t ep_rt_thread_session_state_list_t;
-typedef struct _rt_mono_list_iterator_internal_t ep_rt_thread_session_state_list_iterator_t;
-
-typedef struct _rt_mono_array_internal_t ep_rt_thread_session_state_array_t;
-typedef struct _rt_mono_array_iterator_internal_t ep_rt_thread_session_state_array_iterator_t;
-
-typedef struct _rt_mono_list_internal_t ep_rt_sequence_point_list_t;
-typedef struct _rt_mono_list_iterator_internal_t ep_rt_sequence_point_list_iterator_t;
-
-typedef struct _rt_mono_list_internal_t ep_rt_thread_list_t;
-typedef struct _rt_mono_list_iterator_internal_t ep_rt_thread_list_iterator_t;
-
-typedef struct _rt_mono_queue_internal_t ep_rt_provider_callback_data_queue_t;
-
-typedef struct _rt_mono_table_internal_t ep_rt_metadata_labels_hash_map_t;
-typedef struct _rt_mono_iterator_table_internal_t ep_rt_metadata_labels_hash_map_iterator_t;
-
-typedef struct _rt_mono_table_internal_t ep_rt_stack_hash_map_t;
-typedef struct _rt_mono_table_iterator_internal_t ep_rt_stack_hash_map_iterator_t;
-
-typedef struct _rt_mono_table_internal_t ep_rt_thread_sequence_number_hash_map_t;
-typedef struct _rt_mono_table_iterator_internal_t ep_rt_thread_sequence_number_hash_map_iterator_t;
-
+#undef ep_rt_buffer_array_t
 typedef struct _rt_mono_array_internal_t ep_rt_buffer_array_t;
+
+#undef ep_rt_buffer_array_iterator_t
 typedef struct _rt_mono_array_iterator_internal_t ep_rt_buffer_array_iterator_t;
 
+/*
+ * EventPipeBufferList.
+ */
+
+#undef ep_rt_buffer_list_array_t
 typedef struct _rt_mono_array_internal_t ep_rt_buffer_list_array_t;
+
+#undef ep_rt_buffer_list_array_iterator_t
 typedef struct _rt_mono_array_iterator_internal_t ep_rt_buffer_list_array_iterator_t;
 
-typedef struct _rt_mono_array_internal_t ep_rt_thread_array_t;
-typedef struct _rt_mono_array_iterator_internal_t ep_rt_thread_array_iterator_t;
+/*
+ * EventPipeEvent.
+ */
 
-typedef struct _rt_mono_array_internal_t ep_rt_session_id_array_t;
-typedef struct _rt_mono_array_iterator_internal_t ep_rt_session_id_array_iterator_t;
+#undef ep_rt_event_list_t
+typedef struct _rt_mono_list_internal_t ep_rt_event_list_t;
 
+#undef ep_rt_event_list_iterator_t
+typedef struct _rt_mono_list_iterator_internal_t ep_rt_event_list_iterator_t;
+
+/*
+ * EventPipeFile.
+ */
+
+#undef ep_rt_metadata_labels_hash_map_t
+typedef struct _rt_mono_table_internal_t ep_rt_metadata_labels_hash_map_t;
+
+#undef ep_rt_metadata_labels_hash_map_iterator_t
+typedef struct _rt_mono_iterator_table_internal_t ep_rt_metadata_labels_hash_map_iterator_t;
+
+#undef ep_rt_stack_hash_map_t
+typedef struct _rt_mono_table_internal_t ep_rt_stack_hash_map_t;
+
+#undef ep_rt_stack_hash_map_iterator_t
+typedef struct _rt_mono_table_iterator_internal_t ep_rt_stack_hash_map_iterator_t;
+
+/*
+ * EventPipeProvider.
+ */
+
+#undef ep_rt_provider_list_t
+typedef struct _rt_mono_list_internal_t ep_rt_provider_list_t;
+
+#undef ep_rt_provider_list_iterator_t
+typedef struct _rt_mono_list_iterator_internal_t ep_rt_provider_list_iterator_t;
+
+#undef ep_rt_provider_callback_data_queue_t
+typedef struct _rt_mono_queue_internal_t ep_rt_provider_callback_data_queue_t;
+
+/*
+ * EventPipeProviderConfiguration.
+ */
+
+#undef ep_rt_provider_config_array_t
 typedef struct _rt_mono_array_internal_t ep_rt_provider_config_array_t;
+
+#undef ep_rt_provider_config_array_iterator_t
 typedef struct _rt_mono_array_iterator_internal_t ep_rt_provider_config_array_iterator_t;
 
-typedef struct _rt_mono_array_internal_t ep_rt_env_array_utf16_t;
-typedef struct _rt_mono_array_iterator_internal_t ep_rt_env_array_utf16_iterator_t;
+/*
+ * EventPipeSessionProvider.
+ */
 
-typedef THREAD_INFO_TYPE * ep_rt_thread_handle_t;
+#undef ep_rt_session_provider_list_t
+typedef struct _rt_mono_list_internal_t ep_rt_session_provider_list_t;
 
-typedef EventPipeThread * ep_rt_thread_activity_id_handle_t;
+#undef ep_rt_session_provider_list_iterator_t
+typedef struct _rt_mono_list_iterator_internal_t ep_rt_session_provider_list_iterator_t;
 
-typedef gpointer ep_rt_file_handle_t;
+/*
+ * EventPipeSequencePoint.
+ */
 
+#undef ep_rt_sequence_point_list_t
+typedef struct _rt_mono_list_internal_t ep_rt_sequence_point_list_t;
+
+#undef ep_rt_sequence_point_list_iterator_t
+typedef struct _rt_mono_list_iterator_internal_t ep_rt_sequence_point_list_iterator_t;
+
+/*
+ * EventPipeThread.
+ */
+
+#undef ep_rt_thread_list_t
+typedef struct _rt_mono_list_internal_t ep_rt_thread_list_t;
+
+#undef ep_rt_thread_list_iterator_t
+typedef struct _rt_mono_list_iterator_internal_t ep_rt_thread_list_iterator_t;
+
+#undef ep_rt_thread_array_t
+typedef struct _rt_mono_array_internal_t ep_rt_thread_array_t;
+
+#undef ep_rt_thread_array_iterator_t
+typedef struct _rt_mono_array_iterator_internal_t ep_rt_thread_array_iterator_t;
+
+/*
+ * EventPipeThreadSessionState.
+ */
+
+#undef ep_rt_thread_session_state_list_t
+typedef struct _rt_mono_list_internal_t ep_rt_thread_session_state_list_t;
+
+#undef ep_rt_thread_session_state_list_iterator_t
+typedef struct _rt_mono_list_iterator_internal_t ep_rt_thread_session_state_list_iterator_t;
+
+#undef ep_rt_thread_session_state_array_t
+typedef struct _rt_mono_array_internal_t ep_rt_thread_session_state_array_t;
+
+#undef ep_rt_thread_session_state_array_iterator_t
+typedef struct _rt_mono_array_iterator_internal_t ep_rt_thread_session_state_array_iterator_t;
+
+/*
+ * EventPipe.
+ */
+
+#undef ep_rt_session_id_array_t
+typedef struct _rt_mono_array_internal_t ep_rt_session_id_array_t;
+
+#undef ep_rt_session_id_array_iterator_t
+typedef struct _rt_mono_array_iterator_internal_t ep_rt_session_id_array_iterator_t;
+
+#undef ep_rt_method_desc_t
 typedef MonoMethod ep_rt_method_desc_t;
 
+/*
+ * PAL.
+ */
+
+#undef ep_rt_env_array_utf16_t
+typedef struct _rt_mono_array_internal_t ep_rt_env_array_utf16_t;
+
+#undef ep_rt_env_array_utf16_iterator_t
+typedef struct _rt_mono_array_iterator_internal_t ep_rt_env_array_utf16_iterator_t;
+
+#undef ep_rt_file_handle_t
+typedef gpointer ep_rt_file_handle_t;
+
+#undef ep_rt_wait_event_handle_t
 typedef struct _rt_mono_event_internal_t ep_rt_wait_event_handle_t;
 
+#undef ep_rt_lock_handle_t
 typedef struct _rt_mono_lock_internal_t ep_rt_lock_handle_t;
+
+#undef ep_rt_spin_lock_handle_t
 typedef ep_rt_lock_handle_t ep_rt_spin_lock_handle_t;
 
+/*
+ * Thread.
+ */
+
+#undef ep_rt_thread_handle_t
+typedef THREAD_INFO_TYPE * ep_rt_thread_handle_t;
+
+#undef ep_rt_thread_activity_id_handle_t
+typedef EventPipeThread * ep_rt_thread_activity_id_handle_t;
+
+#undef ep_rt_thread_id_t
 typedef MonoNativeThreadId ep_rt_thread_id_t;
+
+#undef ep_rt_thread_start_func
+typedef MonoThreadStart ep_rt_thread_start_func;
+
+#undef ep_rt_thread_start_func_return_t
+typedef mono_thread_start_return_t ep_rt_thread_start_func_return_t;
+
+#undef ep_rt_thread_params_t
+typedef struct _rt_mono_thread_params_t {
+	ep_rt_thread_handle_t thread;
+	EventPipeThreadType thread_type;
+	ep_rt_thread_start_func thread_func;
+	void *thread_params;
+} ep_rt_thread_params_t;
+
+/*
+ * ThreadSequenceNumberMap.
+ */
+
+#undef ep_rt_thread_sequence_number_hash_map_t
+typedef struct _rt_mono_table_internal_t ep_rt_thread_sequence_number_hash_map_t;
+
+#undef ep_rt_thread_sequence_number_hash_map_iterator_t
+typedef struct _rt_mono_table_iterator_internal_t ep_rt_thread_sequence_number_hash_map_iterator_t;
 
 #endif /* ENABLE_PERFTRACING */
 #endif /* __EVENTPIPE_RT_TYPES_MONO_H__ */

--- a/src/native/eventpipe/ds-rt-types.h
+++ b/src/native/eventpipe/ds-rt-types.h
@@ -3,6 +3,24 @@
 
 #ifdef ENABLE_PERFTRACING
 
+/*
+ * DiagnosticsIpcPollHandle.
+ */
+
+#define ds_rt_ipc_poll_handle_array_t ds_rt_redefine
+#define ds_rt_ipc_poll_handle_array_iterator_t ds_rt_redefine
+
+/*
+ * DiagnosticsPort.
+ */
+
+#define ds_rt_port_array_t ds_rt_redefine
+#define ds_rt_port_array_iterator_t ds_rt_redefine
+
+#define ds_rt_port_config_array_t ds_rt_redefine
+#define ds_rt_port_config_array_iterator_t ds_rt_redefine
+#define ds_rt_port_config_array_reverse_iterator_t ds_rt_redefine
+
 #ifndef EP_NO_RT_DEPENDENCY
 #include DS_RT_TYPES_H
 #endif

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -26,14 +26,22 @@
 #define DS_RT_DECLARE_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DECLARE_ARRAY_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#define DS_RT_DEFINE_ARRAY ds_rt_redefine
+
 #define DS_RT_DECLARE_LOCAL_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DECLARE_LOCAL_ARRAY_PREFIX(ds, array_name, array_type, iterator_type, item_type)
+
+#define DS_RT_DEFINE_LOCAL_ARRAY ds_rt_redefine
 
 #define DS_RT_DECLARE_ARRAY_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DECLARE_ARRAY_ITERATOR_PREFIX(ds, array_name, array_type, iterator_type, item_type)
 
+#define DS_RT_DEFINE_ARRAY_ITERATOR ds_rt_redefine
+
 #define DS_RT_DECLARE_ARRAY_REVERSE_ITERATOR(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DECLARE_ARRAY_REVERSE_ITERATOR_PREFIX(ds, array_name, array_type, iterator_type, item_type)
+
+#define DS_RT_DEFINE_ARRAY_REVERSE_ITERATOR ds_rt_redefine
 
 /*
 * AutoTrace.

--- a/src/native/eventpipe/ep-rt-types.h
+++ b/src/native/eventpipe/ep-rt-types.h
@@ -9,6 +9,134 @@
 #define EP_UNLIKELY(expr) ep_rt_redefine
 
 /*
+ * EventPipeBuffer.
+ */
+
+#define ep_rt_buffer_array_t ep_rt_redefine
+#define ep_rt_buffer_array_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeBufferList.
+ */
+
+#define ep_rt_buffer_list_array_t ep_rt_redefine
+#define ep_rt_buffer_list_array_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeEvent.
+ */
+
+#define ep_rt_event_list_t ep_rt_redefine
+#define ep_rt_event_list_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeFile.
+ */
+
+#define ep_rt_metadata_labels_hash_map_t ep_rt_redefine
+#define ep_rt_metadata_labels_hash_map_iterator_t ep_rt_redefine
+
+#define ep_rt_stack_hash_map_t ep_rt_redefine
+#define ep_rt_stack_hash_map_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeProvider.
+ */
+
+#define ep_rt_provider_list_t ep_rt_redefine
+#define ep_rt_provider_list_iterator_t ep_rt_redefine
+
+#define ep_rt_provider_callback_data_queue_t ep_rt_redefine
+
+/*
+ * EventPipeProviderConfiguration.
+ */
+
+#define ep_rt_provider_config_array_t ep_rt_redefine
+#define ep_rt_provider_config_array_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeSessionProvider.
+ */
+
+#define ep_rt_session_provider_list_t ep_rt_redefine
+#define ep_rt_session_provider_list_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeSequencePoint.
+ */
+
+#define ep_rt_sequence_point_list_t ep_rt_redefine
+#define ep_rt_sequence_point_list_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeThread.
+ */
+
+#define ep_rt_thread_list_t ep_rt_redefine
+#define ep_rt_thread_list_iterator_t ep_rt_redefine
+
+#define ep_rt_thread_array_t ep_rt_redefine
+#define ep_rt_thread_array_iterator_t ep_rt_redefine
+
+/*
+ * EventPipeThreadSessionState.
+ */
+
+#define ep_rt_thread_session_state_list_t ep_rt_redefine
+#define ep_rt_thread_session_state_list_iterator_t ep_rt_redefine
+
+#define ep_rt_thread_session_state_array_t ep_rt_redefine
+#define ep_rt_thread_session_state_array_iterator_t ep_rt_redefine
+
+/*
+ * EventPipe.
+ */
+
+#define ep_rt_session_id_array_t ep_rt_redefine
+#define ep_rt_session_id_array_iterator_t ep_rt_redefine
+
+#define ep_rt_method_desc_t ep_rt_redefine
+
+/*
+ * PAL.
+ */
+
+#define ep_rt_env_array_utf16_t ep_rt_redefine
+#define ep_rt_env_array_utf16_iterator_t ep_rt_redefine
+
+#define ep_rt_file_handle_t ep_rt_redefine
+
+#define ep_rt_wait_event_handle_t ep_rt_redefine
+
+#define ep_rt_lock_handle_t ep_rt_redefine
+
+#define ep_rt_spin_lock_handle_t ep_rt_redefine
+
+/*
+ * Thread.
+ */
+
+#define ep_rt_thread_handle_t ep_rt_redefine;
+
+#define ep_rt_thread_activity_id_handle_t ep_rt_redefine;
+
+#define ep_rt_thread_id_t ep_rt_redefine;
+
+#define ep_rt_thread_start_func ep_rt_redefine;
+
+#define ep_rt_thread_start_func_return_t ep_rt_redefine
+
+#define ep_rt_thread_params_t ep_rt_redefine
+
+/*
+ * ThreadSequenceNumberMap.
+ */
+
+#define ep_rt_thread_sequence_number_hash_map_t ep_rt_redefine
+#define ep_rt_thread_sequence_number_hash_map_iterator_t ep_rt_redefine
+
+/*
  * ErrorHandling.
  */
 

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -36,6 +36,8 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 #define EP_RT_DECLARE_LIST(list_name, list_type, item_type) \
 	EP_RT_DECLARE_LIST_PREFIX(ep, list_name, list_type, item_type)
 
+#define EP_RT_DEFINE_LIST ep_rt_redefine
+
 #define EP_RT_DECLARE_LIST_ITERATOR_PREFIX(prefix_name, list_name, list_type, iterator_type, item_type) \
 	static iterator_type EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, list_name, iterator_begin) (const list_type *list); \
 	static bool EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, list_name, iterator_end) (const list_type *list, const iterator_type *iterator); \
@@ -43,7 +45,9 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 	static item_type EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, list_name, iterator_value) (const iterator_type *iterator);
 
 #define EP_RT_DECLARE_LIST_ITERATOR(list_name, list_type, iterator_type, item_type) \
-	EP_RT_DECLARE_LIST_ITERATOR_PREFIX(ep, list_name, list_type, iterator_type, item_type) \
+	EP_RT_DECLARE_LIST_ITERATOR_PREFIX(ep, list_name, list_type, iterator_type, item_type)
+
+#define EP_RT_DEFINE_LIST_ITERATOR ep_rt_redefine
 
 #define EP_RT_DECLARE_QUEUE_PREFIX(prefix_name, queue_name, queue_type, item_type) \
 	static void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, queue_name, alloc) (queue_type *queue); \
@@ -56,6 +60,8 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 
 #define EP_RT_DECLARE_QUEUE(queue_name, queue_type, item_type) \
 	EP_RT_DECLARE_QUEUE_PREFIX(ep, queue_name, queue_type, item_type)
+
+#define EP_RT_DEFINE_QUEUE ep_rt_redefine
 
 #define EP_RT_DECLARE_ARRAY_PREFIX(prefix_name, array_name, array_type, iterator_type, item_type) \
 	static void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, alloc) (array_type *ep_array); \
@@ -75,8 +81,12 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 #define EP_RT_DECLARE_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DECLARE_ARRAY_PREFIX(ep, array_name, array_type, iterator_type, item_type)
 
+#define EP_RT_DEFINE_ARRAY ep_rt_redefine
+
 #define EP_RT_DECLARE_LOCAL_ARRAY(array_name, array_type, iterator_type, item_type) \
 	EP_RT_DECLARE_LOCAL_ARRAY_PREFIX(ep, array_name, array_type, iterator_type, item_type)
+
+#define EP_RT_DEFINE_LOCAL_ARRAY ep_rt_redefine
 
 #define EP_RT_DECLARE_ARRAY_ITERATOR_PREFIX(prefix_name, array_name, array_type, iterator_type, item_type) \
 	static iterator_type EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, iterator_begin) (const array_type *ep_array); \
@@ -91,10 +101,14 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 	static item_type EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, array_name, reverse_iterator_value) (const iterator_type *iterator);
 
 #define EP_RT_DECLARE_ARRAY_ITERATOR(array_name, array_type, iterator_type, item_type) \
-	EP_RT_DECLARE_ARRAY_ITERATOR_PREFIX(ep, array_name, array_type, iterator_type, item_type) \
+	EP_RT_DECLARE_ARRAY_ITERATOR_PREFIX(ep, array_name, array_type, iterator_type, item_type)
+
+#define EP_RT_DEFINE_ARRAY_ITERATOR ep_rt_redefine
 
 #define EP_RT_DECLARE_ARRAY_REVERSE_ITERATOR(array_name, array_type, iterator_type, item_type) \
-	EP_RT_DECLARE_ARRAY_REVERSE_ITERATOR_PREFIX(ep, array_name, array_type, iterator_type, item_type) \
+	EP_RT_DECLARE_ARRAY_REVERSE_ITERATOR_PREFIX(ep, array_name, array_type, iterator_type, item_type)
+
+#define EP_RT_DEFINE_ARRAY_REVERSE_ITERATOR ep_rt_redefine
 
 #define EP_RT_DECLARE_HASH_MAP_BASE_PREFIX(prefix_name, hash_map_name, hash_map_type, key_type, value_type) \
 	static void EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, alloc) (hash_map_type *hash_map, uint32_t (*hash_callback)(const void *), bool (*eq_callback)(const void *, const void *), void (*key_free_callback)(void *), void (*value_free_callback)(void *)); \
@@ -116,8 +130,12 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 #define EP_RT_DECLARE_HASH_MAP(hash_map_name, hash_map_type, key_type, value_type) \
 	EP_RT_DECLARE_HASH_MAP_PREFIX(ep, hash_map_name, hash_map_type, key_type, value_type)
 
+#define EP_RT_DEFINE_HASH_MAP ep_rt_redefine
+
 #define EP_RT_DECLARE_HASH_MAP_REMOVE(hash_map_name, hash_map_type, key_type, value_type) \
 	EP_RT_DECLARE_HASH_MAP_REMOVE_PREFIX(ep, hash_map_name, hash_map_type, key_type, value_type)
+
+#define EP_RT_DEFINE_HASH_MAP_REMOVE ep_rt_redefine
 
 #define EP_RT_DECLARE_HASH_MAP_ITERATOR_PREFIX(prefix_name, hash_map_name, hash_map_type, iterator_type, key_type, value_type) \
 	static iterator_type EP_RT_BUILD_TYPE_FUNC_NAME(prefix_name, hash_map_name, iterator_begin) (const hash_map_type *hash_map); \
@@ -128,6 +146,8 @@ prefix_name ## _rt_ ## type_name ## _ ## func_name
 
 #define EP_RT_DECLARE_HASH_MAP_ITERATOR(hash_map_name, hash_map_type, iterator_type, key_type, value_type) \
 	EP_RT_DECLARE_HASH_MAP_ITERATOR_PREFIX(ep, hash_map_name, hash_map_type, iterator_type, key_type, value_type)
+
+#define EP_RT_DEFINE_HASH_MAP_ITERATOR ep_rt_redefine
 
 /*
 * Atomics.
@@ -414,7 +434,7 @@ ep_rt_wait_event_wait (
 
 static
 EventPipeWaitHandle
-ep_rt_wait_event_get_handle (ep_rt_wait_event_handle_t *wait_event);
+ep_rt_wait_event_get_wait_handle (ep_rt_wait_event_handle_t *wait_event);
 
 static
 bool
@@ -469,6 +489,8 @@ ep_rt_object_free (void *ptr);
 /*
  * PAL.
  */
+
+#define EP_RT_DEFINE_THREAD_FUNC ep_rt_redefine
 
 static
 bool


### PR DESCRIPTION
PR makes sure all functions and types part of the runtime shim API is included in ep-rt.h, ep-rt-types.h, ds-rt.h and ds-rt-types.h to better describe what a runtime needs to implement in order to use library.

PR also structure/align the order of functions and types in shim headers as well as the mono and coreclr implementations of the shim API and types. Done to make it easier to locate functions and types in API and both runtime implementations.