### PR TITLE
Remove OrderedDictionary usage from ReflectTypeDescriptionProvider

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.ComponentModel
 {
@@ -118,7 +117,7 @@ namespace System.ComponentModel
         /// <summary>
         /// Gets the attributes collection.
         /// </summary>
-        protected virtual Attribute[] Attributes => _attributes;
+        protected internal virtual Attribute[] Attributes => _attributes;
 
         /// <summary>
         /// Gets the number of attributes.


### PR DESCRIPTION
This is showing up a bit on ASP.NET startup paths, and we can be more efficient (and simpler) in how we handle allocations and work.

As a microbenchmark, I tweaked TypeDescriptor.GetAttributes in both the original and PR bits to not cache attributes, so that the benchmark would simulate the impact on the first call per type.  Then used it on types with no attributes, one attribute, and five identical attributes:

| Method |           Toolchain |     Mean | Ratio | Allocated |
|------- |-------------------- |---------:|------:|----------:|
|   None | \master\corerun.exe | 217.9 ns |  1.00 |     272 B |
|   None |     \pr\corerun.exe | 195.6 ns |  0.89 |     112 B |
|        |                     |          |       |           |
|    One | \master\corerun.exe | 491.9 ns |  1.00 |     512 B |
|    One |     \pr\corerun.exe | 279.9 ns |  0.80 |     360 B |
|        |                     |          |       |           |
|   Five | \master\corerun.exe | 396.6 ns |  1.00 |     640 B |
|   Five |     \pr\corerun.exe | 375.5 ns |  0.95 |     472 B |

So, not a huge win, but the code gets simpler as well, and we remove one of the remaining dependencies on OrderedDictionary.