### PR TITLE
Pop LMF frames in exception handlers on wasm, since the normal pop LMF code might not get executed in case of an exception.

### DIFF
--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -138,6 +138,7 @@ MONO_JIT_ICALL (mini_llvmonly_resolve_iface_call_gsharedvt) \
 MONO_JIT_ICALL (mini_llvmonly_resolve_vcall_gsharedvt) \
 MONO_JIT_ICALL (mini_llvmonly_throw_nullref_exception) \
 MONO_JIT_ICALL (mini_llvmonly_throw_aot_failed_exception) \
+MONO_JIT_ICALL (mini_llvmonly_pop_lmf) \
 MONO_JIT_ICALL (mono_amd64_resume_unwind)	\
 MONO_JIT_ICALL (mono_amd64_start_gsharedvt_call)	\
 MONO_JIT_ICALL (mono_amd64_throw_corlib_exception)	\

--- a/src/mono/mono/mini/aot-runtime.h
+++ b/src/mono/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 179
+#define MONO_AOT_FILE_VERSION 180
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/src/mono/mono/mini/llvmonly-runtime.c
+++ b/src/mono/mono/mini/llvmonly-runtime.c
@@ -815,3 +815,15 @@ mini_llvmonly_throw_aot_failed_exception (const char *name)
 	g_free (msg);
 	mono_llvm_throw_exception ((MonoObject*)ex);
 }
+
+/*
+ * mini_llvmonly_pop_lmf:
+ *
+ *   Pop LMF off the LMF stack.
+ */
+void
+mini_llvmonly_pop_lmf (MonoLMF *lmf)
+{
+	if (lmf->previous_lmf)
+		mono_set_lmf (lmf->previous_lmf);
+}

--- a/src/mono/mono/mini/llvmonly-runtime.c
+++ b/src/mono/mono/mini/llvmonly-runtime.c
@@ -825,5 +825,5 @@ void
 mini_llvmonly_pop_lmf (MonoLMF *lmf)
 {
 	if (lmf->previous_lmf)
-		mono_set_lmf (lmf->previous_lmf);
+		mono_set_lmf ((MonoLMF*)lmf->previous_lmf);
 }

--- a/src/mono/mono/mini/llvmonly-runtime.h
+++ b/src/mono/mono/mini/llvmonly-runtime.h
@@ -35,4 +35,6 @@ G_EXTERN_C void mini_llvmonly_throw_nullref_exception (void);
 
 G_EXTERN_C void mini_llvmonly_throw_aot_failed_exception (const char *name);
 
+G_EXTERN_C void mini_llvmonly_pop_lmf (MonoLMF *lmf);
+
 #endif

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -8052,6 +8052,7 @@ call_end:
 
 #ifdef TARGET_WASM
 			if (common_call && needs_stack_walk)
+				/* If an exception is thrown, the LMF is popped by a call to mini_llvmonly_pop_lmf () */
 				emit_pop_lmf (cfg);
 #endif
 
@@ -11667,6 +11668,17 @@ mono_ldptr:
 	if (cfg->compile_aot)
 		/* FIXME: The plt slots require a GOT var even if the method doesn't use it */
 		mono_get_got_var (cfg);
+#endif
+
+#ifdef TARGET_WASM
+	if (cfg->lmf_var) {
+		// mini_llvmonly_pop_lmf () might be called before emit_push_lmf () so initialize the LMF
+		cfg->cbb = init_localsbb;
+		EMIT_NEW_VARLOADA (cfg, ins, cfg->lmf_var, NULL);
+		int lmf_reg = ins->dreg;
+
+		EMIT_NEW_STORE_MEMBASE (cfg, ins, OP_STORE_MEMBASE_IMM, lmf_reg, MONO_STRUCT_OFFSET (MonoLMF, previous_lmf), 0);
+	}
 #endif
 
 	if (cfg->method == method && cfg->got_var)

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4913,6 +4913,7 @@ register_icalls (void)
 	register_icall (mini_llvmonly_init_delegate_virtual, mono_icall_sig_void_object_object_ptr, TRUE);
 	register_icall (mini_llvmonly_throw_nullref_exception, mono_icall_sig_void, TRUE);
 	register_icall (mini_llvmonly_throw_aot_failed_exception, mono_icall_sig_void_ptr, TRUE);
+	register_icall (mini_llvmonly_pop_lmf, mono_icall_sig_void_ptr, TRUE);
 
 	register_icall (mono_get_assembly_object, mono_icall_sig_object_ptr, TRUE);
 	register_icall (mono_get_method_object, mono_icall_sig_object_ptr, TRUE);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46613.