### PR TITLE
Add strict validation to System.IO.Compression.GZipStream

### DIFF
--- a/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
@@ -58,6 +58,7 @@ namespace System.IO.Compression
         public GZipStream(System.IO.Stream stream, System.IO.Compression.CompressionLevel compressionLevel, bool leaveOpen) { }
         public GZipStream(System.IO.Stream stream, System.IO.Compression.CompressionMode mode) { }
         public GZipStream(System.IO.Stream stream, System.IO.Compression.CompressionMode mode, bool leaveOpen) { }
+        public GZipStream(System.IO.Stream stream, System.IO.Compression.CompressionMode mode, bool leaveOpen, bool strictValidation) { }
         public System.IO.Stream BaseStream { get { throw null; } }
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -20,6 +20,11 @@ namespace System.IO.Compression
             _deflateStream = new DeflateStream(stream, mode, leaveOpen, ZLibNative.GZip_DefaultWindowBits);
         }
 
+        public GZipStream(Stream stream, CompressionMode mode, bool leaveOpen, bool strictValidation)
+        {
+            _deflateStream = new DeflateStream(stream, mode, leaveOpen, ZLibNative.GZip_DefaultWindowBits, strictValidation: strictValidation);
+        }
+
         // Implies mode = Compress
         public GZipStream(Stream stream, CompressionLevel compressionLevel) : this(stream, compressionLevel, leaveOpen: false)
         {

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -285,6 +285,7 @@ namespace System.IO.Compression
             }
         }
 
+        // https://stackoverflow.com/questions/9456563/gzipstream-doesnt-detect-corrupt-data-even-crc32-passes
         [Fact]
         public void StrictValidation()
         {
@@ -312,7 +313,7 @@ namespace System.IO.Compression
 
                 using (var decomStream = new MemoryStream(cmpData))
                 {
-                    using (var hgs = new GZipStream(decomStream, CompressionMode.Decompress, false))
+                    using (var hgs = new GZipStream(decomStream, CompressionMode.Decompress, false, strictValidation: true))
                     {
                         using (var reader = new StreamReader(hgs))
                         {
@@ -348,7 +349,7 @@ namespace System.IO.Compression
             {
                (
                     s => new System.IO.Compression.GZipStream(s, System.IO.Compression.CompressionLevel.Fastest),
-                    s => new System.IO.Compression.GZipStream(s, CompressionMode.Decompress)
+                    s => new System.IO.Compression.GZipStream(s, CompressionMode.Decompress, false, strictValidation: true)
                )
             };
             string r = null;


### PR DESCRIPTION
The current implementation of `System.IO.Compression.GzipStream` seems to not be as strict regarding error handling as it could be when it comes to corrupt data.

For context, [this](https://stackoverflow.com/questions/9456563/gzipstream-doesnt-detect-corrupt-data-even-crc32-passes) is a good thread about this exact issue, I believe. There is likely even more info in the [old connect ticket](http://connect.microsoft.com/VisualStudio/feedback/details/726860/gzipstream-does-not-seem-to-detect-corrupt-data) but it's been unaccessible for a while.

So I have compared the `System.IO.Compression.GzipStream` implementation with its managed and bindings counterparts, namely `zlib.managed`, `ICSharpCode.SharpZipLib` and `SharpCompress` when it comes to handling corrupt data.

As for test cases, I retrieved the code from the [SO question](https://stackoverflow.com/questions/9456563/gzipstream-doesnt-detect-corrupt-data-even-crc32-passes) and also added another test which hits a different code path.

This is the other test case https://github.com/mfkl/zlib-validation/blob/main/ConsoleApp1/Program.cs

This is the result:
```
System.IO.Compression
Expected: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Actual  : ////////////////////////////////////////////////////

zlib.managed
Expected: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Actual  : xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

ICSharpCode.SharpZipLib
Expected: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Actual  : /xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

SharpCompress
Expected: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Actual  : /xxxxxxxxx//xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                                                                                                                                                                  
```

My understanding is that the `System.IO.Compression.GzipStream` implementation ignores `ZLibNative.ErrorCode.BufError` errors in most cases, while other implementions are stricter about it.

My proposed fix is to add an overload with a simple boolean which, when set to true, would take into account the BufError returned by the native lib, and throw accordingly.

I've run the compression test suites and made sure I did not break anything. If there is another approach to go at this, feel free to let me know.

Feedback welcome!