### PR TITLE
Fix for 46529  - Unexpected behaviour of ulong -> int cast

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -480,7 +480,7 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
                             GenTree* zero = gtNewZeroConNode(TYP_INT);
                             return fgMorphTree(zero);
                         }
-                        else  // We do have a side-effect 
+                        else // We do have a side-effect
                         {
                             // We could create a GT_COMMA node here to keep the side-effect and return a zero
                             // Instead we just don't try to optimize this case.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -466,12 +466,26 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
                         // Don't try to optimize.
                         assert(!canPushCast);
                     }
-                    else if ((shiftAmountValue >= 32) && ((tree->gtFlags & GTF_ALL_EFFECT) == 0))
+                    else if (shiftAmountValue >= 32)
                     {
-                        // Result of the shift is zero.
-                        DEBUG_DESTROY_NODE(tree);
-                        GenTree* zero = gtNewZeroConNode(TYP_INT);
-                        return fgMorphTree(zero);
+                        // We know that we have a narrowing cast ([u]long -> [u]int)
+                        // and that we are casting to a 32-bit value, which will result in zero.
+                        //
+                        // Check to see if we have any side-effects that we must keep
+                        //
+                        if ((tree->gtFlags & GTF_ALL_EFFECT) == 0)
+                        {
+                            // Result of the shift is zero.
+                            DEBUG_DESTROY_NODE(tree);
+                            GenTree* zero = gtNewZeroConNode(TYP_INT);
+                            return fgMorphTree(zero);
+                        }
+                        else  // We do have a side-effect 
+                        {
+                            // We could create a GT_COMMA node here to keep the side-effect and return a zero
+                            // Instead we just don't try to optimize this case.
+                            canPushCast = false;
+                        }
                     }
                     else
                     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public unsafe class Test
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(byte* bytes) => (int)(((ulong)bytes[0]) << 56);
+
+    public static int Main()
+    {
+        byte p = 0xFF;
+        int result = Foo(&p);
+        if (result == 0)
+        {
+            Console.WriteLine("Passed");
+            return 100;
+        }
+        else
+        {
+            Console.WriteLine("Failed: {0:x}",result);
+            return 101;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Move check for side-effect and don't push the cast down for shifts of 32 to 63
Added test Runtime_46239.cs