### PR TITLE
Switch over framework packaging to use Crossgen2

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -1,5 +1,20 @@
 <Project>
   <Target Name="ResolveReadyToRunCompilers" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
+    <!-- The following property group can be simplified once runtime repo switches over to SDK 6.0 drop -->
+    <PropertyGroup>
+      <CrossDir></CrossDir>
+      <CrossDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)'">x64</CrossDir>
+      <Crossgen2Dir>$(CoreCLRArtifactsPath)\$(CrossDir)\crossgen2</Crossgen2Dir>
+      <Crossgen2Exe>$(Crossgen2Dir)\crossgen2$(ExeSuffix)</Crossgen2Exe>
+      <PublishReadyToRunCrossgen2ExtraArgs>--targetarch:$(TargetArchitecture)</PublishReadyToRunCrossgen2ExtraArgs>
+
+      <JitTargetOSComponent>unix</JitTargetOSComponent>
+      <JitTargetOSComponent Condition="'$(TargetOS)' == 'windows'">win</JitTargetOSComponent>
+      <JitBuildArchitecture>$(TargetArchitecture)</JitBuildArchitecture>
+      <JitBuildArchitecture Condition="'$(CrossDir)' != ''">$(CrossDir)</JitBuildArchitecture>
+      <JitLibrary>$(Crossgen2Dir)\$(LibPrefix)clrjit_$(JitTargetOSComponent)_$(TargetArchitecture)_$(JitBuildArchitecture)$(LibSuffix)</JitLibrary>
+    </PropertyGroup>
+
     <ItemGroup Condition="'$(RuntimeFlavor)' != 'Mono'">
       <_crossTargetJit Include="@(CoreCLRCrossTargetFiles)" Condition="'%(FileName)' == '$(LibPrefix)clrjit' and '%(Extension)' == '$(LibSuffix)'" />
       <_clrjit Include="@(RuntimeFiles)" Condition="'%(FileName)' == '$(LibPrefix)clrjit' and '%(Extension)' == '$(LibSuffix)'" />
@@ -16,5 +31,34 @@
                     JitPath="@(_clrjit)"
                     DiaSymReader="$(_diaSymReaderPathIfExists)" />
     </ItemGroup>
+    <ItemGroup>
+      <Crossgen2Tool Include="$(Crossgen2Exe)" JitPath="$(JitLibrary)" />
+    </ItemGroup>
   </Target>
+
+  <!-- Hack to patch DOTNET_ROOT for the duration of Crossgen2 compilation to unblock -->
+  <!-- Crossgen2 bring-up before SDK 6.0 Preview 2 propagates to the runtime repo. -->
+  <!-- https://github.com/dotnet/runtime/issues/48252 -->
+
+  <PropertyGroup>
+    <OriginalDotnetRootValue />
+    <DOTNET_ROOT />
+  </PropertyGroup>
+
+  <Target Name="PatchDotnetRootBeforeRunningCrossgen2" BeforeTargets="_CreateR2RImages">
+    <PropertyGroup>
+      <OriginalDotnetRootValue>$(DOTNET_ROOT)</OriginalDotnetRootValue>
+      <DOTNET_ROOT>$(RepoRoot)</DOTNET_ROOT>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="RestoreDotnetRootAfterRunningCrossgen2" AfterTargets="_CreateR2RImages">
+    <PropertyGroup>
+      <DOTNET_ROOT>$(OriginalDotnetRootValue)</DOTNET_ROOT>
+    </PropertyGroup>
+  </Target>
+
+  <!-- End of hack to patch DOTNET_ROOT for the duration of Crossgen2 compilation. -->
+  <!-- This can be removed once the runtime repo rolled forward to .NET 6 Preview 2 SDK repo drop. -->
+  <!-- https://github.com/dotnet/runtime/issues/48252 -->
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets
@@ -2,7 +2,7 @@
   <Target Name="ResolveReadyToRunCompilers" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
     <!-- The following property group can be simplified once runtime repo switches over to SDK 6.0 drop -->
     <PropertyGroup>
-      <CrossDir></CrossDir>
+      <CrossDir />
       <CrossDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)'">x64</CrossDir>
       <Crossgen2Dir>$(CoreCLRArtifactsPath)\$(CrossDir)\crossgen2</Crossgen2Dir>
       <Crossgen2Exe>$(Crossgen2Dir)\crossgen2$(ExeSuffix)</Crossgen2Exe>


### PR DESCRIPTION
Based on Jeremy's advice I have modified the pack build projects
to use the Crossgen2 compiler. As we're still using the 5.0 version
of the SDK, this change synthesizes the name of the JIT library -
upgrading SDK to version 6 will facilitate further cleanup in
these scripts.

Thanks

Tomas

P.S. I'm not sure whether we should add crossgen2 to 'RuntimeFiles' - I originally did that but the packs build complains the "public key not found" in the managed crossgen2 assemblies. I would naively assume that we're publishing Crossgen2 as a separate nuget package so we shouldn't need to include in runtime too.

/cc @dotnet/crossgen-contrib 