### PR TITLE
Enable HttpHeaderValueCollection.GetEnumerator to return an empty singleton

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
@@ -165,26 +165,25 @@ namespace System.Net.Http.Headers
         public IEnumerator<T> GetEnumerator()
         {
             object? storeValue = _store.GetParsedValues(_descriptor);
+            return storeValue is null ?
+                ((IEnumerable<T>)Array.Empty<T>()).GetEnumerator() :
+                Iterate(storeValue);
 
-            if (storeValue == null)
+            static IEnumerator<T> Iterate(object storeValue)
             {
-                yield break;
-            }
-
-            List<object>? storeValues = storeValue as List<object>;
-
-            if (storeValues == null)
-            {
-                Debug.Assert(storeValue is T);
-                yield return (T)storeValue;
-            }
-            else
-            {
-                // We have multiple values. Iterate through the values and return them.
-                foreach (object item in storeValues)
+                if (storeValue is List<object> storeValues)
                 {
-                    Debug.Assert(item is T);
-                    yield return (T)item;
+                    // We have multiple values. Iterate through the values and return them.
+                    foreach (object item in storeValues)
+                    {
+                        Debug.Assert(item is T);
+                        yield return (T)item;
+                    }
+                }
+                else
+                {
+                    Debug.Assert(storeValue is T);
+                    yield return (T)storeValue;
                 }
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
@@ -166,7 +166,7 @@ namespace System.Net.Http.Headers
         {
             object? storeValue = _store.GetParsedValues(_descriptor);
             return storeValue is null ?
-                ((IEnumerable<T>)Array.Empty<T>()).GetEnumerator() :
+                ((IEnumerable<T>)Array.Empty<T>()).GetEnumerator() : // use singleton empty array enumerator
                 Iterate(storeValue);
 
             static IEnumerator<T> Iterate(object storeValue)


### PR DESCRIPTION
An empty collection is common.  We can avoid the enumerator allocation in such cases.
cc: @geoffkizer 