### PR TITLE
Fold casts of constants in the importer

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13479,7 +13479,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                  */
 
                 type = genActualType(lclTyp);
-
                 // If this is a no-op cast, just use op1.
                 if (!ovfl && (type == op1->TypeGet()) && (genTypeSize(type) == genTypeSize(lclTyp)))
                 {
@@ -13488,18 +13487,25 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 // Work is evidently required, add cast node
                 else
                 {
+                    GenTree* castOp = op1;
                     if (callNode)
                     {
-                        op1 = gtNewCastNodeL(type, op1, uns, lclTyp);
+                        op1 = gtNewCastNodeL(type, castOp, uns, lclTyp);
                     }
                     else
                     {
-                        op1 = gtNewCastNode(type, op1, uns, lclTyp);
+                        op1 = gtNewCastNode(type, castOp, uns, lclTyp);
                     }
 
                     if (ovfl)
                     {
                         op1->gtFlags |= (GTF_OVERFLOW | GTF_EXCEPT);
+                    }
+
+                    if (castOp->OperIsConst() && opts.OptimizationEnabled())
+                    {
+                        // Try and fold the introduced cast
+                        op1 = gtFoldExprConst(op1);
                     }
                 }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13487,14 +13487,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 // Work is evidently required, add cast node
                 else
                 {
-                    GenTree* castOp = op1;
                     if (callNode)
                     {
-                        op1 = gtNewCastNodeL(type, castOp, uns, lclTyp);
+                        op1 = gtNewCastNodeL(type, op1, uns, lclTyp);
                     }
                     else
                     {
-                        op1 = gtNewCastNode(type, castOp, uns, lclTyp);
+                        op1 = gtNewCastNode(type, op1, uns, lclTyp);
                     }
 
                     if (ovfl)
@@ -13502,7 +13501,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         op1->gtFlags |= (GTF_OVERFLOW | GTF_EXCEPT);
                     }
 
-                    if (castOp->OperIsConst() && opts.OptimizationEnabled())
+                    if (op1->gtGetOp1()->OperIsConst() && opts.OptimizationEnabled())
                     {
                         // Try and fold the introduced cast
                         op1 = gtFoldExprConst(op1);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13479,6 +13479,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                  */
 
                 type = genActualType(lclTyp);
+
                 // If this is a no-op cast, just use op1.
                 if (!ovfl && (type == op1->TypeGet()) && (genTypeSize(type) == genTypeSize(lclTyp)))
                 {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12211,7 +12211,9 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                     {
                         tree = gtFoldExpr(tree);
                     }
-                    else
+
+                    // We may fail to fold
+                    if (!tree->OperIsConst())
                     {
                         tree->AsOp()->CheckDivideByConstOptimized(this);
                     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12211,8 +12211,11 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                     {
                         tree = gtFoldExpr(tree);
                     }
+                    else
+                    {
+                        tree->AsOp()->CheckDivideByConstOptimized(this);
+                    }
 
-                    tree->AsOp()->CheckDivideByConstOptimized(this);
                     return tree;
                 }
             }


### PR DESCRIPTION
See #47123 for more context. I have rerun the crossgen diffs and got some more changes, but nothing major (the regressions are still due to more inlining).

<details>
<summary>Crossgen diffs</summary>

```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 33727626
Total bytes of diff: 33727893
Total bytes of delta: 267 (0.00% of base)
    diff is a regression.

Top file regressions (bytes):
         205 : System.DirectoryServices.dasm (0.06% of base)
         121 : FSharp.Core.dasm (0.01% of base)
          86 : System.ServiceModel.Syndication.dasm (0.10% of base)
          16 : System.Private.DataContractSerialization.dasm (0.00% of base)
          11 : System.Data.Odbc.dasm (0.01% of base)
           8 : System.Security.Cryptography.Algorithms.dasm (0.00% of base)
           8 : System.Security.Cryptography.Cng.dasm (0.00% of base)
           1 : System.Memory.dasm (0.00% of base)

Top file improvements (bytes):
         -69 : System.Private.CoreLib.dasm (-0.00% of base)
         -49 : System.Net.Primitives.dasm (-0.08% of base)
         -49 : System.Private.Uri.dasm (-0.06% of base)
         -22 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)

12 total files with Code Size differences (4 improved, 8 regressed), 258 unchanged.

Top method regressions (bytes):
          65 ( 7.80% of base) : FSharp.Core.dasm - HashCompare:GenericEqualityArbArray(bool,System.Collections.IEqualityComparer,System.Array,System.Array):bool
          53 (15.59% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.ActiveDirectorySite:GetComputerSite():System.DirectoryServices.ActiveDirectory.ActiveDirectorySite
          51 (10.83% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.Domain:CreateLocalSideOfTrustRelationship(System.String,int,System.String):this
          51 (10.71% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.Forest:CreateLocalSideOfTrustRelationship(System.String,int,System.String):this
          50 (33.11% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.DirectoryContext:isCurrentForest():bool:this
          46 ( 4.92% of base) : FSharp.Core.dasm - HashCompare:GenericComparisonArbArrayWithComparer(GenericComparer,System.Array,System.Array):int
          26 (36.62% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateAlternateLink(System.Uri,System.String):System.ServiceModel.Syndication.SyndicationLink
          26 (36.62% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateSelfLink(System.Uri,System.String):System.ServiceModel.Syndication.SyndicationLink
          17 ( 8.54% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationItem:AddPermalink(System.Uri):this
          17 (25.76% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateAlternateLink(System.Uri):System.ServiceModel.Syndication.SyndicationLink
          17 (25.76% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateSelfLink(System.Uri):System.ServiceModel.Syndication.SyndicationLink
          10 ( 6.94% of base) : System.Private.DataContractSerialization.dasm - System.Xml.ValueHandle:ToULong():long:this
          10 ( 1.66% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationFeed:TryReadTextInputFromExtension(System.ServiceModel.Syndication.SyndicationElementExtensionCollection):System.ServiceModel.Syndication.SyndicationTextInput:this
           9 ( 0.67% of base) : System.Data.Odbc.dasm - System.Data.Odbc.OdbcDataReader:GetBytesOrChars(int,long,System.Array,bool,int,int):long:this
           8 ( 4.40% of base) : System.Private.CoreLib.dasm - System.Enum:ToUInt64():long:this
           8 (25.00% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:.ctor(System.Uri):this
           6 ( 1.94% of base) : System.Private.DataContractSerialization.dasm - System.Xml.ValueHandle:ToLong():long:this
           5 ( 3.16% of base) : FSharp.Core.dasm - OperatorIntrinsics:loop@5442-7(long,int):long
           5 ( 3.31% of base) : FSharp.Core.dasm - OperatorIntrinsics:loop@5442-8(long,int):long
           4 ( 0.58% of base) : System.Security.Cryptography.Algorithms.dasm - DSACng:VerifySignatureCore(System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],int):bool:this

Top method improvements (bytes):
         -49 (-6.69% of base) : System.Net.Primitives.dasm - System.IPv4AddressHelper:ParseNonCanonical(long,int,byref,bool):long
         -49 (-6.69% of base) : System.Private.Uri.dasm - System.IPv4AddressHelper:ParseNonCanonical(long,int,byref,bool):long
         -31 (-10.73% of base) : System.Private.CoreLib.dasm - System.DateTimeOffset:.cctor()
         -23 (-16.31% of base) : System.Private.CoreLib.dasm - System.Convert:ToDateTime(System.String):System.DateTime
         -23 (-15.33% of base) : System.Private.CoreLib.dasm - System.Convert:ToDateTime(System.String,System.IFormatProvider):System.DateTime
         -22 (-4.10% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.DiagnosticsPass:FindSurprisingSignExtensionBits(Microsoft.CodeAnalysis.CSharp.BoundExpression):long
         -11 (-21.15% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationFeed:CreateLink():System.ServiceModel.Syndication.SyndicationLink:this
         -11 (-21.15% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationItem:CreateLink():System.ServiceModel.Syndication.SyndicationLink:this
          -7 (-20.59% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:.ctor():this
          -3 (-0.47% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.Rss20FeedFormatter:ReadAlternateLink(System.Xml.XmlReader,System.Uri,System.ServiceModel.Syndication.TryParseUriCallback,bool):System.ServiceModel.Syndication.SyndicationLink
          -3 (-0.32% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.Rss20FeedFormatter:ReadMediaEnclosure(System.Xml.XmlReader,System.Uri):System.ServiceModel.Syndication.SyndicationLink:this

Top method regressions (percentages):
          26 (36.62% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateAlternateLink(System.Uri,System.String):System.ServiceModel.Syndication.SyndicationLink
          26 (36.62% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateSelfLink(System.Uri,System.String):System.ServiceModel.Syndication.SyndicationLink
          50 (33.11% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.DirectoryContext:isCurrentForest():bool:this
          17 (25.76% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateAlternateLink(System.Uri):System.ServiceModel.Syndication.SyndicationLink
          17 (25.76% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:CreateSelfLink(System.Uri):System.ServiceModel.Syndication.SyndicationLink
           8 (25.00% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:.ctor(System.Uri):this
          53 (15.59% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.ActiveDirectorySite:GetComputerSite():System.DirectoryServices.ActiveDirectory.ActiveDirectorySite
          51 (10.83% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.Domain:CreateLocalSideOfTrustRelationship(System.String,int,System.String):this
          51 (10.71% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.Forest:CreateLocalSideOfTrustRelationship(System.String,int,System.String):this
          17 ( 8.54% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationItem:AddPermalink(System.Uri):this
          65 ( 7.80% of base) : FSharp.Core.dasm - HashCompare:GenericEqualityArbArray(bool,System.Collections.IEqualityComparer,System.Array,System.Array):bool
          10 ( 6.94% of base) : System.Private.DataContractSerialization.dasm - System.Xml.ValueHandle:ToULong():long:this
          46 ( 4.92% of base) : FSharp.Core.dasm - HashCompare:GenericComparisonArbArrayWithComparer(GenericComparer,System.Array,System.Array):int
           8 ( 4.40% of base) : System.Private.CoreLib.dasm - System.Enum:ToUInt64():long:this
           5 ( 3.31% of base) : FSharp.Core.dasm - OperatorIntrinsics:loop@5442-8(long,int):long
           5 ( 3.16% of base) : FSharp.Core.dasm - OperatorIntrinsics:loop@5442-7(long,int):long
           6 ( 1.94% of base) : System.Private.DataContractSerialization.dasm - System.Xml.ValueHandle:ToLong():long:this
          10 ( 1.66% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationFeed:TryReadTextInputFromExtension(System.ServiceModel.Syndication.SyndicationElementExtensionCollection):System.ServiceModel.Syndication.SyndicationTextInput:this
           4 ( 1.02% of base) : System.Security.Cryptography.Cng.dasm - System.Security.Cryptography.ECDsaCng:VerifyHash(System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte]):bool:this
           4 ( 0.96% of base) : System.Security.Cryptography.Algorithms.dasm - ECDsaCng:VerifyHashCore(System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],int):bool:this

Top method improvements (percentages):
         -11 (-21.15% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationFeed:CreateLink():System.ServiceModel.Syndication.SyndicationLink:this
         -11 (-21.15% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationItem:CreateLink():System.ServiceModel.Syndication.SyndicationLink:this
          -7 (-20.59% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.SyndicationLink:.ctor():this
         -23 (-16.31% of base) : System.Private.CoreLib.dasm - System.Convert:ToDateTime(System.String):System.DateTime
         -23 (-15.33% of base) : System.Private.CoreLib.dasm - System.Convert:ToDateTime(System.String,System.IFormatProvider):System.DateTime
         -31 (-10.73% of base) : System.Private.CoreLib.dasm - System.DateTimeOffset:.cctor()
         -49 (-6.69% of base) : System.Net.Primitives.dasm - System.IPv4AddressHelper:ParseNonCanonical(long,int,byref,bool):long
         -49 (-6.69% of base) : System.Private.Uri.dasm - System.IPv4AddressHelper:ParseNonCanonical(long,int,byref,bool):long
         -22 (-4.10% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.DiagnosticsPass:FindSurprisingSignExtensionBits(Microsoft.CodeAnalysis.CSharp.BoundExpression):long
          -3 (-0.47% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.Rss20FeedFormatter:ReadAlternateLink(System.Xml.XmlReader,System.Uri,System.ServiceModel.Syndication.TryParseUriCallback,bool):System.ServiceModel.Syndication.SyndicationLink
          -3 (-0.32% of base) : System.ServiceModel.Syndication.dasm - System.ServiceModel.Syndication.Rss20FeedFormatter:ReadMediaEnclosure(System.Xml.XmlReader,System.Uri):System.ServiceModel.Syndication.SyndicationLink:this

36 total methods with Code Size differences (11 improved, 25 regressed), 236098 unchanged.
Found 48 files with textual diffs.
```
</details>

Example of a regression: https://www.diffchecker.com/jtOQlJX4.
Example of an improvement: https://www.diffchecker.com/7G19dkSM.

I haven't rerun the PMI diffs yet as they take a really long time on my machine (1.5 hours for two full runs) and kind of make everything else hard to use (80+ processes), and I want to ensure I have the right logic in the right place first (which is unlikely to be true as of this PR's submission). It is expected that they will be more sizeable.

Edit: looks like some things are being folded that shouldn't be. Investigating...
Edit: looks like there was a bug in the morphing of long modulus.
Edit: investigating unexpected regressions...
Edit: regressions have been analyzed, see below.