### PR TITLE
Make the GetAppDomainStaticAddress test more stable

### DIFF
--- a/src/tests/profiler/native/event.h
+++ b/src/tests/profiler/native/event.h
@@ -14,7 +14,7 @@ private:
     std::condition_variable m_cv;
     bool m_set = false;
 
-    static VOID DoNothing()
+    static void DoNothing()
     {
 
     }
@@ -57,8 +57,11 @@ public:
 
     void Signal()
     {
-        std::unique_lock<std::mutex> lock(m_mtx);
-        m_set = true;
+        {
+            std::lock_guard<std::mutex> guard(m_mtx);
+            m_set = true;
+        }
+
         m_cv.notify_one();
     }
 };
@@ -70,7 +73,7 @@ private:
     std::condition_variable m_cv;
     bool m_set = false;
 
-    static VOID DoNothing()
+    static void DoNothing()
     {
 
     }
@@ -98,13 +101,17 @@ public:
 
     void Signal()
     {
-        std::unique_lock<std::mutex> lock(m_mtx);
-        m_set = true;
+        {
+            std::lock_guard<std::mutex> guard(m_mtx);
+            m_set = true;
+        }
+
+        m_cv.notify_all();
     }
 
     void Reset()
     {
-        std::unique_lock<std::mutex> lock(m_mtx);
+        std::lock_guard<std::mutex> guard(m_mtx);
         m_set = false;
     }
 };

--- a/src/tests/profiler/unittest/getappdomainstaticaddress.cs
+++ b/src/tests/profiler/unittest/getappdomainstaticaddress.cs
@@ -30,9 +30,6 @@ namespace Profiler.Tests
         static int RunTest()
         {
             LoadCollectibleAssembly();
-
-            Thread.Sleep(TimeSpan.FromSeconds(3));
-
             return 100;
         }
 
@@ -47,8 +44,9 @@ namespace Profiler.Tests
             object instance = Activator.CreateInstance(testType);
 
             Console.WriteLine(instance.GetHashCode());
-
+            Thread.Sleep(TimeSpan.FromSeconds(2));
             collectibleContext.Unload();
+            Thread.Sleep(TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/src/tests/profiler/unittest/getappdomainstaticaddress.cs
+++ b/src/tests/profiler/unittest/getappdomainstaticaddress.cs
@@ -30,6 +30,9 @@ namespace Profiler.Tests
         static int RunTest()
         {
             LoadCollectibleAssembly();
+
+            Thread.Sleep(TimeSpan.FromSeconds(3));
+
             return 100;
         }
 
@@ -44,9 +47,8 @@ namespace Profiler.Tests
             object instance = Activator.CreateInstance(testType);
 
             Console.WriteLine(instance.GetHashCode());
-            Thread.Sleep(TimeSpan.FromSeconds(2));
+            GC.Collect();
             collectibleContext.Unload();
-            Thread.Sleep(TimeSpan.FromSeconds(1));
         }
     }
 }


### PR DESCRIPTION
I discovered this issue while working on some changes in the VM related to static fields.

I believe the intent of the sleep is to give some time so that the profiler can find the static field during the after garbage collection callback. 

Before my change, it is possible that the loading and the unloading happen between two consecutive GCs. If that's the case, the profiler would fail to detect the static field of the collectible assembly. The change forced a 2-second window for the collectible static field to exist so that it won't happen.