### PR TITLE
make sure TcpClient is properly initialized when using name in ctor

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -74,6 +74,9 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
+            _family = AddressFamily.Unknown;
+            InitializeClientSocket();
+
             try
             {
                 Connect(hostname, port);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -75,7 +75,6 @@ namespace System.Net.Sockets
             }
 
             _family = AddressFamily.Unknown;
-            InitializeClientSocket();
 
             try
             {
@@ -174,6 +173,11 @@ namespace System.Net.Sockets
                             if ((address.AddressFamily == AddressFamily.InterNetwork && Socket.OSSupportsIPv4) || Socket.OSSupportsIPv6)
                             {
                                 var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                                if (address.IsIPv4MappedToIPv6)
+                                {
+                                    socket.DualMode = true;
+                                }
+
                                 // Use of Interlocked.Exchanged ensures _clientSocket is written before Disposed is read.
                                 Interlocked.Exchange(ref _clientSocket!, socket);
                                 if (Disposed)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -493,6 +493,40 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Connect_MappedV4_Success(bool useConnect)
+        {
+            if (!Socket.OSSupportsIPv6 || !Socket.OSSupportsIPv4)
+            {
+                return;
+            }
+
+            using (var server = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                // Set up a server socket to which to connect
+                server.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                server.Listen(1);
+                var endpoint = (IPEndPoint)server.LocalEndPoint;
+
+                string serverAddress = $"::ffff:{endpoint.Address.ToString()}";
+
+                TcpClient client;
+                if (useConnect)
+                {
+                    client = new TcpClient();
+                    client.Connect(serverAddress, endpoint.Port);
+                }
+                else
+                {
+                    client = new TcpClient(serverAddress, endpoint.Port);
+                }
+
+                Assert.True(client.Connected);
+            }
+        }
+
         private sealed class DerivedTcpClient : TcpClient
         {
             public new bool Active

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -524,6 +524,7 @@ namespace System.Net.Sockets.Tests
                 }
 
                 Assert.True(client.Connected);
+                client.Dispose();
             }
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -500,7 +500,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(true, "::1")]
         public void CtorConnect_Success(bool useIPv6, string connectString)
         {
-            if (!Socket.OSSupportsIPv6 || !Socket.OSSupportsIPv4)
+            if (!Socket.OSSupportsIPv6)
             {
                 return;
             }


### PR DESCRIPTION
We missed one of the constructors when updated TcpClient to use dual mode sockets.

fixes  #46724
