### PR TITLE
Make SNI unique in TLS test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -126,6 +126,7 @@ namespace System.Net.Http.Functional.Tests
 #pragma warning restore 0618
                 }
 
+                // Use a different SNI for each connection to prevent TLS 1.3 renegotiation issue: https://github.com/dotnet/runtime/issues/47378
                 client.DefaultRequestHeaders.Host = getTestSNIName();
 
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -86,7 +86,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     yield return new object[] { protocol, true };
 #pragma warning disable 0618 // SSL2/3 are deprecated
-                     // On certain platforms these are completely disabled and cannot be used at all.
+                    // On certain platforms these are completely disabled and cannot be used at all.
                     if (protocol != SslProtocols.Ssl2 && protocol != SslProtocols.Ssl3)
                     {
                         yield return new object[] { protocol, false };
@@ -126,15 +126,22 @@ namespace System.Net.Http.Functional.Tests
 #pragma warning restore 0618
                 }
 
+                client.DefaultRequestHeaders.Host = getTestSNIName();
+
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                        server.AcceptConnectionSendResponseAndCloseAsync(),
-                        client.GetAsync(url));
+                       server.AcceptConnectionSendResponseAndCloseAsync(),
+                       client.GetAsync(url));
                 }, options);
 
                 Assert.Equal(1, count);
+            }
+
+            string getTestSNIName()
+            {
+                return $"{nameof(GetAsync_AllowedSSLVersion_Succeeds)}_{acceptedProtocol}_{requestOnlyThisProtocol}";
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -133,8 +133,8 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {
                     await TestHelper.WhenAllCompletedOrAnyFailed(
-                       server.AcceptConnectionSendResponseAndCloseAsync(),
-                       client.GetAsync(url));
+                      server.AcceptConnectionSendResponseAndCloseAsync(),
+                      client.GetAsync(url));
                 }, options);
 
                 Assert.Equal(1, count);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -79,7 +79,7 @@ namespace System.Net.Security.Tests
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
             using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
             {
-                string serverHost = Guid.NewGuid().ToString("N") + "." + serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
+                string serverHost = getTestSNIName();
                 var clientCertificates = new X509CertificateCollection() { clientCertificate };
 
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
@@ -98,6 +98,16 @@ namespace System.Net.Security.Tests
                         _clientStream.HashAlgorithm == HashAlgorithmType.Sha512,
                         _clientStream.SslProtocol + " " + _clientStream.HashAlgorithm);
                 }
+            }
+
+            string getTestSNIName()
+            {
+                static string ProtocolToString(SslProtocols? protocol)
+                {
+                    return (protocol?.ToString() ?? "null").Replace(", ", "_");
+                }
+
+                return $"{nameof(ClientAndServer_OneOrBothUseDefault_Ok)}_{ProtocolToString(clientProtocols)}_{ProtocolToString(serverProtocols)}";
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -79,6 +79,7 @@ namespace System.Net.Security.Tests
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
             using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
             {
+                // Use a different SNI for each connection to prevent TLS 1.3 renegotiation issue: https://github.com/dotnet/runtime/issues/47378
                 string serverHost = getTestSNIName();
                 var clientCertificates = new X509CertificateCollection() { clientCertificate };
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -79,7 +79,8 @@ namespace System.Net.Security.Tests
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
             using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
             {
-                string serverHost = serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
+                string serverHost = Guid.NewGuid().ToString("N") + "." + serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
+                Console.WriteLine(serverHost);
                 var clientCertificates = new X509CertificateCollection() { clientCertificate };
 
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
@@ -130,6 +131,7 @@ namespace System.Net.Security.Tests
                 case SslPolicyErrors.None:
                 case SslPolicyErrors.RemoteCertificateChainErrors:
                 case SslPolicyErrors.RemoteCertificateNameMismatch:
+                case SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch:
                     return true;
                 case SslPolicyErrors.RemoteCertificateNotAvailable:
                 default:

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -80,7 +80,6 @@ namespace System.Net.Security.Tests
             using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
             {
                 string serverHost = Guid.NewGuid().ToString("N") + "." + serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
-                Console.WriteLine(serverHost);
                 var clientCertificates = new X509CertificateCollection() { clientCertificate };
 
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(


### PR DESCRIPTION
As TLS 1.3 doesn't support renegotiation it can happen the connection is not negotiated when server switch between TLS 1.2 and 1.3.

Fixes #47378