### PR TITLE
Optimize DispatchProxy generated code

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -40,9 +40,9 @@ namespace System.Reflection
     //
     internal static class DispatchProxyGenerator
     {
-        // Generated proxies have a private Action field that all generated methods
-        // invoke.  It is the first field in the class and the first ctor parameter.
-        private const int InvokeActionFieldAndCtorParameterIndex = 0;
+        // Generated proxies have a private MethodInfo[] field that generated methods use to get the corresponding MethodInfo.
+        // It is the first field in the class and the first ctor parameter.
+        private const int MethodInfosFieldAndCtorParameterIndex = 0;
 
         // Proxies are requested for a pair of types: base type and interface type.
         // The generated proxy will subclass the given base type and implement the interface type.
@@ -57,9 +57,11 @@ namespace System.Reflection
         // This approach is used to prevent regenerating identical proxy types for identical T/Proxy pairs,
         // which would ultimately be a more expensive leak.
         // Proxy instances are not cached.  Their lifetime is entirely owned by the caller of DispatchProxy.Create.
-        private static readonly Dictionary<Type, Dictionary<Type, Type>> s_baseTypeAndInterfaceToGeneratedProxyType = new Dictionary<Type, Dictionary<Type, Type>>();
+        private static readonly Dictionary<Type, Dictionary<Type, GeneratedTypeInfo>> s_baseTypeAndInterfaceToGeneratedProxyType = new Dictionary<Type, Dictionary<Type, GeneratedTypeInfo>>();
         private static readonly ProxyAssembly s_proxyAssembly = new ProxyAssembly();
         private static readonly MethodInfo s_dispatchProxyInvokeMethod = typeof(DispatchProxy).GetTypeInfo().GetDeclaredMethod("Invoke")!;
+        private static readonly MethodInfo s_getTypeFromHandleMethod = typeof(Type).GetRuntimeMethod("GetTypeFromHandle", new Type[] { typeof(RuntimeTypeHandle) })!;
+        private static readonly MethodInfo s_makeGenericMethodMethod = typeof(MethodInfo).GetMethod("MakeGenericMethod", new Type[] { typeof(Type[]) })!;
 
         // Returns a new instance of a proxy the derives from 'baseType' and implements 'interfaceType'
         internal static object CreateProxyInstance(
@@ -69,24 +71,23 @@ namespace System.Reflection
             Debug.Assert(baseType != null);
             Debug.Assert(interfaceType != null);
 
-            Type proxiedType = GetProxyType(baseType, interfaceType);
-            return Activator.CreateInstance(proxiedType, (Action<object[]>)DispatchProxyGenerator.Invoke)!;
+            GeneratedTypeInfo proxiedType = GetProxyType(baseType, interfaceType);
+            return Activator.CreateInstance(proxiedType.GeneratedType, new object[] { proxiedType.MethodInfos })!;
         }
 
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-        private static Type GetProxyType(
+        private static GeneratedTypeInfo GetProxyType(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type baseType,
             Type interfaceType)
         {
             lock (s_baseTypeAndInterfaceToGeneratedProxyType)
             {
-                if (!s_baseTypeAndInterfaceToGeneratedProxyType.TryGetValue(baseType, out Dictionary<Type, Type>? interfaceToProxy))
+                if (!s_baseTypeAndInterfaceToGeneratedProxyType.TryGetValue(baseType, out Dictionary<Type, GeneratedTypeInfo>? interfaceToProxy))
                 {
-                    interfaceToProxy = new Dictionary<Type, Type>();
+                    interfaceToProxy = new Dictionary<Type, GeneratedTypeInfo>();
                     s_baseTypeAndInterfaceToGeneratedProxyType[baseType] = interfaceToProxy;
                 }
 
-                if (!interfaceToProxy.TryGetValue(interfaceType, out Type? generatedProxy))
+                if (!interfaceToProxy.TryGetValue(interfaceType, out GeneratedTypeInfo? generatedProxy))
                 {
                     generatedProxy = GenerateProxyType(baseType, interfaceType);
                     interfaceToProxy[interfaceType] = generatedProxy;
@@ -97,8 +98,7 @@ namespace System.Reflection
         }
 
         // Unconditionally generates a new proxy type derived from 'baseType' and implements 'interfaceType'
-        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-        private static Type GenerateProxyType(
+        private static GeneratedTypeInfo GenerateProxyType(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type baseType,
             Type interfaceType)
         {
@@ -139,59 +139,23 @@ namespace System.Reflection
 
             pb.AddInterfaceImpl(interfaceType);
 
-            Type generatedProxyType = pb.CreateType();
+            GeneratedTypeInfo generatedProxyType = pb.CreateType();
             return generatedProxyType;
         }
 
-        // All generated proxy methods call this static helper method to dispatch.
-        // Its job is to unpack the arguments and the 'this' instance and to dispatch directly
-        // to the (abstract) DispatchProxy.Invoke() method.
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-            Justification = "MakeGenericMethod is safe here because the user code invoking the generic method will reference " +
-            "the GenericTypes being used, which will guarantee the requirements of the generic method.")]
-        private static void Invoke(object?[] args)
+        private class GeneratedTypeInfo
         {
-            PackedArgs packed = new PackedArgs(args);
-            MethodBase method = s_proxyAssembly.ResolveMethodToken(packed.DeclaringType, packed.MethodToken);
-            if (method.IsGenericMethodDefinition)
-                method = ((MethodInfo)method).MakeGenericMethod(packed.GenericTypes!);
-
-            // Call (protected method) DispatchProxy.Invoke()
-            try
+            public GeneratedTypeInfo(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type generatedType,
+                MethodInfo[] methodInfos)
             {
-                Debug.Assert(s_dispatchProxyInvokeMethod != null);
-                object? returnValue = s_dispatchProxyInvokeMethod!.Invoke(packed.DispatchProxy,
-                                                                       new object?[] { method, packed.Args });
-                packed.ReturnValue = returnValue;
+                GeneratedType = generatedType;
+                MethodInfos = methodInfos;
             }
-            catch (TargetInvocationException tie)
-            {
-                Debug.Assert(tie.InnerException != null);
-                ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
-            }
-        }
 
-        private class PackedArgs
-        {
-            internal const int DispatchProxyPosition = 0;
-            internal const int DeclaringTypePosition = 1;
-            internal const int MethodTokenPosition = 2;
-            internal const int ArgsPosition = 3;
-            internal const int GenericTypesPosition = 4;
-            internal const int ReturnValuePosition = 5;
-
-            internal static readonly Type[] PackedTypes = new Type[] { typeof(object), typeof(Type), typeof(int), typeof(object[]), typeof(Type[]), typeof(object) };
-
-            private readonly object?[] _args;
-            internal PackedArgs() : this(new object[PackedTypes.Length]) { }
-            internal PackedArgs(object?[] args) { _args = args; }
-
-            internal DispatchProxy? DispatchProxy { get { return (DispatchProxy?)_args[DispatchProxyPosition]; } }
-            internal Type? DeclaringType { get { return (Type?)_args[DeclaringTypePosition]; } }
-            internal int MethodToken { get { return (int)_args[MethodTokenPosition]!; } }
-            internal object[]? Args { get { return (object[]?)_args[ArgsPosition]; } }
-            internal Type[]? GenericTypes { get { return (Type[]?)_args[GenericTypesPosition]; } }
-            internal object? ReturnValue { /*get { return args[ReturnValuePosition]; }*/ set { _args[ReturnValuePosition] = value; } }
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+            public Type GeneratedType { get; }
+            public MethodInfo[] MethodInfos { get; }
         }
 
         private class ProxyAssembly
@@ -200,10 +164,6 @@ namespace System.Reflection
             private readonly ModuleBuilder _mb;
             private int _typeId;
 
-            // Maintain a MethodBase-->int, int-->MethodBase mapping to permit generated code
-            // to pass methods by token
-            private readonly Dictionary<MethodBase, int> _methodToToken = new Dictionary<MethodBase, int>();
-            private readonly List<MethodBase> _methodsByToken = new List<MethodBase>();
             private readonly HashSet<string?> _ignoresAccessAssemblyNames = new HashSet<string?>();
             private ConstructorInfo? _ignoresAccessChecksToAttributeConstructor;
 
@@ -268,36 +228,16 @@ namespace System.Reflection
                     }
                 }
             }
