### PR TITLE
Fix building libraries with Ninja.

### DIFF
--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.5)
+cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0091 NEW)
 
 # C Compiler flags

--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.14.5)
+cmake_policy(SET CMP0091 NEW)
 
 # C Compiler flags
-SET (CMAKE_C_FLAGS_INIT                     "/W0 /FC")
+SET (CMAKE_C_FLAGS_INIT                     "/FC")
 SET (CMAKE_C_FLAGS_DEBUG_INIT               "/Od /Zi")
 SET (CMAKE_C_FLAGS_RELEASE_INIT             "/Ox")
 SET (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT      "/O2 /Zi")
@@ -66,7 +67,7 @@ if ($ENV{__BuildArch} STREQUAL "x86")
 endif ()
 
 # enable control-flow-guard support for native components
-add_compile_options(/guard:cf) 
+add_compile_options(/guard:cf)
 list(APPEND __SharedLinkArgs /GUARD:CF)
 
 # Statically linked CRT (libcmt[d].lib, libvcruntime[d].lib and libucrt[d].lib) by default. This is done to avoid
@@ -76,8 +77,7 @@ list(APPEND __SharedLinkArgs /GUARD:CF)
 # won't do the same for debug/checked builds since ucrtbased.dll is not redistributable and Debug/Checked builds are not
 # production-time scenarios.
 
-add_compile_options($<$<CONFIG:DEBUG>:/MTd>)
-add_compile_options($<$<CONFIG:RELEASE>:/MT>)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 add_compile_options($<$<CONFIG:RELEASE>:/GL>)
 add_compile_options($<$<CONFIG:RELEASE>:/O1>)


### PR DESCRIPTION
Fixes #45763

You need to delete the intermediate files and let CMake regenerate them from scratch for this fix to work.