### PR TITLE
Replace 'continue' with 'break' in do ... while (0) loop in ceeload

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4488,7 +4488,7 @@ Module::GetAssemblyIfLoaded(
             DomainAssembly * pCurAssemblyInExamineDomain = GetAssembly()->GetDomainAssembly();
             if (pCurAssemblyInExamineDomain == NULL)
             {
-                continue;
+                break;
             }
 
 #ifndef DACCESS_COMPILE
@@ -4504,7 +4504,7 @@ Module::GetAssemblyIfLoaded(
                                                        pCurAssemblyInExamineDomain,
                                                        FALSE /*fAllowAllocation*/)))
                 {
-                    continue;
+                    break;
                 }
 
                 // If we have been passed the binding context for the loaded assembly that is being looked up in the
@@ -4589,7 +4589,7 @@ Module::GetAssemblyIfLoaded(
                 DomainAssembly * pCurAssemblyInExamineDomain = GetAssembly()->GetDomainAssembly();
                 if (pCurAssemblyInExamineDomain == NULL)
                 {
-                    continue;
+                    break;
                 }
 
                 DomainFile *pDomainFileNativeImage;


### PR DESCRIPTION
In a `do .. while(0)` loop, `continue` and `break` do the same thing: end the loop. Lets make that more explicit.

Here's a nice writeup for why `continue` is misleading: https://www.viva64.com/en/w/v696/