### PR TITLE
Fix assert on unhandled SIGSEGV

### DIFF
--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -418,7 +418,7 @@ PALAPI
 PAL_TerminateEx(
     int exitCode);
 
-typedef VOID (*PSHUTDOWN_CALLBACK)(void);
+typedef VOID (*PSHUTDOWN_CALLBACK)(bool isExecutingOnAltStack);
 
 PALIMPORT
 VOID

--- a/src/coreclr/pal/src/include/pal/process.h
+++ b/src/coreclr/pal/src/include/pal/process.h
@@ -163,7 +163,7 @@ Function:
 
 (no return value)
 --*/
-VOID PROCNotifyProcessShutdown();
+VOID PROCNotifyProcessShutdown(bool isExecutingOnAltStack = false);
 
 /*++
 Function:

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3046,16 +3046,30 @@ Function
 
 (no return value)
 --*/
-__attribute__((destructor))
 VOID
-PROCNotifyProcessShutdown()
+PROCNotifyProcessShutdown(bool isExecutingOnAltStack)
 {
     // Call back into the coreclr to clean up the debugger transport pipes
     PSHUTDOWN_CALLBACK callback = InterlockedExchangePointer(&g_shutdownCallback, NULL);
     if (callback != NULL)
     {
-        callback();
+        callback(isExecutingOnAltStack);
     }
+}
+
+/*++
+Function
+  PROCNotifyProcessShutdownDestructor
+
+  Called at process exit, invokes process shutdown notification
+
+(no return value)
+--*/
+__attribute__((destructor))
+VOID
+PROCNotifyProcessShutdownDestructor()
+{
+    PROCNotifyProcessShutdown(/* isExecutingOnAltStack */ false);
 }
 
 /*++

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -593,13 +593,18 @@ do { \
 
 #ifndef CROSSGEN_COMPILE
 #ifdef TARGET_UNIX
-void EESocketCleanupHelper()
+void EESocketCleanupHelper(bool isExecutingOnAltStack)
 {
     CONTRACTL
     {
         GC_NOTRIGGER;
         MODE_ANY;
     } CONTRACTL_END;
+
+    if (isExecutingOnAltStack)
+    {
+        GetThread()->SetExecutingOnAltStack();
+    }
 
     // Close the debugger transport socket first
     if (g_pDebugInterface != NULL)


### PR DESCRIPTION
When `SIGSEGV` is not handled by .NET runtime (e.g. when it occurs in code
out of its control), the `SIGSEGV` handler ends up calling
`DiagnosticServer::Shutdown` in the runtime via a registered shutdown callback.
That method ends up calling `Thread::GetFrame`, which asserts if the
current SP is out of a valid range for the regular stack. The problem is
that SIGSEGV handler is called on an alternate stack and so this
callback ends up being called on that stack too. That causes this
assertion to fail, because the current thread is not marked as executing
on alternate stack, which would skip that assert.

This change fixes it by passing through a bool flag indicating whether
the callback was called on an alternate stack or not. And in that
callback, we set the flag on the thread accordingly.

Close #47142