### PR TITLE
Minor cleanup for Rfc2898DeriveBytes

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -16,7 +16,6 @@ namespace System.Security.Cryptography
     {
         private const int MinimumSaltSize = 8;
 
-        private readonly byte[] _password;
         private byte[] _salt;
         private uint _iterations;
         private HMAC _hmac;
@@ -51,9 +50,8 @@ namespace System.Security.Cryptography
             _salt = new byte[salt.Length + sizeof(uint)];
             salt.AsSpan().CopyTo(_salt);
             _iterations = (uint)iterations;
-            _password = password.CloneByteArray();
             HashAlgorithm = hashAlgorithm;
-            _hmac = OpenHmac();
+            _hmac = OpenHmac(password);
             // _blockSize is in bytes, HashSize is in bits.
             _blockSize = _hmac.HashSize >> 3;
 
@@ -98,9 +96,9 @@ namespace System.Security.Cryptography
             RandomNumberGenerator.Fill(_salt.AsSpan(0, saltSize));
 
             _iterations = (uint)iterations;
-            _password = Encoding.UTF8.GetBytes(password);
+            byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
             HashAlgorithm = hashAlgorithm;
-            _hmac = OpenHmac();
+            _hmac = OpenHmac(passwordBytes);
             // _blockSize is in bytes, HashSize is in bits.
             _blockSize = _hmac.HashSize >> 3;
 
@@ -155,8 +153,6 @@ namespace System.Security.Cryptography
 
                 if (_buffer != null)
                     Array.Clear(_buffer, 0, _buffer.Length);
-                if (_password != null)
-                    Array.Clear(_password, 0, _password.Length);
                 if (_salt != null)
                     Array.Clear(_salt, 0, _salt.Length);
             }
@@ -228,9 +224,9 @@ namespace System.Security.Cryptography
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "HMACSHA1 is needed for compat. (https://github.com/dotnet/runtime/issues/17618)")]
-        private HMAC OpenHmac()
+        private HMAC OpenHmac(byte[] password)
         {
-            Debug.Assert(_password != null);
+            Debug.Assert(password != null);
 
             HashAlgorithmName hashAlgorithm = HashAlgorithm;
 
@@ -238,13 +234,13 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_HashAlgorithmNameNullOrEmpty);
 
             if (hashAlgorithm == HashAlgorithmName.SHA1)
-                return new HMACSHA1(_password);
+                return new HMACSHA1(password);
             if (hashAlgorithm == HashAlgorithmName.SHA256)
-                return new HMACSHA256(_password);
+                return new HMACSHA256(password);
             if (hashAlgorithm == HashAlgorithmName.SHA384)
-                return new HMACSHA384(_password);
+                return new HMACSHA384(password);
             if (hashAlgorithm == HashAlgorithmName.SHA512)
-                return new HMACSHA512(_password);
+                return new HMACSHA512(password);
 
             throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));
         }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -116,7 +116,6 @@ namespace System.Security.Cryptography
             Initialize();
         }
 
-
         public int IterationCount
         {
             get

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -99,6 +99,7 @@ namespace System.Security.Cryptography
             byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
             HashAlgorithm = hashAlgorithm;
             _hmac = OpenHmac(passwordBytes);
+            CryptographicOperations.ZeroMemory(passwordBytes);
             // _blockSize is in bytes, HashSize is in bits.
             _blockSize = _hmac.HashSize >> 3;
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/Rfc2898Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/Rfc2898Tests.cs
@@ -409,6 +409,26 @@ namespace System.Security.Cryptography.DeriveBytesTests
             }
         }
 
+        [Fact]
+        public static void Ctor_PasswordMutatedAfterCreate()
+        {
+            byte[] passwordBytes = Encoding.UTF8.GetBytes(TestPassword);
+            byte[] derived;
+
+            using (Rfc2898DeriveBytes deriveBytes = new Rfc2898DeriveBytes(passwordBytes, s_testSaltB, DefaultIterationCount))
+            {
+                derived = deriveBytes.GetBytes(64);
+            }
+
+            using (Rfc2898DeriveBytes deriveBytes = new Rfc2898DeriveBytes(passwordBytes, s_testSaltB, DefaultIterationCount))
+            {
+                passwordBytes[0] ^= 0xFF; // Flipping a byte after the object is constructed should not be observed.
+
+                byte[] actual = deriveBytes.GetBytes(64);
+                Assert.Equal(derived, actual);
+            }
+        }
+
         private static void TestKnownValue(string password, byte[] salt, int iterationCount, byte[] expected)
         {
             byte[] output;

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/Rfc2898Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/Rfc2898Tests.cs
@@ -429,6 +429,18 @@ namespace System.Security.Cryptography.DeriveBytesTests
             }
         }
 
+        [Fact]
+        public static void Ctor_PasswordBytes_NotCleared()
+        {
+            byte[] passwordBytes = Encoding.UTF8.GetBytes(TestPassword);
+            byte[] passwordBytesOriginal = passwordBytes.AsSpan().ToArray();
+
+            using (Rfc2898DeriveBytes deriveBytes = new Rfc2898DeriveBytes(passwordBytes, s_testSaltB, DefaultIterationCount))
+            {
+                Assert.Equal(passwordBytesOriginal, passwordBytes);
+            }
+        }
+
         private static void TestKnownValue(string password, byte[] salt, int iterationCount, byte[] expected)
         {
             byte[] output;


### PR DESCRIPTION
The `_password` field is not needed since `CryptDeriveKey` was not ported from the Desktop framework and that was the only API that needed it.

Removing the field also allows removing a defensive copy and clearing it during disposal. 