### PR TITLE
Fixed compilation for libicu 68.

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_calendarData.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_calendarData.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include "pal_locale_internal.h"

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_calendarData.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_calendarData.c
@@ -126,8 +126,8 @@ int32_t GlobalizationNative_GetCalendars(
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
-    UEnumeration* pEnum = ucal_getKeywordValuesForLocale("calendar", locale, TRUE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
+    UEnumeration* pEnum = ucal_getKeywordValuesForLocale("calendar", locale, true, &err);
     int stringEnumeratorCount = uenum_count(pEnum, &err);
     int calendarsReturned = 0;
     for (int i = 0; i < stringEnumeratorCount && calendarsReturned < calendarsCapacity; i++)
@@ -197,7 +197,7 @@ ResultCode GlobalizationNative_GetCalendarInfo(
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
 
     if (U_FAILURE(err))
         return UnknownError;
@@ -209,7 +209,7 @@ ResultCode GlobalizationNative_GetCalendarInfo(
         case CalendarData_MonthDay:
             return GetMonthDayPattern(locale, result, resultCapacity);
         default:
-            assert(FALSE);
+            assert(false);
             return UnknownError;
     }
 }
@@ -230,19 +230,19 @@ static int InvokeCallbackForDatePattern(const char* locale,
     UDateFormat* pFormat = udat_open(UDAT_NONE, style, locale, NULL, 0, NULL, 0, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     UErrorCode ignore = U_ZERO_ERROR;
-    int32_t patternLen = udat_toPattern(pFormat, FALSE, NULL, 0, &ignore) + 1;
+    int32_t patternLen = udat_toPattern(pFormat, false, NULL, 0, &ignore) + 1;
 
     UChar* pattern = (UChar*)calloc((size_t)patternLen, sizeof(UChar));
     if (pattern == NULL)
     {
         udat_close(pFormat);
-        return FALSE;
+        return false;
     }
 
-    udat_toPattern(pFormat, FALSE, pattern, patternLen, &err);
+    udat_toPattern(pFormat, false, pattern, patternLen, &err);
     udat_close(pFormat);
 
     if (U_SUCCESS(err))
@@ -270,7 +270,7 @@ static int InvokeCallbackForDateTimePattern(const char* locale,
     UDateTimePatternGenerator* pGenerator = udatpg_open(locale, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udatpg_getBestPattern(pGenerator, patternSkeleton, -1, NULL, 0, &ignore) + 1;
@@ -279,7 +279,7 @@ static int InvokeCallbackForDateTimePattern(const char* locale,
     if (bestPattern == NULL)
     {
         udatpg_close(pGenerator);
-        return FALSE;
+        return false;
     }
 
     udatpg_getBestPattern(pGenerator, patternSkeleton, -1, bestPattern, patternLen, &err);
@@ -312,7 +312,7 @@ static int32_t EnumSymbols(const char* locale,
     UDateFormat* pFormat = udat_open(UDAT_DEFAULT, UDAT_DEFAULT, locale, NULL, 0, NULL, 0, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     char localeWithCalendarName[ULOC_FULLNAME_CAPACITY];
     STRING_COPY(localeWithCalendarName, sizeof(localeWithCalendarName), locale);
@@ -324,7 +324,7 @@ static int32_t EnumSymbols(const char* locale,
     if (U_FAILURE(err))
     {
         udat_close(pFormat);
-        return FALSE;
+        return false;
     }
 
     udat_setCalendar(pFormat, pCalendar);
@@ -424,7 +424,7 @@ static int32_t EnumAbbrevEraNames(const char* locale,
     char* parentNamePtr = parentNameBuf;
     STRING_COPY(localeNamePtr, sizeof(localeNameBuf), locale);
 
-    while (TRUE)
+    while (true)
     {
         UErrorCode status = U_ZERO_ERROR;
         const char* name = GetCalendarName(calendarId);
@@ -439,7 +439,7 @@ static int32_t EnumAbbrevEraNames(const char* locale,
         {
             EnumUResourceBundle(erasResBundle, callback, context);
             CloseResBundle(rootResBundle, calResBundle, targetCalResBundle, erasColResBundle, erasResBundle);
-            return TRUE;
+            return true;
         }
 
         // Couldn't find the data we need for this locale, we should fallback.
@@ -492,10 +492,10 @@ int32_t GlobalizationNative_EnumCalendarInfo(EnumCalendarInfoCallback callback,
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     switch (dataType)
     {
@@ -536,8 +536,8 @@ int32_t GlobalizationNative_EnumCalendarInfo(EnumCalendarInfoCallback callback,
         case CalendarData_AbbrevEraNames:
             return EnumAbbrevEraNames(locale, calendarId, callback, context);
         default:
-            assert(FALSE);
-            return FALSE;
+            assert(false);
+            return false;
     }
 }
 
@@ -581,7 +581,7 @@ int32_t GlobalizationNative_GetJapaneseEraStartDate(int32_t era,
     UCalendar* pCal = ucal_open(NULL, 0, JAPANESE_LOCALE_AND_CALENDAR, UCAL_TRADITIONAL, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     ucal_set(pCal, UCAL_ERA, era);
     ucal_set(pCal, UCAL_YEAR, 1);
@@ -591,7 +591,7 @@ int32_t GlobalizationNative_GetJapaneseEraStartDate(int32_t era,
     if (U_FAILURE(err))
     {
         ucal_close(pCal);
-        return FALSE;
+        return false;
     }
 
     // set the date to Jan 1
@@ -628,5 +628,5 @@ int32_t GlobalizationNative_GetJapaneseEraStartDate(int32_t era,
     }
 
     ucal_close(pCal);
-    return FALSE;
+    return false;
 }

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.c
@@ -3,6 +3,7 @@
 //
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "pal_icushim_internal.h"

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.c
@@ -34,7 +34,7 @@ void GlobalizationNative_ChangeCase(
     // compiler wasn't doing that optimization, and it results in an ~15-20% perf
     // improvement on longer strings.)
 
-    UBool isError = FALSE;
+    UBool isError = false;
     (void)isError; // only used for assert
     int32_t srcIdx = 0, dstIdx = 0;
     UChar32 srcCodepoint, dstCodepoint;
@@ -46,7 +46,7 @@ void GlobalizationNative_ChangeCase(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = u_toupper(srcCodepoint);
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
     else
@@ -56,7 +56,7 @@ void GlobalizationNative_ChangeCase(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = u_tolower(srcCodepoint);
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
 }
@@ -74,7 +74,7 @@ void GlobalizationNative_ChangeCaseInvariant(
 {
     // See algorithmic comment in ChangeCase.
 
-    UBool isError = FALSE;
+    UBool isError = false;
     (void)isError; // only used for assert
     int32_t srcIdx = 0, dstIdx = 0;
     UChar32 srcCodepoint, dstCodepoint;
@@ -89,7 +89,7 @@ void GlobalizationNative_ChangeCaseInvariant(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0131) ? (UChar32)0x0131 : u_toupper(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
     else
@@ -102,7 +102,7 @@ void GlobalizationNative_ChangeCaseInvariant(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0130) ? (UChar32)0x0130 : u_tolower(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
 }
@@ -119,7 +119,7 @@ void GlobalizationNative_ChangeCaseTurkish(
 {
     // See algorithmic comment in ChangeCase.
 
-    UBool isError = FALSE;
+    UBool isError = false;
     (void)isError; // only used for assert
     int32_t srcIdx = 0, dstIdx = 0;
     UChar32 srcCodepoint, dstCodepoint;
@@ -133,7 +133,7 @@ void GlobalizationNative_ChangeCaseTurkish(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
     else
@@ -145,7 +145,7 @@ void GlobalizationNative_ChangeCaseTurkish(
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
+            assert(isError == false && srcIdx == dstIdx);
         }
     }
 }

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -368,7 +368,7 @@ static UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t o
 // Returns TRUE if all the collation elements in str are completely ignorable
 static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lpStr, int32_t length)
 {
-    int result = TRUE;
+    int result = true;
     UErrorCode err = U_ZERO_ERROR;
     UCollationElements* pCollElem = ucol_openElements(pColl, lpStr, length, &err);
 
@@ -379,7 +379,7 @@ static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lp
         {
             if (curCollElem != UCOL_IGNORABLE)
             {
-                result = FALSE;
+                result = false;
                 break;
             }
         }
@@ -387,7 +387,7 @@ static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lp
         ucol_closeElements(pCollElem);
     }
 
-    return U_SUCCESS(err) ? result : FALSE;
+    return U_SUCCESS(err) ? result : false;
 }
 
 static void CreateSortHandle(SortHandle** ppSortHandle)
@@ -496,7 +496,7 @@ static inline int32_t CreateNewSearchNode(SortHandle* pSortHandle, int32_t optio
     SearchIteratorNode* node = (SearchIteratorNode*) malloc(sizeof(SearchIteratorNode));
     if (node == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     node->searchIterator = USED_STRING_SEARCH; // Mark the new node search handle as borrowed.
@@ -517,9 +517,9 @@ static inline int32_t CreateNewSearchNode(SortHandle* pSortHandle, int32_t optio
 
         pCurrent = pCurrent->next;
 
-    } while (TRUE);
+    } while (true);
 
-    return TRUE;
+    return true;
 }
 
 // Restore previously borrowed search handle to the linked list.
@@ -531,12 +531,12 @@ static inline int32_t RestoreSearchHandle(SortHandle* pSortHandle, UStringSearch
     {
         if (pCurrent->searchIterator == USED_STRING_SEARCH && pal_atomic_cas_ptr((void* volatile*)&(pCurrent->searchIterator), pSearchIterator, USED_STRING_SEARCH))
         {
-            return TRUE;
+            return true;
         }
         pCurrent = pCurrent->next;
     }
 
-    return FALSE;
+    return false;
 }
 
 // return -1 if couldn't borrow search handle from the SortHandle cache, otherwise, it return the slot number of the cache.
@@ -559,7 +559,7 @@ static int32_t GetSearchIteratorUsingCollator(
         *pSearchIterator = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, cwSourceLength, pColl, NULL, &err);
         if (!U_SUCCESS(err))
         {
-            assert(FALSE && "Couldn't open the search iterator.");
+            assert(false && "Couldn't open the search iterator.");
             return -1;
         }
 
@@ -597,7 +597,7 @@ static int32_t GetSearchIteratorUsingCollator(
         *pSearchIterator = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, cwSourceLength, pColl, NULL, &err);
         if (!U_SUCCESS(err))
         {
-            assert(FALSE && "Couldn't open a new search iterator.");
+            assert(false && "Couldn't open a new search iterator.");
             return -1;
         }
 
@@ -645,7 +645,7 @@ static inline int32_t GetSearchIterator(
     const UCollator* pColl = GetCollatorFromSortHandle(pSortHandle, options, &err);
     if (!U_SUCCESS(err))
     {
-        assert(FALSE && "Couldn't get the collator.");
+        assert(false && "Couldn't get the collator.");
         return -1;
     }
 
@@ -672,7 +672,7 @@ int32_t GlobalizationNative_GetSortVersion(SortHandle* pSortHandle)
     }
     else
     {
-        assert(FALSE && "Unexpected ucol_getVersion to fail.");
+        assert(false && "Unexpected ucol_getVersion to fail.");
     }
     return result;
 }
@@ -860,13 +860,13 @@ static int32_t inline SimpleAffix_Iterators(UCollationElements* pPatternIterator
     assert(strength >= UCOL_SECONDARY);
 
     UErrorCode errorCode = U_ZERO_ERROR;
-    int32_t movePattern = TRUE, moveSource = TRUE;
+    int32_t movePattern = true, moveSource = true;
     int32_t patternElement = UCOL_IGNORABLE, sourceElement = UCOL_IGNORABLE;
     int32_t capturedOffset = 0;
 
     int32_t collationElementMask = GetCollationElementMask(strength);
 
-    while (TRUE)
+    while (true)
     {
         if (movePattern)
         {
@@ -880,7 +880,7 @@ static int32_t inline SimpleAffix_Iterators(UCollationElements* pPatternIterator
             }
             sourceElement = forwardSearch ? ucol_next(pSourceIterator, &errorCode) : ucol_previous(pSourceIterator, &errorCode);
         }
-        movePattern = TRUE; moveSource = TRUE;
+        movePattern = true; moveSource = true;
 
         if (patternElement == UCOL_NULLORDER)
         {
@@ -894,7 +894,7 @@ static int32_t inline SimpleAffix_Iterators(UCollationElements* pPatternIterator
             }
             else if (forwardSearch && ((sourceElement & UCOL_PRIMARYORDERMASK) == 0) && (sourceElement & UCOL_SECONDARYORDERMASK) != 0)
             {
-                return FALSE; // the next character in source text is a combining character, an example: "o\u0308".StartsWith("o")
+                return false; // the next character in source text is a combining character, an example: "o\u0308".StartsWith("o")
             }
             else
             {
@@ -903,15 +903,15 @@ static int32_t inline SimpleAffix_Iterators(UCollationElements* pPatternIterator
         }
         else if (patternElement == UCOL_IGNORABLE)
         {
-            moveSource = FALSE;
+            moveSource = false;
         }
         else if (sourceElement == UCOL_IGNORABLE)
         {
-            movePattern = FALSE;
+            movePattern = false;
         }
         else if ((patternElement & collationElementMask) != (sourceElement & collationElementMask))
         {
-            return FALSE;
+            return false;
         }
     }
 
@@ -920,12 +920,12 @@ ReturnTrue:
     {
         *pCapturedOffset = capturedOffset;
     }
-    return TRUE;
+    return true;
 }
 
 static int32_t SimpleAffix(const UCollator* pCollator, UErrorCode* pErrorCode, const UChar* pPattern, int32_t patternLength, const UChar* pText, int32_t textLength, int32_t forwardSearch, int32_t* pMatchedLength)
 {
-    int32_t result = FALSE;
+    int32_t result = false;
 
     UCollationElements* pPatternIterator = ucol_openElements(pCollator, pPattern, patternLength, pErrorCode);
     if (U_SUCCESS(*pErrorCode))
@@ -956,7 +956,7 @@ static int32_t SimpleAffix(const UCollator* pCollator, UErrorCode* pErrorCode, c
 
 static int32_t ComplexStartsWith(SortHandle* pSortHandle, const UChar* pPattern, int32_t patternLength, const UChar* pText, int32_t textLength, int32_t options, int32_t* pMatchedLength)
 {
-    int32_t result = FALSE;
+    int32_t result = false;
     UErrorCode err = U_ZERO_ERROR;
 
     const UCollator* pCollator = GetCollatorFromSortHandle(pSortHandle, options, &err);
@@ -977,7 +977,7 @@ static int32_t ComplexStartsWith(SortHandle* pSortHandle, const UChar* pPattern,
     {
         if (idx == 0)
         {
-            result = TRUE;
+            result = true;
         }
         else
         {
@@ -1017,15 +1017,15 @@ int32_t GlobalizationNative_StartsWith(
     const UCollator* pCollator = GetCollatorFromSortHandle(pSortHandle, options, &err);
     if (!U_SUCCESS(err))
     {
-        return FALSE;
+        return false;
     }
 
-    return SimpleAffix(pCollator, &err, lpTarget, cwTargetLength, lpSource, cwSourceLength, TRUE, pMatchedLength);
+    return SimpleAffix(pCollator, &err, lpTarget, cwTargetLength, lpSource, cwSourceLength, true, pMatchedLength);
 }
 
 static int32_t ComplexEndsWith(SortHandle* pSortHandle, const UChar* pPattern, int32_t patternLength, const UChar* pText, int32_t textLength, int32_t options, int32_t* pMatchedLength)
 {
-    int32_t result = FALSE;
+    int32_t result = false;
 
     UErrorCode err = U_ZERO_ERROR;
     const UCollator* pCollator = GetCollatorFromSortHandle(pSortHandle, options, &err);
@@ -1049,7 +1049,7 @@ static int32_t ComplexEndsWith(SortHandle* pSortHandle, const UChar* pPattern, i
 
         if (matchEnd == textLength)
         {
-            result = TRUE;
+            result = true;
         }
         else
         {
@@ -1092,9 +1092,9 @@ int32_t GlobalizationNative_EndsWith(
 
     if (!U_SUCCESS(err))
     {
-        return FALSE;
+        return false;
     }
-    return SimpleAffix(pCollator, &err, lpTarget, cwTargetLength, lpSource, cwSourceLength, FALSE, pMatchedLength);
+    return SimpleAffix(pCollator, &err, lpTarget, cwTargetLength, lpSource, cwSourceLength, false, pMatchedLength);
 }
 
 int32_t GlobalizationNative_GetSortKey(

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
@@ -58,7 +58,7 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
         if (dlsym(libicuuc, symbolName) == NULL)
         {
             if (minorVer == -1)
-                return FALSE;
+                return false;
 
             // Now try the _majorVer_minorVer added
             sprintf(symbolVersion, "_%d_%d%s", majorVer, minorVer, suffix);
@@ -66,20 +66,20 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
             if (dlsym(libicuuc, symbolName) == NULL)
             {
                 if (subVer == -1)
-                    return FALSE;
+                    return false;
 
                 // Finally, try the _majorVer_minorVer_subVer added
                 sprintf(symbolVersion, "_%d_%d_%d%s", majorVer, minorVer, subVer, suffix);
                 sprintf(symbolName, "u_strlen%s", symbolVersion);
                 if (dlsym(libicuuc, symbolName) == NULL)
                 {
-                    return FALSE;
+                    return false;
                 }
             }
         }
     }
 
-    return TRUE;
+    return true;
 }
 
 #endif // TARGET_UNIX
@@ -98,12 +98,12 @@ static int FindICULibs()
     libicuuc = LoadLibraryExW(L"icu.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (libicuuc == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     // Windows has a single dll for icu.
     libicui18n = libicuuc;
-    return TRUE;
+    return true;
 }
 
 static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbolName, char* symbolVersion, char* suffix)
@@ -119,7 +119,7 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
         if (GetProcAddress(lib, symbolName) == NULL)
         {
             if (minorVer == -1)
-                return FALSE;
+                return false;
 
             // Now try the _majorVer_minorVer added
             sprintf_s(symbolVersion, MaxICUVersionStringWithSuffixLength, "_%d_%d%s", majorVer, minorVer, suffix);
@@ -127,19 +127,19 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
             if (GetProcAddress(lib, symbolName) == NULL)
             {
                 if (subVer == -1)
-                    return FALSE;
+                    return false;
                 // Finally, try the _majorVer_minorVer_subVer added
                 sprintf_s(symbolVersion, MaxICUVersionStringWithSuffixLength, "_%d_%d_%d%s", majorVer, minorVer, subVer, suffix);
                 sprintf_s(symbolName, SYMBOL_NAME_SIZE, "u_strlen%s", symbolVersion);
                 if (GetProcAddress(lib, symbolName) == NULL)
                 {
-                    return FALSE;
+                    return false;
                 }
             }
         }
     }
 
-    return TRUE;
+    return true;
 }
 
 #elif defined(TARGET_OSX)
@@ -155,13 +155,13 @@ static int FindICULibs()
 
     if (libicuuc == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     // in OSX all ICU APIs exist in the same library libicucore.A.dylib
     libicui18n = libicuuc;
 
-    return TRUE;
+    return true;
 }
 
 #elif defined(TARGET_ANDROID)
@@ -176,14 +176,14 @@ static int FindICULibs(char* symbolName, char* symbolVersion)
 
     if (libicui18n == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     libicuuc = dlopen("libicuuc.so", RTLD_LAZY);
 
     if (libicuuc == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     char symbolSuffix[SYMBOL_CUSTOM_SUFFIX_SIZE]="";
@@ -191,12 +191,12 @@ static int FindICULibs(char* symbolName, char* symbolVersion)
     {
         if (FindSymbolVersion(i, -1, -1, symbolName, symbolVersion, symbolSuffix))
         {
-            return TRUE;
+            return true;
         }
     }
 
     fprintf(stderr, "Cannot determine ICU version.");
-    return FALSE;
+    return false;
 }
 
 #else // !TARGET_WINDOWS && !TARGET_OSX && !TARGET_ANDROID
@@ -290,12 +290,12 @@ static int FindLibUsingOverride(const char* versionPrefix, char* symbolName, cha
         {
             if (OpenICULibraries(first, second, third, versionPrefix, symbolName, symbolVersion))
             {
-                return TRUE;
+                return true;
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 // Search for library files with names including the major version.
@@ -309,11 +309,11 @@ static int FindLibWithMajorVersion(const char* versionPrefix, char* symbolName, 
     {
         if (OpenICULibraries(i, -1, -1, versionPrefix, symbolName, symbolVersion))
         {
-            return TRUE;
+            return true;
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 // Select the highest supported version of ICU present on the local machine
@@ -326,12 +326,12 @@ static int FindLibWithMajorMinorVersion(const char* versionPrefix, char* symbolN
         {
             if (OpenICULibraries(i, j, -1, versionPrefix, symbolName, symbolVersion))
             {
-                return TRUE;
+                return true;
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 // Select the highest supported version of ICU present on the local machine
@@ -346,13 +346,13 @@ static int FindLibWithMajorMinorSubVersion(const char* versionPrefix, char* symb
             {
                 if (OpenICULibraries(i, j, k, versionPrefix, symbolName, symbolVersion))
                 {
-                    return TRUE;
+                    return true;
                 }
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 
@@ -392,27 +392,27 @@ int32_t GlobalizationNative_LoadICU()
 
     if (!FindICULibs())
     {
-        return FALSE;
+        return false;
     }
 
 #elif defined(TARGET_ANDROID)
     if (!FindICULibs(symbolName, symbolVersion))
     {
-        return FALSE;
+        return false;
     }
 #else
     if (!FindICULibs(VERSION_PREFIX_NONE, symbolName, symbolVersion))
     {
         if (!FindICULibs(VERSION_PREFIX_SUSE, symbolName, symbolVersion))
         {
-            return FALSE;
+            return false;
         }
     }
 #endif // TARGET_WINDOWS || TARGET_OSX
 
     FOR_ALL_ICU_FUNCTIONS
     ValidateICUDataCanLoad();
-    return TRUE;
+    return true;
 }
 
 void GlobalizationNative_InitICUFunctions(void* icuuc, void* icuin, const char* version, const char* suffix)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include "pal_icushim_internal.h"
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_locale.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_locale.c
@@ -15,7 +15,7 @@ int32_t UErrorCodeToBool(UErrorCode status)
 {
     if (U_SUCCESS(status))
     {
-        return TRUE;
+        return true;
     }
 
     // assert errors that should never occur
@@ -24,7 +24,7 @@ int32_t UErrorCodeToBool(UErrorCode status)
 
     // add possible SetLastError support here
 
-    return FALSE;
+    return false;
 }
 
 int32_t GetLocale(const UChar* localeName,
@@ -197,7 +197,7 @@ int32_t GlobalizationNative_GetLocaleName(const UChar* localeName, UChar* value,
     UErrorCode status = U_ZERO_ERROR;
 
     char localeNameBuffer[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, localeNameBuffer, ULOC_FULLNAME_CAPACITY, TRUE, &status);
+    GetLocale(localeName, localeNameBuffer, ULOC_FULLNAME_CAPACITY, true, &status);
     u_charsToUChars_safe(localeNameBuffer, value, valueLength, &status);
 
     if (U_SUCCESS(status))
@@ -245,10 +245,10 @@ int32_t GlobalizationNative_IsPredefinedLocale(const UChar* localeName)
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
 
     if (U_FAILURE(err))
-        return FALSE;
+        return false;
 
     // ures_open returns err = U_ZERO_ERROR when ICU has data for localeName.
     // If it is fake locale, it will return err = U_USING_FALLBACK_WARNING || err = U_USING_DEFAULT_WARNING.

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_locale.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_locale.c
@@ -3,6 +3,7 @@
 //
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_localeNumberData.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_localeNumberData.c
@@ -3,6 +3,7 @@
 //
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_localeNumberData.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_localeNumberData.c
@@ -56,10 +56,10 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
     }
 
     int index = 0;
-    int minusAdded = FALSE;
-    int digitAdded = FALSE;
-    int currencyAdded = FALSE;
-    int spaceAdded = FALSE;
+    int minusAdded = false;
+    int digitAdded = false;
+    int currencyAdded = false;
+    int spaceAdded = false;
 
     for (int i = iStart; i <= iEnd; i++)
     {
@@ -69,7 +69,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_MINUS:
             case UCHAR_OPENPAREN:
             case UCHAR_CLOSEPAREN:
-                minusAdded = TRUE;
+                minusAdded = true;
                 break;
         }
     }
@@ -104,7 +104,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_ZERO:
                 if (!digitAdded)
                 {
-                    digitAdded = TRUE;
+                    digitAdded = true;
                     destPattern[index++] = 'n';
                 }
                 break;
@@ -112,7 +112,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_CURRENCY:
                 if (!currencyAdded)
                 {
-                    currencyAdded = TRUE;
+                    currencyAdded = true;
                     destPattern[index++] = 'C';
                 }
                 break;
@@ -121,7 +121,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_NBSPACE:
                 if (!spaceAdded)
                 {
-                    spaceAdded = TRUE;
+                    spaceAdded = true;
                     destPattern[index++] = ' ';
                 }
                 break;
@@ -129,7 +129,7 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
             case UCHAR_MINUS:
             case UCHAR_OPENPAREN:
             case UCHAR_CLOSEPAREN:
-                minusAdded = TRUE;
+                minusAdded = true;
                 destPattern[index++] = (char)ch;
                 break;
 
@@ -159,7 +159,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
     const int MAX_DOTNET_NUMERIC_PATTERN_LENGTH = 6; // example: "(C n)" plus terminator
 
     UErrorCode ignore = U_ZERO_ERROR;
-    int32_t icuPatternLength = unum_toPattern(pNumberFormat, FALSE, NULL, 0, &ignore) + 1;
+    int32_t icuPatternLength = unum_toPattern(pNumberFormat, false, NULL, 0, &ignore) + 1;
 
     UChar* icuPattern = (UChar*)calloc((size_t)icuPatternLength, sizeof(UChar));
     if (icuPattern == NULL)
@@ -169,7 +169,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
 
     UErrorCode err = U_ZERO_ERROR;
 
-    unum_toPattern(pNumberFormat, FALSE, icuPattern, icuPatternLength, &err);
+    unum_toPattern(pNumberFormat, false, icuPattern, icuPatternLength, &err);
 
     assert(U_SUCCESS(err));
 
@@ -197,7 +197,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
         }
     }
 
-    assert(FALSE); // should have found a valid pattern
+    assert(false); // should have found a valid pattern
 
     free(normalizedPattern);
     return INVALID_FORMAT;
@@ -238,7 +238,7 @@ static int GetCurrencyNegativePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), TRUE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), true);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -269,7 +269,7 @@ static int GetCurrencyPositivePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), FALSE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), false);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -300,7 +300,7 @@ static int GetNumberNegativePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), TRUE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), true);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -332,7 +332,7 @@ static int GetPercentNegativePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), TRUE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), true);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -363,7 +363,7 @@ static int GetPercentPositivePattern(const char* locale)
 
     if (U_SUCCESS(status))
     {
-        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), FALSE);
+        int value = GetNumericPattern(pFormat, Patterns, ARRAY_LENGTH(Patterns), false);
         if (value >= 0)
         {
             unum_close(pFormat);
@@ -407,11 +407,11 @@ int32_t GlobalizationNative_GetLocaleInfoInt(
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &status);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
 
     if (U_FAILURE(status))
     {
-        return FALSE;
+        return false;
     }
 
     switch (localeNumberData)
@@ -514,7 +514,7 @@ int32_t GlobalizationNative_GetLocaleInfoInt(
             break;
         default:
             status = U_UNSUPPORTED_ERROR;
-            assert(FALSE);
+            assert(false);
             break;
     }
 
@@ -533,7 +533,7 @@ int32_t GlobalizationNative_GetLocaleInfoGroupingSizes(
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &status);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
 
     if (U_FAILURE(status))
     {

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_localeStringData.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_localeStringData.c
@@ -3,6 +3,7 @@
 //
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_localeStringData.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_localeStringData.c
@@ -210,7 +210,7 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &status);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
 
     if (U_FAILURE(status))
     {
@@ -266,10 +266,10 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
             status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INTL_CURRENCY_SYMBOL, value, valueLength);
             break;
         case LocaleString_CurrencyEnglishName:
-            status = GetLocaleCurrencyName(locale, FALSE, value, valueLength);
+            status = GetLocaleCurrencyName(locale, false, value, valueLength);
             break;
         case LocaleString_CurrencyNativeName:
-            status = GetLocaleCurrencyName(locale, TRUE, value, valueLength);
+            status = GetLocaleCurrencyName(locale, true, value, valueLength);
             break;
         case LocaleString_MonetaryDecimalSeparator:
             status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_SEPARATOR_SYMBOL, value, valueLength);
@@ -279,10 +279,10 @@ int32_t GlobalizationNative_GetLocaleInfoString(const UChar* localeName,
                 GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
             break;
         case LocaleString_AMDesignator:
-            status = GetLocaleInfoAmPm(locale, TRUE, value, valueLength);
+            status = GetLocaleInfoAmPm(locale, true, value, valueLength);
             break;
         case LocaleString_PMDesignator:
-            status = GetLocaleInfoAmPm(locale, FALSE, value, valueLength);
+            status = GetLocaleInfoAmPm(locale, false, value, valueLength);
             break;
         case LocaleString_PositiveSign:
             status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PLUS_SIGN_SYMBOL, value, valueLength);
@@ -350,10 +350,10 @@ int32_t GlobalizationNative_GetLocaleTimeFormat(const UChar* localeName,
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
     UDateFormatStyle style = (shortFormat != 0) ? UDAT_SHORT : UDAT_MEDIUM;
     UDateFormat* pFormat = udat_open(style, UDAT_NONE, locale, NULL, 0, NULL, 0, &err);
-    udat_toPattern(pFormat, FALSE, value, valueLength, &err);
+    udat_toPattern(pFormat, false, value, valueLength, &err);
     udat_close(pFormat);
     return UErrorCodeToBool(err);
 }

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_normalization.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_normalization.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "pal_icushim_internal.h"

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_normalization.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_normalization.c
@@ -47,7 +47,7 @@ int32_t GlobalizationNative_IsNormalized(
 
     if (U_SUCCESS(err))
     {
-        return isNormalized == TRUE ? 1 : 0;
+        return isNormalized == true ? 1 : 0;
     }
     else
     {

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_normalization.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_normalization.c
@@ -48,7 +48,7 @@ int32_t GlobalizationNative_IsNormalized(
 
     if (U_SUCCESS(err))
     {
-        return isNormalized == true ? 1 : 0;
+        return isNormalized ? 1 : 0;
     }
     else
     {

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
@@ -19,7 +19,7 @@ ResultCode GlobalizationNative_GetTimeZoneDisplayName(const UChar* localeName,
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
-    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, FALSE, &err);
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
 
     int32_t timeZoneIdLength = -1; // timeZoneId is NULL-terminated
     UCalendar* calendar = ucal_open(timeZoneId, timeZoneIdLength, locale, UCAL_DEFAULT, &err);

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "pal_errors_internal.h"


### PR DESCRIPTION
libicu 68 deprecated its defines for `TRUE/FALSE`. This makes use of standard `<stdbool.h>` constants.
The change only lower-cases the constant names, we were already including the header file.

Fixes https://github.com/dotnet/runtime/issues/47346