### PR TITLE
Calculate loopSize based on post align adjusted size

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1378,13 +1378,6 @@ protected:
     {
         instrDescAlign* idaNext; // next align in the group/method
         insGroup*       idaIG;   // containing group
-#ifdef DEBUG
-        // amount of padding this align instruction adds.
-
-        // Before emitLoopAlignAdjustments(), it will be opts.compJitAlignPaddingLimit
-        // After that, it will be actual padding calculated based on offset of idaIG->igNext.
-        unsigned paddingNeeded;
-#endif
     };
 #endif
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1378,6 +1378,13 @@ protected:
     {
         instrDescAlign* idaNext; // next align in the group/method
         insGroup*       idaIG;   // containing group
+#ifdef DEBUG
+        // amount of padding this align instruction adds.
+
+        // Before emitLoopAlignAdjustments(), it will be opts.compJitAlignPaddingLimit
+        // After that, it will be actual padding calculated based on offset of idaIG->igNext.
+        unsigned paddingNeeded;
+#endif
     };
 #endif
 
@@ -1759,18 +1766,19 @@ private:
     void          emitJumpDistBind(); // Bind all the local jumps in method
 
 #if FEATURE_LOOP_ALIGN
-    instrDescAlign* emitCurIGAlignList;                                 // list of align instructions in current IG
-    unsigned        emitLastInnerLoopStartIgNum;                        // Start IG of last inner loop
-    unsigned        emitLastInnerLoopEndIgNum;                          // End IG of last inner loop
-    unsigned        emitLastAlignedIgNum;                               // last IG that has align instruction
-    instrDescAlign* emitAlignList;                                      // list of local align instructions in method
-    instrDescAlign* emitAlignLast;                                      // last align instruction in method
-    unsigned getLoopSize(insGroup* igLoopHeader, unsigned maxLoopSize); // Get the smallest loop size
+    instrDescAlign* emitCurIGAlignList;          // list of align instructions in current IG
+    unsigned        emitLastInnerLoopStartIgNum; // Start IG of last inner loop
+    unsigned        emitLastInnerLoopEndIgNum;   // End IG of last inner loop
+    unsigned        emitLastAlignedIgNum;        // last IG that has align instruction
+    instrDescAlign* emitAlignList;               // list of local align instructions in method
+    instrDescAlign* emitAlignLast;               // last align instruction in method
+    unsigned getLoopSize(insGroup* igLoopHeader,
+                         unsigned maxLoopSize DEBUG_ARG(bool isAlignAdjusted)); // Get the smallest loop size
     void emitLoopAlignment();
     bool emitEndsWithAlignInstr(); // Validate if newLabel is appropriate
     void emitSetLoopBackEdge(BasicBlock* loopTopBlock);
     void     emitLoopAlignAdjustments(); // Predict if loop alignment is needed and make appropriate adjustments
-    unsigned emitCalculatePaddingForLoopAlignment(insGroup* ig, size_t offset DEBUG_ARG(bool displayAlignmentDetails));
+    unsigned emitCalculatePaddingForLoopAlignment(insGroup* ig, size_t offset DEBUG_ARG(bool isAlignAdjusted));
 #endif
 
     void emitCheckFuncletBranch(instrDesc* jmp, insGroup* jmpIG); // Check for illegal branches between funclets

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2674,9 +2674,6 @@ void emitter::emitLoopAlign(unsigned short paddingBytes)
     instrDescAlign* id = emitNewInstrAlign();
     id->idCodeSize(paddingBytes);
     id->idaIG = emitCurIG;
-#ifdef DEBUG
-    id->paddingNeeded = paddingBytes;
-#endif
 
     /* Append this instruction to this IG's alignment list */
     id->idaNext = emitCurIGAlignList;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2673,12 +2673,15 @@ void emitter::emitLoopAlign(unsigned short paddingBytes)
     paddingBytes       = min(paddingBytes, MAX_ENCODED_SIZE); // We may need to skip up to 15 bytes of code
     instrDescAlign* id = emitNewInstrAlign();
     id->idCodeSize(paddingBytes);
-    emitCurIGsize += paddingBytes;
-
     id->idaIG = emitCurIG;
+#ifdef DEBUG
+    id->paddingNeeded = paddingBytes;
+#endif
 
     /* Append this instruction to this IG's alignment list */
-    id->idaNext        = emitCurIGAlignList;
+    id->idaNext = emitCurIGAlignList;
+
+    emitCurIGsize += paddingBytes;
     emitCurIGAlignList = id;
 }
 
@@ -9408,8 +9411,7 @@ BYTE* emitter::emitOutputAlign(insGroup* ig, instrDesc* id, BYTE* dst)
     assert(0 <= paddingToAdd && paddingToAdd < emitComp->opts.compJitAlignLoopBoundary);
 
 #ifdef DEBUG
-    bool     displayAlignmentDetails = (emitComp->opts.disAsm /*&& emitComp->opts.disAddr*/) || emitComp->verbose;
-    unsigned paddingNeeded           = emitCalculatePaddingForLoopAlignment(ig, (size_t)dst, displayAlignmentDetails);
+    unsigned paddingNeeded = emitCalculatePaddingForLoopAlignment(ig, (size_t)dst, true);
 
     // For non-adaptive, padding size is spread in multiple instructions, so don't bother checking
     if (emitComp->opts.compJitAlignLoopAdaptive)


### PR DESCRIPTION
During outputting the `align` instruction, we recalculate the alignment needed to make sure that the padding we calculated earlier still matches when calculated on the basis of actual buffer address. In that, we calculate loopSize in `getLoopSize()`. While walking through the IGs in the loop, if we encounter that an IG is also marked as `IGF_LOOP_ALIGN`, we know that its size included the `align` instruction size and we were taking off that amount from `loopSize` (because that is not part of a loop). However, during outputting, we would have also adjusted the `align` instruction size of such IG and we should take that into account instead of max size of `align` instruction.

~I have added a field `paddingAdded` in `instrDescAlign` that tracks the adjusted padding amount which will be used to deduct it when we calculate `loopSize` during outputting the instruction. Since the check in `emitOutputAlign()` is under `#ifdef DEBUG`, I am including the `paddingAdded` field under `#ifdef DEBUG` as well. During release, we will never need this and hence will be unnecessary.~

I have also made minor changes in `JITDUMP`.

Fixes: https://github.com/dotnet/runtime/issues/47094