### PR TITLE
mark FileStream.Lock and Unlock as unsupported on macOS

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -394,12 +394,16 @@ namespace Microsoft.VisualBasic
         public static void Input(int FileNumber, ref object Value) { }
         public static void Input(int FileNumber, ref float Value) { }
         public static void Input(int FileNumber, ref string Value) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public static string InputString(int FileNumber, int CharCount) { throw null; }
         public static void Kill(string PathName) { }
         public static string LineInput(int FileNumber) { throw null; }
         public static long Loc(int FileNumber) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public static void Lock(int FileNumber) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public static void Lock(int FileNumber, long Record) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public static void Lock(int FileNumber, long FromRecord, long ToRecord) { }
         public static long LOF(int FileNumber) { throw null; }
         public static void MkDir(string Path) { }
@@ -415,8 +419,11 @@ namespace Microsoft.VisualBasic
         public static Microsoft.VisualBasic.SpcInfo SPC(short Count) { throw null; }
         public static Microsoft.VisualBasic.TabInfo TAB() { throw null; }
         public static Microsoft.VisualBasic.TabInfo TAB(short Column) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public static void Unlock(int FileNumber) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public static void Unlock(int FileNumber, long Record) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public static void Unlock(int FileNumber, long FromRecord, long ToRecord) { }
         public static void Write(int FileNumber, params object[] Output) { }
         public static void WriteLine(int FileNumber, params object[] Output) { }

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6BinaryFile.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6BinaryFile.vb
@@ -4,6 +4,7 @@
 Imports System
 Imports Microsoft.VisualBasic.CompilerServices.ExceptionUtils
 Imports Microsoft.VisualBasic.CompilerServices.Utils
+Imports System.Runtime.Versioning
 
 Namespace Microsoft.VisualBasic.CompilerServices
 
@@ -24,6 +25,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Sub
 
         ' the implementation of Lock in base class VB6RandomFile does not handle m_lRecordLen=-1
+        <UnsupportedOSPlatform("macos")> 
         Friend Overloads Overrides Sub Lock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))
@@ -47,6 +49,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Sub
 
         ' see Lock description
+        <UnsupportedOSPlatform("macos")> 
         Friend Overloads Overrides Sub Unlock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6File.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6File.vb
@@ -7,6 +7,7 @@ Imports System.Security
 Imports System.Globalization
 Imports System.IO
 Imports System.Text
+Imports System.Runtime.Versioning
 
 Imports Microsoft.VisualBasic.CompilerServices.StructUtils
 Imports Microsoft.VisualBasic.CompilerServices.ExceptionUtils
@@ -595,15 +596,18 @@ Namespace Microsoft.VisualBasic.CompilerServices
             Return m_position
         End Function
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overridable Overloads Sub Lock()
             'Lock the whole file, not just the current size of file, since file could change.
             m_file.Lock(0, Int32.MaxValue)
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overridable Overloads Sub Unlock()
             m_file.Unlock(0, Int32.MaxValue)
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overridable Overloads Sub Lock(ByVal Record As Long)
             If m_lRecordLen = -1 Then
                 m_file.Lock((Record - 1), 1)
@@ -612,6 +616,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             End If
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overridable Overloads Sub Unlock(ByVal Record As Long)
             If m_lRecordLen = -1 Then
                 m_file.Unlock((Record - 1), 1)
@@ -620,6 +625,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             End If
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overridable Overloads Sub Lock(ByVal RecordStart As Long, ByVal RecordEnd As Long)
             If m_lRecordLen = -1 Then
                 m_file.Lock((RecordStart - 1), (RecordEnd - RecordStart) + 1)
@@ -628,6 +634,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             End If
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overridable Overloads Sub Unlock(ByVal RecordStart As Long, ByVal RecordEnd As Long)
             If m_lRecordLen = -1 Then
                 m_file.Unlock((RecordStart - 1), (RecordEnd - RecordStart) + 1)

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6RandomFile.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/VB6RandomFile.vb
@@ -3,6 +3,7 @@
 
 Imports System
 Imports System.IO
