### PR TITLE
Name some more threads

### DIFF
--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
@@ -487,7 +487,7 @@ namespace Microsoft.Win32
                             s_windowThread = new Thread(new ThreadStart(systemEvents.WindowThreadProc))
                             {
                                 IsBackground = true,
-                                Name = ".NET SystemEvents"
+                                Name = ".NET System Events"
                             };
                             s_windowThread.Start();
                             s_eventWindowReady.WaitOne();

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1473,7 +1473,11 @@ namespace System
                 // on work triggered from the signal handling thread.
                 // We use a new thread rather than queueing to the ThreadPool in order to prioritize handling
                 // in case the ThreadPool is saturated.
-                Thread handlerThread = new Thread(HandleBreakEvent) { IsBackground = true, Name = ".NET Console Break" };
+                Thread handlerThread = new Thread(HandleBreakEvent)
+                {
+                    IsBackground = true,
+                    Name = ".NET Console Break"
+                };
                 handlerThread.Start(ctrlCode);
             }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1473,7 +1473,7 @@ namespace System
                 // on work triggered from the signal handling thread.
                 // We use a new thread rather than queueing to the ThreadPool in order to prioritize handling
                 // in case the ThreadPool is saturated.
-                Thread handlerThread = new Thread(HandleBreakEvent) { IsBackground = true };
+                Thread handlerThread = new Thread(HandleBreakEvent) { IsBackground = true, Name = ".NET Console Break" };
                 handlerThread.Start(ctrlCode);
             }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -165,7 +165,7 @@ namespace System.Diagnostics
                 if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
                 {
                     ThreadStart threadStart = new ThreadStart(ShellExecuteFunction);
-                    Thread executionThread = new Thread(threadStart) { IsBackground = true };
+                    Thread executionThread = new Thread(threadStart) { IsBackground = true, Name = ".NET STA Execution" };
                     executionThread.SetApartmentState(ApartmentState.STA);
                     executionThread.Start();
                     executionThread.Join();

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -168,7 +168,7 @@ namespace System.Diagnostics
                     Thread executionThread = new Thread(threadStart)
                     {
                         IsBackground = true,
-                        Name = ".NET STA Execution"
+                        Name = ".NET Process STA"
                     };
                     executionThread.SetApartmentState(ApartmentState.STA);
                     executionThread.Start();

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -165,7 +165,11 @@ namespace System.Diagnostics
                 if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
                 {
                     ThreadStart threadStart = new ThreadStart(ShellExecuteFunction);
-                    Thread executionThread = new Thread(threadStart) { IsBackground = true, Name = ".NET STA Execution" };
+                    Thread executionThread = new Thread(threadStart)
+                    {
+                        IsBackground = true,
+                        Name = ".NET STA Execution"
+                    };
                     executionThread.SetApartmentState(ApartmentState.STA);
                     executionThread.Start();
                     executionThread.Join();

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
@@ -345,7 +345,8 @@ namespace System.DirectoryServices.Protocols
             // Start the thread.
             var thread = new Thread(new ThreadStart(ThreadRoutine))
             {
-                IsBackground = true
+                IsBackground = true,
+                Name = ".NET Ldap Results"
             };
             thread.Start();
         }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
@@ -346,7 +346,7 @@ namespace System.DirectoryServices.Protocols
             var thread = new Thread(new ThreadStart(ThreadRoutine))
             {
                 IsBackground = true,
-                Name = ".NET Ldap Results"
+                Name = ".NET LDAP Results Retriever"
             };
             thread.Start();
         }

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -517,9 +517,6 @@ namespace System.IO
             /// </summary>
             private void ProcessEvents()
             {
-                // It's OK to set the name since we specified TaskCreationOptions.LongRunning
-                Thread.CurrentThread.Name = ".NET File Watcher";
-
                 // When cancellation is requested, clear out all watches.  This should force any active or future reads
                 // on the inotify handle to return 0 bytes read immediately, allowing us to wake up from the blocking call
                 // and exit the processing loop and clean up.

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -517,6 +517,9 @@ namespace System.IO
             /// </summary>
             private void ProcessEvents()
             {
+                // It's OK to set the name since we specified TaskCreationOptions.LongRunning
+                Thread.CurrentThread.Name = ".NET File Watcher";
+
                 // When cancellation is requested, clear out all watches.  This should force any active or future reads
                 // on the inotify handle to return 0 bytes read immediately, allowing us to wake up from the blocking call
                 // and exit the processing loop and clean up.

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -204,7 +204,7 @@ namespace System.IO
                             object[] inputArgs = (object[])args!;
                             WatchForFileSystemEventsThreadStart((ManualResetEventSlim)inputArgs[0], (SafeEventStreamHandle)inputArgs[1]);
                         })
