### PR TITLE
Take SuppressGCTransition into account in IL stub caching

### DIFF
--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -259,7 +259,8 @@ protected:
                 DWORD dwStubFlags,
                 int iLCIDParamIdx,
                 MethodDesc* pTargetMD)
-            : m_slIL(dwStubFlags, pStubModule, signature, pTypeContext, pTargetMD, iLCIDParamIdx)
+        : m_slIL(dwStubFlags, pStubModule, signature, pTypeContext, pTargetMD, iLCIDParamIdx)
+        , m_dwStubFlags(dwStubFlags)
     {
         STANDARD_VM_CONTRACT;
 
@@ -291,7 +292,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
         m_slIL.Begin(dwStubFlags);
-        m_dwStubFlags = dwStubFlags;
+        _ASSERTE(m_dwStubFlags == dwStubFlags);
     }
 
     void MarshalReturn(MarshalInfo* pInfo, int argOffset)
@@ -1202,6 +1203,8 @@ public:
     }
 
     TokenLookupMap* GetTokenLookupMap() { WRAPPER_NO_CONTRACT; return m_slIL.GetTokenLookupMap(); }
+
+    DWORD GetFlags() const { return m_dwStubFlags; }
 
 protected:
     CQuickBytes         m_qbNativeFnSigBuffer;
