### PR TITLE
Avoid Marshal.SizeOf in EventSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1866,6 +1866,7 @@ namespace System.Diagnostics.Tracing
                         dataType = Enum.GetUnderlyingType(dataType);
 
                         if (dataType == typeof(byte) || dataType == typeof(sbyte)
+                            || dataType == typeof(bool) || dataType == typeof(char)
                             || dataType == typeof(ushort) || dataType == typeof(short))
                         {
                             dataType = typeof(int);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1865,9 +1865,11 @@ namespace System.Diagnostics.Tracing
                     {
                         dataType = Enum.GetUnderlyingType(dataType);
 
-                        int dataTypeSize = System.Runtime.InteropServices.Marshal.SizeOf(dataType);
-                        if (dataTypeSize < sizeof(int))
+                        if (dataType == typeof(byte) || dataType == typeof(sbyte)
+                            || dataType == typeof(ushort) || dataType == typeof(short))
+                        {
                             dataType = typeof(int);
+                        }
                         goto Again;
                     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1866,7 +1866,6 @@ namespace System.Diagnostics.Tracing
                         dataType = Enum.GetUnderlyingType(dataType);
 
                         if (dataType == typeof(byte) || dataType == typeof(sbyte)
-                            || dataType == typeof(bool) || dataType == typeof(char)
                             || dataType == typeof(ushort) || dataType == typeof(short))
                         {
                             dataType = typeof(int);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1865,10 +1865,15 @@ namespace System.Diagnostics.Tracing
                     {
                         dataType = Enum.GetUnderlyingType(dataType);
 
-                        if (dataType == typeof(byte) || dataType == typeof(sbyte)
-                            || dataType == typeof(ushort) || dataType == typeof(short))
+                        // Enums less than 4 bytes in size should be treated as int.
+                        switch (Type.GetTypeCode(dataType))
                         {
-                            dataType = typeof(int);
+                            case TypeCode.Byte:
+                            case TypeCode.SByte:
+                            case TypeCode.Int16:
+                            case TypeCode.UInt16:
+                                dataType = typeof(int);
+                                break;
                         }
                         goto Again;
                     }


### PR DESCRIPTION
We're getting the marshalling size of an enum underlying type - there are not that many of those. I chose not to treat `char` and `bool`, but we could (the only other remaining options).

Calling into `Marshal.SizeOf` increases the risk that `EventSource` is going call itself recursively - see the comment at the beginning of the method.

This was originally introduced in https://github.com/dotnet/coreclr/pull/19205.