-                        { IsBackground = true, Name = ".NET File System Watcher" }.UnsafeStart(new object[] { runLoopStarted, eventStream });
+                        { IsBackground = true, Name = ".NET File Watcher" }.UnsafeStart(new object[] { runLoopStarted, eventStream });
 
                         runLoopStarted.Wait();
                     }

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -204,7 +204,7 @@ namespace System.IO
                             object[] inputArgs = (object[])args!;
                             WatchForFileSystemEventsThreadStart((ManualResetEventSlim)inputArgs[0], (SafeEventStreamHandle)inputArgs[1]);
                         })
-                        { IsBackground = true }.UnsafeStart(new object[] { runLoopStarted, eventStream });
+                        { IsBackground = true, Name = ".NET File System Watcher" }.UnsafeStart(new object[] { runLoopStarted, eventStream });
 
                         runLoopStarted.Wait();
                     }

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -204,7 +204,10 @@ namespace System.IO
                             object[] inputArgs = (object[])args!;
                             WatchForFileSystemEventsThreadStart((ManualResetEventSlim)inputArgs[0], (SafeEventStreamHandle)inputArgs[1]);
                         })
-                        { IsBackground = true, Name = ".NET File Watcher" }.UnsafeStart(new object[] { runLoopStarted, eventStream });
+                        {
+                            IsBackground = true,
+                            Name = ".NET File Watcher"
+                        }.UnsafeStart(new object[] { runLoopStarted, eventStream });
 
                         runLoopStarted.Wait();
                     }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -179,7 +179,7 @@ namespace System.Net.NetworkInformation
             }
             s_runLoopThread = new Thread(RunLoopThreadStart);
             s_runLoopThread.IsBackground = true;
-            s_runLoopThread.Name = ".NET Net Address Change";
+            s_runLoopThread.Name = ".NET Network Address Change";
             s_runLoopThread.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -177,10 +177,11 @@ namespace System.Net.NetworkInformation
                         IntPtr.Zero);
                 }
             }
-            s_runLoopThread = new Thread(RunLoopThreadStart);
-            s_runLoopThread.IsBackground = true;
-            s_runLoopThread.Name = ".NET Network Address Change";
-            s_runLoopThread.Start();
+            s_runLoopThread = new Thread(RunLoopThreadStart)
+            {
+                 IsBackground = true,
+                 Name = ".NET Network Address Change"
+            }.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }
 

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -179,7 +179,7 @@ namespace System.Net.NetworkInformation
             }
             s_runLoopThread = new Thread(RunLoopThreadStart);
             s_runLoopThread.IsBackground = true;
-            s_runLoopThread.Name = ".NET Network Address Change"
+            s_runLoopThread.Name = ".NET Network Address Change";
             s_runLoopThread.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -179,6 +179,7 @@ namespace System.Net.NetworkInformation
             }
             s_runLoopThread = new Thread(RunLoopThreadStart);
             s_runLoopThread.IsBackground = true;
