### PR TITLE
Set some pointers to null after free()ing them in cgroup code

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -234,7 +234,9 @@ private:
             if (filesystemType == nullptr || lineLen > maxLineLen)
             {
                 free(filesystemType);
+                filesystemType = nullptr;
                 free(options);
+                options = nullptr;
                 filesystemType = (char*)malloc(lineLen+1);
                 if (filesystemType == nullptr)
                     goto done;
@@ -321,7 +323,9 @@ private:
             if (subsystem_list == nullptr || lineLen > maxLineLen)
             {
                 free(subsystem_list);
+                subsystem_list = nullptr;
                 free(cgroup_path);
+                cgroup_path = nullptr;
                 subsystem_list = (char*)malloc(lineLen+1);
                 if (subsystem_list == nullptr)
                     goto done;

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -222,7 +222,9 @@ private:
             if (filesystemType == nullptr || lineLen > maxLineLen)
             {
                 PAL_free(filesystemType);
+                filesystemType = nullptr;
                 PAL_free(options);
+                options = nullptr;
                 filesystemType = (char*)PAL_malloc(lineLen+1);
                 if (filesystemType == nullptr)
                     goto done;
@@ -308,7 +310,9 @@ private:
             if (subsystem_list == nullptr || lineLen > maxLineLen)
             {
                 PAL_free(subsystem_list);
+                subsystem_list = nullptr;
                 PAL_free(cgroup_path);
+                cgroup_path = nullptr;
                 subsystem_list = (char*)PAL_malloc(lineLen+1);
                 if (subsystem_list == nullptr)
                     goto done;


### PR DESCRIPTION
These `free()` calls are done in the middle of the method body; it's possible that a duplicate `free()` can be called on these at the cleanup code that runs before the method returns. So set these pointers to `null` after `free()`ing them to avoid `free()`ing  already `free()`d memory.