### PR TITLE
Remove dead code around x86 delegate interop.

### DIFF
--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -187,7 +187,7 @@ public:
         // If we get here we must have at least one stack slot left to shuffle (this method should only be called
         // when AnythingToShuffle(pArg) == true).
         if (m_currentByteStackIndex < m_argLocDesc->m_byteStackSize)
-        {            
+        {
             const unsigned byteIndex = m_argLocDesc->m_byteStackIndex + m_currentByteStackIndex;
             index = byteIndex / TARGET_POINTER_SIZE;
             m_currentByteStackIndex += TARGET_POINTER_SIZE;
@@ -1375,31 +1375,6 @@ OBJECTREF COMDelegate::ConvertToDelegate(LPVOID pCallback, MethodTable* pMT)
         // Also, mark this delegate as an unmanaged function pointer wrapper.
         delObj->SetInvocationCount(DELEGATE_MARKER_UNMANAGEDFPTR);
     }
-
-#if defined(TARGET_X86)
-    GCPROTECT_BEGIN(delObj);
-
-    Stub *pInterceptStub = NULL;
-
-    {
-        GCX_PREEMP();
-
-        MethodDesc *pStubMD = pClass->m_pForwardStubMD;
-        _ASSERTE(pStubMD != NULL && pStubMD->IsILStub());
-
-    }
-
-    if (pInterceptStub != NULL)
-    {
-        // install the outer-most stub to sync block
-        SyncBlock *pSyncBlock = delObj->GetSyncBlock();
-
-        InteropSyncBlockInfo *pInteropInfo = pSyncBlock->GetInteropInfo();
-        VERIFY(pInteropInfo->SetInterceptStub(pInterceptStub));
-    }
-
-    GCPROTECT_END();
-#endif // TARGET_X86
 
     return delObj;
 }

--- a/src/coreclr/vm/stubhelpers.cpp
+++ b/src/coreclr/vm/stubhelpers.cpp
@@ -549,24 +549,6 @@ FCIMPL2(void*, StubHelpers::GetDelegateTarget, DelegateObject *pThisUNSAFE, UINT
 
     DELEGATEREF orefThis = (DELEGATEREF)ObjectToOBJECTREF(pThisUNSAFE);
 
-#if defined(TARGET_X86)
-    // On x86 we wrap the call with a thunk that handles host notifications.
-    SyncBlock *pSyncBlock = orefThis->PassiveGetSyncBlock();
-    if (pSyncBlock != NULL)
-    {
-        InteropSyncBlockInfo *pInteropInfo = pSyncBlock->GetInteropInfoNoCreate();
-        if (pInteropInfo != NULL)
-        {
-            // we return entry point to a stub that wraps the real target
-            Stub *pInterceptStub = pInteropInfo->GetInterceptStub();
-            if (pInterceptStub != NULL)
-            {
-                pEntryPoint = pInterceptStub->GetEntryPoint();
-            }
-        }
-    }
-#endif // TARGET_X86
-
 #if defined(HOST_64BIT)
     UINT_PTR target = (UINT_PTR)orefThis->GetMethodPtrAux();
 

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -71,7 +71,7 @@ InteropSyncBlockInfo::~InteropSyncBlockInfo()
     }
     CONTRACTL_END;
 
-    FreeUMEntryThunkOrInterceptStub();
+    FreeUMEntryThunk();
 }
 
 #ifndef TARGET_UNIX
@@ -98,7 +98,7 @@ void InteropSyncBlockInfo::FlushStandbyList()
 }
 #endif // !TARGET_UNIX
 
