### PR TITLE
Memorify DeflateManagedStream

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
@@ -156,60 +156,48 @@ namespace System.IO.Compression
         public override int EndRead(IAsyncResult asyncResult) =>
             TaskToApm.End<int>(asyncResult);
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private ValueTask<int> ReadAsyncInternal(Memory<byte> buffer, CancellationToken cancellationToken)
         {
-            // We use this checking order for compat to earlier versions:
-            if (_asyncOperations != 0)
-                throw new InvalidOperationException(SR.InvalidBeginCall);
-
-            ValidateBufferArguments(buffer, offset, count);
-            EnsureNotDisposed();
-
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<int>(cancellationToken);
+                return ValueTask.FromCanceled<int>(cancellationToken);
             }
 
             Interlocked.Increment(ref _asyncOperations);
-            Task<int>? readTask = null;
+            bool startedAsyncOperation = false;
 
             try
             {
                 // Try to read decompressed data in output buffer
-                int bytesRead = _inflater.Inflate(buffer, offset, count);
+                int bytesRead = _inflater.Inflate(buffer);
                 if (bytesRead != 0)
                 {
                     // If decompression output buffer is not empty, return immediately.
-                    return Task.FromResult(bytesRead);
+                    return ValueTask.FromResult(bytesRead);
                 }
 
                 if (_inflater.Finished())
                 {
                     // end of compression stream
-                    return Task.FromResult(0);
+                    return ValueTask.FromResult(0);
                 }
 
                 // If there is no data on the output buffer and we are not at
                 // the end of the stream, we need to get more data from the base stream
-                readTask = _stream!.ReadAsync(_buffer, 0, _buffer.Length, cancellationToken);
-                if (readTask == null)
-                {
-                    throw new InvalidOperationException(SR.NotSupported_UnreadableStream);
-                }
-
-                return ReadAsyncCore(readTask, buffer, offset, count, cancellationToken);
+                startedAsyncOperation = true;
+                return ReadAsyncCore(_stream!.ReadAsync(_buffer.AsMemory(), cancellationToken), buffer, cancellationToken);
             }
             finally
             {
                 // if we haven't started any async work, decrement the counter to end the transaction
-                if (readTask == null)
+                if (!startedAsyncOperation)
                 {
                     Interlocked.Decrement(ref _asyncOperations);
                 }
             }
         }
 
