### PR TITLE
Fix unrolling for LocateLastFoundChar and LocateLastFoundByte

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1893,14 +1893,18 @@ namespace System
             var vector64 = Vector.AsVectorUInt64(match);
             ulong candidate = 0;
             int i = Vector<ulong>.Count - 1;
-            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
-            for (; i >= 0; i--)
+
+            // This pattern is only unrolled by the Jit if the limit is Vector<T>.Count
+            // As such, we need a dummy iteration variable for that condition to be satisfied
+            for (int j = 0; j < Vector<ulong>.Count; j++)
             {
                 candidate = vector64[i];
                 if (candidate != 0)
                 {
                     break;
                 }
+
+                i--;
             }
 
             // Single LEA instruction with jitted const (using function result)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -1615,14 +1615,18 @@ namespace System
             var vector64 = Vector.AsVectorUInt64(match);
             ulong candidate = 0;
             int i = Vector<ulong>.Count - 1;
-            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
-            for (; i >= 0; i--)
+
+            // This pattern is only unrolled by the Jit if the limit is Vector<T>.Count
+            // As such, we need a dummy iteration variable for that condition to be satisfied
+            for (int j = 0; j < Vector<ulong>.Count; j++)
             {
                 candidate = vector64[i];
                 if (candidate != 0)
                 {
                     break;
                 }
+
+                i--;
             }
 
             // Single LEA instruction with jitted const (using function result)


### PR DESCRIPTION
Despite what the comments say, the pattern employed by these methods is not recognized by the Jit, because the loop will not have a flag `LPFLG_SIMD_LIMIT` set on it, which only happens for loops with limits that have `GTF_ICON_SIMD_COUNT` set on them, which in turn is only set for `Vector_.Count` nodes during importation.

This can be confirmed by looking at the assembly:
````asm
; Method LocateLastFoundChar(System.Numerics.Vector`1[UInt16]):int
G_M37433_IG01:
       sub      rsp, 56
       vzeroupper 
G_M37433_IG02:
       vmovupd  xmm0, xmmword ptr [rcx]
       mov      eax, 1
G_M37433_IG03:
       cmp      eax, 2
       jae      SHORT G_M37433_IG06
       vmovupd  xmmword ptr [rsp+28H], xmm0
       mov      rdx, qword ptr [rsp+8*rax+28H]
       test     rdx, rdx
       jne      SHORT G_M37433_IG04
       dec      eax
       test     eax, eax
       jge      SHORT G_M37433_IG03
G_M37433_IG04:
       or       rdx, 1
       bsr      rdx, rdx
       sar      edx, 4
       lea      eax, [rdx+4*rax]
G_M37433_IG05:
       add      rsp, 56
       ret      
G_M37433_IG06:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 68
````

This PR fixes the issue by introducing a new loop counter that satisfies the Jit's requirements. I have also collected a small benchmark (source can be found here: https://gist.github.com/SingleAccretion/d17ef1b0e885b50fffed47c82afdc29e). This is only for illustrative/sanity checking purposes, as:
1) It seems to be sensitive to alignment.
2) It was collected on a machine without AVX2.
3) It is a microbenchmark of a method that will be inlined into another method and never be used on its own.
> BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4820K CPU 3.70GHz (Ivy Bridge), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
  DefaultJob : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT

|          Method |                match |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD | Code Size |
|---------------- |--------------------- |----------:|----------:|----------:|----------:|------:|--------:|----------:|
| FindLastCharOld | <0, 0(...)5535> [28] | 0.7789 ns | 0.0521 ns | 0.0512 ns | 0.7866 ns |  1.24 |    0.15 |      68 B |
| FindLastCharNew | <0, 0(...)5535> [28] | 0.6026 ns | 0.0501 ns | 0.0702 ns | 0.6168 ns |  1.00 |    0.00 |      63 B |
|                 |                      |           |           |           |           |       |         |           |
| FindLastCharOld | <6553(...)0, 0> [28] | 1.6021 ns | 0.0624 ns | 0.0584 ns | 1.6234 ns |  2.05 |    0.17 |      68 B |
| FindLastCharNew | <6553(...)0, 0> [28] | 0.7893 ns | 0.0534 ns | 0.0572 ns | 0.7439 ns |  1.00 |    0.00 |      63 B |

> MultimodalDistribution
  LocateLastFoundCharBenchmarks.FindLastCharOld: Default -> It seems that the distribution is bimodal (mValue = 3.25)
  LocateLastFoundCharBenchmarks.FindLastCharNew: Default -> It seems that the distribution is bimodal (mValue = 3.29)
  LocateLastFoundCharBenchmarks.FindLastCharNew: Default -> It seems that the distribution can have several modes (mValue = 3.09)

Notes:
- Placing `i--` at the end of the loop body is deliberate: `for (int j = 0; j < Vector<ulong>.Count; j++, i--)` breaks the recognition of the pattern (`for (int j = 0; j < Vector<ulong>.Count; i--, j++)` works).
- This change should result in machine code size regression on AVX2-enabled machines. [Sharplab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgDkBXfGKASzFwG4BYAKDMq0ASgwB2GVsxoBhCPgAOrADYsAyiwBu7GFz59iAZkoAmctPIBvctfJ8b1+Ww3YMMQUnKtx5ADIQwLjA+eBgAYhBiACbSABbYUHQwAO4AFABqMGAY0AA8DLgx0BgAfOT4LmAxAJR29ha19tbOUOQamdlQqOQAvOQZWdA0AIK4/R0AqgCS4qgp5RiVVTy8jTbjorjYAGYwNKoA1qzy06wYKREY5AxKEKIA5uQBopGskYFLDY1el6w9fe25a63O7FGQRbxwchUZafewAejh5AAKjFWLhyPIXK4oKJPOjbkoAJ5XURQCBKFSRcjAYkAKVOni25AwMTcSkkDLR/wGUBySNBsjEGFhNgR5BG5FwDEqaHISTcohgMCp2HIkSY+GJpxYLlYt1a8VY2GAKnIW2gzLil0gz1Oetx2Wpbk2ElwW1YypF1nNLRS33IACs/qROIHyDluR08jd7gLwRhQwGANRJmorVaWL2NJ4vN6uP5tHmoADarAAussM18mSkc69AuQAIS9Uhpqt1LNV4CwbD7Svt6wAXz06YHrDgcH7GeHvE7YtUXjupp8AFEhp4NhgoNKJPqkqcYoHTq4qTbcJcUgItmIsvbyLApUoMG2q8QAOyecgAKnIKHISd8fxAmCc9wiiWJ4lrbBbTzGAPlHIdPk+YsAFkYBZCBIkmBQlBSNCMKwnCAHl5F3DZhjuO4H1wVg2mmdlREXKoy0+RxaIbagPH9PwAlcECwnBaI4igFIgXuMoKmqHpSgAIVOEidTI3AaD8O5jDmSSqnIYpShQZZByAA===) suggests it will not be significant.
- There is some duplication of code between the `Byte` and `Char` versions which only differ in their last line. The methods could be folded into one without performance loss. However, this would disrupt the nice "Char/Byte" pattern that the source files have. My personal opinion here would be that it's not worth it.
- It could be argued that fixing the source here is wrong, and we should really fix the Jit. I think that's a fair opinion, at the same time, fixing the Jit here seems to be non-trivial, and a cursory look on `source.dot.net` for places where `Vector<T>.Count` is used suggests that this problematic pattern is not widespread (only the fixed methods show up). The unrolling today is laser-focused on the `for (int i = 0; i < Vector<T>.Count; i++)` case, and I think it makes sense to leave it that way until more significant investment in the area is determined to be needed.