### PR TITLE
Fix covariant returns issue with partially canonical instantiation

### DIFF
--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -1170,7 +1170,7 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
                 continue;
 
             Instantiation parentClassInst = pParentMD->GetClassInstantiation();
-            if (ClassLoader::IsTypicalSharedInstantiation(parentClassInst))
+            if (ClassLoader::IsCanonicalGenericInstantiation(parentClassInst))
             {
                 parentClassInst = pParentMT->GetInstantiation();
             }
@@ -1179,7 +1179,7 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
             TypeHandle hType1 = methodSig1.GetReturnProps().GetTypeHandleThrowing(pParentMD->GetModule(), &context1, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
 
             Instantiation classInst = pMD->GetClassInstantiation();
-            if (ClassLoader::IsTypicalSharedInstantiation(classInst))
+            if (ClassLoader::IsCanonicalGenericInstantiation(classInst))
             {
                 classInst = pMT->GetInstantiation();
             }

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -1169,21 +1169,11 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
             if (!pMD->RequiresCovariantReturnTypeChecking() && !pParentMD->RequiresCovariantReturnTypeChecking())
                 continue;
 
-            Instantiation parentClassInst = pParentMD->GetClassInstantiation();
-            if (ClassLoader::IsCanonicalGenericInstantiation(parentClassInst))
-            {
-                parentClassInst = pParentMT->GetInstantiation();
-            }
-            SigTypeContext context1(parentClassInst, pMD->GetMethodInstantiation());
+            SigTypeContext context1(pParentMT->GetInstantiation(), pMD->GetMethodInstantiation());
             MetaSig methodSig1(pParentMD);
             TypeHandle hType1 = methodSig1.GetReturnProps().GetTypeHandleThrowing(pParentMD->GetModule(), &context1, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
 
-            Instantiation classInst = pMD->GetClassInstantiation();
-            if (ClassLoader::IsCanonicalGenericInstantiation(classInst))
-            {
-                classInst = pMT->GetInstantiation();
-            }
-            SigTypeContext context2(classInst, pMD->GetMethodInstantiation());
+            SigTypeContext context2(pMT->GetInstantiation(), pMD->GetMethodInstantiation());
             MetaSig methodSig2(pMD);
             TypeHandle hType2 = methodSig2.GetReturnProps().GetTypeHandleThrowing(pMD->GetModule(), &context2, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
 

--- a/src/tests/Regressions/coreclr/GitHub_43763/test43763.cs
+++ b/src/tests/Regressions/coreclr/GitHub_43763/test43763.cs
@@ -1,4 +1,7 @@
-﻿class Program
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+class Program
 {
     static int Main(string[] args)
     {

--- a/src/tests/Regressions/coreclr/GitHub_45037/test45037.cs
+++ b/src/tests/Regressions/coreclr/GitHub_45037/test45037.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/tests/Regressions/coreclr/GitHub_45082/test45082.cs
+++ b/src/tests/Regressions/coreclr/GitHub_45082/test45082.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/tests/Regressions/coreclr/GitHub_47007/test47007.cs
+++ b/src/tests/Regressions/coreclr/GitHub_47007/test47007.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+class Base<T1>
+{
+    public virtual Base<T1> Method() => null;
+}
+class Derived<T1, T2> : Base<T1>
+{
+    public override Derived<T1, T2> Method() => null;
+}
+
+class Program
+{
+    static int Main()
+    {
+        _ = new Derived<string, int>();
+
+        return 100;
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_47007/test47007.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_47007/test47007.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test47007.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The ClassLoader::ValidateMethodsWithCovariantReturnTypes was properly
handling canonical instantiations only when all the type parameters were
canonical. But when only some of them were cannonical, it was not
getting the non-canonical version of the instantiation and the
validation was failing.

This change fixes it by using ClassLoader::IsCanonicalGenericInstantiation
instead of the IsTypicalSharedInstantiation.

I've also added a regression test for the problem and added couple of
missing licence headers to regression tests I have recently created.

Close #47007 