+Imports System.Runtime.Versioning
 
 Imports Microsoft.VisualBasic.CompilerServices.ExceptionUtils
 Imports Microsoft.VisualBasic.CompilerServices.Utils
@@ -120,6 +121,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             CloseTheFile()
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overloads Overrides Sub Lock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))
@@ -134,6 +136,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
             m_file.Lock(lStartByte, lLength)
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Friend Overloads Overrides Sub Unlock(ByVal lStart As Long, ByVal lEnd As Long)
             If lStart > lEnd Then
                 Throw New ArgumentException(SR.Format(SR.Argument_InvalidValue1, "Start"))

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
@@ -1000,6 +1000,7 @@ Namespace Microsoft.VisualBasic
             End Try
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Public Function InputString(ByVal FileNumber As Integer, ByVal CharCount As Integer) As String
             Try
                 Dim oFile As VB6File
@@ -1037,31 +1038,37 @@ Namespace Microsoft.VisualBasic
             Return oFile.LineInput()
         End Function
 
+        <UnsupportedOSPlatform("macos")> 
         Public Sub Lock(ByVal FileNumber As Integer)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Lock()
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Public Sub Lock(ByVal FileNumber As Integer, ByVal Record As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Lock(Record)
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Public Sub Lock(ByVal FileNumber As Integer, ByVal FromRecord As Long, ByVal ToRecord As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Lock(FromRecord, ToRecord)
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Public Sub Unlock(ByVal FileNumber As Integer)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Unlock()
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Public Sub Unlock(ByVal FileNumber As Integer, ByVal Record As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Unlock(Record)
         End Sub
 
+        <UnsupportedOSPlatform("macos")> 
         Public Sub Unlock(ByVal FileNumber As Integer, ByVal FromRecord As Long, ByVal ToRecord As Long)
             Dim assem As System.Reflection.Assembly = System.Reflection.Assembly.GetCallingAssembly()
             GetStream(assem, FileNumber).Unlock(FromRecord, ToRecord)

--- a/src/libraries/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.cs
+++ b/src/libraries/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.cs
@@ -119,6 +119,7 @@ namespace System.IO.IsolatedStorage
         public override void Flush() { }
         public override void Flush(bool flushToDisk) { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public override void Lock(long position, long length) { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
@@ -127,6 +128,7 @@ namespace System.IO.IsolatedStorage
         public override int ReadByte() { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public override void Unlock(long position, long length) { }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
@@ -4,6 +4,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 
 namespace System.IO.IsolatedStorage
 {
@@ -327,11 +328,13 @@ namespace System.IO.IsolatedStorage
             get { return _fs.Handle; }
         }
 
+        [UnsupportedOSPlatform("macos")]
         public override void Unlock(long position, long length)
         {
             _fs.Unlock(position, length);
         }
 
+        [UnsupportedOSPlatform("macos")]
         public override void Lock(long position, long length)
         {
             _fs.Lock(position, length);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
@@ -256,6 +257,7 @@ namespace System.IO
         [Obsolete("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
         public virtual IntPtr Handle => SafeFileHandle.DangerousGetHandle();
 
+        [UnsupportedOSPlatform("macos")]
         public virtual void Lock(long position, long length)
         {
             if (position < 0 || length < 0)
@@ -271,6 +273,7 @@ namespace System.IO
             LockInternal(position, length);
         }
 
+        [UnsupportedOSPlatform("macos")]
         public virtual void Unlock(long position, long length)
         {
             if (position < 0 || length < 0)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7139,6 +7139,7 @@ namespace System.IO
         public override void Flush() { }
         public virtual void Flush(bool flushToDisk) { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public virtual void Lock(long position, long length) { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
         public override int Read(System.Span<byte> buffer) { throw null; }
@@ -7147,6 +7148,7 @@ namespace System.IO
         public override int ReadByte() { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
         public virtual void Unlock(long position, long length) { }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }


### PR DESCRIPTION
the both [call](https://github.com/dotnet/runtime/blob/911b1d395ef4e59c63048003d676e295414c8d15/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs#L259-L287) methods that throw on macOS:

https://github.com/dotnet/runtime/blob/911b1d395ef4e59c63048003d676e295414c8d15/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Lock.OSX.cs#L8-L16