### PR TITLE
Fix weight computation in jit

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3341,7 +3341,7 @@ public:
         {
             if (dsc1->lvIsRegArg)
             {
-                weight2 += 2 * BB_UNITY_WEIGHT_UNSIGNED;
+                weight1 += 2 * BB_UNITY_WEIGHT_UNSIGNED;
             }
 
             if (varTypeIsGC(dsc1->TypeGet()))


### PR DESCRIPTION
This appears to be a typo. `weight1` is from `dsc1` and `weight2` is from `dsc2`. If we are checking whether `dsc1` is a register arg, we should be adjusting `weight1`, not `weight2`.