### PR TITLE
Deduplicate Unwind and GC info table

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsGCInfoNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsGCInfoNode.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class RuntimeFunctionsGCInfoNode : ArrayOfEmbeddedDataNode<MethodGCInfoNode>
@@ -9,6 +11,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             : base("RuntimeFunctionsGCInfo_Begin", "RuntimeFunctionsGCInfo_End", new EmbeddedObjectNodeComparer(new CompilerComparer()))
         {
         }
+
+        public HashSet<MethodGCInfoNode> Deduplicator;
 
         public override int ClassCode => 316678892;
 


### PR DESCRIPTION
* Remove duplicated unwind and GC info table entries.
* Overall, reduces the framework size with CG2 by 2.4MB (89,835,064 -> 87,439,416 bytes)

cc @dotnet/crossgen-contrib 