### PR TITLE
[browser][tests][outerloop] Standup OuterLoop tests on CI cleanup

### DIFF
--- a/src/libraries/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/libraries/System.Threading/tests/ThreadLocalTests.cs
@@ -367,9 +367,8 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [OuterLoop]
-        [PlatformSpecific(~TestPlatforms.Browser)] // Operation is not supported on this platform.
         public static void ValuesGetterDoesNotThrowUnexpectedExceptionWhenDisposed()
         {
             var startTest = new ManualResetEvent(false);


### PR DESCRIPTION
Clean up test in System.Threading to use PlatformDetection instead of PlatformSpecific.

- Add `[ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]`
- Addresses review comment from https://github.com/dotnet/runtime/pull/45949#discussion_r560969825