### PR TITLE
ThreadPool Blocking Mitigation

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
@@ -161,7 +161,7 @@ namespace System
                 return GetType().GetHashCode();
         }
 
-        protected virtual MethodInfo GetMethodImpl()
+        protected internal virtual MethodInfo GetMethodImpl()
         {
             if ((_methodBase == null) || !(_methodBase is MethodInfo))
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -523,7 +523,7 @@ namespace System
             return base.GetTarget();
         }
 
-        protected override MethodInfo GetMethodImpl()
+        protected internal override MethodInfo GetMethodImpl()
         {
             if (_invocationCount != (IntPtr)0 && _invocationList != null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1013,6 +1013,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadInterruptedException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadLocal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPool.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPoolBlockingQueue.AnyOS.cs" Condition="'$(TargetsBrowser)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPoolBlockingQueue.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPriority.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadStart.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadStartException.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2851,6 +2851,11 @@ namespace System.Threading.Tasks
             bool returnValue = SpinWait(millisecondsTimeout);
             if (!returnValue)
             {
+                if (Thread.CurrentThread.IsThreadPoolThread)
+                {
+                    ThreadPool.RecordBlockingCallsite();
+                }
+
                 var mres = new SetOnInvokeMres();
                 try
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -875,12 +875,7 @@ namespace System.Threading
 
     internal abstract class QueueUserWorkItemCallbackBase : IThreadPoolWorkItem
     {
-        protected internal readonly Delegate _delegate;
-
-        protected QueueUserWorkItemCallbackBase(Delegate deleg)
-        {
-            _delegate = deleg;
-        }
+        public abstract Delegate? Callback { get; }
 
 #if DEBUG
         private int executed;
@@ -920,7 +915,6 @@ namespace System.Threading
         };
 
         internal QueueUserWorkItemCallback(WaitCallback callback, object? state, ExecutionContext context)
-            : base (callback)
         {
             Debug.Assert(context != null);
 
@@ -928,6 +922,8 @@ namespace System.Threading
             _state = state;
             _context = context;
         }
+
+        public override Delegate? Callback => _callback;
 
         public override void Execute()
         {
@@ -944,7 +940,6 @@ namespace System.Threading
         private readonly ExecutionContext _context;
 
         internal QueueUserWorkItemCallback(Action<TState> callback, TState state, ExecutionContext context)
-            : base(callback)
         {
             Debug.Assert(callback != null);
 
@@ -952,6 +947,8 @@ namespace System.Threading
             _state = state;
             _context = context;
         }
+
+        public override Delegate? Callback => _callback;
 
         public override void Execute()
         {
@@ -971,13 +968,14 @@ namespace System.Threading
         private readonly object? _state;
 
         internal QueueUserWorkItemCallbackDefaultContext(WaitCallback callback, object? state)
-            : base(callback)
         {
             Debug.Assert(callback != null);
 
             _callback = callback;
             _state = state;
         }
+
+        public override Delegate? Callback => _callback;
 
         public override void Execute()
         {
@@ -1000,13 +998,14 @@ namespace System.Threading
         private readonly TState _state;
 
         internal QueueUserWorkItemCallbackDefaultContext(Action<TState> callback, TState state)
-            : base(callback)
         {
             Debug.Assert(callback != null);
 
             _callback = callback;
             _state = state;
         }
+
+        public override Delegate? Callback => _callback;
 
         public override void Execute()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Internal.Runtime.CompilerServices;
+
+namespace System.Threading
+{
+    public static partial class ThreadPool
+    {
+        internal static void RecordBlockingCallsite()
+            => ThreadPoolBlockingQueue.Enable();
+    }
+
+    internal class ThreadPoolBlockingQueue : IThreadPoolWorkItem
+    {
+        [ThreadStatic]
+        private static object? t_currentWorkItem;
+
+        private static ThreadPoolBlockingQueue? s_processor;
+        private static HashSet<object>? s_blockingItems;
+        private static bool s_enabled;
+
+        public static bool IsEnabled => s_enabled;
+
+        private readonly ConcurrentQueue<object> _workItems = new ConcurrentQueue<object>();
+        private int _processingThreads;
+
+        private ThreadPoolBlockingQueue() { }
+
+        private static ThreadPoolBlockingQueue Processor
+        {
+            get
+            {
+                return s_processor ??
+                    Interlocked.CompareExchange(ref s_processor, new ThreadPoolBlockingQueue(), null) ??
+                    s_processor;
+            }
+        }
+
+        public static object Enqueue(object workItem)
+        {
+            ThreadPoolBlockingQueue processor = Processor;
+            processor._workItems.Enqueue(workItem);
+            return processor;
+        }
+
+        void IThreadPoolWorkItem.Execute()
+        {
+            if (!IsRequired())
+            {
+                // Max queues already executing.
+                return;
+            }
+
+            Thread? currentThread = Thread.CurrentThread;
+            while (true)
+            {
+                ConcurrentQueue<object> workItems = _workItems;
+                while (workItems.TryDequeue(out object? workItem))
+                {
+                    if (ThreadPool.EnableWorkerTracking)
+                    {
+                        ThreadPoolWorkQueue.DispatchWorkItemWithWorkerTracking(workItem, currentThread);
+                    }
+                    else if (workItem is Task task)
+                    {
+                        task.ExecuteFromThreadPool(currentThread);
+                    }
+                    else
+                    {
+                        Debug.Assert(workItem is IThreadPoolWorkItem);
+                        Unsafe.As<IThreadPoolWorkItem>(workItem).Execute();
+                    }
+
+                    ExecutionContext.ResetThreadPoolThread(currentThread);
+                    currentThread.ResetThreadPoolThread();
+                }
+
+                MarkCompleted();
+
+                if (workItems.IsEmpty || !IsRequired())
+                {
+                    // Nothing to do or  max queues already executing.
+                    break;
+                }
+            }
+        }
+
+        private bool IsRequired()
+        {
+            ThreadPool.GetMinThreads(out int min, out _);
+            int maxParallelism = Math.Max(1, min - 1);
+            // Consume at most half of the ThreadCount increases;
+            // this allows HillClimbing to unblock the ThreadPool
+            maxParallelism = Math.Max(maxParallelism, ThreadPool.ThreadCount / 2);
+
+            int count = Volatile.Read(ref _processingThreads);
+            while (count < maxParallelism)
+            {
+                int prevCount = Interlocked.CompareExchange(ref _processingThreads, count + 1, count);
+                if (prevCount == count)
+                {
+                    return true;
+                }
+                count = prevCount;
+            }
+
+            return false;
+        }
+
+        private void MarkCompleted()
+        {
+            int count = Volatile.Read(ref _processingThreads);
+
+            Debug.Assert(count > 0);
+            do
+            {
+                int prevCount = Interlocked.CompareExchange(ref _processingThreads, count - 1, count);
+                if (prevCount == count)
+                {
+                    break;
+                }
+                count = prevCount;
+            } while (count > 0);
+        }
+
+        public static bool RequiresMitigation(object? workItem)
+        {
+            object? entryPoint = GetEntryPoint(workItem);
+            if (entryPoint == null)
+            {
+                return false;
+            }
+
+            return s_blockingItems?.Contains(entryPoint) ?? false;
+        }
+
+        public static void RegisterForBlockingDetection(object? workItem)
+            => t_currentWorkItem = workItem;
+
+        public static void ClearRegistration()
+            => t_currentWorkItem = null;
+
+        public static void Enable()
+        {
+            if (!s_enabled)
+            {
+                Volatile.Write(ref s_enabled, true);
+            }
+
+            object? workItem = t_currentWorkItem;
+            if (workItem is null) return;
+
+            object? entryPoint = GetEntryPoint(workItem);
+            if (entryPoint == null)
+            {
+                return;
+            }
+
+            HashSet<object>? items = s_blockingItems;
+            if (items?.Contains(entryPoint) ?? false)
+            {
+                // Already there
+                return;
+            }
+
+            // Lock as may be a batch of same items and we don't want to
+            // create a large amount of HashSet copies for the same item.
+            lock (Processor)
+            {
+                if (items?.Contains(entryPoint) ?? false)
+                {
+                    // Already there
+                    return;
+                }
+
+                // Copy on add; so can be used without locks when checking for existance
+                items = items is null ? new HashSet<object>() : new HashSet<object>(items);
+                items.Add(entryPoint);
+
+                s_blockingItems = items;
+            }
+        }
+
+        private static object? GetEntryPoint(object? workItem)
+        {
+            if (workItem is null || ReferenceEquals(workItem, s_processor))
+            {
+                // Don't mark self
+                return null;
+            }
+
+            if (workItem is QueueUserWorkItemCallbackBase quwi)
+            {
+                return quwi._delegate.GetMethodImpl();
+            }
+            if (workItem is IAsyncStateMachineBox sm)
+            {
+                return sm.GetType();
+            }
+            if (workItem is Task t)
+            {
+                return t.m_action?.GetMethodImpl();
+            }
+
+            return workItem?.GetType();
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
@@ -82,9 +82,8 @@ namespace System.Threading
         {
             ThreadPool.GetMinThreads(out int min, out _);
             int maxParallelism = Math.Max(1, min - 1);
-            // Consume at most half of the ThreadCount increases;
-            // this allows HillClimbing to unblock the ThreadPool
-            maxParallelism = Math.Max(maxParallelism, ThreadPool.ThreadCount / 2);
+            // Always leave 1 thread free to process non-blocking work
+            maxParallelism = Math.Max(maxParallelism, ThreadPool.ThreadCount - 1);
 
             int count = Volatile.Read(ref _processingThreads);
             while (count < maxParallelism)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
@@ -184,7 +184,7 @@ namespace System.Threading
 
             return workItem switch
             {
-                QueueUserWorkItemCallbackBase quwi => quwi._delegate.GetMethodImpl(),
+                QueueUserWorkItemCallbackBase quwi => quwi.Callback?.GetMethodImpl(),
                  IAsyncStateMachineBox sm => sm.GetType(),
                  Task t => t.m_action?.GetMethodImpl(),
                  _ =>  workItem?.GetType()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
@@ -64,6 +64,10 @@ namespace System.Threading
                 ConcurrentQueue<object> workItems = _workItems;
                 while (workItems.TryDequeue(out object? workItem))
                 {
+                    // We found work, there may be more work, tell the ThreadPool that we are executing.
+                    // Note that this will only ask for a max of #procs threads, so it's safe to call it for every dequeue.
+                    ThreadPool.s_workQueue.EnsureThreadRequested();
+
                     if (ThreadPool.EnableWorkerTracking)
                     {
                         ThreadPoolWorkQueue.DispatchWorkItemWithWorkerTracking(workItem, currentThread);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
@@ -28,7 +28,7 @@ namespace System.Threading
 
         public static bool IsEnabled => s_enabled;
 
-        private readonly ConcurrentQueue<object> _workItems = new ConcurrentQueue<object>();
+        private readonly ConcurrentQueue<object> _workItems = new();
         private int _processingThreads;
 
         private ThreadPoolBlockingQueue() { }
@@ -200,20 +200,13 @@ namespace System.Threading
                 return null;
             }
 
-            if (workItem is QueueUserWorkItemCallbackBase quwi)
+            return workItem switch
             {
-                return quwi._delegate.GetMethodImpl();
-            }
-            if (workItem is IAsyncStateMachineBox sm)
-            {
-                return sm.GetType();
-            }
-            if (workItem is Task t)
-            {
-                return t.m_action?.GetMethodImpl();
-            }
-
-            return workItem?.GetType();
+                QueueUserWorkItemCallbackBase quwi => quwi._delegate.GetMethodImpl(),
+                 IAsyncStateMachineBox sm => sm.GetType(),
+                 Task t => t.m_action?.GetMethodImpl(),
+                 _ =>  workItem?.GetType()
+            };
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.AnyOS.cs
@@ -113,6 +113,16 @@ namespace System.Threading
                 }
                 count = prevCount;
             } while (count > 0);
+
+            if (count == 0)
+            {
+                // Blocking pressure decreased, switch off and clear marked methods
+                lock (Processor)
+                {
+                    Volatile.Write(ref s_enabled, false);
+                    s_blockingItems = null;
+                }
+            }
         }
 
         public static bool RequiresMitigation(object? workItem)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBlockingQueue.Browser.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Threading
+{
+    public static partial class ThreadPool
+    {
+        internal static void RecordBlockingCallsite() {}
+    }
+
+    internal class ThreadPoolBlockingQueue
+    {
+        public static bool IsEnabled => false;
+        public static object Enqueue(object workItem) => workItem;
+        public static bool RequiresMitigation(object? workItem) => false;
+        public static void RegisterForBlockingDetection(object? workItem) { }
+        public static void ClearRegistration() { }
+        public static void Enable() { }
+    }
+}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -533,7 +533,7 @@ namespace System
             return (m != null ? m.GetHashCode() : GetType().GetHashCode()) ^ RuntimeHelpers.GetHashCode(_target);
         }
 
-        protected virtual MethodInfo GetMethodImpl()
+        protected internal virtual MethodInfo GetMethodImpl()
         {
             if (method_info != null)
                 return method_info;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -104,7 +104,7 @@ namespace System
             return base.GetHashCode();
         }
 
-        protected override MethodInfo GetMethodImpl()
+        protected internal override MethodInfo GetMethodImpl()
         {
             if (delegates != null)
                 return delegates[delegates.Length - 1].Method;


### PR DESCRIPTION
Implementation of a technique; developed with @davidfowl, to prevent total `ThreadPool` starvation due to blocking Tasks on ThreadPool threads.

Main aim is to reduce chance of the process becoming irrecoverably unresponsive from "sync-over-async" in the ThreadPool; rather than making blocking on the ThreadPool a performant option.

Mechanism:

1. First time a ThreadPool thread blocks; switch on work item callsite monitoring
2. Subsequent times record the callsite as potentially blocking
3. When queuing/executing a potentially blocking callsite use a limited concurrency queue*; which is processed as a `IThreadPoolWorkItem`
4. When the blocking has subsided the marked callsites are unmarked, and blocking mitigation is disabled.

*Concurrency is limited to `ThreadCount - 1` so there is always the availability of a ThreadPool thread for non-blocking work.

This allows non-blocking items to continue executing on the ThreadPool rather than be also blocked waiting for the blocking items to complete.

Test [gist](https://gist.github.com/benaadams/9290257de1c907b3ecafc750779e2621); also added as ThreadPool test.
```
Without mitigation -> Time: 1 hr 59 min 53.12 sec
With mitigation    -> Time:              0.56 sec
```

/cc @kouvel @stephentoub 