-
-            internal void GetTokenForMethod(MethodBase method, out Type type, out int token)
-            {
-                Debug.Assert(method.DeclaringType != null);
-                type = method.DeclaringType!;
-                token = 0;
-                if (!_methodToToken.TryGetValue(method, out token))
-                {
-                    _methodsByToken.Add(method);
-                    token = _methodsByToken.Count - 1;
-                    _methodToToken[method] = token;
-                }
-            }
-
-            internal MethodBase ResolveMethodToken(Type? type, int token)
-            {
-                Debug.Assert(token >= 0 && token < _methodsByToken.Count);
-                return _methodsByToken[token];
-            }
         }
 
         private class ProxyBuilder
         {
-            private static readonly MethodInfo s_delegateInvoke = typeof(Action<object[]>).GetMethod("Invoke")!;
-
             private readonly ProxyAssembly _assembly;
             private readonly TypeBuilder _tb;
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
             private readonly Type _proxyBaseType;
             private readonly List<FieldBuilder> _fields;
+            private readonly List<MethodInfo> _methodInfos;
 
             internal ProxyBuilder(
                 ProxyAssembly assembly,
@@ -309,7 +249,9 @@ namespace System.Reflection
                 _proxyBaseType = proxyBaseType;
 
                 _fields = new List<FieldBuilder>();
-                _fields.Add(tb.DefineField("invoke", typeof(Action<object[]>), FieldAttributes.Private));
+                _fields.Add(tb.DefineField("_methodInfos", typeof(MethodInfo[]), FieldAttributes.Private));
+
+                _methodInfos = new List<MethodInfo>();
             }
 
             private void Complete()
@@ -341,11 +283,10 @@ namespace System.Reflection
                 il.Emit(OpCodes.Ret);
             }
 
