### PR TITLE
Update SafeHandle types to have public parameterless constructors and add InitHandle API

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ISymWrapperCore.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ISymWrapperCore.cs
@@ -502,7 +502,7 @@ namespace System.Reflection.Emit
     //--------------------------------------------------------------------------------------
     internal sealed class PunkSafeHandle : SafeHandle
     {
-        internal PunkSafeHandle()
+        public PunkSafeHandle()
             : base((IntPtr)0, true)
         {
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -14,7 +14,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System
 {
-    internal class SafeTypeNameParserHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeTypeNameParserHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         #region QCalls
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]

--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -152,7 +152,7 @@ namespace Microsoft.NET.HostModel
         /// </summary>
         private class SafeUpdateHandle : SafeHandle
         {
-            private SafeUpdateHandle() : base(IntPtr.Zero, true)
+            public SafeUpdateHandle() : base(IntPtr.Zero, true)
             {
             }
 

--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -150,7 +150,7 @@ namespace Microsoft.NET.HostModel
         /// native resources for the update handle without updating
         /// the target file.
         /// </summary>
-        private class SafeUpdateHandle : SafeHandle
+        private sealed class SafeUpdateHandle : SafeHandle
         {
             public SafeUpdateHandle() : base(IntPtr.Zero, true)
             {

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFArray.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFArray.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeCFArrayHandle : SafeHandle
     {
-        private SafeCFArrayHandle()
+        public SafeCFArrayHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFData.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeCFDataHandle : SafeHandle
     {
-        internal SafeCFDataHandle()
+        public SafeCFDataHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFDate.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFDate.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeCFDateHandle : SafeHandle
     {
-        internal SafeCFDateHandle()
+        public SafeCFDateHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFDictionary.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFDictionary.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeCFDictionaryHandle : SafeHandle
     {
-        private SafeCFDictionaryHandle()
+        public SafeCFDictionaryHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFError.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFError.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeCFErrorHandle : SafeHandle
     {
-        internal SafeCFErrorHandle()
+        public SafeCFErrorHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFString.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFString.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeCFStringHandle : SafeHandle
     {
-        internal SafeCFStringHandle()
+        public SafeCFStringHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
@@ -42,7 +42,7 @@ namespace System.Security.Cryptography.Apple
 {
     internal sealed class SafeDigestCtxHandle : SafeHandle
     {
-        internal SafeDigestCtxHandle()
+        public SafeDigestCtxHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
@@ -42,7 +42,7 @@ namespace System.Security.Cryptography.Apple
 {
     internal sealed class SafeHmacHandle : SafeHandle
     {
-        internal SafeHmacHandle()
+        public SafeHmacHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.cs
@@ -292,7 +292,7 @@ namespace System.Security.Cryptography.Apple
 {
     internal class SafeKeychainItemHandle : SafeHandle
     {
-        internal SafeKeychainItemHandle()
+        public SafeKeychainItemHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -310,7 +310,7 @@ namespace System.Security.Cryptography.Apple
 
     internal class SafeKeychainHandle : SafeHandle
     {
-        internal SafeKeychainHandle()
+        public SafeKeychainHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -412,7 +412,7 @@ namespace System.Net
 {
     internal sealed class SafeSslHandle : SafeHandle
     {
-        internal SafeSslHandle()
+        public SafeSslHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Symmetric.cs
@@ -83,7 +83,7 @@ internal static partial class Interop
 
 namespace System.Security.Cryptography
 {
-    internal class SafeAppleCryptorHandle : SafeHandle
+    internal sealed class SafeAppleCryptorHandle : SafeHandle
     {
         public SafeAppleCryptorHandle()
             : base(IntPtr.Zero, ownsHandle: true)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
@@ -101,7 +101,7 @@ internal static partial class Interop
 
 namespace System.Security.Cryptography.X509Certificates
 {
-    internal class SafeOcspRequestHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeOcspRequestHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeOcspRequestHandle()
             : base(true)
@@ -116,7 +116,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
     }
 
-    internal class SafeOcspResponseHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeOcspResponseHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeOcspResponseHandle()
             : base(true)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Win32.SafeHandles
             }
         }
 
-        private SafeSslHandle() : base(IntPtr.Zero, true)
+        public SafeSslHandle() : base(IntPtr.Zero, true)
         {
         }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeSslContextHandle : SafeHandle
     {
-        private SafeSslContextHandle()
+        public SafeSslContextHandle()
             : base(IntPtr.Zero, true)
         {
         }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Win32.SafeHandles
     /// </summary>
     internal sealed class SafeSharedX509NameHandle : SafeInteriorHandle
     {
-        private SafeSharedX509NameHandle() :
+        public SafeSharedX509NameHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -61,7 +61,7 @@ namespace Microsoft.Win32.SafeHandles
     /// </summary>
     internal sealed class SafeSharedX509NameStackHandle : SafeInteriorHandle
     {
-        private SafeSharedX509NameStackHandle() :
+        public SafeSharedX509NameStackHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeX509StackHandle : SafeHandle
     {
-        private SafeX509StackHandle() :
+        public SafeX509StackHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -100,7 +100,7 @@ namespace Microsoft.Win32.SafeHandles
     {
         internal static readonly SafeSharedX509StackHandle InvalidHandle = new SafeSharedX509StackHandle();
 
-        private SafeSharedX509StackHandle() :
+        public SafeSharedX509StackHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeX509StoreCtxHandle : SafeHandle
     {
-        private SafeX509StoreCtxHandle() :
+        public SafeX509StoreCtxHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/SafeHashHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/SafeHashHandle.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography
     {
         private SafeProvHandle? _parent;
 
-        private SafeHashHandle() : base(true)
+        public SafeHashHandle() : base(true)
         {
             SetHandle(IntPtr.Zero);
         }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/SafeKeyHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/SafeKeyHandle.cs
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography
         private bool _fPublicOnly;
         private SafeProvHandle? _parent;
 
-        private SafeKeyHandle() : base(true)
+        public SafeKeyHandle() : base(true)
         {
             SetHandle(IntPtr.Zero);
             _keySpec = 0;

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/SafeProvHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/SafeProvHandle.cs
@@ -18,7 +18,7 @@ namespace System.Security.Cryptography
         private uint _flags;
         private bool _fPersistKeyInCsp;
 
-        private SafeProvHandle() : base(true)
+        public SafeProvHandle() : base(true)
         {
             SetHandle(IntPtr.Zero);
             _containerName = null;

--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
@@ -80,7 +80,7 @@ internal static partial class Interop
 
         internal sealed class SafeCloseIcmpHandle : SafeHandleZeroOrMinusOneIsInvalid
         {
-            private SafeCloseIcmpHandle() : base(true)
+            public SafeCloseIcmpHandle() : base(true)
             {
             }
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -148,7 +148,7 @@ namespace System.Net.Security
     {
 #endif
 
-        internal SafeFreeCertContext() : base(true) { }
+        public SafeFreeCertContext() : base(true) { }
 
         // This must be ONLY called from this file.
         internal void Set(IntPtr value)
@@ -1080,7 +1080,7 @@ namespace System.Net.Security
 
     internal sealed class SafeDeleteSslContext : SafeDeleteContext
     {
-        internal SafeDeleteSslContext() : base() { }
+        public SafeDeleteSslContext() : base() { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
@@ -14,7 +14,7 @@ namespace System.Net.Sockets
     {
         private readonly SafeSocketHandle? _socketHandle;
 
-        private SafeNativeOverlapped()
+        public SafeNativeOverlapped()
             : this(IntPtr.Zero)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeAsn1ObjectHandle : SafeHandle
     {
-        private SafeAsn1ObjectHandle() :
+        public SafeAsn1ObjectHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -28,7 +28,7 @@ namespace Microsoft.Win32.SafeHandles
 
     internal sealed class SafeAsn1BitStringHandle : SafeHandle
     {
-        private SafeAsn1BitStringHandle() :
+        public SafeAsn1BitStringHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -48,7 +48,7 @@ namespace Microsoft.Win32.SafeHandles
 
     internal sealed class SafeAsn1OctetStringHandle : SafeHandle
     {
-        private SafeAsn1OctetStringHandle() :
+        public SafeAsn1OctetStringHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Win32.SafeHandles
             return status == Interop.NetSecurityNative.Status.GSS_S_COMPLETE;
         }
 
-        private SafeGssNameHandle()
+        public SafeGssNameHandle()
             : base(IntPtr.Zero, true)
         {
         }
@@ -70,7 +70,7 @@ namespace Microsoft.Win32.SafeHandles
     /// <summary>
     /// Wrapper around a gss_cred_id_t_desc_struct*
     /// </summary>
-    internal class SafeGssCredHandle : SafeHandle
+    internal sealed class SafeGssCredHandle : SafeHandle
     {
         private static readonly Lazy<bool> s_IsNtlmInstalled = new Lazy<bool>(InitIsNtlmInstalled);
 
@@ -132,7 +132,7 @@ namespace Microsoft.Win32.SafeHandles
             return retHandle;
         }
 
-        private SafeGssCredHandle()
+        public SafeGssCredHandle()
             : base(IntPtr.Zero, true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBCryptAlgorithmHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBCryptAlgorithmHandle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeBCryptAlgorithmHandle : SafeBCryptHandle
     {
-        private SafeBCryptAlgorithmHandle()
+        public SafeBCryptAlgorithmHandle()
             : base()
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBCryptHashHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBCryptHashHandle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeBCryptHashHandle : SafeBCryptHandle
     {
-        private SafeBCryptHashHandle()
+        public SafeBCryptHashHandle()
             : base()
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBCryptKeyHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBCryptKeyHandle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeBCryptKeyHandle : SafeBCryptHandle
     {
-        private SafeBCryptKeyHandle()
+        public SafeBCryptKeyHandle()
             : base()
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBignumHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBignumHandle.Unix.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeBignumHandle : SafeHandle
     {
-        private SafeBignumHandle() :
+        public SafeBignumHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeBioHandle.Unix.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Win32.SafeHandles
     {
         private SafeHandle? _parent;
 
-        private SafeBioHandle() :
+        public SafeBioHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCreateHandle.OSX.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCreateHandle.OSX.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Win32.SafeHandles
     /// </summary>
     internal sealed partial class SafeCreateHandle : SafeHandle
     {
-        internal SafeCreateHandle() : base(IntPtr.Zero, true) { }
+        public SafeCreateHandle() : base(IntPtr.Zero, true) { }
 
         internal SafeCreateHandle(IntPtr ptr) : base(IntPtr.Zero, true)
         {

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeDsaHandle.Unix.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeDsaHandle : SafeHandle
     {
-        private SafeDsaHandle() :
+        public SafeDsaHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEcKeyHandle.Unix.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeEcKeyHandle : SafeHandle
     {
-        private SafeEcKeyHandle() :
+        public SafeEcKeyHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEventStreamHandle.OSX.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEventStreamHandle.OSX.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Win32.SafeHandles
     /// </summary>
     internal sealed partial class SafeEventStreamHandle : SafeHandle
     {
-        internal SafeEventStreamHandle() : base(IntPtr.Zero, true) { }
+        public SafeEventStreamHandle() : base(IntPtr.Zero, true) { }
 
         internal SafeEventStreamHandle(IntPtr ptr) : base(IntPtr.Zero, true)
         {

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpCipherCtxHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpCipherCtxHandle.Unix.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeEvpCipherCtxHandle : SafeHandle
     {
-        private SafeEvpCipherCtxHandle() :
+        public SafeEvpCipherCtxHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpMdCtxHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpMdCtxHandle.Unix.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeEvpMdCtxHandle : SafeHandle
     {
-        private SafeEvpMdCtxHandle() :
+        public SafeEvpMdCtxHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPKeyHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPKeyHandle.Unix.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography
     {
         internal static readonly SafeEvpPKeyHandle InvalidHandle = new SafeEvpPKeyHandle();
 
-        private SafeEvpPKeyHandle() :
+        public SafeEvpPKeyHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPkeyCtxHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeEvpPkeyCtxHandle.Unix.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeEvpPKeyCtxHandle : SafeHandle
     {
-        private SafeEvpPKeyCtxHandle()
+        public SafeEvpPKeyCtxHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeFindHandle : SafeHandle
     {
-        internal SafeFindHandle() : base(IntPtr.Zero, true) { }
+        public SafeFindHandle() : base(IntPtr.Zero, true) { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeHmacCtxHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeHmacCtxHandle.Unix.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeHmacCtxHandle : SafeHandle
     {
-        private SafeHmacCtxHandle() :
+        public SafeHmacCtxHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLibraryHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLibraryHandle.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeLibraryHandle() : base(true) { }
+        public SafeLibraryHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLocalAllocHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLocalAllocHandle.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeLocalAllocHandle : SafeBuffer
     {
-        private SafeLocalAllocHandle() : base(true) { }
+        public SafeLocalAllocHandle() : base(true) { }
 
         internal static readonly SafeLocalAllocHandle Zero = new SafeLocalAllocHandle();
 

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaHandle.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeLsaHandle : SafeHandle
     {
-        internal SafeLsaHandle()
+        public SafeLsaHandle()
             : base(IntPtr.Zero, true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaMemoryHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaMemoryHandle.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeLsaMemoryHandle : SafeBuffer
     {
-        private SafeLsaMemoryHandle() : base(true) { }
+        public SafeLsaMemoryHandle() : base(true) { }
 
         // 0 is an Invalid Handle
         internal SafeLsaMemoryHandle(IntPtr handle) : base(true)

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaPolicyHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaPolicyHandle.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeLsaPolicyHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private SafeLsaPolicyHandle() : base(true) { }
+        public SafeLsaPolicyHandle() : base(true) { }
 
         // 0 is an Invalid Handle
         internal SafeLsaPolicyHandle(IntPtr handle) : base(true)

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaReturnBufferHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeLsaReturnBufferHandle.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeLsaReturnBufferHandle : SafeBuffer
     {
-        private SafeLsaReturnBufferHandle() : base(true) { }
+        public SafeLsaReturnBufferHandle() : base(true) { }
 
         // 0 is an Invalid Handle
         internal SafeLsaReturnBufferHandle(IntPtr handle) : base(true)

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafePerfProviderHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafePerfProviderHandle.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafePerfProviderHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private SafePerfProviderHandle() : base(true) { }
+        public SafePerfProviderHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafePkcs7Handle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafePkcs7Handle.Unix.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafePkcs7Handle : SafeHandle
     {
-        private SafePkcs7Handle() :
+        public SafePkcs7Handle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeRsaHandle.Unix.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeRsaHandle : SafeHandle
     {
-        private SafeRsaHandle() :
+        public SafeRsaHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeTokenHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeTokenHandle.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeTokenHandle : SafeHandle
     {
-        private SafeTokenHandle() : base(IntPtr.Zero, true) { }
+        public SafeTokenHandle() : base(IntPtr.Zero, true) { }
 
         // 0 is an Invalid Handle
         internal SafeTokenHandle(IntPtr handle) : base(IntPtr.Zero, true)

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Win32.SafeHandles
 
         internal static readonly SafeX509Handle InvalidHandle = new SafeX509Handle();
 
-        private SafeX509Handle() :
+        public SafeX509Handle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -48,7 +48,7 @@ namespace Microsoft.Win32.SafeHandles
 
     internal sealed class SafeX509CrlHandle : SafeHandle
     {
-        private SafeX509CrlHandle() :
+        public SafeX509CrlHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -68,7 +68,7 @@ namespace Microsoft.Win32.SafeHandles
 
     internal sealed class SafeX509StoreHandle : SafeHandle
     {
-        private SafeX509StoreHandle() :
+        public SafeX509StoreHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/X509ExtensionSafeHandles.Unix.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/X509ExtensionSafeHandles.Unix.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeX509ExtensionHandle : SafeHandle
     {
-        private SafeX509ExtensionHandle() :
+        public SafeX509ExtensionHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -29,7 +29,7 @@ namespace Microsoft.Win32.SafeHandles
 
     internal sealed class SafeEkuExtensionHandle : SafeHandle
     {
-        private SafeEkuExtensionHandle() :
+        public SafeEkuExtensionHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
@@ -276,7 +276,7 @@ namespace System.Buffers
         private sealed class VirtualAllocHandle : SafeHandle
         {
             // Called by P/Invoke when returning SafeHandles
-            private VirtualAllocHandle()
+            public VirtualAllocHandle()
                 : base(IntPtr.Zero, ownsHandle: true)
             {
             }

--- a/src/libraries/Microsoft.Win32.Registry/ref/Microsoft.Win32.Registry.cs
+++ b/src/libraries/Microsoft.Win32.Registry/ref/Microsoft.Win32.Registry.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeRegistryHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
+        public SafeRegistryHandle() : base (default(bool)) {}
         public SafeRegistryHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base (default(bool)) { }
         protected override bool ReleaseHandle() { throw null; }
     }

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcEnvironmentHandle.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcEnvironmentHandle.cs
@@ -8,7 +8,7 @@ namespace System.Data.Odbc
 {
     internal sealed class OdbcEnvironmentHandle : OdbcHandle
     {
-        internal OdbcEnvironmentHandle() : base(ODBC32.SQL_HANDLE.ENV, null)
+        public OdbcEnvironmentHandle() : base(ODBC32.SQL_HANDLE.ENV, null)
         {
             ODBC32.RetCode retcode;
 

--- a/src/libraries/System.Data.OleDb/src/DbPropSet.cs
+++ b/src/libraries/System.Data.OleDb/src/DbPropSet.cs
@@ -16,7 +16,7 @@ namespace System.Data.OleDb
         // stores the exception with last error.HRESULT from IDBProperties.GetProperties
         private Exception? lastErrorFromProvider;
 
-        private DBPropSet() : base(IntPtr.Zero, true)
+        public DBPropSet() : base(IntPtr.Zero, true)
         {
             propertySetCount = 0;
         }

--- a/src/libraries/System.Data.OleDb/src/SafeHandles.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeHandles.cs
@@ -15,7 +15,7 @@ namespace System.Data.OleDb
     {
         private IntPtr handle2;   // this must be protected so derived classes can use out params.
 
-        private DualCoTaskMem() : base(IntPtr.Zero, true)
+        public DualCoTaskMem() : base(IntPtr.Zero, true)
         {
             this.handle2 = IntPtr.Zero;
         }

--- a/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/WrappedIUnknown.cs
+++ b/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/WrappedIUnknown.cs
@@ -14,7 +14,7 @@ namespace System.Data.ProviderBase
 
     internal class WrappedIUnknown : SafeHandle
     {
-        internal WrappedIUnknown() : base(IntPtr.Zero, true)
+        public WrappedIUnknown() : base(IntPtr.Zero, true)
         {
         }
 

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/CoTaskMemSafeHandle.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/CoTaskMemSafeHandle.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.Eventing.Reader
     /// </summary>
     internal sealed class CoTaskMemSafeHandle : SafeHandle
     {
-        internal CoTaskMemSafeHandle()
+        public CoTaskMemSafeHandle()
             : base(IntPtr.Zero, true)
         {
         }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/CoTaskMemUnicodeSafeHandle.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/CoTaskMemUnicodeSafeHandle.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.Eventing.Reader
     /// </summary>
     internal sealed class CoTaskMemUnicodeSafeHandle : SafeHandle
     {
-        internal CoTaskMemUnicodeSafeHandle()
+        public CoTaskMemUnicodeSafeHandle()
             : base(IntPtr.Zero, true)
         {
         }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogHandle.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogHandle.cs
@@ -11,8 +11,7 @@ namespace System.Diagnostics.Eventing.Reader
     /// </summary>
     internal sealed class EventLogHandle : SafeHandle
     {
-        // Called by P/Invoke when returning SafeHandles
-        private EventLogHandle()
+        public EventLogHandle()
             : base(IntPtr.Zero, true)
         {
         }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/SafeEventLogReadHandle.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/SafeEventLogReadHandle.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeEventLogReadHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeEventLogReadHandle() : base(true) { }
+        public SafeEventLogReadHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/SafeEventLogWriteHandle.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/SafeEventLogWriteHandle.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeEventLogWriteHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeEventLogWriteHandle() : base(true) { }
+        public SafeEventLogWriteHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
+++ b/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
+        public SafeProcessHandle() : base (default(bool)) { }
         public SafeProcessHandle(System.IntPtr existingHandle, bool ownsHandle) : base (default(bool)) { }
         protected override bool ReleaseHandle() { throw null; }
     }

--- a/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
+++ b/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
@@ -34,11 +34,5 @@ namespace Microsoft.Win32.SafeHandles
         {
             SetHandle(existingHandle);
         }
-
-        internal void InitialSetHandle(IntPtr h)
-        {
-            Debug.Assert(IsInvalid, "Safe handle should only be set once");
-            base.handle = h;
-        }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
+++ b/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Win32.SafeHandles
     {
         internal static readonly SafeProcessHandle InvalidHandle = new SafeProcessHandle();
 
-        internal SafeProcessHandle()
+        public SafeProcessHandle()
             : this(IntPtr.Zero)
         {
         }

--- a/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeThreadHandle.cs
+++ b/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeThreadHandle.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeThreadHandle : SafeHandle
     {
-        internal SafeThreadHandle()
+        public SafeThreadHandle()
             : base(new IntPtr(0), true)
         {
         }

--- a/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeThreadHandle.cs
+++ b/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeThreadHandle.cs
@@ -25,12 +25,6 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
 
-        internal void InitialSetHandle(IntPtr h)
-        {
-            Debug.Assert(IsInvalid, "Safe handle should only be set once");
-            base.SetHandle(h);
-        }
-
         public override bool IsInvalid
         {
             get { return handle == IntPtr.Zero || handle == new IntPtr(-1); }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -610,7 +610,7 @@ namespace System.Diagnostics
                     }
 
                     if (processInfo.hProcess != IntPtr.Zero && processInfo.hProcess != new IntPtr(-1))
-                        procSH.InitialSetHandle(processInfo.hProcess);
+                        Marshal.InitHandle(procSH, processInfo.hProcess);
                     if (processInfo.hThread != IntPtr.Zero && processInfo.hThread != new IntPtr(-1))
                         Interop.Kernel32.CloseHandle(processInfo.hThread);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/SafeHandles.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/SafeHandles.Linux.cs
@@ -9,7 +9,7 @@ namespace System.DirectoryServices.Protocols
     {
         internal bool _needDispose;
 
-        internal ConnectionHandle()
+        public ConnectionHandle()
             :base(true)
         {
             Interop.Ldap.ldap_initialize(out handle, null);
@@ -44,7 +44,7 @@ namespace System.DirectoryServices.Protocols
 
     internal sealed class SafeBerHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeBerHandle() : base(true)
+        public SafeBerHandle() : base(true)
         {
             SetHandle(Interop.Ldap.ber_alloc(1));
             if (handle == IntPtr.Zero)

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/SafeHandles.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/SafeHandles.Windows.cs
@@ -7,7 +7,7 @@ namespace System.DirectoryServices.Protocols
 {
     internal sealed class SafeBerHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeBerHandle() : base(true)
+        public SafeBerHandle() : base(true)
         {
             SetHandle(Interop.Ldap.ber_alloc(1));
             if (handle == IntPtr.Zero)
@@ -36,7 +36,7 @@ namespace System.DirectoryServices.Protocols
     {
         internal bool _needDispose;
 
-        internal ConnectionHandle() : base(true)
+        public ConnectionHandle() : base(true)
         {
             SetHandle(Interop.Ldap.ldap_init(null, 389));
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/SafeHandle.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/SafeHandle.cs
@@ -8,6 +8,8 @@ namespace System.DirectoryServices.ActiveDirectory
 {
     internal sealed class PolicySafeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
+        public PolicySafeHandle() : base(true) { }
+
         internal PolicySafeHandle(IntPtr value) : base(true)
         {
             SetHandle(value);
@@ -18,7 +20,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
     internal sealed class LsaLogonProcessSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private LsaLogonProcessSafeHandle() : base(true) { }
+        public LsaLogonProcessSafeHandle() : base(true) { }
 
         internal LsaLogonProcessSafeHandle(IntPtr value) : base(true)
         {
@@ -30,7 +32,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
     internal sealed class LoadLibrarySafeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private LoadLibrarySafeHandle() : base(true) { }
+        public LoadLibrarySafeHandle() : base(true) { }
 
         internal LoadLibrarySafeHandle(IntPtr value) : base(true)
         {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/SafeCustomLineCapHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/SafeCustomLineCapHandle.cs
@@ -9,7 +9,7 @@ using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
 namespace System.Drawing.Drawing2D
 {
-    internal class SafeCustomLineCapHandle : SafeHandle
+    internal sealed class SafeCustomLineCapHandle : SafeHandle
     {
         // Create a SafeHandle, informing the base class
         // that this SafeHandle instance "owns" the handle,

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintController.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintController.Windows.cs
@@ -20,12 +20,7 @@ namespace System.Drawing.Printing
         /// </remarks>
         internal sealed class SafeDeviceModeHandle : SafeHandle
         {
-            /// <summary>
-            /// This constructor is used by the P/Invoke marshaling layer
-            /// to allocate a SafeHandle instance. P/Invoke then does the
-            /// appropriate method call, storing the handle in this class.
-            /// </summary>
-            private SafeDeviceModeHandle() : base(IntPtr.Zero, ownsHandle: true)
+            public SafeDeviceModeHandle() : base(IntPtr.Zero, ownsHandle: true)
             {
             }
 

--- a/src/libraries/System.IO.MemoryMappedFiles/ref/System.IO.MemoryMappedFiles.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/ref/System.IO.MemoryMappedFiles.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeMemoryMappedFileHandle() : base (default(bool)) { }
+        public SafeMemoryMappedFileHandle() : base (default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
         protected override bool ReleaseHandle() { throw null; }
     }
     public sealed partial class SafeMemoryMappedViewHandle : System.Runtime.InteropServices.SafeBuffer
     {
-        internal SafeMemoryMappedViewHandle() : base (default(bool)) { }
+        public SafeMemoryMappedViewHandle() : base (default(bool)) { }
         protected override bool ReleaseHandle() { throw null; }
     }
 }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/ILLink/ILLinkTrim_LibraryBuild.xml
@@ -1,8 +1,0 @@
-<linker>
-  <assembly fullname="System.IO.MemoryMappedFiles">
-    <type fullname="Microsoft.Win32.SafeHandles.SafeMemoryMappedViewHandle">
-      <!-- don't trim the default constructor, since it is necessary for p/invokes made by external code -->
-      <method name=".ctor" />
-    </type>
-  </assembly>
-</linker>

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedFileHandle.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
+
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        protected override bool ReleaseHandle()
+        public SafeMemoryMappedFileHandle()
+            : base(true)
         {
-            return Interop.Kernel32.CloseHandle(handle);
         }
-
-        public override bool IsInvalid => base.IsInvalid;
     }
 }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedViewHandle.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Microsoft/Win32/SafeMemoryMappedViewHandle.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeMemoryMappedViewHandle : SafeBuffer
     {
-        internal SafeMemoryMappedViewHandle()
+        public SafeMemoryMappedViewHandle()
             : base(true)
         {
         }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <!-- Compiled Source Files -->
   <ItemGroup>
+    <Compile Include="Microsoft\Win32\SafeMemoryMappedFileHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeMemoryMappedViewHandle.cs" />
     <Compile Include="System\IO\MemoryMappedFiles\MemoryMappedFileOptions.cs" />
     <Compile Include="System\IO\MemoryMappedFiles\MemoryMappedFileAccess.cs" />

--- a/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.cs
+++ b/src/libraries/System.IO.Pipes/ref/System.IO.Pipes.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafePipeHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
+        public SafePipeHandle() : base (default(bool)) { }
         public SafePipeHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base (default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
         protected override bool ReleaseHandle() { throw null; }

--- a/src/libraries/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.cs
+++ b/src/libraries/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafePipeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafePipeHandle()
+        public SafePipeHandle()
             : this(new IntPtr(DefaultInvalidHandle), true)
         {
         }

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SafeSerialDeviceHandle.Unix.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SafeSerialDeviceHandle.Unix.cs
@@ -12,7 +12,7 @@ namespace System.IO.Ports
 {
     internal sealed class SafeSerialDeviceHandle : SafeHandleMinusOneIsInvalid
     {
-        private SafeSerialDeviceHandle() : base(ownsHandle: true)
+        public SafeSerialDeviceHandle() : base(ownsHandle: true)
         {
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpRequestQueueV2Handle.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpRequestQueueV2Handle.cs
@@ -8,7 +8,7 @@ namespace System.Net
 {
     internal sealed class HttpRequestQueueV2Handle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private HttpRequestQueueV2Handle() : base(true)
+        public HttpRequestQueueV2Handle() : base(true)
         {
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/SafeWebSocketHandle.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/SafeWebSocketHandle.cs
@@ -9,7 +9,7 @@ namespace System.Net.WebSockets
     // but we use a SafeHandle because it provides us the guarantee that WebSocketDeleteHandle will always get called.
     internal sealed class SafeWebSocketHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeWebSocketHandle()
+        public SafeWebSocketHandle()
             : base(true)
         {
         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SafeCancelMibChangeNotify.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SafeCancelMibChangeNotify.cs
@@ -9,7 +9,7 @@ namespace System.Net.NetworkInformation
     // CancelMibChangeNotify2 guarantees that after it returns, the callback will NEVER be called.  It may block
     // for a small amount of time if the callback is currently in progress, which is fine (and, intentional).
 
-    internal class SafeCancelMibChangeNotify : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeCancelMibChangeNotify : SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeCancelMibChangeNotify() : base(true) { }
 

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SafeFreeMibTable.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SafeFreeMibTable.cs
@@ -5,7 +5,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.NetworkInformation
 {
-    internal class SafeFreeMibTable : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeFreeMibTable : SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeFreeMibTable() : base(true) { }
 

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -220,6 +220,7 @@ namespace System.Net.Sockets
     }
     public sealed partial class SafeSocketHandle : Microsoft.Win32.SafeHandles.SafeHandleMinusOneIsInvalid
     {
+        public SafeSocketHandle() : base (default(bool)) { }
         public SafeSocketHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base (default(bool)) { }
         protected override bool ReleaseHandle() { throw null; }
     }

--- a/src/libraries/System.Net.Sockets/src/ILLink/ILLinkTrim_LibraryBuild.xml
+++ b/src/libraries/System.Net.Sockets/src/ILLink/ILLinkTrim_LibraryBuild.xml
@@ -1,8 +1,0 @@
-<linker>
-  <assembly fullname="System.Net.Sockets">
-    <type fullname="System.Net.Sockets.SafeSocketHandle">
-      <!-- don't trim the default constructor, since it is necessary for p/invokes made by external code -->
-      <method name=".ctor" />
-    </type>
-  </assembly>
-</linker>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.cs
@@ -38,7 +38,7 @@ namespace System.Net.Sockets
             SetHandleAndValid(preexistingHandle);
         }
 
-        private SafeSocketHandle() : base(ownsHandle: true) => OwnsHandle = true;
+        public SafeSocketHandle() : base(ownsHandle: true) => OwnsHandle = true;
 
         internal bool OwnsHandle { get; }
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private SafeFileHandle() : this(ownsHandle: true)
+        public SafeFileHandle() : this(ownsHandle: true)
         {
         }
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
     {
         private bool? _isAsync;
 
-        private SafeFileHandle() : base(true)
+        public SafeFileHandle() : base(true)
         {
             _isAsync = null;
         }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFindHandle.Windows.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeFindHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeFindHandle() : base(true) { }
+        public SafeFindHandle() : base(true) { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.cs
@@ -17,7 +17,7 @@ namespace Internal.Win32.SafeHandles
 #endif
     sealed partial class SafeRegistryHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeRegistryHandle() : base(true) { }
+        public SafeRegistryHandle() : base(true) { }
 
         public SafeRegistryHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
         {

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeWaitHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeWaitHandle.cs
@@ -7,8 +7,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeWaitHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        // Called by P/Invoke marshaler
-        private SafeWaitHandle() : base(true)
+        public SafeWaitHandle() : base(true)
         {
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1002,6 +1002,10 @@ namespace System.Runtime.InteropServices
         /// </summary>
         /// <param name="safeHandle"><see cref="SafeHandle"/> instance to update</param>
         /// <param name="handle">Pre-existing handle</param>
-        public static void InitHandle(SafeHandle safeHandle, IntPtr handle) => safeHandle.SetHandle(handle);
+        public static void InitHandle(SafeHandle safeHandle, IntPtr handle) 
+        {
+            // To help maximize performance of P/Invokes, don't check if safeHandle is null.
+            safeHandle.SetHandle(handle);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1002,7 +1002,7 @@ namespace System.Runtime.InteropServices
         /// </summary>
         /// <param name="safeHandle"><see cref="SafeHandle"/> instance to update</param>
         /// <param name="handle">Pre-existing handle</param>
-        public static void InitHandle(SafeHandle safeHandle, IntPtr handle) 
+        public static void InitHandle(SafeHandle safeHandle, IntPtr handle)
         {
             // To help maximize performance of P/Invokes, don't check if safeHandle is null.
             safeHandle.SetHandle(handle);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -996,5 +996,12 @@ namespace System.Runtime.InteropServices
 
         [SupportedOSPlatform("windows")]
         public static Type? GetTypeFromCLSID(Guid clsid) => GetTypeFromCLSID(clsid, null, throwOnError: false);
+
+        /// <summary>
+        /// Initializes the underlying handle of a newly created <see cref="SafeHandle" /> to the provided value.
+        /// </summary>
+        /// <param name="safeHandle"><see cref="SafeHandle"/> instance to update</param>
+        /// <param name="handle">Pre-existing handle</param>
+        public static void InitHandle(SafeHandle safeHandle, IntPtr handle) => safeHandle.SetHandle(handle);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
@@ -74,7 +74,7 @@ namespace System.Runtime.InteropServices
         }
 #endif
 
-        protected void SetHandle(IntPtr handle) => this.handle = handle;
+        protected internal void SetHandle(IntPtr handle) => this.handle = handle;
 
         public IntPtr DangerousGetHandle() => handle;
 

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -601,6 +601,7 @@ namespace System.Runtime.InteropServices
         public static string GetTypeInfoName(System.Runtime.InteropServices.ComTypes.ITypeInfo typeInfo) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static object GetUniqueObjectForIUnknown(System.IntPtr unknown) { throw null; }
+        public static void InitHandle(SafeHandle safeHandle, IntPtr handle) { }
         public static bool IsComObject(object o) { throw null; }
         public static bool IsTypeVisibleFromCom(System.Type t) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="System\Runtime\InteropServices\Marshal\GetTypeInfoNameTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetUniqueObjectForIUnknownTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\GetUniqueObjectForIUnknownTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\InitHandleTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\IsComObjectTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\IsComObjectTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\Marshal\ReleaseTests.cs" />

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/InitHandleTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/InitHandleTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Runtime.InteropServices.Tests
+{
+    public class InitHandleTests
+    {
+        [Fact]
+        public void InitHandle_SetsHandle()
+        {
+            var safeHandle = new TestSafeHandle();
+            nint underlyingHandle = 42;
+
+            Marshal.InitHandle(safeHandle, underlyingHandle);
+
+            Assert.Equal((IntPtr)underlyingHandle, safeHandle.DangerousGetHandle());
+        }
+
+        class TestSafeHandle : SafeHandle
+        {
+            public TestSafeHandle() : base(IntPtr.Zero, true) { }
+
+            public override bool IsInvalid => handle == IntPtr.Zero;
+
+            protected override bool ReleaseHandle() => true;
+        }
+    }
+}

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Win32.SafeHandles
     }
     public sealed partial class SafeFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
+        public SafeFileHandle() : base (default(bool)) { }
         public SafeFileHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base (default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
         protected override bool ReleaseHandle() { throw null; }
@@ -34,6 +35,7 @@ namespace Microsoft.Win32.SafeHandles
     }
     public sealed partial class SafeWaitHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
+        public SafeWaitHandle() : base (default(bool)) { }
         public SafeWaitHandle(System.IntPtr existingHandle, bool ownsHandle) : base (default(bool)) { }
         protected override bool ReleaseHandle() { throw null; }
     }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
@@ -64,6 +64,7 @@ namespace System.Security.Cryptography
     }
     public sealed partial class SafeEvpPKeyHandle : System.Runtime.InteropServices.SafeHandle
     {
+        public SafeEvpPKeyHandle() : base (default(System.IntPtr), default(bool)) { }
         public SafeEvpPKeyHandle(System.IntPtr handle, bool ownsHandle) : base (default(System.IntPtr), default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateHandle() { throw null; }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Microsoft/Win32/SafeHandles/SafeCryptMsgHandle.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Microsoft/Win32/SafeHandles/SafeCryptMsgHandle.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeCryptMsgHandle : SafeHandle
     {
-        private SafeCryptMsgHandle() :
+        public SafeCryptMsgHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Microsoft/Win32/SafeHandles/SafeHeapAllocHandle.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Microsoft/Win32/SafeHandles/SafeHeapAllocHandle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeHeapAllocHandle : SafeBuffer, IDisposable
     {
-        private SafeHeapAllocHandle() : base(true) { }
+        public SafeHeapAllocHandle() : base(true) { }
 
         internal static SafeHeapAllocHandle Alloc(int size)
         {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeX509ChainHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal SafeX509ChainHandle() : base (default(bool)) { }
+        public SafeX509ChainHandle() : base (default(bool)) { }
         protected override void Dispose(bool disposing) { }
         protected override bool ReleaseHandle() { throw null; }
     }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafeX509ChainHandle.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Microsoft/Win32/SafeHandles/SafeX509ChainHandle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed class SafeX509ChainHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private SafeX509ChainHandle()
+        public SafeX509ChainHandle()
             : base(true)
         {
         }

--- a/src/libraries/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
+++ b/src/libraries/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeAccessTokenHandle : System.Runtime.InteropServices.SafeHandle
     {
+        public SafeAccessTokenHandle() : base (default(System.IntPtr), default(bool)) { }
         public SafeAccessTokenHandle(System.IntPtr handle) : base (default(System.IntPtr), default(bool)) { }
         public static Microsoft.Win32.SafeHandles.SafeAccessTokenHandle InvalidHandle { get { throw null; } }
         public override bool IsInvalid { get { throw null; } }

--- a/src/libraries/System.Security.Principal.Windows/src/Microsoft/Win32/SafeHandles/SafeAccessTokenHandle.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/Microsoft/Win32/SafeHandles/SafeAccessTokenHandle.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed class SafeAccessTokenHandle : SafeHandle
     {
-        private SafeAccessTokenHandle() : base(IntPtr.Zero, true) { }
+        public SafeAccessTokenHandle() : base(IntPtr.Zero, true) { }
 
         // 0 is an Invalid Handle
         public SafeAccessTokenHandle(IntPtr handle) : base(handle, true) { }

--- a/src/libraries/System.ServiceProcess.ServiceController/src/Microsoft/Win32/SafeHandles/SafeServiceHandle.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/Microsoft/Win32/SafeHandles/SafeServiceHandle.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
     /// <summary>
     /// Used to wrap handles gotten from OpenSCManager or OpenService
     /// </summary>
-    internal class SafeServiceHandle : SafeHandle
+    internal sealed class SafeServiceHandle : SafeHandle
     {
         internal SafeServiceHandle(IntPtr handle) : base(IntPtr.Zero, true)
         {

--- a/src/libraries/System.Speech/src/Internal/HGlobalSafeHandle.cs
+++ b/src/libraries/System.Speech/src/Internal/HGlobalSafeHandle.cs
@@ -12,7 +12,7 @@ namespace System.Speech.Internal
     {
         #region Constructors
 
-        internal HGlobalSafeHandle() : base(IntPtr.Zero, true)
+        public HGlobalSafeHandle() : base(IntPtr.Zero, true)
         {
         }
 

--- a/src/libraries/System.Text.Encoding.CodePages/src/Microsoft/Win32/SafeHandles/SafeAllocHHandle.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/Microsoft/Win32/SafeHandles/SafeAllocHHandle.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeAllocHHandle : SafeBuffer
     {
-        private SafeAllocHHandle() : base(true) { }
+        public SafeAllocHHandle() : base(true) { }
 
         internal SafeAllocHHandle(IntPtr handle) : base(true)
         {


### PR DESCRIPTION
Implements the API changes described in https://github.com/dotnet/runtime/issues/46830.

Make all non-abstract SafeHandle types have public parameterless constructors. Add the InitHandle API that initializes the underlying handle of the SafeHandle object.

Contributes to #46830

See https://github.com/dotnet/runtime/issues/45633 for linker context.