### PR TITLE
Return accurate size of addressing mode dsp/dsp+cnst instr descriptor

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7448,14 +7448,14 @@ size_t emitter::emitSizeOfInsDsc(instrDesc* id)
                 }
                 else
                 {
-                    return sizeof(instrDescAmd);
+                    return sizeof(instrDescCns);
                 }
             }
             else
             {
                 if (id->idIsLargeDsp())
                 {
-                    return sizeof(instrDescDsp);
+                    return sizeof(instrDescAmd);
                 }
                 else
                 {

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7416,8 +7416,6 @@ size_t emitter::emitSizeOfInsDsc(instrDesc* id)
         case ID_OP_CNS:
         case ID_OP_DSP:
         case ID_OP_DSP_CNS:
-        case ID_OP_AMD:
-        case ID_OP_AMD_CNS:
             if (id->idIsLargeCns())
             {
                 if (id->idIsLargeDsp())
@@ -7427,6 +7425,30 @@ size_t emitter::emitSizeOfInsDsc(instrDesc* id)
                 else
                 {
                     return sizeof(instrDescCns);
+                }
+            }
+            else
+            {
+                if (id->idIsLargeDsp())
+                {
+                    return sizeof(instrDescDsp);
+                }
+                else
+                {
+                    return sizeof(instrDesc);
+                }
+            }
+        case ID_OP_AMD:
+        case ID_OP_AMD_CNS:
+            if (id->idIsLargeCns())
+            {
+                if (id->idIsLargeDsp())
+                {
+                    return sizeof(instrDescCnsAmd);
+                }
+                else
+                {
+                    return sizeof(instrDescAmd);
                 }
             }
             else


### PR DESCRIPTION
During spmi `asmdiffs` with cross compiled jit, I noticed we hit the following assert https://github.com/dotnet/runtime/blob/035821a2eda0b4d87382f1bb24c69d25390bf8f5/src/coreclr/jit/emit.cpp#L1270 

It happens because for `ID_OP_AMD` and `ID_OP_AMD_CNS` format, we create `instrDescCnsAmd` but then in `emitSizeOfInsDsc()`, when we try to calculate the size, we calculate the size of `instrDescCnsDsp` instead. They don't match for cross compilation scenario like running `superpmi asmdiffs` for cross target. E.g. While running with `clrjit_win_x86_x64.dll`, `sizeof(instrDescCnsAmd) == 40` but `sizeof(instrDescCnsDsp) == 32`.  The is because `instrDescCnsDsp` contains a field of type `target_ssize_t ` which is different for x64 vs. x86.

https://github.com/dotnet/runtime/blob/035821a2eda0b4d87382f1bb24c69d25390bf8f5/src/coreclr/jit/emit.h#L1401

The fix is to return the size of right struct for these formats.