+            s_runLoopThread.Name = ".NET Network Address Change"
             s_runLoopThread.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -181,7 +181,8 @@ namespace System.Net.NetworkInformation
             {
                  IsBackground = true,
                  Name = ".NET Network Address Change"
-            }.Start();
+            };
+            s_runLoopThread.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }
 

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -179,7 +179,7 @@ namespace System.Net.NetworkInformation
             }
             s_runLoopThread = new Thread(RunLoopThreadStart);
             s_runLoopThread.IsBackground = true;
-            s_runLoopThread.Name = ".NET Network Address Change";
+            s_runLoopThread.Name = ".NET Net Address Change";
             s_runLoopThread.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Unix.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Unix.cs
@@ -153,7 +153,7 @@ namespace System.Net.NetworkInformation
             new Thread(s => LoopReadSocket((int)s!))
             {
                 IsBackground = true,
-                Name = ".NET Net Address Monitor"
+                Name = ".NET Network Address Change"
             }.UnsafeStart(newSocket);
         }
 

--- a/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -471,7 +471,7 @@ namespace System.Net
 
             if (oldState == TimerThreadState.Idle)
             {
-                new Thread(new ThreadStart(ThreadProc)).Start();
+                new Thread(new ThreadStart(ThreadProc) { IsBackground = true, Name = ".NET Networking Timer" }).Start();
             }
         }
 
@@ -481,9 +481,6 @@ namespace System.Net
         /// </summary>
         private static void ThreadProc()
         {
-            // Set this thread as a background thread.  On AppDomain/Process shutdown, the thread will just be killed.
-            Thread.CurrentThread.IsBackground = true;
-
             // Keep a permanent lock on s_Queues.  This lets for example Shutdown() know when this thread isn't running.
             lock (s_queues)
             {

--- a/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -471,7 +471,11 @@ namespace System.Net
 
             if (oldState == TimerThreadState.Idle)
             {
-                new Thread(new ThreadStart(ThreadProc)) { IsBackground = true, Name = ".NET Network Timer" }.Start();
+                new Thread(new ThreadStart(ThreadProc))
+                {
+                    IsBackground = true,
+                    Name = ".NET Network Timer"
+                }.Start();
             }
         }
 

--- a/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -471,7 +471,7 @@ namespace System.Net
 
             if (oldState == TimerThreadState.Idle)
             {
-                new Thread(new ThreadStart(ThreadProc) { IsBackground = true, Name = ".NET Networking Timer" }).Start();
+                new Thread(new ThreadStart(ThreadProc)) { IsBackground = true, Name = ".NET Networking Timer" }.Start();
             }
         }
 

--- a/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -471,7 +471,7 @@ namespace System.Net
 
             if (oldState == TimerThreadState.Idle)
             {
-                new Thread(new ThreadStart(ThreadProc)) { IsBackground = true, Name = ".NET Networking Timer" }.Start();
+                new Thread(new ThreadStart(ThreadProc)) { IsBackground = true, Name = ".NET Net Timer" }.Start();
             }
         }
 

--- a/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -471,7 +471,7 @@ namespace System.Net
 
             if (oldState == TimerThreadState.Idle)
             {
-                new Thread(new ThreadStart(ThreadProc)) { IsBackground = true, Name = ".NET Net Timer" }.Start();
+                new Thread(new ThreadStart(ThreadProc)) { IsBackground = true, Name = ".NET Network Timer" }.Start();
             }
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -157,9 +157,11 @@ namespace System.Net.Sockets
                     throw new InternalException(err);
                 }
 