@@ -4444,7 +4447,6 @@ MethodDesc* CreateInteropILStub(
                          CorNativeLinkType        nlType,
                          CorNativeLinkFlags       nlFlags,
                          CorInfoCallConvExtension unmgdCallConv,
-                         DWORD                    dwStubFlags,            // NDirectStubFlags
                          int                      nParamTokens,
                          mdParamDef*              pParamTokenArray,
                          int                      iLCIDArg,
@@ -4477,6 +4479,8 @@ MethodDesc* CreateInteropILStub(
     // pTargetMD may be null in the case of calli pinvoke
     // and vararg pinvoke.
     //
+
+    DWORD dwStubFlags = pss->GetFlags();
 
 #ifdef FEATURE_COMINTEROP
     //
@@ -4820,7 +4824,6 @@ MethodDesc* NDirect::CreateCLRToNativeILStub(
                 nlType,
                 nlFlags,
                 unmgdCallConv,
-                dwStubFlags,
                 numParamTokens,
                 pParamTokenArray,
                 iLCIDArg);
@@ -4894,7 +4897,6 @@ MethodDesc* NDirect::CreateFieldAccessILStub(
                 (CorNativeLinkType)0,
                 (CorNativeLinkFlags)0,
                 MetaSig::GetDefaultUnmanagedCallingConvention(),
-                dwStubFlags,
                 numParamTokens,
                 pParamTokenArray,
                 -1);
@@ -5003,7 +5005,6 @@ MethodDesc* NDirect::CreateStructMarshalILStub(MethodTable* pMT)
         (CorNativeLinkType)0,
         (CorNativeLinkFlags)0,
         CorInfoCallConvExtension::Managed,
-        dwStubFlags,
         numParamTokens,
         pParamTokenArray,
         -1,

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -485,13 +485,13 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
         if (SF_IsSharedStub(dwStubFlags))
         {
             size_t cbSizeOfBlob = pHashBlob->m_cbSizeOfBlob;
-            AllocMemHolder<ILStubHashBlob> pBlobHolder( m_heap->AllocMem(S_SIZE_T(cbSizeOfBlob)) );
 
             CrstHolder ch(&m_crst);
 
             const ILStubCacheEntry* phe = m_hashMap.LookupPtr(pHashBlob);
             if (phe == NULL)
             {
+                AllocMemHolder<ILStubHashBlob> pBlobHolder( m_heap->AllocMem(S_SIZE_T(cbSizeOfBlob)) );
                 pBlob = pBlobHolder;
                 _ASSERTE(pHashBlob->m_cbSizeOfBlob == cbSizeOfBlob);
                 memcpy(pBlob, pHashBlob, cbSizeOfBlob);

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -20,20 +20,10 @@
 
 const char* FormatSig(MethodDesc* pMD, LoaderHeap *pHeap, AllocMemTracker *pamTracker);
 
-ILStubCache::ILStubCache(LoaderHeap *pHeap) :
-    CClosedHashBase(
-#ifdef _DEBUG
-                      3,
-#else
-                      17,    // CClosedHashTable will grow as necessary
-#endif
-
-                      sizeof(ILCHASHENTRY),
-                      FALSE
-                   ),
-    m_crst(CrstStubCache, CRST_UNSAFE_ANYMODE),
-    m_heap(pHeap),
-    m_pStubMT(NULL)
+ILStubCache::ILStubCache(LoaderHeap *pHeap)
+    : m_crst(CrstStubCache, CRST_UNSAFE_ANYMODE)
+    , m_heap(pHeap)
+    , m_pStubMT(NULL)
 {
     WRAPPER_NO_CONTRACT;
 }
@@ -45,7 +35,6 @@ void ILStubCache::Init(LoaderHeap* pHeap)
     CONSISTENCY_CHECK(NULL == m_heap);
     m_heap = pHeap;
 }
-
 
 #ifndef DACCESS_COMPILE
 
@@ -434,8 +423,8 @@ MethodTable* ILStubCache::GetOrCreateStubMethodTable(Module* pModule)
 //
 
 MethodDesc* ILStubCache::GetStubMethodDesc(
-    MethodDesc *pTargetMD,
-    ILStubHashBlob* pParams,
+    MethodDesc* pTargetMD,
+    ILStubHashBlob* pHashBlob,
     DWORD dwStubFlags,
     Module* pSigModule,
     PCCOR_SIGNATURE pSig,
@@ -452,27 +441,21 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
     CONTRACT_END;
 
     MethodDesc*     pMD         = NULL;
-    bool bFireETWCacheHitEvent = true;
 
 #ifndef DACCESS_COMPILE
     ILStubHashBlob* pBlob       = NULL;
 
     INDEBUG(LPCSTR  pszResult   = "[hit cache]");
 
-
     if (SF_IsSharedStub(dwStubFlags))
     {
         CrstHolder ch(&m_crst);
 
         // Try to find the stub
-        ILCHASHENTRY*   phe         = NULL;
-
-        phe = (ILCHASHENTRY*)Find((LPVOID)pParams);
+        ILStubCacheEntry* phe = m_hashMap.Lookup(pHashBlob);
         if (phe)
         {
             pMD = phe->m_pMethodDesc;
-            if (pMD == pLastMD)
-                bFireETWCacheHitEvent = false;
         }
     }
 
@@ -501,55 +484,36 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
 
         if (SF_IsSharedStub(dwStubFlags))
         {
-            size_t cbSizeOfBlob = pParams->m_cbSizeOfBlob;
+            size_t cbSizeOfBlob = pHashBlob->m_cbSizeOfBlob;
             AllocMemHolder<ILStubHashBlob> pBlobHolder( m_heap->AllocMem(S_SIZE_T(cbSizeOfBlob)) );
 
             CrstHolder ch(&m_crst);
 
-            ILCHASHENTRY*   phe         = NULL;
-
-            bool bNew;
-            phe = (ILCHASHENTRY*)FindOrAdd((LPVOID)pParams, bNew);
-            bILStubCreator |= bNew;
-
-            if (NULL != phe)
+            ILStubCacheEntry* phe = m_hashMap.Lookup(pHashBlob);
+            if (phe == NULL)
             {
-                if (bNew)
-                {
-                    pBlobHolder.SuppressRelease();
+                pBlobHolder.SuppressRelease();
+                pBlob = pBlobHolder;
 
-                    phe->m_pMethodDesc   = pMD;
-                    pBlob = pBlobHolder;
-                    phe->m_pBlob         = pBlob;
+                phe = new ILStubCacheEntry{ pMD, pBlob };
+                _ASSERTE(pHashBlob->m_cbSizeOfBlob == cbSizeOfBlob);
+                memcpy(pBlob, pHashBlob, cbSizeOfBlob);
 
-                    _ASSERTE(pParams->m_cbSizeOfBlob == cbSizeOfBlob);
-                    memcpy(pBlob, pParams, cbSizeOfBlob);
-
-                    INDEBUG(pszResult   = "[missed cache]");
-                    bFireETWCacheHitEvent = false;
-                }
-                else
-                {
-                    INDEBUG(pszResult   = "[hit cache][wasted new MethodDesc due to race]");
-                }
-                pMD = phe->m_pMethodDesc;
+                m_hashMap.Add(phe);
+                bILStubCreator = true;
+                INDEBUG(pszResult   = "[missed cache]");
             }
             else
             {
-                pMD = NULL;
+                INDEBUG(pszResult   = "[hit cache][wasted new MethodDesc due to race]");
             }
+
+            pMD = phe->m_pMethodDesc;
         }
         else
         {
             INDEBUG(pszResult   = "[cache disabled for COM->CLR field access stubs]");
         }
-    }
-
-
-    if (!pMD)
-    {
-        // Couldn't grow hash table due to lack of memory.
-        COMPlusThrowOM();
     }
 
 #ifdef _DEBUG
@@ -562,7 +526,7 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
     RETURN pMD;
 }
 
-void ILStubCache::DeleteEntry(void* pParams)
+void ILStubCache::DeleteEntry(ILStubHashBlob* pHashBlob)
 {
     CONTRACTL
     {
@@ -571,18 +535,17 @@ void ILStubCache::DeleteEntry(void* pParams)
         MODE_ANY;
     }
     CONTRACTL_END;
+
     CrstHolder ch(&m_crst);
 
-    ILCHASHENTRY*   phe         = NULL;
-
-    phe = (ILCHASHENTRY*)Find((LPVOID)pParams);
+    ILStubCacheEntry *phe = m_hashMap.Lookup(pHashBlob);
     if (phe)
     {
 #ifdef _DEBUG
         LOG((LF_STUBS, LL_INFO1000, "ILSTUBCACHE: ILStubCache::DeleteEntry StubMD: %p\n", phe->m_pMethodDesc));
 #endif
-
-        Delete(pParams);
+        m_hashMap.Remove(pHashBlob);
+        delete phe;
     }
 }
 
@@ -603,153 +566,30 @@ void ILStubCache::AddMethodDescChunkWithLockTaken(MethodDesc *pMD)
 #endif // DACCESS_COMPILE
 }
 
-//---------------------------------------------------------
-// Destructor
-//---------------------------------------------------------
-ILStubCache::~ILStubCache()
+ILStubCache::ILStubCacheTraits::count_t ILStubCache::ILStubCacheTraits::Hash(_In_ key_t key)
 {
-}
+    LIMITED_METHOD_CONTRACT;
 
-
-//*****************************************************************************
-// Hash is called with a pointer to an element in the table.  You must override
-// this method and provide a hash algorithm for your element type.
-//*****************************************************************************
-unsigned int ILStubCache::Hash(       // The key value.
-    void const*  pData)                // Raw data to hash.
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    const ILStubHashBlob* pBlob = (const ILStubHashBlob *)pData;
-
-    size_t cb   = pBlob->m_cbSizeOfBlob - sizeof(ILStubHashBlobBase);
+    size_t cb = key->m_cbSizeOfBlob - sizeof(ILStubHashBlobBase);
     int   hash = 0;
 
     for (size_t i = 0; i < cb; i++)
     {
-        hash = _rotl(hash,1) + pBlob->m_rgbBlobData[i];
+        hash = _rotl(hash, 1) + key->m_rgbBlobData[i];
     }
 
     return hash;
 }
 
