### PR TITLE
Dogfood .NET6 SDK & use native SDK for Apple Silicon native builds (WIP)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,8 +38,8 @@
   <!-- The TFMs to build and test against. -->
   <PropertyGroup>
     <NetCoreAppCurrentVersion>$(MajorVersion).$(MinorVersion)</NetCoreAppCurrentVersion>
-    <AspNetCoreAppCurrentVersion>5.0</AspNetCoreAppCurrentVersion>
-    <NetCoreAppToolCurrentVersion>5.0</NetCoreAppToolCurrentVersion>
+    <AspNetCoreAppCurrentVersion>6.0</AspNetCoreAppCurrentVersion>
+    <NetCoreAppToolCurrentVersion>6.0</NetCoreAppToolCurrentVersion>
     <NetCoreAppCurrentIdentifier>.NETCoreApp</NetCoreAppCurrentIdentifier>
     <NetCoreAppCurrentTargetFrameworkMoniker>$(NetCoreAppCurrentIdentifier),Version=v$(NetCoreAppCurrentVersion)</NetCoreAppCurrentTargetFrameworkMoniker>
     <NetCoreAppCurrent>net$(NetCoreAppCurrentVersion)</NetCoreAppCurrent>

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -57,7 +57,7 @@ if [[ "$cpuname" == "unknown" ]]; then
 fi
 
 case $cpuname in
-  aarch64)
+  aarch64|arm64)
     buildarch=arm64
     ;;
   amd64|x86_64)

--- a/eng/targetframeworksuffix.props
+++ b/eng/targetframeworksuffix.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup Condition="'$(TargetFrameworkSuffix)' != '' and '$(TargetFrameworkSuffix)' != 'windows'">
     <TargetPlatformIdentifier>$(TargetFrameworkSuffix)</TargetPlatformIdentifier>
-    <TargetPlatformVersion>0.0</TargetPlatformVersion>
+    <TargetPlatformVersion>1.0</TargetPlatformVersion>
     <TargetPlatformMoniker>$(TargetFrameworkSuffix),Version=$(TargetPlatformVersion)</TargetPlatformMoniker>
   </PropertyGroup>
   

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.100-preview.1.21103.13",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100"
+    "dotnet": "6.0.100-preview.1.21103.13"
   },
   "native-tools": {
     "cmake": "3.16.4",


### PR DESCRIPTION
This doesn't work yet....  Looking for some help...

I see lots of errors like this
```
/Users/stmaclea/git/runtime/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj : 
  error NU1012: 
  Platform version is not present for one or more target frameworks, even though they have specified a platform: net6.0-unix, net6.0-osx, net6.0-ios, net6.0-tvos [/Users/stmaclea/git/runtime/Build.proj]
  Failed to restore /Users/stmaclea/git/runtime/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj (in 20 ms).
```

I am not sure about the `osx-x64` error, but it might also be a SDK issue.

/cc @vitek-karas @ViktorHofer @janvorli @mangod9 @jkoritzinsky 

Experiment related to #46960