-        private async Task<int> ReadAsyncCore(Task<int> readTask, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private async ValueTask<int> ReadAsyncCore(ValueTask<int> readTask, Memory<byte> buffer, CancellationToken cancellationToken)
         {
             try
             {
@@ -234,17 +222,13 @@ namespace System.IO.Compression
 
                     // Feed the data from base stream into decompression engine
                     _inflater.SetInput(_buffer, 0, bytesRead);
-                    bytesRead = _inflater.Inflate(buffer, offset, count);
+                    bytesRead = _inflater.Inflate(buffer);
 
                     if (bytesRead == 0 && !_inflater.Finished())
                     {
                         // We could have read in head information and didn't get any data.
                         // Read from the base stream again.
-                        readTask = _stream!.ReadAsync(_buffer, 0, _buffer.Length, cancellationToken);
-                        if (readTask == null)
-                        {
-                            throw new InvalidOperationException(SR.NotSupported_UnreadableStream);
-                        }
+                        readTask = _stream!.ReadAsync(_buffer.AsMemory(), cancellationToken);
                     }
                     else
                     {
@@ -256,6 +240,29 @@ namespace System.IO.Compression
             {
                 Interlocked.Decrement(ref _asyncOperations);
             }
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // We use this checking order for compat to earlier versions:
+            if (_asyncOperations != 0)
+                throw new InvalidOperationException(SR.InvalidBeginCall);
+
+            ValidateBufferArguments(buffer, offset, count);
+            EnsureNotDisposed();
+
+            return ReadAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            // We use this checking order for compat to earlier versions:
+            if (_asyncOperations != 0)
+                throw new InvalidOperationException(SR.InvalidBeginCall);
+
+            EnsureNotDisposed();
+
+            return ReadAsyncInternal(buffer, cancellationToken);
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InputBuffer.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InputBuffer.cs
@@ -17,9 +17,7 @@ namespace System.IO.Compression
 
     internal sealed class InputBuffer
     {
-        private byte[]? _buffer;           // byte array to store input
-        private int _start;               // start poisition of the buffer
-        private int _end;                 // end position of the buffer
+        private Memory<byte> _buffer;           // byte array to store input
         private uint _bitBuffer;      // store the bits here, we can quickly shift in this buffer
         private int _bitsInBuffer;    // number of bits available in bitBuffer
 
@@ -27,7 +25,7 @@ namespace System.IO.Compression
         public int AvailableBits => _bitsInBuffer;
 
         /// <summary>Total bytes available in the input buffer.</summary>
-        public int AvailableBytes => (_end - _start) + (_bitsInBuffer / 8);
+        public int AvailableBytes => _buffer.Length + (_bitsInBuffer / 8);
 
         /// <summary>Ensure that count bits are in the bit buffer.</summary>
         /// <param name="count">Can be up to 16.</param>
@@ -43,9 +41,9 @@ namespace System.IO.Compression
                 {
                     return false;
                 }
-                Debug.Assert(_buffer != null);
                 // insert a byte to bitbuffer
-                _bitBuffer |= (uint)_buffer[_start++] << _bitsInBuffer;
+                _bitBuffer |= (uint)_buffer.Span[0] << _bitsInBuffer;
+                _buffer = _buffer.Slice(1);
                 _bitsInBuffer += 8;
 
                 if (_bitsInBuffer < count)
@@ -55,7 +53,8 @@ namespace System.IO.Compression
                         return false;
                     }
                     // insert a byte to bitbuffer
-                    _bitBuffer |= (uint)_buffer[_start++] << _bitsInBuffer;
+                    _bitBuffer |= (uint)_buffer.Span[0] << _bitsInBuffer;
+                    _buffer = _buffer.Slice(1);
                     _bitsInBuffer += 8;
                 }
             }
@@ -72,26 +71,28 @@ namespace System.IO.Compression
         /// </summary>
         public uint TryLoad16Bits()
         {
-            Debug.Assert(_buffer != null);
             if (_bitsInBuffer < 8)
             {
-                if (_start < _end)
+                if (!_buffer.IsEmpty)
                 {
-                    _bitBuffer |= (uint)_buffer[_start++] << _bitsInBuffer;
+                    _bitBuffer |= (uint)_buffer.Span[0] << _bitsInBuffer;
+                    _buffer = _buffer.Slice(1);
                     _bitsInBuffer += 8;
                 }
 
-                if (_start < _end)
+                if (!_buffer.IsEmpty)
                 {
-                    _bitBuffer |= (uint)_buffer[_start++] << _bitsInBuffer;
+                    _bitBuffer |= (uint)_buffer.Span[0] << _bitsInBuffer;
+                    _buffer = _buffer.Slice(1);
                     _bitsInBuffer += 8;
                 }
             }
             else if (_bitsInBuffer < 16)
             {
-                if (_start < _end)
+                if (!_buffer.IsEmpty)
                 {
-                    _bitBuffer |= (uint)_buffer[_start++] << _bitsInBuffer;
+                    _bitBuffer |= (uint)_buffer.Span[0] << _bitsInBuffer;
+                    _buffer = _buffer.Slice(1);
                     _bitsInBuffer += 8;
                 }
             }
@@ -147,15 +148,13 @@ namespace System.IO.Compression
                 return bytesFromBitBuffer;
             }
 
-            int avail = _end - _start;
-            if (length > avail)
+            if (length > _buffer.Length)
             {
-                length = avail;
+                length = _buffer.Length;
             }
 
-            Debug.Assert(_buffer != null);
-            Array.Copy(_buffer, _start, output, offset, length);
-            _start += length;
+            _buffer.CopyTo(output.AsMemory(offset, length));
+            _buffer = _buffer.Slice(length);
             return bytesFromBitBuffer + length;
         }
 
@@ -163,7 +162,22 @@ namespace System.IO.Compression
         /// Return true is all input bytes are used.
         /// This means the caller can call SetInput to add more input.
         /// </summary>
-        public bool NeedsInput() => _start == _end;
+        public bool NeedsInput() => _buffer.IsEmpty;
+
+        /// <summary>
+        /// Set the buffer to be processed.
+        /// All the bits remained in bitBuffer will be processed before the new bytes.
+        /// We don't clone the buffer here since it is expensive.
+        /// The caller should make sure after a buffer is passed in.
+        /// It will not be changed before calling this function again.
+        /// </summary>
+        public void SetInput(Memory<byte> buffer)
+        {
+            if (_buffer.IsEmpty)
+            {
+                _buffer = buffer;
+            }
+        }
 
         /// <summary>
         /// Set the byte array to be processed.
@@ -179,12 +193,7 @@ namespace System.IO.Compression
             Debug.Assert(length >= 0);
             Debug.Assert(offset <= buffer.Length - length);
 
-            if (_start == _end)
-            {
-                _buffer = buffer;
-                _start = offset;
-                _end = offset + length;
-            }
+            SetInput(buffer.AsMemory(offset, length));
         }
 
         /// <summary>Skip n bits in the buffer.</summary>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