-//*****************************************************************************
-// Compare is used in the typical memcmp way, 0 is eqaulity, -1/1 indicate
-// direction of miscompare.  In this system everything is always equal or not.
-//*****************************************************************************
-unsigned int ILStubCache::Compare(    // 0, -1, or 1.
-    void const*  pData,                // Raw key data on lookup.
-    BYTE*        pElement)             // The element to compare data against.
+bool ILStubCache::ILStubCacheTraits::Equals(_In_ key_t lhs, _In_ key_t rhs)
 {
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+    LIMITED_METHOD_CONTRACT;
 
-    const ILStubHashBlob* pBlob1    = (const ILStubHashBlob*)pData;
-    const ILStubHashBlob* pBlob2    = (const ILStubHashBlob*)GetKey(pElement);
-    size_t cb1 = pBlob1->m_cbSizeOfBlob - sizeof(ILStubHashBlobBase);
-    size_t cb2 = pBlob2->m_cbSizeOfBlob - sizeof(ILStubHashBlobBase);
+    if (lhs->m_cbSizeOfBlob != rhs->m_cbSizeOfBlob)
+        return false;
 
-    if (cb1 != cb2)
-    {
-        return 1; // not equal
-    }
-    else
-    {
-        // @TODO: use memcmp
-        for (size_t i = 0; i < cb1; i++)
-        {
-            if (pBlob1->m_rgbBlobData[i] != pBlob2->m_rgbBlobData[i])
-            {
-                return 1; // not equal
-            }
-        }
-        return 0;   // equal
-    }
-}
-
-//*****************************************************************************
-// Return true if the element is free to be used.
-//*****************************************************************************
-CClosedHashBase::ELEMENTSTATUS ILStubCache::Status(     // The status of the entry.
-    BYTE*        pElement)             // The element to check.
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    MethodDesc* pMD = ((ILCHASHENTRY*)pElement)->m_pMethodDesc;
-
-    if (pMD == NULL)
-    {
-        return FREE;
-    }
-    else if (pMD == (MethodDesc*)(-((INT_PTR)1)))
-    {
-        return DELETED;
-    }
-    else
-    {
-        return USED;
-    }
-}
-
-//*****************************************************************************
-// Sets the status of the given element.
-//*****************************************************************************
-void ILStubCache::SetStatus(
-    BYTE*         pElement,            // The element to set status for.
-    CClosedHashBase::ELEMENTSTATUS eStatus)             // New status.
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    ILCHASHENTRY* phe = (ILCHASHENTRY*)pElement;
-
-    switch (eStatus)
-    {
-        case FREE:    phe->m_pMethodDesc = NULL;   break;
-        case DELETED: phe->m_pMethodDesc = (MethodDesc*)(-((INT_PTR)1)); break;
-        default:
-            _ASSERTE(!"MLCacheEntry::SetStatus(): Bad argument.");
-    }
-}
-
-//*****************************************************************************
-// Returns the internal key value for an element.
-//*****************************************************************************
-void* ILStubCache::GetKey(             // The data to hash on.
-    BYTE*        pElement)             // The element to return data ptr for.
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    ILCHASHENTRY* phe = (ILCHASHENTRY*)pElement;
-    return (void *)(phe->m_pBlob);
+    size_t blobDataSize = lhs->m_cbSizeOfBlob - sizeof(ILStubHashBlobBase);
+    return memcmp(lhs->m_rgbBlobData, rhs->m_rgbBlobData, blobDataSize) == 0;
 }
 
 #ifdef FEATURE_PREJIT

