### PR TITLE
[wasm][bindings] Treat null string as null when converting

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -86,6 +86,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
+        public static void MarshalNullStringToCS()
+        {
+            HelperMarshal._stringResource = null;
+            Runtime.InvokeJS("App.call_test_method(\"InvokeString\", [ null ])");
+            Assert.Null(HelperMarshal._stringResource);
+        }
+
+        [Fact]
         public static void MarshalStringToJS()
         {
             HelperMarshal._marshalledString = HelperMarshal._stringResource = null;

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -226,7 +226,9 @@ var BindingSupportLib = {
 		},
 
 		js_string_to_mono_string: function (string) {
-			if (typeof (string) === "symbol")
+			if (string === null)
+				return null;
+			else if (typeof (string) === "symbol")
 				return this.js_string_to_mono_string_interned (string);
 			else if (typeof (string) !== "string")
 				throw new Error ("Expected string argument");


### PR DESCRIPTION
The tighter argument checks are failing when handling null strings