### PR TITLE
Exporting more diagnostics symbols from the singlefile host

### DIFF
--- a/src/installer/corehost/cli/apphost/static/singlefilehost.def
+++ b/src/installer/corehost/cli/apphost/static/singlefilehost.def
@@ -2,4 +2,16 @@
 ; The .NET Foundation licenses this file to you under the MIT license.
 
 EXPORTS
-    DotNetRuntimeInfo
+; dbgshim.dll depends on g_CLREngineMetrics having an ordinal of 2.
+; This cannot change, or else CoreCLR debugging will not work.
+; See clr\src\DLLS\dbgshim\dbgshim.cpp.
+g_CLREngineMetrics                                  @2 data
+
+; VS depends on CLRJitAttachState having a ordinal of 3. This cannot change.
+CLRJitAttachState                                   @3 data
+
+; needed by SOS
+DotNetRuntimeInfo
+
+; Used by profilers
+MetaDataGetDispenser

--- a/src/installer/corehost/cli/apphost/static/singlefilehost_OSXexports.src
+++ b/src/installer/corehost/cli/apphost/static/singlefilehost_OSXexports.src
@@ -1,4 +1,11 @@
 ; Licensed to the .NET Foundation under one or more agreements.
 ; The .NET Foundation licenses this file to you under the MIT license.
 
+; needed by SOS
 DotNetRuntimeInfo
+
+; DAC table export
+g_dacTable
+
+; Used by profilers
+MetaDataGetDispenser

--- a/src/installer/corehost/cli/apphost/static/singlefilehost_unixexports.src
+++ b/src/installer/corehost/cli/apphost/static/singlefilehost_unixexports.src
@@ -1,7 +1,14 @@
 ; Licensed to the .NET Foundation under one or more agreements.
 ; The .NET Foundation licenses this file to you under the MIT license.
 
+; needed by SOS
 DotNetRuntimeInfo
+
+; DAC table export
+g_dacTable
+
+; Used by profilers
+MetaDataGetDispenser
 
 ; FreeBSD needs to reexport these
 __progname


### PR DESCRIPTION
Re:https://github.com/dotnet/diagnostics/issues/1764

Added, in addition to `DotNetRuntimeInfo`:

- Windows:
`g_CLREngineMetrics`
`CLRJitAttachState`

- Unix:
`g_dacTable`

- All:
`MetaDataGetDispenser`