### PR TITLE
bandaid for #44072

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -117,9 +117,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NativeClients/Dispatch/*">
             <Issue>https://github.com/dotnet/runtime/issues/44186</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/diagnosticport/diagnosticport/*">
-            <Issue>https://github.com/dotnet/runtime/issues/44072</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->

--- a/src/tests/tracing/eventpipe/diagnosticport/diagnosticport.cs
+++ b/src/tests/tracing/eventpipe/diagnosticport/diagnosticport.cs
@@ -117,7 +117,13 @@ namespace Tracing.Tests.DiagnosticPortValidation
                         circularBufferSizeMB: 1000,
                         format: EventPipeSerializationFormat.NetTrace,
                         providers: new List<Provider> { 
-                            new Provider("Microsoft-Windows-DotNETRuntimePrivate", 0x80000000, EventLevel.Verbose)
+                            new Provider("Microsoft-Windows-DotNETRuntimePrivate", 0x80000000, EventLevel.Verbose),
+                            // workaround for https://github.com/dotnet/runtime/issues/44072 which happens because the
+                            // above provider only sends 2 events and that can cause EventPipeEventSource (from TraceEvent)
+                            // to not dispatch the events if the EventBlock is a size not divisible by 8 (the reading alignment in TraceEvent).
+                            // Adding this provider keeps data flowing over the pipe so the reader doesn't get stuck waiting for data
+                            // that won't come otherwise.
+                            new Provider("Microsoft-DotNETCore-SampleProfiler")
                         });
                     Logger.logger.Log("Starting EventPipeSession over standard connection");
                     using Stream eventStream = EventPipeClient.CollectTracing(pid, config, out var sessionId);
@@ -216,7 +222,13 @@ namespace Tracing.Tests.DiagnosticPortValidation
                         circularBufferSizeMB: 1000,
                         format: EventPipeSerializationFormat.NetTrace,
                         providers: new List<Provider> { 
-                            new Provider("Microsoft-Windows-DotNETRuntimePrivate", 0x80000000, EventLevel.Verbose)
+                            new Provider("Microsoft-Windows-DotNETRuntimePrivate", 0x80000000, EventLevel.Verbose),
+                            // workaround for https://github.com/dotnet/runtime/issues/44072 which happens because the
+                            // above provider only sends 2 events and that can cause EventPipeEventSource (from TraceEvent)
+                            // to not dispatch the events if the EventBlock is a size not divisible by 8 (the reading alignment in TraceEvent).
+                            // Adding this provider keeps data flowing over the pipe so the reader doesn't get stuck waiting for data
+                            // that won't come otherwise.
+                            new Provider("Microsoft-DotNETCore-SampleProfiler")
                         });
                     Logger.logger.Log("Starting EventPipeSession over standard connection");
                     using Stream eventStream = EventPipeClient.CollectTracing(pid, config, out var sessionId);


### PR DESCRIPTION
* real fix needs to happen in TraceEvent

As noted in #44072, the intermittent failure is caused by the reader (`EventPipeEventSource`) indefinitely pausing while trying to read bytes to reach 8-byte alignment.  `EventBlocks` are not required to be aligned lengths.  There are only 2 events associated with the keyword `EEStartupStart` belongs to, so once those events have been received there won't be more data sent.  If the `EventBlock` containing those events is not an 8-byte aligned size, the reader will read the `EventBlock`, but not dispatch the events until it receives enough data to fill the alignment requirement.  That data won't arrive, so the test fails with the reader never reporting that the `EEStartupStart` event fired.

The bandaid fix is to put another provider on the test that guarantees there will be more data to read and the `EventBlock` containing `EEStartupStart` will get dispatched by `EventPipeEventSource`.  In this case, I'm adding `Microsoft-DotNETCore-SampleProfiler`, but theoretically any other provider that generates an event would be sufficient.

I'm hacking up a patch for the reader code in TraceEvent that will prevent this corner case, but that will take time to flow into the runtime repo, so this bandaid will do for now.

I'll open the PR in draft mode to run the CI a few times through and then mark it for review.  I want these tests turned back on before we complete #46079.

CC @tommcdon @noahfalk @sywhang @lateralusX @brianrob 