### PR TITLE
CG2 Add lazy string literal loading support

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -43,8 +43,8 @@ namespace ILCompiler.DependencyAnalysis.X64
         {
             if (node.RepresentsIndirectionCell)
             {
-                Builder.EmitByte(0x67);
-                Builder.EmitByte(0x48);
+                AddrMode rexAddrMode = new AddrMode(Register.RAX, null, 0, 0, AddrModeSize.Int64);
+                EmitRexPrefix(regDst, ref rexAddrMode);
                 Builder.EmitByte(0x8B);
                 Builder.EmitByte((byte)(0x00 | ((byte)regDst << 3) | 0x05));
                 Builder.EmitReloc(node, RelocType.IMAGE_REL_BASED_REL32);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2755,8 +2755,7 @@ namespace Internal.JitInterface
 
         private CorInfoHelpFunc getLazyStringLiteralHelper(CORINFO_MODULE_STRUCT_* handle)
         {
-            // TODO: Lazy string literal helper
-            return CorInfoHelpFunc.CORINFO_HELP_UNDEF;
+            return CorInfoHelpFunc.CORINFO_HELP_STRCNS_CURRENT_MODULE;
         }
 
         private CORINFO_MODULE_STRUCT_* embedModuleHandle(CORINFO_MODULE_STRUCT_* handle, ref void* ppIndirection)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2753,11 +2753,6 @@ namespace Internal.JitInterface
         private void getFunctionFixedEntryPoint(CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult)
         { throw new NotImplementedException("getFunctionFixedEntryPoint"); }
 
-        private CorInfoHelpFunc getLazyStringLiteralHelper(CORINFO_MODULE_STRUCT_* handle)
-        {
-            return CorInfoHelpFunc.CORINFO_HELP_STRCNS_CURRENT_MODULE;
-        }
-
         private CORINFO_MODULE_STRUCT_* embedModuleHandle(CORINFO_MODULE_STRUCT_* handle, ref void* ppIndirection)
         { throw new NotImplementedException("embedModuleHandle"); }
         private CORINFO_CLASS_STRUCT_* embedClassHandle(CORINFO_CLASS_STRUCT_* handle, ref void* ppIndirection)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -801,7 +801,7 @@ namespace Internal.JitInterface
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_STRCNS_CURRENT_MODULE:
                     id = ReadyToRunHelper.GetString;
-                    break;
+                    return _compilation.NodeFactory.ImportThunk(ReadyToRunHelper.GetString, _compilation.NodeFactory.HelperImports, useVirtualCall: false);
 
                 case CorInfoHelpFunc.CORINFO_HELP_INITCLASS:
                 case CorInfoHelpFunc.CORINFO_HELP_INITINSTCLASS:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -800,7 +800,6 @@ namespace Internal.JitInterface
                     id = ReadyToRunHelper.ReversePInvokeExit;
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_STRCNS_CURRENT_MODULE:
-                    id = ReadyToRunHelper.GetString;
                     return _compilation.NodeFactory.ImportThunk(ReadyToRunHelper.GetString, _compilation.NodeFactory.HelperImports, useVirtualCall: false);
 
                 case CorInfoHelpFunc.CORINFO_HELP_INITCLASS:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -799,6 +799,9 @@ namespace Internal.JitInterface
                 case CorInfoHelpFunc.CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT:
                     id = ReadyToRunHelper.ReversePInvokeExit;
                     break;
+                case CorInfoHelpFunc.CORINFO_HELP_STRCNS_CURRENT_MODULE:
+                    id = ReadyToRunHelper.GetString;
+                    break;
 
                 case CorInfoHelpFunc.CORINFO_HELP_INITCLASS:
                 case CorInfoHelpFunc.CORINFO_HELP_INITINSTCLASS:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -822,6 +822,11 @@ namespace Internal.JitInterface
             return _compilation.NodeFactory.GetReadyToRunHelperCell(id);
         }
 
+        private CorInfoHelpFunc getLazyStringLiteralHelper(CORINFO_MODULE_STRUCT_* handle)
+        {
+            return CorInfoHelpFunc.CORINFO_HELP_STRCNS_CURRENT_MODULE;
+        }
+
         private void getFunctionEntryPoint(CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult, CORINFO_ACCESS_FLAGS accessFlags)
         {
             throw new RequiresRuntimeJitException(HandleToObject(ftn).ToString());

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
@@ -197,6 +197,13 @@ namespace ILCompiler.PEWriter
                         break;
                     }
 
+                case RelocType.IMAGE_REL_BASED_ARM64_BRANCH26:
+                    {
+                        relocationLength = 4;
+                        delta = targetRVA - sourceRVA;
+                        break;
+                    }
+
                 case RelocType.IMAGE_REL_BASED_ARM64_PAGEBASE_REL21:
                     {
                         relocationLength = 4;


### PR DESCRIPTION
* Currently all string literals are loaded as method load pre-code fixups.
* Match CG1 implementation and allow the JIT to use lazy string literal resolution so cold code strings are lazy loaded.