--- a/src/coreclr/vm/ilstubcache.h
+++ b/src/coreclr/vm/ilstubcache.h
@@ -98,13 +98,17 @@ private: // Inner classes
         ILStubHashBlob *m_pBlob;
     };
 
-    class ILStubCacheTraits : public DeleteElementsOnDestructSHashTraits<DefaultSHashTraits<ILStubCacheEntry *>>
+    class ILStubCacheTraits : public DefaultSHashTraits<ILStubCacheEntry>
     {
     public:
         using key_t = const ILStubHashBlob *;
-        static const key_t GetKey(_In_ element_t e) { LIMITED_METHOD_CONTRACT; return e->m_pBlob; }
+        static const key_t GetKey(_In_ const element_t& e) { LIMITED_METHOD_CONTRACT; return e.m_pBlob; }
         static count_t Hash(_In_ key_t key);
         static bool Equals(_In_ key_t lhs, _In_ key_t rhs);
+        static bool IsNull(_In_ const element_t& e) { LIMITED_METHOD_CONTRACT; return e.m_pMethodDesc == NULL; }
+        static const element_t Null() { LIMITED_METHOD_CONTRACT; return ILStubCacheEntry(); }
+        static bool IsDeleted(const element_t &e) { LIMITED_METHOD_CONTRACT; return e.m_pMethodDesc == (MethodDesc *)-1; }
+        static const element_t Deleted() { LIMITED_METHOD_CONTRACT; return ILStubCacheEntry{(MethodDesc *)-1, NULL}; }
     };
 
 private:

