### PR TITLE
Disable ClosedDuringOperation_Throws_ObjectDisposedExceptionOrSocketException

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
@@ -99,6 +99,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47561")]
         public async Task ClosedDuringOperation_Throws_ObjectDisposedExceptionOrSocketException(bool closeOrDispose)
         {
             if (UsesSync && PlatformDetection.IsOSX)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -105,6 +105,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47561")]
         public async Task ClosedDuringOperation_Throws_ObjectDisposedExceptionOrSocketException(bool closeOrDispose)
         {
             if (UsesSync && PlatformDetection.IsOSX)
@@ -299,7 +300,7 @@ namespace System.Net.Sockets.Tests
                 AssertExtensions.SequenceEqual(sendBuffer, receiveBuffer);
                 Assert.Equal(sender.LocalEndPoint, saea.RemoteEndPoint);
                 Assert.Equal(((IPEndPoint)sender.LocalEndPoint).Address, saea.ReceiveMessageFromPacketInfo.Address);
-            }   
+            }
         }
     }
 


### PR DESCRIPTION
Disable tests to unblock CI. Tracked in https://github.com/dotnet/runtime/issues/47561