### PR TITLE
NameResolutionPal.Unix: fixed loss of address family information in async lookup

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_networking.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networking.c
@@ -601,12 +601,6 @@ int32_t SystemNative_GetHostEntryForNameAsync(const uint8_t* address, int32_t ad
         return GetAddrInfoErrorFlags_EAI_BADARG;
     }
 
-    sa_family_t platformFamily;
-    if (!TryConvertAddressFamilyPalToPlatform(addressFamily, &platformFamily))
-    {
-        return GetAddrInfoErrorFlags_EAI_FAMILY;
-    }
-
     struct GetAddrInfoAsyncState* state = malloc(sizeof(*state) + addrlen + 1);
 
     if (state == NULL)

--- a/src/libraries/Native/Unix/System.Native/pal_networking.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networking.c
@@ -616,24 +616,22 @@ int32_t SystemNative_GetHostEntryForNameAsync(const uint8_t* address, int32_t ad
 
     memcpy(state->address, address, addrlen + 1);
 
-    *state = (struct GetAddrInfoAsyncState) {
-        .gai_request = {
-            .ar_name = state->address,
-            .ar_service = NULL,
-            .ar_request = &state->hint,
-            .ar_result = NULL
-        },
-        .gai_requests = &state->gai_request,
-        .sigevent = {
-            .sigev_notify = SIGEV_THREAD,
-            .sigev_value = {
-                .sival_ptr = state
-            },
-            .sigev_notify_function = GetHostEntryForNameAsyncComplete
-        },
-        .entry = entry,
-        .callback = callback
+    state->gai_request = (struct gaicb) {
+        .ar_name = state->address,
+        .ar_service = NULL,
+        .ar_request = &state->hint,
+        .ar_result = NULL
     };
+    state->gai_requests = &state->gai_request;
+    state->sigevent = (struct sigevent) {
+        .sigev_notify = SIGEV_THREAD,
+        .sigev_value = {
+            .sival_ptr = state
+        },
+        .sigev_notify_function = GetHostEntryForNameAsyncComplete
+    };
+    state->entry = entry;
+    state->callback = callback;
 
     atomic_thread_fence(memory_order_release);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/47103

C's [designated struct initializer](https://github.com/dotnet/runtime/blob/f685ce550bb70363a33cc6f623a51efc8f8ad04b/src/libraries/Native/Unix/System.Native/pal_networking.c#L625-L642) worked at the time it was [suggested](https://github.com/dotnet/runtime/pull/34633#discussion_r405118798) as for `ar_request` a [static const value](https://github.com/dotnet/runtime/pull/34633#discussion_r405113785) was used. 
Then address family handling got added to master and while resolving the merge conflict and refactoring a bit of code the static const value was gone, and while (recursively) initializing the struct `state` the `hint`-field got lost (overwritten)*, and so the address family information that is used in the (native) callback of the async lookup.

This PR changes the initialization of the `state`-struct, so that the information isn't lost.

I've also removed some dead code, that was an artefact of refactoring and it's removal got lost during all the changes in #34633.

I'm wondering why the outerloop-test in my linux-vm didn't fail back then...

\* quoting the [docs](https://gcc.gnu.org/onlinedocs/gcc/Designated-Inits.html):
> Omitted fields are implicitly initialized the same as for objects that have static storage duration. 