### PR TITLE
ilasm: Use memmove instead of memcpy for overlapping copy

### DIFF
--- a/src/coreclr/ilasm/asmtemplates.h
+++ b/src/coreclr/ilasm/asmtemplates.h
@@ -444,7 +444,7 @@ public:
                 if (cmp == 0)
                 {
                     delete (*mid);
-                    memcpy(mid,mid+1,(BYTE*)&m_Arr[m_ulOffset+m_ulCount]-(BYTE*)mid-1);
+                    memmove(mid,mid+1,(BYTE*)&m_Arr[m_ulOffset+m_ulCount]-(BYTE*)mid-1);
                     m_ulCount--;
                     return TRUE;
                 }


### PR DESCRIPTION
`memcpy` is defined to only work when the source and destination memory regions do not overlap. In here, they do. So let's use `memmove` instead.