### PR TITLE
Pgo phase2

### DIFF
--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -279,6 +279,8 @@ public:
 
     enum class PgoInstrumentationKind
     {
+        // This must be kept in sync with PgoInstrumentationKind in PgoFormat.cs
+
         // Schema data types
         None = 0,
         FourByte = 1,
@@ -299,11 +301,11 @@ public:
         DescriptorMin = 0x40,
 
         Done = None, // All instrumentation schemas must end with a record which is "Done"
-        BasicBlockIntCount = DescriptorMin | FourByte, // 4 byte basic block counter, using unsigned 4 byte int
-        TypeHandleHistogramCount = (DescriptorMin * 1) | FourByte | AlignPointer, // 4 byte counter that is part of a type histogram
-        TypeHandleHistogramTypeHandle = (DescriptorMin * 1) | TypeHandle, // TypeHandle that is part of a type histogram
-        Version = (DescriptorMin * 2) | None, // Version is encoded in the Other field of the schema
-        NumRuns = (DescriptorMin * 3) | None, // Number of runs is encoded in the Other field of the schema
+        BasicBlockIntCount = (DescriptorMin * 1) | FourByte, // 4 byte basic block counter, using unsigned 4 byte int
+        TypeHandleHistogramCount = (DescriptorMin * 2) | FourByte | AlignPointer, // 4 byte counter that is part of a type histogram
+        TypeHandleHistogramTypeHandle = (DescriptorMin * 3) | TypeHandle, // TypeHandle that is part of a type histogram
+        Version = (DescriptorMin * 4) | None, // Version is encoded in the Other field of the schema
+        NumRuns = (DescriptorMin * 5) | None, // Number of runs is encoded in the Other field of the schema
     };
 
     struct PgoInstrumentationSchema

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -295,7 +295,7 @@ public:
         Align8Byte = 0x20,
         AlignPointer = 0x30,
 
-        // Mask of all schema data types
+        // Mask of all schema alignment types
         AlignMask = 0x30,
 
         DescriptorMin = 0x40,

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -929,7 +929,7 @@ namespace ETW
         static VOID MethodRestored(MethodDesc * pMethodDesc);
         static VOID MethodTableRestored(MethodTable * pMethodTable);
         static VOID DynamicMethodDestroyed(MethodDesc *pMethodDesc);
-        static VOID LogMethodInstrumentationData(MethodDesc* method, uint32_t cbData, BYTE *data);
+        static VOID LogMethodInstrumentationData(MethodDesc* method, uint32_t cbData, BYTE *data, TypeHandle* pTypeHandles, uint32_t typeHandles);
 #else // FEATURE_EVENT_TRACE
     public:
         static VOID GetR2RGetEntryPointStart(MethodDesc *pMethodDesc) {};
@@ -941,7 +941,7 @@ namespace ETW
         static VOID MethodRestored(MethodDesc * pMethodDesc) {};
         static VOID MethodTableRestored(MethodTable * pMethodTable) {};
         static VOID DynamicMethodDestroyed(MethodDesc *pMethodDesc) {};
-        static VOID LogMethodInstrumentationData(MethodDesc* method, uint32_t cbData, BYTE *data) {};
+        static VOID LogMethodInstrumentationData(MethodDesc* method, uint32_t cbData, BYTE *data, TypeHandle* pTypeHandles, uint32_t typeHandles) {};
 #endif // FEATURE_EVENT_TRACE
     };
 

--- a/src/coreclr/inc/pgo_formatprocessing.h
+++ b/src/coreclr/inc/pgo_formatprocessing.h
@@ -122,6 +122,8 @@ bool ReadCompressedInts(const uint8_t *pByte, size_t cbDataMax, IntHandler intPr
             if (cbDataMax < 9)
                 return false;
             signedInt = (int64_t)((((int64_t)*(pByte + 1)) << 56 | ((int64_t)*(pByte+2)) << 48 | ((int64_t)*(pByte+3)) << 40 | ((int64_t)*(pByte+4)) << 32) | ((int64_t)*(pByte + 5)) << 24 | ((int64_t)*(pByte+6)) << 16 | ((int64_t)*(pByte+7)) << 8 | ((int64_t)*(pByte+8)));
+            pByte += 9;
+            cbDataMax -= 9;
         }
         else
         {
@@ -186,22 +188,22 @@ public:
 
         if ((processingState & InstrumentationDataProcessingState::ILOffset) == InstrumentationDataProcessingState::ILOffset)
         {
-            curSchema.ILOffset += (int32_t)curValue;
+            curSchema.ILOffset = (int32_t)((int64_t)curSchema.ILOffset + curValue);
             processingState = processingState & ~InstrumentationDataProcessingState::ILOffset;
         }
         else if ((processingState & InstrumentationDataProcessingState::Type) == InstrumentationDataProcessingState::Type)
         {
-            curSchema.InstrumentationKind = static_cast<ICorJitInfo::PgoInstrumentationKind>(static_cast<int>(curSchema.InstrumentationKind) + (int32_t)curValue);
+            curSchema.InstrumentationKind = static_cast<ICorJitInfo::PgoInstrumentationKind>(static_cast<int64_t>(curSchema.InstrumentationKind) + curValue);
             processingState = processingState & ~InstrumentationDataProcessingState::Type;
         }
         else if ((processingState & InstrumentationDataProcessingState::Count) == InstrumentationDataProcessingState::Count)
         {
-            curSchema.Count += (int32_t)curValue;
+            curSchema.Count = (int32_t)((int64_t)curSchema.Count + curValue);
             processingState = processingState & ~InstrumentationDataProcessingState::Count;
         }
         else if ((processingState & InstrumentationDataProcessingState::Other) == InstrumentationDataProcessingState::Other)
         {
-            curSchema.Other += (int32_t)curValue;
+            curSchema.Other = (int32_t)((int64_t)curSchema.Other + curValue);
             processingState = processingState & ~InstrumentationDataProcessingState::Other;
         }
 

--- a/src/coreclr/inc/pgo_formatprocessing.h
+++ b/src/coreclr/inc/pgo_formatprocessing.h
@@ -276,6 +276,9 @@ bool ReadInstrumentationData(const uint8_t *pByte, size_t cbDataMax, SchemaAndDa
                     return false;
                 }
                 break;
+            default:
+                assert(false);
+                break;
             }
             dataCountToRead--;
             return true;
@@ -369,11 +372,13 @@ bool ReadInstrumentationSchemaWithLayout(const uint8_t *pByte, size_t cbDataMax,
 
 inline bool ReadInstrumentationSchemaWithLayoutIntoSArray(const uint8_t *pByte, size_t cbDataMax, size_t initialOffset, SArray<ICorJitInfo::PgoInstrumentationSchema>* pSchemas)
 {
-    return ReadInstrumentationSchemaWithLayout(pByte, cbDataMax, initialOffset, [pSchemas](const ICorJitInfo::PgoInstrumentationSchema &schema)
+    auto lambda = [pSchemas](const ICorJitInfo::PgoInstrumentationSchema &schema)
     {
         pSchemas->Append(schema);
         return true;
-    });
+    };
+
+    return ReadInstrumentationSchemaWithLayout(pByte, cbDataMax, initialOffset, lambda);
 }
 
 

--- a/src/coreclr/inc/pgo_formatprocessing.h
+++ b/src/coreclr/inc/pgo_formatprocessing.h
@@ -51,18 +51,55 @@ inline ICorJitInfo::PgoInstrumentationKind operator~(ICorJitInfo::PgoInstrumenta
     return static_cast<ICorJitInfo::PgoInstrumentationKind>(~static_cast<int>(a));
 }
 
