### PR TITLE
Make changes to reference assembly rerun compile

### DIFF
--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -25,6 +25,8 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>ResolvedMatchingContract</OutputItemType>
     </ProjectReference>
+    <!-- We aren't referencing the contract, but make sure it's considered as an input to Compile so that if it changes we rebuild and rerun API compat -->
+    <CustomAdditionalCompileInputs Include="$(ContractAssemblyPath)" />  
   </ItemGroup>
 
   <!-- intentionally empty since we no longer need a target -->

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -17,7 +17,6 @@
     <!-- We aren't referencing the contract, but make sure it's considered as an input to Compile so that if it changes we rebuild and rerun API compat -->
     <ProjectReference Include="$(ContractProject)" ReferenceOutputAssembly="false" OutputItemType="CustomAdditionalCompileInputs" />
   </ItemGroup>
-  
   <!-- intentionally empty since we no longer need a target -->
   <Target Name="ResolveMatchingContract" />
 

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -12,7 +12,7 @@
     <RunApiCompat Condition="'$(HasMatchingContract)' != 'true'">false</RunApiCompat>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(HasMatchingContract)' == 'true' and '$(ContractProject)' != '' ">
+  <ItemGroup Condition="'$(HasMatchingContract)' == 'true' and '$(ContractProject)' != '' and '@(ResolvedMatchingContract)' == ''">
     <ProjectReference Include="$(ContractProject)" ReferenceOutputAssembly="false" OutputItemType="ResolvedMatchingContract" />
     <!-- We aren't referencing the contract, but make sure it's considered as an input to Compile so that if it changes we rebuild and rerun API compat -->
     <ProjectReference Include="$(ContractProject)" ReferenceOutputAssembly="false" OutputItemType="CustomAdditionalCompileInputs" />

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <!-- Use implementation referencepath if no contract tfm is set. This item transform is executed at the time this property is evaluated in the API Compat targets. -->
+    <!-- Use implementation referencepath if no contract dependency path is set.
+         This item transform is executed at the time this property is evaluated in the API Compat targets. -->
     <ContractDependencyPaths Condition="'$(ContractDependencyPaths)' == ''">@(ReferencePath->'%(RelativeDir)'->Distinct())</ContractDependencyPaths>
   </PropertyGroup>
 

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -1,34 +1,22 @@
 <Project>
   <PropertyGroup>
-    <ContractDependencyPaths Condition="'$(DisableImplicitFrameworkReferences)' == 'true' and
-                                        '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">$(MicrosoftNetCoreAppRefPackRefDir)</ContractDependencyPaths>
-    <!-- Use implementation referencepath if no contract tfm is set. -->
-    <ContractDependencyPaths Condition="'$(ContractDependencyPaths)' == ''">$(ContractDependencyPaths);@(ReferencePath->'%(RelativeDir)'->Distinct())</ContractDependencyPaths>
+    <!-- Use implementation referencepath if no contract tfm is set. This item transform is executed at the time this property is evaluated in the API Compat targets. -->
+    <ContractDependencyPaths Condition="'$(ContractDependencyPaths)' == ''">@(ReferencePath->'%(RelativeDir)'->Distinct())</ContractDependencyPaths>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
     <ContractProject Condition="'$(ContractProject)' == ''">$(LibrariesProjectRoot)$(MSBuildProjectName)\ref\$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
-    <ContractAssemblyPath Condition="'$(ContractAssemblyPath)' == '' and
-                                     '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                                     $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">$(NetCoreAppCurrentRefPath)$(TargetFileName)</ContractAssemblyPath>
-    <_TargetFrameworkWithoutPlatform>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '(-[^;]+)', ''))</_TargetFrameworkWithoutPlatform>
-    <ContractAssemblyPath Condition="'$(ContractAssemblyPath)' == ''">$([MSBuild]::NormalizePath('$(BaseOutputPath)', 'ref', '$(_TargetFrameworkWithoutPlatform)-$(Configuration)', '$(TargetFileName)'))</ContractAssemblyPath>
     <!-- Disable API compat if the project doesn't have reference assembly -->
     <RunApiCompat Condition="'$(HasMatchingContract)' != 'true'">false</RunApiCompat>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(HasMatchingContract)' == 'true'">
-    <ResolvedMatchingContract Condition="Exists('$(ContractAssemblyPath)')" Include="$(ContractAssemblyPath)" />
-    <!-- If the contract doesn't exist in the default contract output path add a project reference to the contract project to resolve -->
-    <ProjectReference Condition="'@(ResolvedMatchingContract)' == ''" Include="$(ContractProject)">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>ResolvedMatchingContract</OutputItemType>
-    </ProjectReference>
+  <ItemGroup Condition="'$(HasMatchingContract)' == 'true' and '$(ContractProject)' != '' ">
+    <ProjectReference Include="$(ContractProject)" ReferenceOutputAssembly="false" OutputItemType="ResolvedMatchingContract" />
     <!-- We aren't referencing the contract, but make sure it's considered as an input to Compile so that if it changes we rebuild and rerun API compat -->
-    <CustomAdditionalCompileInputs Include="$(ContractAssemblyPath)" />  
+    <ProjectReference Include="$(ContractProject)" ReferenceOutputAssembly="false" OutputItemType="CustomAdditionalCompileInputs" />
   </ItemGroup>
-
+  
   <!-- intentionally empty since we no longer need a target -->
   <Target Name="ResolveMatchingContract" />
 

--- a/src/libraries/shims/Directory.Build.targets
+++ b/src/libraries/shims/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <ResolvedMatchingContract Include="$(ContractAssemblyPath)" />
+  </ItemGroup>
+
+  <Import Project="..\Directory.Build.targets" />
+</Project>


### PR DESCRIPTION
@geoffkizer noticed that making a change only to a ref wouldn't cause ApiCompat to fail.  This was because the src project doesn't recompile, so ApiCompat doesn't rerun.

This won't completely solve the problem since there's a condition on the reference from src->ref, so it's still a race condition when you build the SLN.  If the ref happens to build before src it will catch the change, otherwise it won't.  We could remove that condition on src->ref, but then it would substantially grow the project graph for single project src build.

https://github.com/dotnet/runtime/blob/ddcbc3400e3282bdfedc4575c28437779d45b936/eng/resolveContract.targets#L22-L27

I measured a no-op incremental build of src\System.Net.Sockets.csproj and today it is 2s on my machine.  
If I remove the condition on the src->ref project reference that goes up to 3.7s.  It would go up a lot more for things at the top of the stack.
For example, System.Net.Http.Json will go from ~5s to ~10s.

That said, this would only hit folks building the src csproj directly, which might be unlikely.  Those folks can always do --no-dependencies if they want a faster build.

Let me know if folks think it's worthwhile to remove that fast-path for better incremental.