### PR TITLE
[mono] Add basic Vector128 support for arm64.

### DIFF
--- a/src/mono/mono/mini/mini-llvm-cpp.cpp
+++ b/src/mono/mono/mini/mini-llvm-cpp.cpp
@@ -61,7 +61,15 @@ mono_llvm_dump_module (LLVMModuleRef module)
 {
 	/* Same as LLVMDumpModule (), but print to stdout */
 	fflush (stdout);
-	outs () << (*unwrap (module));
+	outs () << (*unwrap (module)) << "\n";
+	outs ().flush ();
+}
+
+void
+mono_llvm_dump_type (LLVMTypeRef type)
+{
+	fflush (stdout);
+	outs () << (*unwrap (type)) << "\n";
 	outs ().flush ();
 }
 

--- a/src/mono/mono/mini/mini-llvm-cpp.h
+++ b/src/mono/mono/mini/mini-llvm-cpp.h
@@ -64,6 +64,9 @@ mono_llvm_dump_value (LLVMValueRef value);
 void
 mono_llvm_dump_module (LLVMModuleRef module);
 
+void
+mono_llvm_dump_type (LLVMTypeRef type);
+
 LLVMValueRef
 mono_llvm_build_alloca (LLVMBuilderRef builder, LLVMTypeRef Ty, 
 						LLVMValueRef ArraySize,

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1230,7 +1230,7 @@ convert_full (EmitContext *ctx, LLVMValueRef v, LLVMTypeRef dtype, gboolean is_u
 		// printf ("\n");
 		// printf ("XXXih: convert_full failure:\n");
 		mono_llvm_dump_value (v);
-		mono_llvm_dump_value (LLVMConstNull (dtype));
+		mono_llvm_dump_type (dtype);
 		printf ("\n");
 		// printf ("XXXih: method_name = %s\n", ctx->method_name);
 		// printf ("XXXih: module:\n");
@@ -3734,6 +3734,7 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 		switch (ainfo->storage) {
 		case LLVMArgVtypeInReg:
 		case LLVMArgVtypeByVal:
+		case LLVMArgAsIArgs:
 #ifdef ENABLE_NETCORE
 			// FIXME: Enabling this fails on windows
 		case LLVMArgVtypeAddr:
@@ -9613,6 +9614,7 @@ emit_method_inner (EmitContext *ctx)
 		linfo->rgctx_arg = TRUE;
 	else if (needs_extra_arg (ctx, cfg->method))
 		linfo->dummy_arg = TRUE;
+
 	ctx->method_type = method_type = sig_to_llvm_sig_full (ctx, sig, linfo);
 	if (!ctx_ok (ctx))
 		return;

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1228,13 +1228,14 @@ convert_full (EmitContext *ctx, LLVMValueRef v, LLVMTypeRef dtype, gboolean is_u
 			return LLVMBuildBitCast (ctx->builder, v, dtype, "");
 
 		// printf ("\n");
-		// printf ("XXXih: module:\n");
-		// mono_llvm_dump_module(ctx->lmodule);
-		// printf ("\n");
-		// printf ("XXXih: method_name = %s\n", ctx->method_name);
+		// printf ("XXXih: convert_full failure:\n");
 		mono_llvm_dump_value (v);
 		mono_llvm_dump_value (LLVMConstNull (dtype));
 		printf ("\n");
+		// printf ("XXXih: method_name = %s\n", ctx->method_name);
+		// printf ("XXXih: module:\n");
+		// mono_llvm_dump_module(ctx->lmodule);
+		// printf ("\n");
 		g_assert_not_reached ();
 		return NULL;
 	} else {
@@ -4326,6 +4327,8 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 		if (!addresses [call->inst.dreg])
 			addresses [call->inst.dreg] = build_alloca (ctx, sig->ret);
 		LLVMBuildStore (builder, lcall, convert_full (ctx, addresses [call->inst.dreg], LLVMPointerType (LLVMTypeOf (lcall), 0), FALSE));
+		if (MONO_CLASS_IS_SIMD (ctx->cfg, mono_class_from_mono_type_internal (sig->ret)))
+			values [ins->dreg] = LLVMBuildBitCast(builder, lcall, type_to_llvm_type (ctx, sig->ret), "callret_cvt_simd");
 		break;
 	case LLVMArgVtypeRetAddr:
 	case LLVMArgVtypeByRef:

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1227,15 +1227,9 @@ convert_full (EmitContext *ctx, LLVMValueRef v, LLVMTypeRef dtype, gboolean is_u
 		if (LLVMGetTypeKind (stype) == LLVMVectorTypeKind && LLVMGetTypeKind (dtype) == LLVMVectorTypeKind)
 			return LLVMBuildBitCast (ctx->builder, v, dtype, "");
 
-		// printf ("\n");
-		// printf ("XXXih: convert_full failure:\n");
 		mono_llvm_dump_value (v);
 		mono_llvm_dump_type (dtype);
 		printf ("\n");
-		// printf ("XXXih: method_name = %s\n", ctx->method_name);
-		// printf ("XXXih: module:\n");
-		// mono_llvm_dump_module(ctx->lmodule);
-		// printf ("\n");
 		g_assert_not_reached ();
 		return NULL;
 	} else {

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -2593,8 +2593,9 @@ build_alloca_llvm_type (EmitContext *ctx, LLVMTypeRef t, int align)
 	return build_alloca_llvm_type_name (ctx, t, align, "");
 }
 
+
 static LLVMValueRef
-build_alloca (EmitContext *ctx, MonoType *t)
+build_named_alloca (EmitContext *ctx, MonoType *t, char const *name)
 {
 	MonoClass *k = mono_class_from_mono_type_internal (t);
 	int align;
@@ -2610,7 +2611,13 @@ build_alloca (EmitContext *ctx, MonoType *t)
 	while (mono_is_power_of_two (align) == -1)
 		align ++;
 
-	return build_alloca_llvm_type (ctx, type_to_llvm_type (ctx, t), align);
+	return build_alloca_llvm_type_name (ctx, type_to_llvm_type (ctx, t), align, name);
+}
+
+static LLVMValueRef
+build_alloca (EmitContext *ctx, MonoType *t)
+{
+	return build_named_alloca (ctx, t, "");
 }
 
 static LLVMValueRef
@@ -3599,9 +3606,9 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 			/* Could be already created by an OP_VPHI */
 			if (!ctx->addresses [var->dreg]) {
 				if (var->flags & MONO_INST_LMF)
-					ctx->addresses [var->dreg] = build_alloca_llvm_type (ctx, LLVMArrayType (LLVMInt8Type (), MONO_ABI_SIZEOF (MonoLMF)), sizeof (target_mgreg_t));
+					ctx->addresses [var->dreg] = build_alloca_llvm_type_name (ctx, LLVMArrayType (LLVMInt8Type (), MONO_ABI_SIZEOF (MonoLMF)), sizeof (target_mgreg_t), "entry_lmf");
 				else
-					ctx->addresses [var->dreg] = build_alloca (ctx, var->inst_vtype);
+					ctx->addresses [var->dreg] = build_named_alloca (ctx, var->inst_vtype, "entry");
 				//LLVMSetValueName (ctx->addresses [var->dreg], g_strdup_printf ("vreg_loc_%d", var->dreg));
 			}
 			ctx->vreg_cli_types [var->dreg] = var->inst_vtype;
@@ -5201,10 +5208,12 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			case LLVMArgVtypeAsScalar: {
 				LLVMTypeRef ret_type = LLVMGetReturnType (LLVMGetElementType (LLVMTypeOf (method)));
 				LLVMValueRef retval;
-
-				g_assert (addresses [ins->sreg1]);
-
-				retval = LLVMBuildLoad (builder, LLVMBuildBitCast (builder, addresses [ins->sreg1], LLVMPointerType (ret_type, 0), ""), "");
+				if (MONO_CLASS_IS_SIMD (ctx->cfg, mono_class_from_mono_type_internal (sig->ret)))
+					retval = LLVMBuildBitCast (builder, values [ins->sreg1], ret_type, "setret_cvt_simd");
+				else {
+					g_assert (addresses [ins->sreg1]);
+					retval = LLVMBuildLoad (builder, LLVMBuildBitCast (builder, addresses [ins->sreg1], LLVMPointerType (ret_type, 0), ""), "");
+				}
 				LLVMBuildRet (builder, retval);
 				break;
 			}
@@ -6755,7 +6764,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			}
 
 			if (!addresses [ins->dreg])
-				addresses [ins->dreg] = build_alloca (ctx, m_class_get_byval_arg (klass));
+				addresses [ins->dreg] = build_named_alloca (ctx, m_class_get_byval_arg (klass), "vzero");
 			LLVMValueRef ptr = LLVMBuildBitCast (builder, addresses [ins->dreg], LLVMPointerType (LLVMInt8Type (), 0), "");
 			emit_memset (ctx, builder, ptr, const_int32 (mono_class_value_size (klass, NULL)), 0);
 			break;
@@ -6922,11 +6931,38 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			/* 
 			 * SIMD
 			 */
-#if defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_WASM)
+#if defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_WASM)
+		case OP_EXPAND_I1:
+		case OP_EXPAND_I2:
+		case OP_EXPAND_I4:
+		case OP_EXPAND_I8:
+		case OP_EXPAND_R4:
+		case OP_EXPAND_R8: {
+			LLVMTypeRef t;
+			LLVMValueRef mask [32], v;
+			int i;
+
+#ifdef ENABLE_NETCORE
+			t = simd_class_to_llvm_type (ctx, ins->klass);
+#else
+			t = simd_op_to_llvm_type (ins->opcode);
+#endif
+			for (i = 0; i < 32; ++i)
+				mask [i] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
+
+			v = convert (ctx, values [ins->sreg1], LLVMGetElementType (t));
+
+			values [ins->dreg] = LLVMBuildInsertElement (builder, LLVMConstNull (t), v, LLVMConstInt (LLVMInt32Type (), 0, FALSE), "");
+			values [ins->dreg] = LLVMBuildShuffleVector (builder, values [ins->dreg], LLVMGetUndef (t), LLVMConstVector (mask, LLVMGetVectorSize (t)), "");
+			break;
+		}
 		case OP_XZERO: {
 			values [ins->dreg] = LLVMConstNull (type_to_llvm_type (ctx, m_class_get_byval_arg (ins->klass)));
 			break;
 		}
+#endif // defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_WASM)
+
+#if defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_WASM)
 		case OP_LOADX_MEMBASE: {
 			LLVMTypeRef t = type_to_llvm_type (ctx, m_class_get_byval_arg (ins->klass));
 			LLVMValueRef src;
@@ -7174,31 +7210,6 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			values [ins->dreg] = LLVMBuildExtractElement (builder, lhs, LLVMConstInt (LLVMInt32Type (), ins->inst_c0, FALSE), "");
 			if (zext)
 				values [ins->dreg] = LLVMBuildZExt (builder, values [ins->dreg], LLVMInt32Type (), "");
-			break;
-		}
-
-		case OP_EXPAND_I1:
-		case OP_EXPAND_I2:
-		case OP_EXPAND_I4:
-		case OP_EXPAND_I8:
-		case OP_EXPAND_R4:
-		case OP_EXPAND_R8: {
-			LLVMTypeRef t;
-			LLVMValueRef mask [32], v;
-			int i;
-
-#ifdef ENABLE_NETCORE
-			t = simd_class_to_llvm_type (ctx, ins->klass);
-#else
-			t = simd_op_to_llvm_type (ins->opcode);
-#endif
-			for (i = 0; i < 32; ++i)
-				mask [i] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
-
-			v = convert (ctx, values [ins->sreg1], LLVMGetElementType (t));
-
-			values [ins->dreg] = LLVMBuildInsertElement (builder, LLVMConstNull (t), v, LLVMConstInt (LLVMInt32Type (), 0, FALSE), "");
-			values [ins->dreg] = LLVMBuildShuffleVector (builder, values [ins->dreg], LLVMGetUndef (t), LLVMConstVector (mask, LLVMGetVectorSize (t)), "");
 			break;
 		}
 

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -314,8 +314,9 @@ enum {
 #define MONO_IS_ZERO(ins) (((ins)->opcode == OP_VZERO) || ((ins)->opcode == OP_XZERO))
 
 #ifdef TARGET_ARM64
-// FIXME: enable for Arm64
-#define MONO_CLASS_IS_SIMD(cfg, klass) (0)
+// SIMD is only supported on arm64 when using the LLVM backend. When not using
+// the LLVM backend, treat SIMD datatypes as regular value types.
+#define MONO_CLASS_IS_SIMD(cfg, klass) ( ((cfg)->opt & MONO_OPT_SIMD) && ( COMPILE_LLVM (cfg) ) && m_class_is_simd_type (klass) )
 #else
 #define MONO_CLASS_IS_SIMD(cfg, klass) (((cfg)->opt & MONO_OPT_SIMD) && m_class_is_simd_type (klass))
 #endif

--- a/src/mono/mono/mini/simd-intrinsics-netcore.c
+++ b/src/mono/mono/mini/simd-intrinsics-netcore.c
@@ -267,7 +267,33 @@ get_vector_t_elem_type (MonoType *vector_type)
 	return etype;
 }
 
-#ifdef TARGET_AMD64
+static MonoInst *
+emit_arch_vector128_create_multi (MonoCompile *cfg, MonoMethodSignature *fsig, MonoType *etype, MonoInst **args)
+{
+#if defined(TARGET_AMD64)
+	MonoInst *ins, *load;
+
+	// FIXME: Optimize this
+	MONO_INST_NEW (cfg, ins, OP_LOCALLOC_IMM);
+	ins->dreg = alloc_preg (cfg);
+	ins->inst_imm = 16;
+	MONO_ADD_INS (cfg->cbb, ins);
+
+	int esize = mono_class_value_size (mono_class_from_mono_type_internal (etype), NULL);
+	int store_opcode = mono_type_to_store_membase (cfg, etype);
+	for (int i = 0; i < fsig->param_count; ++i)
+		MONO_EMIT_NEW_STORE_MEMBASE (cfg, store_opcode, ins->dreg, i * esize, args [i]->dreg);
+
+	load = emit_simd_ins (cfg, klass, OP_SSE_LOADU, ins->dreg, -1);
+	load->inst_c0 = 16;
+	load->inst_c1 = get_underlying_type (etype);
+	return load;
+#else
+	return NULL;
+#endif
+}
+
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
 
 static int
 type_to_expand_op (MonoType *type)
@@ -293,6 +319,72 @@ type_to_expand_op (MonoType *type)
 		g_assert_not_reached ();
 	}
 }
+
+static guint16 vector_128_methods [] = {
+	SN_AsByte,
+	SN_AsDouble,
+	SN_AsInt16,
+	SN_AsInt32,
+	SN_AsInt64,
+	SN_AsSByte,
+	SN_AsSingle,
+	SN_AsUInt16,
+	SN_AsUInt32,
+	SN_AsUInt64,
+	SN_Create,
+	SN_CreateScalarUnsafe,
+};
+
+static MonoInst*
+emit_vector128 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
+{
+	MonoClass *klass;
+	int id;
+
+	if (!COMPILE_LLVM (cfg))
+		return NULL;
+
+	klass = cmethod->klass;
+	id = lookup_intrins (vector_128_methods, sizeof (vector_128_methods), cmethod);
+	if (id == -1)
+		return NULL;
+
+	if (!strcmp (m_class_get_name (cfg->method->klass), "Vector256"))
+		return NULL; // TODO: Fix Vector256.WithUpper/WithLower
+
+	MonoTypeEnum arg0_type = fsig->param_count > 0 ? get_underlying_type (fsig->params [0]) : MONO_TYPE_VOID;
+
+	switch (id) {
+	case SN_AsByte:
+	case SN_AsDouble:
+	case SN_AsInt16:
+	case SN_AsInt32:
+	case SN_AsInt64:
+	case SN_AsSByte:
+	case SN_AsSingle:
+	case SN_AsUInt16:
+	case SN_AsUInt32:
+	case SN_AsUInt64:
+		return emit_simd_ins (cfg, klass, OP_XCAST, args [0]->dreg, -1);
+	case SN_Create: {
+		MonoType *etype = get_vector_t_elem_type (fsig->ret);
+		if (fsig->param_count == 1 && mono_metadata_type_equal (fsig->params [0], etype))
+			return emit_simd_ins (cfg, klass, type_to_expand_op (etype), args [0]->dreg, -1);
+		else
+			return emit_arch_vector128_create_multi (cfg, fsig, etype, args);
+	}
+	case SN_CreateScalarUnsafe:
+		return emit_simd_ins_for_sig (cfg, klass, OP_CREATE_SCALAR_UNSAFE, -1, arg0_type, fsig, args);
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+#endif // defined(TARGET_AMD64) || defined(TARGET_ARM64)
+
+#ifdef TARGET_AMD64
 
 static guint16 vector_methods [] = {
 	SN_ConvertToDouble,
@@ -702,7 +794,7 @@ emit_sys_numerics_vector_t (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSig
 
 	return NULL;
 }
-#endif // !TARGET_ARM64
+#endif // TARGET_AMD64
 
 static MonoInst*
 emit_invalid_operation (MonoCompile *cfg, const char* message)
@@ -713,6 +805,7 @@ emit_invalid_operation (MonoCompile *cfg, const char* message)
 }
 
 #ifdef TARGET_ARM64
+
 
 static SimdIntrinsic armbase_methods [] = {
 	{SN_LeadingSignCount},
@@ -1845,89 +1938,10 @@ emit_x86_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature 
 	return NULL;
 }
 
-static guint16 vector_128_methods [] = {
-	SN_AsByte,
-	SN_AsDouble,
-	SN_AsInt16,
-	SN_AsInt32,
-	SN_AsInt64,
-	SN_AsSByte,
-	SN_AsSingle,
-	SN_AsUInt16,
-	SN_AsUInt32,
-	SN_AsUInt64,
-	SN_Create,
-	SN_CreateScalarUnsafe,
-};
-
 static guint16 vector_128_t_methods [] = {
 	SN_get_Count,
 	SN_get_Zero,
 };
-
-static MonoInst*
-emit_vector128 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
-{
-	MonoClass *klass;
-	int id;
-
-	if (!COMPILE_LLVM (cfg))
-		return NULL;
-
-	klass = cmethod->klass;
-	id = lookup_intrins (vector_128_methods, sizeof (vector_128_methods), cmethod);
-	if (id == -1)
-		return NULL;
-
-	if (!strcmp (m_class_get_name (cfg->method->klass), "Vector256"))
-		return NULL; // TODO: Fix Vector256.WithUpper/WithLower
-
-	MonoTypeEnum arg0_type = fsig->param_count > 0 ? get_underlying_type (fsig->params [0]) : MONO_TYPE_VOID;
-
-	switch (id) {
-	case SN_AsByte:
-	case SN_AsDouble:
-	case SN_AsInt16:
-	case SN_AsInt32:
-	case SN_AsInt64:
-	case SN_AsSByte:
-	case SN_AsSingle:
-	case SN_AsUInt16:
-	case SN_AsUInt32:
-	case SN_AsUInt64:
-		return emit_simd_ins (cfg, klass, OP_XCAST, args [0]->dreg, -1);
-	case SN_Create: {
-		MonoType *etype = get_vector_t_elem_type (fsig->ret);
-		if (fsig->param_count == 1 && mono_metadata_type_equal (fsig->params [0], etype)) {
-			return emit_simd_ins (cfg, klass, type_to_expand_op (etype), args [0]->dreg, -1);
-		} else {
-			MonoInst *ins, *load;
-
-			// FIXME: Optimize this
-			MONO_INST_NEW (cfg, ins, OP_LOCALLOC_IMM);
-			ins->dreg = alloc_preg (cfg);
-			ins->inst_imm = 16;
-			MONO_ADD_INS (cfg->cbb, ins);
-
-			int esize = mono_class_value_size (mono_class_from_mono_type_internal (etype), NULL);
-			int store_opcode = mono_type_to_store_membase (cfg, etype);
-			for (int i = 0; i < fsig->param_count; ++i)
-				MONO_EMIT_NEW_STORE_MEMBASE (cfg, store_opcode, ins->dreg, i * esize, args [i]->dreg);
-
-			load = emit_simd_ins (cfg, klass, OP_SSE_LOADU, ins->dreg, -1);
-			load->inst_c0 = 16;
-			load->inst_c1 = get_underlying_type (etype);
-			return load;
-		}
-	}
-	case SN_CreateScalarUnsafe:
-		return emit_simd_ins_for_sig (cfg, klass, OP_CREATE_SCALAR_UNSAFE, -1, arg0_type, fsig, args);
-	default:
-		break;
-	}
-
-	return NULL;
-}
 
 static MonoInst*
 emit_vector128_t (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
@@ -2029,8 +2043,6 @@ emit_amd64_intrinsics (const char *class_ns, const char *class_name, MonoCompile
 	if (!strcmp (class_ns, "System.Runtime.Intrinsics")) {
 		if (!strcmp (class_name, "Vector128`1"))
 			return emit_vector128_t (cfg, cmethod, fsig, args);
-		if (!strcmp (class_name, "Vector128"))
-			return emit_vector128 (cfg, cmethod, fsig, args);
 		if (!strcmp (class_name, "Vector256`1"))
 			return emit_vector256_t (cfg, cmethod, fsig, args);
 	}
@@ -2096,6 +2108,13 @@ mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	// If cmethod->klass is nested, the namespace is on the enclosing class.
 	if (m_class_get_nested_in (cmethod->klass))
 		class_ns = m_class_get_name_space (m_class_get_nested_in (cmethod->klass));
+
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+	if (!strcmp (class_ns, "System.Runtime.Intrinsics")) {
+		if (!strcmp (class_name, "Vector128"))
+			return emit_vector128 (cfg, cmethod, fsig, args);
+	}
+#endif // defined(TARGET_AMD64) || defined(TARGET_ARM64)
 
 	return emit_simd_intrinsics (class_ns, class_name, cfg, cmethod, fsig, args);
 }

--- a/src/mono/mono/mini/simd-intrinsics-netcore.c
+++ b/src/mono/mono/mini/simd-intrinsics-netcore.c
@@ -268,7 +268,7 @@ get_vector_t_elem_type (MonoType *vector_type)
 }
 
 static MonoInst *
-emit_arch_vector128_create_multi (MonoCompile *cfg, MonoMethodSignature *fsig, MonoType *etype, MonoInst **args)
+emit_arch_vector128_create_multi (MonoCompile *cfg, MonoMethodSignature *fsig, MonoClass *klass, MonoType *etype, MonoInst **args)
 {
 #if defined(TARGET_AMD64)
 	MonoInst *ins, *load;
@@ -338,14 +338,11 @@ static guint16 vector_128_methods [] = {
 static MonoInst*
 emit_vector128 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
 {
-	MonoClass *klass;
-	int id;
-
 	if (!COMPILE_LLVM (cfg))
 		return NULL;
 
-	klass = cmethod->klass;
-	id = lookup_intrins (vector_128_methods, sizeof (vector_128_methods), cmethod);
+	MonoClass *klass = cmethod->klass;
+	int id = lookup_intrins (vector_128_methods, sizeof (vector_128_methods), cmethod);
 	if (id == -1)
 		return NULL;
 
@@ -371,7 +368,7 @@ emit_vector128 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig
 		if (fsig->param_count == 1 && mono_metadata_type_equal (fsig->params [0], etype))
 			return emit_simd_ins (cfg, klass, type_to_expand_op (etype), args [0]->dreg, -1);
 		else
-			return emit_arch_vector128_create_multi (cfg, fsig, etype, args);
+			return emit_arch_vector128_create_multi (cfg, fsig, klass, etype, args);
 	}
 	case SN_CreateScalarUnsafe:
 		return emit_simd_ins_for_sig (cfg, klass, OP_CREATE_SCALAR_UNSAFE, -1, arg0_type, fsig, args);


### PR DESCRIPTION
This change:

- Unpacks SIMD parameters passed via multiple GPRs (`LLVMArgVtypeAsIArgs`) into
local LLVM SSA vector-typed values on function entry. The calling convention we
use on arm and arm64 has "large" value types passed in multiple GPRs when
possible, and the way this is currently encoded in the LLVM IR we emit is by
using parameters with the LLVM type `[Size x {i32 or i64}]`, where the
resulting size of this type, in bytes, is at least as large as the size of the
value type encoded within.

- Packs SIMD return values into multiple GPRs (`LLVMArgVtypeAsScalar`); the way
this is currently encoded in the LLVM IR we emit for arm64 (but not arm) is by
using a "wide" LLVM integer type (e.g. `i128`).

- Makes `OP_LDADDR` aware of our special-case handling of SIMD value types:
SIMD value types passed via an indirection (`LLVMArgVtypeAddr` or
`LLVMArgVtypeByRef`) are loaded from memory to an LLVM SSA value in the initial
basic block, but `OP_LDADDR` had previously assumed that any value type passed
via an indirection had an associated LLVM SSA value containing an indirection
rather than the actual value.

- Adds a debugging utility function (`mono_llvm_dump_type`).

- Gives greppable names to some allocas.

- Makes some formerly amd64-specific SIMD-related opcodes also work on arm64.

This code is all a bit messy (especially the parts surrounding parameter
passing); this change does not clean any of this up.