### PR TITLE
Clean up crossgen2.csproj file

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -57,9 +57,7 @@
 
   <PropertyGroup>
     <CrossHostArch></CrossHostArch>
-    <CrossHostArch Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildArchitecture)' == 'x64'">x64</CrossHostArch>
-    <CrossHostArch Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' == 'x64'">x64</CrossHostArch>
-    <CrossHostArch Condition="'$(TargetArchitecture)' == 'x86' and '$(BuildArchitecture)' == 'x64'">x64</CrossHostArch>
+    <CrossHostArch Condition="'$(TargetArchitecture)' != 'x64' and '$(BuildArchitecture)' == 'x64'">x64</CrossHostArch>
 
     <TargetOSComponent>unix</TargetOSComponent>
     <TargetOSComponent Condition="'$(TargetOS)' == 'windows'">win</TargetOSComponent>
@@ -70,13 +68,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(RuntimeBinDir)\$(JitInterfaceLibraryName)"
+    <Content Include="$(RuntimeBinDir)$(JitInterfaceLibraryName)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="%(FileName)%(Extension)"
      />
 
-    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibPrefix)clrjit_*_$(TargetArchitecture)$(LibSuffix)"
+    <Content Include="$(RuntimeBinDir)$(NativeArchFolder)$(LibPrefix)clrjit_*_$(TargetArchitecture)$(LibSuffix)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="%(FileName)%(Extension)"
@@ -86,7 +84,8 @@
   <!-- On windows we can re-use the clrjit.dll produced in the build for aot compilation. On Linux
        this works at runtime, but makes it difficult to debug the jit.-->
   <ItemGroup Condition="'$(TargetOS)' == 'windows'">
-    <Content Include="$(RuntimeBinDir)\$(NativeArchFolder)$(LibPrefix)clrjit$(LibSuffix)"
+    <Content Remove="$(RuntimeBinDir)$(LibPrefix)clrjit_$(TargetSpec)$(LibSuffix)" />
+    <Content Include="$(RuntimeBinDir)$(NativeArchFolder)$(LibPrefix)clrjit$(LibSuffix)"
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       Link="$(LibPrefix)clrjit_$(TargetSpec)$(LibSuffix)"
@@ -96,13 +95,13 @@
   <Target Name="CreateCrossTargetingPackage" AfterTargets="Build" Condition="'$(CrossHostArch)' != ''">
 
     <PropertyGroup>
-      <CrossPackageFolder>$(RuntimeBinDir)\$(CrossHostArch)\crossgen2</CrossPackageFolder>
+      <CrossPackageFolder>$(RuntimeBinDir)$(CrossHostArch)\crossgen2</CrossPackageFolder>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageFile Include="$(RuntimeBinDir)\crossgen2\*"
-        Exclude="$(RuntimeBinDir)\crossgen2\$(JitInterfaceLibraryName);$(RuntimeBinDir)\crossgen2\$(LibPrefix)clrjit_*$(LibSuffix)" />
-      <PackageFile Include="$(RuntimeBinDir)\$(CrossHostArch)\$(LibPrefix)jitinterface_$(CrossHostArch)$(LibSuffix)" />
+      <PackageFile Include="$(RuntimeBinDir)crossgen2\*"
+        Exclude="$(RuntimeBinDir)crossgen2\$(JitInterfaceLibraryName);$(RuntimeBinDir)crossgen2\$(LibPrefix)clrjit_*$(LibSuffix)" />
+      <PackageFile Include="$(RuntimeBinDir)$(CrossHostArch)\$(LibPrefix)jitinterface_$(CrossHostArch)$(LibSuffix)" />
     </ItemGroup>
 
     <MakeDir Directories="$(CrossPackageFolder)" />


### PR DESCRIPTION
• Avoid double-writing of crossgen2\clrjit_win_x64_x64.dll file.
• Avoid extra slashes in paths.