### PR TITLE
Reduce CG2 R2R image sizes

### DIFF
--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
@@ -264,6 +264,12 @@ namespace Internal.NativeFormat
             return val._offset;
         }
 
+        public void SetCurrentOffset(Vertex val)
+        {
+            val._iteration = _iteration;
+            val._offset = GetCurrentOffset();
+        }
+
         public int GetCurrentOffset()
         {
             return _encoder.Size;
@@ -1587,7 +1593,7 @@ namespace Internal.NativeFormat
         {
             if (_fixups != null)
             {
-                int existingOffset = _fixups._offset;
+                int existingOffset = writer.GetCurrentOffset(_fixups);
                 if (existingOffset != -1)
                 {
                     writer.WriteUnsigned((_methodIndex << 2) | 3);
@@ -1596,6 +1602,7 @@ namespace Internal.NativeFormat
                 else
                 {
                     writer.WriteUnsigned((_methodIndex << 2) | 1);
+                    writer.SetCurrentOffset(_fixups);
                     _fixups.Save(writer);
                 }
             }
@@ -1653,8 +1660,7 @@ namespace Internal.NativeFormat
             else
             {
                 writer.WriteUnsigned(0);
-                _debugInfo._iteration = writer.GetNumberOfIterations();
-                _debugInfo._offset = writer.GetCurrentOffset();
+                writer.SetCurrentOffset(_debugInfo);
                 _debugInfo.Save(writer);
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -71,7 +71,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (!uniqueSignatures.TryGetValue(signature, out signatureBlob))
                 {
                     signatureBlob = new BlobVertex(signature);
-                    hashtableSection.Place(signatureBlob);
                     uniqueSignatures.Add(signature, signatureBlob);
                 }
 
@@ -80,7 +79,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (fixup != null && !uniqueFixups.TryGetValue(fixup, out fixupBlob))
                 {
                     fixupBlob = new BlobVertex(fixup);
-                    hashtableSection.Place(fixupBlob);
                     uniqueFixups.Add(fixup, fixupBlob);
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -83,8 +83,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             VertexArray vertexArray = new VertexArray(arraySection);
             arraySection.Place(vertexArray);
 
-            Section fixupSection = writer.NewSection();
-
             Dictionary<byte[], BlobVertex> uniqueFixups = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
 
             for (int rid = 0; rid < ridToEntryPoint.Count; rid++)
@@ -98,7 +96,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     if (fixups != null && !uniqueFixups.TryGetValue(fixups, out fixupBlobVertex))
                     {
                         fixupBlobVertex = new BlobVertex(fixups);
-                        fixupSection.Place(fixupBlobVertex);
                         uniqueFixups.Add(fixups, fixupBlobVertex);
                     }
                     EntryPointVertex entryPointVertex = new EntryPointVertex((uint)entryPoint.MethodIndex, fixupBlobVertex);

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -19,10 +19,11 @@ namespace ILCompiler.Reflection.ReadyToRun
     public abstract class ReadyToRunSignature
     {
         private SignatureDecoder _decoder;
-
-        public ReadyToRunSignature(SignatureDecoder decoder)
+        public ReadyToRunFixupKind FixupKind {get;private set;}
+        public ReadyToRunSignature(SignatureDecoder decoder, ReadyToRunFixupKind fixupKind)
         {
             _decoder = decoder;
+            FixupKind = fixupKind;
         }
 
         public string ToString(SignatureFormattingOptions options)
@@ -40,7 +41,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// </summary>
     public class TodoSignature : ReadyToRunSignature
     {
-        public TodoSignature(SignatureDecoder decoder) : base(decoder)
+        public TodoSignature(SignatureDecoder decoder, ReadyToRunFixupKind fixupKind) : base(decoder, fixupKind)
         {
         }
     }
@@ -49,7 +50,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     {
         public uint MethodDefToken { get; set; }
 
-        public MethodDefEntrySignature(SignatureDecoder decoder) : base(decoder)
+        public MethodDefEntrySignature(SignatureDecoder decoder) : base(decoder, ReadyToRunFixupKind.MethodEntry_DefToken)
         {
         }
     }
@@ -58,7 +59,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     {
         public uint MethodRefToken { get; set; }
 
-        public MethodRefEntrySignature(SignatureDecoder decoder) : base(decoder)
+        public MethodRefEntrySignature(SignatureDecoder decoder) : base(decoder, ReadyToRunFixupKind.MethodEntry_RefToken)
         {
         }
     }
@@ -1135,7 +1136,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="builder">Output signature builder</param>
         private ReadyToRunSignature ParseSignature(ReadyToRunFixupKind fixupType, StringBuilder builder)
         {
-            ReadyToRunSignature result = new TodoSignature(this);
+            ReadyToRunSignature result = new TodoSignature(this, fixupType);
             switch (fixupType)
             {
                 case ReadyToRunFixupKind.ThisObjDictionaryLookup:

--- a/src/coreclr/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/tools/r2rdump/R2RDump.cs
@@ -206,6 +206,7 @@ namespace R2RDump
         abstract internal void DumpBytes(int rva, uint size, string name = "Raw", bool convertToOffset = true);
         abstract internal void DumpSectionContents(ReadyToRunSection section);
         abstract internal void DumpQueryCount(string q, string title, int count);
+        abstract internal void DumpFixupStats();
 
         public TextWriter Writer => _writer;
 
@@ -415,6 +416,7 @@ namespace R2RDump
                 if (standardDump)
                 {
                     _dumper.DumpAllMethods();
+                    _dumper.DumpFixupStats();
                 }
             }
 

--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -11,6 +11,7 @@ using System.Reflection.PortableExecutable;
 using System.Text;
 
 using ILCompiler.Reflection.ReadyToRun;
+using Internal.ReadyToRunConstants;
 using Internal.Runtime;
 
 namespace R2RDump
@@ -476,6 +477,29 @@ namespace R2RDump
         internal override void DumpQueryCount(string q, string title, int count)
         {
             _writer.WriteLine(count + " result(s) for \"" + q + "\"");
+            SkipLine();
+        }
+
+        internal override void DumpFixupStats()
+        {
+            WriteDivider("Eager fixup counts across all methods");
+            
+            // Group all fixups across methods by fixup kind, and sum each category
+            var sortedFixupCounts = _r2r.Methods.Where(m => m.Fixups != null)
+                .SelectMany(m => m.Fixups)
+                .GroupBy(f => f.Signature.FixupKind)
+                .Select(group => new {
+                    FixupKind = group.Key,
+                    Count = group.Count()
+                }).OrderByDescending(x => x.Count);
+
+            Console.WriteLine($"                      Fixup | Count");
+            foreach (var fixupAndCount in sortedFixupCounts)
+            {
+                Console.WriteLine($"{fixupAndCount.FixupKind, 27} | {fixupAndCount.Count, 5}");
+            }
+            Console.WriteLine("-----------------------------------");
+            Console.WriteLine($"                      Total | {sortedFixupCounts.Sum(x => x.Count), 5}");
             SkipLine();
         }
     }


### PR DESCRIPTION
* Fix production of `MethodDefEntrypoint` table so fixup lists are closer to the array entries that reference them. This reduces the encoded sizes of the offsets to the fixup lists and reduces S.P.C size by 1.3% (124kB).
* Add fixup count summary table to R2RDump for analysis of fixup trends in the image.
* For example these are all the eager fixups in S.P.C compiled with CG2

Fixup | CG1 | CG2
--- | --- | ---
TypeHandle | 25681 | 22716
StringHandle | 4602 | 9487
Check_InstructionSetSupport | 0 | 1717
IndirectPInvokeTarget | 226 | 577
MethodDictionary | 224 | 205
TypeDictionary | 101 | 101
PInvokeTarget | 16 | 24
MethodEntry_DefToken | 0 | 9
FieldHandle | 4 | 4
MethodHandle | 4 | 0
Total | 30876 | 34840