### PR TITLE
FileSystem.AccessControl tests not cleaning files properly

### DIFF
--- a/src/libraries/Common/tests/System/IO/TempDirectory.cs
+++ b/src/libraries/Common/tests/System/IO/TempDirectory.cs
@@ -9,7 +9,7 @@ namespace System.IO
     /// Represents a temporary directory.  Creating an instance creates a directory at the specified path,
     /// and disposing the instance deletes the directory.
     /// </summary>
-    public sealed class TempDirectory : IDisposable
+    public class TempDirectory : IDisposable
     {
         public const int MaxNameLength = 255;
 
@@ -40,7 +40,7 @@ namespace System.IO
 
         public string GenerateRandomFilePath() => IO.Path.Combine(Path, IO.Path.GetRandomFileName());
 
-        private void DeleteDirectory()
+        protected virtual void DeleteDirectory()
         {
             try { Directory.Delete(Path, recursive: true); }
             catch { /* Ignore exceptions on disposal paths */ }

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace System.IO
         {
             using var directory = new TempAclDirectory();
             var directoryInfo = new DirectoryInfo(directory.Path);
-            DirectorySecurity directorySecurity = directoryInfo.GetAccessControl(AccessControlSections.Access);
+            DirectorySecurity directorySecurity = directoryInfo.GetAccessControl();
             Assert.NotNull(directorySecurity);
             Assert.Equal(typeof(FileSystemRights), directorySecurity.AccessRightType);
         }
@@ -97,7 +97,7 @@ namespace System.IO
         {
             using var directory = new TempAclDirectory();
             using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
-            using FileStream fileStream = File.Open(file.Path, FileMode.Append, FileAccess.Write, FileShare.Delete);
+            using FileStream fileStream = File.Open(file.Path, FileMode.Append, FileAccess.Write, FileShare.None);
             FileSecurity fileSecurity = FileSystemAclExtensions.GetAccessControl(fileStream);
             Assert.NotNull(fileSecurity);
             Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
@@ -154,7 +154,7 @@ namespace System.IO
         {
             using var directory = new TempAclDirectory();
             using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
-            using FileStream fileStream = File.Open(file.Path, FileMode.Open, FileAccess.Write, FileShare.None);
+            using FileStream fileStream = File.Open(file.Path, FileMode.Append, FileAccess.Write, FileShare.None);
             AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => FileSystemAclExtensions.SetAccessControl(fileStream, fileSecurity: null));
         }
 
@@ -231,7 +231,7 @@ namespace System.IO
         }
 
         [Theory]
-        // Must have at least one Read, otherwise the TempAclDirectory will fail to delete that item on dispose
+        // Must have at least one ReadData, otherwise the TempAclDirectory will fail to delete that item on dispose
         [MemberData(nameof(RightsToAllow))]
         public void DirectoryInfo_Create_AllowSpecific_AccessRules(FileSystemRights rights)
         {

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -154,7 +154,7 @@ namespace System.IO
         {
             using var directory = new TempAclDirectory();
             using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
-            using FileStream fileStream = File.Open(file.Path, FileMode.Open, FileAccess.Write, FileShare.Delete);
+            using FileStream fileStream = File.Open(file.Path, FileMode.Open, FileAccess.Write, FileShare.None);
             AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => FileSystemAclExtensions.SetAccessControl(fileStream, fileSecurity: null));
         }
 

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -552,7 +552,7 @@ namespace System.IO
 
         private void Verify_FileSecurity_CreateFile(FileSecurity expectedSecurity)
         {
-            Verify_FileSecurity_CreateFile(FileMode.Create, FileSystemRights.FullControl, FileShare.ReadWrite, DefaultBufferSize, FileOptions.Asynchronous, expectedSecurity);
+            Verify_FileSecurity_CreateFile(FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, expectedSecurity);
         }
 
         private void Verify_FileSecurity_CreateFile(FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity expectedSecurity)

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -63,7 +63,7 @@ namespace System.IO
             using var directory = new TempAclDirectory();
             using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
             var fileInfo = new FileInfo(file.Path);
-            FileSecurity fileSecurity = fileInfo.GetAccessControl(AccessControlSections.Access);
+            FileSecurity fileSecurity = fileInfo.GetAccessControl();
             Assert.NotNull(fileSecurity);
             Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
         }
@@ -149,15 +149,12 @@ namespace System.IO
             Assert.Throws<ArgumentNullException>("fileStream", () => FileSystemAclExtensions.SetAccessControl((FileStream)null, fileSecurity: null));
         }
 
-        [Theory]
-        [InlineData(FileMode.Append)]
-        [InlineData(FileMode.Open)]
-        [InlineData(FileMode.OpenOrCreate)]
-        public void SetAccessControl_FileStream_FileSecurity_InvalidFileSecurityObject(FileMode mode)
+        [Fact]
+        public void SetAccessControl_FileStream_FileSecurity_InvalidFileSecurityObject()
         {
             using var directory = new TempAclDirectory();
             using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
-            using FileStream fileStream = File.Open(file.Path, mode, FileAccess.Write, FileShare.None);
+            using FileStream fileStream = File.Open(file.Path, FileMode.Open, FileAccess.Write, FileShare.None);
             AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => FileSystemAclExtensions.SetAccessControl(fileStream, fileSecurity: null));
         }
 

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -149,12 +149,15 @@ namespace System.IO
             Assert.Throws<ArgumentNullException>("fileStream", () => FileSystemAclExtensions.SetAccessControl((FileStream)null, fileSecurity: null));
         }
 
