### PR TITLE
Remove dead code related to draining IO threadpool.

### DIFF
--- a/src/coreclr/vm/comthreadpool.cpp
+++ b/src/coreclr/vm/comthreadpool.cpp
@@ -736,17 +736,6 @@ struct BindIoCompletion_Args
     LPOVERLAPPED lpOverlapped;
 };
 
-void SetAsyncResultProperties(
-    OVERLAPPEDDATAREF overlapped,
-    DWORD dwErrorCode,
-    DWORD dwNumBytes
-)
-{
-    STATIC_CONTRACT_THROWS;
-    STATIC_CONTRACT_GC_NOTRIGGER;
-    STATIC_CONTRACT_MODE_ANY;
-}
-
 VOID BindIoCompletionCallBack_Worker(LPVOID args)
 {
     STATIC_CONTRACT_THROWS;
@@ -783,9 +772,6 @@ VOID BindIoCompletionCallBack_Worker(LPVOID args)
     {
         // no user delegate to callback
         _ASSERTE((overlapped->m_callback == NULL) || !"This is benign, but should be optimized");
-
-
-        SetAsyncResultProperties(overlapped, ErrorCode, numBytesTransferred);
     }
     GCPROTECT_END();
 }
@@ -830,21 +816,6 @@ void WINAPI BindIoCompletionCallbackStub(DWORD ErrorCode,
 {
     WRAPPER_NO_CONTRACT;
     BindIoCompletionCallbackStubEx(ErrorCode, numBytesTransferred, lpOverlapped, TRUE);
-
-#ifndef TARGET_UNIX
-    extern Volatile<ULONG> g_fCompletionPortDrainNeeded;
-
-    Thread *pThread = GetThread();
-    if (g_fCompletionPortDrainNeeded && pThread)
-    {
-        // We have started draining completion port.
-        // The next job picked up by this thread is going to be after our special marker.
-        if (!pThread->IsCompletionPortDrained())
-        {
-            pThread->MarkCompletionPortDrained();
-        }
-    }
-#endif // !TARGET_UNIX
 }
 
 FCIMPL1(FC_BOOL_RET, ThreadPoolNative::CorBindIoCompletionCallback, HANDLE fileHandle)

--- a/src/coreclr/vm/nativeoverlapped.h
+++ b/src/coreclr/vm/nativeoverlapped.h
@@ -21,8 +21,8 @@ struct NATIVEOVERLAPPED_AND_HANDLE
     OBJECTHANDLE m_handle;
 };
 
-// This should match the managed Overlapped object.
-// If you make any change here, you need to change the managed part Overlapped.
+// This should match the managed OverlappedData object.
+// If you make any change here, you need to change the managed part OverlappedData.
 class OverlappedDataObject : public Object
 {
 public:

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1542,8 +1542,6 @@ Thread::Thread()
 #endif // defined(GCCOVER_TOLERATE_SPURIOUS_AV)
 #endif // HAVE_GCCOVER
 
-    m_fCompletionPortDrained = FALSE;
-
     m_debuggerActivePatchSkipper = NULL;
     m_dwThreadHandleBeingUsed = 0;
     SetProfilerCallbacksAllowed(TRUE);

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -4304,25 +4304,7 @@ public:
 #endif // defined(GCCOVER_TOLERATE_SPURIOUS_AV)
 #endif // HAVE_GCCOVER
 
-private:
-    BOOL m_fCompletionPortDrained;
 public:
-    void MarkCompletionPortDrained()
-    {
-        LIMITED_METHOD_CONTRACT;
-        FastInterlockExchange ((LONG*)&m_fCompletionPortDrained, TRUE);
-    }
-    void UnmarkCompletionPortDrained()
-    {
-        LIMITED_METHOD_CONTRACT;
-        FastInterlockExchange ((LONG*)&m_fCompletionPortDrained, FALSE);
-    }
-    BOOL IsCompletionPortDrained()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_fCompletionPortDrained;
-    }
-
     static BOOL CheckThreadStackSize(SIZE_T *SizeToCommitOrReserve,
                                       BOOL   isSizeToReserve  // When TRUE, the previous argument is the stack size to reserve.
                                                               // Otherwise, it is the size to commit.

--- a/src/coreclr/vm/win32threadpool.h
+++ b/src/coreclr/vm/win32threadpool.h
@@ -276,8 +276,6 @@ public:
         return GlobalCompletionPort != NULL;
     }
 
-    static BOOL DrainCompletionPortQueue();
-
     static BOOL RegisterWaitForSingleObject(PHANDLE phNewWaitObject,
                                             HANDLE hWaitObject,
                                             WAITORTIMERCALLBACK Callback,
@@ -303,17 +301,6 @@ public:
                                                        LPOVERLAPPED lpOverlapped);
 #endif
 
-    static VOID WINAPI CallbackForInitiateDrainageOfCompletionPortQueue(
-        DWORD dwErrorCode,
-        DWORD dwNumberOfBytesTransfered,
-        LPOVERLAPPED lpOverlapped
-    );
-
-    static VOID WINAPI CallbackForContinueDrainageOfCompletionPortQueue(
-        DWORD dwErrorCode,
-        DWORD dwNumberOfBytesTransfered,
-        LPOVERLAPPED lpOverlapped
-    );
 
     static BOOL SetAppDomainRequestsActive(BOOL UnmanagedTP = FALSE);
     static void ClearAppDomainRequestsActive(BOOL UnmanagedTP = FALSE,  LONG index = -1);
@@ -359,11 +346,8 @@ public:
 
     static FORCEINLINE BOOL AreEtwIOQueueEventsSpeciallyHandled(LPOVERLAPPED_COMPLETION_ROUTINE Function)
     {
-        // We ignore drainage events b/c they are uninteresting
         // We handle registered waits at a higher abstraction level
-        return (Function == ThreadpoolMgr::CallbackForInitiateDrainageOfCompletionPortQueue
-                || Function == ThreadpoolMgr::CallbackForContinueDrainageOfCompletionPortQueue
-                || Function == ThreadpoolMgr::WaitIOCompletionCallback
+        return (Function == ThreadpoolMgr::WaitIOCompletionCallback
 #ifdef TARGET_WINDOWS // the IO completion thread pool is currently only available on Windows
                 || Function == ThreadpoolMgr::ManagedWaitIOCompletionCallback
 #endif
@@ -1119,8 +1103,6 @@ private:
     SVAL_DECL(LONG,MaxFreeCPThreads);                   // = MaxFreeCPThreadsPerCPU * Number of CPUS
 
     DECLSPEC_ALIGN(MAX_CACHE_LINE_SIZE) static LONG GateThreadStatus;    // See GateThreadStatus enumeration
-
-    static Volatile<LONG> NumCPInfrastructureThreads;   // number of threads currently busy handling draining cycle
 
     SVAL_DECL(LONG,cpuUtilization);
 


### PR DESCRIPTION
It looks like this was previously used by AppDomain unloading. To remove this code, I noticed that `ThreadpoolMgr::DrainCompletionPortQueue` is not called anywhere and "pulled the string" on anything it referenced.

I also made a small correction to the comment for the native OverlappedDataObject.