### PR TITLE
Revert "Re-enable RunThreadLocalTest8_Values on Mono"

### DIFF
--- a/src/libraries/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/libraries/System.Threading/tests/ThreadLocalTests.cs
@@ -224,6 +224,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/43981", TestRuntimes.Mono)]
         public static void RunThreadLocalTest8_Values()
         {
             // Test adding values and updating values


### PR DESCRIPTION
Reverts dotnet/runtime#47277

Looks like it still fails on SLES: https://github.com/dotnet/runtime/issues/43981#issuecomment-765052613

@lambdageek I think this didn't show up on the PR because SLES isn't in the set of Helix queues we're running tests on for PRs, just master builds.