### PR TITLE
Fix profiler sync issue

### DIFF
--- a/src/tests/profiler/native/profiler.h
+++ b/src/tests/profiler/native/profiler.h
@@ -68,14 +68,14 @@ public:
 // ELT hooks will continue to be called. We would AV if we tried to call
 // in to freed resources.
 #define SHUTDOWNGUARD()                         \
-    ShutdownGuard();                            \
+    ShutdownGuard shutdownGuard;                \
     if (ShutdownGuard::HasShutdownStarted())    \
     {                                           \
         return S_OK;                            \
     }
 
 #define SHUTDOWNGUARD_RETVOID()                 \
-    ShutdownGuard();                            \
+    ShutdownGuard shutdownGuard;                \
     if (ShutdownGuard::HasShutdownStarted())    \
     {                                           \
         return;                                 \


### PR DESCRIPTION
Because there was not a named variable some compilers were optimizing out the RAII guard.