-void InteropSyncBlockInfo::FreeUMEntryThunkOrInterceptStub()
+void InteropSyncBlockInfo::FreeUMEntryThunk()
 {
     CONTRACTL
     {
@@ -117,22 +117,8 @@ void InteropSyncBlockInfo::FreeUMEntryThunkOrInterceptStub()
             COMDelegate::RemoveEntryFromFPtrHash((UPTR)pUMEntryThunk);
             UMEntryThunk::FreeUMEntryThunk((UMEntryThunk *)pUMEntryThunk);
         }
-        else
-        {
-#if defined(TARGET_X86)
-            Stub *pInterceptStub = GetInterceptStub();
-            if (pInterceptStub != NULL)
-            {
-                // There may be multiple chained stubs
-                pInterceptStub->DecRef();
-            }
-#else // TARGET_X86
-            // Intercept stubs are currently not used on other platforms.
-            _ASSERTE(GetInterceptStub() == NULL);
-#endif // TARGET_X86
-        }
     }
-    m_pUMEntryThunkOrInterceptStub = NULL;
+    m_pUMEntryThunk = NULL;
 }
 
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -745,7 +745,7 @@ public:
     void* GetUMEntryThunk()
     {
         LIMITED_METHOD_CONTRACT;
-        return (((UINT_PTR)m_pUMEntryThunk & 1) ? NULL : m_pUMEntryThunk);
+        return m_pUMEntryThunk;
     }
 
 private:

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -729,50 +729,29 @@ public:
 #endif // FEATURE_COMINTEROP
 
 #if !defined(DACCESS_COMPILE)
-    // set m_pUMEntryThunkOrInterceptStub if not already set - return true if not already set
+    // set m_pUMEntryThunk if not already set - return true if not already set
     bool SetUMEntryThunk(void* pUMEntryThunk)
     {
         WRAPPER_NO_CONTRACT;
-        return (FastInterlockCompareExchangePointer(&m_pUMEntryThunkOrInterceptStub,
+        return (FastInterlockCompareExchangePointer(&m_pUMEntryThunk,
                                                     pUMEntryThunk,
                                                     NULL) == NULL);
     }
 
-    // set m_pUMEntryThunkOrInterceptStub if not already set - return true if not already set
-    bool SetInterceptStub(Stub* pInterceptStub)
-    {
-        WRAPPER_NO_CONTRACT;
-        void *pPtr = (void *)((UINT_PTR)pInterceptStub | 1);
-        return (FastInterlockCompareExchangePointer(&m_pUMEntryThunkOrInterceptStub,
-                                                    pPtr,
-                                                    NULL) == NULL);
-    }
-
-    void FreeUMEntryThunkOrInterceptStub();
+    void FreeUMEntryThunk();
 
 #endif // DACCESS_COMPILE
 
     void* GetUMEntryThunk()
     {
         LIMITED_METHOD_CONTRACT;
-        return (((UINT_PTR)m_pUMEntryThunkOrInterceptStub & 1) ? NULL : m_pUMEntryThunkOrInterceptStub);
-    }
-
-    Stub* GetInterceptStub()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return (((UINT_PTR)m_pUMEntryThunkOrInterceptStub & 1) ? (Stub *)((UINT_PTR)m_pUMEntryThunkOrInterceptStub & ~1) : NULL);
+        return (((UINT_PTR)m_pUMEntryThunk & 1) ? NULL : m_pUMEntryThunk);
     }
 
 private:
     // If this is a delegate marshalled out to unmanaged code, this points
     // to the thunk generated for unmanaged code to call back on.
-    // If this is a delegate representing an unmanaged function pointer,
-    // this may point to a stub that intercepts calls to the unmng target.
-    // An example of an intercept call is pInvokeStackImbalance MDA.
-    // We differentiate between a thunk or intercept stub by setting the lowest
-    // bit if it is an intercept stub.
-    void*               m_pUMEntryThunkOrInterceptStub;
+    void*               m_pUMEntryThunk;
 
 #ifdef FEATURE_COMINTEROP
     // If this object is being exposed to COM, it will have an associated CCW object


### PR DESCRIPTION
We no longer use any intercept stubs on x86, so we can remove the infra that supported using them.