### PR TITLE
Include crossgen2 tool when crossgening SPC.

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -196,7 +196,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+clr.nativecorelib+'))">
-    <ProjectToBuild Include="$(CoreClrProjectRoot)crossgen-corelib.proj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2.csproj;
+                             $(CoreClrProjectRoot)crossgen-corelib.proj" Category="clr" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+clr.packages+'))">


### PR DESCRIPTION
Jit developers were used to build with `clr.runtime+Clr.CoreLib+Clr.NativeCoreLib` and it was self-sufficient. Now Clr.NativeCoreLib requires crossgen2 so add them to the subset so we can iterate without building other tools (like R2R dump).