### PR TITLE
Add missing dlclose on error

### DIFF
--- a/src/installer/corehost/cli/hostmisc/pal.unix.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.unix.cpp
@@ -222,7 +222,10 @@ bool pal::get_loaded_library(
     pal::proc_t proc = pal::get_symbol(dll_maybe, symbol_name);
     Dl_info info;
     if (dladdr(proc, &info) == 0)
+    {
+        dlclose(dll_maybe);
         return false;
+    }
 
     *dll = dll_maybe;
     path->assign(info.dli_fname);


### PR DESCRIPTION
I *think* this is a resource leak, but I am not sure.

If the symbol is not found, close the library before returning false.

Otherwise, the library is not stored anywhere and never cleaned up.