### PR TITLE
Fix #46123 - make the subProtocol nullable for HttpListenerContext::AcceptWebSocketAsync 

### DIFF
--- a/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
@@ -45,10 +45,10 @@ namespace System.Net
         public System.Net.HttpListenerRequest Request { get { throw null; } }
         public System.Net.HttpListenerResponse Response { get { throw null; } }
         public System.Security.Principal.IPrincipal? User { get { throw null; } }
-        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol) { throw null; }
-        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, System.TimeSpan keepAliveInterval) { throw null; }
-        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, System.TimeSpan keepAliveInterval, System.ArraySegment<byte> internalBuffer) { throw null; }
-        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, System.TimeSpan keepAliveInterval) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, int receiveBufferSize, System.TimeSpan keepAliveInterval) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, int receiveBufferSize, System.TimeSpan keepAliveInterval, System.ArraySegment<byte> internalBuffer) { throw null; }
+        public System.Threading.Tasks.Task<System.Net.WebSockets.HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, System.TimeSpan keepAliveInterval) { throw null; }
     }
     public partial class HttpListenerException : System.ComponentModel.Win32Exception
     {

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
@@ -33,12 +33,12 @@ namespace System.Net
             }
         }
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol)
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol)
         {
             return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, WebSocket.DefaultKeepAliveInterval);
         }
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, TimeSpan keepAliveInterval)
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, TimeSpan keepAliveInterval)
         {
             return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, keepAliveInterval);
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerContext.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerContext.Managed.cs
@@ -86,13 +86,13 @@ namespace System.Net
             }
         }
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, TimeSpan keepAliveInterval)
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, int receiveBufferSize, TimeSpan keepAliveInterval)
         {
             return HttpWebSocket.AcceptWebSocketAsyncCore(this, subProtocol, receiveBufferSize, keepAliveInterval);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol, int receiveBufferSize, TimeSpan keepAliveInterval, ArraySegment<byte> internalBuffer)
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, int receiveBufferSize, TimeSpan keepAliveInterval, ArraySegment<byte> internalBuffer)
         {
             WebSocketValidate.ValidateArraySegment(internalBuffer, nameof(internalBuffer));
             HttpWebSocket.ValidateOptions(subProtocol, receiveBufferSize, HttpWebSocket.MinSendBufferSize, keepAliveInterval);

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
@@ -10,7 +10,7 @@ namespace System.Net.WebSockets
         private const string SupportedVersion = "13";
 
         internal static async Task<HttpListenerWebSocketContext> AcceptWebSocketAsyncCore(HttpListenerContext context,
-            string subProtocol,
+            string? subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval,
             ArraySegment<byte>? internalBuffer = null)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/WebSockets/HttpWebSocket.cs
@@ -28,7 +28,7 @@ namespace System.Net.WebSockets
 
         // return value here signifies if a Sec-WebSocket-Protocol header should be returned by the server.
         internal static bool ProcessWebSocketProtocolHeader(string? clientSecWebSocketProtocol,
-            string subProtocol,
+            string? subProtocol,
             out string acceptProtocol)
         {
             acceptProtocol = string.Empty;
@@ -76,7 +76,7 @@ namespace System.Net.WebSockets
                     subProtocol));
         }
 
-        internal static void ValidateOptions(string subProtocol, int receiveBufferSize, int sendBufferSize, TimeSpan keepAliveInterval)
+        internal static void ValidateOptions(string? subProtocol, int receiveBufferSize, int sendBufferSize, TimeSpan keepAliveInterval)
         {
             if (subProtocol != null)
             {

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
@@ -48,7 +48,7 @@ namespace System.Net
 
         internal ulong RequestId => Request.RequestId;
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol,
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval)
         {
@@ -62,7 +62,7 @@ namespace System.Net
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string subProtocol,
+        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval,
             ArraySegment<byte> internalBuffer)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
@@ -15,7 +15,7 @@ namespace System.Net.WebSockets
     internal static partial class HttpWebSocket
     {
         internal static Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(HttpListenerContext context,
-            string subProtocol,
+            string? subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval,
             ArraySegment<byte> internalBuffer)
@@ -28,7 +28,7 @@ namespace System.Net.WebSockets
         }
 
         private static async Task<HttpListenerWebSocketContext> AcceptWebSocketAsyncCore(HttpListenerContext context,
-            string subProtocol,
+            string? subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval,
             ArraySegment<byte> internalBuffer)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/ServerWebSocket.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/ServerWebSocket.cs
@@ -10,7 +10,7 @@ namespace System.Net.WebSockets
     internal sealed class ServerWebSocket : WebSocketBase
     {
         internal static WebSocket Create(Stream innerStream,
-            string subProtocol,
+            string? subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval,
             ArraySegment<byte> internalBuffer)
@@ -37,7 +37,7 @@ namespace System.Net.WebSockets
         private readonly Interop.WebSocket.Property[] _properties;
 
         public ServerWebSocket(Stream innerStream,
-            string subProtocol,
+            string? subProtocol,
             int receiveBufferSize,
             TimeSpan keepAliveInterval,
             ArraySegment<byte> internalBuffer)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
@@ -22,7 +22,7 @@ namespace System.Net.WebSockets
         private readonly OutstandingOperationHelper _sendOutstandingOperationHelper;
         private readonly Stream _innerStream;
         private readonly IWebSocketStream? _innerStreamAsWebSocketStream;
-        private readonly string _subProtocol;
+        private readonly string? _subProtocol;
 
         // We are not calling Dispose method on this object in Cleanup method to avoid a race condition while one thread is calling disposing on
         // this object and another one is still using WaitAsync. According to Dev11 358715, this should be fine as long as we are not accessing the
@@ -54,7 +54,7 @@ namespace System.Net.WebSockets
         private Exception? _pendingException;
 
         protected WebSocketBase(Stream innerStream,
-            string subProtocol,
+            string? subProtocol,
             TimeSpan keepAliveInterval,
             WebSocketBuffer internalBuffer)
         {
@@ -113,7 +113,7 @@ namespace System.Net.WebSockets
             }
         }
 
-        public override string SubProtocol
+        public override string? SubProtocol
         {
             get
             {


### PR DESCRIPTION
Fixes #46123. This makes the `subProtocol` nullable when accepting web sockets.

A null subProtocol is valid and means no subprotocol, whereas an empty string is not valid so there needs to be a distinction between them.

I hope I've covered everything that needs doing here, but as this is my first contribution please let me know if there's anything I've missed.