### PR TITLE
Port some CoreRT Threading classes to Mono

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LowLevelMonitor.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LowLevelMonitor.cs
@@ -23,6 +23,9 @@ internal static partial class Interop
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LowLevelMonitor_Wait")]
         internal static extern void LowLevelMonitor_Wait(IntPtr monitor);
 
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LowLevelMonitor_TimedWait")]
+        internal static extern bool LowLevelMonitor_TimedWait(IntPtr monitor, int timeoutMilliseconds);
+
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LowLevelMonitor_Signal_Release")]
         internal static extern void LowLevelMonitor_Signal_Release(IntPtr monitor);
     }

--- a/src/libraries/Native/Unix/Common/pal_config.h.in
+++ b/src/libraries/Native/Unix/Common/pal_config.h.in
@@ -116,6 +116,7 @@
 #cmakedefine01 HAVE_GETGROUPLIST
 #cmakedefine01 HAVE_SYS_PROCINFO_H
 #cmakedefine01 HAVE_IOSS_H
+#cmakedefine01 HAVE_MACH_ABSOLUTE_TIME
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/libraries/Native/Unix/System.Native/entrypoints.c
+++ b/src/libraries/Native/Unix/System.Native/entrypoints.c
@@ -223,6 +223,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_LowLevelMonitor_Acquire)
     DllImportEntry(SystemNative_LowLevelMonitor_Release)
     DllImportEntry(SystemNative_LowLevelMonitor_Wait)
+    DllImportEntry(SystemNative_LowLevelMonitor_TimedWait)
     DllImportEntry(SystemNative_LowLevelMonitor_Signal_Release)
     DllImportEntry(SystemNative_UTimensat)
     DllImportEntry(SystemNative_GetTimestamp)

--- a/src/libraries/Native/Unix/System.Native/pal_threading.h
+++ b/src/libraries/Native/Unix/System.Native/pal_threading.h
@@ -18,4 +18,6 @@ PALEXPORT void SystemNative_LowLevelMonitor_Release(LowLevelMonitor* monitor);
 
 PALEXPORT void SystemNative_LowLevelMonitor_Wait(LowLevelMonitor* monitor);
 
+PALEXPORT uint32_t SystemNative_LowLevelMonitor_TimedWait(LowLevelMonitor* monitor, int32_t timeoutMilliseconds);
+
 PALEXPORT void SystemNative_LowLevelMonitor_Signal_Release(LowLevelMonitor* monitor);

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -1004,6 +1004,19 @@ check_c_source_compiles(
     "
     HAVE_BUILTIN_MUL_OVERFLOW)
 
+check_c_source_compiles(
+    "
+    #include <stdlib.h>
+    #include <mach/mach_time.h>
+    int main()
+    {
+      int ret;
+      mach_timebase_info_data_t timebaseInfo;
+      ret = mach_timebase_info(&timebaseInfo);
+      mach_absolute_time();
+      exit(ret);
+    }" HAVE_MACH_ABSOLUTE_TIME)
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/Common/pal_config.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/Common/pal_config.h)

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3004,6 +3004,9 @@
   <data name="Overflow_Int64" xml:space="preserve">
     <value>Value was either too large or too small for an Int64.</value>
   </data>
+  <data name="Overflow_MutexReacquireCount" xml:space="preserve">
+    <value>The current thread attempted to reacquire a mutex that has reached its maximum acquire count.</value>
+  </data>
   <data name="Overflow_NegateTwosCompNum" xml:space="preserve">
     <value>Negating the minimum value of a twos complement number is invalid.</value>
   </data>
@@ -3582,6 +3585,9 @@
   </data>
   <data name="InvalidOperation_InvalidComUnRegFunctionSig" xml:space="preserve">
     <value>COM unregister function must have a System.Type parameter and a void return type.</value>
+  </data>
+  <data name="InvalidOperation_InvalidHandle" xml:space="preserve">
+    <value>The handle is invalid.</value>
   </data>
   <data name="InvalidOperation_MultipleComRegFunctions" xml:space="preserve">
     <value>Type '{0}' has more than one COM registration function.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
@@ -161,6 +161,13 @@ namespace System.Runtime.InteropServices
             success = true;
         }
 
+        // Used by internal callers to avoid declaring a bool to pass by ref
+        internal void DangerousAddRef()
+        {
+            bool success = false;
+            DangerousAddRef(ref success);
+        }
+
         public void DangerousRelease() => InternalRelease(disposeOrFinalizeOperation: false);
 
         private void InternalRelease(bool disposeOrFinalizeOperation)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
@@ -44,6 +44,19 @@ namespace System.Threading
             Interop.Sys.LowLevelMonitor_Wait(_nativeMonitor);
         }
 
+        private bool WaitCore(int timeoutMilliseconds)
+        {
+            Debug.Assert(timeoutMilliseconds >= -1);
+
+            if (timeoutMilliseconds < 0)
+            {
+                WaitCore();
+                return true;
+            }
+
+            return Interop.Sys.LowLevelMonitor_TimedWait(_nativeMonitor, timeoutMilliseconds);
+        }
+
         private void Signal_ReleaseCore()
         {
             Interop.Sys.LowLevelMonitor_Signal_Release(_nativeMonitor);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.cs
@@ -90,6 +90,16 @@ namespace System.Threading
             SetOwnerThreadToCurrent();
         }
 
+        public bool Wait(int timeoutMilliseconds)
+        {
+            Debug.Assert(timeoutMilliseconds >= -1);
+
+            ResetOwnerThread();
+            bool waitResult = WaitCore(timeoutMilliseconds);
+            SetOwnerThreadToCurrent();
+            return waitResult;
+        }
+
         public void Signal_Release()
         {
             ResetOwnerThread();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -429,6 +429,8 @@ namespace System.Threading
             WaitMultiple(waitHandles, false, millisecondsTimeout);
         internal static int WaitAny(ReadOnlySpan<SafeWaitHandle> safeWaitHandles, int millisecondsTimeout) =>
             WaitAnyMultiple(safeWaitHandles, millisecondsTimeout);
+        internal static int WaitAny(ReadOnlySpan<WaitHandle> waitHandles, int millisecondsTimeout) =>
+            WaitMultiple(waitHandles, false, millisecondsTimeout);
         public static int WaitAny(WaitHandle[] waitHandles, TimeSpan timeout) =>
             WaitMultiple(waitHandles, false, ToTimeoutMilliseconds(timeout));
         public static int WaitAny(WaitHandle[] waitHandles) =>

--- a/src/mono/mono/metadata/icall-decl.h
+++ b/src/mono/mono/metadata/icall-decl.h
@@ -293,9 +293,11 @@ ICALL_EXPORT gpointer   ves_icall_System_Runtime_InteropServices_Marshal_ReAlloc
 ICALL_EXPORT      char* ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi    (const gunichar2*, int);
 ICALL_EXPORT gunichar2*	ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalUni	(const gunichar2*, int);
 
+#ifndef ENABLE_NETCORE
 ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_CreateSemaphore_icall     (gint32 initialCount, gint32 maximumCount, const gunichar2 *name, gint32 name_length, gint32 *win32error);
 ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_OpenSemaphore_icall       (const gunichar2 *name, gint32 name_length, gint32 rights, gint32 *win32error);
 ICALL_EXPORT MonoBoolean ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount);
+#endif
 
 #ifdef ENABLE_NETCORE
 ICALL_EXPORT gpointer ves_icall_System_Threading_LowLevelLifoSemaphore_InitInternal (void);

--- a/src/mono/mono/metadata/icall-def-netcore.h
+++ b/src/mono/mono/metadata/icall-def-netcore.h
@@ -1,6 +1,3 @@
-ICALL_TYPE(SAFEWAITHANDLE, "Microsoft.Win32.SafeHandles.SafeWaitHandle", SAFEWAITHANDLE_1) // && UNIX
-NOHANDLES(ICALL(SAFEWAITHANDLE_1, "CloseEventInternal", ves_icall_System_Threading_Events_CloseEvent_internal))
-
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_20)
 NOHANDLES(ICALL(RUNTIME_20, "AnnotateMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_AnnotateMicrosoftTelemetry))
 NOHANDLES(ICALL(RUNTIME_19, "CheckCrashReportLog_internal", ves_icall_Mono_Runtime_CheckCrashReportingLog))
@@ -449,11 +446,6 @@ HANDLES(STRING_9, "FastAllocateString", ves_icall_System_String_FastAllocateStri
 HANDLES(STRING_10, "InternalIntern", ves_icall_System_String_InternalIntern, MonoString, 1, (MonoString))
 HANDLES(STRING_11, "InternalIsInterned", ves_icall_System_String_InternalIsInterned, MonoString, 1, (MonoString))
 
-ICALL_TYPE(NATIVEC, "System.Threading.EventWaitHandle", EWH_1) // && Unix
-HANDLES(EWH_1, "CreateEventInternal", ves_icall_System_Threading_Events_CreateEvent_icall, gpointer, 5, (MonoBoolean, MonoBoolean, const_gunichar2_ptr, gint32, gint32_ref))
-NOHANDLES(ICALL(EWH_2, "ResetEventInternal",  ves_icall_System_Threading_Events_ResetEvent_internal))
-NOHANDLES(ICALL(EWH_3, "SetEventInternal",    ves_icall_System_Threading_Events_SetEvent_internal))
-
 ICALL_TYPE(ILOCK, "System.Threading.Interlocked", ILOCK_1)
 NOHANDLES(ICALL(ILOCK_1, "Add(int&,int)", ves_icall_System_Threading_Interlocked_Add_Int))
 NOHANDLES(ICALL(ILOCK_2, "Add(long&,long)", ves_icall_System_Threading_Interlocked_Add_Long))
@@ -494,16 +486,6 @@ HANDLES(MONIT_7, "Monitor_wait", ves_icall_System_Threading_Monitor_Monitor_wait
 NOHANDLES(ICALL(MONIT_8, "get_LockContentionCount", ves_icall_System_Threading_Monitor_Monitor_LockContentionCount))
 HANDLES(MONIT_9, "try_enter_with_atomic_var", ves_icall_System_Threading_Monitor_Monitor_try_enter_with_atomic_var, void, 4, (MonoObject, guint32, MonoBoolean, MonoBoolean_ref))
 
-ICALL_TYPE(MUTEX, "System.Threading.Mutex", MUTEX_1)
-HANDLES(MUTEX_1, "CreateMutex_icall", ves_icall_System_Threading_Mutex_CreateMutex_icall, gpointer, 4, (MonoBoolean, const_gunichar2_ptr, gint32, MonoBoolean_ref))
-HANDLES(MUTEX_2, "OpenMutex_icall", ves_icall_System_Threading_Mutex_OpenMutex_icall, gpointer, 4, (const_gunichar2_ptr, gint32, gint32, gint32_ref))
-NOHANDLES(ICALL(MUTEX_3, "ReleaseMutex_internal", ves_icall_System_Threading_Mutex_ReleaseMutex_internal))
-
-ICALL_TYPE(SEMA, "System.Threading.Semaphore", SEMA_1)
-NOHANDLES(ICALL(SEMA_1, "CreateSemaphore_icall", ves_icall_System_Threading_Semaphore_CreateSemaphore_icall))
-NOHANDLES(ICALL(SEMA_2, "OpenSemaphore_icall", ves_icall_System_Threading_Semaphore_OpenSemaphore_icall))
-NOHANDLES(ICALL(SEMA_3, "ReleaseSemaphore_internal", ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal))
-
 ICALL_TYPE(THREAD, "System.Threading.Thread", THREAD_1)
 HANDLES(THREAD_1, "ClrState", ves_icall_System_Threading_Thread_ClrState, void, 2, (MonoInternalThread, guint32))
 HANDLES(ITHREAD_2, "FreeInternal", ves_icall_System_Threading_InternalThread_Thread_free_internal, void, 1, (MonoInternalThread))
@@ -520,10 +502,6 @@ HANDLES(THREAD_10, "SetState", ves_icall_System_Threading_Thread_SetState, void,
 HANDLES(THREAD_11, "SleepInternal", ves_icall_System_Threading_Thread_Sleep_internal, void, 2, (gint32, MonoBoolean))
 HANDLES(THREAD_13, "StartInternal", ves_icall_System_Threading_Thread_StartInternal, void, 1, (MonoThreadObject))
 NOHANDLES(ICALL(THREAD_14, "YieldInternal", ves_icall_System_Threading_Thread_YieldInternal))
-
-ICALL_TYPE(WAITH, "System.Threading.WaitHandle", WAITH_1)
-HANDLES(WAITH_1, "SignalAndWait_Internal", ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal, gint32, 3, (gpointer, gpointer, gint32))
-HANDLES(WAITH_2, "Wait_internal", ves_icall_System_Threading_WaitHandle_Wait_internal, gint32, 4, (gpointer_ptr, gint32, MonoBoolean, gint32))
 
 ICALL_TYPE(TYPE, "System.Type", TYPE_1)
 HANDLES(TYPE_1, "internal_from_handle", ves_icall_System_Type_internal_from_handle, MonoReflectionType, 1, (MonoType_ref))

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -2458,6 +2458,7 @@ map_native_wait_result_to_managed (MonoW32HandleWaitRet val, gsize numobjects)
 	}
 }
 
+#ifndef ENABLE_NETCORE
 gint32
 ves_icall_System_Threading_WaitHandle_Wait_internal (gpointer *handles, gint32 numhandles, MonoBoolean waitall, gint32 timeout, MonoError *error)
 {
@@ -2556,6 +2557,7 @@ ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (gpointer toSignal,
 
 	return map_native_wait_result_to_managed (ret, 1);
 }
+#endif
 
 gint32 ves_icall_System_Threading_Interlocked_Increment_Int (gint32 *location)
 {

--- a/src/mono/mono/metadata/w32event-unix.c
+++ b/src/mono/mono/metadata/w32event-unix.c
@@ -274,19 +274,6 @@ mono_w32event_create_full (MonoBoolean manual, MonoBoolean initial, const char *
 	return event;
 }
 
-gpointer
-ves_icall_System_Threading_Events_CreateEvent_icall (MonoBoolean manual, MonoBoolean initial,
-	const gunichar2* name, gint32 name_length, gint32 *win32error, MonoError *error)
-{
-	*win32error = ERROR_SUCCESS;
-	gsize utf8_name_length = 0;
-	char *utf8_name = mono_utf16_to_utf8len (name, name_length, &utf8_name_length, error);
-	return_val_if_nok (error, NULL);
-	gpointer result = mono_w32event_create_full (manual, initial, utf8_name, utf8_name_length, win32error);
-	g_free (utf8_name);
-	return result;
-}
-
 gboolean
 ves_icall_System_Threading_Events_SetEvent_internal (gpointer handle)
 {
@@ -372,13 +359,26 @@ ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle)
 	return TRUE;
 }
 
+#ifndef ENABLE_NETCORE
+gpointer
+ves_icall_System_Threading_Events_CreateEvent_icall (MonoBoolean manual, MonoBoolean initial,
+	const gunichar2* name, gint32 name_length, gint32 *win32error, MonoError *error)
+{
+	*win32error = ERROR_SUCCESS;
+	gsize utf8_name_length = 0;
+	char *utf8_name = mono_utf16_to_utf8len (name, name_length, &utf8_name_length, error);
+	return_val_if_nok (error, NULL);
+	gpointer result = mono_w32event_create_full (manual, initial, utf8_name, utf8_name_length, win32error);
+	g_free (utf8_name);
+	return result;
+}
+
 void
 ves_icall_System_Threading_Events_CloseEvent_internal (gpointer handle)
 {
 	mono_w32handle_close (handle);
 }
 
-#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Events_OpenEvent_icall (const gunichar2 *name, gint32 name_length,
 	gint32 rights, gint32 *win32error, MonoError *error)

--- a/src/mono/mono/metadata/w32event-win32.c
+++ b/src/mono/mono/metadata/w32event-win32.c
@@ -45,6 +45,7 @@ mono_w32event_reset (gpointer handle)
 	ResetEvent (handle);
 }
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Events_CreateEvent_icall (MonoBoolean manual, MonoBoolean initial,
 	const gunichar2 *name, gint32 name_length, gint32 *win32error, MonoError *error)
@@ -93,3 +94,4 @@ ves_icall_System_Threading_Events_OpenEvent_icall (const gunichar2 *name, gint32
 
 	return handle;
 }
+#endif

--- a/src/mono/mono/metadata/w32event.h
+++ b/src/mono/mono/metadata/w32event.h
@@ -36,9 +36,11 @@ ICALL_EXPORT
 gboolean
 ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle);
 
+#ifndef ENABLE_NETCORE
 ICALL_EXPORT
 void
 ves_icall_System_Threading_Events_CloseEvent_internal (gpointer handle);
+#endif
 
 typedef struct MonoW32HandleNamedEvent MonoW32HandleNamedEvent;
 

--- a/src/mono/mono/metadata/w32mutex-unix.c
+++ b/src/mono/mono/metadata/w32mutex-unix.c
@@ -341,6 +341,7 @@ namedmutex_create (gboolean owned, const char *utf8_name, gsize utf8_len)
 	return handle;
 }
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Mutex_CreateMutex_icall (MonoBoolean owned, const gunichar2 *name,
 	gint32 name_length, MonoBoolean *created, MonoError *error)
