### PR TITLE
Disable sourcelink locally consistently

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -193,6 +193,10 @@
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
     <!-- Turn off end of life target framework checks as we intentionally build older .NETCoreApp configurations. -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <!-- Disable source link when building locally. -->
+    <DisableSourceLink Condition="'$(DisableSourceLink)' == '' and
+                                  '$(ContinuousIntegrationBuild)' != 'true' and
+                                  '$(OfficialBuildId)' == ''">false</DisableSourceLink>
   </PropertyGroup>
 
   <!-- RepositoryEngineeringDir isn't set when Installer tests import this file. -->

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -28,12 +28,6 @@
     <Platform Condition="'$(Platform)' == ''">$(TargetArchitecture)</Platform>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DisableSourceLink)' == 'true'">
-    <EnableSourceLink>false</EnableSourceLink>
-    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-  </PropertyGroup>
-
   <!-- Set up Default symbol and optimization for Configuration -->
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -95,9 +95,6 @@
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- Microsoft.Extensions projects have a separate StrongNameKeyId -->
     <StrongNameKeyId Condition="$(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">MicrosoftAspNetCore</StrongNameKeyId>
-
-    <!-- Workaround for codecov issue https://github.com/tonerdo/coverlet/issues/312 -->
-    <EnableSourceLink Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''">false</EnableSourceLink>
   </PropertyGroup>
 
   <!-- Disable some standard properties for building our projects -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/47130

With https://github.com/dotnet/arcade/commit/1530d9cb7628473c9b165cb9a1f47739f3faae77 it's now possible to build the repo without source link being enabled. Previously the generation of the native versions file was failing without source link. Disabling source link by default locally for the runtimes and installer - it was already disabled for all libraries.