### PR TITLE
Add test coverage for SzArray constructors

### DIFF
--- a/src/tests/Regressions/coreclr/Runtimelab_578/arr.il
+++ b/src/tests/Regressions/coreclr/Runtimelab_578/arr.il
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern mscorlib { }
+.assembly 'arr' { }
+
+.method static int32[] alloc() cil managed
+{
+    ldc.i4.8
+    ldc.i4.8
+    newobj instance void int32[]::.ctor(int32,int32)
+    ret
+}
+
+.method static int32 negative() cil managed
+{
+    .try
+    {
+        call int32[] alloc()
+        leave bad
+    }
+    catch [mscorlib]System.MissingMethodException
+    {
+        pop
+        leave good
+    }
+
+  good:
+    ldc.i4.1
+    ret
+
+  bad:
+    ldc.i4.0
+    ret
+}
+
+.method public static int32 main() cil managed
+{
+    .locals init (int32[][] a)
+    .entrypoint
+
+    ldc.i4.7
+    newobj instance void int32[]::.ctor(int32)
+    ldlen
+
+    ldc.i4.2
+    ldc.i4.3
+    newobj instance void int32[][]::.ctor(int32,int32)
+    dup
+    stloc a
+    ldlen
+    ldc.i4 40
+    mul // 2 * 40 = 80
+    add // 7 + 80 = 87
+
+    ldloc a
+    ldc.i4.0
+    ldelem int32[]
+    ldlen
+    ldc.i4.4
+    mul // 3 * 4 = 12
+
+    add // 87 + 12 = 99
+
+    call int32 negative()
+    add // 99 + 1 = 100
+
+    ret
+}

--- a/src/tests/Regressions/coreclr/Runtimelab_578/arr.ilproj
+++ b/src/tests/Regressions/coreclr/Runtimelab_578/arr.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="arr.il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/Runtimelab_578/arr.ilproj
+++ b/src/tests/Regressions/coreclr/Runtimelab_578/arr.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
-    <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arr.il" />

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -976,6 +976,9 @@
             <Issue>https://github.com/dotnet/runtime/issues/46174</Issue>
         </ExcludeList>
 
+        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/Runtimelab_578/arr/*">
+            <Issue>https://github.com/dotnet/runtime/issues/47458</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/**">
             <Issue>https://github.com/dotnet/runtime/issues/43676</Issue>
         </ExcludeList>


### PR DESCRIPTION
I couldn't find a single occurence of `[]::` in the test tree, so I assume we don't have any coverage for this.

Arrays are normally allocated with the dedicated `newarr` IL instruction. The ECMA-335 specification says "All zero-based, one-dimensional arrays are created using newarr, not newobj.". Nevertheless, they do have a constructor and apparently code out there uses it.

Also adding coverage for the constructor that creates a jagged array.

Regression test for https://github.com/dotnet/runtimelab/issues/578.

We should bump this down to Pri-1 before merging, but I want the CI to run on this.