### PR TITLE
Add more logging for abrupt test failures on Linux

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -177,11 +177,17 @@ fi
 
 if [[ "$(uname -s)" == "Linux" && $test_exitcode -ne 0 ]]; then
   if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
-     have_sleep=$(which sleep)
-     if [ -x "$have_sleep" ]; then
-         echo Waiting a few seconds for any dump to be written..
-          sleep 10s
-     fi
+
+    # For SIGKILL, in Helix, dump some of the kernel log, in case there is a hint
+    if [[ $test_exitcode -eq 137 ]]; then
+      dmesg | tail -50
+    fi
+
+    have_sleep=$(which sleep)
+    if [ -x "$have_sleep" ]; then
+      echo Waiting a few seconds for any dump to be written..
+      sleep 10s
+    fi
   fi
 
   echo cat /proc/sys/kernel/core_pattern: $(cat /proc/sys/kernel/core_pattern)

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -178,8 +178,8 @@ fi
 if [[ "$(uname -s)" == "Linux" && $test_exitcode -ne 0 ]]; then
   if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
 
-    # For SIGKILL, in Helix, dump some of the kernel log, in case there is a hint
-    if [[ $test_exitcode -eq 137 ]]; then
+    # For abrupt failures, in Helix, dump some of the kernel log, in case there is a hint
+    if [[ $test_exitcode -ne 1 ]]; then
       dmesg | tail -50
     fi
 

--- a/src/libraries/Native/Windows/System.IO.Compression.Native/zlib.md
+++ b/src/libraries/Native/Windows/System.IO.Compression.Native/zlib.md
@@ -1,0 +1,6 @@
+
+.\zlib (for Arm/Arm64)
+is from https://github.com/madler/zlib/releases/tag/v1.2.11
+
+.\zlib-intel (for x64/x86)
+is from https://github.com/jtkukunas/zlib/tree/v1.2.11.1_jtkv6.3

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -73,7 +73,6 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                 sb.AppendFormat($"###\tArchitecture: {RuntimeInformation.ProcessArchitecture.ToString()}").AppendLine();
                 foreach (string prop in new string[]
                 {
-                        #pragma warning disable 0618 // some of these Int32-returning properties are marked obsolete
                         nameof(p.BasePriority),
                         nameof(p.HandleCount),
                         nameof(p.Id),
@@ -83,21 +82,14 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                         nameof(p.MainWindowTitle),
                         nameof(p.MaxWorkingSet),
                         nameof(p.MinWorkingSet),
-                        nameof(p.NonpagedSystemMemorySize),
                         nameof(p.NonpagedSystemMemorySize64),
-                        nameof(p.PagedMemorySize),
                         nameof(p.PagedMemorySize64),
-                        nameof(p.PagedSystemMemorySize),
                         nameof(p.PagedSystemMemorySize64),
-                        nameof(p.PeakPagedMemorySize),
                         nameof(p.PeakPagedMemorySize64),
-                        nameof(p.PeakVirtualMemorySize),
                         nameof(p.PeakVirtualMemorySize64),
-                        nameof(p.PeakWorkingSet),
                         nameof(p.PeakWorkingSet64),
                         nameof(p.PriorityBoostEnabled),
                         nameof(p.PriorityClass),
-                        nameof(p.PrivateMemorySize),
                         nameof(p.PrivateMemorySize64),
                         nameof(p.PrivilegedProcessorTime),
                         nameof(p.ProcessName),
@@ -107,11 +99,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                         nameof(p.StartTime),
                         nameof(p.TotalProcessorTime),
                         nameof(p.UserProcessorTime),
-                        nameof(p.VirtualMemorySize),
                         nameof(p.VirtualMemorySize64),
-                        nameof(p.WorkingSet),
                         nameof(p.WorkingSet64),
-                        #pragma warning restore 0618
                 })
                 {
                     sb.Append($"###\t{prop}: ");
@@ -131,7 +120,18 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             if (osd.Contains("Linux"))
             {
                 // Dump several procfs files and /etc/os-release
-                foreach (string path in new string[] { "/proc/self/mountinfo", "/proc/self/cgroup", "/proc/self/limits", "/etc/os-release", "/etc/sysctl.conf", "/proc/meminfo" })
+                foreach (string path in new string[] {
+                    "/proc/self/mountinfo",
+                    "/proc/self/cgroup",
+                    "/proc/self/limits",
+                    "/etc/os-release",
+                    "/etc/sysctl.conf",
+                    "/proc/meminfo",
+                    "/proc/sys/vm/oom_kill_allocating_task",
+                    "/proc/sys/kernel/core_pattern",
+                    "/proc/sys/kernel/core_uses_pid",
+                    "/proc/sys/kernel/coredump_filter"
+                })
                 {
                     Console.WriteLine($"### CONTENTS OF \"{path}\":");
                     try


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/issues/46516 .. we continue to get 1-2 failures every day, only on Ubuntu 18.04, always SIGKILL.
1. Log oom_kill_allocating_task - also the dump related values currently logged in RunnerTemplate.sh, so they're in one place
2. Stop logging [worthless Process properties.](https://github.com/dotnet/runtime/issues/46901)
3. Log the tail of the kernel log in abrupt test failures in Helix on Linux.

Also add zlib readme not worth a separate PR.