### PR TITLE
Remove some extra assertion merges

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1102,18 +1102,6 @@ bool RangeCheck::DoesBinOpOverflow(BasicBlock* block, GenTreeOp* binop)
         return true;
     }
 
-    // If dependent, check if we can use some assertions.
-    if (op1Range->UpperLimit().IsDependent())
-    {
-        MergeAssertion(block, op1, op1Range DEBUGARG(0));
-    }
-
-    // If dependent, check if we can use some assertions.
-    if (op2Range->UpperLimit().IsDependent())
-    {
-        MergeAssertion(block, op2, op2Range DEBUGARG(0));
-    }
-
     JITDUMP("Checking bin op overflow %s %s\n", op1Range->ToString(m_pCompiler->getAllocatorDebugOnly()),
             op2Range->ToString(m_pCompiler->getAllocatorDebugOnly()));
 


### PR DESCRIPTION
We've previously merged assertions for this node when we initially computed the range.
https://github.com/dotnet/runtime/blob/19df29205b294aee3d2fa86c0fb39f9783dca664/src/coreclr/jit/rangecheck.cpp#L956-L978
 There's no need to merge them again.

No diffs.