-        [Fact]
-        public void SetAccessControl_FileStream_FileSecurity_InvalidFileSecurityObject()
+        [Theory]
+        [InlineData(FileMode.Append)]
+        [InlineData(FileMode.Open)]
+        [InlineData(FileMode.OpenOrCreate)]
+        public void SetAccessControl_FileStream_FileSecurity_InvalidFileSecurityObject(FileMode mode)
         {
             using var directory = new TempAclDirectory();
             using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
-            using FileStream fileStream = File.Open(file.Path, FileMode.Open, FileAccess.Write, FileShare.None);
+            using FileStream fileStream = File.Open(file.Path, mode, FileAccess.Write, FileShare.None);
             AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => FileSystemAclExtensions.SetAccessControl(fileStream, fileSecurity: null));
         }
 

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -211,14 +211,21 @@ namespace System.IO
             }
         }
 
-        [Fact]
-        public void DirectoryInfo_Create_DirectorySecurityWithSpecificAccessRule()
+        [Theory]
+        // Must have at least one Read, otherwise the TempAclDirectory will fail to delete that item on dispose
+        [InlineData(FileSystemRights.FullControl)]
+        [InlineData(FileSystemRights.Read)]
+        [InlineData(FileSystemRights.Read | FileSystemRights.Write)]
+        [InlineData(FileSystemRights.Read | FileSystemRights.Write | FileSystemRights.ExecuteFile)]
+        [InlineData(FileSystemRights.ReadAndExecute)]
+        [InlineData(FileSystemRights.ReadAttributes | FileSystemRights.ReadData | FileSystemRights.ReadPermissions)]
+        public void DirectoryInfo_Create_DirectorySecurityWithSpecificAccessRule(FileSystemRights rights)
         {
             using var directory = new TempAclDirectory();
             string path = Path.Combine(directory.Path, "directory");
             DirectoryInfo info = new DirectoryInfo(path);
 
-            DirectorySecurity expectedSecurity = GetDirectorySecurity(FileSystemRights.FullControl);
+            DirectorySecurity expectedSecurity = GetDirectorySecurity(rights);
 
             info.Create(expectedSecurity);
 

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="FileSystemAuditRuleTests.cs" />
     <Compile Include="FileSystemSecurityTests.cs" />
     <Compile Include="Helpers.cs" />
+    <Compile Include="TempAclDirectory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.IO.FileSystem.AccessControl.csproj" SkipUseReferenceAssembly="true" />

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace System.IO
+{
+    /// <summary>
+    /// Represents a temporary directory.
+    /// Disposing will recurse all files and directories inside it, ensure the
+    /// appropriate access control is set, then delete all of them.
+    /// </summary>
+    public sealed class TempAclDirectory : TempDirectory
+    {
+        protected override void DeleteDirectory()
+        {
+            try
+            {
+                var identity = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+                var accessRule = new FileSystemAccessRule(identity, FileSystemRights.FullControl, AccessControlType.Allow);
+
+                foreach (string file in Directory.EnumerateFiles(Path, "*", SearchOption.AllDirectories))
+                {
+                    var fileSecurity = new FileSecurity(file, AccessControlSections.Access);
+                    var fileInfo = new FileInfo(file);
+                    fileInfo.SetAccessControl(fileSecurity);
+                }
+
+                foreach (string directory in Directory.EnumerateDirectories(Path, "*", SearchOption.AllDirectories))
+                {
+                    var directorySecurity = new DirectorySecurity(directory, AccessControlSections.Access);
+                    var directoryInfo = new DirectoryInfo(directory);
+                    directoryInfo.SetAccessControl(directorySecurity);
+                }
+
+                Directory.Delete(Path, recursive: true);
+            }
+            catch () { /* Do not throw because we call this on finalize */ }
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
@@ -16,8 +16,8 @@ namespace System.IO
     {
         protected override void DeleteDirectory()
         {
-            //try
-            //{
+            try
+            {
                 var identity = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
                 var accessRule = new FileSystemAccessRule(identity, FileSystemRights.FullControl, AccessControlType.Allow);
 
@@ -36,8 +36,8 @@ namespace System.IO
                 var rootDirInfo = new DirectoryInfo(Path);
                 rootDirInfo.SetAccessControl(new DirectorySecurity(Path, AccessControlSections.Access));
                 rootDirInfo.Delete(recursive: true);
-            //}
-            //catch { /* Do not throw because we call this on finalize */ }
+            }
+            catch { /* Do not throw because we call this on finalize */ }
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
@@ -15,8 +15,8 @@ namespace System.IO
     {
         protected override void DeleteDirectory()
         {
-            try
-            {
+            //try
+            //{
                 var identity = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
                 var accessRule = new FileSystemAccessRule(identity, FileSystemRights.FullControl, AccessControlType.Allow);
 
@@ -35,8 +35,8 @@ namespace System.IO
                 }
 
                 Directory.Delete(Path, recursive: true);
-            }
-            catch () { /* Do not throw because we call this on finalize */ }
+            //}
+            // catch { /* Do not throw because we call this on finalize */ }
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
@@ -24,17 +24,23 @@ namespace System.IO
                 foreach (string dirPath in Directory.EnumerateDirectories(Path, "*", SearchOption.AllDirectories))
                 {
                     var dirInfo = new DirectoryInfo(dirPath);
-                    dirInfo.SetAccessControl(new DirectorySecurity(dirPath, AccessControlSections.Access));
+                    var dirSecurity = new DirectorySecurity(dirPath, AccessControlSections.Access);
+                    dirSecurity.AddAccessRule(accessRule);
+                    dirInfo.SetAccessControl(dirSecurity);
                 }
 
                 foreach (string filePath in Directory.EnumerateFiles(Path, "*", SearchOption.AllDirectories))
                 {
                     var fileInfo = new FileInfo(filePath);
-                    fileInfo.SetAccessControl(new FileSecurity(filePath, AccessControlSections.Access));
+                    var fileSecurity = new FileSecurity(filePath, AccessControlSections.Access);
+                    fileSecurity.AddAccessRule(accessRule);
+                    fileInfo.SetAccessControl(fileSecurity);
                 }
 
                 var rootDirInfo = new DirectoryInfo(Path);
-                rootDirInfo.SetAccessControl(new DirectorySecurity(Path, AccessControlSections.Access));
+                var rootSecurity = new DirectorySecurity(Path, AccessControlSections.Access);
+                rootSecurity.AddAccessRule(accessRule);
+                rootDirInfo.SetAccessControl(rootSecurity);
                 rootDirInfo.Delete(recursive: true);
             }
             catch { /* Do not throw because we call this on finalize */ }

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/TempAclDirectory.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Security.AccessControl;
 using System.Security.Principal;
 
@@ -20,23 +21,23 @@ namespace System.IO
                 var identity = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
                 var accessRule = new FileSystemAccessRule(identity, FileSystemRights.FullControl, AccessControlType.Allow);
 
-                foreach (string file in Directory.EnumerateFiles(Path, "*", SearchOption.AllDirectories))
+                foreach (string dirPath in Directory.EnumerateDirectories(Path, "*", SearchOption.AllDirectories))
                 {
-                    var fileSecurity = new FileSecurity(file, AccessControlSections.Access);
-                    var fileInfo = new FileInfo(file);
-                    fileInfo.SetAccessControl(fileSecurity);
+                    var dirInfo = new DirectoryInfo(dirPath);
+                    dirInfo.SetAccessControl(new DirectorySecurity(dirPath, AccessControlSections.Access));
                 }
 
-                foreach (string directory in Directory.EnumerateDirectories(Path, "*", SearchOption.AllDirectories))
+                foreach (string filePath in Directory.EnumerateFiles(Path, "*", SearchOption.AllDirectories))
                 {
-                    var directorySecurity = new DirectorySecurity(directory, AccessControlSections.Access);
-                    var directoryInfo = new DirectoryInfo(directory);
-                    directoryInfo.SetAccessControl(directorySecurity);
+                    var fileInfo = new FileInfo(filePath);
+                    fileInfo.SetAccessControl(new FileSecurity(filePath, AccessControlSections.Access));
                 }
 
-                Directory.Delete(Path, recursive: true);
+                var rootDirInfo = new DirectoryInfo(Path);
+                rootDirInfo.SetAccessControl(new DirectorySecurity(Path, AccessControlSections.Access));
+                rootDirInfo.Delete(recursive: true);
             //}
-            // catch { /* Do not throw because we call this on finalize */ }
+            //catch { /* Do not throw because we call this on finalize */ }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44766

The TempDirectory helper class is disposable. The finalizer calls a function that deletes the folders left behind, without throwing exceptions on fail.

This protective try catch hid some additional errors that were not caught when these unit tests were first written, so I'm fixing them:

- I created a class that inherits from TempDirectory to override the folder deleting method
- In the finalizer, I iterate through all the files and folders created by the test, ensure their ACLs give me full control (in case the tests prevent deletion), then attempt to delete the tree.
- To verify my changes, I did not put the finalizer code in a try catch, so I could see the errors thrown when attempting to delete the tree.
- The deletion exceptions helped me find that GetAccessControl needs to be called with the AccessControlSections.Access argument, otherwise they throw "PrivilegeNotHeldException: The process does not possess the 'SeSecurityPrivilege' privilege which is required for this operation."
- I avoided creating files and directories using a FileSecurity or DirectorySecurity that did not have its access rules defined. Files and folders created this way could not be deleted.
- I avoided testing AccessControlType.Deny. This would also cause deletion exceptions.
- Moved some repeated code into common methods.
- Before commiting, I made sure to put the file/folder deletion code inside a try catch to prevent finalizer exceptions.