### PR TITLE
Use CorInfoCallConvExtension throughout runtime interop code

### DIFF
--- a/src/coreclr/vm/clrtocomcall.cpp
+++ b/src/coreclr/vm/clrtocomcall.cpp
@@ -165,7 +165,7 @@ MethodDesc* ComPlusCall::GetILStubMethodDesc(MethodDesc* pMD, DWORD dwStubFlags)
                     &sigDesc,
                     (CorNativeLinkType)0,
                     (CorNativeLinkFlags)0,
-                    (CorPinvokeMap)0,
+                    MetaSig::GetDefaultUnmanagedCallingConvention(),
                     dwStubFlags);
 }
 

--- a/src/coreclr/vm/comtoclrcall.cpp
+++ b/src/coreclr/vm/comtoclrcall.cpp
@@ -1461,7 +1461,7 @@ MethodDesc* ComCall::GetILStubMethodDesc(MethodDesc *pCallMD, DWORD dwStubFlags)
     return NDirect::CreateCLRToNativeILStub(&sigDesc,
                                             (CorNativeLinkType)0,
                                             (CorNativeLinkFlags)0,
-                                            (CorPinvokeMap)0,
+                                            MetaSig::GetDefaultUnmanagedCallingConvention(),
                                             dwStubFlags);
 }
 

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -1626,24 +1626,7 @@ void NDirectStubLinker::SetCallingConvention(CorInfoCallConvExtension unmngCallC
     else
 #endif // !TARGET_X86
     {
-        CorCallingConvention uNativeCallingConv = (CorCallingConvention)0;
-        switch (unmngCallConv)
-        {
-            case CorInfoCallConvExtension::C:
-                uNativeCallingConv = IMAGE_CEE_CS_CALLCONV_C;
-                break;
-            case CorInfoCallConvExtension::Stdcall:
-                uNativeCallingConv = IMAGE_CEE_CS_CALLCONV_STDCALL;
-                break;
-            case CorInfoCallConvExtension::Thiscall:
-                uNativeCallingConv = IMAGE_CEE_CS_CALLCONV_THISCALL;
-                break;
-            default:
-                _ASSERTE(!"Invalid calling convention.");
-                uNativeCallingConv = IMAGE_CEE_CS_CALLCONV_STDCALL;
-                break;
-        }
-        SetStubTargetCallingConv(uNativeCallingConv);
+        SetStubTargetCallingConv(unmngCallConv);
     }
 }
 