@@ -442,6 +443,7 @@ ves_icall_System_Threading_Mutex_OpenMutex_icall (const gunichar2 *name, gint32 
 	g_free (utf8_name);
 	return handle;
 }
+#endif
 
 gpointer
 mono_w32mutex_open (const char* utf8_name, gint32 rights G_GNUC_UNUSED, gint32 *win32error)

--- a/src/mono/mono/metadata/w32mutex-win32.c
+++ b/src/mono/mono/metadata/w32mutex-win32.c
@@ -21,6 +21,7 @@ mono_w32mutex_init (void)
 {
 }
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Mutex_CreateMutex_icall (MonoBoolean owned, const gunichar2 *name,
 	gint32 name_length, MonoBoolean *created, MonoError *error)
@@ -65,3 +66,4 @@ ves_icall_System_Threading_Mutex_OpenMutex_icall (const gunichar2 *name, gint32 
 
 	return ret;
 }
+#endif

--- a/src/mono/mono/metadata/w32semaphore-unix.c
+++ b/src/mono/mono/metadata/w32semaphore-unix.c
@@ -236,6 +236,7 @@ exit:
 // These functions appear to be using coop-aware locking functions, and so this file does not include explicit
 // GC-safe transitions like its corresponding Windows version
 
+#ifndef ENABLE_NETCORE
 gpointer
 ves_icall_System_Threading_Semaphore_CreateSemaphore_icall (gint32 initialCount, gint32 maximumCount,
 	const gunichar2 *name, gint32 name_length, gint32 *win32error)
@@ -359,6 +360,7 @@ exit:
 	mono_error_set_pending_exception (error);				\
 	return handle;
 }
+#endif
 
 MonoW32HandleNamespace*
 mono_w32semaphore_get_namespace (MonoW32HandleNamedSemaphore *semaphore)

--- a/src/mono/mono/metadata/w32semaphore-win32.c
+++ b/src/mono/mono/metadata/w32semaphore-win32.c
@@ -21,6 +21,7 @@ mono_w32semaphore_init (void)
 {
 }
 
+#ifndef ENABLE_NETCORE
 #if HAVE_API_SUPPORT_WIN32_CREATE_SEMAPHORE || HAVE_API_SUPPORT_WIN32_CREATE_SEMAPHORE_EX
 gpointer
 ves_icall_System_Threading_Semaphore_CreateSemaphore_icall (gint32 initialCount, gint32 maximumCount,
@@ -65,3 +66,4 @@ ves_icall_System_Threading_Semaphore_OpenSemaphore_icall (const gunichar2 *name,
 	*win32error = GetLastError ();
 	return sem;
 }
+#endif

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -262,9 +262,14 @@
       <Compile Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeWaitHandle.Unix.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Environment.Unix.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Threading\EventWaitHandle.Unix.Mono.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\LowLevelLifoSemaphore.Unix.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Threading\Mutex.Unix.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Threading\Semaphore.Unix.Mono.cs" />
-      <Compile Include="$(BclSourcesRoot)\System\Threading\LowLevelLifoSemaphore.Unix.Mono.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\WaitHandle.Unix.Mono.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\WaitSubsystem.HandleManager.Unix.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\WaitSubsystem.ThreadWaitInfo.Unix.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\WaitSubsystem.Unix.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\WaitSubsystem.WaitableObject.Unix.cs" />
 
       <Compile Include="$(BclSourcesRoot)\System\IO\MonoIOError.cs" />
   </ItemGroup>

--- a/src/mono/netcore/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeWaitHandle.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeWaitHandle.Unix.Mono.cs
@@ -1,20 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    public partial class SafeWaitHandle
+    public sealed partial class SafeWaitHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         protected override bool ReleaseHandle()
         {
-            CloseEventInternal(handle);
+            WaitSubsystem.DeleteHandle(handle);
             return true;
         }
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void CloseEventInternal(IntPtr handle);
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.Mono.cs
@@ -2,98 +2,82 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Win32.SafeHandles;
-using System.Runtime.CompilerServices;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
     public partial class EventWaitHandle
     {
-        public bool Set()
-        {
-            SafeWaitHandle handle = ValidateHandle(out bool release);
-
-            try
-            {
-                return SetEventInternal(handle.DangerousGetHandle());
-            }
-            finally
-            {
-                if (release)
-                    handle.DangerousRelease();
-            }
-        }
-
-        public bool Reset()
-        {
-            SafeWaitHandle handle = ValidateHandle(out bool release);
-
-            try
-            {
-                return ResetEventInternal(handle.DangerousGetHandle());
-            }
-            finally
-            {
-                if (release)
-                    handle.DangerousRelease();
-            }
-        }
-
-        private unsafe void CreateEventCore(bool initialState, EventResetMode mode, string? name, out bool createdNew)
+        private void CreateEventCore(bool initialState, EventResetMode mode, string? name, out bool createdNew)
         {
             if (name != null)
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
 
-            SafeWaitHandle handle = new SafeWaitHandle(CreateEventInternal(mode == EventResetMode.ManualReset, initialState, null, 0, out int errorCode), ownsHandle: true);
-            if (errorCode != 0)
-                throw new NotImplementedException("errorCode");
-            SafeWaitHandle = handle;
-
+            SafeWaitHandle = WaitSubsystem.NewEvent(initialState, mode);
             createdNew = true;
         }
 
-        private static OpenExistingResult OpenExistingWorker(string name, out EventWaitHandle result)
+        private static OpenExistingResult OpenExistingWorker(string name, out EventWaitHandle? result)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
         }
 
-        internal static bool Set(SafeWaitHandle waitHandle)
+        public bool Reset()
         {
-            bool release = false;
+            SafeWaitHandle waitHandle = ValidateHandle();
             try
             {
-                waitHandle.DangerousAddRef(ref release);
-                return SetEventInternal(waitHandle.DangerousGetHandle());
+                WaitSubsystem.ResetEvent(waitHandle.DangerousGetHandle());
+                return true;
             }
             finally
             {
-                if (release)
-                    waitHandle.DangerousRelease();
+                waitHandle.DangerousRelease();
             }
         }
 
-        private SafeWaitHandle ValidateHandle(out bool success)
+        public bool Set()
+        {
+            SafeWaitHandle waitHandle = ValidateHandle();
+            try
+            {
+                WaitSubsystem.SetEvent(waitHandle.DangerousGetHandle());
+                return true;
+            }
+            finally
+            {
+                waitHandle.DangerousRelease();
+            }
+        }
+
+        internal static bool Set(SafeWaitHandle waitHandle)
+        {
+            waitHandle.DangerousAddRef();
+            try
+            {
+                WaitSubsystem.SetEvent(waitHandle.DangerousGetHandle());
+                return true;
+            }
+            finally
+            {
+                waitHandle.DangerousRelease();
+            }
+        }
+
+        private SafeWaitHandle ValidateHandle()
         {
             // The field value is modifiable via the public <see cref="WaitHandle.SafeWaitHandle"/> property, save it locally
             // to ensure that one instance is used in all places in this method
             SafeWaitHandle waitHandle = SafeWaitHandle;
             if (waitHandle.IsInvalid)
             {
-                throw new InvalidOperationException();
+                ThrowInvalidHandleException();
             }
 
-            success = false;
-            waitHandle.DangerousAddRef(ref success);
+            waitHandle.DangerousAddRef();
             return waitHandle;
         }
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern unsafe IntPtr CreateEventInternal(bool manual, bool initialState, char* name, int name_length, out int errorCode);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern bool ResetEventInternal(IntPtr handle);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern bool SetEventInternal(IntPtr handle);
-
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/LowLevelLock.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/LowLevelLock.cs
@@ -36,5 +36,11 @@ namespace System.Threading
         {
             Debug.Assert(Monitor.IsEntered(this));
         }
+
+        [Conditional("DEBUG")]
+        public void VerifyIsNotLocked()
+        {
+            Debug.Assert(!Monitor.IsEntered(this));
+        }
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Mutex.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Mutex.Unix.Mono.cs
@@ -1,78 +1,50 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
-    public partial class Mutex
+    public sealed partial class Mutex
     {
-        private Mutex(IntPtr handle) => Handle = handle;
-
-        public void ReleaseMutex()
+        private void CreateMutexCore(bool initiallyOwned, string? name, out bool createdNew)
         {
-            if (!ReleaseMutex_internal(Handle))
-                throw new ApplicationException(SR.Arg_SynchronizationLockException);
-        }
+            if (name != null)
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
+            }
 
-        private void CreateMutexCore(bool initiallyOwned, string? name, out bool createdNew) =>
-            Handle = CreateMutex_internal(initiallyOwned, name, out createdNew);
-
-        private static unsafe IntPtr CreateMutex_internal(bool initiallyOwned, string? name, out bool created)
-        {
-            fixed (char* fixed_name = name)
-                return CreateMutex_icall(initiallyOwned, fixed_name,
-                    name?.Length ?? 0, out created);
+            SafeWaitHandle = WaitSubsystem.NewMutex(initiallyOwned);
+            createdNew = true;
         }
 
         private static OpenExistingResult OpenExistingWorker(string name, out Mutex? result)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            result = null;
-            if ((name.Length == 0) ||
-                (name.Length > 260))
-            {
-                return OpenExistingResult.NameInvalid;
-            }
-
-            MonoIOError error;
-            IntPtr handle = OpenMutex_internal(name, out error);
-            if (handle == IntPtr.Zero)
-            {
-                if (error == MonoIOError.ERROR_FILE_NOT_FOUND)
-                {
-                    return OpenExistingResult.NameNotFound;
-                }
-                else if (error == MonoIOError.ERROR_ACCESS_DENIED)
-                {
-                    throw new UnauthorizedAccessException();
-                }
-                else
-                {
-                    return OpenExistingResult.PathNotFound;
-                }
-            }
-
-            result = new Mutex(handle);
-            return OpenExistingResult.Success;
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
         }
 
