### PR TITLE
Fix m_isSuspendedForGarbageCollection

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -5945,7 +5945,7 @@ void Debugger::SuspendForGarbageCollectionCompleted()
     }
     CONTRACTL_END;
 
-    this->m_isSuspendedForGarbageCollection = FALSE;
+    this->m_isSuspendedForGarbageCollection = TRUE;
 
     if (!CORDebuggerAttached() || !this->m_isGarbageCollectionEventsEnabledLatch)
     {
@@ -5984,7 +5984,8 @@ void Debugger::ResumeForGarbageCollectionStarted()
     }
     CONTRACTL_END;
 
-    this->m_isSuspendedForGarbageCollection = TRUE;
+    this->m_isSuspendedForGarbageCollection = FALSE;
+
     if (!CORDebuggerAttached() || !this->m_isGarbageCollectionEventsEnabledLatch)
     {
         return;


### PR DESCRIPTION
When #46763 was cherry-picked from .NET 5.0 where it was actually tested, the `m_isSuspendedForGarbageCollection` state was somehow inverted.  It is not clear how his happened.  It is interesting the context for both patch lines is identical, so this could have been an issue with cherry-pick patch line correction (or it could be user error).