-            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-            internal Type CreateType()
+            internal GeneratedTypeInfo CreateType()
             {
                 this.Complete();
-                return _tb.CreateType()!;
+                return new GeneratedTypeInfo(_tb.CreateType()!, _methodInfos.ToArray());
             }
 
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
@@ -388,7 +329,9 @@ namespace System.Reflection
                     if (!mi.IsVirtual || mi.IsFinal)
                         continue;
 
-                    MethodBuilder mdb = AddMethodImpl(mi);
+                    int methodInfoIndex = _methodInfos.Count;
+                    _methodInfos.Add(mi);
+                    MethodBuilder mdb = AddMethodImpl(mi, methodInfoIndex);
                     if (propertyMap.TryGetValue(mi, out PropertyAccessorInfo? associatedProperty))
                     {
                         if (MethodInfoEqualityComparer.Instance.Equals(associatedProperty.InterfaceGetMethod, mi))
@@ -446,7 +389,7 @@ namespace System.Reflection
                 }
             }
 
-            private MethodBuilder AddMethodImpl(MethodInfo mi)
+            private MethodBuilder AddMethodImpl(MethodInfo mi, int methodInfoIndex)
             {
                 ParameterInfo[] parameters = mi.GetParameters();
                 Type[] paramTypes = ParamTypes(parameters, false);
@@ -487,54 +430,52 @@ namespace System.Reflection
                     }
                 }
 
-                // object[] packed = new object[PackedArgs.PackedTypes.Length];
-                GenericArray<object> packedArr = new GenericArray<object>(il, PackedArgs.PackedTypes.Length);
-
-                // packed[PackedArgs.DispatchProxyPosition] = this;
-                packedArr.BeginSet(PackedArgs.DispatchProxyPosition);
+                // MethodInfo methodInfo = _methodInfos[methodInfoIndex];
+                LocalBuilder methodInfoLocal = il.DeclareLocal(typeof(MethodInfo));
                 il.Emit(OpCodes.Ldarg_0);
-                packedArr.EndSet(typeof(DispatchProxy));
+                il.Emit(OpCodes.Ldfld, _fields[MethodInfosFieldAndCtorParameterIndex]); // MethodInfo[] _methodInfos
+                il.Emit(OpCodes.Ldc_I4, methodInfoIndex);
+                il.Emit(OpCodes.Ldelem_Ref);
+                il.Emit(OpCodes.Stloc, methodInfoLocal);
 
