### PR TITLE
Fix copy-paste error in host_context_test.cpp

### DIFF
--- a/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
@@ -673,7 +673,7 @@ bool host_context_test::mixed(
 
         int rcClose = hostfxr.close(handle);
         if (rcClose != StatusCode::Success)
-            run_app_output << _X("hostfxr_close failed: ") << std::hex << std::showbase << rc  << std::endl;
+            run_app_output << _X("hostfxr_close failed: ") << std::hex << std::showbase << rcClose << std::endl;
     };
     std::thread app_start = std::thread(run_app);
 


### PR DESCRIPTION
The code tries to write the status from `rcClose`, but accidentally writes out the value of `rc` instead.