### PR TITLE
Fix Unix FileStatus flag retrieval without perf regression

### DIFF
--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -49,7 +49,7 @@ namespace System.IO.Enumeration
             // so we use DT_UNKNOWN as a sentinel value. As such, check if the dirent is a
             // directory.
             else if ((directoryEntry.InodeType == Interop.Sys.NodeType.DT_LNK || directoryEntry.InodeType == Interop.Sys.NodeType.DT_UNKNOWN) &&
-                     entry._status.TryRefreshMainCache(entry.FullPath)) // Only call lstat if inode is link or unknown
+                     entry._status.TryRefreshSecondaryCache(entry.FullPath)) // Only call stat if inode is link or unknown
             {
                 // Symlink or unknown: Stat should tell us if we can resolve it to a directory.
                 isDirectory = entry._status.HasSecondaryDirectoryFlag;
@@ -62,7 +62,7 @@ namespace System.IO.Enumeration
                 isSymlink = true;
             }
             else if (directoryEntry.InodeType == Interop.Sys.NodeType.DT_UNKNOWN &&
-                     entry._status.TryRefreshSecondaryCache(entry.FullPath)) // Only call stat if inode is unknown
+                     entry._status.TryRefreshMainCache(entry.FullPath)) // Only call lstat if inode is unknown
             {
                 isSymlink = entry._status.HasSymbolicLinkFlag;
             }
@@ -153,8 +153,7 @@ namespace System.IO.Enumeration
         public DateTimeOffset LastWriteTimeUtc => _status.GetLastWriteTime(FullPath, continueOnError: true);
         public bool IsDirectory => _status.InitiallyDirectory;
         public bool IsHidden =>
-            (_directoryEntry.NameLength > 0 && _directoryEntry.Name[0] == '.') ||
-            (_status.IsMainCacheValid && _status.HasHiddenFlag);
+            (_directoryEntry.NameLength > 0 && _directoryEntry.Name[0] == '.') || _status.IsHidden(FullPath, continueOnError: true);
 
         public FileSystemInfo ToFileSystemInfo()
         {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -66,7 +66,8 @@ namespace System.IO.Enumeration
             }
 
             entry._status = default;
-            FileStatus.Initialize(ref entry._status, isDirectory);
+            entry._status.Invalidate();
+            entry._status.InitiallyDirectory = isDirectory;
 
             FileAttributes attributes = default;
             if (isSymlink)

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -159,8 +159,17 @@ namespace System.IO.Enumeration
 
         public FileSystemInfo ToFileSystemInfo()
         {
+            Debug.Assert(!PathInternal.IsPartiallyQualified(FullPath), "FullPath should be fully qualified when constructed from directory enumeration");
+
             string fullPath = ToFullPath();
-            return FileSystemInfo.Create(fullPath, new string(FileName), ref _status);
+            string fileName = new(FileName);
+
+            FileSystemInfo info = IsDirectory
+                ? new DirectoryInfo(fullPath, fileName: fileName, isNormalized: true)
+                : new FileInfo(fullPath, fileName: fileName, isNormalized: true);
+
+            info.Init(ref _status);
+            return info;
         }
 
         /// <summary>

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -72,14 +72,22 @@ namespace System.IO.Enumeration
 
             FileAttributes attributes = default;
             if (isSymlink)
+            {
                 attributes |= FileAttributes.ReparsePoint;
+            }
             if (isDirectory)
+            {
                 attributes |= FileAttributes.Directory;
-            if (directoryEntry.Name[0] == '.')
+            }
+            if (entry.IsHidden)
+            {
                 attributes |= FileAttributes.Hidden;
+            }
 
             if (attributes == default)
+            {
                 attributes = FileAttributes.Normal;
+            }
 
             entry._initialAttributes = attributes;
             return attributes;
@@ -145,7 +153,9 @@ namespace System.IO.Enumeration
         public DateTimeOffset LastAccessTimeUtc => _status.GetLastAccessTime(FullPath, continueOnError: true);
         public DateTimeOffset LastWriteTimeUtc => _status.GetLastWriteTime(FullPath, continueOnError: true);
         public bool IsDirectory => _status.InitiallyDirectory;
-        public bool IsHidden => _directoryEntry.Name[0] == '.';
+        public bool IsHidden =>
+            (_directoryEntry.NameLength > 0 && _directoryEntry.Name[0] == '.') ||
+            (_status.IsMainCacheValid && _status.HasHiddenFlag);
 
         public FileSystemInfo ToFileSystemInfo()
         {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -34,7 +34,7 @@ namespace System.IO
 
         // Checks if the main path (without following symbolic links) has the hidden attribute
         // Only call if Refresh has been successfully called at least once
-        private bool HasHiddenFlag =>
+        internal bool HasHiddenFlag =>
             (_mainCache.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN;
 
         // Checks if the main path (without following symbolic links) has the read-only attribute

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -41,12 +41,6 @@ namespace System.IO
             }
         }
 