-                // packed[PackedArgs.DeclaringTypePosition] = typeof(iface);
-                MethodInfo Type_GetTypeFromHandle = typeof(Type).GetRuntimeMethod("GetTypeFromHandle", new Type[] { typeof(RuntimeTypeHandle) })!;
-                _assembly.GetTokenForMethod(mi, out Type declaringType, out int methodToken);
-                packedArr.BeginSet(PackedArgs.DeclaringTypePosition);
-                il.Emit(OpCodes.Ldtoken, declaringType);
-                il.Emit(OpCodes.Call, Type_GetTypeFromHandle);
-                packedArr.EndSet(typeof(object));
-
-                // packed[PackedArgs.MethodTokenPosition] = iface method token;
-                packedArr.BeginSet(PackedArgs.MethodTokenPosition);
-                il.Emit(OpCodes.Ldc_I4, methodToken);
-                packedArr.EndSet(typeof(int));
-
-                // packed[PackedArgs.ArgsPosition] = args;
-                packedArr.BeginSet(PackedArgs.ArgsPosition);
-                argsArr.Load();
-                packedArr.EndSet(typeof(object[]));
-
-                // packed[PackedArgs.GenericTypesPosition] = mi.GetGenericArguments();
                 if (mi.ContainsGenericParameters)
                 {
-                    packedArr.BeginSet(PackedArgs.GenericTypesPosition);
+                    // methodInfo = methodInfo.MakeGenericMethod(mi.GetGenericArguments());
+                    il.Emit(OpCodes.Ldloc, methodInfoLocal);
+
                     Type[] genericTypes = mi.GetGenericArguments();
                     GenericArray<Type> typeArr = new GenericArray<Type>(il, genericTypes.Length);
                     for (int i = 0; i < genericTypes.Length; ++i)
                     {
                         typeArr.BeginSet(i);
                         il.Emit(OpCodes.Ldtoken, genericTypes[i]);
-                        il.Emit(OpCodes.Call, Type_GetTypeFromHandle);
+                        il.Emit(OpCodes.Call, s_getTypeFromHandleMethod);
                         typeArr.EndSet(typeof(Type));
                     }
                     typeArr.Load();
-                    packedArr.EndSet(typeof(Type[]));
+
+                    il.Emit(OpCodes.Callvirt, s_makeGenericMethodMethod);
+                    il.Emit(OpCodes.Stloc, methodInfoLocal);
                 }
 
-                // Call static DispatchProxyHelper.Invoke(object[])
+                // object result = this.Invoke(methodInfo, args);
+                LocalBuilder? resultLocal = mi.ReturnType != typeof(void) ?
+                    il.DeclareLocal(typeof(object)) :
+                    null;
                 il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, _fields[InvokeActionFieldAndCtorParameterIndex]); // delegate
-                packedArr.Load();
-                il.Emit(OpCodes.Call, s_delegateInvoke);
+                il.Emit(OpCodes.Ldloc, methodInfoLocal);
+                argsArr.Load();
+                il.Emit(OpCodes.Callvirt, s_dispatchProxyInvokeMethod);
+
+                if (resultLocal != null)
+                {
+                    il.Emit(OpCodes.Stloc, resultLocal);
+                }
+                else
+                {
+                    // drop the result for void methods
+                    il.Emit(OpCodes.Pop);
+                }
 
                 for (int i = 0; i < parameters.Length; i++)
                 {
@@ -546,9 +487,10 @@ namespace System.Reflection
                     }
                 }
 
-                if (mi.ReturnType != typeof(void))
+                if (resultLocal != null)
                 {
-                    packedArr.Get(PackedArgs.ReturnValuePosition);
+                    // return (mi.ReturnType)result;
+                    il.Emit(OpCodes.Ldloc, resultLocal);
                     Convert(il, typeof(object), mi.ReturnType, false);
                 }
 


### PR DESCRIPTION
* Remove unnecessary allocs
* Call the Invoke method directly from generated code


### Benchmark Results

Using the following benchmark:

