### PR TITLE
[mono] Throw NullReferenceException directly

### DIFF
--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -1649,7 +1649,7 @@ handle_enum:
 		int pos;
 		mono_mb_emit_byte (mb, CEE_DUP);
 		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
-		mono_mb_emit_exception_full (mb, "Mono", "NullByRefReturnException", NULL);
+		mono_mb_emit_exception (mb, "NullReferenceException", NULL);
 		mono_mb_patch_branch (mb, pos);
 #endif
 

--- a/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -635,10 +635,5 @@
 		<!-- mono_method_has_unmanaged_callers_only_attribute () -->
 		<!-- aot-compiler.c -->
 		<type fullname="System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute"/>
-
-		<type fullname="Mono.NullByRefReturnException">
-			<!-- marshal-ilgen.c:emit_invoke_call -->
-			<method signature="System.Void .ctor()" />
-		</type>
 	</assembly>
 </linker>

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
@@ -117,11 +117,4 @@ namespace Mono
         public T4 Item4;
         public T5 Item5;
     }
-
-    internal class NullByRefReturnException : Exception
-    {
-        public NullByRefReturnException()
-        {
-        }
-    }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -377,10 +377,6 @@ namespace System.Reflection
                 {
                     o = InternalInvoke(obj, parameters, out exc);
                 }
-                catch (Mono.NullByRefReturnException)
-                {
-                    throw new NullReferenceException();
-                }
                 catch (OverflowException)
                 {
                     throw;
@@ -395,10 +391,6 @@ namespace System.Reflection
                 try
                 {
                     o = InternalInvoke(obj, parameters, out exc);
-                }
-                catch (Mono.NullByRefReturnException)
-                {
-                    throw new NullReferenceException();
                 }
             }
 


### PR DESCRIPTION
It's not clear to me why we have an intermediary exception and rethrow in managed, so we'll see if this breaks anything.

cc: @vargaz in case you remember the reasoning here