### PR TITLE
EventPipe C library CoreClr ep_rt_object_array_alloc should zero init.

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1888,7 +1888,7 @@ ep_rt_execute_rundown (void)
 
 // STATIC_CONTRACT_NOTHROW
 #undef ep_rt_object_array_alloc
-#define ep_rt_object_array_alloc(obj_type,size) (new (nothrow) obj_type [size])
+#define ep_rt_object_array_alloc(obj_type,size) (new (nothrow) obj_type [size]())
 
 // STATIC_CONTRACT_NOTHROW
 #undef ep_rt_object_array_free


### PR DESCRIPTION
EventPipe C library is defensive in its type allocators:

ep_rt_object_alloc
ep_rt_object_array_alloc

meaning that they will zero init memory before returned. On Mono this is done through use of g_new0 and on CoreClr we use C++11 zero init feature when allocating struct (only type allocated through these functions).

On CoreClr this was only applied for ep_rt_object_alloc but not for ep_rt_object_array_alloc meaning that ep_rt_object_array_alloc would return arrays of allocated objects but not zero initialized.

PR makes sure we call new (nothrow) utilizing C++11's zero initialization capabilities of non-class types without constructors.