### PR TITLE
Revert "Use socketpair to implement Process.Start redirection"

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_process.c
+++ b/src/libraries/Native/Unix/System.Native/pal_process.c
@@ -20,8 +20,9 @@
 #if HAVE_CRT_EXTERNS_H
 #include <crt_externs.h>
 #endif
+#if HAVE_PIPE2
 #include <fcntl.h>
-#include <sys/socket.h>
+#endif
 #include <pthread.h>
 
 #if HAVE_SCHED_SETAFFINITY || HAVE_SCHED_GETAFFINITY
@@ -55,7 +56,7 @@ c_static_assert(PAL_PRIO_PROCESS == (int)PRIO_PROCESS);
 c_static_assert(PAL_PRIO_PGRP == (int)PRIO_PGRP);
 c_static_assert(PAL_PRIO_USER == (int)PRIO_USER);
 
-#ifndef SOCK_CLOEXEC
+#if !HAVE_PIPE2
 static pthread_mutex_t ProcessCreateLock = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
@@ -190,31 +191,6 @@ static int SetGroups(uint32_t* userGroups, int32_t userGroupsLength, uint32_t* p
     return rv;
 }
 
-static int32_t SocketPair(int32_t sv[2])
-{
-    int32_t result;
-
-    int type = SOCK_STREAM;
-#ifdef SOCK_CLOEXEC
-    type |= SOCK_CLOEXEC;
-#endif
-
-    while ((result = socketpair(AF_UNIX, type, 0, sv)) < 0 && errno == EINTR);
-
-#ifndef SOCK_CLOEXEC
-    if (result == 0)
-    {
-        while ((result = fcntl(sv[READ_END_OF_PIPE], F_SETFD, FD_CLOEXEC)) < 0 && errno == EINTR);
-        if (result == 0)
-        {
-            while ((result = fcntl(sv[WRITE_END_OF_PIPE], F_SETFD, FD_CLOEXEC)) < 0 && errno == EINTR);
-        }
-    }
-#endif
-
-    return result;
-}
-
 int32_t SystemNative_ForkAndExecProcess(const char* filename,
                                       char* const argv[],
                                       char* const envp[],
@@ -233,7 +209,7 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
                                       int32_t* stderrFd)
 {
 #if HAVE_FORK
-#ifndef SOCK_CLOEXEC
+#if !HAVE_PIPE2
     bool haveProcessCreateLock = false;
 #endif
     bool success = true;
@@ -289,11 +265,11 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
         goto done;
     }
 
