### PR TITLE
Prevent IpcTraceTest (EventPipe tests) to hang on certain test failures.

### DIFF
--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -282,8 +282,15 @@ namespace Tracing.Tests.Common
                 }
             });
 
+            var waitSentinelEventTask = new Task(() => {
+                sentinelEventReceived.WaitOne();
+            });
+
             readerTask.Start();
-            sentinelEventReceived.WaitOne();
+            waitSentinelEventTask.Start();
+
+            // Will throw if the reader task throws any exceptions before signaling sentinelEventReceived.
+            Task.WaitAny(readerTask, waitSentinelEventTask);
 
             Logger.logger.Log("Starting event generating action...");
             _eventGeneratingAction();


### PR DESCRIPTION
If an exception is throwed in IpcTraceTest::Validate readerTask before it signals sentinelEventReceived, test will hang on:

sentinelEventReceived.WaitOne();

When hitting this case the error is hard to spot and looks like a hanging IPC client, but when looking at it from the runtime side
you get a correct close of IPC channel and termination of streaming thread.

I have hit this in a scenario where we hit an exception deep within EventPipeEventSource constructor, in that case due to a runtime issue loading a library on Windows, but since the exception is not rethrown from the task, no error is seen on client side, the test will just hang forever.

With this fix, the test will wait on either the sentinelEventReceived or readerTask and if readerTask get signaled due to an exception, it will be re-throwed all the way up to RunAndValidateEventCounts printing test failure and exception info into the log, simplify the debugging of these kind of failures a lot.