### PR TITLE
Update to dotnet/runtime version 6.0.0-preview.2.21076.5

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -166,33 +166,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>38017c3935de95d0335bac04f4901ddfc2718656</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="6.0.0-alpha.1.21068.2">
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="6.0.0-preview.2.21076.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5c5bb6a340d04a476045d37436530297eff189b7</Sha>
+      <Sha>e61c0eac22470091fc8126d375e5b80e13335ca1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="6.0.0-alpha.1.21068.2">
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="6.0.0-preview.2.21076.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5c5bb6a340d04a476045d37436530297eff189b7</Sha>
+      <Sha>e61c0eac22470091fc8126d375e5b80e13335ca1</Sha>
     </Dependency>
-    <Dependency Name="runtime.native.System.IO.Ports" Version="6.0.0-alpha.1.21068.2">
+    <Dependency Name="runtime.native.System.IO.Ports" Version="6.0.0-preview.2.21076.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5c5bb6a340d04a476045d37436530297eff189b7</Sha>
+      <Sha>e61c0eac22470091fc8126d375e5b80e13335ca1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="6.0.0-alpha.1.21068.2">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="6.0.0-preview.2.21076.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5c5bb6a340d04a476045d37436530297eff189b7</Sha>
+      <Sha>e61c0eac22470091fc8126d375e5b80e13335ca1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="6.0.0-alpha.1.21068.2">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="6.0.0-preview.2.21076.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5c5bb6a340d04a476045d37436530297eff189b7</Sha>
+      <Sha>e61c0eac22470091fc8126d375e5b80e13335ca1</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="6.0.0-alpha.1.21068.2">
+    <Dependency Name="System.Text.Json" Version="6.0.0-preview.2.21076.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5c5bb6a340d04a476045d37436530297eff189b7</Sha>
+      <Sha>e61c0eac22470091fc8126d375e5b80e13335ca1</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="6.0.0-alpha.1.21068.2">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="6.0.0-preview.2.21076.5">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5c5bb6a340d04a476045d37436530297eff189b7</Sha>
+      <Sha>e61c0eac22470091fc8126d375e5b80e13335ca1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.21075.2">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,11 +63,11 @@
     <NuGetBuildTasksPackVersion>5.9.0-preview.2</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppVersion>6.0.0-alpha.1.20612.4</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCoreDotNetHostVersion>6.0.0-alpha.1.21068.2</MicrosoftNETCoreDotNetHostVersion>
-    <MicrosoftNETCoreDotNetHostPolicyVersion>6.0.0-alpha.1.21068.2</MicrosoftNETCoreDotNetHostPolicyVersion>
+    <MicrosoftNETCoreDotNetHostVersion>6.0.0-preview.2.21076.5</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>6.0.0-preview.2.21076.5</MicrosoftNETCoreDotNetHostPolicyVersion>
     <MicrosoftExtensionsDependencyModelVersion>3.1.0</MicrosoftExtensionsDependencyModelVersion>
     <!-- CoreClr dependencies -->
-    <MicrosoftNETCoreILAsmVersion>6.0.0-alpha.1.21068.2</MicrosoftNETCoreILAsmVersion>
+    <MicrosoftNETCoreILAsmVersion>6.0.0-preview.2.21076.5</MicrosoftNETCoreILAsmVersion>
     <!-- Libraries dependencies -->
     <StyleCopAnalyzersVersion>1.2.0-beta.304</StyleCopAnalyzersVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
@@ -95,14 +95,14 @@
     <SystemSecurityCryptographyCngVersion>4.7.0</SystemSecurityCryptographyCngVersion>
     <SystemSecurityCryptographyPkcsVersion>4.7.0</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyOpenSslVersion>4.7.0</SystemSecurityCryptographyOpenSslVersion>
-    <SystemTextJsonVersion>6.0.0-alpha.1.21068.2</SystemTextJsonVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0-alpha.1.21068.2</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemTextJsonVersion>6.0.0-preview.2.21076.5</SystemTextJsonVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0-preview.2.21076.5</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemThreadingVersion>4.3.0</SystemThreadingVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.1</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
-    <runtimenativeSystemIOPortsVersion>6.0.0-alpha.1.21068.2</runtimenativeSystemIOPortsVersion>
+    <runtimenativeSystemIOPortsVersion>6.0.0-preview.2.21076.5</runtimenativeSystemIOPortsVersion>
     <!-- Runtime-Assets dependencies -->
     <SystemComponentModelTypeConverterTestDataVersion>5.0.0-beta.21062.1</SystemComponentModelTypeConverterTestDataVersion>
     <SystemDrawingCommonTestDataVersion>5.0.0-beta.21062.1</SystemDrawingCommonTestDataVersion>

--- a/global.json
+++ b/global.json
@@ -17,7 +17,7 @@
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21062.10",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21062.10",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "6.0.0-alpha.1.21068.2",
+    "Microsoft.NET.Sdk.IL": "6.0.0-preview.2.21076.5",
     "Microsoft.Build.NoTargets": "2.0.1",
     "Microsoft.Build.Traversal": "2.1.1"
   }


### PR DESCRIPTION
Build ID 20210126.5

Fixes #42250 cc @jkotas 

Before this:
```
sn -vf c:\src\dotnet\runtime\artifacts\bin\System.Runtime.CompilerServices.Unsafe\net6.0-Debug\System.Runtime.CompilerServices.Unsafe.dll

Microsoft (R) .NET Framework Strong Name Utility  Version 4.0.30319.0
Copyright (c) Microsoft Corporation.  All rights reserved.

c:\src\dotnet\runtime\artifacts\bin\System.Runtime.CompilerServices.Unsafe\net6.0-Debug\System.Runtime.CompilerServices.Unsafe.dll is a delay-signed or test-signed assembly
```

After:
```
sn -vf c:\src\dotnet\runtime\artifacts\bin\System.Runtime.CompilerServices.Unsafe\net6.0-Debug\System.Runtime.CompilerServices.Unsafe.dll

Microsoft (R) .NET Framework Strong Name Utility  Version 4.0.30319.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Failed to verify assembly -- Strong name validation failed.
```

Which is a good thing, SN doesn't know about public sign, but is observing that the assembly says it should be signed (rather than delay signed) and the signature is bogus, which is what public sign does.