@@ -2982,10 +2965,7 @@ void PInvokeStaticSigInfo::InitCallConv(CorInfoCallConvExtension callConv, BOOL 
     }
     else if (hr == S_FALSE)
     {
-        // Do the same WinAPI to StdCall or CDecl for the signature calling convention as well. We need
-        // to do this before we check to make sure the PInvoke map calling convention and the
-        // signature calling convention match for compatibility reasons.
-        sigCallConv = GetDefaultCallConv(bIsVarArg);
+        sigCallConv = CorInfoCallConvExtension::Managed;
     }
 
     if (callConv != CorInfoCallConvExtension::Managed && sigCallConv != CorInfoCallConvExtension::Managed && callConv != sigCallConv)

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -2496,7 +2496,7 @@ protected:
 namespace
 {
     // Use CorInfoCallConvExtension::Managed as a sentinel represent a user-provided WinApi calling convention.
-    CorInfoCallConvExtension CallConvWinApiSentinel = CorInfoCallConvExtension::Managed;
+    constexpr CorInfoCallConvExtension CallConvWinApiSentinel = CorInfoCallConvExtension::Managed;
 
     // Returns the unmanaged calling convention for callConv or CallConvWinApiSentinel
     // if the calling convention is not provided or WinApi.

--- a/src/coreclr/vm/dllimport.h
+++ b/src/coreclr/vm/dllimport.h
@@ -90,11 +90,11 @@ public:
     static void PopulateNDirectMethodDesc(NDirectMethodDesc* pNMD, PInvokeStaticSigInfo* pSigInfo);
 
     static MethodDesc* CreateCLRToNativeILStub(
-                    StubSigDesc*       pSigDesc,
-                    CorNativeLinkType  nlType,
-                    CorNativeLinkFlags nlFlags,
-                    CorPinvokeMap      unmgdCallConv,
-                    DWORD              dwStubFlags); // NDirectStubFlags
+                    StubSigDesc*             pSigDesc,
+                    CorNativeLinkType        nlType,
+                    CorNativeLinkFlags       nlFlags,
+                    CorInfoCallConvExtension unmgdCallConv,
+                    DWORD                    dwStubFlags); // NDirectStubFlags
 
 #ifdef FEATURE_COMINTEROP
     static MethodDesc* CreateFieldAccessILStub(
@@ -331,7 +331,7 @@ public:
     void ReportErrors();
 
 private:
-    void InitCallConv(CorPinvokeMap callConv, BOOL bIsVarArg);
+    void InitCallConv(CorInfoCallConvExtension callConv, BOOL bIsVarArg);
     void DllImportInit(MethodDesc* pMD, LPCUTF8 *pLibName, LPCUTF8 *pEntryPointName);
     void PreInit(Module* pModule, MethodTable *pClass);
     void PreInit(MethodDesc* pMD);
@@ -383,13 +383,13 @@ public:
         else
             m_wFlags &= ~PINVOKE_STATIC_SIGINFO_IS_DELEGATE_INTEROP;
     }
-    CorPinvokeMap GetCallConv() { LIMITED_METHOD_CONTRACT; return m_callConv; }
+    CorInfoCallConvExtension GetCallConv() { LIMITED_METHOD_CONTRACT; return m_callConv; }
     Signature GetSignature() { LIMITED_METHOD_CONTRACT; return m_sig; }
 
 private:
     Module* m_pModule;
     Signature m_sig;
-    CorPinvokeMap m_callConv;
+    CorInfoCallConvExtension m_callConv;
     WORD m_error;
 
     enum
@@ -447,7 +447,7 @@ public:
                 MethodDesc* pTargetMD,
                 int  iLCIDParamIdx);
 
-    void    SetCallingConvention(CorPinvokeMap unmngCallConv, BOOL fIsVarArg);
+    void    SetCallingConvention(CorInfoCallConvExtension unmngCallConv, BOOL fIsVarArg);
 
     void    Begin(DWORD dwStubFlags);
     void    End(DWORD dwStubFlags);
