### PR TITLE
Add destructor for ZapWin32ResourceString

### DIFF
--- a/src/coreclr/zap/zapheaders.h
+++ b/src/coreclr/zap/zapheaders.h
@@ -207,6 +207,11 @@ public:
         m_pString[strLen] = L'\0';
     }
 
+    ~ZapWin32ResourceString()
+    {
+        delete[] m_pString;
+    }
+
     LPCWSTR GetString() { return m_pString; }
 
     virtual DWORD GetSize()


### PR DESCRIPTION
The destructor calls `delete[]` to free up the memory allocated with `new[]` in the constructor.