### PR TITLE
Stops logging MSBuild errors when AOT compiler writes to stderr

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -105,6 +105,8 @@
       <BundleAssemblies Condition="'$(RunAOTCompilation)' != 'true'" Include="$(PublishDir)*.dll" />
     </ItemGroup>
 
+    <RemoveDir Directories="$(BundleDir)" />
+
     <MonoAOTCompiler Condition="'$(RunAOTCompilation)' == 'true'"
         CompilerBinaryPath="$(MicrosoftNetCoreAppRuntimePackNativeDir)cross\$(PackageRID)\mono-aot-cross"
         Mode="Full"
@@ -119,7 +121,6 @@
 
     <!-- Run App bundler, it uses AOT libs (if needed), link all native bits, compile simple UI (written in ObjC)
          and produce an app bundle (with xcode project) -->
-    <RemoveDir Directories="$(BundleDir)" />
     <AppleAppBuilderTask
         TargetOS="$(TargetOS)"
         Arch="$(TargetArchitecture)"

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -68,7 +68,7 @@ internal class Utils
             {
                 if (!silent)
                 {
-                    LogInfo(e.Data, outputMessageImportance);
+                    LogWarning(e.Data);
                     outputBuilder.AppendLine(e.Data);
                 }
                 errorBuilder.AppendLine(e.Data);
@@ -122,6 +122,12 @@ internal class Utils
     {
         if (msg != null)
             Logger?.LogMessage(importance, msg);
+    }
+
+    public static void LogWarning(string? msg)
+    {
+        if (msg != null)
+            Logger?.LogWarning(msg);
     }
 
     public static void LogError(string? msg)

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -68,7 +68,7 @@ internal class Utils
             {
                 if (!silent)
                 {
-                    LogError(e.Data);
+                    LogInfo(e.Data, outputMessageImportance);
                     outputBuilder.AppendLine(e.Data);
                 }
                 errorBuilder.AppendLine(e.Data);


### PR DESCRIPTION
The MonoAotCompiler task will just write to the MSBuild log as info rather than error.  Prevents AOT compilation from failing when no real failure occurred