### PR TITLE
NameResolution-Tests: enable GetHostEntryAsync_InvalidHost_LogsError on Windows

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -78,8 +78,7 @@ namespace System.Net.NameResolution.Tests
                     }
                     catch (SocketException e) when (e.SocketErrorCode == SocketError.HostNotFound)
                     {
-                        // Wait a bit to let the event source write it's log
-                        await Task.Delay(100).ConfigureAwait(false);
+                        await WaitForErrorEventAsync(events);
                     }
                     catch (Exception e)
                     {
@@ -94,6 +93,20 @@ namespace System.Net.NameResolution.Tests
                     Assert.NotNull(ev.Payload[0]);
                     Assert.NotNull(ev.Payload[1]);
                     Assert.NotNull(ev.Payload[2]);
+                }
+            }
+
+            static async Task WaitForErrorEventAsync(ConcurrentQueue<EventWrittenEventArgs> events)
+            {
+                const int ErrorEventId = 5;
+                DateTime startTime = DateTime.UtcNow;
+
+                while (!events.Any(e => e.EventId == ErrorEventId))
+                {
+                    if (DateTime.UtcNow.Subtract(startTime) > TimeSpan.FromSeconds(30))
+                        throw new TimeoutException("Timeout waiting for error event");
+
+                    await Task.Delay(100);
                 }
             }
         }

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -63,7 +63,6 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
-        [PlatformSpecific(~TestPlatforms.Windows)]  // Unreliable on Windows.
         public async Task GetHostEntryAsync_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Error))


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/34633#issuecomment-746681771 a product bug in regards of logging was found.
This didn't show up in tests, as it was disabled for Windows https://github.com/dotnet/runtime/blob/911b1d395ef4e59c63048003d676e295414c8d15/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs#L66 and prior #34633 Unix was async-over-sync, so didn't touch this test in the same way is it does now.

On local testing I couldn't spot any unrealiable behavior, per https://github.com/dotnet/runtime/pull/34633#discussion_r544521828 we should give this a try to see what happens.

---

Edit: Fixes https://github.com/dotnet/runtime/issues/47104
