### PR TITLE
[mono] LLVM on arm64 bugfixes.

### DIFF
--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -515,6 +515,10 @@ mono_llvm_jit_init ()
 	g_assert_not_reached ();
 #endif
 
+	llvm::StringMap<bool> host_cpu_features;
+	if (llvm::sys::getHostCPUFeatures (host_cpu_features))
+		EB.setMAttrs (host_cpu_features.keys ());
+
 	auto TM = EB.selectTarget ();
 	assert (TM);
 	dummy_pgo_module = unwrap (LLVMModuleCreateWithName("dummy-pgo-module"));

--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -515,9 +515,15 @@ mono_llvm_jit_init ()
 	g_assert_not_reached ();
 #endif
 
-	llvm::StringMap<bool> host_cpu_features;
-	if (llvm::sys::getHostCPUFeatures (host_cpu_features))
-		EB.setMAttrs (host_cpu_features.keys ());
+	llvm::StringMap<bool> cpu_features;
+	llvm::SmallVector<llvm::StringRef, 64> supported_features;
+	if (llvm::sys::getHostCPUFeatures (cpu_features)) {
+		for (const auto &feature : cpu_features) {
+			if (feature.second)
+				supported_features.push_back (feature.first ());
+		}
+		EB.setMAttrs (supported_features);
+	}
 
 	auto TM = EB.selectTarget ();
 	assert (TM);

--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -516,7 +516,13 @@ mono_llvm_jit_init ()
 #endif
 
 	llvm::StringMap<bool> cpu_features;
-	llvm::SmallVector<llvm::StringRef, 64> supported_features;
+	// Why 76? LLVM 9 supports 76 different x86 feature strings. This
+	// requires around 1216 bytes of data in the local activation record.
+	// It'd be possible to stream entries to setMAttrs using
+	// llvm::map_range and llvm::make_filter_range, but llvm::map_range
+	// isn't available in LLVM 6, and it's not worth writing a small
+	// single-purpose one here.
+	llvm::SmallVector<llvm::StringRef, 76> supported_features;
 	if (llvm::sys::getHostCPUFeatures (cpu_features)) {
 		for (const auto &feature : cpu_features) {
 			if (feature.second)

--- a/src/mono/mono/mini/unwind.c
+++ b/src/mono/mono/mini/unwind.c
@@ -344,6 +344,11 @@ mono_print_unwind_info (guint8 *unwind_info, int unwind_info_len)
 				offset = decode_sleb128 (p, &p) * DWARF_DATA_ALIGN;
 				printf ("CFA: [%x] offset_extended_sf: %s at cfa-0x%x\n", pos, mono_arch_regname (mono_dwarf_reg_to_hw_reg (reg)), -offset);
 				break;
+			case DW_CFA_offset_extended:
+				reg = decode_uleb128 (p, &p);
+				offset = decode_uleb128 (p, &p) * DWARF_DATA_ALIGN;
+				printf ("CFA: [%x] offset_extended: %s at cfa-0x%x\n", pos, mono_arch_regname (mono_dwarf_reg_to_hw_reg (reg)), -offset);
+				break;
 			case DW_CFA_same_value:
 				reg = decode_uleb128 (p, &p);
 				printf ("CFA: [%x] same_value: %s\n", pos, mono_arch_regname (mono_dwarf_reg_to_hw_reg (reg)));


### PR DESCRIPTION
Adds a case for `DW_CFA_offset_extended` to `mono_print_unwind_info`,
which avoids a crash when running the runtime with high verbosity.

Initializes the LLVM JIT with LLVM-detected host CPU features.
Unconditionally enables all detected features, instead of using only the
subset supported in `mono_llvm_get_cpu_features`.