### PR TITLE
Use new/delete allocator in EventPipe C IPC PAL library for C++ consumers.

### DIFF
--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -36,6 +36,8 @@ endif(CORECLR_SET_RPATH)
 
 OPTION(CLR_CMAKE_ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 
+set(FEATURE_PERFTRACING_C_LIB 1)
+
 #----------------------------------------------------
 # Cross target Component build specific configuration
 #----------------------------------------------------

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1888,15 +1888,15 @@ ep_rt_execute_rundown (void)
 
 // STATIC_CONTRACT_NOTHROW
 #undef ep_rt_object_array_alloc
-#define ep_rt_object_array_alloc(obj_type,size) (new (nothrow) obj_type [size])
+#define ep_rt_object_array_alloc(obj_type,size) (new (nothrow) obj_type [size]())
 
 // STATIC_CONTRACT_NOTHROW
 #undef ep_rt_object_array_free
-#define ep_rt_object_array_free(obj_ptr) do { if (obj_ptr) delete [] obj_ptr; } while(0)
+#define ep_rt_object_array_free(obj_ptr) do { delete [] obj_ptr; } while(0)
 
 // STATIC_CONTRACT_NOTHROW
 #undef ep_rt_object_free
-#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) delete obj_ptr; } while(0)
+#define ep_rt_object_free(obj_ptr) do { delete obj_ptr; } while(0)
 
 /*
  * PAL.

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1322,10 +1322,10 @@ ep_rt_execute_rundown (void)
 #define ep_rt_object_array_alloc(obj_type,size) (g_new0 (obj_type, size))
 
 #undef ep_rt_object_free
-#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) g_free (obj_ptr); } while(0)
+#define ep_rt_object_free(obj_ptr) do { g_free (obj_ptr); } while(0)
 
 #undef ep_rt_object_array_free
-#define ep_rt_object_array_free(obj_ptr) do { if (obj_ptr) g_free (obj_ptr); } while(0)
+#define ep_rt_object_array_free(obj_ptr) do { g_free (obj_ptr); } while(0)
 
 /*
  * PAL.

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1321,21 +1321,11 @@ ep_rt_execute_rundown (void)
 #undef ep_rt_object_array_alloc
 #define ep_rt_object_array_alloc(obj_type,size) (g_new0 (obj_type, size))
 
-static
-inline
-void
-ep_rt_object_array_free (void *ptr)
-{
-	g_free (ptr);
-}
+#undef ep_rt_object_free
+#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) g_free (obj_ptr); } while(0)
 
-static
-inline
-void
-ep_rt_object_free (void *ptr)
-{
-	g_free (ptr);
-}
+#undef ep_rt_object_array_free
+#define ep_rt_object_array_free(obj_ptr) do { if (obj_ptr) g_free (obj_ptr); } while(0)
 
 /*
  * PAL.

--- a/src/native/eventpipe/ds-ipc-posix.c
+++ b/src/native/eventpipe/ds-ipc-posix.c
@@ -58,29 +58,33 @@
 #define DS_EXIT_BLOCKING_PAL_SECTION
 #endif
 
+#ifndef __cplusplus
 #undef ep_rt_object_alloc
 #define ep_rt_object_alloc(obj_type) ((obj_type *)calloc(1, sizeof(obj_type)))
 
-static
-inline
-void
-ep_rt_object_free (void *ptr)
-{
-	if (ptr)
-		free (ptr);
-}
+#undef ep_rt_object_free
+#define ep_rt_object_free (obj_ptr) do { if (obj_ptr) free (obj_ptr); } while(0)
 
 #undef ep_rt_object_array_alloc
 #define ep_rt_object_array_alloc(obj_type,size) ((obj_type *)calloc (size, sizeof(obj_type)))
 
-static
-inline
-void
-ep_rt_object_array_free (void *ptr)
-{
-	if (ptr)
-		free (ptr);
-}
+#undef ep_rt_object_array_free
+#define ep_rt_object_array_free(obj_ptr) do { if (obj_ptr) free (obj_ptr); } while(0)
+#else
+#include <new>
+#undef ep_rt_object_alloc
+#define ep_rt_object_alloc(obj_type) (new (nothrow) obj_type())
+
+#undef ep_rt_object_free
+#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) delete obj_ptr; } while(0)
+
+#undef ep_rt_object_array_alloc
+#define ep_rt_object_array_alloc(obj_type,size) (new (nothrow) obj_type [size])
+
+#undef ep_rt_object_array_free
+#define ep_rt_object_array_free(obj_ptr) do { if (obj_ptr) delete [] obj_ptr; } while(0)
+#endif
+
 #endif /* !FEATURE_PERFTRACING_C_LIB_STANDALONE_PAL */
 
 #ifdef __APPLE__

--- a/src/native/eventpipe/ds-ipc-posix.c
+++ b/src/native/eventpipe/ds-ipc-posix.c
@@ -58,7 +58,20 @@
 #define DS_EXIT_BLOCKING_PAL_SECTION
 #endif
 
-#ifndef __cplusplus
+#ifdef DS_RT_IPC_PAL_USE_DEFAULT_STD_ALLOCATOR
+#include <new>
+#undef ep_rt_object_alloc
+#define ep_rt_object_alloc(obj_type) (new (std::nothrow) obj_type())
+
+#undef ep_rt_object_free
+#define ep_rt_object_free(obj_ptr) do { delete obj_ptr; } while(0)
+
+#undef ep_rt_object_array_alloc
+#define ep_rt_object_array_alloc(obj_type,size) (new (std::nothrow) obj_type [size]())
+
+#undef ep_rt_object_array_free
+#define ep_rt_object_array_free(obj_ptr) do { delete [] obj_ptr; } while(0)
+#else
 #undef ep_rt_object_alloc
 #define ep_rt_object_alloc(obj_type) ((obj_type *)calloc(1, sizeof(obj_type)))
 
@@ -70,19 +83,6 @@
 
 #undef ep_rt_object_array_free
 #define ep_rt_object_array_free(obj_ptr) do { if (obj_ptr) free (obj_ptr); } while(0)
-#else
-#include <new>
-#undef ep_rt_object_alloc
-#define ep_rt_object_alloc(obj_type) (new (nothrow) obj_type())
-
-#undef ep_rt_object_free
-#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) delete obj_ptr; } while(0)
-
-#undef ep_rt_object_array_alloc
-#define ep_rt_object_array_alloc(obj_type,size) (new (nothrow) obj_type [size])
-
-#undef ep_rt_object_array_free
-#define ep_rt_object_array_free(obj_ptr) do { if (obj_ptr) delete [] obj_ptr; } while(0)
 #endif
 
 #endif /* !FEATURE_PERFTRACING_C_LIB_STANDALONE_PAL */

--- a/src/native/eventpipe/ds-ipc-win32.c
+++ b/src/native/eventpipe/ds-ipc-win32.c
@@ -41,19 +41,19 @@
 #define DS_EXIT_BLOCKING_PAL_SECTION
 #endif
 
-#ifndef __cplusplus
-#undef ep_rt_object_alloc
-#define ep_rt_object_alloc(obj_type) ((obj_type *)calloc(1, sizeof(obj_type)))
-
-#undef ep_rt_object_free
-#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) free (obj_ptr); } while(0)
-#else
+#ifdef DS_RT_IPC_PAL_USE_DEFAULT_STD_ALLOCATOR
 #include <new>
 #undef ep_rt_object_alloc
 #define ep_rt_object_alloc(obj_type) (new (std::nothrow) obj_type())
 
 #undef ep_rt_object_free
-#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) delete obj_ptr; } while(0)
+#define ep_rt_object_free(obj_ptr) do { delete obj_ptr; } while(0)
+#else
+#undef ep_rt_object_alloc
+#define ep_rt_object_alloc(obj_type) ((obj_type *)calloc(1, sizeof(obj_type)))
+
+#undef ep_rt_object_free
+#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) free (obj_ptr); } while(0)
 #endif
 #endif /* !FEATURE_PERFTRACING_C_LIB_STANDALONE_PAL */
 

--- a/src/native/eventpipe/ds-ipc-win32.c
+++ b/src/native/eventpipe/ds-ipc-win32.c
@@ -41,17 +41,20 @@
 #define DS_EXIT_BLOCKING_PAL_SECTION
 #endif
 
+#ifndef __cplusplus
 #undef ep_rt_object_alloc
 #define ep_rt_object_alloc(obj_type) ((obj_type *)calloc(1, sizeof(obj_type)))
 
-static
-inline
-void
-ep_rt_object_free (void *ptr)
-{
-	if (ptr)
-		free (ptr);
-}
+#undef ep_rt_object_free
+#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) free (obj_ptr); } while(0)
+#else
+#include <new>
+#undef ep_rt_object_alloc
+#define ep_rt_object_alloc(obj_type) (new (std::nothrow) obj_type())
+
+#undef ep_rt_object_free
+#define ep_rt_object_free(obj_ptr) do { if (obj_ptr) delete obj_ptr; } while(0)
+#endif
 #endif /* !FEATURE_PERFTRACING_C_LIB_STANDALONE_PAL */
 
 /*

--- a/src/native/eventpipe/ds-rt-config.h
+++ b/src/native/eventpipe/ds-rt-config.h
@@ -3,6 +3,10 @@
 
 #include "ep-rt-config.h"
 
+#ifdef FEATURE_CORECLR
+#define DS_RT_IPC_PAL_USE_DEFAULT_STD_ALLOCATOR
+#endif
+
 #ifdef EP_INLINE_GETTER_SETTER
 #define DS_INLINE_GETTER_SETTER
 #endif


### PR DESCRIPTION
Align allocators used in Diagnostic Server C library PAL layer with allocators used in EventPipe C library. On C++ implementations (CoreClr) the Diagnostic Server C library PAL layer used regular C calloc/free, but on C++ EventPipe/Diagnostic Server library it used new/delete. This PR will align the allocators to use new/delete when compiled under C++ and user calloc/free when compiled under C.