-        private static unsafe IntPtr OpenMutex_internal(string name, out MonoIOError error)
+        public void ReleaseMutex()
         {
-            fixed (char* fixed_name = name)
-                return OpenMutex_icall(fixed_name, name?.Length ?? 0, 0x000001 /* MutexRights.Modify */, out error);
+            // The field value is modifiable via the public <see cref="WaitHandle.SafeWaitHandle"/> property, save it locally
+            // to ensure that one instance is used in all places in this method
+            SafeWaitHandle waitHandle = SafeWaitHandle;
+            if (waitHandle.IsInvalid)
+            {
+                ThrowInvalidHandleException();
+            }
+
+            waitHandle.DangerousAddRef();
+            try
+            {
+                WaitSubsystem.ReleaseMutex(waitHandle.DangerousGetHandle());
+            }
+            finally
+            {
+                waitHandle.DangerousRelease();
+            }
         }
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern unsafe IntPtr CreateMutex_icall(bool initiallyOwned, char* name, int name_length, out bool created);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern unsafe IntPtr OpenMutex_icall(char* name, int name_length, int rights, out MonoIOError error);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern bool ReleaseMutex_internal(IntPtr handle);
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.Mono.cs
@@ -1,104 +1,50 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
 using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
-    public partial class Semaphore
+    public sealed partial class Semaphore
     {
-        private const int MAX_PATH = 260;
-
-        private Semaphore(SafeWaitHandle handle) => this.SafeWaitHandle = handle;
-
-        private int ReleaseCore(int releaseCount)
+        private void CreateSemaphoreCore(int initialCount, int maximumCount, string? name, out bool createdNew)
         {
-            if (!ReleaseSemaphore_internal(SafeWaitHandle.DangerousGetHandle(), releaseCount, out int previousCount))
-                throw new SemaphoreFullException();
+            if (name != null)
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
+            }
 
-            return previousCount;
+            SafeWaitHandle = WaitSubsystem.NewSemaphore(initialCount, maximumCount);
+            createdNew = true;
         }
 
         private static OpenExistingResult OpenExistingWorker(string name, out Semaphore? result)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
+        }
 
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(name));
-
-            if (name.Length > MAX_PATH)
-                throw new ArgumentException(SR.Argument_WaitHandleNameTooLong);
-
-            var myHandle = new SafeWaitHandle(OpenSemaphore_internal(name,
-                /*SemaphoreRights.Modify | SemaphoreRights.Synchronize*/ 0x000002 | 0x100000,
-                out MonoIOError errorCode), true);
-
-            if (myHandle.IsInvalid)
+        private int ReleaseCore(int releaseCount)
+        {
+            // The field value is modifiable via the public <see cref="WaitHandle.SafeWaitHandle"/> property, save it locally
+            // to ensure that one instance is used in all places in this method
+            SafeWaitHandle waitHandle = SafeWaitHandle;
+            if (waitHandle.IsInvalid)
             {
-                result = null;
-                switch (errorCode)
-                {
-                    case MonoIOError.ERROR_FILE_NOT_FOUND:
-                    case MonoIOError.ERROR_INVALID_NAME:
-                        return OpenExistingResult.NameNotFound;
-                    case MonoIOError.ERROR_PATH_NOT_FOUND:
-                        return OpenExistingResult.PathNotFound;
-                    case MonoIOError.ERROR_INVALID_HANDLE when !string.IsNullOrEmpty(name):
-                        return OpenExistingResult.NameInvalid;
-                    default:
-                        //this is for passed through NativeMethods Errors
-                        throw new IOException($"Unknown Error '{errorCode}'");
-                }
+                ThrowInvalidHandleException();
             }
 
-            result = new Semaphore(myHandle);
-            return OpenExistingResult.Success;
-        }
-
-        private void CreateSemaphoreCore(int initialCount, int maximumCount, string? name, out bool createdNew)
-        {
-            if (name?.Length > MAX_PATH)
-                throw new ArgumentException(SR.Argument_WaitHandleNameTooLong);
-
-            var myHandle = new SafeWaitHandle(CreateSemaphore_internal(initialCount, maximumCount, name, out MonoIOError errorCode), true);
-
-            if (myHandle.IsInvalid)
+            waitHandle.DangerousAddRef();
+            try
             {
-                if (errorCode == MonoIOError.ERROR_INVALID_HANDLE && !string.IsNullOrEmpty(name))
-                    throw new WaitHandleCannotBeOpenedException(SR.Format(SR.Threading_WaitHandleCannotBeOpenedException_InvalidHandle, name));
-
-                throw new IOException($"Unknown Error '{errorCode}'");
+                return WaitSubsystem.ReleaseSemaphore(waitHandle.DangerousGetHandle(), releaseCount);
             }
-
-            this.SafeWaitHandle = myHandle;
-            createdNew = errorCode != MonoIOError.ERROR_ALREADY_EXISTS;
+            finally
+            {
+                waitHandle.DangerousRelease();
+            }
         }