-        internal static void Initialize(ref FileStatus status, bool isDirectory)
-        {
-            status.InitiallyDirectory = isDirectory;
-            status._fileStatusInitialized = -1;
-        }
-
         internal FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
         {
             // IMPORTANT: Attribute logic must match the logic in FileSystemEntry
@@ -132,6 +126,12 @@ namespace System.IO
         {
             EnsureStatInitialized(path, continueOnError);
             return _fileStatus.Size;
+        }
+
+        internal static void Initialize(ref FileStatus status, bool isDirectory)
+        {
+            status.InitiallyDirectory = isDirectory;
+            status._fileStatusInitialized = -1;
         }
 
         internal void Invalidate() =>

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -36,9 +36,13 @@ namespace System.IO
         // DirectoryInfo around this status struct or (2) actually are part of a DirectoryInfo.
         internal bool InitiallyDirectory { get; private set; }
 
+        private bool IsValid =>
+            _initializedMainCache == 0 && // Should always be successfully refreshed
+            (_initializedSecondaryCache == -1 || _initializedSecondaryCache == 0); // Only refreshed when path is detected to be a symbolic link
+
         internal void EnsureStatInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            if (_initializedMainCache == -1)
+            if (!IsValid)
             {
                 Refresh(path);
             }
@@ -114,7 +118,7 @@ namespace System.IO
 
         internal bool GetExists(ReadOnlySpan<char> path)
         {
-            if (_initializedMainCache == -1)
+            if (!IsValid)
             {
                 Refresh(path);
             }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -233,13 +233,11 @@ namespace System.IO
             // If lstat indicated the path is a symlink
             if (HasSymbolicLinkFlag)
             {
-                if (!VerifyStatCall(Interop.Sys.Stat(path, out _secondaryCache), out _initializedSecondaryCache))
+                    // attempt to check the target to see if it is a directory
+                if (VerifyStatCall(Interop.Sys.Stat(path, out _secondaryCache), out _initializedSecondaryCache))
                 {
-                    _exists = false;
-                    return;
+                    _isDirectory = (_secondaryCache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
                 }
-                // attempt to check the target to see if it is a directory
-                _isDirectory = (_secondaryCache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
             }
 
             _exists = true;

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -77,12 +77,14 @@ namespace System.IO
 
         // Checks if the main path is a symbolic link
         // Only call if Refresh has been successfully called at least once
-        private bool HasSymbolicLinkFlag =>
+        internal bool HasSymbolicLinkFlag =>
             (_mainCache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK;
 
         // We track intent of creation to know whether or not we want to (1) create a
         // DirectoryInfo around this status struct or (2) actually are part of a DirectoryInfo.
         internal bool InitiallyDirectory { get; set; }
+
+        internal bool IsMainCacheValid => _initializedMainCache == 0;
 
         internal bool IsSecondaryCacheValid => _initializedSecondaryCache == 0;
 

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -96,7 +96,7 @@ namespace System.IO
         {
             if (!IsValid)
             {
-                Refresh(path);
+                RefreshCaches(path);
             }
 
             if (!continueOnError)
@@ -241,7 +241,7 @@ namespace System.IO
             return HasSymbolicLinkFlag;
         }
 
-        internal void Refresh(ReadOnlySpan<char> path)
+        internal void RefreshCaches(ReadOnlySpan<char> path)
         {
             // This should not throw, instead we store the result so that we can throw it
             // when someone actually accesses a property.

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -73,6 +73,8 @@ namespace System.IO
             }
         }
 
+        internal bool HasSecondaryDirectoryFlag => HasDirectoryFlag(_secondaryCache);
+
         // Checks if the main path is a symbolic link
         // Only call if Refresh has been successfully called at least once
         private bool HasSymbolicLinkFlag =>
@@ -81,6 +83,8 @@ namespace System.IO
         // We track intent of creation to know whether or not we want to (1) create a
         // DirectoryInfo around this status struct or (2) actually are part of a DirectoryInfo.
         internal bool InitiallyDirectory { get; set; }
+
+        internal bool IsSecondaryCacheValid => _initializedSecondaryCache == 0;
 
         private bool IsValid =>
             _initializedMainCache == 0 && // Should always be successfully refreshed
@@ -202,7 +206,7 @@ namespace System.IO
         // Checks if the specified stat or lstat cache has the directory attribute
         // Only call if Refresh has been successfully called at least once and
         // you're certain the passed-in cache was successfully retrieved
-        private bool HasDirectoryFlag(Interop.Sys.FileStatus cache) =>
+        private static bool HasDirectoryFlag(Interop.Sys.FileStatus cache) =>
             (cache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
 
         internal void Invalidate()

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -253,7 +253,7 @@ namespace System.IO
             // If it is a symlink, then subsequently get details on the target of the symlink,
             // storing those results separately.  We only report failure if the initial
             // lstat fails, as a broken symlink should still report info on exists, attributes, etc.
-            if (!VerifyStatCall(Interop.Sys.LStat(path, out _mainCache), out _initializedMainCache))
+            if (!TryRefreshMainCache(path))
             {
                 _exists = false;
                 return;
@@ -263,7 +263,7 @@ namespace System.IO
 
             if (HasSymbolicLinkFlag)
             {
-                if (VerifyStatCall(Interop.Sys.Stat(path, out _secondaryCache), out _initializedSecondaryCache))
+                if (TryRefreshSecondaryCache(path))
                 {
                     _isDirectory = HasDirectoryFlag(_secondaryCache);
                 }
@@ -271,6 +271,12 @@ namespace System.IO
 
             _exists = true;
         }
+
+        internal bool TryRefreshMainCache(ReadOnlySpan<char> path) =>
+            VerifyStatCall(Interop.Sys.LStat(path, out _mainCache), out _initializedMainCache);
+
+        internal bool TryRefreshSecondaryCache(ReadOnlySpan<char> path) =>
+            VerifyStatCall(Interop.Sys.Stat(path, out _secondaryCache), out _initializedSecondaryCache);
 
         private unsafe void SetAccessOrWriteTime(string path, DateTimeOffset time, bool isAccessTime)
         {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -69,7 +69,7 @@ namespace System.IO
                 (_fileStatus.Mode & (int)writeBit) == 0);     // but not write permission
         }
 
-        public FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
+        internal FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
         {
             // IMPORTANT: Attribute logic must match the logic in FileSystemEntry
 
@@ -96,7 +96,7 @@ namespace System.IO
             return attributes != default ? attributes : FileAttributes.Normal;
         }
 
-        public void SetAttributes(string path, FileAttributes attributes)
+        internal void SetAttributes(string path, FileAttributes attributes)
         {
             // Validate that only flags from the attribute are being provided.  This is an
             // approximation for the validation done by the Win32 function.
@@ -271,7 +271,7 @@ namespace System.IO
             return _fileStatus.Size;
         }
 
-        public void Refresh(ReadOnlySpan<char> path)
+        internal void Refresh(ReadOnlySpan<char> path)
         {
             // This should not throw, instead we store the result so that we can throw it
             // when someone actually accesses a property.

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -202,25 +202,57 @@ namespace System.IO
 
         internal bool IsDirectory(ReadOnlySpan<char> path, bool continueOnError = false)
         {
+            // We first check if main path has directory flag, then follow the symbolic link in case the target has directory flag
+            // So we need to try to refresh both caches
             EnsureCachesInitialized(path, continueOnError);
             return _isDirectory; // Value should be set in Refresh
         }
 
         internal bool IsHidden(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureCachesInitialized(path, continueOnError);
+            // We only check for the hidden flag in the main path without following symbolic links
+            if (!IsMainCacheValid)
+            {
+                if (!TryRefreshMainCache(path))
+                {
+                    if (!continueOnError)
+                    {
+                        ThrowOnCacheInitializationError(path);
+                    }
+                }
+            }
             return HasHiddenFlag;
         }
 
         internal bool IsReadOnly(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureCachesInitialized(path, continueOnError);
+            // We only check for the readonly flag in the main path without following symbolic links
+            if (!IsMainCacheValid)
+            {
+                if (!TryRefreshMainCache(path))
+                {
+                    if (!continueOnError)
+                    {
+                        ThrowOnCacheInitializationError(path);
+                    }
+                }
+            }
             return HasReadOnlyFlag;
         }
 
         internal bool IsSymbolicLink(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureCachesInitialized(path, continueOnError);
+            // We only check for the symbolic link flag in the main path without following symbolic links
+            if (!IsMainCacheValid)
+            {
+                if (!TryRefreshMainCache(path))
+                {
+                    if (!continueOnError)
+                    {
+                        ThrowOnCacheInitializationError(path);
+                    }
+                }
+            }
             return HasSymbolicLinkFlag;
         }
 

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -164,11 +164,14 @@ namespace System.IO
         internal static void Initialize(ref FileStatus status, bool isDirectory)
         {
             status.InitiallyDirectory = isDirectory;
-            status._initializedMainCache = -1;
+            status.Invalidate();
         }
 
-        internal void Invalidate() =>
+        internal void Invalidate()
+        {
             _initializedMainCache = -1;
+            _initializedSecondaryCache = -1;
+        }
 
         internal bool IsReadOnly(ReadOnlySpan<char> path, bool continueOnError = false)
         {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -15,10 +15,19 @@ namespace System.IO
         // The last cached lstat information about the file
         private Interop.Sys.FileStatus _mainCache;
 
+        // The last cached stat information about the file
+        // Refresh only collects this if lstat determines the path is a symbolic link
+        private Interop.Sys.FileStatus _secondaryCache;
+
         // -1 if _mainCache isn't initialized - Refresh should always change this value
         // 0 if _mainCache was initialized with no errors
         // or the errno error code (always positive value)
         private int _initializedMainCache;
+
+        // -1 if _secondaryCache isn't initialized - Refresh only changes this value if lstat determines the path is a symbolic link
+        // 0 if _secondaryCache was initialized with no errors
+        // or the errno error code (always positive value)
+        private int _initializedSecondaryCache;
 
         // Is a directory as of the last refresh
         internal bool _isDirectory;

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -101,24 +101,7 @@ namespace System.IO
 
             if (!continueOnError)
             {
-                int errno = 0;
-
-                // Lstat should always be initialized by Refresh
-                if (_initializedMainCache != 0)
-                {
-                    errno = _initializedMainCache;
-                }
-                // Stat is optionally initialized when Refresh detects object is a symbolic link
-                else if (_initializedSecondaryCache != 0 && _initializedSecondaryCache != -1)
-                {
-                    errno = _initializedSecondaryCache;
-                }
-
-                if (errno != 0)
-                {
-                    Invalidate();
-                    throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
-                }
+                ThrowOnCacheInitializationError(path);
             }
         }
 
@@ -270,6 +253,27 @@ namespace System.IO
             }
 
             _exists = true;
+        }
+        private void ThrowOnCacheInitializationError(ReadOnlySpan<char> path)
+        {
+            int errno = 0;
+
+            // Lstat should always be initialized by Refresh
+            if (_initializedMainCache != 0)
+            {
+                errno = _initializedMainCache;
+            }
+            // Stat is optionally initialized when Refresh detects object is a symbolic link
+            else if (_initializedSecondaryCache != 0 && _initializedSecondaryCache != -1)
+            {
+                errno = _initializedSecondaryCache;
+            }
+
+            if (errno != 0)
+            {
+                Invalidate();
+                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
+            }
         }
 
         internal bool TryRefreshMainCache(ReadOnlySpan<char> path) =>

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -54,22 +54,32 @@ namespace System.IO
             EnsureStatInitialized(path);
 
             if (!_exists)
+            {
                 return (FileAttributes)(-1);
+            }
 
             FileAttributes attributes = default;
 
             if (IsReadOnly(path))
+            {
                 attributes |= FileAttributes.ReadOnly;
+            }
 
             if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK)
+            {
                 attributes |= FileAttributes.ReparsePoint;
+            }
 
             if (_isDirectory)
+            {
                 attributes |= FileAttributes.Directory;
+            }
 
             // If the filename starts with a period or has UF_HIDDEN flag set, it's hidden.
             if (fileName.Length > 0 && (fileName[0] == '.' || (_fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN))
+            {
                 attributes |= FileAttributes.Hidden;
+            }
 
             return attributes != default ? attributes : FileAttributes.Normal;
         }
@@ -78,15 +88,21 @@ namespace System.IO
         {
             EnsureStatInitialized(path, continueOnError);
             if (!_exists)
+            {
                 return DateTimeOffset.FromFileTime(0);
+            }
 
             if ((_fileStatus.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0)
+            {
                 return UnixTimeToDateTimeOffset(_fileStatus.BirthTime, _fileStatus.BirthTimeNsec);
+            }
 
             // fall back to the oldest time we have in between change and modify time
             if (_fileStatus.MTime < _fileStatus.CTime ||
                 (_fileStatus.MTime == _fileStatus.CTime && _fileStatus.MTimeNsec < _fileStatus.CTimeNsec))
+            {
                 return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
+            }
 
             return UnixTimeToDateTimeOffset(_fileStatus.CTime, _fileStatus.CTimeNsec);
         }
@@ -95,7 +111,9 @@ namespace System.IO
         internal bool GetExists(ReadOnlySpan<char> path)
         {
             if (_fileStatusInitialized == -1)
+            {
                 Refresh(path);
+            }
 
             return _exists && InitiallyDirectory == _isDirectory;
         }
@@ -104,7 +122,9 @@ namespace System.IO
         {
             EnsureStatInitialized(path, continueOnError);
             if (!_exists)
+            {
                 return DateTimeOffset.FromFileTime(0);
+            }
             return UnixTimeToDateTimeOffset(_fileStatus.ATime, _fileStatus.ATimeNsec);
         }
 
@@ -257,7 +277,9 @@ namespace System.IO
             EnsureStatInitialized(path);
 
             if (!_exists)
+            {
                 FileSystemInfo.ThrowNotFound(path);
+            }
 
             if (Interop.Sys.CanSetHiddenFlag)
             {
@@ -321,7 +343,9 @@ namespace System.IO
         {
             EnsureStatInitialized(path, continueOnError);
             if (!_exists)
+            {
                 return DateTimeOffset.FromFileTime(0);
+            }
             return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
         }
 

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -9,6 +9,9 @@ namespace System.IO
     {
         private const int NanosecondsPerTick = 100;
 
+        // Exists as of the last refresh
+        private bool _exists;
+
         // The last cached stat information about the file
         private Interop.Sys.FileStatus _fileStatus;
 
@@ -16,25 +19,103 @@ namespace System.IO
         // errors, or the errno error code.
         private int _fileStatusInitialized;
 
+        // Is a directory as of the last refresh
+        internal bool _isDirectory;
+
         // We track intent of creation to know whether or not we want to (1) create a
         // DirectoryInfo around this status struct or (2) actually are part of a DirectoryInfo.
         internal bool InitiallyDirectory { get; private set; }
 
-        // Is a directory as of the last refresh
-        internal bool _isDirectory;
+        internal void EnsureStatInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            if (_fileStatusInitialized == -1)
+            {
+                Refresh(path);
+            }
 
-        // Exists as of the last refresh
-        private bool _exists;
+            if (_fileStatusInitialized != 0 && !continueOnError)
+            {
+                int errno = _fileStatusInitialized;
+                _fileStatusInitialized = -1;
+                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
+            }
+        }
 
-        internal static void Initialize(
-            ref FileStatus status,
-            bool isDirectory)
+        internal static void Initialize(ref FileStatus status, bool isDirectory)
         {
             status.InitiallyDirectory = isDirectory;
             status._fileStatusInitialized = -1;
         }
 
-        internal void Invalidate() => _fileStatusInitialized = -1;
+        internal FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
+        {
+            // IMPORTANT: Attribute logic must match the logic in FileSystemEntry
+
+            EnsureStatInitialized(path);
+
+            if (!_exists)
+                return (FileAttributes)(-1);
+
+            FileAttributes attributes = default;
+
+            if (IsReadOnly(path))
+                attributes |= FileAttributes.ReadOnly;
+
+            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK)
+                attributes |= FileAttributes.ReparsePoint;
+
+            if (_isDirectory)
+                attributes |= FileAttributes.Directory;
+
+            // If the filename starts with a period or has UF_HIDDEN flag set, it's hidden.
+            if (fileName.Length > 0 && (fileName[0] == '.' || (_fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN))
+                attributes |= FileAttributes.Hidden;
+
+            return attributes != default ? attributes : FileAttributes.Normal;
+        }
+
+        internal DateTimeOffset GetCreationTime(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            EnsureStatInitialized(path, continueOnError);
+            if (!_exists)
+                return DateTimeOffset.FromFileTime(0);
+
+            if ((_fileStatus.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0)
+                return UnixTimeToDateTimeOffset(_fileStatus.BirthTime, _fileStatus.BirthTimeNsec);
+
+            // fall back to the oldest time we have in between change and modify time
+            if (_fileStatus.MTime < _fileStatus.CTime ||
+                (_fileStatus.MTime == _fileStatus.CTime && _fileStatus.MTimeNsec < _fileStatus.CTimeNsec))
+                return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
+
+            return UnixTimeToDateTimeOffset(_fileStatus.CTime, _fileStatus.CTimeNsec);
+        }
+
+
+        internal bool GetExists(ReadOnlySpan<char> path)
+        {
+            if (_fileStatusInitialized == -1)
+                Refresh(path);
+
+            return _exists && InitiallyDirectory == _isDirectory;
+        }
+
+        internal DateTimeOffset GetLastAccessTime(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            EnsureStatInitialized(path, continueOnError);
+            if (!_exists)
+                return DateTimeOffset.FromFileTime(0);
+            return UnixTimeToDateTimeOffset(_fileStatus.ATime, _fileStatus.ATimeNsec);
+        }
+
+        internal long GetLength(ReadOnlySpan<char> path, bool continueOnError = false)
+        {
+            EnsureStatInitialized(path, continueOnError);
+            return _fileStatus.Size;
+        }
+
+        internal void Invalidate() =>
+            _fileStatusInitialized = -1;
 
         internal bool IsReadOnly(ReadOnlySpan<char> path, bool continueOnError = false)
         {
@@ -69,31 +150,91 @@ namespace System.IO
                 (_fileStatus.Mode & (int)writeBit) == 0);     // but not write permission
         }
 
-        internal FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
+        internal void Refresh(ReadOnlySpan<char> path)
         {
-            // IMPORTANT: Attribute logic must match the logic in FileSystemEntry
+            // This should not throw, instead we store the result so that we can throw it
+            // when someone actually accesses a property.
 
+            // Use lstat to get the details on the object, without following symlinks.
+            // If it is a symlink, then subsequently get details on the target of the symlink,
+            // storing those results separately.  We only report failure if the initial
+            // lstat fails, as a broken symlink should still report info on exists, attributes, etc.
+            _isDirectory = false;
+            path = Path.TrimEndingDirectorySeparator(path);
+
+            int result = Interop.Sys.LStat(path, out _fileStatus);
+            if (result < 0)
+            {
+                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+
+                // This should never set the error if the file can't be found.
+                // (see the Windows refresh passing returnErrorOnNotFound: false).
+                if (errorInfo.Error == Interop.Error.ENOENT
+                    || errorInfo.Error == Interop.Error.ENOTDIR)
+                {
+                    _fileStatusInitialized = 0;
+                    _exists = false;
+                }
+                else
+                {
+                    _fileStatusInitialized = errorInfo.RawErrno;
+                }
+                return;
+            }
+
+            _exists = true;
+
+            // IMPORTANT: Is directory logic must match the logic in FileSystemEntry
+            _isDirectory = (_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+
+            // If we're a symlink, attempt to check the target to see if it is a directory
+            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK &&
+                Interop.Sys.Stat(path, out Interop.Sys.FileStatus targetStatus) >= 0)
+            {
+                _isDirectory = (targetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+            }
+
+            _fileStatusInitialized = 0;
+        }
+
+        private unsafe void SetAccessOrWriteTime(string path, DateTimeOffset time, bool isAccessTime)
+        {
+            // force a refresh so that we have an up-to-date times for values not being overwritten
+            _fileStatusInitialized = -1;
             EnsureStatInitialized(path);
 
-            if (!_exists)
-                return (FileAttributes)(-1);
+            // we use utimes()/utimensat() to set the accessTime and writeTime
+            Interop.Sys.TimeSpec* buf = stackalloc Interop.Sys.TimeSpec[2];
 
-            FileAttributes attributes = default;
+            long seconds = time.ToUnixTimeSeconds();
 
-            if (IsReadOnly(path))
-                attributes |= FileAttributes.ReadOnly;
+            const long TicksPerMillisecond = 10000;
+            const long TicksPerSecond = TicksPerMillisecond * 1000;
+            long nanoseconds = (time.UtcDateTime.Ticks - DateTimeOffset.UnixEpoch.Ticks - seconds * TicksPerSecond) * NanosecondsPerTick;
 
-            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK)
-                attributes |= FileAttributes.ReparsePoint;
-
-            if (_isDirectory)
-                attributes |= FileAttributes.Directory;
-
-            // If the filename starts with a period or has UF_HIDDEN flag set, it's hidden.
-            if (fileName.Length > 0 && (fileName[0] == '.' || (_fileStatus.UserFlags & (uint)Interop.Sys.UserFlags.UF_HIDDEN) == (uint)Interop.Sys.UserFlags.UF_HIDDEN))
-                attributes |= FileAttributes.Hidden;
-
-            return attributes != default ? attributes : FileAttributes.Normal;
+#if TARGET_BROWSER
+            buf[0].TvSec = seconds;
+            buf[0].TvNsec = nanoseconds;
+            buf[1].TvSec = seconds;
+            buf[1].TvNsec = nanoseconds;
+#else
+            if (isAccessTime)
+            {
+                buf[0].TvSec = seconds;
+                buf[0].TvNsec = nanoseconds;
+                buf[1].TvSec = _fileStatus.MTime;
+                buf[1].TvNsec = _fileStatus.MTimeNsec;
+            }
+            else
+            {
+                buf[0].TvSec = _fileStatus.ATime;
+                buf[0].TvNsec = _fileStatus.ATimeNsec;
+                buf[1].TvSec = seconds;
+                buf[1].TvNsec = nanoseconds;
+            }
+#endif
+            Interop.CheckIo(Interop.Sys.UTimensat(path, buf), path, InitiallyDirectory);
+            _fileStatusInitialized = -1;
         }
 
         internal void SetAttributes(string path, FileAttributes attributes)
@@ -161,33 +302,7 @@ namespace System.IO
             _fileStatusInitialized = -1;
         }
 
-        internal bool GetExists(ReadOnlySpan<char> path)
-        {
-            if (_fileStatusInitialized == -1)
-                Refresh(path);
-
-            return _exists && InitiallyDirectory == _isDirectory;
-        }
-
-        internal DateTimeOffset GetCreationTime(ReadOnlySpan<char> path, bool continueOnError = false)
-        {
-            EnsureStatInitialized(path, continueOnError);
-            if (!_exists)
-                return DateTimeOffset.FromFileTime(0);
-
-            if ((_fileStatus.Flags & Interop.Sys.FileStatusFlags.HasBirthTime) != 0)
-                return UnixTimeToDateTimeOffset(_fileStatus.BirthTime, _fileStatus.BirthTimeNsec);
-
-            // fall back to the oldest time we have in between change and modify time
-            if (_fileStatus.MTime < _fileStatus.CTime ||
-                (_fileStatus.MTime == _fileStatus.CTime && _fileStatus.MTimeNsec < _fileStatus.CTimeNsec))
-                return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
-
-            return UnixTimeToDateTimeOffset(_fileStatus.CTime, _fileStatus.CTimeNsec);
-        }
-
-        internal void SetCreationTime(string path, DateTimeOffset time)
-        {
+        internal void SetCreationTime(string path, DateTimeOffset time) =>
             // Unix provides APIs to update the last access time (atime) and last modification time (mtime).
             // There is no API to update the CreationTime.
             // Some platforms (e.g. Linux) don't store a creation time. On those platforms, the creation time
@@ -198,17 +313,9 @@ namespace System.IO
             // CreationTime, GetCreationTime will return the value that was previously set (when that value
             // wasn't in the future).
             SetLastWriteTime(path, time);
-        }
 
-        internal DateTimeOffset GetLastAccessTime(ReadOnlySpan<char> path, bool continueOnError = false)
-        {
-            EnsureStatInitialized(path, continueOnError);
-            if (!_exists)
-                return DateTimeOffset.FromFileTime(0);
-            return UnixTimeToDateTimeOffset(_fileStatus.ATime, _fileStatus.ATimeNsec);
-        }
-
-        internal void SetLastAccessTime(string path, DateTimeOffset time) => SetAccessOrWriteTime(path, time, isAccessTime: true);
+        internal void SetLastAccessTime(string path, DateTimeOffset time) =>
+            SetAccessOrWriteTime(path, time, isAccessTime: true);
 
         internal DateTimeOffset GetLastWriteTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
@@ -218,119 +325,10 @@ namespace System.IO
             return UnixTimeToDateTimeOffset(_fileStatus.MTime, _fileStatus.MTimeNsec);
         }
 
-        internal void SetLastWriteTime(string path, DateTimeOffset time) => SetAccessOrWriteTime(path, time, isAccessTime: false);
+        internal void SetLastWriteTime(string path, DateTimeOffset time) =>
+            SetAccessOrWriteTime(path, time, isAccessTime: false);
 
-        private DateTimeOffset UnixTimeToDateTimeOffset(long seconds, long nanoseconds)
-        {
-            return DateTimeOffset.FromUnixTimeSeconds(seconds).AddTicks(nanoseconds / NanosecondsPerTick).ToLocalTime();
-        }
-
-        private unsafe void SetAccessOrWriteTime(string path, DateTimeOffset time, bool isAccessTime)
-        {
-            // force a refresh so that we have an up-to-date times for values not being overwritten
-            _fileStatusInitialized = -1;
-            EnsureStatInitialized(path);
-
-            // we use utimes()/utimensat() to set the accessTime and writeTime
-            Interop.Sys.TimeSpec* buf = stackalloc Interop.Sys.TimeSpec[2];
-
-            long seconds = time.ToUnixTimeSeconds();
-
-            const long TicksPerMillisecond = 10000;
-            const long TicksPerSecond = TicksPerMillisecond * 1000;
-            long nanoseconds = (time.UtcDateTime.Ticks - DateTimeOffset.UnixEpoch.Ticks - seconds * TicksPerSecond) * NanosecondsPerTick;
-
-#if TARGET_BROWSER
-            buf[0].TvSec = seconds;
-            buf[0].TvNsec = nanoseconds;
-            buf[1].TvSec = seconds;
-            buf[1].TvNsec = nanoseconds;
-#else
-            if (isAccessTime)
-            {
-                buf[0].TvSec = seconds;
-                buf[0].TvNsec = nanoseconds;
-                buf[1].TvSec = _fileStatus.MTime;
-                buf[1].TvNsec = _fileStatus.MTimeNsec;
-            }
-            else
-            {
-                buf[0].TvSec = _fileStatus.ATime;
-                buf[0].TvNsec = _fileStatus.ATimeNsec;
-                buf[1].TvSec = seconds;
-                buf[1].TvNsec = nanoseconds;
-            }
-#endif
-            Interop.CheckIo(Interop.Sys.UTimensat(path, buf), path, InitiallyDirectory);
-            _fileStatusInitialized = -1;
-        }
-
-        internal long GetLength(ReadOnlySpan<char> path, bool continueOnError = false)
-        {
-            EnsureStatInitialized(path, continueOnError);
-            return _fileStatus.Size;
-        }
-
-        internal void Refresh(ReadOnlySpan<char> path)
-        {
-            // This should not throw, instead we store the result so that we can throw it
-            // when someone actually accesses a property.
-
-            // Use lstat to get the details on the object, without following symlinks.
-            // If it is a symlink, then subsequently get details on the target of the symlink,
-            // storing those results separately.  We only report failure if the initial
-            // lstat fails, as a broken symlink should still report info on exists, attributes, etc.
-            _isDirectory = false;
-            path = Path.TrimEndingDirectorySeparator(path);
-
-            int result = Interop.Sys.LStat(path, out _fileStatus);
-            if (result < 0)
-            {
-                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
-
-                // This should never set the error if the file can't be found.
-                // (see the Windows refresh passing returnErrorOnNotFound: false).
-                if (errorInfo.Error == Interop.Error.ENOENT
-                    || errorInfo.Error == Interop.Error.ENOTDIR)
-                {
-                    _fileStatusInitialized = 0;
-                    _exists = false;
-                }
-                else
-                {
-                    _fileStatusInitialized = errorInfo.RawErrno;
-                }
-                return;
-            }
-
-            _exists = true;
-
-            // IMPORTANT: Is directory logic must match the logic in FileSystemEntry
-            _isDirectory = (_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-
-            // If we're a symlink, attempt to check the target to see if it is a directory
-            if ((_fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFLNK &&
-                Interop.Sys.Stat(path, out Interop.Sys.FileStatus targetStatus) >= 0)
-            {
-                _isDirectory = (targetStatus.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-            }
-
-            _fileStatusInitialized = 0;
-        }
-
-        internal void EnsureStatInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
-        {
-            if (_fileStatusInitialized == -1)
-            {
-                Refresh(path);
-            }
-
-            if (_fileStatusInitialized != 0 && !continueOnError)
-            {
-                int errno = _fileStatusInitialized;
-                _fileStatusInitialized = -1;
-                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
-            }
-        }
+        private DateTimeOffset UnixTimeToDateTimeOffset(long seconds, long nanoseconds) =>
+            DateTimeOffset.FromUnixTimeSeconds(seconds).AddTicks(nanoseconds / NanosecondsPerTick).ToLocalTime();
     }
 }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -80,7 +80,7 @@ namespace System.IO
 
         // We track intent of creation to know whether or not we want to (1) create a
         // DirectoryInfo around this status struct or (2) actually are part of a DirectoryInfo.
-        internal bool InitiallyDirectory { get; private set; }
+        internal bool InitiallyDirectory { get; set; }
 
         private bool IsValid =>
             _initializedMainCache == 0 && // Should always be successfully refreshed
@@ -204,12 +204,6 @@ namespace System.IO
         // you're certain the passed-in cache was successfully retrieved
         private bool HasDirectoryFlag(Interop.Sys.FileStatus cache) =>
             (cache.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-
-        internal static void Initialize(ref FileStatus status, bool isDirectory)
-        {
-            status.InitiallyDirectory = isDirectory;
-            status.Invalidate();
-        }
 
         internal void Invalidate()
         {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs
@@ -92,7 +92,7 @@ namespace System.IO
             _initializedMainCache == 0 && // Should always be successfully refreshed
             (_initializedSecondaryCache == -1 || _initializedSecondaryCache == 0); // Only refreshed when path is detected to be a symbolic link
 
-        internal void EnsureStatInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
+        internal void EnsureCachesInitialized(ReadOnlySpan<char> path, bool continueOnError = false)
         {
             if (!IsValid)
             {
@@ -126,7 +126,7 @@ namespace System.IO
         {
             // IMPORTANT: Attribute logic must match the logic in FileSystemEntry
 
-            EnsureStatInitialized(path);
+            EnsureCachesInitialized(path);
 
             if (!_exists)
             {
@@ -161,7 +161,7 @@ namespace System.IO
 
         internal DateTimeOffset GetCreationTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             if (!_exists)
             {
                 return DateTimeOffset.FromFileTime(0);
@@ -185,13 +185,13 @@ namespace System.IO
 
         internal bool GetExists(ReadOnlySpan<char> path)
         {
-            EnsureStatInitialized(path, continueOnError: true);
+            EnsureCachesInitialized(path, continueOnError: true);
             return _exists && InitiallyDirectory == _isDirectory;
         }
 
         internal DateTimeOffset GetLastAccessTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             if (!_exists)
             {
                 return DateTimeOffset.FromFileTime(0);
@@ -201,7 +201,7 @@ namespace System.IO
 
         internal long GetLength(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             return _mainCache.Size;
         }
 
@@ -219,25 +219,25 @@ namespace System.IO
 
         internal bool IsDirectory(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             return _isDirectory; // Value should be set in Refresh
         }
 
         internal bool IsHidden(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             return HasHiddenFlag;
         }
 
         internal bool IsReadOnly(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             return HasReadOnlyFlag;
         }
 
         internal bool IsSymbolicLink(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             return HasSymbolicLinkFlag;
         }
 
@@ -282,7 +282,7 @@ namespace System.IO
         {
             // force a refresh so that we have an up-to-date times for values not being overwritten
             Invalidate();
-            EnsureStatInitialized(path);
+            EnsureCachesInitialized(path);
 
             // we use utimes()/utimensat() to set the accessTime and writeTime
             Interop.Sys.TimeSpec* buf = stackalloc Interop.Sys.TimeSpec[2];
@@ -335,7 +335,7 @@ namespace System.IO
                 throw new ArgumentException(SR.Arg_InvalidFileAttrs, "Attributes");
             }
 
-            EnsureStatInitialized(path);
+            EnsureCachesInitialized(path);
 
             if (!_exists)
             {
@@ -403,7 +403,7 @@ namespace System.IO
 
         internal DateTimeOffset GetLastWriteTime(ReadOnlySpan<char> path, bool continueOnError = false)
         {
-            EnsureStatInitialized(path, continueOnError);
+            EnsureCachesInitialized(path, continueOnError);
             if (!_exists)
             {
                 return DateTimeOffset.FromFileTime(0);

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -11,7 +11,8 @@ namespace System.IO
 
         protected FileSystemInfo()
         {
-            FileStatus.Initialize(ref _fileStatus, this is DirectoryInfo);
+            _fileStatus.Invalidate();
+            _fileStatus.InitiallyDirectory = this is DirectoryInfo;
         }
 
         internal static unsafe FileSystemInfo Create(string fullPath, string fileName, ref FileStatus fileStatus)

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -20,7 +20,7 @@ namespace System.IO
         internal unsafe void Init(ref FileStatus fileStatus)
         {
             _fileStatus = fileStatus;
-            _fileStatus.EnsureStatInitialized(FullPath);
+            _fileStatus.EnsureCachesInitialized(FullPath);
         }
 
         public FileAttributes Attributes

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -51,7 +51,7 @@ namespace System.IO
 
         internal long LengthCore => _fileStatus.GetLength(FullPath);
 
-        public void Refresh() => _fileStatus.Refresh(FullPath);
+        public void Refresh() => _fileStatus.RefreshCaches(FullPath);
 
         internal static void ThrowNotFound(string path)
         {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -15,18 +15,6 @@ namespace System.IO
             _fileStatus.InitiallyDirectory = this is DirectoryInfo;
         }
 
-        internal static unsafe FileSystemInfo Create(string fullPath, string fileName, ref FileStatus fileStatus)
-        {
-            FileSystemInfo info = fileStatus.InitiallyDirectory
-                ? (FileSystemInfo)new DirectoryInfo(fullPath, fileName: fileName, isNormalized: true)
-                : new FileInfo(fullPath, fileName: fileName, isNormalized: true);
-
-            Debug.Assert(!PathInternal.IsPartiallyQualified(fullPath), $"'{fullPath}' should be fully qualified when constructed from directory enumeration");
-
-            info.Init(ref fileStatus);
-            return info;
-        }
-
         internal void Invalidate() => _fileStatus.Invalidate();
 
         internal unsafe void Init(ref FileStatus fileStatus)

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -113,18 +113,42 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
-        public void IsHiddenAttribute()
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        public void IsHiddenAttribute_Windows_OSX()
         {
-            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
-            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
-
             // Put a period in front to make it hidden on Unix
-            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, "." + GetTestFileName()));
+            IsHiddenAttributeInternal(useDotPrefix: false, useHiddenFlag: true);
+
+        }
+
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void IsHiddenAttribute_Unix()
+        {
+            // Windows and MacOS hide a file by setting the hidden attribute
+            IsHiddenAttributeInternal(useDotPrefix: true, useHiddenFlag: false);
+        }
+
+        private void IsHiddenAttributeInternal(bool useDotPrefix, bool useHiddenFlag)
+        {
+            string prefix = useDotPrefix ? "." : "";
+
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+
+            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, prefix + GetTestFileName()));
 
             fileOne.Create().Dispose();
             fileTwo.Create().Dispose();
-            if (PlatformDetection.IsWindows)
-                fileTwo.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
+
+            if (useHiddenFlag)
+            {
+                fileTwo.Attributes |= FileAttributes.Hidden;
+            }
+
+            FileInfo fileCheck = new FileInfo(fileTwo.FullName);
+            Assert.Equal(fileTwo.Attributes, fileCheck.Attributes);
 
             IEnumerable<string> enumerable = new FileSystemEnumerable<string>(
                 testDirectory.FullName,
@@ -132,6 +156,30 @@ namespace System.IO.Tests.Enumeration
                 new EnumerationOptions() { AttributesToSkip = 0 })
             {
                 ShouldIncludePredicate = (ref FileSystemEntry entry) => entry.IsHidden
+            };
+
+            Assert.Equal(new string[] { fileTwo.FullName }, enumerable);
+        }
+
+        [Fact]
+        public void IsReadOnlyAttribute()
+        {
+            DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
+
+            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
+
+            fileOne.Create().Dispose();
+            fileTwo.Create().Dispose();
+
+            fileTwo.Attributes |= FileAttributes.ReadOnly;
+
+            IEnumerable<string> enumerable = new FileSystemEnumerable<string>(
+                 testDirectory.FullName,
+                 (ref FileSystemEntry entry) => entry.ToFullPath(),
+                 new EnumerationOptions() { AttributesToSkip = 0 })
+            {
+                ShouldIncludePredicate = (ref FileSystemEntry entry) => (entry.Attributes & FileAttributes.ReadOnly) != 0
             };
 
             Assert.Equal(new string[] { fileTwo.FullName }, enumerable);

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -116,9 +116,8 @@ namespace System.IO.Tests.Enumeration
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public void IsHiddenAttribute_Windows_OSX()
         {
-            // Put a period in front to make it hidden on Unix
+            // Windows and MacOS hide a file by setting the hidden attribute
             IsHiddenAttributeInternal(useDotPrefix: false, useHiddenFlag: true);
-
         }
 
 
@@ -126,7 +125,7 @@ namespace System.IO.Tests.Enumeration
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void IsHiddenAttribute_Unix()
         {
-            // Windows and MacOS hide a file by setting the hidden attribute
+            // Put a period in front to make it hidden on Unix
             IsHiddenAttributeInternal(useDotPrefix: true, useHiddenFlag: false);
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/SkipAttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/SkipAttributeTests.cs
@@ -21,25 +21,42 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
-        public void SkippingHiddenFiles()
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        public void SkippingHiddenFiles_Windows_OSX()
+        {
+            SkippingHiddenFilesInternal(useDotPrefix: false, useHiddenFlag: true);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void SkippingHiddenFiles_Unix()
+        {
+            SkippingHiddenFilesInternal(useDotPrefix: true, useHiddenFlag: false);
+        }
+
+        private void SkippingHiddenFilesInternal(bool useDotPrefix, bool useHiddenFlag)
         {
             DirectoryInfo testDirectory = Directory.CreateDirectory(GetTestFilePath());
             DirectoryInfo testSubdirectory = Directory.CreateDirectory(Path.Combine(testDirectory.FullName, GetTestFileName()));
-            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
 
-            // Put a period in front to make it hidden on Unix
-            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, "." + GetTestFileName()));
+            FileInfo fileOne = new FileInfo(Path.Combine(testDirectory.FullName, GetTestFileName()));
             FileInfo fileThree = new FileInfo(Path.Combine(testSubdirectory.FullName, GetTestFileName()));
-            FileInfo fileFour = new FileInfo(Path.Combine(testSubdirectory.FullName, "." + GetTestFileName()));
+
+            // Put a period in front of files two and four to make them hidden on Unix
+            string prefix = useDotPrefix ? "." : "";
+            FileInfo fileTwo = new FileInfo(Path.Combine(testDirectory.FullName, prefix + GetTestFileName()));
+            FileInfo fileFour = new FileInfo(Path.Combine(testSubdirectory.FullName, prefix + GetTestFileName()));
 
             fileOne.Create().Dispose();
             fileTwo.Create().Dispose();
-            if (PlatformDetection.IsWindows)
-                fileTwo.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
             fileThree.Create().Dispose();
             fileFour.Create().Dispose();
-            if (PlatformDetection.IsWindows)
-                fileFour.Attributes = fileTwo.Attributes | FileAttributes.Hidden;
+
+            if (useHiddenFlag)
+            {
+                fileTwo.Attributes |= FileAttributes.Hidden;
+                fileFour.Attributes |= FileAttributes.Hidden;
+            }
 
             // Default EnumerationOptions is to skip hidden
             string[] paths = GetPaths(testDirectory.FullName, new EnumerationOptions());


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37301
Addresses https://github.com/dotnet/runtime/issues/41739

_If you are reviewing this PR, please take a look at each commit individually (small incremental changes)._

`FileSystemEntry` and `FileSystemInfo` were not reporting their `hidden` flags correctly on Linux and MacOS.

On Linux and MacOS, the `hidden` attribute can be set by prefixing the file or folder name with a dot.

On MacOS and Windows, the `hidden` attribute can be set by prefixing the Hidden flag on the file or folder.

The original PR introduced a perf regression due to a new `stat` call.

The `FileStatus` and `FileSystemEntry` initialization code had duplicate code when setting flags. The right way to fix it is to move all the `stat` and `lstat` calling inside `FileStatus`.

`FileSystemEntry` also has some special needs when detecting directories and symbolic links: since it has access to the `InodeType`, some info can be inferred from them, saving `stat` calls. So that logic had to be preserved in the `FileSystemEntry` initialization method, while deferring as much as possible to `FileStatus`.

Across `FileStatus`, I ensured the `stat` and `lstat` calls only get executed lazily (don't call again if already initialized), unless explicitly asking to refresh them (forcing the new `stat` call).

I also added the original unit tests to verify both the hidden flag and the readonly flag (we didn't have unit tests for the last one).

I made sure all unit tests are passing in MacOS I also ran a temporary unit test with the below code to quickly verify that the performance regression is gone:

<details>
  <summary>Temporary perf test</summary>

  ```cs
[Fact]
public void Test()
{
    var sw = new Diagnostics.Stopwatch();
    // Inside the `experiments` folder, I created one symbolic link that points to a folder,
    // and one symbolic link that points to a file
    // This ensures the `IsSymbolicLink` method I added is called.
    string path = "/Users/calope/Public/repos/experiments";
    string pattern = "*";

    Console.WriteLine("Starting...");
    sw.Start();
    for (int i = 0; i < 7000; i++)
    {
       // This is the exact same code we have in a FileSystem benchmark:
       // https://github.com/dotnet/performance/blob/a25a963e3f14214102207a2b75a5ece25162a333/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.Directory.cs#L117
        Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories).Count();
    }
    sw.Stop();
    Console.WriteLine($"Elapsed: {sw.ElapsedMilliseconds}");
}
  ```

</details>

cc @iSazonov 

**Pending**: I want to get official dotnet/performance results for all the IO.FIleSystem performance tests. But I need to figure out how to run the micro benchmarks in .NET 6.0 in MacOS, because the [Preventing regressions](https://github.com/dotnet/performance/blob/master/docs/benchmarking-workflow-dotnet-runtime.md#preventing-regressions) instructions are not working anymore. I get this error:

<details>
  <summary>Error message</summary>

  ```
calope@Carloss-MacBook-Pro performance % cd src/benchmarks/micro 
calope@Carloss-MacBook-Pro micro % dotnet run -c release -f netcoreapp5.0 --artifacts "~/Public/perf_after" --corerun "~/Public/repos/runtime/artifacts/bin/testhost/net6.0-OSX-Release-x64/shared/Microsoft.NETCore.App/6.0.0/corerun" --filter System.IO.Tests.Perf_Directory.EnumerateFiles
/usr/local/share/dotnet/sdk/5.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(141,5): 
error NETSDK1045: The current .NET SDK does not support targeting .NET Core 6.0.  
Either target .NET Core 5.0 or lower, or use a version of the .NET SDK that supports .NET Core 6.0. 
[/Users/calope/Public/repos/performance/src/benchmarks/micro/MicroBenchmarks.csproj]
The build failed. Fix the build errors and run again.
  ```
</details>

Edits:
- I had originally reported a perf improvement with my original changes. Unfortunately, they also had a bug uncovered by the CI, which I'm investigating.
- CI issues fixed. Duration of the test before and after my changes:
   - Without changes: 44894
   - With changes: 46904