-                var thread = new Thread(static s => ((SocketAsyncEngine)s!).EventLoop());
-                thread.IsBackground = true;
-                thread.Name = ".NET Sockets";
+                var thread = new Thread(static s => ((SocketAsyncEngine)s!).EventLoop())
+                {
+                    thread.IsBackground = true,
+                    thread.Name = ".NET Sockets"
+                };
                 thread.UnsafeStart(this);
             }
             catch

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -159,8 +159,8 @@ namespace System.Net.Sockets
 
                 var thread = new Thread(static s => ((SocketAsyncEngine)s!).EventLoop())
                 {
-                    thread.IsBackground = true,
-                    thread.Name = ".NET Sockets"
+                    IsBackground = true,
+                    Name = ".NET Sockets"
                 };
                 thread.UnsafeStart(this);
             }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2569,9 +2569,6 @@
   <data name="InvalidOperation_UnknownEnumType" xml:space="preserve">
     <value>Unknown enum type.</value>
   </data>
-  <data name="InvalidOperation_WriteOnce" xml:space="preserve">
-    <value>This property has already been set and cannot be modified.</value>
-  </data>
   <data name="InvalidOperation_WrongAsyncResultOrEndCalledMultiple" xml:space="preserve">
     <value>Either the IAsyncResult object did not come from the corresponding async method on this type, or the End method was called multiple times with the same IAsyncResult.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -151,7 +151,11 @@ namespace System.Diagnostics.Tracing
                     {
                         s_pollingThreadSleepEvent = new AutoResetEvent(false);
                         s_counterGroupEnabledList = new List<CounterGroup>();
-                        s_pollingThread = new Thread(PollForValues) { IsBackground = true, Name = ".NET Counter Poller"  };
+                        s_pollingThread = new Thread(PollForValues)
+                        {
+                            IsBackground = true,
+                            Name = ".NET Counter Poller"
+                        };
 #if ES_BUILD_STANDALONE
                         s_pollingThread.Start();
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -151,7 +151,7 @@ namespace System.Diagnostics.Tracing
                     {
                         s_pollingThreadSleepEvent = new AutoResetEvent(false);
                         s_counterGroupEnabledList = new List<CounterGroup>();
-                        s_pollingThread = new Thread(PollForValues) { IsBackground = true, Name = ".NET Counter Polling"  };
+                        s_pollingThread = new Thread(PollForValues) { IsBackground = true, Name = ".NET Counter Poller"  };
 #if ES_BUILD_STANDALONE
                         s_pollingThread.Start();
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -151,7 +151,7 @@ namespace System.Diagnostics.Tracing
                     {
                         s_pollingThreadSleepEvent = new AutoResetEvent(false);
                         s_counterGroupEnabledList = new List<CounterGroup>();
-                        s_pollingThread = new Thread(PollForValues) { IsBackground = true };
+                        s_pollingThread = new Thread(PollForValues) { IsBackground = true, Name = ".NET Counter Polling"  };
 #if ES_BUILD_STANDALONE
                         s_pollingThread.Start();
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -170,10 +170,12 @@ namespace System.Threading
                 {
                     // Thread pool threads must start in the default execution context without transferring the context, so
                     // using UnsafeStart() instead of Start()
-                    Thread gateThread = new Thread(GateThreadStart, SmallStackSizeBytes);
-                    gateThread.IsThreadPoolThread = true;
-                    gateThread.IsBackground = true;
-                    gateThread.Name = ".NET ThreadPool Gate";
+                    Thread gateThread = new Thread(GateThreadStart, SmallStackSizeBytes)
+                    {
+                        IsThreadPoolThread = true,
+                        IsBackground = true,
+                        Name = ".NET ThreadPool Gate"
+                    };
                     gateThread.UnsafeStart();
                     created = true;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -186,10 +186,12 @@ namespace System.Threading
 
                 // Thread pool threads must start in the default execution context without transferring the context, so
                 // using UnsafeStart() instead of Start()
-                Thread waitThread = new Thread(WaitThreadStart, SmallStackSizeBytes);
-                waitThread.IsThreadPoolThread = true;
-                waitThread.IsBackground = true;
-                waitThread.Name = ".NET ThreadPool Wait";
+                Thread waitThread = new Thread(WaitThreadStart, SmallStackSizeBytes)
+                {
+                    IsThreadPoolThread = true,
+                    IsBackground = true,
+                    Name = ".NET ThreadPool Wait"
+                };
                 waitThread.UnsafeStart();
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -295,6 +295,7 @@ namespace System.Threading
                     Thread workerThread = new Thread(s_workerThreadStart);
                     workerThread.IsThreadPoolThread = true;
                     workerThread.IsBackground = true;
+                    // thread name will be set in thread proc
                     workerThread.UnsafeStart();
                 }
                 catch (ThreadStartException)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -49,7 +49,7 @@ namespace System.Threading.Tasks
                 new Thread(s_longRunningThreadWork)
                 {
                     IsBackground = true,
-                    Name = ".NET ThreadPool Long Running Worker"
+                    Name = ".NET Long Running Task"
                 }.UnsafeStart(task);
 #pragma warning restore CA1416
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -46,7 +46,11 @@ namespace System.Threading.Tasks
             {
                 // Run LongRunning tasks on their own dedicated thread.
 #pragma warning disable CA1416 // TODO: https://github.com/dotnet/runtime/issues/44922
-                new Thread(s_longRunningThreadWork) { IsBackground = true, Name = ".NET ThreadPool Long Running Worker"}.UnsafeStart(task);
+                new Thread(s_longRunningThreadWork)
+                {
+                    IsBackground = true,
+                    Name = ".NET ThreadPool Long Running Worker"
+                }.UnsafeStart(task);
 #pragma warning restore CA1416
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -47,6 +47,7 @@ namespace System.Threading.Tasks
                 // Run LongRunning tasks on their own dedicated thread.
 #pragma warning disable CA1416 // TODO: https://github.com/dotnet/runtime/issues/44922
                 new Thread(s_longRunningThreadWork) { IsBackground = true }.UnsafeStart(task);
+                // Do not name thread; user code may expect to do this
 #pragma warning restore CA1416
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -46,8 +46,7 @@ namespace System.Threading.Tasks
             {
                 // Run LongRunning tasks on their own dedicated thread.
 #pragma warning disable CA1416 // TODO: https://github.com/dotnet/runtime/issues/44922
-                new Thread(s_longRunningThreadWork) { IsBackground = true }.UnsafeStart(task);
-                // Do not name thread; user code may expect to do this
+                new Thread(s_longRunningThreadWork) { IsBackground = true, Name = ".NET ThreadPool Long Running Worker"}.UnsafeStart(task);
 #pragma warning restore CA1416
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -343,10 +343,10 @@ namespace System.Threading
             {
                 lock (this)
                 {
-                    _name = value;
-                    ThreadNameChanged(value);
-                    if (value != null)
+                    if (_name != value)
                     {
+                        _name = value;
+                        ThreadNameChanged(value);
                         _mayNeedResetForThreadPool = true;
                     }
                 }
@@ -362,7 +362,6 @@ namespace System.Threading
             {
                 _name = ThreadPool.WorkerThreadName;
                 ThreadNameChanged(ThreadPool.WorkerThreadName);
-                _name = null;
             }
         }
 
@@ -389,7 +388,7 @@ namespace System.Threading
 
             _mayNeedResetForThreadPool = false;
 
-            if (_name != null)
+            if (_name != ThreadPool.WorkerThreadName)
             {
                 SetThreadPoolWorkerThreadName();
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -343,11 +343,6 @@ namespace System.Threading
             {
                 lock (this)
                 {
-                    if (_name != null)
-                    {
-                        throw new InvalidOperationException(SR.InvalidOperation_WriteOnce);
-                    }
-
                     _name = value;
                     ThreadNameChanged(value);
                     if (value != null)
@@ -365,7 +360,6 @@ namespace System.Threading
 
             lock (this)
             {
-                // Bypass the exception from setting the property
                 _name = ThreadPool.WorkerThreadName;
                 ThreadNameChanged(ThreadPool.WorkerThreadName);
                 _name = null;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
@@ -36,9 +36,11 @@ namespace System.Threading
 
             // The timer thread must start in the default execution context without transferring the context, so
             // using UnsafeStart() instead of Start()
-            Thread timerThread = new Thread(TimerThread);
-            timerThread.Name = ".NET Timers";
-            timerThread.IsBackground = true;
+            Thread timerThread = new Thread(TimerThread)
+            {
+                Name = ".NET Timers",
+                IsBackground = true
+            };
             timerThread.UnsafeStart();
 
             // Do this after creating the thread in case thread creation fails so that it will try again next time

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
@@ -37,6 +37,7 @@ namespace System.Threading
             // The timer thread must start in the default execution context without transferring the context, so
             // using UnsafeStart() instead of Start()
             Thread timerThread = new Thread(TimerThread);
+            timerThread.Name = ".NET Timers";
             timerThread.IsBackground = true;
             timerThread.UnsafeStart();
 

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -621,19 +621,20 @@ namespace System.Threading.Threads.Tests
                 {
                     var ct = Thread.CurrentThread;
                     Assert.Equal(name, ct.Name);
-                    Assert.Throws<InvalidOperationException>(() => ct.Name = null);
-                    Assert.Throws<InvalidOperationException>(() => ct.Name = name + "b");
+                    ct.Name = name + "xyz";
+                    Assert.Equal(name + "xyz", ct.Name);
+                    ct.Name = null;
+                    Assert.Null(ct.Name);
+                    ct.Name = name;
                     Assert.Equal(name, ct.Name);
                 });
             t.IsBackground = true;
             Assert.Null(t.Name);
             t.Name = null;
-            t.Name = null;
             Assert.Null(t.Name);
+            t.Name = name + "xyz";
+            Assert.Equal(name + "xyz", t.Name);
             t.Name = name;
-            Assert.Equal(name, t.Name);
-            Assert.Throws<InvalidOperationException>(() => t.Name = null);
-            Assert.Throws<InvalidOperationException>(() => t.Name = name + "b");
             Assert.Equal(name, t.Name);
             t.Start();
             waitForThread();
@@ -642,13 +643,13 @@ namespace System.Threading.Threads.Tests
             {
                 var ct = Thread.CurrentThread;
                 Assert.Null(ct.Name);
-                ct.Name = null;
+                ct.Name = name;
+                Assert.Equal(name, ct.Name);
+                ct.Name = name + "xyz";
+                Assert.Equal(name + "xyz", ct.Name);
                 ct.Name = null;
                 Assert.Null(ct.Name);
                 ct.Name = name;
-                Assert.Equal(name, ct.Name);
-                Assert.Throws<InvalidOperationException>(() => ct.Name = null);
-                Assert.Throws<InvalidOperationException>(() => ct.Name = name + "b");
                 Assert.Equal(name, ct.Name);
             });
         }

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -709,7 +709,7 @@ namespace System.Threading.ThreadPools.Tests
                     verifyNameWorkItem = _ =>
                     {
                         Thread currentThread = Thread.CurrentThread;
-                        if (currentThread.Name != null)
+                        if (currentThread.Name == nameof(WorkerThreadStateResetTest))
                         {
                             failureMessage += $"Name was not reset: {currentThread.Name}{Environment.NewLine}";
                         }


### PR DESCRIPTION
Set a Name on several threads that didn't already have one. It's sometimes handy in debugging when you have a lot of threads listed. Don't set one on the thread used by long running tasks as it runs user code: that would be a breaking change. 

Incidentally PortableThreadPool already sets the thread name for its worker threads, then after a thread is returned to the pool it resets it in a special way that won't throw - not sure why, since the user code ought not to have been able to rename it successfully. Either a vestige or I'm missing something.