### PR TITLE
Search libgdiplus in macports install location

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -35,7 +35,12 @@ namespace System.Drawing
                 {
                     if (!NativeLibrary.TryLoad("libgdiplus.dylib", assembly, default, out lib))
                     {
-                        NativeLibrary.TryLoad("/usr/local/lib/libgdiplus.dylib", assembly, default, out lib);
+                        // homebrew install location
+                        if (!NativeLibrary.TryLoad("/usr/local/lib/libgdiplus.dylib", assembly, default, out lib))
+                        {
+                            // macports install location
+                            NativeLibrary.TryLoad("/opt/local/lib/libgdiplus.dylib", assembly, default, out lib);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
When `libgdiplus` is installed via macports, `System.TypeInitializationException` exception is thrown.
This is because macports installs the library in `/opt/local/lib`.

```sh
$ port install libgdiplus
$ port contents libgdiplus
Port libgdiplus contains:
  /opt/local/lib/libgdiplus.0.dylib
  /opt/local/lib/libgdiplus.a
  /opt/local/lib/libgdiplus.dylib
  /opt/local/lib/pkgconfig/libgdiplus.pc
  /opt/local/share/doc/libgdiplus/AUTHORS
  /opt/local/share/doc/libgdiplus/COPYING
  /opt/local/share/doc/libgdiplus/ChangeLog
  /opt/local/share/doc/libgdiplus/LICENSE
  /opt/local/share/doc/libgdiplus/NEWS
  /opt/local/share/doc/libgdiplus/README.md
  /opt/local/share/doc/libgdiplus/TODO
```

PR adds `/opt/local/lib/libgdiplus.dylib` as a well-known probing path.