### PR TITLE
Update the generic collection types to internally use GC.AllocateUninitializedArray<T>

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -346,7 +346,7 @@ namespace System.Collections.Generic
 
             if (count != 0)
             {
-                T[] array = new T[count];
+                T[] array = GC.AllocateUninitializedArray<T>(count);
                 CopyTo(array, 0);
                 info.AddValue(ValuesName, array, typeof(T[]));
             }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -47,7 +47,7 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
-            _array = new T[capacity];
+            _array = GC.AllocateUninitializedArray<T>(capacity);
         }
 
         // Fills a Queue with the elements of an ICollection.  Uses the enumerator
@@ -317,7 +317,7 @@ namespace System.Collections.Generic
                 return Array.Empty<T>();
             }
 
-            T[] arr = new T[_size];
+            T[] arr = GC.AllocateUninitializedArray<T>(_size);
 
             if (_head < _tail)
             {
@@ -336,7 +336,7 @@ namespace System.Collections.Generic
         // must be >= _size.
         private void SetCapacity(int capacity)
         {
-            T[] newarray = new T[capacity];
+            T[] newarray = GC.AllocateUninitializedArray<T>(capacity);
             if (_size > 0)
             {
                 if (_head < _tail)

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -89,8 +89,8 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
-            keys = new TKey[capacity];
-            values = new TValue[capacity];
+            keys = GC.AllocateUninitializedArray<TKey>(capacity);
+            values = GC.AllocateUninitializedArray<TValue>(capacity);
             comparer = Comparer<TKey>.Default;
         }
 
@@ -238,8 +238,8 @@ namespace System.Collections.Generic
 
                     if (value > 0)
                     {
-                        TKey[] newKeys = new TKey[value];
-                        TValue[] newValues = new TValue[value];
+                        TKey[] newKeys = GC.AllocateUninitializedArray<TKey>(value);
+                        TValue[] newValues = GC.AllocateUninitializedArray<TValue>(value);
                         if (_size > 0)
                         {
                             Array.Copy(keys, newKeys, _size);

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -884,7 +884,7 @@ namespace System.Collections.Generic
             if (asSorted != null && treeSubset == null && HasEqualComparer(asSorted) && (asSorted.Count > this.Count / 2))
             {
                 // First do a merge sort to an array.
-                T[] merged = new T[asSorted.Count + this.Count];
+                T[] merged = GC.AllocateUninitializedArray<T>(asSorted.Count + this.Count);
                 int c = 0;
                 Enumerator mine = this.GetEnumerator();
                 Enumerator theirs = asSorted.GetEnumerator();
@@ -1026,7 +1026,7 @@ namespace System.Collections.Generic
             if (asSorted != null && treeSubset == null && HasEqualComparer(asSorted))
             {
                 // First do a merge sort to an array.
-                T[] merged = new T[this.Count];
+                T[] merged = GC.AllocateUninitializedArray<T>(this.Count);
                 int c = 0;
                 Enumerator mine = this.GetEnumerator();
                 Enumerator theirs = asSorted.GetEnumerator();
@@ -1590,7 +1590,7 @@ namespace System.Collections.Generic
 
             if (root != null)
             {
-                T[] items = new T[Count];
+                T[] items = GC.AllocateUninitializedArray<T>(Count);
                 CopyTo(items, 0);
                 info.AddValue(ItemsName, items, typeof(T[]));
             }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -43,7 +43,7 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
-            _array = new T[capacity];
+            _array = GC.AllocateUninitializedArray<T>(capacity);
         }
 
         // Fills a Stack with the contents of a particular collection.  The items are
@@ -294,7 +294,7 @@ namespace System.Collections.Generic
             if (_size == 0)
                 return Array.Empty<T>();
 
-            T[] objArray = new T[_size];
+            T[] objArray = GC.AllocateUninitializedArray<T>(_size);
             int i = 0;
             while (i < _size)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -354,7 +354,7 @@ namespace System.Collections.Generic
 
             if (_buckets != null)
             {
-                var array = new KeyValuePair<TKey, TValue>[Count];
+                var array = GC.AllocateUninitializedArray<KeyValuePair<TKey, TValue>>(Count);
                 CopyTo(array, 0);
                 info.AddValue(KeyValuePairsName, array, typeof(KeyValuePair<TKey, TValue>[]));
             }
@@ -489,8 +489,8 @@ namespace System.Collections.Generic
         private int Initialize(int capacity)
         {
             int size = HashHelpers.GetPrime(capacity);
-            int[] buckets = new int[size];
-            Entry[] entries = new Entry[size];
+            int[] buckets = GC.AllocateUninitializedArray<int>(size);
+            Entry[] entries = GC.AllocateUninitializedArray<Entry>(size);
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _freeList = -1;
@@ -744,7 +744,7 @@ namespace System.Collections.Generic
             Debug.Assert(_entries != null, "_entries should be non-null");
             Debug.Assert(newSize >= _entries.Length);
 
-            Entry[] entries = new Entry[newSize];
+            Entry[] entries = GC.AllocateUninitializedArray<Entry>(newSize);
 
             int count = _count;
             Array.Copy(_entries, entries, count);
@@ -769,7 +769,7 @@ namespace System.Collections.Generic
             }
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
-            _buckets = new int[newSize];
+            _buckets = GC.AllocateUninitializedArray<int>(newSize);
 #if TARGET_64BIT
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -399,7 +399,7 @@ namespace System.Collections.Generic
 
             if (_buckets != null)
             {
-                var array = new T[Count];
+                var array = GC.AllocateUninitializedArray<T>(Count);
                 CopyTo(array);
                 info.AddValue(ElementsName, array, typeof(T[]));
             }
@@ -426,8 +426,8 @@ namespace System.Collections.Generic
 
             if (capacity != 0)
             {
-                _buckets = new int[capacity];
-                _entries = new Entry[capacity];
+                _buckets = GC.AllocateUninitializedArray<int>(capacity);
+                _entries = GC.AllocateUninitializedArray<Entry>(capacity);
 #if TARGET_64BIT
                 _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)capacity);
 #endif
@@ -974,7 +974,7 @@ namespace System.Collections.Generic
             Debug.Assert(_entries != null, "_entries should be non-null");
             Debug.Assert(newSize >= _entries.Length);
 
-            var entries = new Entry[newSize];
+            var entries = GC.AllocateUninitializedArray<Entry>(newSize);
 
             int count = _count;
             Array.Copy(_entries, entries, count);
@@ -1000,7 +1000,7 @@ namespace System.Collections.Generic
             }
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
-            _buckets = new int[newSize];
+            _buckets = GC.AllocateUninitializedArray<int>(newSize);
 #if TARGET_64BIT
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
 #endif
@@ -1071,8 +1071,8 @@ namespace System.Collections.Generic
         private int Initialize(int capacity)
         {
             int size = HashHelpers.GetPrime(capacity);
-            var buckets = new int[size];
-            var entries = new Entry[size];
+            var buckets = GC.AllocateUninitializedArray<int>(size);
+            var entries = GC.AllocateUninitializedArray<Entry>(size);
 
             // Assign member variables after both arrays are allocated to guard against corruption from OOM if second fails.
             _freeList = -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -51,7 +51,7 @@ namespace System.Collections.Generic
             if (capacity == 0)
                 _items = s_emptyArray;
             else
-                _items = new T[capacity];
+                _items = GC.AllocateUninitializedArray<T>(capacity);
         }
 
         // Constructs a List, copying the contents of the given collection. The
@@ -72,7 +72,7 @@ namespace System.Collections.Generic
                 }
                 else
                 {
-                    _items = new T[count];
+                    _items = GC.AllocateUninitializedArray<T>(count);
                     c.CopyTo(_items, 0);
                     _size = count;
                 }
@@ -108,7 +108,7 @@ namespace System.Collections.Generic
                 {
                     if (value > 0)
                     {
-                        T[] newItems = new T[value];
+                        T[] newItems = GC.AllocateUninitializedArray<T>(value);
                         if (_size > 0)
                         {
                             Array.Copy(_items, newItems, _size);
@@ -1030,7 +1030,7 @@ namespace System.Collections.Generic
                 return s_emptyArray;
             }
 
-            T[] array = new T[_size];
+            T[] array = GC.AllocateUninitializedArray<T>(_size);
             Array.Copy(_items, array, _size);
             return array;
         }


### PR DESCRIPTION
As per the title, this updates the generic collection types to internally use GC.AllocateUninitializedArray<T>.

When `T` is a reference type, this should not differ from the standard `new T[]` as the API ensures the array is zeroed anyways for correctness.
However, when `T` is a value type and particularly when the size of `T` or the collection is large, this can help avoid needless zeroing in the underlying APIs.

Most of the collection types are already optimized to only zero removed elements if `T` is a reference type and internally track and check their bounds so this should be completely safe.

For a simple test, such as [System.Collections.CtorGivenSize<int>.List](https://github.com/dotnet/performance/blob/master/src/benchmarks/micro/libraries/System.Collections/Create/CtorGivenSize.cs) which creates a `List` with a capacity of 512, this shows some small gains:

```
BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.19042
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.100-alpha.1.21056.1
  [Host]     : .NET 6.0.0 (6.0.21.5406), X64 RyuJIT
  Job-RSPOMU : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT
  Job-ECGLUA : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  IterationTime=250.0000 ms
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1
```

| Method |        Job |                                                                                                      Toolchain | Size |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------- |----------- |--------------------------------------------------------------------------------------------------------------- |----- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|   List | Job-RSPOMU |      \runtime\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe |  512 | 65.10 ns | 0.783 ns | 0.694 ns | 65.12 ns | 64.24 ns | 66.48 ns |  1.37 |    0.04 | 0.1256 | 0.0008 |     - |      2 KB |
|   List | Job-ECGLUA | \runtime_base\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe |  512 | 47.48 ns | 1.022 ns | 1.136 ns | 47.29 ns | 46.09 ns | 50.31 ns |  1.00 |    0.00 | 0.1256 | 0.0019 |     - |      2 KB |

For string, it is likewise showing essentially no difference:
| Method |        Job |                                                                                                      Toolchain | Size |     Mean |    Error |   StdDev |   Median |      Min |       Max | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------- |----------- |--------------------------------------------------------------------------------------------------------------- |----- |---------:|---------:|---------:|---------:|---------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
|   List | Job-RSPOMU |      \runtime\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe |  512 | 98.22 ns | 2.805 ns | 2.881 ns | 98.63 ns | 93.72 ns | 103.37 ns |  1.04 |    0.04 | 0.2480 | 0.0072 |     - |      4 KB |
|   List | Job-ECGLUA | \runtime_base\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe |  512 | 94.07 ns | 1.643 ns | 1.537 ns | 94.72 ns | 91.21 ns |  96.11 ns |  1.00 |    0.00 | 0.2481 | 0.0074 |     - |      4 KB |

I haven't run the full suite of performance tests, but similar gains should be seen for effectively any value type for the given collections.