### PR TITLE
Mono: support CallConvSuppressGCTransition

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3688,13 +3688,19 @@ mono_marshal_get_native_func_wrapper_indirect (MonoClass *caller_class, MonoMeth
 	g_assert (!sig->hasthis && ! sig->explicit_this);
 	g_assert (!sig->is_inflated && !sig->has_type_parameters);
 
+#if 0
+	/*
+	 * Since calli sigs are already part of ECMA-335, they were already used by C++/CLI, which
+	 * allowed non-blittable types.  So the C# function pointers spec doesn't restrict this to
+	 * blittable tyhpes only.
+	 */
 	g_assertf (type_is_blittable (sig->ret), "sig return type %s is not blittable\n", mono_type_full_name (sig->ret));
 
 	for (int i = 0; i < sig->param_count; ++i) {
 		MonoType *ty = sig->params [i];
 		g_assertf (type_is_blittable (ty), "sig param %d (type %s) is not blittable\n", i, mono_type_full_name (ty));
 	}
-	/* g_assert (every param and return type is blittable) */
+#endif
 
 	GHashTable *cache = get_cache (&image->wrapper_caches.native_func_wrapper_indirect_cache,
 				       (GHashFunc)mono_signature_hash, 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -805,6 +805,7 @@ struct _MonoMethodSignature {
 	unsigned int  pinvoke             : 1;
 	unsigned int  is_inflated         : 1;
 	unsigned int  has_type_parameters : 1;
+	unsigned int  suppress_gc_transition : 1;
 	MonoType     *params [MONO_ZERO_LEN_ARRAY];
 };
 

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7086,9 +7086,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				method->dynamic case; for other wrapper types assume the code knows
 				what its doing and added its own GC transitions */
 
-				/* TODO: unmanaged[SuppressGCTransition] call conv will set
-				 * skip_gc_trans to TRUE*/
-				gboolean skip_gc_trans = FALSE;
+				gboolean skip_gc_trans = fsig->suppress_gc_transition;
 				if (!skip_gc_trans) {
 #if 0
 					fprintf (stderr, "generating wrapper for calli in method %s with wrapper type %s\n", method->name, mono_wrapper_type_to_str (method->wrapper_type));

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2459,9 +2459,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)JIT/IL_Conformance/Old/Base/ckfinite/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest/**">
-            <Issue>https://github.com/dotnet/runtime/issues/46451</Issue>
-        </ExcludeList>
         <!-- End interpreter issues -->
     </ItemGroup>
 


### PR DESCRIPTION
* Parse modopt encoded calling conventions
   Add `suppress_gc_transition` bit to `MonoMethodSignature` to add support for the `SuppressGCTransition` unmanaged calling convention modifier.

* Don't emit a wrapper on `calli` if `suppress_gc_transition` is set 

   This adds support for `delegate* unmanaged[Cdecl, SuppressGCTransition] <TRet, TArgs...>` function pointers. (And other base calling conventions other than Cdecl).

* Allow blittable types in `mono_marshal_get_native_func_wrapper_indirect`

   This was already used by C++/CLI, so the C# function pointers spec allows blittable types in unmanaged function pointer types.

* Remove SuppressGCTransitionTest from exclude list

Fixes #46451, Contributes to https://github.com/dotnet/runtime/issues/38480