-
-        private static unsafe IntPtr CreateSemaphore_internal(int initialCount, int maximumCount, string? name, out MonoIOError errorCode)
-        {
-            // FIXME Check for embedded nuls in name.
-            fixed (char* fixed_name = name)
-                return CreateSemaphore_icall(initialCount, maximumCount,
-                    fixed_name, name?.Length ?? 0, out errorCode);
-        }
-
-        private static unsafe IntPtr OpenSemaphore_internal(string name, int rights, out MonoIOError errorCode)
-        {
-            // FIXME Check for embedded nuls in name.
-            fixed (char* fixed_name = name)
-                return OpenSemaphore_icall(fixed_name, name?.Length ?? 0, rights, out errorCode);
-        }
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern unsafe IntPtr CreateSemaphore_icall(int initialCount, int maximumCount, char* name, int nameLength, out MonoIOError errorCode);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern unsafe IntPtr OpenSemaphore_icall(char* name, int nameLength, int rights, out MonoIOError errorCode);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern bool ReleaseSemaphore_internal(IntPtr handle, int releaseCount, out int previousCount);
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitHandle.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitHandle.Mono.cs
@@ -1,53 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
 namespace System.Threading
 {
-    public partial class WaitHandle
+    public abstract partial class WaitHandle
     {
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern unsafe int Wait_internal(IntPtr* handles, int numHandles, bool waitAll, int ms);
-
-        private static int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout)
+        internal static void ThrowInvalidHandleException()
         {
-            unsafe
-            {
-                return Wait_internal(&waitHandle, 1, false, millisecondsTimeout);
-            }
+            var ex = new InvalidOperationException(SR.InvalidOperation_InvalidHandle);
+            ex.HResult = HResults.E_HANDLE;
+            throw ex;
         }
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int SignalAndWait_Internal(IntPtr waitHandleToSignal, IntPtr waitHandleToWaitOn, int millisecondsTimeout);
-
-        private const int ERROR_TOO_MANY_POSTS = 0x12A;
-        private const int ERROR_NOT_OWNED_BY_CALLER = 0x12B;
-
-        private static int SignalAndWaitCore(IntPtr waitHandleToSignal, IntPtr waitHandleToWaitOn, int millisecondsTimeout)
-        {
-            int ret = SignalAndWait_Internal(waitHandleToSignal, waitHandleToWaitOn, millisecondsTimeout);
-            if (ret == ERROR_TOO_MANY_POSTS)
-                throw new InvalidOperationException(SR.Threading_WaitHandleTooManyPosts);
-            if (ret == ERROR_NOT_OWNED_BY_CALLER)
-                throw new ApplicationException("Attempt to release mutex not owned by caller");
-            return ret;
-        }
-
-        internal static int WaitMultipleIgnoringSyncContext(Span<IntPtr> waitHandles, bool waitAll, int millisecondsTimeout)
-        {
-            unsafe
-            {
-                fixed (IntPtr* handles = &MemoryMarshal.GetReference(waitHandles))
-                {
-                    return Wait_internal(handles, waitHandles.Length, waitAll, millisecondsTimeout);
-                }
-            }
-        }
-
-        // FIXME: Move to shared
-        internal static int WaitAny(ReadOnlySpan<WaitHandle> waitHandles, int millisecondsTimeout) =>
-            WaitMultiple(waitHandles, false, millisecondsTimeout);
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.Mono.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Threading
+{
+    public abstract partial class WaitHandle
+    {
+        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout) =>
+            WaitSubsystem.Wait(handle, millisecondsTimeout, true);
+
+        internal static int WaitMultipleIgnoringSyncContext(Span<IntPtr> handles, bool waitAll, int millisecondsTimeout) =>
+            WaitSubsystem.Wait(handles, waitAll, millisecondsTimeout);
+
+        private static int SignalAndWaitCore(IntPtr handleToSignal, IntPtr handleToWaitOn, int millisecondsTimeout) =>
+            WaitSubsystem.SignalAndWait(handleToSignal, handleToWaitOn, millisecondsTimeout);
+    }
+}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.HandleManager.Unix.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.HandleManager.Unix.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime;
+using System.Runtime.InteropServices;
+
+namespace System.Threading
+{
+    internal static partial class WaitSubsystem
+    {
+        private static class HandleManager
+        {
+            public static IntPtr NewHandle(WaitableObject waitableObject)
+            {
+                Debug.Assert(waitableObject != null);
+
+                IntPtr handle = GCHandle.ToIntPtr(GCHandle.Alloc(waitableObject, GCHandleType.Normal));
+
+                // SafeWaitHandle treats -1 and 0 as invalid, and the handle should not be these values anyway
+                Debug.Assert(handle != IntPtr.Zero);
+                Debug.Assert(handle != new IntPtr(-1));
+                return handle;
+            }
+
+            public static WaitableObject FromHandle(IntPtr handle)
+            {
+                if (handle == IntPtr.Zero || handle == new IntPtr(-1))
+                {
+                    WaitHandle.ThrowInvalidHandleException();
+                }
+
+                // We don't know if any other handles are invalid, and this may crash or otherwise do bad things, that is by
+                // design, IntPtr is unsafe by nature.
+                return (WaitableObject)GCHandle.FromIntPtr(handle).Target!;
+            }
+
+            /// <summary>
+            /// Unlike on Windows, a handle may not be deleted more than once with this implementation
+            /// </summary>
+            public static void DeleteHandle(IntPtr handle)
+            {
+                if (handle == IntPtr.Zero || handle == new IntPtr(-1))
+                {
+                    return;
+                }
+
+                // We don't know if any other handles are invalid, and this may crash or otherwise do bad things, that is by
+                // design, IntPtr is unsafe by nature.
+                FromHandle(handle).OnDeleteHandle();
+                GCHandle.FromIntPtr(handle).Free();
+            }
+        }
+    }
+}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
@@ -1,0 +1,734 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Threading
+{
+    internal static partial class WaitSubsystem
+    {
+        /// <summary>
+        /// Contains thread-specific information for the wait subsystem. There is one instance per thread that is registered
+        /// using <see cref="WaitedListNode"/>s with each <see cref="WaitableObject"/> that the thread is waiting upon.
+        ///
+        /// Used by the wait subsystem on Unix, so this class cannot have any dependencies on the wait subsystem.
+        /// </summary>
+        public sealed class ThreadWaitInfo
+        {
+            private readonly Thread _thread;
+
+            /// <summary>
+            /// The monitor the thread would wait upon when the wait needs to be interruptible
+            /// </summary>
+            private LowLevelMonitor _waitMonitor;
+
+
+            /// <summary>
+            /// Thread wait state. The following members indicate the waiting state of the thread, and convery information from
+            /// a signaler to the waiter. They are synchronized with <see cref="_waitMonitor"/>.
+            /// </summary>
+            private WaitSignalState _waitSignalState;
+
+            /// <summary>
+            /// Index of the waitable object in <see cref="_waitedObjects"/>, which got signaled and satisfied the wait. -1 if
+            /// the wait has not yet been satisfied.
+            /// </summary>
+            private int _waitedObjectIndexThatSatisfiedWait;
+
+            /// <summary>
+            /// Information about the current wait, including the type of wait, the <see cref="WaitableObject"/>s involved in
+            /// the wait, etc. They are synchronized with <see cref="s_lock"/>.
+            /// </summary>
+            private bool _isWaitForAll;
+
+            /// <summary>
+            /// Number of <see cref="WaitableObject"/>s the thread is waiting upon
+            /// </summary>
+            private int _waitedCount;
+
+            /// <summary>
+            /// - <see cref="WaitableObject"/>s that are waited upon by the thread. This array is also used for temporarily
+            ///   storing <see cref="WaitableObject"/>s corresponding to <see cref="WaitHandle"/>s when the thread is not
+            ///   waiting.
+            /// - The filled count is <see cref="_waitedCount"/>
+            /// - Indexes in all arrays that use <see cref="_waitedCount"/> correspond
+            /// </summary>
+            private WaitableObject?[] _waitedObjects;
+
+            /// <summary>
+            /// - Nodes used for registering a thread's wait on each <see cref="WaitableObject"/>, in the
+            ///   <see cref="WaitableObject.WaitersHead"/> linked list
+            /// - The filled count is <see cref="_waitedCount"/>
+            /// - Indexes in all arrays that use <see cref="_waitedCount"/> correspond
+            /// </summary>
+            private WaitedListNode[] _waitedListNodes;
+
+            /// <summary>
+            /// Indicates whether the next wait should be interrupted.
+            ///
+            /// Synchronization:
+            /// - In most cases, reads and writes are synchronized with <see cref="s_lock"/>
+            /// - Sleep(nonzero) intentionally does not acquire <see cref="s_lock"/>, but it must acquire
+            ///   <see cref="_waitMonitor"/> to do the wait. To support this case, a pending interrupt is recorded while
+            ///   <see cref="s_lock"/> and <see cref="_waitMonitor"/> are locked, and the read and reset for Sleep(nonzero) are
+            ///   done while <see cref="_waitMonitor"/> is locked.
+            /// - Sleep(0) intentionally does not acquire any lock, so it uses an interlocked compare-exchange for the read and
+            ///   reset, see <see cref="CheckAndResetPendingInterrupt_NotLocked"/>
+            /// </summary>
+            private int _isPendingInterrupt;
+
+            ////////////////////////////////////////////////////////////////
+
+            /// <summary>
+            /// Linked list of mutex <see cref="WaitableObject"/>s that are owned by the thread and need to be abandoned before
+            /// the thread exits. The linked list has only a head and no tail, which means acquired mutexes are prepended and
+            /// mutexes are abandoned in reverse order.
+            /// </summary>
+            private WaitableObject? _lockedMutexesHead;
+
+            public ThreadWaitInfo(Thread thread)
+            {
+                Debug.Assert(thread != null);
+
+                _thread = thread;
+                _waitMonitor.Initialize();
+                _waitSignalState = WaitSignalState.NotWaiting;
+                _waitedObjectIndexThatSatisfiedWait = -1;
+
+                // Preallocate to make waiting for single handle fault-free
+                _waitedObjects = new WaitableObject[1];
+                _waitedListNodes = new WaitedListNode[1] { new WaitedListNode(this, 0) };
+            }
+
+            ~ThreadWaitInfo()
+            {
+                _waitMonitor.Dispose();
+            }
+
+            public Thread Thread => _thread;
+
+            private bool IsWaiting
+            {
+                get
+                {
+                    _waitMonitor.VerifyIsLocked();
+                    return _waitSignalState < WaitSignalState.NotWaiting;
+                }
+            }
+
+            /// <summary>
+            /// Callers must ensure to clear the array after use. Once <see cref="RegisterWait(int, bool, bool)"/> is called (followed
+            /// by a call to <see cref="Wait(int, bool, bool)"/>, the array will be cleared automatically.
+            /// </summary>
+            public WaitableObject?[] GetWaitedObjectArray(int requiredCapacity)
+            {
+                Debug.Assert(_thread == Thread.CurrentThread);
+                Debug.Assert(_waitedCount == 0);
+
+#if DEBUG
+                for (int i = 0; i < _waitedObjects.Length; ++i)
+                {
+                    Debug.Assert(_waitedObjects[i] == null);
+                }
+#endif
+
+                int currentLength = _waitedObjects.Length;
+                if (currentLength < requiredCapacity)
+                    _waitedObjects = new WaitableObject[Math.Max(requiredCapacity,
+                        Math.Min(WaitHandle.MaxWaitHandles, 2 * currentLength))];
+
+                return _waitedObjects;
+            }
+
+            private WaitedListNode[] GetWaitedListNodeArray(int requiredCapacity)
+            {
+                Debug.Assert(_thread == Thread.CurrentThread);
+                Debug.Assert(_waitedCount == 0);
+
+                int currentLength = _waitedListNodes.Length;
+                if (currentLength < requiredCapacity)
+                {
+                    WaitedListNode[] newItems = new WaitedListNode[Math.Max(requiredCapacity,
+                        Math.Min(WaitHandle.MaxWaitHandles, 2 * currentLength))];
+
+                    Array.Copy(_waitedListNodes, 0, newItems, 0, currentLength);
+                    for (int i = currentLength; i < newItems.Length; i++)
+                        newItems[i] = new WaitedListNode(this, i);
+
+                    _waitedListNodes = newItems;
+                }
+
+                return _waitedListNodes;
+            }
+
+            /// <summary>
+            /// The caller is expected to populate <see cref="GetWaitedObjectArray"/> and pass in the number of objects filled
+            /// </summary>
+            public void RegisterWait(int waitedCount, bool prioritize, bool isWaitForAll)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(_thread == Thread.CurrentThread);
+
+                Debug.Assert(waitedCount > (isWaitForAll ? 1 : 0));
+                Debug.Assert(waitedCount <= _waitedObjects.Length);
+
+                Debug.Assert(_waitedCount == 0);
+
+                WaitableObject?[] waitedObjects = _waitedObjects;
+#if DEBUG
+                for (int i = 0; i < waitedCount; ++i)
+                {
+                    Debug.Assert(waitedObjects[i] != null);
+                }
+                for (int i = waitedCount; i < waitedObjects.Length; ++i)
+                {
+                    Debug.Assert(waitedObjects[i] == null);
+                }
+#endif
+
+                bool success = false;
+                WaitedListNode[] waitedListNodes;
+                try
+                {
+                    waitedListNodes = GetWaitedListNodeArray(waitedCount);
+                    success = true;
+                }
+                finally
+                {
+                    if (!success)
+                    {
+                        // Once this function is called, the caller is effectively transferring ownership of the waited objects
+                        // to this and the wait functions. On exception, clear the array.
+                        for (int i = 0; i < waitedCount; ++i)
+                        {
+                            waitedObjects[i] = null;
+                        }
+                    }
+                }
+
+                _isWaitForAll = isWaitForAll;
+                _waitedCount = waitedCount;
+                if (prioritize)
+                {
+                    for (int i = 0; i < waitedCount; ++i)
+                    {
+                        waitedListNodes[i].RegisterPrioritizedWait(waitedObjects[i]!);
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < waitedCount; ++i)
+                    {
+                        waitedListNodes[i].RegisterWait(waitedObjects[i]!);
+                    }
+                }
+            }
+
+            public void UnregisterWait()
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(_waitedCount > (_isWaitForAll ? 1 : 0));
+
+                for (int i = 0; i < _waitedCount; ++i)
+                {
+                    _waitedListNodes[i].UnregisterWait(_waitedObjects[i]!);
+                    _waitedObjects[i] = null;
+                }
+                _waitedCount = 0;
+            }
+
+            private int ProcessSignaledWaitState()
+            {
+                s_lock.VerifyIsNotLocked();
+                _waitMonitor.VerifyIsLocked();
+                Debug.Assert(_thread == Thread.CurrentThread);
+
+                switch (_waitSignalState)
+                {
+                    case WaitSignalState.Waiting:
+                    case WaitSignalState.Waiting_Interruptible:
+                        return WaitHandle.WaitTimeout;
+
+                    case WaitSignalState.NotWaiting_SignaledToSatisfyWait:
+                        {
+                            Debug.Assert(_waitedObjectIndexThatSatisfiedWait >= 0);
+                            int waitedObjectIndexThatSatisfiedWait = _waitedObjectIndexThatSatisfiedWait;
+                            _waitedObjectIndexThatSatisfiedWait = -1;
+                            return waitedObjectIndexThatSatisfiedWait;
+                        }
+
+                    case WaitSignalState.NotWaiting_SignaledToSatisfyWaitWithAbandonedMutex:
+                        {
+                            Debug.Assert(_waitedObjectIndexThatSatisfiedWait >= 0);
+                            int waitedObjectIndexThatSatisfiedWait = _waitedObjectIndexThatSatisfiedWait;
+                            _waitedObjectIndexThatSatisfiedWait = -1;
+                            return WaitHandle.WaitAbandoned + waitedObjectIndexThatSatisfiedWait;
+                        }
+
+                    case WaitSignalState.NotWaiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount:
+                        Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
+                        throw new OverflowException(SR.Overflow_MutexReacquireCount);
+
+                    default:
+                        Debug.Assert(_waitSignalState == WaitSignalState.NotWaiting_SignaledToInterruptWait);
+                        Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
+                        throw new ThreadInterruptedException();
+                }
+            }
+
+            public int Wait(int timeoutMilliseconds, bool interruptible, bool isSleep)
+            {
+                if (isSleep)
+                {
+                    s_lock.VerifyIsNotLocked();
+                }
+                else
+                {
+                    s_lock.VerifyIsLocked();
+                }
+                Debug.Assert(_thread == Thread.CurrentThread);
+
+                Debug.Assert(timeoutMilliseconds >= -1);
+                Debug.Assert(timeoutMilliseconds != 0); // caller should have taken care of it
+
+                _thread.SetWaitSleepJoinState();
+
+                // <see cref="_waitMonitor"/> must be acquired before <see cref="s_lock"/> is released, to ensure that there is
+                // no gap during which a waited object may be signaled to satisfy the wait but the thread may not yet be in a
+                // wait state to accept the signal
+                _waitMonitor.Acquire();
+                if (!isSleep)
+                {
+                    s_lock.Release();
+                }
+
+                Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
+                Debug.Assert(_waitSignalState == WaitSignalState.NotWaiting);
+
+                // A signaled state may be set only when the thread is in one of the following states
+                _waitSignalState = interruptible ? WaitSignalState.Waiting_Interruptible : WaitSignalState.Waiting;
+
+                try
+                {
+                    if (isSleep && interruptible && CheckAndResetPendingInterrupt)
+                    {
+                        throw new ThreadInterruptedException();
+                    }
+
+                    if (timeoutMilliseconds < 0)
+                    {
+                        do
+                        {
+                            _waitMonitor.Wait();
+                        } while (IsWaiting);
+
+                        int waitResult = ProcessSignaledWaitState();
+                        Debug.Assert(waitResult != WaitHandle.WaitTimeout);
+                        return waitResult;
+                    }
+
+                    int elapsedMilliseconds = 0;
+                    int startTimeMilliseconds = Environment.TickCount;
+                    while (true)
+                    {
+                        bool monitorWaitResult = _waitMonitor.Wait(timeoutMilliseconds - elapsedMilliseconds);
+
+                        // It's possible for the wait to have timed out, but before the monitor could reacquire the lock, a
+                        // signaler could have acquired it and signaled to satisfy the wait or interrupt the thread. Accept the
+                        // signal and ignore the wait timeout.
+                        int waitResult = ProcessSignaledWaitState();
+                        if (waitResult != WaitHandle.WaitTimeout)
+                        {
+                            return waitResult;
+                        }
+
+                        if (monitorWaitResult)
+                        {
+                            elapsedMilliseconds = Environment.TickCount - startTimeMilliseconds;
+                            if (elapsedMilliseconds < timeoutMilliseconds)
+                            {
+                                continue;
+                            }
+                        }
+
+                        // Timeout
+                        Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
+                        break;
+                    }
+                }
+                finally
+                {
+                    _waitSignalState = WaitSignalState.NotWaiting;
+                    _waitMonitor.Release();
+
+                    _thread.ClearWaitSleepJoinState();
+                }
+
+                // Timeout. It's ok to read <see cref="_waitedCount"/> without acquiring <see cref="s_lock"/> here, because it
+                // is initially set by this thread, and another thread cannot unregister this thread's wait without first
+                // signaling this thread, in which case this thread wouldn't be timing out.
+                Debug.Assert(isSleep == (_waitedCount == 0));
+                if (!isSleep)
+                {
+                    s_lock.Acquire();
+                    UnregisterWait();
+                    s_lock.Release();
+                }
+                return WaitHandle.WaitTimeout;
+            }
+
+            public static void UninterruptibleSleep0()
+            {
+                s_lock.VerifyIsNotLocked();
+
+                // On Unix, a thread waits on a condition variable. The timeout time will have already elapsed at the time
+                // of the call. The documentation does not state whether the thread yields or does nothing before returning
+                // an error, and in some cases, suggests that doing nothing is acceptable. The behavior could also be
+                // different between distributions. Yield directly here.
+                Thread.Yield();
+            }
+
+            public static void Sleep(int timeoutMilliseconds, bool interruptible)
+            {
+                s_lock.VerifyIsNotLocked();
+                Debug.Assert(timeoutMilliseconds >= -1);
+
+                if (timeoutMilliseconds == 0)
+                {
+                    if (interruptible && Thread.CurrentThread._waitInfo.CheckAndResetPendingInterrupt_NotLocked)
+                    {
+                        throw new ThreadInterruptedException();
+                    }
+
+                    UninterruptibleSleep0();
+                    return;
+                }
+
+                int waitResult =
+                    Thread
+                        .CurrentThread
+                        ._waitInfo
+                        .Wait(timeoutMilliseconds, interruptible, isSleep: true);
+                Debug.Assert(waitResult == WaitHandle.WaitTimeout);
+            }
+
+            public bool TrySignalToSatisfyWait(WaitedListNode registeredListNode, bool isAbandonedMutex)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(_thread != Thread.CurrentThread);
+
+                Debug.Assert(registeredListNode != null);
+                Debug.Assert(registeredListNode.WaitInfo == this);
+                Debug.Assert(registeredListNode.WaitedObjectIndex >= 0);
+                Debug.Assert(registeredListNode.WaitedObjectIndex < _waitedCount);
+
+                Debug.Assert(_waitedCount > (_isWaitForAll ? 1 : 0));
+
+                int signaledWaitedObjectIndex = registeredListNode.WaitedObjectIndex;
+                bool isWaitForAll = _isWaitForAll;
+                bool wouldAnyMutexReacquireCountOverflow = false;
+                if (isWaitForAll)
+                {
+                    // Determine if all waits would be satisfied
+                    if (!WaitableObject.WouldWaitForAllBeSatisfiedOrAborted(
+                            _thread,
+                            _waitedObjects,
+                            _waitedCount,
+                            signaledWaitedObjectIndex,
+                            ref wouldAnyMutexReacquireCountOverflow,
+                            ref isAbandonedMutex))
+                    {
+                        return false;
+                    }
+                }
+
+                // The wait would be satisfied. Before making changes to satisfy the wait, acquire the monitor and verify that
+                // the thread can accept a signal.
+                _waitMonitor.Acquire();
+
+                if (!IsWaiting)
+                {
+                    _waitMonitor.Release();
+                    return false;
+                }
+
+                if (isWaitForAll && !wouldAnyMutexReacquireCountOverflow)
+                {
+                    // All waits would be satisfied, accept the signals
+                    WaitableObject.SatisfyWaitForAll(this, _waitedObjects, _waitedCount, signaledWaitedObjectIndex);
+                }
+
+                UnregisterWait();
+
+                Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
+                if (wouldAnyMutexReacquireCountOverflow)
+                {
+                    _waitSignalState = WaitSignalState.NotWaiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount;
+                }
+                else
+                {
+                    _waitedObjectIndexThatSatisfiedWait = signaledWaitedObjectIndex;
+                    _waitSignalState =
+                        isAbandonedMutex
+                            ? WaitSignalState.NotWaiting_SignaledToSatisfyWaitWithAbandonedMutex
+                            : WaitSignalState.NotWaiting_SignaledToSatisfyWait;
+                }
+
+                _waitMonitor.Signal_Release();
+                return !wouldAnyMutexReacquireCountOverflow;
+            }
+
+            public void TrySignalToInterruptWaitOrRecordPendingInterrupt()
+            {
+                s_lock.VerifyIsLocked();
+
+                _waitMonitor.Acquire();
+
+                if (_waitSignalState != WaitSignalState.Waiting_Interruptible)
+                {
+                    RecordPendingInterrupt();
+                    _waitMonitor.Release();
+                    return;
+                }
+
+                if (_waitedCount != 0)
+                {
+                    UnregisterWait();
+                }
+
+                Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
+                _waitSignalState = WaitSignalState.NotWaiting_SignaledToInterruptWait;
+
+                _waitMonitor.Signal_Release();
+            }
+
+            private void RecordPendingInterrupt()
+            {
+                s_lock.VerifyIsLocked();
+                _waitMonitor.VerifyIsLocked();
+
+                _isPendingInterrupt = 1;
+            }
+
+            public bool CheckAndResetPendingInterrupt
+            {
+                get
+                {
+#if DEBUG
+                    Debug.Assert(s_lock.IsLocked || _waitMonitor.IsLocked);
+#endif
+
+                    if (_isPendingInterrupt == 0)
+                    {
+                        return false;
+                    }
+                    _isPendingInterrupt = 0;
+                    return true;
+                }
+            }
+
+            private bool CheckAndResetPendingInterrupt_NotLocked
+            {
+                get
+                {
+                    s_lock.VerifyIsNotLocked();
+                    _waitMonitor.VerifyIsNotLocked();
+
+                    return Interlocked.CompareExchange(ref _isPendingInterrupt, 0, 1) != 0;
+                }
+            }
+
+            public WaitableObject? LockedMutexesHead
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+                    return _lockedMutexesHead;
+                }
+                set
+                {
+                    s_lock.VerifyIsLocked();
+                    _lockedMutexesHead = value;
+                }
+            }
+
+            public void OnThreadExiting()
+            {
+                // Abandon locked mutexes. Acquired mutexes are prepended to the linked list, so the mutexes are abandoned in
+                // last-acquired-first-abandoned order.
+                s_lock.Acquire();
+                try
+                {
+                    while (true)
+                    {
+                        WaitableObject? waitableObject = LockedMutexesHead;
+                        if (waitableObject == null)
+                        {
+                            break;
+                        }
+
+                        waitableObject.AbandonMutex();
+                        Debug.Assert(LockedMutexesHead != waitableObject);
+                    }
+                }
+                finally
+                {
+                    s_lock.Release();
+                }
+            }
+
+            public sealed class WaitedListNode
+            {
+                /// <summary>
+                /// For <see cref="WaitedListNode"/>s registered with <see cref="WaitableObject"/>s, this provides information
+                /// about the thread that is waiting and the <see cref="WaitableObject"/>s it is waiting upon
+                /// </summary>
+                private readonly ThreadWaitInfo _waitInfo;
+
+                /// <summary>
+                /// Index of the waited object corresponding to this node
+                /// </summary>
+                private readonly int _waitedObjectIndex;
+
+                /// <summary>
+                /// Link in the <see cref="WaitableObject.WaitersHead"/> linked list
+                /// </summary>
+                private WaitedListNode? _previous, _next;
+
+                public WaitedListNode(ThreadWaitInfo waitInfo, int waitedObjectIndex)
+                {
+                    Debug.Assert(waitInfo != null);
+                    Debug.Assert(waitedObjectIndex >= 0);
+                    Debug.Assert(waitedObjectIndex < WaitHandle.MaxWaitHandles);
+
+                    _waitInfo = waitInfo;
+                    _waitedObjectIndex = waitedObjectIndex;
+                }
+
+                public ThreadWaitInfo WaitInfo
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+                        return _waitInfo;
+                    }
+                }
+
+                public int WaitedObjectIndex
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+                        return _waitedObjectIndex;
+                    }
+                }
+
+                public WaitedListNode? Previous
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+                        return _previous;
+                    }
+                }
+
+                public WaitedListNode? Next
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+                        return _next;
+                    }
+                }
+
+                public void RegisterWait(WaitableObject waitableObject)
+                {
+                    s_lock.VerifyIsLocked();
+                    Debug.Assert(_waitInfo.Thread == Thread.CurrentThread);
+
+                    Debug.Assert(waitableObject != null);
+
+                    Debug.Assert(_previous == null);
+                    Debug.Assert(_next == null);
+
+                    WaitedListNode? tail = waitableObject.WaitersTail;
+                    if (tail != null)
+                    {
+                        _previous = tail;
+                        tail._next = this;
+                    }
+                    else
+                    {
+                        waitableObject.WaitersHead = this;
+                    }
+                    waitableObject.WaitersTail = this;
+                }
+
+                public void RegisterPrioritizedWait(WaitableObject waitableObject)
+                {
+                    s_lock.VerifyIsLocked();
+                    Debug.Assert(_waitInfo.Thread == Thread.CurrentThread);
+
+                    Debug.Assert(waitableObject != null);
+
+                    Debug.Assert(_previous == null);
+                    Debug.Assert(_next == null);
+
+                    WaitedListNode? head = waitableObject.WaitersHead;
+                    if (head != null)
+                    {
+                        _next = head;
+                        head._previous = this;
+                    }
+                    else
+                    {
+                        waitableObject.WaitersTail = this;
+                    }
+                    waitableObject.WaitersHead = this;
+                }
+
+                public void UnregisterWait(WaitableObject waitableObject)
+                {
+                    s_lock.VerifyIsLocked();
+                    Debug.Assert(waitableObject != null);
+
+                    WaitedListNode? previous = _previous;
+                    WaitedListNode? next = _next;
+
+                    if (previous != null)
+                    {
+                        previous._next = next;
+                        _previous = null;
+                    }
+                    else
+                    {
+                        Debug.Assert(waitableObject.WaitersHead == this);
+                        waitableObject.WaitersHead = next;
+                    }
+
+                    if (next != null)
+                    {
+                        next._previous = previous;
+                        _next = null;
+                    }
+                    else
+                    {
+                        Debug.Assert(waitableObject.WaitersTail == this);
+                        waitableObject.WaitersTail = previous;
+                    }
+                }
+            }
+
+            private enum WaitSignalState : byte
+            {
+                Waiting,
+                Waiting_Interruptible,
+                NotWaiting,
+                NotWaiting_SignaledToSatisfyWait,
+                NotWaiting_SignaledToSatisfyWaitWithAbandonedMutex,
+                NotWaiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount,
+                NotWaiting_SignaledToInterruptWait
+            }
+        }
+    }
+}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -1,0 +1,426 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Threading
+{
+    /// # Wait subsystem
+    ///
+    /// ## Types
+    ///
+    /// <see cref="WaitSubsystem"/>
+    ///   - Static API surface for dealing with synchronization objects that support multi-wait, and to put a thread into a wait
+    ///     state, on Unix
+    ///   - Any interaction with the wait subsystem from outside should go through APIs on this class, and should not directly
+    ///     go through any of the nested classes
+    ///
+    /// <see cref="WaitableObject"/>
+    ///   - An object that supports the features of <see cref="EventWaitHandle"/>, <see cref="Semaphore"/>, and
+    ///     <see cref="Mutex"/>. The handle of each of those classes is associated with a <see cref="WaitableObject"/>.
+    ///
+    /// <see cref="ThreadWaitInfo"/>
+    ///   - Keeps information about a thread's wait and provides functionlity to put a thread into a wait state and to take it
+    ///     out of a wait state. Each thread has an instance available through <see cref="Thread._waitInfo"/>.
+    ///
+    /// <see cref="HandleManager"/>
+    ///   - Provides functionality to allocate a handle associated with a <see cref="WaitableObject"/>, to retrieve the object
+    ///     from a handle, and to delete a handle.
+    ///
+    /// <see cref="LowLevelLock"/> and <see cref="LowLevelMonitor"/>
+    ///   - These are "low level" in the sense they don't depend on this wait subsystem, and any waits done are not
+    ///     interruptible
+    ///   - <see cref="LowLevelLock"/> is used for the process-wide lock <see cref="s_lock"/>
+    ///   - <see cref="LowLevelMonitor"/> is the main system dependency of the wait subsystem, and all waits are done through
+    ///     it. It is backed by a C++ equivalent in CoreLib.Native's pal_threading.*, which wraps a pthread mutex/condition
+    ///     pair. Each thread has an instance in <see cref="ThreadWaitInfo._waitMonitor"/>, which is used to synchronize the
+    ///     thread's wait state and for waiting. <see cref="LowLevelLock"/> also uses an instance of
+    ///     <see cref="LowLevelMonitor"/> for waiting.
+    ///
+    /// ## Design goals
+    ///
+    /// Behave similarly to wait operations on Windows
+    ///   - The design is similar to the one used by CoreCLR's PAL, but much simpler due to there being no need for supporting
+    ///     process/thread waits, or cross-process multi-waits (which CoreCLR also does not support but there are many design
+    ///     elements specific to it)
+    ///   - Waiting
+    ///     - A waiter keeps an array of objects on which it is waiting (see <see cref="ThreadWaitInfo._waitedObjects"/>).
+    ///     - The waiter registers a <see cref="ThreadWaitInfo.WaitedListNode"/> with each <see cref="WaitableObject"/>
+    ///     - The waiter waits on its own <see cref="ThreadWaitInfo._waitMonitor"/> to go into a wait state
+    ///     - Upon timeout, the waiter unregisters the wait and continues
+    ///   - Sleeping
+    ///     - Sleeping is just another way of waiting, only there would not be any waited objects
+    ///   - Signaling
+    ///     - A signaler iterates over waiters and tries to release waiters based on the signal count
+    ///     - For each waiter, the signaler checks if the waiter's wait can be terminated
+    ///     - When a waiter's wait can be terminated, the signaler does everything necesary before waking the waiter, such that
+    ///       the waiter can simply continue after awakening, including unregistering the wait and assigning ownership if
+    ///       applicable
+    ///   - Interrupting
+    ///     - Interrupting is just another way of signaling a waiting thread. The interrupter unregisters the wait and wakes the
+    ///       waiter.
+    ///   - Wait release fairness
+    ///     - As mentioned above in how signaling works, waiters are released in fair order (first come, first served)
+    ///     - This is mostly done to match the behavior of synchronization objects in Windows, which are also fair
+    ///     - Events have an implicit requirement to be fair
+    ///       - For a <see cref="ManualResetEvent"/>, Set/Reset in quick succession requires that it wakes up all waiters,
+    ///         implying that the design cannot be to signal a thread to wake and have it check the state when it awakens some
+    ///         time in the future
+    ///       - For an <see cref="AutoResetEvent"/>, Set/Set in quick succession requires that it wakes up two threads, implying
+    ///         that a Set/Wait in quick succession cannot have the calling thread accept its own signal if there is a waiter
+    ///     - There is an advantage to being fair, as it guarantees that threads are only awakened when necessary. That is, a
+    ///       thread will never wake up and find that it has to go back to sleep because the wait is not satisfied (except due
+    ///       to spurious wakeups caused by external factors).
+    ///   - Synchronization
+    ///     - A process-wide lock <see cref="s_lock"/> is used to synchronize most operations and the signal state of all
+    ///       <see cref="WaitableObject"/>s in the process. Given that it is recommended to use alternative synchronization
+    ///       types (<see cref="ManualResetEventSlim"/>, <see cref="SemaphoreSlim"/>, <see cref="Monitor"/>) for single-wait
+    ///       cases, it is probably not worth optimizing for the single-wait case. It is possible with a small design change to
+    ///       bypass the lock and use interlocked operations for uncontended cases, but at the cost of making multi-waits more
+    ///       complicated and slower.
+    ///     - The wait state of a thread (<see cref="ThreadWaitInfo._waitSignalState"/>), among other things, is synchornized
+    ///       using the thread's <see cref="ThreadWaitInfo._waitMonitor"/>, so signalers and interrupters acquire the monitor's
+    ///       lock before checking the wait state of a thread and signaling the thread to wake up.
+    ///
+    /// Self-consistent in the event of any exception
+    ///   - Try/finally is used extensively, including around any operation that could fail due to out-of-memory
+    ///
+    /// Decent balance between memory usage and performance
+    ///   - <see cref="WaitableObject"/> is intended to be as small as possible while avoiding virtual calls and casts
+    ///   - As <see cref="Mutex"/> is not commonly used and requires more state, some of its state is separated into
+    ///     <see cref="WaitableObject._ownershipInfo"/>
+    ///   - When support for cross-process objects is added, the current thought is to have an <see cref="object"/> field that
+    ///     is used for both cross-process state and ownership state.
+    ///
+    /// No allocation in typical cases of any operation except where necessary
+    ///   - Since the maximum number of wait handles for a multi-wait operation is limited to
+    ///     <see cref="WaitHandle.MaxWaitHandles"/>, arrays necessary for holding information about a multi-wait, and list nodes
+    ///     necessary for registering a wait, are precreated with a low initial capacity that covers most typical cases
+    ///   - Threads track owned mutexes by linking the <see cref="WaitableObject.OwnershipInfo"/> instance into a linked list
+    ///     <see cref="ThreadWaitInfo.LockedMutexesHead"/>. <see cref="WaitableObject.OwnershipInfo"/> is itself a list node,
+    ///     and is created along with the mutex <see cref="WaitableObject"/>.
+    ///
+    /// Minimal p/invokes in typical uncontended cases
+    ///   - <see cref="HandleManager"/> currently uses <see cref="Runtime.InteropServices.GCHandle"/> in the interest of
+    ///     simplicity, which p/invokes and does a cast to get the <see cref="WaitableObject"/> from a handle
+    ///   - Most of the wait subsystem is written in C#, so there is no initially required p/invoke
+    ///   - <see cref="LowLevelLock"/>, used by the process-wide lock <see cref="s_lock"/>, uses interlocked operations to
+    ///     acquire and release the lock when there is no need to wait or to release a waiter. This is significantly faster than
+    ///     using <see cref="LowLevelMonitor"/> as a lock, which uses pthread mutex functionality through p/invoke. The lock is
+    ///     typically not held for very long, especially since allocations inside the lock will be rare.
+    ///   - Since <see cref="s_lock"/> provides mutual exclusion for the states of all <see cref="WaitableObject"/>s in the
+    ///     process, any operation that does not involve waiting or releasing a wait can occur with minimal p/invokes
+    ///
+#if CORERT
+    [EagerStaticClassConstruction] // the wait subsystem is used during lazy class construction
+#endif
+    internal static partial class WaitSubsystem
+    {
+        private static readonly LowLevelLock s_lock = new LowLevelLock();
+
+        private static SafeWaitHandle NewHandle(WaitableObject waitableObject)
+        {
+            IntPtr handle = HandleManager.NewHandle(waitableObject);
+            SafeWaitHandle? safeWaitHandle = null;
+            try
+            {
+                safeWaitHandle = new SafeWaitHandle(handle, ownsHandle: true);
+                return safeWaitHandle;
+            }
+            finally
+            {
+                if (safeWaitHandle == null)
+                {
+                    HandleManager.DeleteHandle(handle);
+                }
+            }
+        }
+
+        public static SafeWaitHandle NewEvent(bool initiallySignaled, EventResetMode resetMode)
+        {
+            return NewHandle(WaitableObject.NewEvent(initiallySignaled, resetMode));
+        }
+
+        public static SafeWaitHandle NewSemaphore(int initialSignalCount, int maximumSignalCount)
+        {
+            return NewHandle(WaitableObject.NewSemaphore(initialSignalCount, maximumSignalCount));
+        }
+
+        public static SafeWaitHandle NewMutex(bool initiallyOwned)
+        {
+            WaitableObject waitableObject = WaitableObject.NewMutex();
+            SafeWaitHandle safeWaitHandle = NewHandle(waitableObject);
+            if (!initiallyOwned)
+            {
+                return safeWaitHandle;
+            }
+
+            // Acquire the mutex. A thread's <see cref="ThreadWaitInfo"/> has a reference to all <see cref="Mutex"/>es locked
+            // by the thread. See <see cref="ThreadWaitInfo.LockedMutexesHead"/>. So, acquire the lock only after all
+            // possibilities for exceptions have been exhausted.
+            ThreadWaitInfo waitInfo = Thread.CurrentThread._waitInfo;
+            bool acquiredLock = waitableObject.Wait(waitInfo, timeoutMilliseconds: 0, interruptible: false, prioritize: false) == 0;
+            Debug.Assert(acquiredLock);
+            return safeWaitHandle;
+        }
+
+        public static void DeleteHandle(IntPtr handle)
+        {
+            HandleManager.DeleteHandle(handle);
+        }
+
+        public static void SetEvent(IntPtr handle)
+        {
+            SetEvent(HandleManager.FromHandle(handle));
+        }
+
+        public static void SetEvent(WaitableObject waitableObject)
+        {
+            Debug.Assert(waitableObject != null);
+
+            s_lock.Acquire();
+            try
+            {
+                waitableObject.SignalEvent();
+            }
+            finally
+            {
+                s_lock.Release();
+            }
+        }
+
+        public static void ResetEvent(IntPtr handle)
+        {
+            ResetEvent(HandleManager.FromHandle(handle));
+        }
+
+        public static void ResetEvent(WaitableObject waitableObject)
+        {
+            Debug.Assert(waitableObject != null);
+
+            s_lock.Acquire();
+            try
+            {
+                waitableObject.UnsignalEvent();
+            }
+            finally
+            {
+                s_lock.Release();
+            }
+        }
+
+        public static int ReleaseSemaphore(IntPtr handle, int count)
+        {
+            Debug.Assert(count > 0);
+            return ReleaseSemaphore(HandleManager.FromHandle(handle), count);
+        }
+
+        public static int ReleaseSemaphore(WaitableObject waitableObject, int count)
+        {
+            Debug.Assert(waitableObject != null);
+            Debug.Assert(count > 0);
+
+            s_lock.Acquire();
+            try
+            {
+                return waitableObject.SignalSemaphore(count);
+            }
+            finally
+            {
+                s_lock.Release();
+            }
+        }
+
+        public static void ReleaseMutex(IntPtr handle)
+        {
+            ReleaseMutex(HandleManager.FromHandle(handle));
+        }
+
+        public static void ReleaseMutex(WaitableObject waitableObject)
+        {
+            Debug.Assert(waitableObject != null);
+
+            s_lock.Acquire();
+            try
+            {
+                waitableObject.SignalMutex();
+            }
+            finally
+            {
+                s_lock.Release();
+            }
+        }
+
+        public static int Wait(IntPtr handle, int timeoutMilliseconds, bool interruptible)
+        {
+            Debug.Assert(timeoutMilliseconds >= -1);
+            return Wait(HandleManager.FromHandle(handle), timeoutMilliseconds, interruptible);
+        }
+
+        public static int Wait(
+            WaitableObject waitableObject,
+            int timeoutMilliseconds,
+            bool interruptible = true,
+            bool prioritize = false)
+        {
+            Debug.Assert(waitableObject != null);
+            Debug.Assert(timeoutMilliseconds >= -1);
+
+            return waitableObject.Wait(Thread.CurrentThread._waitInfo, timeoutMilliseconds, interruptible, prioritize);
+        }
+
+        public static int Wait(
+            Span<IntPtr> waitHandles,
+            bool waitForAll,
+            int timeoutMilliseconds)
+        {
+            Debug.Assert(waitHandles != null);
+            Debug.Assert(waitHandles.Length > 0);
+            Debug.Assert(waitHandles.Length <= WaitHandle.MaxWaitHandles);
+            Debug.Assert(timeoutMilliseconds >= -1);
+
+            ThreadWaitInfo waitInfo = Thread.CurrentThread._waitInfo;
+            WaitableObject?[] waitableObjects = waitInfo.GetWaitedObjectArray(waitHandles.Length);
+            bool success = false;
+            try
+            {
+                for (int i = 0; i < waitHandles.Length; ++i)
+                {
+                    Debug.Assert(waitHandles[i] != IntPtr.Zero);
+                    WaitableObject waitableObject = HandleManager.FromHandle(waitHandles[i]);
+                    if (waitForAll)
+                    {
+                        // Check if this is a duplicate, as wait-for-all does not support duplicates. Including the parent
+                        // loop, this becomes a brute force O(n^2) search, which is intended since the typical array length is
+                        // short enough that this would actually be faster than other alternatives. Also, the worst case is not
+                        // so bad considering that the array length is limited by <see cref="WaitHandle.MaxWaitHandles"/>.
+                        for (int j = 0; j < i; ++j)
+                        {
+                            if (waitableObject == waitableObjects[j])
+                            {
+                                throw new DuplicateWaitObjectException("waitHandles[" + i + ']');
+                            }
+                        }
+                    }
+
+                    waitableObjects[i] = waitableObject;
+                }
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    for (int i = 0; i < waitHandles.Length; ++i)
+                    {
+                        waitableObjects[i] = null;
+                    }
+                }
+            }
+
+            if (waitHandles.Length == 1)
+            {
+                WaitableObject waitableObject = waitableObjects[0]!;
+                waitableObjects[0] = null;
+                return
+                    waitableObject.Wait(waitInfo, timeoutMilliseconds, interruptible: true, prioritize : false);
+            }
+
+            return
+                WaitableObject.Wait(
+                    waitableObjects,
+                    waitHandles.Length,
+                    waitForAll,
+                    waitInfo,
+                    timeoutMilliseconds,
+                    interruptible: true,
+                    prioritize: false);
+        }
+
+        public static int SignalAndWait(
+            IntPtr handleToSignal,
+            IntPtr handleToWaitOn,
+            int timeoutMilliseconds)
+        {
+            Debug.Assert(timeoutMilliseconds >= -1);
+
+            return
+                SignalAndWait(
+                    HandleManager.FromHandle(handleToSignal),
+                    HandleManager.FromHandle(handleToWaitOn),
+                    timeoutMilliseconds);
+        }
+
+        public static int SignalAndWait(
+            WaitableObject waitableObjectToSignal,
+            WaitableObject waitableObjectToWaitOn,
+            int timeoutMilliseconds,
+            bool interruptible = true,
+            bool prioritize = false)
+        {
+            Debug.Assert(waitableObjectToSignal != null);
+            Debug.Assert(waitableObjectToWaitOn != null);
+            Debug.Assert(timeoutMilliseconds >= -1);
+
+            ThreadWaitInfo waitInfo = Thread.CurrentThread._waitInfo;
+            bool waitCalled = false;
+            s_lock.Acquire();
+            try
+            {
+                // A pending interrupt does not signal the specified handle
+                if (interruptible && waitInfo.CheckAndResetPendingInterrupt)
+                {
+                    throw new ThreadInterruptedException();
+                }
+
+                waitableObjectToSignal.Signal(1);
+                waitCalled = true;
+                return waitableObjectToWaitOn.Wait_Locked(waitInfo, timeoutMilliseconds, interruptible, prioritize);
+            }
+            finally
+            {
+                // Once the wait function is called, it will release the lock
+                if (waitCalled)
+                {
+                    s_lock.VerifyIsNotLocked();
+                }
+                else
+                {
+                    s_lock.Release();
+                }
+            }
+        }
+
+        public static void UninterruptibleSleep0()
+        {
+            ThreadWaitInfo.UninterruptibleSleep0();
+        }
+
+        public static void Sleep(int timeoutMilliseconds, bool interruptible = true)
+        {
+            ThreadWaitInfo.Sleep(timeoutMilliseconds, interruptible);
+        }
+
+        public static void Interrupt(Thread thread)
+        {
+            Debug.Assert(thread != null);
+
+            s_lock.Acquire();
+            try
+            {
+                thread._waitInfo.TrySignalToInterruptWaitOrRecordPendingInterrupt();
+            }
+            finally
+            {
+                s_lock.Release();
+            }
+        }
+
+        public static void OnThreadExiting(Thread thread)
+        {
+            thread._waitInfo.OnThreadExiting();
+        }
+    }
+}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
@@ -1,0 +1,914 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Threading
+{
+    internal static partial class WaitSubsystem
+    {
+        /// <summary>
+        /// A synchronization object that can participate in <see cref="WaitSubsystem"/>'s wait operations.
+        ///
+        /// Used by the wait subsystem on Unix, so this class cannot have any dependencies on the wait subsystem.
+        /// </summary>
+        public sealed class WaitableObject
+        {
+            private readonly WaitableObjectType _type;
+            private int _signalCount;
+            private readonly int _maximumSignalCount;
+
+            /// <summary>
+            /// Only <see cref="Mutex"/> has a thread ownership requirement, and it's a less common type to be used, so
+            /// ownership info is separated to reduce the size. For other types, this is null.
+            /// </summary>
+            private readonly OwnershipInfo? _ownershipInfo;
+
+            /// <summary>
+            /// Linked list of information about waiting threads
+            /// </summary>
+            private ThreadWaitInfo.WaitedListNode? _waitersHead, _waitersTail;
+
+            private WaitableObject(
+                WaitableObjectType type,
+                int initialSignalCount,
+                int maximumSignalCount,
+                OwnershipInfo? ownershipInfo)
+            {
+                Debug.Assert(initialSignalCount >= 0);
+                Debug.Assert(maximumSignalCount > 0);
+                Debug.Assert(initialSignalCount <= maximumSignalCount);
+
+                _type = type;
+                _signalCount = initialSignalCount;
+                _maximumSignalCount = maximumSignalCount;
+                _ownershipInfo = ownershipInfo;
+            }
+
+            public static WaitableObject NewEvent(bool initiallySignaled, EventResetMode resetMode)
+            {
+                Debug.Assert((resetMode == EventResetMode.AutoReset) || (resetMode == EventResetMode.ManualReset));
+
+                return
+                    new WaitableObject(
+                        resetMode == EventResetMode.ManualReset
+                            ? WaitableObjectType.ManualResetEvent
+                            : WaitableObjectType.AutoResetEvent,
+                        initiallySignaled ? 1 : 0,
+                        1,
+                        null);
+            }
+
+            public static WaitableObject NewSemaphore(int initialSignalCount, int maximumSignalCount)
+            {
+                return new WaitableObject(WaitableObjectType.Semaphore, initialSignalCount, maximumSignalCount, null);
+            }
+
+            public static WaitableObject NewMutex()
+            {
+                return new WaitableObject(WaitableObjectType.Mutex, 1, 1, new OwnershipInfo());
+            }
+
+            public void OnDeleteHandle()
+            {
+                s_lock.Acquire();
+                try
+                {
+                    if (IsMutex && !IsSignaled)
+                    {
+                        // A thread has a reference to all <see cref="Mutex"/>es locked by it, see
+                        // <see cref="ThreadWaitInfo.LockedMutexesHead"/>. Abandon the mutex to remove the reference to it.
+                        AbandonMutex();
+                    }
+                }
+                finally
+                {
+                    s_lock.Release();
+                }
+            }
+
+            private bool IsEvent
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+
+                    bool result = _type <= WaitableObjectType.AutoResetEvent;
+                    Debug.Assert(!result || _maximumSignalCount == 1);
+                    Debug.Assert(!result || _ownershipInfo == null);
+                    return result;
+                }
+            }
+
+            private bool IsManualResetEvent
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+
+                    bool result = _type == WaitableObjectType.ManualResetEvent;
+                    Debug.Assert(!result || _maximumSignalCount == 1);
+                    Debug.Assert(!result || _ownershipInfo == null);
+                    return result;
+                }
+            }
+
+            private bool IsAutoResetEvent
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+
+                    bool result = _type == WaitableObjectType.AutoResetEvent;
+                    Debug.Assert(!result || _maximumSignalCount == 1);
+                    Debug.Assert(!result || _ownershipInfo == null);
+                    return result;
+                }
+            }
+
+            private bool IsSemaphore
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+
+                    bool result = _type == WaitableObjectType.Semaphore;
+                    Debug.Assert(!result || _maximumSignalCount > 0);
+                    Debug.Assert(!result || _ownershipInfo == null);
+                    return result;
+                }
+            }
+
+            private bool IsMutex
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+
+                    bool result = _type == WaitableObjectType.Mutex;
+                    Debug.Assert(!result || _maximumSignalCount == 1);
+                    Debug.Assert(!result || _ownershipInfo != null);
+                    return result;
+                }
+            }
+
+            private bool IsAbandonedMutex
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+                    return IsMutex && _ownershipInfo != null && _ownershipInfo.IsAbandoned;
+                }
+            }
+
+            public ThreadWaitInfo.WaitedListNode? WaitersHead
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+                    return _waitersHead;
+                }
+                set
+                {
+                    s_lock.VerifyIsLocked();
+                    _waitersHead = value;
+                }
+            }
+
+            public ThreadWaitInfo.WaitedListNode? WaitersTail
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+                    return _waitersTail;
+                }
+                set
+                {
+                    s_lock.VerifyIsLocked();
+                    _waitersTail = value;
+                }
+            }
+
+            private bool IsSignaled
+            {
+                get
+                {
+                    s_lock.VerifyIsLocked();
+
+                    bool isSignaled = _signalCount != 0;
+                    Debug.Assert(isSignaled || !IsMutex || (_ownershipInfo != null && _ownershipInfo.Thread != null));
+                    return isSignaled;
+                }
+            }
+
+            private void AcceptSignal(ThreadWaitInfo waitInfo)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(IsSignaled);
+
+                switch (_type)
+                {
+                    case WaitableObjectType.ManualResetEvent:
+                        return;
+
+                    case WaitableObjectType.AutoResetEvent:
+                    case WaitableObjectType.Semaphore:
+                        --_signalCount;
+                        return;
+
+                    default:
+                        Debug.Assert(_type == WaitableObjectType.Mutex);
+                        --_signalCount;
+
+                        Debug.Assert(_ownershipInfo!.Thread == null);
+                        _ownershipInfo!.AssignOwnership(this, waitInfo);
+                        return;
+                }
+            }
+
+            public int Wait(ThreadWaitInfo waitInfo, int timeoutMilliseconds, bool interruptible, bool prioritize)
+            {
+                Debug.Assert(waitInfo != null);
+                Debug.Assert(waitInfo.Thread == Thread.CurrentThread);
+
+                Debug.Assert(timeoutMilliseconds >= -1);
+
+                s_lock.Acquire();
+
+                if (interruptible && waitInfo.CheckAndResetPendingInterrupt)
+                {
+                    s_lock.Release();
+                    throw new ThreadInterruptedException();
+                }
+
+                return Wait_Locked(waitInfo, timeoutMilliseconds, interruptible, prioritize);
+            }
+
+            /// <summary>
+            /// This function does not check for a pending thread interrupt. Callers are expected to do that soon after
+            /// acquiring <see cref="s_lock"/>.
+            /// </summary>
+            public int Wait_Locked(ThreadWaitInfo waitInfo, int timeoutMilliseconds, bool interruptible, bool prioritize)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(waitInfo != null);
+                Debug.Assert(waitInfo.Thread == Thread.CurrentThread);
+
+                Debug.Assert(timeoutMilliseconds >= -1);
+                Debug.Assert(!interruptible || !waitInfo.CheckAndResetPendingInterrupt);
+
+                bool needToWait = false;
+                try
+                {
+                    if (IsSignaled)
+                    {
+                        bool isAbandoned = IsAbandonedMutex;
+                        AcceptSignal(waitInfo);
+                        return isAbandoned ? WaitHandle.WaitAbandoned : WaitHandle.WaitSuccess;
+                    }
+
+                    if (IsMutex && _ownershipInfo != null && _ownershipInfo.Thread == waitInfo.Thread)
+                    {
+                        if (!_ownershipInfo.CanIncrementReacquireCount)
+                        {
+                            throw new OverflowException(SR.Overflow_MutexReacquireCount);
+                        }
+                        _ownershipInfo.IncrementReacquireCount();
+                        return WaitHandle.WaitSuccess;
+                    }
+
+                    if (timeoutMilliseconds == 0)
+                    {
+                        return WaitHandle.WaitTimeout;
+                    }
+
+                    WaitableObject?[] waitableObjects = waitInfo.GetWaitedObjectArray(1);
+                    waitableObjects[0] = this;
+                    waitInfo.RegisterWait(1, prioritize, isWaitForAll: false);
+                    needToWait = true;
+                }
+                finally
+                {
+                    // Once the wait function is called, it will release the lock
+                    if (!needToWait)
+                    {
+                        s_lock.Release();
+                    }
+                }
+
+                return
+                    waitInfo.Wait(
+                        timeoutMilliseconds,
+                        interruptible,
+                        isSleep: false);
+            }
+
+            public static int Wait(
+                WaitableObject?[]? waitableObjects,
+                int count,
+                bool waitForAll,
+                ThreadWaitInfo waitInfo,
+                int timeoutMilliseconds,
+                bool interruptible,
+                bool prioritize)
+            {
+                s_lock.VerifyIsNotLocked();
+                Debug.Assert(waitInfo != null);
+                Debug.Assert(waitInfo.Thread == Thread.CurrentThread);
+
+                Debug.Assert(waitableObjects != null);
+                Debug.Assert(waitableObjects.Length >= count);
+                Debug.Assert(count > 1);
+                Debug.Assert(timeoutMilliseconds >= -1);
+
+                bool needToWait = false;
+                s_lock.Acquire();
+                try
+                {
+                    if (interruptible && waitInfo.CheckAndResetPendingInterrupt)
+                    {
+                        throw new ThreadInterruptedException();
+                    }
+
+                    if (!waitForAll)
+                    {
+                        // Check if any is already signaled
+                        for (int i = 0; i < count; ++i)
+                        {
+                            WaitableObject waitableObject = waitableObjects[i]!;
+                            Debug.Assert(waitableObject != null);
+
+                            if (waitableObject.IsSignaled)
+                            {
+                                bool isAbandoned = waitableObject.IsAbandonedMutex;
+                                waitableObject.AcceptSignal(waitInfo);
+                                if (isAbandoned)
+                                {
+                                    return WaitHandle.WaitAbandoned + i;
+                                }
+                                return WaitHandle.WaitSuccess + i;
+                            }
+
+                            if (waitableObject.IsMutex)
+                            {
+                                OwnershipInfo ownershipInfo = waitableObject._ownershipInfo!;
+                                if (ownershipInfo.Thread == waitInfo.Thread)
+                                {
+                                    if (!ownershipInfo.CanIncrementReacquireCount)
+                                    {
+                                        throw new OverflowException(SR.Overflow_MutexReacquireCount);
+                                    }
+                                    ownershipInfo.IncrementReacquireCount();
+                                    return WaitHandle.WaitSuccess + i;
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Check if all are already signaled
+                        bool areAllSignaled = true;
+                        bool isAnyAbandonedMutex = false;
+                        for (int i = 0; i < count; ++i)
+                        {
+                            WaitableObject waitableObject = waitableObjects[i]!;
+                            Debug.Assert(waitableObject != null);
+
+                            if (waitableObject.IsSignaled)
+                            {
+                                if (!isAnyAbandonedMutex && waitableObject.IsAbandonedMutex)
+                                {
+                                    isAnyAbandonedMutex = true;
+                                }
+                                continue;
+                            }
+
+                            if (waitableObject.IsMutex)
+                            {
+                                OwnershipInfo ownershipInfo = waitableObject._ownershipInfo!;
+                                if (ownershipInfo.Thread == waitInfo.Thread)
+                                {
+                                    if (!ownershipInfo.CanIncrementReacquireCount)
+                                    {
+                                        throw new OverflowException(SR.Overflow_MutexReacquireCount);
+                                    }
+                                    continue;
+                                }
+                            }
+
+                            areAllSignaled = false;
+                            break;
+                        }
+
+                        if (areAllSignaled)
+                        {
+                            for (int i = 0; i < count; ++i)
+                            {
+                                WaitableObject waitableObject = waitableObjects[i]!;
+                                if (waitableObject.IsSignaled)
+                                {
+                                    waitableObject.AcceptSignal(waitInfo);
+                                    continue;
+                                }
+
+                                Debug.Assert(waitableObject.IsMutex);
+                                OwnershipInfo ownershipInfo = waitableObject._ownershipInfo!;
+                                Debug.Assert(ownershipInfo.Thread == waitInfo.Thread);
+                                ownershipInfo.IncrementReacquireCount();
+                            }
+
+                            if (isAnyAbandonedMutex)
+                            {
+                                throw new AbandonedMutexException();
+                            }
+                            return WaitHandle.WaitSuccess;
+                        }
+                    }
+
+                    if (timeoutMilliseconds == 0)
+                    {
+                        return WaitHandle.WaitTimeout;
+                    }
+
+                    waitableObjects = null; // no need to clear this anymore, RegisterWait / Wait will take over from here
+                    waitInfo.RegisterWait(count, prioritize, waitForAll);
+                    needToWait = true;
+                }
+                finally
+                {
+                    if (waitableObjects != null)
+                    {
+                        for (int i = 0; i < count; ++i)
+                        {
+                            waitableObjects[i] = null;
+                        }
+                    }
+
+                    // Once the wait function is called, it will release the lock
+                    if (!needToWait)
+                    {
+                        s_lock.Release();
+                    }
+                }
+
+                return waitInfo.Wait(timeoutMilliseconds, interruptible, isSleep: false);
+            }
+
+            public static bool WouldWaitForAllBeSatisfiedOrAborted(
+                Thread waitingThread,
+                WaitableObject?[] waitedObjects,
+                int waitedCount,
+                int signaledWaitedObjectIndex,
+                ref bool wouldAnyMutexReacquireCountOverflow,
+                ref bool isAnyAbandonedMutex)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(waitingThread != null);
+                Debug.Assert(waitingThread != Thread.CurrentThread);
+                Debug.Assert(waitedObjects != null);
+                Debug.Assert(waitedObjects.Length >= waitedCount);
+                Debug.Assert(waitedCount > 1);
+                Debug.Assert(signaledWaitedObjectIndex >= 0);
+                Debug.Assert(signaledWaitedObjectIndex <= WaitHandle.MaxWaitHandles);
+                Debug.Assert(!wouldAnyMutexReacquireCountOverflow);
+
+                for (int i = 0; i < waitedCount; ++i)
+                {
+                    Debug.Assert(waitedObjects[i] != null);
+                    if (i == signaledWaitedObjectIndex)
+                    {
+                        continue;
+                    }
+
+                    WaitableObject waitedObject = waitedObjects[i]!;
+                    if (waitedObject.IsSignaled)
+                    {
+                        if (!isAnyAbandonedMutex && waitedObject.IsAbandonedMutex)
+                        {
+                            isAnyAbandonedMutex = true;
+                        }
+                        continue;
+                    }
+
+                    if (waitedObject.IsMutex)
+                    {
+                        OwnershipInfo ownershipInfo = waitedObject._ownershipInfo!;
+                        if (ownershipInfo.Thread == waitingThread)
+                        {
+                            if (!ownershipInfo.CanIncrementReacquireCount)
+                            {
+                                // This will cause the wait to be aborted without accepting any signals
+                                wouldAnyMutexReacquireCountOverflow = true;
+                                return true;
+                            }
+                            continue;
+                        }
+                    }
+
+                    return false;
+                }
+
+                return true;
+            }
+
+            public static void SatisfyWaitForAll(
+                ThreadWaitInfo waitInfo,
+                WaitableObject?[] waitedObjects,
+                int waitedCount,
+                int signaledWaitedObjectIndex)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(waitInfo != null);
+                Debug.Assert(waitInfo.Thread != Thread.CurrentThread);
+                Debug.Assert(waitedObjects != null);
+                Debug.Assert(waitedObjects.Length >= waitedCount);
+                Debug.Assert(waitedCount > 1);
+                Debug.Assert(signaledWaitedObjectIndex >= 0);
+                Debug.Assert(signaledWaitedObjectIndex <= WaitHandle.MaxWaitHandles);
+
+                for (int i = 0; i < waitedCount; ++i)
+                {
+                    Debug.Assert(waitedObjects[i] != null);
+                    if (i == signaledWaitedObjectIndex)
+                    {
+                        continue;
+                    }
+
+                    WaitableObject waitedObject = waitedObjects[i]!;
+                    if (waitedObject.IsSignaled)
+                    {
+                        waitedObject.AcceptSignal(waitInfo);
+                        continue;
+                    }
+
+                    Debug.Assert(waitedObject.IsMutex);
+                    OwnershipInfo ownershipInfo = waitedObject._ownershipInfo!;
+                    Debug.Assert(ownershipInfo.Thread == waitInfo.Thread);
+                    ownershipInfo.IncrementReacquireCount();
+                }
+            }
+
+            public void Signal(int count)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(count > 0);
+
+                switch (_type)
+                {
+                    case WaitableObjectType.ManualResetEvent:
+                        Debug.Assert(count == 1);
+                        SignalManualResetEvent();
+                        break;
+
+                    case WaitableObjectType.AutoResetEvent:
+                        Debug.Assert(count == 1);
+                        SignalAutoResetEvent();
+                        break;
+
+                    case WaitableObjectType.Semaphore:
+                        SignalSemaphore(count);
+                        break;
+
+                    default:
+                        Debug.Assert(count == 1);
+                        SignalMutex();
+                        break;
+                }
+            }
+
+            public void SignalEvent()
+            {
+                s_lock.VerifyIsLocked();
+
+                switch (_type)
+                {
+                    case WaitableObjectType.ManualResetEvent:
+                        SignalManualResetEvent();
+                        break;
+
+                    case WaitableObjectType.AutoResetEvent:
+                        SignalAutoResetEvent();
+                        break;
+
+                    default:
+                        WaitHandle.ThrowInvalidHandleException();
+                        break;
+                }
+            }
+
+            private void SignalManualResetEvent()
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(IsManualResetEvent);
+
+                if (IsSignaled)
+                {
+                    return;
+                }
+
+                for (ThreadWaitInfo.WaitedListNode? waiterNode = _waitersHead, nextWaiterNode;
+                    waiterNode != null;
+                    waiterNode = nextWaiterNode)
+                {
+                    // Signaling a waiter will unregister the waiter node, so keep the next node before trying
+                    nextWaiterNode = waiterNode.Next;
+
+                    waiterNode.WaitInfo.TrySignalToSatisfyWait(waiterNode, isAbandonedMutex: false);
+                }
+
+                _signalCount = 1;
+            }
+
+            private void SignalAutoResetEvent()
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(IsAutoResetEvent);
+
+                if (IsSignaled)
+                {
+                    return;
+                }
+
+                for (ThreadWaitInfo.WaitedListNode? waiterNode = _waitersHead, nextWaiterNode;
+                    waiterNode != null;
+                    waiterNode = nextWaiterNode)
+                {
+                    // Signaling a waiter will unregister the waiter node, but it may only abort the wait without satisfying the
+                    // wait, in which case we would try to signal another waiter. So, keep the next node before trying.
+                    nextWaiterNode = waiterNode.Next;
+
+                    if (waiterNode.WaitInfo.TrySignalToSatisfyWait(waiterNode, isAbandonedMutex: false))
+                    {
+                        return;
+                    }
+                }
+
+                _signalCount = 1;
+            }
+
+            public void UnsignalEvent()
+            {
+                s_lock.VerifyIsLocked();
+
+                if (!IsEvent)
+                {
+                    WaitHandle.ThrowInvalidHandleException();
+                }
+
+                if (IsSignaled)
+                {
+                    --_signalCount;
+                }
+            }
+
+            public int SignalSemaphore(int count)
+            {
+                s_lock.VerifyIsLocked();
+                Debug.Assert(count > 0);
+
+                if (!IsSemaphore)
+                {
+                    WaitHandle.ThrowInvalidHandleException();
+                }
+
+                int oldSignalCount = _signalCount;
+                Debug.Assert(oldSignalCount <= _maximumSignalCount);
+                if (count > _maximumSignalCount - oldSignalCount)
+                {
+                    throw new SemaphoreFullException();
+                }
+
+                if (oldSignalCount != 0)
+                {
+                    _signalCount = oldSignalCount + count;
+                    return oldSignalCount;
+                }
+
+                for (ThreadWaitInfo.WaitedListNode? waiterNode = _waitersHead, nextWaiterNode;
+                    waiterNode != null;
+                    waiterNode = nextWaiterNode)
+                {
+                    // Signaling the waiter will unregister the waiter node, so keep the next node before trying
+                    nextWaiterNode = waiterNode.Next;
+
+                    if (waiterNode.WaitInfo.TrySignalToSatisfyWait(waiterNode, isAbandonedMutex: false) && --count == 0)
+                    {
+                        return oldSignalCount;
+                    }
+                }
+
+                _signalCount = count;
+                return oldSignalCount;
+            }
+
+            public void SignalMutex()
+            {
+                s_lock.VerifyIsLocked();
+
+                if (!IsMutex)
+                {
+                    WaitHandle.ThrowInvalidHandleException();
+                }
+
+                if (IsSignaled || _ownershipInfo!.Thread != Thread.CurrentThread)
+                {
+                    throw new ApplicationException(SR.Arg_SynchronizationLockException);
+                }
+
+                if (!_ownershipInfo!.TryDecrementReacquireCount())
+                {
+                    SignalMutex(isAbandoned: false);
+                }
+            }
+
+            public void AbandonMutex()
+            {
+                s_lock.VerifyIsLocked();
+
+                Debug.Assert(IsMutex);
+                Debug.Assert(!IsSignaled);
+
+                // Typically, a mutex is abandoned before a thread that owns the mutex exits. However, any thread may
+                // abandon a mutex since any thread may delete a mutex handle. See <see cref="OnDeleteHandle"/>. Although
+                // Windows does not release waiters when a mutex is abandoned by deleting its handle, this implementation
+                // treats that case as abandonment as well and releases waiters, as it's a bit more robust. As the handle
+                // would be deleted shortly afterwards, it would otherwise not be possible to signal the mutex to release
+                // waiters.
+                SignalMutex(isAbandoned: true);
+            }
+
+            private void SignalMutex(bool isAbandoned)
+            {
+                s_lock.VerifyIsLocked();
+
+                Debug.Assert(IsMutex);
+                Debug.Assert(!IsSignaled);
+
+                _ownershipInfo!.RelinquishOwnership(this, isAbandoned);
+
+                for (ThreadWaitInfo.WaitedListNode? waiterNode = _waitersHead, nextWaiterNode;
+                    waiterNode != null;
+                    waiterNode = nextWaiterNode)
+                {
+                    // Signaling a waiter will unregister the waiter node, but it may only abort the wait without satisfying the
+                    // wait, in which case we would try to signal another waiter. So, keep the next node before trying.
+                    nextWaiterNode = waiterNode.Next;
+
+                    ThreadWaitInfo waitInfo = waiterNode.WaitInfo;
+                    if (waitInfo.TrySignalToSatisfyWait(waiterNode, isAbandoned))
+                    {
+                        _ownershipInfo!.AssignOwnership(this, waitInfo);
+                        return;
+                    }
+                }
+
+                _signalCount = 1;
+            }
+
+            private sealed class OwnershipInfo
+            {
+                private Thread? _thread;
+                private int _reacquireCount;
+                private bool _isAbandoned;
+
+                /// <summary>
+                /// Link in the <see cref="ThreadWaitInfo.LockedMutexesHead"/> linked list
+                /// </summary>
+                private WaitableObject? _previous;
+
+                /// <summary>
+                /// Link in the <see cref="ThreadWaitInfo.LockedMutexesHead"/> linked list
+                /// </summary>
+                private WaitableObject? _next;
+
+                public Thread? Thread
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+                        return _thread;
+                    }
+                }
+
+                public bool IsAbandoned
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+                        return _isAbandoned;
+                    }
+                }
+
+                public void AssignOwnership(WaitableObject waitableObject, ThreadWaitInfo waitInfo)
+                {
+                    s_lock.VerifyIsLocked();
+
+                    Debug.Assert(waitableObject != null);
+                    Debug.Assert(waitableObject.IsMutex);
+                    Debug.Assert(waitableObject._ownershipInfo == this);
+
+                    Debug.Assert(_thread == null);
+                    Debug.Assert(_reacquireCount == 0);
+                    Debug.Assert(_previous == null);
+                    Debug.Assert(_next == null);
+
+                    _thread = waitInfo.Thread;
+                    _isAbandoned = false;
+
+                    WaitableObject? head = waitInfo.LockedMutexesHead;
+                    if (head != null)
+                    {
+                        _next = head;
+                        head._ownershipInfo!._previous = waitableObject;
+                    }
+                    waitInfo.LockedMutexesHead = waitableObject;
+                }
+
+                public void RelinquishOwnership(WaitableObject waitableObject, bool isAbandoned)
+                {
+                    s_lock.VerifyIsLocked();
+
+                    Debug.Assert(waitableObject != null);
+                    Debug.Assert(waitableObject.IsMutex);
+                    Debug.Assert(waitableObject._ownershipInfo == this);
+
+                    Debug.Assert(_thread != null);
+                    ThreadWaitInfo waitInfo = _thread._waitInfo;
+                    Debug.Assert(isAbandoned ? _reacquireCount >= 0 : _reacquireCount == 0);
+                    Debug.Assert(!_isAbandoned);
+
+                    _thread = null;
+                    if (isAbandoned)
+                    {
+                        _reacquireCount = 0;
+                        _isAbandoned = isAbandoned;
+                    }
+
+                    WaitableObject? previous = _previous;
+                    WaitableObject? next = _next;
+
+                    if (previous != null)
+                    {
+                        previous._ownershipInfo!._next = next;
+                        _previous = null;
+                    }
+                    else
+                    {
+                        Debug.Assert(waitInfo.LockedMutexesHead == waitableObject);
+                        waitInfo.LockedMutexesHead = next;
+                    }
+
+                    if (next != null)
+                    {
+                        next._ownershipInfo!._previous = previous;
+                        _next = null;
+                    }
+                }
+
+                public bool CanIncrementReacquireCount
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+
+                        Debug.Assert(_thread != null);
+                        Debug.Assert(_reacquireCount >= 0);
+                        Debug.Assert(!_isAbandoned);
+
+                        return _reacquireCount + 1 > _reacquireCount;
+                    }
+                }
+
+                public void IncrementReacquireCount()
+                {
+                    Debug.Assert(CanIncrementReacquireCount);
+                    ++_reacquireCount;
+                }
+
+                public bool TryDecrementReacquireCount()
+                {
+                    s_lock.VerifyIsLocked();
+
+                    Debug.Assert(_thread == Thread.CurrentThread);
+                    Debug.Assert(_reacquireCount >= 0);
+                    Debug.Assert(!_isAbandoned);
+
+                    if (_reacquireCount == 0)
+                    {
+                        return false;
+                    }
+                    --_reacquireCount;
+                    return true;
+                }
+            }
+
+            private enum WaitableObjectType : byte
+            {
+                ManualResetEvent,
+                AutoResetEvent,
+                Semaphore,
+                Mutex
+            }
+        }
+    }
+}


### PR DESCRIPTION
Draft until I see how this behaves on CI.

Fixes https://github.com/dotnet/runtime/issues/44795

A few notes:

I've attempted to nullable annotate the relevant files but would appreciate someone else checking over my work, since the design does not really lend itself to that.

I can split the time-related parts of the System.Native addition off into a separate header if desired, but since they wouldn't be used elsewhere I just put the relevant includes in the C file.

This can fairly easily be moved to shared if desired, but I've put it in Mono only for now. Given there's a chance we might want to share it eventually after testing in Mono, I've left a CORERT define.

The `TARGET_UNIX` define usage isn't ideal, but given we care about the layout for that particular class it seemed like the easiest option. If it's a problem please let me know.