@@ -569,18 +569,18 @@ class NDirectStubParameters
 {
 public:
 
-    NDirectStubParameters(Signature          sig,
-                          SigTypeContext*    pTypeContext,
-                          Module*            pModule,
-                          Module*            pLoaderModule,
-                          CorNativeLinkType  nlType,
-                          CorNativeLinkFlags nlFlags,
-                          CorPinvokeMap      unmgdCallConv,
-                          DWORD              dwStubFlags,  // NDirectStubFlags
-                          int                nParamTokens,
-                          mdParamDef*        pParamTokenArray,
-                          int                iLCIDArg,
-                          MethodTable*       pMT
+    NDirectStubParameters(Signature                sig,
+                          SigTypeContext*          pTypeContext,
+                          Module*                  pModule,
+                          Module*                  pLoaderModule,
+                          CorNativeLinkType        nlType,
+                          CorNativeLinkFlags       nlFlags,
+                          CorInfoCallConvExtension unmgdCallConv,
+                          DWORD                    dwStubFlags,  // NDirectStubFlags
+                          int                      nParamTokens,
+                          mdParamDef*              pParamTokenArray,
+                          int                      iLCIDArg,
+                          MethodTable*             pMT
                           ) :
         m_sig(sig),
         m_pTypeContext(pTypeContext),
@@ -598,18 +598,18 @@ public:
         LIMITED_METHOD_CONTRACT;
     }
 
-    Signature           m_sig;
-    SigTypeContext*     m_pTypeContext;
-    Module*             m_pModule;
-    Module*             m_pLoaderModule;
-    mdParamDef*         m_pParamTokenArray;
-    CorPinvokeMap       m_unmgdCallConv;
-    CorNativeLinkType   m_nlType;
-    CorNativeLinkFlags  m_nlFlags;
-    DWORD               m_dwStubFlags;
-    int                 m_iLCIDArg;
-    int                 m_nParamTokens;
-    MethodTable*        m_pMT;
+    Signature                m_sig;
+    SigTypeContext*          m_pTypeContext;
+    Module*                  m_pModule;
+    Module*                  m_pLoaderModule;
+    mdParamDef*              m_pParamTokenArray;
+    CorInfoCallConvExtension m_unmgdCallConv;
+    CorNativeLinkType        m_nlType;
+    CorNativeLinkFlags       m_nlFlags;
+    DWORD                    m_dwStubFlags;
+    int                      m_iLCIDArg;
+    int                      m_nParamTokens;
+    MethodTable*             m_pMT;
 };
 
 PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD);

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -607,7 +607,6 @@ bool TryGetCallingConventionFromUnmanagedCallersOnly(MethodDesc* pMD, CorInfoCal
     if (nativeCallableInternalData)
     {
         namedArgs[0].InitI4FieldEnum("CallingConvention", "System.Runtime.InteropServices.CallingConvention", (ULONG)(CorPinvokeMap)0);
-        namedArgs[0].InitI4FieldEnum("CallingConvention", "System.Runtime.InteropServices.CallingConvention", (ULONG)(CorPinvokeMap)0);
     }
     else
     {
@@ -643,7 +642,7 @@ bool TryGetCallingConventionFromUnmanagedCallersOnly(MethodDesc* pMD, CorInfoCal
     else
     {
         // Set WinAPI as the default
-        callConvLocal = (CorInfoCallConvExtension)MetaSig::GetDefaultUnmanagedCallingConvention();
+        callConvLocal = MetaSig::GetDefaultUnmanagedCallingConvention();
 
         CaValue* arrayOfTypes = &namedArgs[0].val;
         for (ULONG i = 0; i < arrayOfTypes->arr.length; i++)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9785,7 +9785,7 @@ namespace
             return CorInfoCallConvExtension::Fastcall;
         case IMAGE_CEE_CS_CALLCONV_UNMANAGED:
         {
-            CorUnmanagedCallingConvention callConvMaybe;
+            CorInfoCallConvExtension callConvMaybe;
             UINT errorResID;
             HRESULT hr = MetaSig::TryGetUnmanagedCallingConventionFromModOpt(mod, pSig, cbSig, &callConvMaybe, pSuppressGCTransition, &errorResID);
 
@@ -9794,11 +9794,11 @@ namespace
 
             if (hr == S_OK)
             {
-                return (CorInfoCallConvExtension)callConvMaybe;
+                return callConvMaybe;
             }
             else
             {
-                return (CorInfoCallConvExtension)MetaSig::GetDefaultUnmanagedCallingConvention();
+                return MetaSig::GetDefaultUnmanagedCallingConvention();
             }
         }
         case IMAGE_CEE_CS_CALLCONV_NATIVEVARARG:
@@ -9833,25 +9833,7 @@ namespace
                 }
 
                 PInvokeStaticSigInfo sigInfo(pMD, PInvokeStaticSigInfo::NO_THROW_ON_ERROR);
-                switch (sigInfo.GetCallConv())
-                {
-                case pmCallConvCdecl:
-                    return CorInfoCallConvExtension::C;
-                    break;
-                case pmCallConvStdcall:
-                    return CorInfoCallConvExtension::Stdcall;
-                    break;
-                case pmCallConvThiscall:
-                    return CorInfoCallConvExtension::Thiscall;
-                    break;
-                case pmCallConvFastcall:
-                    return CorInfoCallConvExtension::Fastcall;
-                    break;
-                default:
-                    _ASSERTE_MSG(false, "bad callconv");
-                    return CorInfoCallConvExtension::Managed;
-                    break;
-                }
+                return sigInfo.GetCallConv();
             }
             else
             {
@@ -9868,7 +9850,7 @@ namespace
                     }
                     return unmanagedCallConv;
                 }
-                return (CorInfoCallConvExtension)MetaSig::GetDefaultUnmanagedCallingConvention();
+                return MetaSig::GetDefaultUnmanagedCallingConvention();
 #endif // CROSSGEN_COMPILE
             }
         }

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -3238,13 +3238,13 @@ private:
 #endif
 public:
 
