### PR TITLE
set private assets and IsImplicitlyDefined to avoid having dependency in the package and 

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -128,8 +128,8 @@
   </ItemGroup>
 
   <!-- TODO: Remove when all required nuget pack features are part of the consumed SDK. -->
-  <ItemGroup Condition="'$(IsPackable)' == 'true' and '$(MSBuildProjectExtension)' != '.pkgproj'">
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="$(NuGetBuildTasksPackVersion)" />
+  <ItemGroup Condition="'$(IsPackable)' == 'true' and '$(IsSourceProject)' == 'true'">
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="$(NuGetBuildTasksPackVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <Target Name="SetGenApiProperties"


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/46438#discussion_r550042037