--- a/src/coreclr/vm/ilstubcache.h
+++ b/src/coreclr/vm/ilstubcache.h
@@ -32,27 +32,12 @@ public:
     BYTE    m_rgbBlobData[1];
 };
 
-
 //
 // This class caches MethodDesc's for dynamically generated IL stubs, it is not
 // persisted in NGEN images.
 //
-class ILStubCache : private CClosedHashBase
+class ILStubCache final
 {
-private:
-    //---------------------------------------------------------
-    // Hash entry for CClosedHashBase.
-    //---------------------------------------------------------
-    struct ILCHASHENTRY
-    {
-        // Values:
-        //   NULL  = free
-        //   -1    = deleted
-        //   other = used
-        MethodDesc*     m_pMethodDesc;
-        ILStubHashBlob* m_pBlob;
-    };
-
 public:
 
     //---------------------------------------------------------
@@ -60,16 +45,11 @@ public:
     //---------------------------------------------------------
     ILStubCache(LoaderHeap* heap = NULL);
 
-    //---------------------------------------------------------
-    // Destructor
-    //---------------------------------------------------------
-    virtual ~ILStubCache();
-
     void Init(LoaderHeap* pHeap);
 
     MethodDesc* GetStubMethodDesc(
         MethodDesc *pTargetMD,
-        ILStubHashBlob* pParams,
+        ILStubHashBlob* pHashBlob,
         DWORD dwStubFlags,      // bitmask of NDirectStubFlags
         Module* pSigModule,
         PCCOR_SIGNATURE pSig,
@@ -78,7 +58,7 @@ public:
         bool& bILStubCreator,
         MethodDesc* pLastMD);
 
-    void DeleteEntry(void *pParams);
+    void DeleteEntry(ILStubHashBlob* pHashBlob);
 
     void AddMethodDescChunkWithLockTaken(MethodDesc *pMD);
 
@@ -100,8 +80,7 @@ public:
 
     MethodTable* GetOrCreateStubMethodTable(Module* pLoaderModule);
 
-private:
-
+private: // static
     static MethodDesc* CreateNewMethodDesc(
         LoaderHeap* pCreationHeap,
         MethodTable* pMT,
@@ -112,48 +91,28 @@ private:
         SigTypeContext *pTypeContext,
         AllocMemTracker* pamTracker);
 
-    // *** OVERRIDES FOR CClosedHashBase ***/
+private: // Inner classes
+    struct ILStubCacheEntry
+    {
+        MethodDesc *m_pMethodDesc;
+        ILStubHashBlob *m_pBlob;
+    };
 
-    //*****************************************************************************
-    // Hash is called with a pointer to an element in the table.  You must override
-    // this method and provide a hash algorithm for your element type.
-    //*****************************************************************************
-    virtual unsigned int Hash(             // The key value.
-        void const*  pData);                // Raw data to hash.
-
-    //*****************************************************************************
-    // Compare is used in the typical memcmp way, 0 is eqaulity, -1/1 indicate
-    // direction of miscompare.  In this system everything is always equal or not.
-    //*****************************************************************************
-    virtual unsigned int Compare(          // 0, -1, or 1.
-        void const*  pData,                 // Raw key data on lookup.
-        BYTE*        pElement);             // The element to compare data against.
-
-    //*****************************************************************************
-    // Return true if the element is free to be used.
-    //*****************************************************************************
-    virtual ELEMENTSTATUS Status(           // The status of the entry.
-        BYTE*        pElement);             // The element to check.
-
-    //*****************************************************************************
-    // Sets the status of the given element.
-    //*****************************************************************************
-    virtual void SetStatus(
-        BYTE*         pElement,             // The element to set status for.
-        ELEMENTSTATUS eStatus);             // New status.
-
-    //*****************************************************************************
-    // Returns the internal key value for an element.
-    //*****************************************************************************
-    virtual void* GetKey(                   // The data to hash on.
-        BYTE*        pElement);             // The element to return data ptr for.
+    class ILStubCacheTraits : public DeleteElementsOnDestructSHashTraits<DefaultSHashTraits<ILStubCacheEntry *>>
+    {
+    public:
+        using key_t = const ILStubHashBlob *;
+        static const key_t GetKey(_In_ element_t e) { LIMITED_METHOD_CONTRACT; return e->m_pBlob; }
+        static count_t Hash(_In_ key_t key);
+        static bool Equals(_In_ key_t lhs, _In_ key_t rhs);
+    };
 
 private:
     Crst            m_crst;
     LoaderHeap*     m_heap;
     MethodTable*    m_pStubMT;
+    SHash<ILStubCacheTraits> m_hashMap;
 };