-    void SetStackArgumentSize(WORD cbDstBuffer, CorPinvokeMap unmgdCallConv)
+    void SetStackArgumentSize(WORD cbDstBuffer, CorInfoCallConvExtension unmgdCallConv)
     {
         LIMITED_METHOD_CONTRACT;
 
 #if defined(TARGET_X86)
         // thiscall passes the this pointer in ECX
-        if (unmgdCallConv == pmCallConvThiscall)
+        if (unmgdCallConv == CorInfoCallConvExtension::Thiscall)
         {
             _ASSERTE(cbDstBuffer >= sizeof(SLOT));
             cbDstBuffer -= sizeof(SLOT);

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -5321,7 +5321,7 @@ MetaSig::TryGetUnmanagedCallingConventionFromModOpt(
     _In_ CORINFO_MODULE_HANDLE pModule,
     _In_ PCCOR_SIGNATURE pSig,
     _In_ ULONG cSig,
-    _Out_ CorUnmanagedCallingConvention *callConvOut,
+    _Out_ CorInfoCallConvExtension *callConvOut,
     _Out_ bool* suppressGCTransitionOut,
     _Out_ UINT *errorResID)
 {
@@ -5350,7 +5350,7 @@ MetaSig::TryGetUnmanagedCallingConventionFromModOpt(
     PCCOR_SIGNATURE pWalk = sigPtr.GetPtr();
     _ASSERTE(pWalk <= pSig + cSig);
 
-    *callConvOut = (CorUnmanagedCallingConvention)0;
+    *callConvOut = CorInfoCallConvExtension::Managed;
     bool found = false;
     while ((pWalk < (pSig + cSig)) && ((*pWalk == ELEMENT_TYPE_CMOD_OPT) || (*pWalk == ELEMENT_TYPE_CMOD_REQD)))
     {
@@ -5387,12 +5387,12 @@ MetaSig::TryGetUnmanagedCallingConventionFromModOpt(
 
         const struct {
             LPCSTR name;
-            CorUnmanagedCallingConvention value;
+            CorInfoCallConvExtension value;
         } knownCallConvs[] = {
-            { CMOD_CALLCONV_NAME_CDECL,     IMAGE_CEE_UNMANAGED_CALLCONV_C },
-            { CMOD_CALLCONV_NAME_STDCALL,   IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL },
-            { CMOD_CALLCONV_NAME_THISCALL,  IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL },
-            { CMOD_CALLCONV_NAME_FASTCALL,  IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL } };
+            { CMOD_CALLCONV_NAME_CDECL,     CorInfoCallConvExtension::C },
+            { CMOD_CALLCONV_NAME_STDCALL,   CorInfoCallConvExtension::Stdcall },
+            { CMOD_CALLCONV_NAME_THISCALL,  CorInfoCallConvExtension::Thiscall },
+            { CMOD_CALLCONV_NAME_FASTCALL,  CorInfoCallConvExtension::Fastcall } };
 
         for (const auto &callConv : knownCallConvs)
         {

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -794,16 +794,16 @@ class MetaSig
             _In_ CORINFO_MODULE_HANDLE pModule,
             _In_ PCCOR_SIGNATURE pSig,
             _In_ ULONG cSig,
-            _Out_ CorUnmanagedCallingConvention *callConvOut,
+            _Out_ CorInfoCallConvExtension *callConvOut,
             _Out_ bool* suppressGCTransitionOut,
             _Out_ UINT *errorResID);
 
-        static CorUnmanagedCallingConvention GetDefaultUnmanagedCallingConvention()
+        static CorInfoCallConvExtension GetDefaultUnmanagedCallingConvention()
         {
 #ifdef TARGET_UNIX
-            return IMAGE_CEE_UNMANAGED_CALLCONV_C;
+            return CorInfoCallConvExtension::C;
 #else // TARGET_UNIX
-            return IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL;
+            return CorInfoCallConvExtension::Stdcall;
 #endif // !TARGET_UNIX
         }
 

--- a/src/coreclr/vm/stubgen.cpp
+++ b/src/coreclr/vm/stubgen.cpp
@@ -2763,6 +2763,69 @@ void ILStubLinker::SetStubTargetCallingConv(CorCallingConvention uNativeCallingC
     }
 }
 
+void ILStubLinker::SetStubTargetCallingConv(CorInfoCallConvExtension callConv)
+{
+    LIMITED_METHOD_CONTRACT;
+    CorCallingConvention originalCallingConvention = m_nativeFnSigBuilder.GetCallingConv();
+    if (originalCallingConvention != IMAGE_CEE_CS_CALLCONV_UNMANAGED)
+    {
+        // For performance reasons, we try to encode the calling convention using
+        // the flags-based method if possible before using modopts.
+        switch (callConv)
+        {
+            case CorInfoCallConvExtension::C:
+                m_nativeFnSigBuilder.SetCallingConv(IMAGE_CEE_CS_CALLCONV_C);
+                break;
+            case CorInfoCallConvExtension::Stdcall:
+                m_nativeFnSigBuilder.SetCallingConv(IMAGE_CEE_CS_CALLCONV_STDCALL);
+                break;
+            case CorInfoCallConvExtension::Thiscall:
+                m_nativeFnSigBuilder.SetCallingConv(IMAGE_CEE_CS_CALLCONV_THISCALL);
+                break;
+            case CorInfoCallConvExtension::Fastcall:
+                m_nativeFnSigBuilder.SetCallingConv(IMAGE_CEE_CS_CALLCONV_FASTCALL);
+                break;
+            default:
+                m_nativeFnSigBuilder.SetCallingConv(IMAGE_CEE_CS_CALLCONV_UNMANAGED);
+                break;
+        }
+    }
+
+    if (m_nativeFnSigBuilder.GetCallingConv() == IMAGE_CEE_CS_CALLCONV_UNMANAGED)
+    {
+        // In this case we're already using the "Unmanaged" calling convention, so encode the specific callconv
+        // with the requisite modopts for the calling convention.
+        switch (callConv)
+        {
+            case CorInfoCallConvExtension::C:
+                m_nativeFnSigBuilder.AddCallConvModOpt(GetToken(CoreLibBinder::GetClass(CLASS__CALLCONV_CDECL)));
+                break;
+            case CorInfoCallConvExtension::Stdcall:
+                m_nativeFnSigBuilder.AddCallConvModOpt(GetToken(CoreLibBinder::GetClass(CLASS__CALLCONV_STDCALL)));
+                break;
+            case CorInfoCallConvExtension::Thiscall:
+                m_nativeFnSigBuilder.AddCallConvModOpt(GetToken(CoreLibBinder::GetClass(CLASS__CALLCONV_THISCALL)));
+                break;
+            case CorInfoCallConvExtension::Fastcall:
+                m_nativeFnSigBuilder.AddCallConvModOpt(GetToken(CoreLibBinder::GetClass(CLASS__CALLCONV_FASTCALL)));
+                break;
+            default:
+                _ASSERTE("Unknown calling convention. Unable to encode it in the native function pointer signature.");
+                break;
+        }
+    }
+
+    if (!m_fIsReverseStub)
+    {
+        if (originalCallingConvention & CORINFO_CALLCONV_HASTHIS)
+        {
+            // Our calling convention had an implied-this beforehand and now it doesn't.
+            // Account for this in the target stack delta.
+            m_iTargetStackDelta++;
+        }
+    }
+}
+
 static size_t GetManagedTypeForMDArray(LocalDesc* pLoc, Module* pModule, PCCOR_SIGNATURE psigManagedArg, SigTypeContext *pTypeContext)
 {
     CONTRACTL

--- a/src/coreclr/vm/stubgen.cpp
+++ b/src/coreclr/vm/stubgen.cpp
@@ -2766,7 +2766,7 @@ void ILStubLinker::SetStubTargetCallingConv(CorCallingConvention uNativeCallingC
 void ILStubLinker::SetStubTargetCallingConv(CorInfoCallConvExtension callConv)
 {
     LIMITED_METHOD_CONTRACT;
-    _ASSERTE(callconv != CorInfoCallConvExtension::Managed);
+    _ASSERTE(callConv != CorInfoCallConvExtension::Managed);
 
     const CorCallingConvention originalCallingConvention = m_nativeFnSigBuilder.GetCallingConv();
     if (originalCallingConvention != IMAGE_CEE_CS_CALLCONV_UNMANAGED)

--- a/src/coreclr/vm/stubgen.cpp
+++ b/src/coreclr/vm/stubgen.cpp
@@ -2766,7 +2766,9 @@ void ILStubLinker::SetStubTargetCallingConv(CorCallingConvention uNativeCallingC
 void ILStubLinker::SetStubTargetCallingConv(CorInfoCallConvExtension callConv)
 {
     LIMITED_METHOD_CONTRACT;
-    CorCallingConvention originalCallingConvention = m_nativeFnSigBuilder.GetCallingConv();
+    _ASSERTE(callconv != CorInfoCallConvExtension::Managed);
+
+    const CorCallingConvention originalCallingConvention = m_nativeFnSigBuilder.GetCallingConv();
     if (originalCallingConvention != IMAGE_CEE_CS_CALLCONV_UNMANAGED)
     {
         // For performance reasons, we try to encode the calling convention using
@@ -2791,6 +2793,8 @@ void ILStubLinker::SetStubTargetCallingConv(CorInfoCallConvExtension callConv)
         }
     }
 
+    // We may have updated the calling convention above, so reread the calling convention
+    // from the signature builder instead of using originalCallingConvention.
     if (m_nativeFnSigBuilder.GetCallingConv() == IMAGE_CEE_CS_CALLCONV_UNMANAGED)
     {
         // In this case we're already using the "Unmanaged" calling convention, so encode the specific callconv

--- a/src/coreclr/vm/stubgen.h
+++ b/src/coreclr/vm/stubgen.h
@@ -604,6 +604,7 @@ protected:
     void SetStubTargetReturnType(CorElementType typ);
     void SetStubTargetReturnType(LocalDesc* pLoc);
     void SetStubTargetCallingConv(CorCallingConvention uNativeCallingConv);
+    void SetStubTargetCallingConv(CorInfoCallConvExtension callConv);
 
     bool ReturnOpcodePopsStack()
     {


### PR DESCRIPTION
As preparation for implementing #46775, this PR changes the interop code in CoreCLR to use CorInfoCallConvExtension as the representation for calling conventions internally instead of CorPinvokeMap or CorUnmanagedCallingConvention.

This change enables us to only have to add support for propagating new calling conventions significantly more easily since we won't need to determine how to represent new calling conventions using the old enums.