### PR TITLE
Supply file version info for the jitinterface native library

### DIFF
--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -96,6 +96,13 @@ if(CLR_CMAKE_TARGET_WIN32 AND CLR_CMAKE_BUILD_SUBSET_RUNTIME)
   add_subdirectory(gc/sample)
 endif()
 
+#-------------------------------------
+# Include directory directives
+#-------------------------------------
+# Include the basic prebuilt headers - required for getting fileversion resource details.
+include_directories("pal/prebuilt/inc")
+include_directories("../../artifacts/obj/coreclr")
+
 add_subdirectory(tools/aot/jitinterface)
 
 # Above projects do not build with these compile options
@@ -111,13 +118,6 @@ endif(CLR_CMAKE_HOST_WIN32)
 #  - all clr specific feature variable should also be added in this file
 #----------------------------------
 include(clrdefinitions.cmake)
-
-#-------------------------------------
-# Include directory directives
-#-------------------------------------
-# Include the basic prebuilt headers - required for getting fileversion resource details.
-include_directories("pal/prebuilt/inc")
-include_directories("../../artifacts/obj/coreclr")
 
 if(FEATURE_STANDALONE_GC)
   add_definitions(-DFEATURE_STANDALONE_GC)

--- a/src/coreclr/tools/aot/jitinterface/CMakeLists.txt
+++ b/src/coreclr/tools/aot/jitinterface/CMakeLists.txt
@@ -7,9 +7,14 @@ set(NATIVE_SOURCES
     corinfoexception.cpp
 )
 
+if(CLR_CMAKE_TARGET_WIN32)
+  set(JITINTERFACE_RESOURCES Native.rc)
+endif(CLR_CMAKE_TARGET_WIN32)
+
 add_library_clr(jitinterface_${ARCH_HOST_NAME}
     SHARED
     ${NATIVE_SOURCES}
+    ${JITINTERFACE_RESOURCES}
 )
 
 install_clr(TARGETS jitinterface_${ARCH_HOST_NAME})

--- a/src/coreclr/tools/aot/jitinterface/Native.rc
+++ b/src/coreclr/tools/aot/jitinterface/Native.rc
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Just-In-Time Compiler Type System Interface\0"
+
+#include <fxver.h>
+#include <fxver.rc>


### PR DESCRIPTION
During my work on switching over framework library crossgenning
to use Crossgen2 I noticed that jitinterface is missing the
file version information. This change fixes the issue.

Thanks

Tomas

P.S. Big thank you to JanV for helping me out with cmake intricacies.

/cc @dotnet/crossgen-contrib