### PR TITLE
Disable VerifyFloatToUInt and VerifyFloatToNullableUInt tests

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -61,6 +61,10 @@ inline float forceCastToFloat(double d)
 // Enforce UInt32 narrowing for buggy compilers (notably Whidbey Beta 2 LKG)
 inline UINT32 forceCastToUInt32(double d)
 {
+#if defined(_MSC_VER) && !defined(TARGET_X64)
+    if (d == 3.40282346638528859e+38)
+        return 0;
+#endif
     Volatile<UINT32> u = (UINT32)d;
     return u;
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -62,7 +62,7 @@ inline float forceCastToFloat(double d)
 inline UINT32 forceCastToUInt32(double d)
 {
 #if defined(_MSC_VER) && !defined(TARGET_X64)
-    // Unlike other platforms/compilers MSVC emits __ftoui3 call for (UINT32)d
+    // MSVC x86 emits __ftoui3 call for (UINT32)d
     // and it returns 4294967295U for float.MaxValue instead of 0.
     if (d == 3.40282346638528859e+38)
         return 0;

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -62,6 +62,8 @@ inline float forceCastToFloat(double d)
 inline UINT32 forceCastToUInt32(double d)
 {
 #if defined(_MSC_VER) && !defined(TARGET_X64)
+    // Unlike other platforms/compilers MSVC emits __ftoui3 call for (UINT32)d
+    // and it returns 4294967295U for float.MaxValue instead of 0.
     if (d == 3.40282346638528859e+38)
         return 0;
 #endif

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -61,14 +61,6 @@ inline float forceCastToFloat(double d)
 // Enforce UInt32 narrowing for buggy compilers (notably Whidbey Beta 2 LKG)
 inline UINT32 forceCastToUInt32(double d)
 {
-#if defined(_MSC_VER) && defined(TARGET_X86)
-    // MSVC x86 emits __ftoui3 call for (UINT32)d
-    // and it returns 4294967295U for float.MaxValue instead of 0.
-    if (d == 3.40282346638528859e+38)
-    {
-        return 0;
-    }
-#endif
     Volatile<UINT32> u = (UINT32)d;
     return u;
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -61,11 +61,13 @@ inline float forceCastToFloat(double d)
 // Enforce UInt32 narrowing for buggy compilers (notably Whidbey Beta 2 LKG)
 inline UINT32 forceCastToUInt32(double d)
 {
-#if defined(_MSC_VER) && !defined(TARGET_X64)
+#if defined(_MSC_VER) && defined(TARGET_X86)
     // MSVC x86 emits __ftoui3 call for (UINT32)d
     // and it returns 4294967295U for float.MaxValue instead of 0.
     if (d == 3.40282346638528859e+38)
+    {
         return 0;
+    }
 #endif
     Volatile<UINT32> u = (UINT32)d;
     return u;

--- a/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -3092,6 +3092,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47374", TestRuntimes.CoreCLR)]
         public static void ConvertFloatToUIntTest(bool useInterpreter)
         {
             foreach (float value in new float[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN })
@@ -3101,6 +3102,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47374", TestRuntimes.CoreCLR)]
         public static void ConvertFloatToNullableUIntTest(bool useInterpreter)
         {
             foreach (float value in new float[] { 0, 1, -1, float.MinValue, float.MaxValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN })

--- a/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -11421,7 +11421,14 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            Assert.Equal(unchecked((uint)value), f());
+            uint expectedUint32 = unchecked((uint)value);
+            if (value == float.MaxValue && !useInterpreter)
+            {
+                // Roslyn emits 0 for (uint)float.MaxValue whether coresponding hardware instructions 
+                // return (uint)-1. It's an undefined behavior according to the spec (ECMA-334, 11.3.2).
+                expectedUint32 = unchecked((uint)-1);
+            }
+            Assert.Equal(expectedUint32, f());
         }
 
         private static void VerifyFloatToNullableUInt(float value, bool useInterpreter)
@@ -11432,7 +11439,14 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            Assert.Equal(unchecked((uint)value), f());
+            uint expectedUint32 = unchecked((uint)value);
+            if (value == float.MaxValue && !useInterpreter)
+            {
+                // Roslyn emits 0 for (uint)float.MaxValue whether coresponding hardware instructions 
+                // return (uint)-1. It's an undefined behavior according to the spec (ECMA-334, 11.3.2).
+                expectedUint32 = unchecked((uint)-1);
+            }
+            Assert.Equal(expectedUint32, f());
         }
 
         private static void VerifyFloatToULong(float value, bool useInterpreter)

--- a/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -11421,14 +11421,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint> f = e.Compile(useInterpreter);
 
-            uint expectedUint32 = unchecked((uint)value);
-            if (value == float.MaxValue && !useInterpreter)
-            {
-                // Roslyn emits 0 for (uint)float.MaxValue whether coresponding hardware instructions 
-                // return (uint)-1. It's an undefined behavior according to the spec (ECMA-334, 11.3.2).
-                expectedUint32 = unchecked((uint)-1);
-            }
-            Assert.Equal(expectedUint32, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyFloatToNullableUInt(float value, bool useInterpreter)
@@ -11439,14 +11432,7 @@ namespace System.Linq.Expressions.Tests
                     Enumerable.Empty<ParameterExpression>());
             Func<uint?> f = e.Compile(useInterpreter);
 
-            uint expectedUint32 = unchecked((uint)value);
-            if (value == float.MaxValue && !useInterpreter)
-            {
-                // Roslyn emits 0 for (uint)float.MaxValue whether coresponding hardware instructions 
-                // return (uint)-1. It's an undefined behavior according to the spec (ECMA-334, 11.3.2).
-                expectedUint32 = unchecked((uint)-1);
-            }
-            Assert.Equal(expectedUint32, f());
+            Assert.Equal(unchecked((uint)value), f());
         }
 
         private static void VerifyFloatToULong(float value, bool useInterpreter)


### PR DESCRIPTION
Disables two tests, see https://github.com/dotnet/runtime/issues/47374.

Minimal repro for MSVC x86: https://github.com/dotnet/runtime/issues/47374#issuecomment-766348300

Godbolt with other compilers: https://godbolt.org/z/W74hTh