-#ifndef SOCK_CLOEXEC
-    // We do not have SOCK_CLOEXEC; take the lock to emulate it race free.
-    // If another process were to be launched between the socket creation and the fcntl call to set CLOEXEC on it, that
-    // file descriptor would be inherited into the other child process, eventually causing a deadlock either in the loop
-    // below that waits for that socket to be closed or in StreamReader.ReadToEnd() in the calling code.
+#if !HAVE_PIPE2
+    // We do not have pipe2(); take the lock to emulate it race free.
+    // If another process were to be launched between the pipe creation and the fcntl call to set CLOEXEC on it, that
+    // file descriptor will be inherited into the other child process, eventually causing a deadlock either in the loop
+    // below that waits for that pipe to be closed or in StreamReader.ReadToEnd() in the calling code.
     if (pthread_mutex_lock(&ProcessCreateLock) != 0)
     {
         // This check is pretty much just checking for trashed memory.
@@ -305,9 +281,9 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
 
     // Open pipes for any requests to redirect stdin/stdout/stderr and set the
     // close-on-exec flag to the pipe file descriptors.
-    if ((redirectStdin  && SocketPair(stdinFds) != 0) ||
-        (redirectStdout && SocketPair(stdoutFds) != 0) ||
-        (redirectStderr && SocketPair(stderrFds) != 0))
+    if ((redirectStdin  && SystemNative_Pipe(stdinFds,  PAL_O_CLOEXEC) != 0) ||
+        (redirectStdout && SystemNative_Pipe(stdoutFds, PAL_O_CLOEXEC) != 0) ||
+        (redirectStderr && SystemNative_Pipe(stderrFds, PAL_O_CLOEXEC) != 0))
     {
         success = false;
         goto done;
@@ -458,7 +434,7 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     *stderrFd = stderrFds[READ_END_OF_PIPE];
 
 done:;
-#ifndef SOCK_CLOEXEC
+#if !HAVE_PIPE2
     if (haveProcessCreateLock)
     {
         pthread_mutex_unlock(&ProcessCreateLock);

--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -342,7 +342,6 @@
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.IO.FileSystem.DriveInfo" />
     <Reference Include="System.Memory" />
-    <Reference Include="System.Net.Sockets" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -5,7 +5,6 @@ using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Net.Sockets;
 using System.Security;
 using System.Text;
 using System.Threading;
@@ -752,31 +751,16 @@ namespace System.Diagnostics
             return TimeSpan.FromSeconds(ticks / (double)ticksPerSecond);
         }
 
-        /// <summary>Opens a stream around the specified socket file descriptor and with the specified access.</summary>
-        /// <param name="fd">The socket file descriptor.</param>
+        /// <summary>Opens a stream around the specified file descriptor and with the specified access.</summary>
+        /// <param name="fd">The file descriptor.</param>
         /// <param name="access">The access mode.</param>
         /// <returns>The opened stream.</returns>
-        private static Stream OpenStream(int fd, FileAccess access)
+        private static FileStream OpenStream(int fd, FileAccess access)
         {
             Debug.Assert(fd >= 0);
-            var socketHandle = new SafeSocketHandle((IntPtr)fd, ownsHandle: true);
-            var socket = new Socket(socketHandle);
-
-            if (!socket.Connected)
-            {
-                // WSL1 workaround -- due to issues with sockets syscalls
-                // socket pairs fd's are erroneously inferred as not connected.
-                // Fall back to using FileStream instead.
-
-                GC.SuppressFinalize(socket);
-                GC.SuppressFinalize(socketHandle);
-
-                return new FileStream(
-                    new SafeFileHandle((IntPtr)fd, ownsHandle: true),
-                    access, StreamBufferSize, isAsync: false);
-            }
-
-            return new NetworkStream(socket, access, ownsSocket: true);
+            return new FileStream(
+                new SafeFileHandle((IntPtr)fd, ownsHandle: true),
+                access, StreamBufferSize, isAsync: false);
         }
 
         /// <summary>Parses a command-line argument string into a list of arguments.</summary>

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -344,42 +344,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [PlatformSpecific(~TestPlatforms.Windows)] // currently on Windows these operations async-over-sync on Windows
-        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        public async Task ReadAsync_OutputStreams_Cancel_RespondsQuickly()
-        {
-            Process p = CreateProcessLong();
-            try
-            {
-                p.StartInfo.RedirectStandardOutput = true;
-                p.StartInfo.RedirectStandardError = true;
-                Assert.True(p.Start());
-
-                using (var cts = new CancellationTokenSource())
-                {
-                    ValueTask<int> vt = p.StandardOutput.ReadAsync(new char[1].AsMemory(), cts.Token);
-                    await Task.Delay(1);
-                    Assert.False(vt.IsCompleted);
-                    cts.Cancel();
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt);
-                }
-
-                using (var cts = new CancellationTokenSource())
-                {
-                    ValueTask<int> vt = p.StandardError.ReadAsync(new char[1].AsMemory(), cts.Token);
-                    await Task.Delay(1);
-                    Assert.False(vt.IsCompleted);
-                    cts.Cancel();
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt);
-                }
-            }
-            finally
-            {
-                p.Kill();
-                p.Dispose();
-            }
-        }
-
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestSyncStreams()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -344,7 +344,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/46489")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/44329")]
         [PlatformSpecific(~TestPlatforms.Windows)] // currently on Windows these operations async-over-sync on Windows	
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public async Task ReadAsync_OutputStreams_Cancel_RespondsQuickly()

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -344,6 +344,43 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/46489")]
+        [PlatformSpecific(~TestPlatforms.Windows)] // currently on Windows these operations async-over-sync on Windows	
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public async Task ReadAsync_OutputStreams_Cancel_RespondsQuickly()
+        {
+            Process p = CreateProcessLong();
+            try
+            {
+                p.StartInfo.RedirectStandardOutput = true;
+                p.StartInfo.RedirectStandardError = true;
+                Assert.True(p.Start());
+
+                using (var cts = new CancellationTokenSource())
+                {
+                    ValueTask<int> vt = p.StandardOutput.ReadAsync(new char[1].AsMemory(), cts.Token);
+                    await Task.Delay(1);
+                    Assert.False(vt.IsCompleted);
+                    cts.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt);
+                }
+
+                using (var cts = new CancellationTokenSource())
+                {
+                    ValueTask<int> vt = p.StandardError.ReadAsync(new char[1].AsMemory(), cts.Token);
+                    await Task.Delay(1);
+                    Assert.False(vt.IsCompleted);
+                    cts.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await vt);
+                }
+            }
+            finally
+            {
+                p.Kill();
+                p.Dispose();
+            }
+        }
+
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestSyncStreams()
         {


### PR DESCRIPTION
Reverts #34861 to address the regression reported in #46469. The goal is to backport the revert to `release-5.0` and consider a different approach for 6 (e.g. the changes in #44647).

cc @jeffhandley.