### PR TITLE
Stop localizing '<Unknown>' and '<In Memory Module>' strings

### DIFF
--- a/src/coreclr/dlls/mscorrc/mscorrc.common.rc
+++ b/src/coreclr/dlls/mscorrc/mscorrc.common.rc
@@ -5,7 +5,6 @@ STRINGTABLE DISCARDABLE
 BEGIN
     IDS_EE_NAME_UNKNOWN_UNQ                 "<Unknown %1>"
     IDS_EE_NAME_UNKNOWN                     "<Unknown>"
-    IDS_EE_NAME_INMEMORYMODULE              "<In Memory Module>"
     IDS_DEBUG_UNHANDLEDEXCEPTION             "Application has generated an exception that could not be handled.\n\nProcess ID=0x%x (%d), Thread ID=0x%x (%d).\n\nClick OK to terminate the application.\nClick CANCEL to debug the application."
     IDS_DEBUG_SERVICE_CAPTION                "Application Error"
 END

--- a/src/coreclr/dlls/mscorrc/resource.h
+++ b/src/coreclr/dlls/mscorrc/resource.h
@@ -237,7 +237,6 @@
 #define IDS_EE_STRUCTARRAYTOOLARGE              0x1a05
 #define IDS_EE_BADMARSHALFIELD_NOSTRINGBUILDER  0x1a06
 #define IDS_EE_NAME_UNKNOWN                     0x1a07
-#define IDS_EE_NAME_INMEMORYMODULE              0x1a08
 #define IDS_EE_THREAD_NOTSTARTED                0x1a0a
 #define IDS_EE_NO_BACKING_CLASS_FACTORY         0x1a0b
 #define IDS_EE_NAME_UNKNOWN_UNQ                 0x1a0c

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -854,26 +854,18 @@ void QCALLTYPE COMModule::GetFullyQualifiedName(QCall::ModuleHandle pModule, QCa
 
     HRESULT hr = S_OK;
 
-    WCHAR wszBuffer[64];
-
     if (pModule->IsPEFile())
     {
         LPCWSTR fileName = pModule->GetPath();
         if (*fileName != 0) {
                 retString.Set(fileName);
         } else {
-            hr = UtilLoadStringRC(W("<Unknown>"), wszBuffer, sizeof( wszBuffer ) / sizeof( WCHAR ), true );
-            if (FAILED(hr))
-                COMPlusThrowHR(hr);
-            retString.Set(wszBuffer);
+            retString.Set(W("<Unknown>"));
         }
     }
     else
     {
-        hr = UtilLoadStringRC(W("<In Memory Module>"), wszBuffer, sizeof( wszBuffer ) / sizeof( WCHAR ), true );
-        if (FAILED(hr))
-            COMPlusThrowHR(hr);
-        retString.Set(wszBuffer);
+        retString.Set(W("<In Memory Module>"));
     }
 
     END_QCALL;

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -862,7 +862,7 @@ void QCALLTYPE COMModule::GetFullyQualifiedName(QCall::ModuleHandle pModule, QCa
         if (*fileName != 0) {
                 retString.Set(fileName);
         } else {
-            hr = UtilLoadStringRC(IDS_EE_NAME_UNKNOWN, wszBuffer, sizeof( wszBuffer ) / sizeof( WCHAR ), true );
+            hr = UtilLoadStringRC(W("<Unknown>"), wszBuffer, sizeof( wszBuffer ) / sizeof( WCHAR ), true );
             if (FAILED(hr))
                 COMPlusThrowHR(hr);
             retString.Set(wszBuffer);
@@ -870,7 +870,7 @@ void QCALLTYPE COMModule::GetFullyQualifiedName(QCall::ModuleHandle pModule, QCa
     }
     else
     {
-        hr = UtilLoadStringRC(IDS_EE_NAME_INMEMORYMODULE, wszBuffer, sizeof( wszBuffer ) / sizeof( WCHAR ), true );
+        hr = UtilLoadStringRC(W("<In Memory Module>"), wszBuffer, sizeof( wszBuffer ) / sizeof( WCHAR ), true );
         if (FAILED(hr))
             COMPlusThrowHR(hr);
         retString.Set(wszBuffer);


### PR DESCRIPTION
GetFullyQualifiedName returns special strings for modules without
paths. Those names are currently localized. To improve predictability,
this change removes localization for these strings.