-
 
 #ifdef FEATURE_PREJIT
 //========================================================================================

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
@@ -21,3 +21,15 @@ BOOL DLL_EXPORT STDMETHODVCALLTYPE NextUInt(/* out */ uint32_t *n)
     *n = (++_n);
     return TRUE;
 }
+
+typedef int (STDMETHODVCALLTYPE *CALLBACKPROC)(int n);
+
+extern "C"
+BOOL DLL_EXPORT InvokeCallback(CALLBACKPROC cb, int* n)
+{
+    if (cb == nullptr || n == nullptr)
+        return FALSE;
+
+    *n = cb((++_n));
+    return TRUE;
+}

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
@@ -25,7 +25,7 @@ BOOL DLL_EXPORT STDMETHODVCALLTYPE NextUInt(/* out */ uint32_t *n)
 typedef int (STDMETHODVCALLTYPE *CALLBACKPROC)(int n);
 
 extern "C"
-BOOL DLL_EXPORT InvokeCallback(CALLBACKPROC cb, int* n)
+BOOL DLL_EXPORT STDMETHODVCALLTYPE InvokeCallback(CALLBACKPROC cb, int* n)
 {
     if (cb == nullptr || n == nullptr)
         return FALSE;

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
@@ -24,32 +24,32 @@ unsafe static class SuppressGCTransitionNative
     [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "NextUInt")]
     public static extern unsafe bool NextUInt_NoInline_GCTransition(int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     [SuppressGCTransition]
     public static extern unsafe int InvokeCallbackFuncPtr_Inline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     public static extern unsafe int InvokeCallbackFuncPtr_Inline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     [SuppressGCTransition]
     public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     [SuppressGCTransition]
     public static extern unsafe int InvokeCallbackVoidPtr_Inline_NoGCTransition(void* cb, int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     public static extern unsafe int InvokeCallbackVoidPtr_Inline_GCTransition(void* cb, int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     [SuppressGCTransition]
     public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_NoGCTransition(void* cb, int* n);
 
-    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
     public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_GCTransition(void* cb, int* n);
 
     private static IntPtr nativeLibrary;

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
@@ -24,6 +24,34 @@ unsafe static class SuppressGCTransitionNative
     [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "NextUInt")]
     public static extern unsafe bool NextUInt_NoInline_GCTransition(int* n);
 
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe int InvokeCallbackFuncPtr_Inline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    public static extern unsafe int InvokeCallbackFuncPtr_Inline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe int InvokeCallbackVoidPtr_Inline_NoGCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    public static extern unsafe int InvokeCallbackVoidPtr_Inline_GCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_NoGCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "InvokeCallback")]
+    public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_GCTransition(void* cb, int* n);
+
     private static IntPtr nativeLibrary;
 
     public static IntPtr GetNextUIntFunctionPointer()
