### PR TITLE
[Configuration] Minor optimizations for ConfigurationProvider

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationKeyComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -41,8 +42,8 @@ namespace Microsoft.Extensions.Configuration
                 int value1 = 0;
                 int value2 = 0;
 
-                bool xIsInt = x != null && int.TryParse(x, out value1);
-                bool yIsInt = y != null && int.TryParse(y, out value2);
+                bool xIsInt = x != null && int.TryParse(x, NumberStyles.None, CultureInfo.InvariantCulture, out value1);
+                bool yIsInt = y != null && int.TryParse(y, NumberStyles.None, CultureInfo.InvariantCulture, out value2);
 
                 int result;
 

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Configuration
 
         private static string Segment(string key, int prefixLength)
         {
-            int indexOf = key.IndexOf(ConfigurationPath.KeyDelimiter, prefixLength, StringComparison.OrdinalIgnoreCase);
+            int indexOf = key.IndexOf(ConfigurationPath.KeyDelimiter, prefixLength, StringComparison.Ordinal);
             return indexOf < 0 ? key.Substring(prefixLength) : key.Substring(prefixLength, indexOf - prefixLength);
         }
 


### PR DESCRIPTION
* In `ConfigurationProvider.Segment` we don't need a case-insensitive comparison because we're looking for a `:`.
* In `ConfigurationKeyComparer` it is safe to use invariant culture to avoid current locale lookup.

Note: Using `NumberStyles.None` will alter the comparison output in
cases where a negative index is supplied (since we are no longer parsing
negative ints as numbers) and keys with whitespace around the number
(for the same reason).