### PR TITLE
Fix wasm package build being skipped

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/monocrossaot.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/monocrossaot.sfxproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_MonoCrossAOTTargetOS Condition="'$(MonoCrossAOTTargetOS)' != ''">+$(MonoCrossAOTTargetOS.ToLowerInvariant())+</_MonoCrossAOTTargetOS>
     <MonoAotTargets Condition="$(_MonoCrossAOTTargetOS.contains('+android+'))">$(MonoAotTargets);android-x64;android-arm64;android-x86;android-arm</MonoAotTargets>
-    <MonoAotTargets Condition="$(_MonoCrossAOTTargetOS.contains('+wasm+'))">$(MonoAotTargets);browser-wasm</MonoAotTargets>
+    <MonoAotTargets Condition="$(_MonoCrossAOTTargetOS.contains('+browser+'))">$(MonoAotTargets);browser-wasm</MonoAotTargets>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
"Browser" is the OS name, "WASM" is the architecture name, and we switch on OS not arch