```C#
    [MemoryDiagnoser]
    public class DispatchProxyBenchmark
    {
        [Params(1, 100)]
        public int Count { get; set; }

        private IFoo _proxy;

        [GlobalSetup]
        public void GlobalSetup()
        {
            _proxy = CountingProxy.Wrap(new Foo());
        }

        [Benchmark]
        public void Invoke()
        {
            for (int i = 0; i < Count; i++)
            {
                _proxy.Property1 = 5;
                _proxy.Method1();
                _proxy.Method2();
            }
        }

        [Benchmark]
        public void InvokeGeneric()
        {
            for (int i = 0; i < Count; i++)
            {
                _proxy.Method3<int>(5);
                _proxy.Method3<double>(4.5);
            }
        }
    }

    interface IFoo
    {
        public int Property1 { get; set; }

        public void Method1();
        public void Method2();
        public void Method3<T>(T t);
    }

    class Foo : IFoo
    {
        public int Property1 { get; set; }

        public void Method1() { }
        public void Method2() { }
        public void Method3<T>(T t) { }
    }

    class CountingProxy : DispatchProxy
    {
        private IFoo _inner;
        public int InvocationCount { get; private set; }

        public static IFoo Wrap(IFoo inner)
        {
            IFoo wrapped = Create<IFoo, CountingProxy>();
            ((CountingProxy)wrapped)._inner = inner;
            return wrapped;
        }

        protected override object Invoke(MethodInfo targetMethod, object[] args)
        {
            InvocationCount++;

            return targetMethod.Invoke(_inner, args);
        }
    }
```

#### Before
|        Method | Count |       Mean |     Error |    StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |------ |-----------:|----------:|----------:|--------:|------:|------:|----------:|
|        Invoke |     1 |   1.134 us | 0.0256 us | 0.0295 us |  0.1156 |     - |     - |     736 B |
| InvokeGeneric |     1 |   2.276 us | 0.0370 us | 0.0309 us |  0.2273 |     - |     - |    1456 B |
|        Invoke |   100 | 111.460 us | 0.9926 us | 0.8289 us | 11.5248 |     - |     - |   73600 B |
| InvokeGeneric |   100 | 231.935 us | 6.6885 us | 7.1566 us | 22.3214 |     - |     - |  145600 B |

#### After
|        Method | Count |         Mean |       Error |      StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |------ |-------------:|------------:|------------:|--------:|------:|------:|----------:|
|        Invoke |     1 |     493.1 ns |     8.76 ns |     7.77 ns |  0.0215 |     - |     - |     136 B |
| InvokeGeneric |     1 |   1,882.9 ns |    51.62 ns |    57.37 ns |  0.1668 |     - |     - |    1056 B |
|        Invoke |   100 |  49,365.7 ns |   934.74 ns | 1,000.16 ns |  2.1351 |     - |     - |   13600 B |
| InvokeGeneric |   100 | 177,488.8 ns | 3,470.60 ns | 3,246.40 ns | 16.3352 |     - |     - |  105600 B |

Which means we are saving 200 bytes per method invocation of a DispatchProxy.

### Generated Code Comparison

In order to easily understand this change, here are the before and after of an example generated class:

#### Before

```C#

public class generatedProxy_1 : TestDispatchProxy, TypeType_GenericMethod
{
	private Action<object[]> invoke;

	public generatedProxy_1(Action<object[]> P_0)
		: this()
	{
		invoke = P_0;
	}

	public override T Echo<T>(T P_0)
	{
		object[] array = new object[1]
		{
			P_0
		};
		object[] array2 = new object[6]
		{
			this,
			typeof(TypeType_GenericMethod),
			0,
			array,
			new global::System.Type[1]
			{
				typeof(T)
			},
			null
		};
		invoke.Invoke(array2);
		return (T)array2[5];
	}
}
```

#### After

```C#
public class generatedProxy_1 : TestDispatchProxy, TypeType_GenericMethod
{
	private MethodInfo[] _methodInfos;

	public generatedProxy_1(MethodInfo[] P_0)
		: this()
	{
		_methodInfos = P_0;
	}

	public override T Echo<T>(T P_0)
	{
		object[] args = new object[1]
		{
			P_0
		};
		MethodInfo methodInfo = _methodInfos[0];
		methodInfo = methodInfo.MakeGenericMethod(typeof(T));
		object obj = ((DispatchProxy)(object)this).Invoke(methodInfo, args);
		return (T)obj;
	}
}
```