### PR TITLE
[browser][docs] Add docs for running tests in different browser

### DIFF
--- a/docs/workflow/testing/libraries/testing-wasm.md
+++ b/docs/workflow/testing/libraries/testing-wasm.md
@@ -101,6 +101,26 @@ To run all tests, including "outer loop" tests (which are typically slower and i
     MSBUILD_ARGS=/p:OuterLoop=true make -C src/mono/wasm/ run-browser-tests-System.AppContext
     ```
 
+### Running tests using different Browsers
+It's possible to set a Browser explicitly by adding `--browser=` command line argument to `XHARNESS_COMMAND`:
+
+- CLI
+    ```
+    XHARNESS_COMMAND="test-browser --browser=safari" ./dotnet.sh build /t:Test src/libraries/System.AppContext/tests /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=Release
+    ```
+
+- Makefile target `run-browser-tests-<test>`
+
+    ```
+    XHARNESS_BROWSER=firefox make -C src/mono/wasm/ run-browser-tests-System.AppContext
+    ```
+
+At the moment supported values are:
+- `chrome`
+- `safari`
+- `firefox`
+
+By default, `chrome` browser is used.
 
 ## Kicking off outer loop tests from GitHub Interface
 

--- a/docs/workflow/testing/libraries/testing-wasm.md
+++ b/docs/workflow/testing/libraries/testing-wasm.md
@@ -28,11 +28,21 @@ PATH=/Users/<your_user>/.jsvu/:$PATH V8
 ### Using Browser Instance
 It's possible to run tests in a browser instance:
 
+#### Chrome
 - An installation of [ChromeDriver - WebDriver for Chrome](https://chromedriver.chromium.org) is required.  Make sure to read [Downloads/Version Selection](https://chromedriver.chromium.org/downloads/version-selection) to setup a working installation of ChromeDriver.
 - Include the [ChromeDriver - WebDriver for Chrome](https://chromedriver.chromium.org) location in your PATH environment.  Default is `/Users/<your_user>/.chromedriver`
 
 ```bash
 PATH=/Users/<your_user>/.chromedriver:$PATH
+```
+
+#### Gecko / Firefox
+
+- Requires gecko driver [Github repository of Mozilla](https://github.com/mozilla/geckodriver/releases)
+- Include the [Github repository of Mozilla](https://github.com/mozilla/geckodriver/releases) location in your PATH environment.  Default is `/Users/<your_user>/.geckodriver`
+
+```bash
+PATH=/Users/<your_user>/.geckodriver:$PATH
 ```
 
 ## Building Libs and Tests for WebAssembly

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -6,6 +6,7 @@ escape_quote = $(subst ",\",$(1))
 DOTNET=$(TOP)/dotnet.sh
 JSVU=$(HOME)/.jsvu
 CHROMEDRIVER?=$(HOME)/.chromedriver
+GECKODRIVER?=$(HOME)/.geckodriver
 
 #
 # These variables are set by wasm.proj
@@ -22,6 +23,7 @@ SYSTEM_NATIVE_LIBDIR?=$(TOP)/src/libraries/Native/Unix/System.Native
 ENABLE_ES6?=false
 _MSBUILD_WASM_BUILD_ARGS=/p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG)
 ENABLE_METADATA_UPDATE?=false
+XHARNESS_BROWSER?=chrome
 
 all: build-native icu-files source-files header-files
 
@@ -180,7 +182,7 @@ run-tests-%:
 	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 run-browser-tests-%:
-	PATH="$(CHROMEDRIVER):$(PATH)" XHARNESS_COMMAND=test-browser $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
+	PATH="$(GECKODRIVER):$(CHROMEDRIVER):$(PATH)" XHARNESS_COMMAND="test-browser --browser=$(XHARNESS_BROWSER)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 run-debugger-tests:
 	if [ ! -z "$(TEST_FILTER)" ]; then \


### PR DESCRIPTION
Doc update on running tests via different browser instances.

Add documentation on running tests using different Browsers other than chrome.

- XHARNESS_COMMAND="test-browser --browser=safari"
- Add ability to run against different browsers from the make file target `run-browser-tests` by adding `XHARNESS_BROWSER= ` to command line.

At the moment supported values are:
- `chrome`
- `safari`
- `firefox`