### PR TITLE
Prealloc ipc slots in poll handle array.

### DIFF
--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -20,6 +20,8 @@ static ds_rt_port_array_t _ds_port_array = { 0 };
 // allows us to track which connections have sent their ResumeRuntime commands
 static DiagnosticsPort *_ds_current_port = NULL;
 
+static const uint32_t _ds_default_poll_handle_array_size = 16;
+
 static
 inline
 bool
@@ -339,7 +341,7 @@ ds_ipc_stream_factory_get_next_available_stream (ds_ipc_error_callback_func call
 
 	DS_RT_DECLARE_LOCAL_IPC_POLL_HANDLE_ARRAY (ipc_poll_handles);
 
-	ds_rt_ipc_poll_handle_array_init (&ipc_poll_handles);
+	ds_rt_ipc_poll_handle_array_init_capacity (&ipc_poll_handles, _ds_default_poll_handle_array_size);
 	ep_raise_error_if_nok (ds_rt_ipc_poll_handle_array_is_valid (&ipc_poll_handles));
 
 	while (!stream) {


### PR DESCRIPTION
Pre-alloc ipc poll handle array to reduce need to grow array after allocation. This is a hint to implementing shim to make sure the array at least is pre-allocated with his amount of memory to reduce growth. On CoreClr the underlying CQuickArrayList is always allocated with a 512 byte internal buffer, so the 16 slots for the ipc poll handle array should fit into that pre-allocated buffer (resulting in no needed heap alloc for the ipc poll handle array). On Mono, the default capacity for a g_array is 16, so that should also match defaults, but g_arrays are always heap allocted, but as long as we don't exceed 16 handles, array will have all needed room. Normally the number of clients handled in ds_ipc_stream_factory_get_next_available_stream is well below 16 handles.