@@ -199,8 +227,79 @@ unsafe class SuppressGCTransitionTest
         Assert.AreEqual(expected, n);
         return n + 1;
     }
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static int ReturnInt(int value)
+    {
+        return value;
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int ILStubCache_NoGCTransition_GCTransition(int expected)
+    {
+        // This test uses a callback marked UnmanagedCallersOnly as a way to verify that
+        // SuppressGCTransition is taken into account when caching IL stubs.
+        // It calls functions with the same signature, differing only in SuppressGCTransition.
+        // When calling an UnmanagedCallersOnly method, the runtime validates that the GC is in
+        // pre-emptive mode. If not, it throws a fatal error that cannot be caught and crashes.
+        // If the stub for the p/invoke with the transition suppressed is incorrectly reused for
+        // the p/invoke without the suppression, invoking the callback would produce a fatal error.
+        Console.WriteLine($"{nameof(ILStubCache_NoGCTransition_GCTransition)} ({expected}) ...");
 
-    public static int Main()
+        int n;
+
+        // Call function that has SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_Inline_NoGCTransition(null, null);
+
+        // Call function with same (blittable) signature, but without SuppressGCTransition.
+        // IL stub should not be re-used, GC transition should occur, and callback should be invoked.
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_Inline_GCTransition(&ReturnInt, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function that has SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_NoInline_NoGCTransition(null, null);
+
+        // Call function with same (non-blittable) signature, but without SuppressGCTransition
+        // IL stub should not be re-used, GC transition should occur, and callback should be invoked.
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_NoInline_GCTransition(&ReturnInt, &n);
+        Assert.AreEqual(expected++, n);
+
+        return n + 1;
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int ILStubCache_GCTransition_NoGCTransition(int expected)
+    {
+        // This test uses a callback marked UnmanagedCallersOnly as a way to verify that
+        // SuppressGCTransition is taken into account when caching IL stubs.
+        // It calls functions with the same signature, differing only in SuppressGCTransition.
+        // When calling an UnmanagedCallersOnly method, the runtime validates that the GC is in
+        // pre-emptive mode. If not, it throws a fatal error that cannot be caught and crashes.
+        Console.WriteLine($"{nameof(ILStubCache_GCTransition_NoGCTransition)} ({expected}) ...");
+
+        int n;
+
+        void* cb = (delegate* unmanaged[Cdecl]<int, int>)&ReturnInt;
+
+        // Call function that does not have SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_GCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function with same (blittable) signature, but with SuppressGCTransition.
+        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_NoGCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function that does not have SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_GCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function with same (non-blittable) signature, but with SuppressGCTransition
+        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
+        expected = n + 1;
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_NoGCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        return n + 1;
+    }
+    public static int Main(string[] args)
     {
         try
         {
@@ -216,6 +315,13 @@ unsafe class SuppressGCTransitionTest
             n = NoInline_NoGCTransition_FunctionPointer(n);
             n = NoInline_GCTransition_FunctionPointer(n);
             n = CallAsFunctionPointer(n);
+            n = ILStubCache_NoGCTransition_GCTransition(n);
+
+            if (args.Length != 0 && args[0].Equals("ILStubCache", StringComparison.OrdinalIgnoreCase))
+            {
+                // This test intentionally results in a fatal error, so only run when manually specified
+                n = ILStubCache_GCTransition_NoGCTransition(n);
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Use the updated stub flags that have `SuppressGCTransition`  taken into account when creating the hash blob used for caching IL stubs.

Fix #46184

cc @AaronRobinsonMSFT @jkoritzinsky 