### PR TITLE
Setting Thread.Name sets the native thread name on MacOS.

### DIFF
--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2252,6 +2252,15 @@ SetThreadDescription(
     IN PCWSTR lpThreadDescription
 );
 
+PALIMPORT
+VOID
+PALAPI
+GetThreadDescription(
+    IN HANDLE hThread,
+    IN size_t length,
+    OUT char* name
+);
+
 #define TLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 
 PALIMPORT

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2252,15 +2252,6 @@ SetThreadDescription(
     IN PCWSTR lpThreadDescription
 );
 
-PALIMPORT
-HRESULT
-PALAPI
-GetThreadDescription(
-    IN HANDLE hThread,
-    IN size_t length,
-    OUT char* name
-);
-
 #define TLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 
 PALIMPORT

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2253,7 +2253,7 @@ SetThreadDescription(
 );
 
 PALIMPORT
-VOID
+HRESULT
 PALAPI
 GetThreadDescription(
     IN HANDLE hThread,

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1704,7 +1704,7 @@ CorUnix::InternalSetThreadDescription(
     #endif
 
     #if defined(__APPLE__)
-    //on macos, pthread_setname_np only works for the calling thread.
+    // on macos, pthread_setname_np only works for the calling thread.
     if (PlatformGetCurrentThreadId() == pTargetThread->GetThreadId()) 
     {
         error = pthread_setname_np(nameBuf);
@@ -1732,7 +1732,7 @@ InternalSetThreadDescriptionExit:
         PAL_free(nameBuf);
     }
 
-#endif // defined(__linux__) || defined(__APPLE__)
+#endif //defined(__linux__) || defined(__APPLE__)
 
     return palError;
 }

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1588,34 +1588,6 @@ GetThreadTimes(
 
 HRESULT
 PALAPI
-GetThreadDescription(
-    IN HANDLE hThread,
-    IN size_t length,
-    OUT char* name)
-{
-    PAL_ERROR palError = NO_ERROR;
-    CPalThread *pCurrentThread;
-    CPalThread *pTargetThread;
-    IPalObject *pobjThread = NULL;
-    pCurrentThread = InternalGetCurrentThread();
-
-    palError = InternalGetThreadDataFromHandle(
-        pCurrentThread,
-        hThread,
-        &pTargetThread,
-        &pobjThread
-        );
-    
-    if (palError == NO_ERROR)
-    {
-        pthread_getname_np(pTargetThread->GetPThreadSelf(), name, length);
-    }
-
-    return HRESULT_FROM_WIN32(palError);
-}
-
-HRESULT
-PALAPI
 SetThreadDescription(
     IN HANDLE hThread,
     IN PCWSTR lpThreadDescription)
@@ -1661,7 +1633,7 @@ CorUnix::InternalSetThreadDescription(
     char *nameBuf = NULL;
 
 // The exact API of pthread_setname_np varies very wildly depending on OS.
-// For now, only Linux and MacOS are implemented.
+// For now, only Linux and macOS are implemented.
 #if defined(__linux__) || defined(__APPLE__)
 
     palError = InternalGetThreadDataFromHandle(
@@ -1710,7 +1682,7 @@ CorUnix::InternalSetThreadDescription(
 
     // Null terminate early.
     // pthread_setname_np only accepts up to 16 chars on Linux and
-    // 64 chars on MacOS.
+    // 64 chars on macOS.
     if (nameSize > MAX_THREAD_NAME_SIZE)
     {
         nameBuf[MAX_THREAD_NAME_SIZE] = '\0';
@@ -1721,7 +1693,7 @@ CorUnix::InternalSetThreadDescription(
     #endif
 
     #if defined(__APPLE__)
-    // on MacOS, pthread_setname_np only works for the calling thread.
+    // on macOS, pthread_setname_np only works for the calling thread.
     if (PlatformGetCurrentThreadId() == pTargetThread->GetThreadId()) 
     {
         error = pthread_setname_np(nameBuf);

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1697,7 +1697,6 @@ CorUnix::InternalSetThreadDescription(
     {
         palError = ERROR_INTERNAL_ERROR;
     }
-#endif // defined(__linux__) || defined(__APPLE__)
 
 InternalSetThreadDescriptionExit:
 
@@ -1714,6 +1713,8 @@ InternalSetThreadDescriptionExit:
     if (NULL != nameBuf) {
         PAL_free(nameBuf);
     }
+
+#endif // defined(__linux__) || defined(__APPLE__)
 
     return palError;
 }

--- a/src/coreclr/pal/tests/palsuite/CMakeLists.txt
+++ b/src/coreclr/pal/tests/palsuite/CMakeLists.txt
@@ -32,6 +32,13 @@ if(FEATURE_EVENT_TRACE)
   add_subdirectory(eventprovider)
 endif(FEATURE_EVENT_TRACE)
 
+if (CLR_CMAKE_TARGET_OSX OR (CLR_CMAKE_TARGET_LINUX AND NOT CLR_CMAKE_TARGET_ALPINE_LINUX))
+   set(PALSUITE_THREAD_NAME_SOURCES
+     threading/SetThreadDescription/test1/pthread_helpers.cpp
+     threading/SetThreadDescription/test1/test1.cpp
+   )
+ endif()
+
 _add_executable(paltests
   paltests.cpp
   common/palsuite.cpp
@@ -893,7 +900,6 @@ _add_executable(paltests
   threading/SetEvent/test2/test2.cpp
   threading/SetEvent/test3/test3.cpp
   threading/SetEvent/test4/test4.cpp
-  threading/SetThreadDescription/test1/test1.cpp
   threading/SignalObjectAndWait/SignalObjectAndWaitTest.cpp
   threading/Sleep/test1/Sleep.cpp
   threading/Sleep/test2/sleep.cpp
@@ -921,7 +927,7 @@ _add_executable(paltests
   threading/WaitForSingleObject/WFSOSemaphoreTest/WFSOSemaphoreTest.cpp
   threading/WaitForSingleObject/WFSOThreadTest/WFSOThreadTest.cpp
   threading/YieldProcessor/test1/test1.cpp
-
+  ${PALSUITE_THREAD_NAME_SOURCES}
 )
 
 add_dependencies(paltests coreclrpal)

--- a/src/coreclr/pal/tests/palsuite/CMakeLists.txt
+++ b/src/coreclr/pal/tests/palsuite/CMakeLists.txt
@@ -893,6 +893,7 @@ _add_executable(paltests
   threading/SetEvent/test2/test2.cpp
   threading/SetEvent/test3/test3.cpp
   threading/SetEvent/test4/test4.cpp
+  threading/SetThreadDescription/test1/test1.cpp
   threading/SignalObjectAndWait/SignalObjectAndWaitTest.cpp
   threading/Sleep/test1/Sleep.cpp
   threading/Sleep/test2/sleep.cpp

--- a/src/coreclr/pal/tests/palsuite/compilableTests.txt
+++ b/src/coreclr/pal/tests/palsuite/compilableTests.txt
@@ -774,11 +774,13 @@ threading/ResetEvent/test2/paltest_resetevent_test2
 threading/ResetEvent/test3/paltest_resetevent_test3
 threading/ResetEvent/test4/paltest_resetevent_test4
 threading/ResumeThread/test1/paltest_resumethread_test1
+threading/SwitchToThread/test1/paltest_switchtothread_test1
 threading/SetErrorMode/test1/paltest_seterrormode_test1
 threading/SetEvent/test1/paltest_setevent_test1
 threading/SetEvent/test2/paltest_setevent_test2
 threading/SetEvent/test3/paltest_setevent_test3
 threading/SetEvent/test4/paltest_setevent_test4
+threading/SetThreadDescription/test1/paltest_setthreaddescription_test1
 threading/SignalObjectAndWait/paltest_signalobjectandwaittest
 threading/Sleep/test1/paltest_sleep_test1
 threading/Sleep/test2/paltest_sleep_test2

--- a/src/coreclr/pal/tests/palsuite/paltestlist.txt
+++ b/src/coreclr/pal/tests/palsuite/paltestlist.txt
@@ -681,6 +681,7 @@ threading/SetEvent/test1/paltest_setevent_test1
 threading/SetEvent/test2/paltest_setevent_test2
 threading/SetEvent/test3/paltest_setevent_test3
 threading/SetEvent/test4/paltest_setevent_test4
+threading/SetThreadDescription/test1/paltest_setthreaddescription_test1
 threading/SwitchToThread/test1/paltest_switchtothread_test1
 threading/ThreadPriority/test1/paltest_threadpriority_test1
 threading/WaitForMultipleObjects/test1/paltest_waitformultipleobjects_test1

--- a/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/pthread_helpers.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/pthread_helpers.cpp
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <stdlib.h>
+#include <pthread.h>
+
+#define NAMELEN 256
+char* GetThreadName()
+{
+    char* threadName = (char*)malloc(sizeof(char) * NAMELEN);
+    pthread_t thread = pthread_self();
+    int rc = pthread_getname_np(thread, threadName, NAMELEN);
+    if (rc != 0)
+    {
+        free(threadName);
+        return NULL;
+    }
+
+    return threadName;
+}

--- a/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/pthread_helpers.hpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/pthread_helpers.hpp
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+char* GetThreadName();

--- a/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/test1.cpp
@@ -13,31 +13,36 @@
 
 #include <palsuite.h>
 
-char * actualThreadName = 0;
-char * expectedThreadName = "Hello, World";
+char * threadName = NULL;
+char * expectedThreadName = NULL;
+char * actualThreadName = new char[256];
 
 DWORD PALAPI SetThreadDescriptionTestThread(LPVOID lpParameter) 
 {
+    HRESULT result;
     HANDLE palThread = GetCurrentThread();
-    WCHAR wideThreadName[32];
-    MultiByteToWideChar(CP_ACP, 0, expectedThreadName, strlen(expectedThreadName)+1, wideThreadName, 32);
-    SetThreadDescription(palThread, wideThreadName);
-    GetThreadDescription(palThread, 32, actualThreadName);
+    WCHAR wideThreadName[256];
 
+    MultiByteToWideChar(CP_ACP, 0, threadName, strlen(threadName)+1, wideThreadName, 256);
+    SetThreadDescription(palThread, wideThreadName);
+    result = GetThreadDescription(palThread, 256, actualThreadName);
     return 0;
 }
 
-BOOL SetThreadDescriptionTest()
+
+BOOL SetThreadDescriptionTest(char* name, char* expected)
 {
     BOOL bResult = FALSE;
     LPSECURITY_ATTRIBUTES lpThreadAttributes = NULL;
     DWORD dwStackSize = 0; 
     LPTHREAD_START_ROUTINE lpStartAddress =  &SetThreadDescriptionTestThread;
-    LPVOID lpParameter = (LPVOID)lpStartAddress;
+    LPVOID lpParameter = (LPVOID)SetThreadDescriptionTestThread;
     DWORD dwCreationFlags = 0; 
     DWORD dwThreadId = 0;
     
-    actualThreadName = new char[32];
+    threadName = name;
+    expectedThreadName = expected;
+
     HANDLE hThread = CreateThread(lpThreadAttributes, 
                             dwStackSize, lpStartAddress, lpParameter, 
                             dwCreationFlags, &dwThreadId );
@@ -52,8 +57,37 @@ BOOL SetThreadDescriptionTest()
         Trace("Unable to create SetThreadDescription test thread");
     }
 
-    delete[] actualThreadName;
     return bResult;
+}
+
+BOOL SetThreadDescriptionTests()
+{
+    if (!SetThreadDescriptionTest("Hello, World", "Hello, World"))
+    {
+        Trace("Setting thread name failed");
+        return false;
+    }
+    
+    // verify that thread name truncations works correctly on linux on macos
+    char * threadName;
+    char * expected;
+    #if defined(__linux__)
+    threadName = "linuxstring15characters";
+    expected = "linuxstring15ch";
+    #endif
+
+    #if defined(__APPLE__)
+    threadName = "appplestring63charactersappplestring63charactersappplestring63characters";
+    expected = "appplestring63charactersappplestring63charactersappplestring63c";
+    #endif
+
+    if (!SetThreadDescriptionTest(threadName, expected))
+    {
+        Trace("Setting thread name truncation failed");
+        return false;
+    }
+
+    return true;
 }
 
 PALTEST(threading_SetThreadDescription_test1_paltest_setthreaddescription_test1, "threading/SetThreadDescription/test1/paltest_setthreaddescription_test1")
@@ -63,11 +97,13 @@ PALTEST(threading_SetThreadDescription_test1_paltest_setthreaddescription_test1,
         return FAIL;
     }
 
-    if (!SetThreadDescriptionTest())
+    if (!SetThreadDescriptionTests())
     {
+        delete[] actualThreadName;
         Fail("Test Failed");
     }
     
+    delete[] actualThreadName;
     PAL_Terminate();
     return PASS;
 } 

--- a/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SetThreadDescription/test1/test1.cpp
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*============================================================
+**
+** Source: test1.cpp
+**
+** Purpose: Test for SetThreadDescription.  Create a thread, call 
+** SetThreadDescription, and then verify that the name of the thread
+** matches what was set.
+**
+**=========================================================*/
+
+#include <palsuite.h>
+
+char * actualThreadName = 0;
+char * expectedThreadName = "Hello, World";
+
+DWORD PALAPI SetThreadDescriptionTestThread(LPVOID lpParameter) 
+{
+    HANDLE palThread = GetCurrentThread();
+    WCHAR wideThreadName[32];
+    MultiByteToWideChar(CP_ACP, 0, expectedThreadName, strlen(expectedThreadName)+1, wideThreadName, 32);
+    SetThreadDescription(palThread, wideThreadName);
+    GetThreadDescription(palThread, 32, actualThreadName);
+
+    return 0;
+}
+
+BOOL SetThreadDescriptionTest()
+{
+    BOOL bResult = FALSE;
+    LPSECURITY_ATTRIBUTES lpThreadAttributes = NULL;
+    DWORD dwStackSize = 0; 
+    LPTHREAD_START_ROUTINE lpStartAddress =  &SetThreadDescriptionTestThread;
+    LPVOID lpParameter = (LPVOID)lpStartAddress;
+    DWORD dwCreationFlags = 0; 
+    DWORD dwThreadId = 0;
+    
+    actualThreadName = new char[32];
+    HANDLE hThread = CreateThread(lpThreadAttributes, 
+                            dwStackSize, lpStartAddress, lpParameter, 
+                            dwCreationFlags, &dwThreadId );
+   
+    if (hThread != INVALID_HANDLE_VALUE)
+    {
+        WaitForSingleObject(hThread, INFINITE);
+        bResult = strcmp(actualThreadName, expectedThreadName) == 0;
+    }
+    else
+    {
+        Trace("Unable to create SetThreadDescription test thread");
+    }
+
+    delete[] actualThreadName;
+    return bResult;
+}
+
+PALTEST(threading_SetThreadDescription_test1_paltest_setthreaddescription_test1, "threading/SetThreadDescription/test1/paltest_setthreaddescription_test1")
+{
+    if (0 != (PAL_Initialize(argc, argv)))
+    {
+        return FAIL;
+    }
+
+    if (!SetThreadDescriptionTest())
+    {
+        Fail("Test Failed");
+    }
+    
+    PAL_Terminate();
+    return PASS;
+} 
+


### PR DESCRIPTION
Setting Thread.Name will now set the name of the native thread
on MacOS - due to API constraints this will not work cross thread.

I couldn't find a good way to write automated tests for this (you can't set the name cross thread, but I'm open to ideas :)) but I tested this in lldb and verified that the thread name shows up in the debugger with a quick little C# program that spins up some threads and sets the name. 

```
using System;
using System.Threading;

namespace HelloThread
{
    class Program
    {
        internal static void ThreadStart(object threadName) {
            Thread.CurrentThread.Name = threadName.ToString();    
            for(;;) {
                Console.Out.WriteLine($"Hello, {threadName}");
                Thread.Sleep(1000);
            }
        }
        
        static void Main(string[] args) {
            Thread t1 = new Thread(ThreadStart);
            t1.Start("thread 1");

            Thread t2 = new Thread(ThreadStart);
            t2.Start("thread 2");

            t1.Join();
            t2.Join();
        }
    }
}

```


<img width="1175" alt="Screen Shot 2021-01-23 at 8 15 07 PM" src="https://user-images.githubusercontent.com/675417/105867141-bd59b880-5fc2-11eb-9c47-a8446fff4aa9.png">

I ran the tests locally and was getting some errors, but I saw the same errors when running them against master so I'm wondering what happens with CI.

Fixes #47087