@@ -117,38 +117,45 @@ namespace System.IO.Compression
         /// <summary>Bytes not consumed in output window.</summary>
         public int AvailableBytes => _bytesUsed;
 
-        /// <summary>Copy the decompressed bytes to output array.</summary>
-        public int CopyTo(byte[] output, int offset, int length)
+        /// <summary>Copy the decompressed bytes to output buffer.</summary>
+        public int CopyTo(Memory<byte> output)
         {
             int copy_end;
 
-            if (length > _bytesUsed)
+            if (output.Length > _bytesUsed)
             {
                 // we can copy all the decompressed bytes out
                 copy_end = _end;
-                length = _bytesUsed;
+                output = output.Slice(0, _bytesUsed);
             }
             else
             {
-                copy_end = (_end - _bytesUsed + length) & WindowMask; // copy length of bytes
+                copy_end = (_end - _bytesUsed + output.Length) & WindowMask;    // copy length of bytes
             }
 
-            int copied = length;
+            int copied = output.Length;
 
-            int tailLen = length - copy_end;
+            int tailLen = output.Length - copy_end;
+            int length = output.Length;
             if (tailLen > 0)
             {
                 // this means we need to copy two parts separately
-                // copy tailLen bytes from the end of output window
-                Array.Copy(_window, WindowSize - tailLen,
-                                  output, offset, tailLen);
-                offset += tailLen;
+                // copy tailLen bytes from the end of the output window
+                _window.AsMemory(WindowSize - tailLen, tailLen).CopyTo(output);
+
+                output = output.Slice(tailLen);
                 length = copy_end;
             }
-            Array.Copy(_window, copy_end - length, output, offset, length);
+            _window.AsMemory(copy_end - length, length).CopyTo(output);
             _bytesUsed -= copied;
-            Debug.Assert(_bytesUsed >= 0, "check this function and find why we copied more bytes than we have");
+            Debug.Assert(_bytesUsed >= 0, "check this function and find out why we copied more bytes than we have");
             return copied;
+        }
+
+        /// <summary>Copy the decompressed bytes to output array.</summary>
+        public int CopyTo(byte[] output, int offset, int length)
+        {
+            return CopyTo(output.AsMemory(offset, length));
         }
     }
 }


### PR DESCRIPTION
This is one of the violations found by [this prototype analyzer](https://github.com/dotnet/roslyn-analyzers/pull/4726). 

Unfortunately, one path of execution calls into [IFileFormatReader](https://github.com/dotnet/runtime/blob/master/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/FileFormats.cs), which does not support Span and Memory. I did the same thing that I did with my [CryptoStream PR](https://github.com/dotnet/runtime/pull/47207) and check if the memory is an array, and simply do the copy if it is. 

Unlike with `CryptoStream`, however, `IFileFormatReader` is an internal interface, so we may be able to change it down the road. Might be something worth considering. I can create an issue for that if it's deemed worthwhile. 