+inline uint32_t InstrumentationKindToSize(ICorJitInfo::PgoInstrumentationKind kind)
+{
+    switch(kind & ICorJitInfo::PgoInstrumentationKind::MarshalMask)
+    {
+        case ICorJitInfo::PgoInstrumentationKind::None:
+            return 0;
+        case ICorJitInfo::PgoInstrumentationKind::FourByte:
+            return 4;
+        case ICorJitInfo::PgoInstrumentationKind::EightByte:
+            return 8;
+        case ICorJitInfo::PgoInstrumentationKind::TypeHandle:
+            return TARGET_POINTER_SIZE;
+        default:
+            _ASSERTE(FALSE);
+            return 0;
+    }
+}
+
+inline UINT InstrumentationKindToAlignment(ICorJitInfo::PgoInstrumentationKind kind)
+{
+    switch(kind & ICorJitInfo::PgoInstrumentationKind::AlignMask)
+    {
+        case ICorJitInfo::PgoInstrumentationKind::Align4Byte:
+            return 4;
+        case ICorJitInfo::PgoInstrumentationKind::Align8Byte:
+            return 8;
+        case ICorJitInfo::PgoInstrumentationKind::AlignPointer:
+            return TARGET_POINTER_SIZE;
+        default:
+            return (UINT)InstrumentationKindToSize(kind);
+    }
+}
+
+#define SIGN_MASK_ONEBYTE_64BIT  0xffffffffffffffc0LL
+#define SIGN_MASK_TWOBYTE_64BIT  0xffffffffffffe000LL
+#define SIGN_MASK_FOURBYTE_64BIT 0xffffffff80000000LL
+
 template<class IntHandler>
 bool ReadCompressedInts(const uint8_t *pByte, size_t cbDataMax, IntHandler intProcessor)
 {
     while (cbDataMax > 0)
     {
-        // This logic is a variant on CorSigUncompressSignedInt which allows for the full range of an int32_t
-        int32_t signedInt;
+        // This logic is a variant on CorSigUncompressSignedInt which allows for the full range of an int64_t
+        int64_t signedInt;
         if ((*pByte & 0x80) == 0x0) // 0??? ????
         {
             signedInt = *pByte >> 1;
             if (*pByte & 1)
-                signedInt |= SIGN_MASK_ONEBYTE;
+                signedInt |= SIGN_MASK_ONEBYTE_64BIT;
 
             pByte += 1;
             cbDataMax -=1;
@@ -75,10 +112,16 @@ bool ReadCompressedInts(const uint8_t *pByte, size_t cbDataMax, IntHandler intPr
             int shiftedInt = ((*pByte & 0x3f) << 8) | *(pByte + 1);
             signedInt = shiftedInt >> 1;
             if (shiftedInt & 1)
-                signedInt |= SIGN_MASK_TWOBYTE;
+                signedInt |= SIGN_MASK_TWOBYTE_64BIT;
 
             pByte += 2;
             cbDataMax -= 2;
+        }
+        else if ((*pByte) == 0xC1)
+        {
+            if (cbDataMax < 9)
+                return false;
+            signedInt = (int64_t)((((int64_t)*(pByte + 1)) << 56 | ((int64_t)*(pByte+2)) << 48 | ((int64_t)*(pByte+3)) << 40 | ((int64_t)*(pByte+4)) << 32) | ((int64_t)*(pByte + 5)) << 24 | ((int64_t)*(pByte+6)) << 16 | ((int64_t)*(pByte+7)) << 8 | ((int64_t)*(pByte+8)));
         }
         else
         {
@@ -90,7 +133,7 @@ bool ReadCompressedInts(const uint8_t *pByte, size_t cbDataMax, IntHandler intPr
             pByte += 5;
             cbDataMax -= 5;
         }
-        
+
         if (!intProcessor(signedInt))
         {
             return false;
@@ -126,58 +169,136 @@ inline InstrumentationDataProcessingState operator~(InstrumentationDataProcessin
     return static_cast<InstrumentationDataProcessingState>(~static_cast<int>(a));
 }
 
-template<class SchemaHandler>
-bool ReadInstrumentationData(const uint8_t *pByte, size_t cbDataMax, SchemaHandler handler)
+class ProcessSchemaUpdateFunctor
 {
-    ICorJitInfo::PgoInstrumentationSchema curSchema;
-    InstrumentationDataProcessingState processingState;
-    bool done = false;
-    
-    memset(&curSchema, 0, sizeof(curSchema));
-    processingState = InstrumentationDataProcessingState::UpdateProcessMaskFlag;
-    ReadCompressedInts(pByte, cbDataMax, [&curSchema, handler, &processingState, &done](int32_t curValue)
+    ICorJitInfo::PgoInstrumentationSchema curSchema = {};
+    InstrumentationDataProcessingState processingState = InstrumentationDataProcessingState::UpdateProcessMaskFlag;
+
+public:
+    const ICorJitInfo::PgoInstrumentationSchema& GetSchema() const { return curSchema; }
+    bool ProcessInteger(int32_t curValue)
     {
         if (processingState == InstrumentationDataProcessingState::UpdateProcessMaskFlag)
         {
             processingState = (InstrumentationDataProcessingState)curValue;
-            return true;
+            return false;
         }
 
         if ((processingState & InstrumentationDataProcessingState::ILOffset) == InstrumentationDataProcessingState::ILOffset)
         {
-            curSchema.ILOffset += curValue;
+            curSchema.ILOffset += (int32_t)curValue;
             processingState = processingState & ~InstrumentationDataProcessingState::ILOffset;
         }
         else if ((processingState & InstrumentationDataProcessingState::Type) == InstrumentationDataProcessingState::Type)
         {
-            curSchema.InstrumentationKind = static_cast<ICorJitInfo::PgoInstrumentationKind>(static_cast<int>(curSchema.InstrumentationKind) + curValue);
+            curSchema.InstrumentationKind = static_cast<ICorJitInfo::PgoInstrumentationKind>(static_cast<int>(curSchema.InstrumentationKind) + (int32_t)curValue);
             processingState = processingState & ~InstrumentationDataProcessingState::Type;
         }
         else if ((processingState & InstrumentationDataProcessingState::Count) == InstrumentationDataProcessingState::Count)
         {
-            curSchema.Count += curValue;
+            curSchema.Count += (int32_t)curValue;
             processingState = processingState & ~InstrumentationDataProcessingState::Count;
         }
         else if ((processingState & InstrumentationDataProcessingState::Other) == InstrumentationDataProcessingState::Other)
         {
-            curSchema.Other += curValue;
+            curSchema.Other += (int32_t)curValue;
             processingState = processingState & ~InstrumentationDataProcessingState::Other;
         }
 
         if (processingState == InstrumentationDataProcessingState::Done)
         {
             processingState = InstrumentationDataProcessingState::UpdateProcessMaskFlag;
-            if (curSchema.InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::Done)
+            return true;
+        }
+        return false;
+    }
+};
+
+template<class SchemaHandler>
+bool ReadInstrumentationSchema(const uint8_t *pByte, size_t cbDataMax, SchemaHandler handler)
+{
+    ProcessSchemaUpdateFunctor schemaHandlerUpdate;
+    bool done = false;
+    
+    ReadCompressedInts(pByte, cbDataMax, [&handler, &schemaHandlerUpdate, &done](int64_t curValue)
+    {
+        if (schemaHandlerUpdate.ProcessInteger((int32_t)curValue))
+        {
+            if (schemaHandlerUpdate.GetSchema().InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::Done)
             {
                 done = true;
                 return false;
             }
 
-            if (!handler(curSchema))
+            if (!handler(schemaHandlerUpdate.GetSchema()))
             {
                 return false;
             }
+        }
+        return true;
+    });
 
+    return done;
+}
+
+template<class SchemaAndDataHandler>
+bool ReadInstrumentationData(const uint8_t *pByte, size_t cbDataMax, SchemaAndDataHandler handler)
+{
+    ProcessSchemaUpdateFunctor schemaHandler;
+    bool done = false;
+    int64_t lastDataValue = 0;
+    int64_t lastTypeDataValue = 0;
+    int32_t dataCountToRead = 0;
+    
+    ReadCompressedInts(pByte, cbDataMax, [&schemaHandler, &done](int64_t curValue)
+    {
+        if (dataCountToRead > 0)
+        {
+            switch(prevSchema.InstrumentationKind & ICorJitInfo::PgoInstrumentationKind::MarshalMask)
+            {
+            case ICorJitInfo::PgoInstrumentationKind::FourByte:
+            case ICorJitInfo::PgoInstrumentationKind::EightByte:
+                lastDataValue += curValue;
+
+                if (!handler(schemaHandler.GetSchema(), lastDataValue, schemaHandler.GetSchema().Count - dataCountToRead))
+                {
+                    return false;
+                }
+                break;
+            case ICorJitInfo::PgoInstrumentationKind::TypeHandle:
+                lastTypeDataValue += curValue;
+
+                if (!handler(schemaHandler.GetSchema(), lastTypeDataValue, schemaHandler.GetSchema().Count - dataCountToRead))
+                {
+                    return false;
+                }
+                break;
+            }
+            dataCountToRead--;
+            if (dataCountToRead > 0)
+            {
+                return true;
+            }
+        }
+        if (schemaHandler(schemaHandler.ProcessInteger((int32_t)curValue)))
+        {
+            if (schemaHandler.GetSchema().InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::Done)
+            {
+                done = true;
+                return false;
+            }
+
+            if (InstrumentationKindToSize(schemaHandler.GetSchema().InstrumentationKind) == 0)
+            {
+                if (!handler(schemaHandler.GetSchema(), 0, 0))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                dataCountToRead = schemaHandler.GetSchema().Count;
+            }
         }
         return true;
     });
@@ -188,13 +309,13 @@ bool ReadInstrumentationData(const uint8_t *pByte, size_t cbDataMax, SchemaHandl
 inline bool CountInstrumentationDataSize(const uint8_t *pByte, size_t cbDataMax, int32_t *pInstrumentationSchemaCount)
 {
     *pInstrumentationSchemaCount = 0;
-    return ReadInstrumentationData(pByte, cbDataMax, [pInstrumentationSchemaCount](const ICorJitInfo::PgoInstrumentationSchema& schema) { (*pInstrumentationSchemaCount)++; return true; });
+    return ReadInstrumentationSchema(pByte, cbDataMax, [pInstrumentationSchemaCount](const ICorJitInfo::PgoInstrumentationSchema& schema) { (*pInstrumentationSchemaCount)++; return true; });
 }
 
 inline bool ComparePgoSchemaEquals(const uint8_t *pByte, size_t cbDataMax, const ICorJitInfo::PgoInstrumentationSchema* schemaTable, size_t cSchemas)
 {
     size_t iSchema = 0;
-    return ReadInstrumentationData(pByte, cbDataMax, [schemaTable, cSchemas, &iSchema](const ICorJitInfo::PgoInstrumentationSchema& schema) 
+    return ReadInstrumentationSchema(pByte, cbDataMax, [schemaTable, cSchemas, &iSchema](const ICorJitInfo::PgoInstrumentationSchema& schema) 
     {
         if (iSchema >= cSchemas)
             return false;
@@ -215,39 +336,6 @@ inline bool ComparePgoSchemaEquals(const uint8_t *pByte, size_t cbDataMax, const
     });
 }
 
-inline uint32_t InstrumentationKindToSize(ICorJitInfo::PgoInstrumentationKind kind)
-{
-    switch(kind & ICorJitInfo::PgoInstrumentationKind::MarshalMask)
-    {
-        case ICorJitInfo::PgoInstrumentationKind::None:
-            return 0;
-        case ICorJitInfo::PgoInstrumentationKind::FourByte:
-            return 4;
-        case ICorJitInfo::PgoInstrumentationKind::EightByte:
-            return 8;
-        case ICorJitInfo::PgoInstrumentationKind::TypeHandle:
-            return TARGET_POINTER_SIZE;
-        default:
-            _ASSERTE(FALSE);
-            return 0;
-    }
-}
-
-inline UINT InstrumentationKindToAlignment(ICorJitInfo::PgoInstrumentationKind kind)
-{
-    switch(kind & ICorJitInfo::PgoInstrumentationKind::AlignMask)
-    {
-        case ICorJitInfo::PgoInstrumentationKind::Align4Byte:
-            return 4;
-        case ICorJitInfo::PgoInstrumentationKind::Align8Byte:
-            return 8;
-        case ICorJitInfo::PgoInstrumentationKind::AlignPointer:
-            return TARGET_POINTER_SIZE;
-        default:
-            return (UINT)InstrumentationKindToSize(kind);
-    }
-}
-
 inline void LayoutPgoInstrumentationSchema(const ICorJitInfo::PgoInstrumentationSchema& prevSchema, ICorJitInfo::PgoInstrumentationSchema* currentSchema)
 {
     size_t instrumentationSize = InstrumentationKindToSize(currentSchema->InstrumentationKind);
@@ -263,13 +351,13 @@ inline void LayoutPgoInstrumentationSchema(const ICorJitInfo::PgoInstrumentation
 }
 
 template<class SchemaHandler>
-bool ReadInstrumentationDataWithLayout(const uint8_t *pByte, size_t cbDataMax, size_t initialOffset, SchemaHandler handler)
+bool ReadInstrumentationSchemaWithLayout(const uint8_t *pByte, size_t cbDataMax, size_t initialOffset, SchemaHandler& handler)
 {
     ICorJitInfo::PgoInstrumentationSchema prevSchema;
     memset(&prevSchema, 0, sizeof(ICorJitInfo::PgoInstrumentationSchema));
     prevSchema.Offset = initialOffset;
 
-    return ReadInstrumentationData(pByte, cbDataMax, [&prevSchema, handler](ICorJitInfo::PgoInstrumentationSchema curSchema)
+    return ReadInstrumentationSchema(pByte, cbDataMax, [&prevSchema, &handler](ICorJitInfo::PgoInstrumentationSchema curSchema)
     {
         LayoutPgoInstrumentationSchema(prevSchema, &curSchema);
         if (!handler(curSchema))
@@ -279,9 +367,9 @@ bool ReadInstrumentationDataWithLayout(const uint8_t *pByte, size_t cbDataMax, s
     });
 }
 
-inline bool ReadInstrumentationDataWithLayoutIntoSArray(const uint8_t *pByte, size_t cbDataMax, size_t initialOffset, SArray<ICorJitInfo::PgoInstrumentationSchema>* pSchemas)
+inline bool ReadInstrumentationSchemaWithLayoutIntoSArray(const uint8_t *pByte, size_t cbDataMax, size_t initialOffset, SArray<ICorJitInfo::PgoInstrumentationSchema>* pSchemas)
 {
-    return ReadInstrumentationDataWithLayout(pByte, cbDataMax, initialOffset, [pSchemas](const ICorJitInfo::PgoInstrumentationSchema &schema)
+    return ReadInstrumentationSchemaWithLayout(pByte, cbDataMax, initialOffset, [pSchemas](const ICorJitInfo::PgoInstrumentationSchema &schema)
     {
         pSchemas->Append(schema);
         return true;
@@ -312,9 +400,60 @@ bool WriteCompressedIntToBytes(int32_t value, ByteWriter& byteWriter)
     }
     else
     {
-        // Unlike CorSigCompressSignedInt, this just writes a header bit
+        // Unlike CorSigCompressSignedInt, this just writes a header byte
         // then a full 4 bytes, ignoring the whole signed bit detail
         byteWriter(0xC0);
+        byteWriter(uint8_t((value >> 24) & 0xff));
+        byteWriter(uint8_t((value >> 16) & 0xff));
+        byteWriter(uint8_t((value >> 8) & 0xff));
+        return byteWriter(uint8_t((value >> 0) & 0xff));
+    }
+}
+
+#define SIGN_MASK_ONEBYTE_64BIT  0xffffffffffffffc0LL
+#define SIGN_MASK_TWOBYTE_64BIT  0xffffffffffffe000LL
+#define SIGN_MASK_FOURBYTE_64BIT 0xffffffff80000000LL
+
+template<class ByteWriter>
+bool WriteCompressedIntToBytes(int64_t value, ByteWriter& byteWriter)
+{
+    uint8_t isSigned = 0;
+
+    // This function is modeled on CorSigCompressSignedInt, but differs in that
+    // it handles arbitrary int64 values, not just a subset
+    if (value < 0)
+        isSigned = 1;
+
+    if ((value & SIGN_MASK_ONEBYTE_64BIT) == 0 || (value & SIGN_MASK_ONEBYTE_64BIT) == SIGN_MASK_ONEBYTE_64BIT)
+    {
+        return byteWriter((uint8_t)((value & ~SIGN_MASK_ONEBYTE) << 1 | isSigned));
+    }
+    else if ((value & SIGN_MASK_TWOBYTE_64BIT) == 0 || (value & SIGN_MASK_TWOBYTE_64BIT) == SIGN_MASK_TWOBYTE_64BIT)
+    {
+        int32_t iData = (int32_t)((value & ~SIGN_MASK_TWOBYTE_64BIT) << 1 | isSigned);
+        _ASSERTE(iData <= 0x3fff);
+        byteWriter(uint8_t((iData >> 8) | 0x80));
+        return byteWriter(uint8_t(iData & 0xff));
+    }
+    else if ((value & SIGN_MASK_FOURBYTE_64BIT) == 0 || (value & SIGN_MASK_FOURBYTE_64BIT) == SIGN_MASK_FOURBYTE_64BIT)
+    {
+        // Unlike CorSigCompressSignedInt, this just writes a header byte
+        // then 4 bytes, ignoring the whole signed bit detail
+        byteWriter(0xC0);
+        byteWriter(uint8_t((value >> 24) & 0xff));
+        byteWriter(uint8_t((value >> 16) & 0xff));
+        byteWriter(uint8_t((value >> 8) & 0xff));
+        return byteWriter(uint8_t((value >> 0) & 0xff));
+    }
+    else
+    {
+        // Unlike CorSigCompressSignedInt, this just writes a header byte
+        // then 8 bytes, ignoring the whole signed bit detail
+        byteWriter(0xC1);
+        byteWriter(uint8_t((value >> 56) & 0xff));
+        byteWriter(uint8_t((value >> 48) & 0xff));
+        byteWriter(uint8_t((value >> 40) & 0xff));
+        byteWriter(uint8_t((value >> 32) & 0xff));
         byteWriter(uint8_t((value >> 24) & 0xff));
         byteWriter(uint8_t((value >> 16) & 0xff));
         byteWriter(uint8_t((value >> 8) & 0xff));
@@ -357,7 +496,7 @@ bool WriteIndividualSchemaToBytes(ICorJitInfo::PgoInstrumentationSchema prevSche
 }
 
 template<class ByteWriter>
-bool WriteInstrumentationToBytes(const ICorJitInfo::PgoInstrumentationSchema* schemaTable, size_t cSchemas, const ByteWriter& byteWriter)
+bool WriteInstrumentationSchemaToBytes(const ICorJitInfo::PgoInstrumentationSchema* schemaTable, size_t cSchemas, const ByteWriter& byteWriter)
 {
     ICorJitInfo::PgoInstrumentationSchema prevSchema;
     memset(&prevSchema, 0, sizeof(ICorJitInfo::PgoInstrumentationSchema));
@@ -378,9 +517,93 @@ bool WriteInstrumentationToBytes(const ICorJitInfo::PgoInstrumentationSchema* sc
     return true;
 }
 
+template<class ByteWriter>
+class SchemaAndDataWriter
+{
+    const ByteWriter& byteWriter;
+    uint8_t* pInstrumentationData;
+    ICorJitInfo::PgoInstrumentationSchema prevSchema = {};
+    int64_t lastIntDataWritten = 0;
+    int64_t lastTypeDataWritten = 0;
+
+public:
+    SchemaAndDataWriter(const ByteWriter& byteWriter, uint8_t* pInstrumentationData) :
+        byteWriter(byteWriter),
+        pInstrumentationData(pInstrumentationData)
+    {}
+
+    bool AppendSchema(ICorJitInfo::PgoInstrumentationSchema schema)
+    {
+        if (!WriteIndividualSchemaToBytes(prevSchema, schema, byteWriter))
+            return false;
+
+        prevSchema = schema;
+        return true;
+    }
+
+    bool AppendDataFromLastSchema()
+    {
+        uint8_t *pData = (pInstrumentationData + prevSchema.Offset);
+        for (int32_t iDataElem = 0; iDataElem < prevSchema.Count; iDataElem++)
+        {
+            int64_t logicalDataToWrite;
+            switch(prevSchema.InstrumentationKind & ICorJitInfo::PgoInstrumentationKind::MarshalMask)
+            {
+                case ICorJitInfo::PgoInstrumentationKind::None:
+                    return true;
+                case ICorJitInfo::PgoInstrumentationKind::FourByte:
+                {
+                    logicalDataToWrite = *(int32_t*)pData;
+                    bool returnValue = WriteCompressedIntToBytes(logicalDataToWrite - lastIntDataWritten, byteWriter);
+                    lastIntDataWritten = logicalDataToWrite;
+                    if (!returnValue)
+                        return false;
+                    pData += 4;
+                    break;
+                }
+                case ICorJitInfo::PgoInstrumentationKind::EightByte:
+                {
+                    logicalDataToWrite = *(int64_t*)pData;
+                    bool returnValue = WriteCompressedIntToBytes(logicalDataToWrite - lastIntDataWritten, byteWriter);
+                    lastIntDataWritten = logicalDataToWrite;
+                    if (!returnValue)
+                        return false;
+                    pData += 8;
+                    break;
+                }
+                case ICorJitInfo::PgoInstrumentationKind::TypeHandle:
+                {
+                    logicalDataToWrite = *(intptr_t*)pData;
+                    bool returnValue = WriteCompressedIntToBytes(logicalDataToWrite - lastTypeDataWritten, byteWriter);
+                    lastTypeDataWritten = logicalDataToWrite;
+                    if (!returnValue)
+                        return false;
+                    pData += sizeof(intptr_t);
+                    break;
+                }
+                default:
+                    _ASSERTE(!"Unexpected type");
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    bool Finish()
+    {
+        // Terminate the schema list with an entry which is Done
+        ICorJitInfo::PgoInstrumentationSchema terminationSchema = prevSchema;
+        terminationSchema.InstrumentationKind = ICorJitInfo::PgoInstrumentationKind::Done;
+        if (!WriteIndividualSchemaToBytes(prevSchema, terminationSchema, byteWriter))
+            return false;
+
+        return true;
+    }
+};
+
 inline bool WriteInstrumentationSchema(const ICorJitInfo::PgoInstrumentationSchema* schemaTable, size_t cSchemas, uint8_t* array, size_t byteCount)
 {
-    return WriteInstrumentationToBytes(schemaTable, cSchemas, [&array, &byteCount](uint8_t data)
+    return WriteInstrumentationSchemaToBytes(schemaTable, cSchemas, [&array, &byteCount](uint8_t data)
     {
         if (byteCount == 0)
             return false;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -398,6 +398,7 @@ namespace Internal.JitInterface
             _inlinedMethods = new ArrayBuilder<MethodDesc>();
             _actualInstructionSetSupported = default(InstructionSetFlags);
             _actualInstructionSetUnsupported = default(InstructionSetFlags);
+            _pgoResults.Clear();
 #endif
         }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Internal.TypeSystem;
+using Microsoft.Pgo;
 
 namespace Internal.JitInterface
 {
@@ -83,6 +84,7 @@ namespace Internal.JitInterface
     { }
 
     public enum HRESULT {
+        S_OK = 0,
         E_NOTIMPL = -2147467263
     }
 
@@ -304,35 +306,6 @@ namespace Internal.JitInterface
         public int ILOffset;
         public int Count;
         public int Other;
-    }
-
-    public enum PgoInstrumentationKind
-    {
-        // Schema data types
-        None = 0,
-        FourByte = 1,
-        EightByte = 2,
-        TypeHandle = 3,
-
-        // Mask of all schema data types
-        MarshalMask = 0xF,
-
-        // ExcessAlignment
-        Align4Byte = 0x10,
-        Align8Byte = 0x20,
-        AlignPointer = 0x30,
-
-        // Mask of all schema data types
-        AlignMask = 0x30,
-
-        DescriptorMin = 0x40,
-
-        Done = None, // All instrumentation schemas must end with a record which is "Done"
-        BasicBlockIntCount = DescriptorMin | FourByte, // 4 byte basic block counter, using unsigned 4 byte int
-        TypeHandleHistogramCount = (DescriptorMin * 1) | FourByte | AlignPointer, // 4 byte counter that is part of a type histogram
-        TypeHandleHistogramTypeHandle = (DescriptorMin * 1) | TypeHandle, // TypeHandle that is part of a type histogram
-        Version = (DescriptorMin * 2) | None, // Version is encoded in the Other field of the schema
-        NumRuns = (DescriptorMin * 3) | None, // Number of runs is encoded in the Other field of the schema
     }
 
     // Flags computed by a runtime compiler

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Internal.Pgo;
 using Internal.TypeSystem;
-using Microsoft.Pgo;
 
 namespace Internal.JitInterface
 {

--- a/src/coreclr/tools/Common/Pgo/PgoFormat.cs
+++ b/src/coreclr/tools/Common/Pgo/PgoFormat.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using ILCompiler;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Pgo
+namespace Internal.Pgo
 {
     public enum PgoInstrumentationKind
     {
@@ -254,7 +254,7 @@ namespace Microsoft.Pgo
                 if ((processingState & InstrumentationDataProcessingState.ILOffset) == InstrumentationDataProcessingState.ILOffset)
                 {
                     if (longsAreCompressed)
-                        curSchema.ILOffset += checked((int)value);
+                        curSchema.ILOffset = checked((int)(value + (long)curSchema.ILOffset));
                     else
                         curSchema.ILOffset = checked((int)value);
 
@@ -272,7 +272,7 @@ namespace Microsoft.Pgo
                 else if ((processingState & InstrumentationDataProcessingState.Count) == InstrumentationDataProcessingState.Count)
                 {
                     if (longsAreCompressed)
-                        curSchema.Count += checked((int)value);
+                        curSchema.Count = checked((int)(value + (long)curSchema.Count));
                     else
                         curSchema.Count = checked((int)value);
                     processingState = processingState & ~InstrumentationDataProcessingState.Count;
@@ -280,7 +280,7 @@ namespace Microsoft.Pgo
                 else if ((processingState & InstrumentationDataProcessingState.Other) == InstrumentationDataProcessingState.Other)
                 {
                     if (longsAreCompressed)
-                        curSchema.Other += checked((int)value);
+                        curSchema.Other = checked((int)(value + (long)curSchema.Other));
                     else
                         curSchema.Other = checked((int)value);
                     processingState = processingState & ~InstrumentationDataProcessingState.Other;

--- a/src/coreclr/tools/Common/Pgo/PgoFormat.cs
+++ b/src/coreclr/tools/Common/Pgo/PgoFormat.cs
@@ -1,0 +1,554 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using ILCompiler;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Pgo
+{
+    public enum PgoInstrumentationKind
+    {
+        // This must be kept in sync with PgoInstrumentationKind in corjit.h
+        // New InstrumentationKinds should recieve corresponding merging logic in
+        // PgoSchemeMergeComparer and the MergeInSchemaElem functions below
+
+        // Schema data types
+        None = 0,
+        FourByte = 1,
+        EightByte = 2,
+        TypeHandle = 3,
+
+        // Mask of all schema data types
+        MarshalMask = 0xF,
+
+        // ExcessAlignment
+        Align4Byte = 0x10,
+        Align8Byte = 0x20,
+        AlignPointer = 0x30,
+
+        // Mask of all schema data types
+        AlignMask = 0x30,
+
+        DescriptorMin = 0x40,
+
+        Done = None, // All instrumentation schemas must end with a record which is "Done"
+        BasicBlockIntCount = (DescriptorMin * 1) | FourByte, // 4 byte basic block counter, using unsigned 4 byte int
+        TypeHandleHistogramCount = (DescriptorMin * 2) | FourByte | AlignPointer, // 4 byte counter that is part of a type histogram
+        TypeHandleHistogramTypeHandle = (DescriptorMin * 3) | TypeHandle, // TypeHandle that is part of a type histogram
+        Version = (DescriptorMin * 4) | None, // Version is encoded in the Other field of the schema
+        NumRuns = (DescriptorMin * 5) | None, // Number of runs is encoded in the Other field of the schema
+    }
+
+    public interface IPgoSchemaDataLoader<TType>
+    {
+        TType TypeFromLong(long input);
+    }
+
+    public interface IPgoEncodedValueEmitter<TType>
+    {
+        void EmitType(TType type, TType previousValue);
+        void EmitLong(long value, long previousValue);
+        void EmitDone();
+    }
+
+    public struct PgoSchemaElem
+    {
+        public PgoInstrumentationKind InstrumentationKind;
+        public int ILOffset;
+        public int Count;
+        public int Other;
+
+        // Data is normally stored as a long
+        // but for Types/Method/Fields/conditions where Count > 1
+        // the DataObject field is used instead
+        public long DataLong;
+        public object DataObject;
+    }
+
+    public class PgoProcessor
+    {
+        private enum InstrumentationDataProcessingState
+        {
+            Done = 0,
+            ILOffset = 0x1,
+            Type = 0x2,
+            Count = 0x4,
+            Other = 0x8,
+            UpdateProcessMask = 0xF,
+            UpdateProcessMaskFlag = 0x100,
+        }
+
+        private const long SIGN_MASK_ONEBYTE_64BIT = unchecked((long)0xffffffffffffffc0L);
+        private const long SIGN_MASK_TWOBYTE_64BIT = unchecked((long)0xffffffffffffe000L);
+        private const long SIGN_MASK_FOURBYTE_64BIT = unchecked((long)0xffffffff80000000L);
+
+        public static IEnumerable<long> PgoEncodedCompressedIntParser(byte[] bytes, int startOffset)
+        {
+            for (int offset = startOffset; offset < bytes.Length;)
+            {
+                // This logic is a variant on CorSigUncompressSignedInt which allows for the full range of an int64_t
+                long signedInt;
+                if ((bytes[offset] & 0x80) == 0x0) // 0??? ????
+                {
+                    int shiftedInt = bytes[offset];
+                    signedInt = shiftedInt >> 1;
+                    if ((shiftedInt & 1) != 0)
+                    {
+                        signedInt |= SIGN_MASK_ONEBYTE_64BIT;
+                    }
+                    offset += 1;
+                }
+                else if ((bytes[offset] & 0xC0) == 0x80) // 10?? ????
+                {
+                    int shiftedInt = (bytes[offset] & 0x3f) << 8 | bytes[offset + 1];
+                    signedInt = shiftedInt >> 1;
+                    if ((shiftedInt & 1) != 0)
+                        signedInt |= SIGN_MASK_TWOBYTE_64BIT;
+
+                    offset += 2;
+                }
+                else if ((bytes[offset]) == 0xC1) // 8 byte specifier
+                {
+                    signedInt = (((long)bytes[offset + 1]) << 56) |
+                                (((long)bytes[offset + 2]) << 48) |
+                                (((long)bytes[offset + 3]) << 40) |
+                                (((long)bytes[offset + 4]) << 32) |
+                                (((long)bytes[offset + 5]) << 24) |
+                                (((long)bytes[offset + 6]) << 16) |
+                                (((long)bytes[offset + 7]) << 8) |
+                                ((long)bytes[offset + 8]);
+                    offset += 9;
+                }
+                else
+                {
+                    signedInt = (((int)bytes[offset + 1]) << 24) |
+                                (((int)bytes[offset + 2]) << 16) |
+                                (((int)bytes[offset + 3]) << 8) |
+                                ((int)bytes[offset + 4]);
+                    offset += 5;
+                }
+
+                yield return signedInt;
+            }
+        }
+
+        public static IEnumerable<byte> PgoEncodedCompressedLongGenerator(IEnumerable<long> input)
+        {
+            foreach (long value in input)
+            {
+                byte isSigned = 0;
+                // This function is modeled on CorSigCompressSignedInt, but differs in that
+                // it handles arbitrary int64 values, not just a subset
+                if (value < 0)
+                    isSigned = 1;
+
+                if ((value & SIGN_MASK_ONEBYTE_64BIT) == 0 || (value & SIGN_MASK_ONEBYTE_64BIT) == SIGN_MASK_ONEBYTE_64BIT)
+                {
+                    yield return (byte)((byte)((value & ~SIGN_MASK_ONEBYTE_64BIT) << 1 | isSigned));
+                }
+                else if ((value & SIGN_MASK_TWOBYTE_64BIT) == 0 || (value & SIGN_MASK_TWOBYTE_64BIT) == SIGN_MASK_TWOBYTE_64BIT)
+                {
+                    int iData = (int)((value & ~SIGN_MASK_TWOBYTE_64BIT) << 1 | isSigned);
+                    yield return (byte)((iData >> 8) | 0x80);
+                    yield return (byte)(iData & 0xff);
+                }
+                else if ((value & SIGN_MASK_FOURBYTE_64BIT) == 0 || (value & SIGN_MASK_FOURBYTE_64BIT) == SIGN_MASK_FOURBYTE_64BIT)
+                {
+                    // Unlike CorSigCompressSignedInt, this just writes a header byte
+                    // then 4 bytes, ignoring the whole signed bit detail
+                    yield return 0xC0;
+                    yield return (byte)((value >> 24) & 0xff);
+                    yield return (byte)((value >> 16) & 0xff);
+                    yield return (byte)((value >> 8) & 0xff);
+                    yield return (byte)((value >> 0) & 0xff);
+                }
+                else
+                {
+                    // Unlike CorSigCompressSignedInt, this just writes a header byte
+                    // then 8 bytes, ignoring the whole signed bit detail
+                    yield return 0xC1;
+                    yield return (byte)((value >> 56) & 0xff);
+                    yield return (byte)((value >> 48) & 0xff);
+                    yield return (byte)((value >> 40) & 0xff);
+                    yield return (byte)((value >> 32) & 0xff);
+                    yield return (byte)((value >> 24) & 0xff);
+                    yield return (byte)((value >> 16) & 0xff);
+                    yield return (byte)((value >> 8) & 0xff);
+                    yield return (byte)((value >> 0) & 0xff);
+                }
+            }
+        }
+
+        public static IEnumerable<PgoSchemaElem> ParsePgoData<TType>(IPgoSchemaDataLoader<TType> dataProvider, IEnumerable<long> inputDataStream, bool longsAreCompressed)
+        {
+            int dataCountToRead = 0;
+            PgoSchemaElem curSchema = default(PgoSchemaElem);
+            InstrumentationDataProcessingState processingState = InstrumentationDataProcessingState.UpdateProcessMaskFlag;
+            long lastDataValue = 0;
+            long lastTypeValue = 0;
+
+            foreach (long value in inputDataStream)
+            {
+                if (dataCountToRead > 0)
+                {
+                    if (curSchema.Count == 1 && 
+                            (((curSchema.InstrumentationKind & PgoInstrumentationKind.MarshalMask) == PgoInstrumentationKind.FourByte) ||
+                            ((curSchema.InstrumentationKind & PgoInstrumentationKind.MarshalMask) == PgoInstrumentationKind.EightByte)))
+                    {
+                        if (longsAreCompressed)
+                            lastDataValue += value;
+                        else
+                            lastDataValue = value;
+                        curSchema.DataLong = lastDataValue;
+                    }
+                    else
+                    {
+                        int dataIndex = curSchema.Count - dataCountToRead;
+                        switch(curSchema.InstrumentationKind & PgoInstrumentationKind.MarshalMask)
+                        {
+                            case PgoInstrumentationKind.FourByte:
+                                if (longsAreCompressed)
+                                    lastDataValue += value;
+                                else
+                                    lastDataValue = value;
+                                ((int[])curSchema.DataObject)[dataIndex] = checked((int)lastDataValue);
+                                break;
+
+                            case PgoInstrumentationKind.EightByte:
+                                if (longsAreCompressed)
+                                    lastDataValue += value;
+                                else
+                                    lastDataValue = value;
+                                ((long[])curSchema.DataObject)[dataIndex] = lastDataValue;
+                                break;
+
+                            case PgoInstrumentationKind.TypeHandle:
+                                if (longsAreCompressed)
+                                    lastTypeValue += value;
+                                else
+                                    lastTypeValue = value;
+                                ((TType[])curSchema.DataObject)[dataIndex] = dataProvider.TypeFromLong(lastTypeValue);
+                                break;
+                        }
+                    }
+                    dataCountToRead--;
+                    if (dataCountToRead == 0)
+                    {
+                        yield return curSchema;
+                        curSchema.DataLong = 0;
+                        curSchema.DataObject = null;
+                    }
+                    continue;
+                }
+
+                if (processingState == InstrumentationDataProcessingState.UpdateProcessMaskFlag)
+                {
+                    processingState = (InstrumentationDataProcessingState)value;
+                    continue;
+                }
+
+                if ((processingState & InstrumentationDataProcessingState.ILOffset) == InstrumentationDataProcessingState.ILOffset)
+                {
+                    if (longsAreCompressed)
+                        curSchema.ILOffset += checked((int)value);
+                    else
+                        curSchema.ILOffset = checked((int)value);
+
+                    processingState = processingState & ~InstrumentationDataProcessingState.ILOffset;
+                }
+                else if ((processingState & InstrumentationDataProcessingState.Type) == InstrumentationDataProcessingState.Type)
+                {
+                    if (longsAreCompressed)
+                        curSchema.InstrumentationKind = (PgoInstrumentationKind)(((int)(curSchema.InstrumentationKind)) + checked((int)value));
+                    else
+                        curSchema.InstrumentationKind = (PgoInstrumentationKind)value;
+
+                    processingState = processingState & ~InstrumentationDataProcessingState.Type;
+                }
+                else if ((processingState & InstrumentationDataProcessingState.Count) == InstrumentationDataProcessingState.Count)
+                {
+                    if (longsAreCompressed)
+                        curSchema.Count += checked((int)value);
+                    else
+                        curSchema.Count = checked((int)value);
+                    processingState = processingState & ~InstrumentationDataProcessingState.Count;
+                }
+                else if ((processingState & InstrumentationDataProcessingState.Other) == InstrumentationDataProcessingState.Other)
+                {
+                    if (longsAreCompressed)
+                        curSchema.Other += checked((int)value);
+                    else
+                        curSchema.Other = checked((int)value);
+                    processingState = processingState & ~InstrumentationDataProcessingState.Other;
+                }
+
+                if (processingState == InstrumentationDataProcessingState.Done)
+                {
+                    processingState = InstrumentationDataProcessingState.UpdateProcessMaskFlag;
+
+                    if (curSchema.InstrumentationKind == PgoInstrumentationKind.Done)
+                    {
+                        yield break;
+                    }
+
+                    switch (curSchema.InstrumentationKind & PgoInstrumentationKind.MarshalMask)
+                    {
+                        case PgoInstrumentationKind.None:
+                            yield return curSchema;
+                            break;
+                            
+                        case PgoInstrumentationKind.FourByte:
+                            if (curSchema.Count > 1)
+                            {
+                                curSchema.DataObject = new int[curSchema.Count];
+                            }
+                            dataCountToRead = curSchema.Count;
+                            break;
+                        case PgoInstrumentationKind.EightByte:
+                            if (curSchema.Count > 1)
+                            {
+                                curSchema.DataObject = new long[curSchema.Count];
+                            }
+                            dataCountToRead = curSchema.Count;
+                            break;
+                        case PgoInstrumentationKind.TypeHandle:
+                            curSchema.DataObject = new TType[curSchema.Count];
+                            dataCountToRead = curSchema.Count;
+                            break;
+                        default:
+                            throw new Exception("Unknown Type");
+                    }
+                }
+            }
+
+            throw new Exception("Partial Instrumentation Data");
+        }
+
+        public static void EncodePgoData<TType>(IEnumerable<PgoSchemaElem> schemas, IPgoEncodedValueEmitter<TType> valueEmitter, bool emitAllElementsUnconditionally)
+        {
+            PgoSchemaElem prevSchema = default(PgoSchemaElem);
+            TType prevEmittedType = default(TType);
+            long prevEmittedIntData = 0;
+
+            foreach (PgoSchemaElem schema in schemas)
+            {
+                int ilOffsetDiff = schema.ILOffset - prevSchema.ILOffset;
+                int OtherDiff = schema.Other - prevSchema.Other;
+                int CountDiff = schema.Count - prevSchema.Count;
+                int TypeDiff = (int)schema.InstrumentationKind - (int)prevSchema.InstrumentationKind;
+
+                InstrumentationDataProcessingState modifyMask = (InstrumentationDataProcessingState)0;
+
+                if (!emitAllElementsUnconditionally)
+                {
+                    if (ilOffsetDiff != 0)
+                        modifyMask = modifyMask | InstrumentationDataProcessingState.ILOffset;
+                    if (TypeDiff != 0)
+                        modifyMask = modifyMask | InstrumentationDataProcessingState.Type;
+                    if (CountDiff != 0)
+                        modifyMask = modifyMask | InstrumentationDataProcessingState.Count;
+                    if (OtherDiff != 0)
+                        modifyMask = modifyMask | InstrumentationDataProcessingState.Other;
+                }
+                else
+                {
+                    modifyMask = InstrumentationDataProcessingState.ILOffset |
+                                 InstrumentationDataProcessingState.Type |
+                                 InstrumentationDataProcessingState.Count |
+                                 InstrumentationDataProcessingState.Other;
+                }
+
+                Debug.Assert(modifyMask != InstrumentationDataProcessingState.Done);
+
+                valueEmitter.EmitLong((long)modifyMask, 0);
+
+                if ((modifyMask & InstrumentationDataProcessingState.ILOffset) == InstrumentationDataProcessingState.ILOffset)
+                    valueEmitter.EmitLong(schema.ILOffset, prevSchema.ILOffset);
+                if ((modifyMask & InstrumentationDataProcessingState.Type) == InstrumentationDataProcessingState.Type)
+                    valueEmitter.EmitLong((long)schema.InstrumentationKind, (long)prevSchema.InstrumentationKind);
+                if ((modifyMask & InstrumentationDataProcessingState.Count) == InstrumentationDataProcessingState.Count)
+                    valueEmitter.EmitLong(schema.Count, prevSchema.Count);
+                if ((modifyMask & InstrumentationDataProcessingState.Other) == InstrumentationDataProcessingState.Other)
+                    valueEmitter.EmitLong(schema.Other, prevSchema.Other);
+
+                for (int i = 0; i < schema.Count; i++)
+                {
+                    switch (schema.InstrumentationKind & PgoInstrumentationKind.MarshalMask)
+                    {
+                        case PgoInstrumentationKind.None:
+                            break;
+                        case PgoInstrumentationKind.FourByte:
+                        {
+                            long valueToEmit;
+                            if (schema.Count == 1)
+                            {
+                                valueToEmit = schema.DataLong;
+                            }
+                            else
+                            {
+                                valueToEmit = ((int[])schema.DataObject)[i];
+                            }
+                            valueEmitter.EmitLong(valueToEmit, prevEmittedIntData);
+                            prevEmittedIntData = valueToEmit;
+                            break;
+                        }
+                        case PgoInstrumentationKind.EightByte:
+                        {
+                            long valueToEmit;
+                            if (schema.Count == 1)
+                            {
+                                valueToEmit = schema.DataLong;
+                            }
+                            else
+                            {
+                                valueToEmit = ((long[])schema.DataObject)[i];
+                            }
+                            valueEmitter.EmitLong(valueToEmit, prevEmittedIntData);
+                            prevEmittedIntData = valueToEmit;
+                            break;
+                        }
+                        case PgoInstrumentationKind.TypeHandle:
+                        {
+                            TType typeToEmit = ((TType[])schema.DataObject)[i];
+                            valueEmitter.EmitType(typeToEmit, prevEmittedType);
+                            prevEmittedType = typeToEmit;
+                            break;
+                        }
+                    }
+                }
+
+                prevSchema = schema;
+            }
+
+            // Emit a "done" schema
+            valueEmitter.EmitDone();
+        }
+
+
+        private class PgoSchemeMergeComparer : IComparer<PgoSchemaElem>
+        {
+            public static PgoSchemeMergeComparer Singleton = new PgoSchemeMergeComparer();
+            int IComparer<PgoSchemaElem>.Compare(PgoSchemaElem x, PgoSchemaElem y)
+            {
+                if (x.ILOffset != y.ILOffset)
+                {
+                    return x.ILOffset.CompareTo(y.ILOffset);
+                }
+                if (x.InstrumentationKind != y.InstrumentationKind)
+                {
+                    return x.ILOffset.CompareTo(y.ILOffset);
+                }
+                // Some InstrumentationKinds may be compared based on the Other field, some may not
+                if (x.Other != y.Other)
+                {
+                    switch (x.InstrumentationKind)
+                    {
+                        // 
+                        default:
+                            // All non-specified kinds are not distinguishable by Other field
+                            break;
+                    }
+                }
+
+                return 0;
+            }
+        }
+
+        public static PgoSchemaElem[] Merge<TType>(ReadOnlySpan<PgoSchemaElem[]> schemasToMerge)
+        {
+            // The merging algorithm will sort the schema data by iloffset, then by InstrumentationKind
+            // From there each individual instrumentation kind shall have a specific merging rule
+            SortedSet<PgoSchemaElem> dataMerger = new SortedSet<PgoSchemaElem>(PgoSchemeMergeComparer.Singleton);
+
+            foreach (PgoSchemaElem[] schemaSet in schemasToMerge)
+            {
+                bool foundNumRuns = false;
+
+                foreach (PgoSchemaElem schema in schemaSet)
+                {
+                    if (schema.InstrumentationKind == PgoInstrumentationKind.NumRuns)
+                        foundNumRuns = true;
+                    MergeInSchemaElem(dataMerger, schema);
+                }
+
+                if (!foundNumRuns)
+                {
+                    PgoSchemaElem oneRunSchema = new PgoSchemaElem();
+                    oneRunSchema.InstrumentationKind = PgoInstrumentationKind.NumRuns;
+                    oneRunSchema.ILOffset = 0;
+                    oneRunSchema.Other = 1;
+                    oneRunSchema.Count = 1;
+                    MergeInSchemaElem(dataMerger, oneRunSchema);
+                }
+            }
+
+            PgoSchemaElem[] result = new PgoSchemaElem[dataMerger.Count];
+            dataMerger.CopyTo(result, 0);
+            return result;
+
+            void MergeInSchemaElem(SortedSet<PgoSchemaElem> dataMerger, PgoSchemaElem schema)
+            {
+                long sortKey = ((long)schema.ILOffset) << 32 | (long)schema.InstrumentationKind;
+                if (dataMerger.TryGetValue(schema, out var existingSchemaItem))
+                {
+                    // Actually merge two schema items
+                    PgoSchemaElem mergedElem = existingSchemaItem;
+
+                    switch (existingSchemaItem.InstrumentationKind)
+                    {
+                    case PgoInstrumentationKind.BasicBlockIntCount:
+                    case PgoInstrumentationKind.TypeHandleHistogramCount:
+                        if ((existingSchemaItem.Count != 1) || (schema.Count != 1))
+                        {
+                            throw new Exception("Unable to merge pgo data. Invalid format");
+                        }
+                        mergedElem.DataLong = existingSchemaItem.DataLong + schema.DataLong;
+                        break;
+
+                    case PgoInstrumentationKind.TypeHandleHistogramTypeHandle:
+                        {
+                            mergedElem.Count = existingSchemaItem.Count + schema.Count;
+                            TType[] newMergedTypeArray = new TType[mergedElem.Count];
+                            mergedElem.DataObject = newMergedTypeArray;
+                            int i = 0;
+                            foreach (TType type in (TType[])existingSchemaItem.DataObject)
+                            {
+                                newMergedTypeArray[i++] = type;
+                            }
+                            foreach (TType type in (TType[])schema.DataObject)
+                            {
+                                newMergedTypeArray[i++] = type;
+                            }
+                            break;
+                        }
+
+                    case PgoInstrumentationKind.Version:
+                        {
+                            mergedElem.Other = Math.Max(existingSchemaItem.Other, schema.Other);
+                            break;
+                        }
+
+                    case PgoInstrumentationKind.NumRuns:
+                        {
+                            mergedElem.Other = existingSchemaItem.Other + schema.Other;
+                            break;
+                        }
+                    }
+
+                    Debug.Assert(dataMerger.Comparer.Compare(schema, mergedElem) == 0);
+                    dataMerger.Remove(schema);
+                    dataMerger.Add(mergedElem);
+                }
+                else
+                {
+                    dataMerger.Add(schema);
+                }
+
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
+++ b/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
@@ -3,7 +3,7 @@
 
 using Internal.TypeSystem;
 
-namespace Microsoft.Pgo
+namespace Internal.Pgo
 {
     public struct TypeSystemEntityOrUnknown
     {

--- a/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
+++ b/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+
+namespace Microsoft.Pgo
+{
+    public struct TypeSystemEntityOrUnknown
+    {
+        public TypeSystemEntityOrUnknown(int unknownIndex)
+        {
+            _data = unknownIndex;
+        }
+
+        public TypeSystemEntityOrUnknown(TypeDesc type)
+        {
+            _data = type;
+        }
+
+        readonly object _data;
+        public TypeDesc AsType => _data as TypeDesc;
+        public MethodDesc AsMethod => _data as MethodDesc;
+        public FieldDesc AsField => _data as FieldDesc;
+        public int AsUnknown => (!(_data is int)) || _data == null ? 0 : (int)_data;
+        public bool IsNull => _data == null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
@@ -9,6 +9,8 @@ using ILCompiler.IBC;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
+using Microsoft.Pgo;
+
 namespace ILCompiler
 {
     [Flags]
@@ -35,13 +37,14 @@ namespace ILCompiler
 
     public class MethodProfileData
     {
-        public MethodProfileData(MethodDesc method, MethodProfilingDataFlags flags, double exclusiveWeight, Dictionary<MethodDesc, int> callWeights, uint scenarioMask)
+        public MethodProfileData(MethodDesc method, MethodProfilingDataFlags flags, double exclusiveWeight, Dictionary<MethodDesc, int> callWeights, uint scenarioMask, PgoSchemaElem[] schemaData)
         {
             Method = method;
             Flags = flags;
             ScenarioMask = scenarioMask;
             ExclusiveWeight = exclusiveWeight;
             CallWeights = callWeights;
+            SchemaData = schemaData;
         }
 
         public readonly MethodDesc Method;
@@ -49,6 +52,7 @@ namespace ILCompiler
         public readonly uint ScenarioMask;
         public readonly double ExclusiveWeight;
         public readonly Dictionary<MethodDesc, int> CallWeights;
+        public readonly PgoSchemaElem[] SchemaData;
     }
 
     public abstract class ProfileData
@@ -178,6 +182,8 @@ namespace ILCompiler
             if (profileData.PartialNGen)
                 partialNgen = true;
 
+            PgoSchemaElem[][] schemaElemMergerArray = new PgoSchemaElem[2][];
+
             foreach (MethodProfileData data in profileData.GetAllMethodProfileData())
             {
                 MethodProfileData dataToMerge;
@@ -203,7 +209,20 @@ namespace ILCompiler
                             }
                         }
                     }
-                    mergedProfileData[data.Method] = new MethodProfileData(data.Method, dataToMerge.Flags | data.Flags, data.ExclusiveWeight + dataToMerge.ExclusiveWeight, mergedCallWeights, dataToMerge.ScenarioMask | data.ScenarioMask);
+
+                    var mergedSchemaData = data.SchemaData;
+                    if (mergedSchemaData == null)
+                    {
+                        mergedSchemaData = dataToMerge.SchemaData;
+                    }
+                    else
+                    {
+                        // Actually merge
+                        schemaElemMergerArray[0] = dataToMerge.SchemaData;
+                        schemaElemMergerArray[1] = data.SchemaData;
+                        mergedSchemaData = PgoProcessor.Merge<TypeSystemEntityOrUnknown>(schemaElemMergerArray);
+                    }
+                    mergedProfileData[data.Method] = new MethodProfileData(data.Method, dataToMerge.Flags | data.Flags, data.ExclusiveWeight + dataToMerge.ExclusiveWeight, mergedCallWeights, dataToMerge.ScenarioMask | data.ScenarioMask, mergedSchemaData);
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileData.cs
@@ -6,10 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using ILCompiler.IBC;
 
+using Internal.Pgo;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
-
-using Microsoft.Pgo;
 
 namespace ILCompiler
 {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -235,6 +235,8 @@ namespace ILCompiler
         private ProfileDataManager _profileData;
         private ReadyToRunFileLayoutOptimizer _fileLayoutOptimizer;
 
+        public ProfileDataManager ProfileData => _profileData;
+
         public ReadyToRunSymbolNodeFactory SymbolNodeFactory { get; }
         public ReadyToRunCompilationModuleGroupBase CompilationModuleGroup { get; }
         private readonly int _customPESectionAlignment;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -219,14 +219,17 @@ namespace ILCompiler
 
                 case OptimizationMode.PreferSize:
                     corJitFlags.Add(CorJitFlag.CORJIT_FLAG_SIZE_OPT);
+                    corJitFlags.Add(CorJitFlag.CORJIT_FLAG_BBOPT);
                     break;
 
                 case OptimizationMode.PreferSpeed:
                     corJitFlags.Add(CorJitFlag.CORJIT_FLAG_SPEED_OPT);
+                    corJitFlags.Add(CorJitFlag.CORJIT_FLAG_BBOPT);
                     break;
 
                 default:
                     // Not setting a flag results in BLENDED_CODE.
+                    corJitFlags.Add(CorJitFlag.CORJIT_FLAG_BBOPT);
                     break;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
@@ -141,7 +141,7 @@ namespace ILCompiler.IBC
                     {
                         if (methodsFoundInData.Add(associatedMethod))
                         {
-                            methodProfileData.Add(new MethodProfileData(associatedMethod, (MethodProfilingDataFlags)entry.Flags, 0, null, scenarioMask));
+                            methodProfileData.Add(new MethodProfileData(associatedMethod, (MethodProfilingDataFlags)entry.Flags, 0, null, scenarioMask, null));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
@@ -10,12 +10,12 @@ using System.Reflection;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Internal.IL;
+using Internal.Pgo;
 
 using System.Linq;
 using System.IO;
 using System.Diagnostics;
 
-using Microsoft.Pgo;
 using System.Reflection.PortableExecutable;
 
 namespace ILCompiler.IBC

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
@@ -15,10 +15,36 @@ using System.Linq;
 using System.IO;
 using System.Diagnostics;
 
+using Microsoft.Pgo;
+using System.Reflection.PortableExecutable;
+
 namespace ILCompiler.IBC
 {
     static class MIbcProfileParser
     {
+        private class MetadataLoaderForPgoData : IPgoSchemaDataLoader<TypeSystemEntityOrUnknown>
+        {
+            private readonly EcmaMethodIL _ilBody;
+
+            public MetadataLoaderForPgoData(EcmaMethodIL ilBody)
+            {
+                _ilBody = ilBody;
+            }
+            TypeSystemEntityOrUnknown IPgoSchemaDataLoader<TypeSystemEntityOrUnknown>.TypeFromLong(long token)
+            {
+                try
+                {
+                    if (token == 0)
+                        return new TypeSystemEntityOrUnknown(0);
+                    return new TypeSystemEntityOrUnknown((TypeDesc)_ilBody.GetObject((int)token));
+                }
+                catch
+                {
+                    return new TypeSystemEntityOrUnknown((int)token);
+                }
+            }
+        }
+
         /// <summary>
         /// Parse an MIBC file for the methods that are interesting.
         /// The version bubble must be specified and will describe the restrict the set of methods parsed to those relevant to the compilation
@@ -42,22 +68,54 @@ namespace ILCompiler.IBC
         /// <returns></returns>
         public static ProfileData ParseMIbcFile(CompilerTypeSystemContext tsc, string filename, HashSet<string> assemblyNamesInVersionBubble, string onlyDefinedInAssembly)
         {
-            byte[] peData;
+            byte[] peData = null;
+            PEReader unprotectedPeReader = null;
 
-            using (var zipFile = ZipFile.OpenRead(filename))
             {
-                var mibcDataEntry = zipFile.GetEntry(Path.GetFileName(filename) + ".dll");
-                using (var mibcDataStream = mibcDataEntry.Open())
+                FileStream fsMibcFile = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false);
+                bool disposeOnException = true;
+
+                try
                 {
-                    peData = new byte[mibcDataEntry.Length];
-                    using (BinaryReader br = new BinaryReader(mibcDataStream))
+                    byte firstByte = (byte)fsMibcFile.ReadByte();
+                    byte secondByte = (byte)fsMibcFile.ReadByte();
+                    fsMibcFile.Seek(0, SeekOrigin.Begin);
+                    if (firstByte == 0x4d && secondByte == 0x5a)
                     {
-                        peData = br.ReadBytes(checked((int)mibcDataEntry.Length));
+                        // Uncompressed Mibc format, starts with 'MZ' prefix like all other PE files
+                        unprotectedPeReader = new PEReader(fsMibcFile, PEStreamOptions.Default);
+                        disposeOnException = false;
                     }
+                    else
+                    {
+                        using (var zipFile = new ZipArchive(fsMibcFile, ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: null))
+                        {
+                            disposeOnException = false;
+                            var mibcDataEntry = zipFile.GetEntry(Path.GetFileName(filename) + ".dll");
+                            using (var mibcDataStream = mibcDataEntry.Open())
+                            {
+                                peData = new byte[mibcDataEntry.Length];
+                                using (BinaryReader br = new BinaryReader(mibcDataStream))
+                                {
+                                    peData = br.ReadBytes(checked((int)mibcDataEntry.Length));
+                                }
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    if (disposeOnException)
+                        fsMibcFile.Dispose();
                 }
             }
 
-            using (var peReader = new System.Reflection.PortableExecutable.PEReader(System.Collections.Immutable.ImmutableArray.Create<byte>(peData)))
+            if (peData != null)
+            {
+                unprotectedPeReader = new PEReader(System.Collections.Immutable.ImmutableArray.Create<byte>(peData));
+            }
+
+            using (var peReader = unprotectedPeReader)
             {
                 var mibcModule = EcmaModule.Create(tsc, peReader, null, null, new CustomCanonResolver(tsc));
 
@@ -135,6 +193,7 @@ namespace ILCompiler.IBC
             ProcessingCallgraphCount,
             ProcessingCallgraphToken,
             ProcessingCallgraphWeight,
+            ProcessingInstrumentationData,
         }
 
         /// <summary>
@@ -164,6 +223,7 @@ namespace ILCompiler.IBC
         static IEnumerable<MethodProfileData> ReadMIbcGroup(TypeSystemContext tsc, EcmaMethod method)
         {
             EcmaMethodIL ilBody = EcmaMethodIL.Create(method);
+            MetadataLoaderForPgoData metadataLoader = new MetadataLoaderForPgoData(ilBody);
             byte[] ilBytes = ilBody.GetILBytes();
             int currentOffset = 0;
             object methodInProgress = null;
@@ -176,6 +236,9 @@ namespace ILCompiler.IBC
             double exclusiveWeight = 0;
             Dictionary<MethodDesc, int> weights = null;
             bool processIntValue = false;
+            List<long> instrumentationDataLongs = null;
+            PgoSchemaElem[] pgoSchemaData = null;
+
             while (currentOffset < ilBytes.Length)
             {
                 ILOpcode opcode = (ILOpcode)ilBytes[currentOffset];
@@ -187,29 +250,36 @@ namespace ILCompiler.IBC
                     case ILOpcode.ldtoken:
                         {
                             uint token = BitConverter.ToUInt32(ilBytes.AsSpan(currentOffset + 1, 4));
-                            metadataObject = null;
-                            try
+                            if (state == MibcGroupParseState.ProcessingInstrumentationData)
                             {
-                                metadataObject = ilBody.GetObject((int)token);
+                                instrumentationDataLongs.Add(token);
                             }
-                            catch (TypeSystemException)
+                            else
                             {
-                                // The method being referred to may be missing. In that situation,
-                                // use the metadataNotResolvable sentinel to indicate that this record should be ignored
-                                metadataObject = metadataNotResolvable;
-                            }
-                            switch (state)
-                            {
-                                case MibcGroupParseState.ProcessingCallgraphToken:
-                                    state = MibcGroupParseState.ProcessingCallgraphWeight;
-                                    break;
-                                case MibcGroupParseState.LookingForNextMethod:
-                                    methodInProgress = metadataObject;
-                                    state = MibcGroupParseState.LookingForOptionalData;
-                                    break;
-                                default:
-                                    state = MibcGroupParseState.LookingForOptionalData;
-                                    break;
+                                metadataObject = null;
+                                try
+                                {
+                                    metadataObject = ilBody.GetObject((int)token);
+                                }
+                                catch (TypeSystemException)
+                                {
+                                    // The method being referred to may be missing. In that situation,
+                                    // use the metadataNotResolvable sentinel to indicate that this record should be ignored
+                                    metadataObject = metadataNotResolvable;
+                                }
+                                switch (state)
+                                {
+                                    case MibcGroupParseState.ProcessingCallgraphToken:
+                                        state = MibcGroupParseState.ProcessingCallgraphWeight;
+                                        break;
+                                    case MibcGroupParseState.LookingForNextMethod:
+                                        methodInProgress = metadataObject;
+                                        state = MibcGroupParseState.LookingForOptionalData;
+                                        break;
+                                    default:
+                                        state = MibcGroupParseState.LookingForOptionalData;
+                                        break;
+                                }
                             }
                         }
                         break;
@@ -299,6 +369,13 @@ namespace ILCompiler.IBC
                         processIntValue = true;
                         break;
 
+                    case ILOpcode.ldc_i8:
+                        if (state == MibcGroupParseState.ProcessingInstrumentationData)
+                        {
+                            instrumentationDataLongs.Add(BitConverter.ToInt64(ilBytes.AsSpan(currentOffset + 1, 8)));
+                        }
+                        break;
+
                     case ILOpcode.ldstr:
                         {
                             UInt32 userStringToken = BitConverter.ToUInt32(ilBytes.AsSpan(currentOffset + 1, 4));
@@ -313,6 +390,20 @@ namespace ILCompiler.IBC
                                     state = MibcGroupParseState.ProcessingCallgraphCount;
                                     break;
 
+                                case "InstrumentationDataStart":
+                                    state = MibcGroupParseState.ProcessingInstrumentationData;
+                                    instrumentationDataLongs = new List<long>();
+                                    break;
+
+                                case "InstrumentationDataEnd":
+                                    if (instrumentationDataLongs != null)
+                                    {
+                                        instrumentationDataLongs.Add(2); // MarshalMask 2 (Type)
+                                        instrumentationDataLongs.Add(0); // PgoInstrumentationKind.Done (0)
+                                        pgoSchemaData = PgoProcessor.ParsePgoData<TypeSystemEntityOrUnknown>(metadataLoader, instrumentationDataLongs, false).ToArray();
+                                    }
+                                    state = MibcGroupParseState.LookingForOptionalData;
+                                    break;
                                 default:
                                     state = MibcGroupParseState.LookingForOptionalData;
                                     break;
@@ -329,10 +420,12 @@ namespace ILCompiler.IBC
                                 // If no exclusive weight is found assign a non zero value that assumes the order in the pgo file is significant.
                                 exclusiveWeight = Math.Min(1000000.0 - profileEntryFound, 0.0) / 1000000.0;
                             }
-                            MethodProfileData mibcData = new MethodProfileData((MethodDesc)methodInProgress, MethodProfilingDataFlags.ReadMethodCode, exclusiveWeight, weights, 0xFFFFFFFF);
+                            MethodProfileData mibcData = new MethodProfileData((MethodDesc)methodInProgress, MethodProfilingDataFlags.ReadMethodCode, exclusiveWeight, weights, 0xFFFFFFFF, pgoSchemaData);
                             state = MibcGroupParseState.LookingForNextMethod;
                             exclusiveWeight = 0;
                             weights = null;
+                            instrumentationDataLongs = null;
+                            pgoSchemaData = null;
                             yield return mibcData;
                         }
                         methodInProgress = null;
@@ -371,8 +464,12 @@ namespace ILCompiler.IBC
                             else
                                 state = MibcGroupParseState.LookingForOptionalData;
                             break;
+                        case MibcGroupParseState.ProcessingInstrumentationData:
+                            instrumentationDataLongs.Add(intValue);
+                            break;
                         default:
                             state = MibcGroupParseState.LookingForOptionalData;
+                            instrumentationDataLongs = null;
                             break;
                     }
                 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
@@ -30,6 +30,8 @@
     <Compile Include="..\..\Common\Internal\NativeFormat\NativeFormat.cs" Link="Common\NativeFormat.cs" />
     <Compile Include="..\..\Common\Internal\NativeFormat\NativeFormatWriter.cs" Link="Common\NativeFormatWriter.cs" />
     <Compile Include="..\..\Common\Internal\NativeFormat\NativeFormatWriter.Primitives.cs" Link="Common\NativeFormatWriter.Primitives.cs" />
+    <Compile Include="..\..\Common\Pgo\PgoFormat.cs" Link="Common\Pgo\PgoFormat.cs" />
+    <Compile Include="..\..\Common\Pgo\TypeSystemEntityOrUnknown.cs" Link="Common\Pgo\TypeSystemEntityOrUnknown.cs" />
     <Compile Include="..\..\Common\System\FormattingHelpers.cs" Link="Common\FormattingHelpers.cs" />
     <Compile Include="..\..\Common\TypeSystem\IL\ILProvider.cs" Link="IL\ILProvider.cs" />
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ComparerIntrinsics.cs" Link="IL\Stubs\ComparerIntrinsics.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -17,13 +17,13 @@ using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem.Interop;
 using Internal.CorConstants;
+using Internal.Pgo;
 using Internal.ReadyToRunConstants;
 
 using ILCompiler;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
 
-using Microsoft.Pgo;
 
 namespace Internal.JitInterface
 {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2403,7 +2403,7 @@ namespace Internal.JitInterface
                         Debug.Assert((bwInstrumentationData.BaseStream.Position % 8) == 0);
                         nativeSchemas[i].Offset = new IntPtr(checked((int)bwInstrumentationData.BaseStream.Position));
                         nativeSchemas[i].ILOffset = pgoResultsSchemas[i].ILOffset;
-                        nativeSchemas[i].Count= pgoResultsSchemas[i].Count;
+                        nativeSchemas[i].Count = pgoResultsSchemas[i].Count;
                         nativeSchemas[i].Other = pgoResultsSchemas[i].Other;
                         nativeSchemas[i].InstrumentationKind = (PgoInstrumentationKind)pgoResultsSchemas[i].InstrumentationKind;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -21,6 +22,8 @@ using Internal.ReadyToRunConstants;
 using ILCompiler;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
+
+using Microsoft.Pgo;
 
 namespace Internal.JitInterface
 {
@@ -308,6 +311,15 @@ namespace Internal.JitInterface
         private NativeVarInfo[] _debugVarInfos;
         private ArrayBuilder<MethodDesc> _inlinedMethods;
         private UnboxingMethodDescFactory _unboxingThunkFactory = new UnboxingMethodDescFactory();
+
+        private struct PgoInstrumentationResults
+        {
+            public PgoInstrumentationSchema* pSchema;
+            public uint countSchemaItems;
+            public byte* pInstrumentationData;
+            public HRESULT hr;
+        }
+        Dictionary<MethodDesc, PgoInstrumentationResults> _pgoResults = new Dictionary<MethodDesc, PgoInstrumentationResults>();
 
         public CorInfoImpl(ReadyToRunCodegenCompilation compilation)
             : this()
@@ -2360,8 +2372,95 @@ namespace Internal.JitInterface
             return 0;
         }
 
-        private HRESULT getPgoInstrumentationResults(CORINFO_METHOD_STRUCT_* ftnHnd, ref PgoInstrumentationSchema* pSchema, ref uint pCountSchemaItems, byte** pInstrumentationData)
-        { throw new NotImplementedException("getPgoInstrumentationResults"); }
+        private PgoSchemaElem[] getPgoInstrumentationResults(MethodDesc method)
+        {
+            return _compilation.ProfileData[method]?.SchemaData;
+        }
+
+        private HRESULT getPgoInstrumentationResults(CORINFO_METHOD_STRUCT_* ftnHnd, ref PgoInstrumentationSchema* pSchema, ref uint countSchemaItems, byte** pInstrumentationData)
+        {
+            MethodDesc methodDesc = HandleToObject(ftnHnd);
+
+            if (!_pgoResults.TryGetValue(methodDesc, out PgoInstrumentationResults pgoResults))
+            {
+                var pgoResultsSchemas = getPgoInstrumentationResults(methodDesc);
+                if (pgoResultsSchemas == null)
+                {
+                    pgoResults.hr = HRESULT.E_NOTIMPL;
+                }
+                else
+                {
+                    PgoInstrumentationSchema[] nativeSchemas = new PgoInstrumentationSchema[pgoResultsSchemas.Length];
+                    MemoryStream msInstrumentationData = new MemoryStream();
+                    BinaryWriter bwInstrumentationData = new BinaryWriter(msInstrumentationData);
+                    for (int i = 0; i < nativeSchemas.Length; i++)
+                    {
+                        if ((bwInstrumentationData.BaseStream.Position % 8) == 4)
+                        {
+                            bwInstrumentationData.Write(0);
+                        }
+
+                        Debug.Assert((bwInstrumentationData.BaseStream.Position % 8) == 0);
+                        nativeSchemas[i].Offset = new IntPtr(checked((int)bwInstrumentationData.BaseStream.Position));
+                        nativeSchemas[i].ILOffset = pgoResultsSchemas[i].ILOffset;
+                        nativeSchemas[i].Count= pgoResultsSchemas[i].Count;
+                        nativeSchemas[i].Other = pgoResultsSchemas[i].Other;
+                        nativeSchemas[i].InstrumentationKind = (PgoInstrumentationKind)pgoResultsSchemas[i].InstrumentationKind;
+
+                        if (pgoResultsSchemas[i].DataObject == null)
+                        {
+                            bwInstrumentationData.Write(pgoResultsSchemas[i].DataLong);
+                        }
+                        else
+                        {
+                            object dataObject = pgoResultsSchemas[i].DataObject;
+                            if (dataObject is int[] intArray)
+                            {
+                                foreach (int intVal in intArray)
+                                    bwInstrumentationData.Write(intVal);
+                            }
+                            else if (dataObject is long[] longArray)
+                            {
+                                foreach (long longVal in longArray)
+                                    bwInstrumentationData.Write(longVal);
+                            }
+                            else if (dataObject is TypeSystemEntityOrUnknown[] typeArray)
+                            {
+                                foreach (TypeSystemEntityOrUnknown typeVal in typeArray)
+                                {
+                                    IntPtr ptrVal = IntPtr.Zero;
+                                    if (typeVal.AsType != null)
+                                        ptrVal = (IntPtr)ObjectToHandle(typeVal.AsType);
+                                    else
+                                    {
+                                        // The "Unknown types are the values from 1-33
+                                        ptrVal = new IntPtr((typeVal.AsUnknown % 32) + 1);
+                                    }
+
+                                    if (IntPtr.Size == 4)
+                                        bwInstrumentationData.Write((int)ptrVal);
+                                    else
+                                        bwInstrumentationData.Write((long)ptrVal);
+                                }
+                            }
+                        }
+                    }
+
+                    bwInstrumentationData.Flush();
+                    pgoResults.pInstrumentationData = (byte*)GetPin(msInstrumentationData.ToArray());
+                    pgoResults.countSchemaItems = (uint)nativeSchemas.Length;
+                    pgoResults.pSchema = (PgoInstrumentationSchema*)GetPin(nativeSchemas);
+                    pgoResults.hr = HRESULT.S_OK;
+                }
+
+                _pgoResults.Add(methodDesc, pgoResults);
+            }
+
+            pSchema = pgoResults.pSchema;
+            countSchemaItems = pgoResults.countSchemaItems;
+            *pInstrumentationData = pgoResults.pInstrumentationData;
+            return pgoResults.hr;
+        }
 
         private CORINFO_CLASS_STRUCT_* getLikelyClass(CORINFO_METHOD_STRUCT_* ftnHnd, CORINFO_CLASS_STRUCT_* baseHnd, uint IlOffset, ref uint pLikelihood, ref uint pNumberOfClasses)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
@@ -22,6 +22,9 @@ namespace ILCompiler.Reflection.ReadyToRun
             _ordinalRva = new Dictionary<int, int>();
 
             DirectoryEntry exportTable = peReader.PEHeaders.PEHeader.ExportTableDirectory;
+            if ((exportTable.Size == 0) || (exportTable.RelativeVirtualAddress == 0))
+                return;
+
             PEMemoryBlock peImage = peReader.GetEntireImage();
             BlobReader exportTableHeader = peImage.GetReader(peReader.GetOffset(exportTable.RelativeVirtualAddress), exportTable.Size);
             if (exportTableHeader.Length == 0)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -10,7 +10,6 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
-using Internal.Pgo;
 using Internal.Runtime;
 
 namespace ILCompiler.Reflection.ReadyToRun

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -10,6 +10,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
+using Internal.Pgo;
 using Internal.Runtime;
 
 namespace ILCompiler.Reflection.ReadyToRun

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -26,6 +26,7 @@ using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using System.Diagnostics.CodeAnalysis;
 using ILCompiler.Reflection.ReadyToRun;
 using Microsoft.Diagnostics.Tools.Pgo;
+using Microsoft.Pgo;
 
 namespace Microsoft.Diagnostics.Tools.Pgo
 {
@@ -62,7 +63,38 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         public double ExcludeEventsBefore { get; set; }
         public double ExcludeEventsAfter { get; set; }
         public bool Warnings { get; set; }
+        public bool Uncompressed { get; set; }
     }
+    class MethodChunks
+    {
+        public bool Done = false;
+        public List<byte[]> InstrumentationData = new List<byte[]>();
+        public int LastChunk = -1;
+    }
+
+    class PgoDataLoader : IPgoSchemaDataLoader<TypeSystemEntityOrUnknown>
+    {
+        private TraceRuntimeDescToTypeSystemDesc _idParser;
+
+        public PgoDataLoader(TraceRuntimeDescToTypeSystemDesc idParser)
+        {
+            _idParser = idParser;
+        }
+
+        public TypeSystemEntityOrUnknown TypeFromLong(long input)
+        {
+            if (input == 0)
+                return new TypeSystemEntityOrUnknown(0);
+
+            TypeDesc type = _idParser.ResolveTypeHandle(input, false);
+            if (type != null)
+            {
+                return new TypeSystemEntityOrUnknown(type);
+            }
+            return new TypeSystemEntityOrUnknown(System.HashCode.Combine(input) | 0x7F000000);
+        }
+    }
+
 
     class Program
     {
@@ -177,6 +209,11 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 {
                     Description = "Generate Call Graph using sampling data",
                     Argument = new Argument<bool>(() => true)
+                },
+                new Option("--uncompressed")
+                {
+                    Description = "Generate Mibc file in an uncompressed format",
+                    Argument = new Argument<bool>(() => false)
                 }
             };
 
@@ -243,6 +280,7 @@ Example tracing commands used to generate the input to this tool:
                 Reason = reason;
                 WeightedCallData = null;
                 ExclusiveWeight = 0;
+                InstrumentationData = null;
             }
 
             public readonly double Millisecond;
@@ -250,6 +288,12 @@ Example tracing commands used to generate the input to this tool:
             public readonly string Reason;
             public Dictionary<MethodDesc, int> WeightedCallData;
             public int ExclusiveWeight;
+            public PgoSchemaElem[] InstrumentationData;
+
+            public override string ToString()
+            {
+                return Method.ToString();
+            }
         }
 
         struct InstructionPointerRange : IComparable<InstructionPointerRange>
@@ -704,6 +748,15 @@ Example tracing commands used to generate the input to this tool:
 
                         try
                         {
+                            byte[] image = File.ReadAllBytes(module.FilePath);
+                            using (FileStream fstream = new FileStream(module.FilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                            {
+                                var r2rCheckPEReader = new System.Reflection.PortableExecutable.PEReader(fstream, System.Reflection.PortableExecutable.PEStreamOptions.LeaveOpen);
+
+                                if (!ILCompiler.Reflection.ReadyToRun.ReadyToRunReader.IsReadyToRunImage(r2rCheckPEReader))
+                                    continue;
+                            }
+
                             var reader = new ILCompiler.Reflection.ReadyToRun.ReadyToRunReader(tsc, module.FilePath);
                             foreach (var methodEntry in reader.GetCustomMethodToRuntimeFunctionMapping<TypeDesc, MethodDesc, R2RSigProviderContext>(sigProvider))
                             {
@@ -823,6 +876,56 @@ Example tracing commands used to generate the input to this tool:
                     }
                 }
 
+                Dictionary<MethodDesc, MethodChunks> instrumentationDataByMethod = new Dictionary<MethodDesc, MethodChunks>();
+
+                foreach (var e in p.EventsInProcess.ByEventType<JitInstrumentationDataVerboseTraceData>())
+                {
+                    AddToInstrumentationData(e.ClrInstanceID, e.MethodID, e.MethodFlags, e.Data);
+                }
+                foreach (var e in p.EventsInProcess.ByEventType<JitInstrumentationDataTraceData>())
+                {
+                    AddToInstrumentationData(e.ClrInstanceID, e.MethodID, e.MethodFlags, e.Data);
+                }
+
+                // Local function used with the above two loops as the behavior is supposed to be identical
+                void AddToInstrumentationData(int eventClrInstanceId, long methodID, int methodFlags, byte[] data)
+                {
+                    if (eventClrInstanceId != clrInstanceId.Value)
+                    {
+                        return;
+                    }
+
+                    MethodDesc method = null;
+                    try
+                    {
+                        method = idParser.ResolveMethodID(methodID, commandLineOptions.VerboseWarnings);
+                    }
+                    catch (Exception)
+                    {
+                    }
+
+                    if (method != null)
+                    {
+                        if (!instrumentationDataByMethod.TryGetValue(method, out MethodChunks perMethodChunks))
+                        {
+                            perMethodChunks = new MethodChunks();
+                            instrumentationDataByMethod.Add(method, perMethodChunks);
+                        }
+                        const int FinalChunkFlag = unchecked((int)0x80000000);
+                        int chunkIndex = methodFlags & ~FinalChunkFlag;
+                        if ((chunkIndex != (perMethodChunks.LastChunk + 1)) || perMethodChunks.Done)
+                        {
+                            instrumentationDataByMethod.Remove(method);
+                            return;
+                        }
+                        perMethodChunks.LastChunk = perMethodChunks.InstrumentationData.Count;
+                        perMethodChunks.InstrumentationData.Add(data);
+                        if ((methodFlags & FinalChunkFlag) == FinalChunkFlag)
+                            perMethodChunks.Done = true;
+                    }
+                }
+
+
                 if (commandLineOptions.DisplayProcessedEvents)
                 {
                     foreach (var entry in methodsToAttemptToPrepare)
@@ -843,6 +946,9 @@ Example tracing commands used to generate the input to this tool:
                 // Deduplicate entries
                 HashSet<MethodDesc> methodsInListAlready = new HashSet<MethodDesc>();
                 List<ProcessedMethodData> methodsUsedInProcess = new List<ProcessedMethodData>();
+
+                PgoDataLoader pgoDataLoader = new PgoDataLoader(idParser);
+
                 foreach (var entry in methodsToAttemptToPrepare)
                 {
                     if (methodsInListAlready.Add(entry.Value.Method))
@@ -853,19 +959,39 @@ Example tracing commands used to generate the input to this tool:
                             exclusiveSamples.TryGetValue(methodData.Method, out methodData.ExclusiveWeight);
                             callGraph.TryGetValue(methodData.Method, out methodData.WeightedCallData);
                         }
+                        if (instrumentationDataByMethod.TryGetValue(methodData.Method, out MethodChunks chunks))
+                        {
+                            int size = 0;
+                            foreach (byte[] arr in chunks.InstrumentationData)
+                            {
+                                size += arr.Length;
+                            }
+
+                            byte[] instrumentationData = new byte[size];
+                            int offset = 0;
+
+                            foreach (byte[] arr in chunks.InstrumentationData)
+                            {
+                                arr.CopyTo(instrumentationData, offset);
+                                offset += arr.Length;
+                            }
+
+                            var intDecompressor = PgoProcessor.PgoEncodedCompressedIntParser(instrumentationData, 0);
+                            methodData.InstrumentationData = PgoProcessor.ParsePgoData<TypeSystemEntityOrUnknown>(pgoDataLoader, intDecompressor, true).ToArray();
+                        }
                         methodsUsedInProcess.Add(methodData);
                     }
                 }
 
-                if (commandLineOptions.PgoFileType.Value == PgoFileType.jittrace)
+                 if (commandLineOptions.PgoFileType.Value == PgoFileType.jittrace)
                     GenerateJittraceFile(commandLineOptions.OutputFileName, methodsUsedInProcess, commandLineOptions.JitTraceOptions);
                 else if (commandLineOptions.PgoFileType.Value == PgoFileType.mibc)
-                    return GenerateMibcFile(tsc, commandLineOptions.OutputFileName, methodsUsedInProcess, commandLineOptions.ValidateOutputFile);
+                    return GenerateMibcFile(tsc, commandLineOptions.OutputFileName, methodsUsedInProcess, commandLineOptions.ValidateOutputFile, commandLineOptions.Uncompressed);
             }
             return 0;
         }
 
-        class MIbcGroup
+        class MIbcGroup : IPgoEncodedValueEmitter<TypeSystemEntityOrUnknown>
         {
             private static int s_emitCount = 0;
 
@@ -880,7 +1006,7 @@ Example tracing commands used to generate the input to this tool:
             private BlobBuilder _buffer;
             private InstructionEncoder _il;
             private string _name;
-            TypeSystemMetadataEmitter _emitter;
+            private TypeSystemMetadataEmitter _emitter;
 
             public void AddProcessedMethodData(ProcessedMethodData processedMethodData)
             {
@@ -902,6 +1028,10 @@ Example tracing commands used to generate the input to this tool:
                 // Repeat <Count of methods called times>
                 //  ldtoken <Method called from this method>
                 //  ldc.i4 <Weight associated with calling the <Method called from this method>>
+                //
+                // ldstr "InstrumentationDataStart"
+                // Encoded ints and longs, using ldc.i4, and ldc.i8 instructions as well as ldtoken <type> instructions
+                // ldstr "InstrumentationDataEnd" as a terminator
                 try
                 {
                     EntityHandle methodHandle = _emitter.GetMethodRef(method);
@@ -924,6 +1054,11 @@ Example tracing commands used to generate the input to this tool:
                             _il.LoadConstantI4(entry.Value);
                         }
                     }
+                    if (processedMethodData.InstrumentationData != null)
+                    {
+                        _il.LoadString(_emitter.GetUserStringHandle("InstrumentationDataStart"));
+                        PgoProcessor.EncodePgoData<TypeSystemEntityOrUnknown>(processedMethodData.InstrumentationData, this, true);
+                    }
                     _il.OpCode(ILOpCode.Pop);
                 }
                 catch (Exception ex)
@@ -942,6 +1077,35 @@ Example tracing commands used to generate the input to this tool:
                 string methodName = basicName + "_" + s_emitCount.ToString(CultureInfo.InvariantCulture);
                 return _emitter.AddGlobalMethod(methodName, _il, 8);
             }
+
+            void IPgoEncodedValueEmitter<TypeSystemEntityOrUnknown>.EmitDone()
+            {
+                _il.LoadString(_emitter.GetUserStringHandle("InstrumentationDataEnd"));
+            }
+
+            void IPgoEncodedValueEmitter<TypeSystemEntityOrUnknown>.EmitLong(long value, long previousValue)
+            {
+                if ((value <= int.MaxValue) && (value >= int.MinValue))
+                {
+                    _il.LoadConstantI4(checked((int)value));
+                }
+                else
+                {
+                    _il.LoadConstantI8(value);
+                }
+            }
+
+            void IPgoEncodedValueEmitter<TypeSystemEntityOrUnknown>.EmitType(TypeSystemEntityOrUnknown type, TypeSystemEntityOrUnknown previousValue)
+            {
+                if (type.AsType != null)
+                {
+                    _il.OpCode(ILOpCode.Ldtoken);
+                    _il.Token(_emitter.GetTypeRef(type.AsType));
+                }
+                else
+                    _il.LoadConstantI4(type.AsUnknown);
+            }
+
         }
 
         private static void AddAssembliesAssociatedWithType(TypeDesc type, HashSet<string> assemblies, out string definingAssembly)
@@ -982,7 +1146,7 @@ Example tracing commands used to generate the input to this tool:
             }
         }
 
-        static int GenerateMibcFile(TraceTypeSystemContext tsc, FileInfo outputFileName, ICollection<ProcessedMethodData> methodsToAttemptToPlaceIntoProfileData, bool validate)
+        static int GenerateMibcFile(TraceTypeSystemContext tsc, FileInfo outputFileName, ICollection<ProcessedMethodData> methodsToAttemptToPlaceIntoProfileData, bool validate, bool uncompressed)
         {
             TypeSystemMetadataEmitter emitter = new TypeSystemMetadataEmitter(new AssemblyName(outputFileName.Name), tsc);
 
@@ -1046,12 +1210,22 @@ Example tracing commands used to generate the input to this tool:
                 outputFileName.Delete();
             }
 
-            using (ZipArchive file = ZipFile.Open(outputFileName.FullName, ZipArchiveMode.Create))
+            if (uncompressed)
             {
-                var entry = file.CreateEntry(outputFileName.Name + ".dll", CompressionLevel.Optimal);
-                using (Stream archiveStream = entry.Open())
+                using (FileStream file = new FileStream(outputFileName.FullName, FileMode.Create))
                 {
-                    peFile.CopyTo(archiveStream);
+                    peFile.CopyTo(file);
+                }
+            }
+            else
+            {
+                using (ZipArchive file = ZipFile.Open(outputFileName.FullName, ZipArchiveMode.Create))
+                {
+                    var entry = file.CreateEntry(outputFileName.Name + ".dll", CompressionLevel.Optimal);
+                    using (Stream archiveStream = entry.Open())
+                    {
+                        peFile.CopyTo(archiveStream);
+                    }
                 }
             }
 

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -26,7 +26,7 @@ using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using System.Diagnostics.CodeAnalysis;
 using ILCompiler.Reflection.ReadyToRun;
 using Microsoft.Diagnostics.Tools.Pgo;
-using Microsoft.Pgo;
+using Internal.Pgo;
 
 namespace Microsoft.Diagnostics.Tools.Pgo
 {

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -976,7 +976,7 @@ Example tracing commands used to generate the input to this tool:
                                 offset += arr.Length;
                             }
 
-                            var intDecompressor = PgoProcessor.PgoEncodedCompressedIntParser(instrumentationData, 0);
+                            var intDecompressor = new PgoProcessor.PgoEncodedCompressedIntParser(instrumentationData, 0);
                             methodData.InstrumentationData = PgoProcessor.ParsePgoData<TypeSystemEntityOrUnknown>(pgoDataLoader, intDecompressor, true).ToArray();
                         }
                         methodsUsedInProcess.Add(methodData);
@@ -1078,9 +1078,10 @@ Example tracing commands used to generate the input to this tool:
                 return _emitter.AddGlobalMethod(methodName, _il, 8);
             }
 
-            void IPgoEncodedValueEmitter<TypeSystemEntityOrUnknown>.EmitDone()
+            bool IPgoEncodedValueEmitter<TypeSystemEntityOrUnknown>.EmitDone()
             {
                 _il.LoadString(_emitter.GetUserStringHandle("InstrumentationDataEnd"));
+                return true;
             }
 
             void IPgoEncodedValueEmitter<TypeSystemEntityOrUnknown>.EmitLong(long value, long previousValue)

--- a/src/coreclr/tools/dotnet-pgo/dotnet-pgo.csproj
+++ b/src/coreclr/tools/dotnet-pgo/dotnet-pgo.csproj
@@ -13,9 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\Pgo\PgoFormat.cs" Link="PgoFormat.cs" />
+    <Compile Include="..\Common\Pgo\TypeSystemEntityOrUnknown.cs" Link="TypeSystemEntityOrUnknown.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj" />
     <ProjectReference Include="../aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.55" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.65" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1228,6 +1228,17 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
     // Used later for a callback.
     CEEInfo ceeInf;
 
+#ifdef FEATURE_PGO
+    EX_TRY
+    {
+        PgoManager::Shutdown();
+    }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(SwallowAllExceptions);
+#endif
+
     if (!fIsDllUnloading)
     {
         ETW::EnumerationLog::ProcessShutdown();
@@ -1339,10 +1350,6 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
 #ifdef FEATURE_PERFMAP
         // Flush and close the perf map file.
         PerfMap::Destroy();
-#endif
-
-#ifdef FEATURE_PGO
-        PgoManager::Shutdown();
 #endif
 
         {

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -5395,7 +5395,7 @@ VOID ETW::MethodLog::GetR2RGetEntryPointStart(MethodDesc *pMethodDesc)
     }
 }
 
-VOID ETW::MethodLog::LogMethodInstrumentationData(MethodDesc* method, uint32_t cbData, BYTE *data)
+VOID ETW::MethodLog::LogMethodInstrumentationData(MethodDesc* method, uint32_t cbData, BYTE *data, TypeHandle* pTypeHandles, uint32_t typeHandles)
 {
     CONTRACTL{
         NOTHROW;
@@ -5410,6 +5410,19 @@ VOID ETW::MethodLog::LogMethodInstrumentationData(MethodDesc* method, uint32_t c
         EX_TRY
         {
             SendMethodDetailsEvent(method);
+
+            // If there are any type handles, fire the BulkType events to describe them
+            if (typeHandles != 0)
+            {
+                BulkTypeEventLogger typeLogger;
+
+                for (uint32_t iTypeHandle = 0; iTypeHandle < typeHandles; iTypeHandle++)
+                {
+                    ETW::TypeSystemLog::LogTypeAndParametersIfNecessary(&typeLogger, (ULONGLONG)pTypeHandles[iTypeHandle].AsPtr(), ETW::TypeSystemLog::kTypeLogBehaviorAlwaysLog);
+                }
+                typeLogger.FireBulkTypeEvent();
+            }
+
             ULONG ulMethodToken=0;
             auto pModule = method->GetModule_NoLogging();
             bool bIsDynamicMethod = method->IsDynamicMethod();

--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -187,21 +187,21 @@ public:
         if (!writer.AppendSchema(schema))
             return false;
 
-        if (!writer.AppendDataFromLastSchema())
-            return false;
-        for (int32_t iEntry = 0; iEntry < schema.Count; iEntry++)
+        if (!writer.AppendDataFromLastSchema([&](int64_t thWritten)
         {
-            size_t entryOffset = schema.Offset + iEntry * InstrumentationKindToSize(schema.InstrumentationKind);
-
-            if ((schema.InstrumentationKind & ICorJitInfo::PgoInstrumentationKind::MarshalMask) == ICorJitInfo::PgoInstrumentationKind::TypeHandle)
+            if (thWritten != 0)
             {
-                TypeHandle th = *(TypeHandle*)(pgoData->header.GetData() + entryOffset);
+                TypeHandle th = *(TypeHandle*)&thWritten;
                 if (!th.IsNull())
                 {
                     typeHandlesEncountered.Append(th);
                 }
             }
+        }))
+        {
+            return false;
         }
+
         return true;
     }
 };

--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -187,7 +187,7 @@ public:
         if (!writer.AppendSchema(schema))
             return false;
 
-        if (!writer.AppendDataFromLastSchema([&](int64_t thWritten)
+        auto lambda = [&](int64_t thWritten)
         {
             if (thWritten != 0)
             {
@@ -197,7 +197,9 @@ public:
                     typeHandlesEncountered.Append(th);
                 }
             }
-        }))
+        };
+
+        if (!writer.AppendDataFromLastSchema(lambda))
         {
             return false;
         }
@@ -278,7 +280,7 @@ void PgoManager::WritePgoData()
         uint8_t* data = pgoData->header.GetData();
 
         unsigned lastOffset  = 0;
-        if (!ReadInstrumentationSchemaWithLayout(pgoData->header.GetData(), pgoData->header.SchemaSizeMax(), pgoData->header.countsOffset, [data, pgoDataFile] (const ICorJitInfo::PgoInstrumentationSchema &schema)
+        auto lambda = [data, pgoDataFile] (const ICorJitInfo::PgoInstrumentationSchema &schema)
         {
             fprintf(pgoDataFile, s_RecordString, schema.InstrumentationKind, schema.ILOffset, schema.Count, schema.Other);
             for (int32_t iEntry = 0; iEntry < schema.Count; iEntry++)
@@ -325,8 +327,9 @@ void PgoManager::WritePgoData()
                 }
             }
             return true;
-        }
-        ))
+        };
+
+        if (!ReadInstrumentationSchemaWithLayout(pgoData->header.GetData(), pgoData->header.SchemaSizeMax(), pgoData->header.countsOffset, lambda))
         {
             return true;;
         }


### PR DESCRIPTION
Funnel PGO instrumentation data from runtime to crossgen2

- Representation of instrumentation data within crossgen2 and dotnet-pgo
- New uncompressed mibc format for easier debugging/faster processing
- Storage of instrumentation data in mibc file
- Parser for instrumentation data to load from mibc file
- Translation of crossgen2 in memory representation of instrumentation data from managed form to jit

Future PGO work will include
- Instrumentation data storage and extraction from R2R files
- Move Pgo type handle histogram processing into JIT (which will make type guessing work in crossgen2 as well as in the runtime)
- Triggers for controlling Pgo data extraction
- Size control for pgo instrumentation data

NOTE: This change relies on processing a new event from the runtime. While the change to the tracing library to parse the event has been accepted by the PerfView repo, it is not yet part of a release, therefore the CI for this change will fail to build.