### PR TITLE
Fix building symbols archive

### DIFF
--- a/src/installer/pkg/sfx/bundle/Microsoft.NETCore.App.Bundle.bundleproj
+++ b/src/installer/pkg/sfx/bundle/Microsoft.NETCore.App.Bundle.bundleproj
@@ -36,4 +36,12 @@
              Properties="OutputPath=$(OutputPath)" />
   </Target>
 
+  <Target Name="PublishSymbolsToDisk">
+    <Error Condition="'$(SymbolsOutputPath)' == ''" Text="Publishing to disk requires the SymbolsOutputPath to be set to the root of the path to write to." />
+
+    <MSBuild Projects="@(BundleComponentReference)"
+             Targets="PublishSymbolsToDisk"
+             Properties="SymbolsOutputPath=$(SymbolsOutputPath)" />
+  </Target>
+
 </Project>

--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -49,6 +49,18 @@
           DestinationFiles="%(FilesToPublish.Destination)" />
   </Target>
 
+  <Target Name="PublishSymbolsToDisk">
+    <Error Condition="'$(SymbolsOutputPath)' == ''" Text="Publishing to disk requires the SymbolsOutputPath to be set to the root of the path to write to." />
+
+    <Copy SourceFiles="$(DotNetHostBinDir)\dotnet.pdb"
+          Condition="'$(TargetOS)' == 'windows'"
+          DestinationFolder="$(SymbolsOutputPath)" />
+
+    <Copy SourceFiles="$(DotNetHostBinDir)\dotnet$(SymbolsSuffix)"
+          Condition="'$(TargetOS)' != 'windows'"
+          DestinationFolder="$(SymbolsOutputPath)" />
+  </Target>
+
   <Target Name="AddLinuxPackageInformation" BeforeTargets="GetDebInstallerJsonProperties;GetRpmInstallerJsonProperties">
     <ItemGroup Condition="'$(GenerateDeb)' == 'true'">
       <LinuxPackageDependency Include="libc6;libgcc1;libstdc++6" />

--- a/src/installer/pkg/sfx/installers/dotnet-hostfxr.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-hostfxr.proj
@@ -33,6 +33,18 @@
           DestinationFolder="$(OutputPath)/host/fxr/$(Version)" />
   </Target>
 
+  <Target Name="PublishSymbolsToDisk">
+    <Error Condition="'$(SymbolsOutputPath)' == ''" Text="Publishing to disk requires the SymbolsOutputPath to be set to the root of the path to write to." />
+
+    <Copy SourceFiles="$(DotNetHostBinDir)\hostfxr.pdb"
+          Condition="'$(TargetOS)' == 'windows'"
+          DestinationFolder="$(SymbolsOutputPath)" />
+
+    <Copy SourceFiles="$(DotNetHostBinDir)\$(LibPrefix)hostfxr$(LibSuffix)$(SymbolsSuffix)"
+          Condition="'$(TargetOS)' != 'windows'"
+          DestinationFolder="$(SymbolsOutputPath)" />
+  </Target>
+
   <Target Name="AddLinuxPackageInformation" BeforeTargets="GetDebInstallerJsonProperties;GetRpmInstallerJsonProperties">
     <ItemGroup Condition="'$(GenerateDeb)' == 'true'">
       <LinuxPackageDependency Include="libc6;libgcc1;libstdc++6" />


### PR DESCRIPTION
When passing `/p:CreateSymbolsArchive=true` the build complained about missing `PublishSymbolsToDisk` targets.