### PR TITLE
Remove extra space

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -196,5 +196,5 @@ indent_size = 2
 # Shell scripts
 [*.sh]
 end_of_line = lf
-[*.{cmd, bat}]
+[*.{cmd,bat}]
 end_of_line = crlf


### PR DESCRIPTION
It won't work properly with the space as it will search for files ending with `. bat` instead of `.bat`