### PR TITLE
[arm64-osx] Remove an apple m1 workaround, newer versions of config.guess from brew work correctly.

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -408,13 +408,6 @@ case "$host" in
 		host_sunos=yes
 		;;
 	*-*-darwin*)
-		# Temporary workaround for Apple Silicon
-		# config.guess returns arm-apple-darwin20.0.0
-		if test $ac_cv_host = arm-apple-darwin20.0.0 -o $ac_cv_target = arm-apple-darwin20.0.0; then
-		   echo "You are running on Apple Silicon, but using an old config.guess, invoke configure like this:"
-		   echo "Run configure using ./configure --host=aarch64-apple-darwin20.0.0 --target=aarch64-apple-darwin20.0.0"
-		   exit 1
-		fi
 		parallel_mark="Disabled_Currently_Hangs_On_MacOSX"
 		host_darwin=yes
 		target_mach=yes


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20772,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
