### PR TITLE
Resolve ILLink warnings in System.Linq.Expressions (Round 1)

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have ILLink annotations.")]
+            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have trimming annotations.")]
         internal static MethodInfo GetArrayEmptyMethodInfo(Type itemType) =>
             ArrayEmptyMethodInfo.MakeGenericMethod(itemType);
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -156,8 +156,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 VisitCallSiteMain(callSite, context));
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:UnrecognizedReflectionPattern",
-            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have linker annotations.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have ILLink annotations.")]
         internal static MethodInfo GetArrayEmptyMethodInfo(Type itemType) =>
             ArrayEmptyMethodInfo.MakeGenericMethod(itemType);
 

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
@@ -5,91 +5,13 @@
       <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Dynamic.Utils.DelegateHelpers.#cctor</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2060</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Dynamic.Utils.DelegateHelpers.GetCSharpThunk(System.Type,System.Boolean,System.Reflection.ParameterInfo[])</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2060</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.Expression.ApplyTypeArgs(System.Reflection.MethodInfo,System.Type[])</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2060</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Runtime.CompilerServices.CallSite`1.CreateCustomUpdateDelegate(System.Reflection.MethodInfo)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2060</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Runtime.CompilerServices.CallSite`1.MakeUpdateDelegate</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2067</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.AssemblyGen.DefineType(System.String,System.Type,System.Reflection.TypeAttributes)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Dynamic.Utils.TypeExtensions.GetAnyStaticMethodValidated(System.Type,System.String,System.Type[])</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Dynamic.Utils.TypeUtils.GetInvokeMethod(System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.ILGen.EmitArray(System.Reflection.Emit.ILGenerator,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.ILGen.EmitGetValue(System.Reflection.Emit.ILGenerator,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.ILGen.EmitGetValueOrDefault(System.Reflection.Emit.ILGenerator,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.ILGen.EmitHasValue(System.Reflection.Emit.ILGenerator,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.ILGen.EmitNonNullableToNullableConversion(System.Reflection.Emit.ILGenerator,System.Type,System.Type,System.Boolean,System.Linq.Expressions.Compiler.ILocalCache)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.ILGen.EmitNullableToNullableConversion(System.Reflection.Emit.ILGenerator,System.Type,System.Type,System.Boolean,System.Linq.Expressions.Compiler.ILocalCache)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.ILGen.TryEmitILConstant(System.Reflection.Emit.ILGenerator,System.Object,System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -123,33 +45,21 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2070</argument>
+      <argument>IL2072</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Expression.Field(System.Linq.Expressions.Expression,System.Type,System.String)</property>
+      <property name="Target">M:System.Linq.Expressions.Expression.ListInit(System.Linq.Expressions.NewExpression,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression})</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2070</argument>
+      <argument>IL2072</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Expression.FindMethod(System.Type,System.String,System.Type[],System.Linq.Expressions.Expression[],System.Reflection.BindingFlags)</property>
+      <property name="Target">M:System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression,System.String,System.Type[],System.Linq.Expressions.Expression[]))</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2070</argument>
+      <argument>IL2072</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Expression.FindProperty(System.Type,System.String,System.Linq.Expressions.Expression[],System.Reflection.BindingFlags)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Expression.New(System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Expression.Property(System.Linq.Expressions.Expression,System.Type,System.String)</property>
+      <property name="Target">M:System.Linq.Expressions.Expression.Property(System.Linq.Expressions.Expression,System.String,System.Linq.Expressions.Expression[])</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -197,12 +107,6 @@
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Expression.ArrayIndex(System.Linq.Expressions.Expression,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression})</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.Expression.CheckMethod(System.Reflection.MethodInfo,System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -234,12 +138,6 @@
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.ExpressionStringBuilder.VisitExtension(System.Linq.Expressions.Expression)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.CallInstruction.GetArrayAccessor(System.Reflection.MethodInfo,System.Int32)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -288,12 +186,6 @@
       <argument>IL2077</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.Interpreter.InitializeLocalInstruction.MutableValue.Run(System.Linq.Expressions.Interpreter.InterpretedFrame)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2077</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.NullableMethodCallInstruction.GetValueOrDefault.Run(System.Linq.Expressions.Interpreter.InterpretedFrame)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 #if !FEATURE_DYNAMIC_DELEGATE
@@ -27,7 +28,7 @@ namespace System.Dynamic.Utils
 
         private static readonly CacheDict<Type, MethodInfo> s_thunks = new CacheDict<Type, MethodInfo>(256);
         private static readonly MethodInfo s_FuncInvoke = typeof(Func<object?[], object?>).GetMethod("Invoke")!;
-        private static readonly MethodInfo s_ArrayEmpty = typeof(Array).GetMethod(nameof(Array.Empty))!.MakeGenericMethod(typeof(object));
+        private static readonly MethodInfo s_ArrayEmpty = GetEmptyObjectArrayMethod();
         private static readonly MethodInfo[] s_ActionThunks = GetActionThunks();
         private static readonly MethodInfo[] s_FuncThunks = GetFuncThunks();
         private static int s_ThunksCreated;
@@ -62,6 +63,11 @@ namespace System.Dynamic.Utils
             return (TReturn)handler(new object?[]{t1, t2});
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have ILLink annotations.")]
+        private static MethodInfo GetEmptyObjectArrayMethod() =>
+            typeof(Array).GetMethod(nameof(Array.Empty))!.MakeGenericMethod(typeof(object));
+
         private static MethodInfo[] GetActionThunks()
         {
             Type delHelpers = typeof(DelegateHelpers);
@@ -78,6 +84,8 @@ namespace System.Dynamic.Utils
                                     delHelpers.GetMethod("FuncThunk2")!};
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "The above ActionThunk and FuncThunk methods don't have ILLink annotations.")]
         private static MethodInfo? GetCSharpThunk(Type returnType, bool hasReturnValue, ParameterInfo[] parameters)
         {
             try

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -64,7 +64,7 @@ namespace System.Dynamic.Utils
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have ILLink annotations.")]
+            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have trimming annotations.")]
         private static MethodInfo GetEmptyObjectArrayMethod() =>
             typeof(Array).GetMethod(nameof(Array.Empty))!.MakeGenericMethod(typeof(object));
 
@@ -85,7 +85,7 @@ namespace System.Dynamic.Utils
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-            Justification = "The above ActionThunk and FuncThunk methods don't have ILLink annotations.")]
+            Justification = "The above ActionThunk and FuncThunk methods don't have trimming annotations.")]
         private static MethodInfo? GetCSharpThunk(Type returnType, bool hasReturnValue, ParameterInfo[] parameters)
         {
             try

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -891,7 +891,7 @@ namespace System.Dynamic.Utils
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
-            Justification = "ILLinker will never remove the Invoke method from delegates.")]
+            Justification = "The trimmer will never remove the Invoke method from delegates.")]
         public static MethodInfo GetInvokeMethod(this Type delegateType)
         {
             Debug.Assert(typeof(Delegate).IsAssignableFrom(delegateType));

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -889,6 +890,8 @@ namespace System.Dynamic.Utils
             return true;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "ILLinker will never remove the Invoke method from delegates.")]
         public static MethodInfo GetInvokeMethod(this Type delegateType)
         {
             Debug.Assert(typeof(Delegate).IsAssignableFrom(delegateType));

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Security;
 using System.Text;
 using System.Threading;
 
@@ -38,7 +38,7 @@ namespace System.Linq.Expressions.Compiler
             _myModule = myAssembly.DefineDynamicModule(name.Name!);
         }
 
-        private TypeBuilder DefineType(string name, Type parent, TypeAttributes attr)
+        private TypeBuilder DefineType(string name, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type parent, TypeAttributes attr)
         {
             ContractUtils.RequiresNotNull(name, nameof(name));
             ContractUtils.RequiresNotNull(parent, nameof(parent));

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -484,7 +485,7 @@ namespace System.Linq.Expressions.Compiler
 
                 if (TryEmitILConstant(il, value, nonNullType))
                 {
-                    il.Emit(OpCodes.Newobj, type.GetConstructor(new[] { nonNullType })!);
+                    il.Emit(OpCodes.Newobj, GetNullableConstructor(type, nonNullType));
                     return true;
                 }
 
@@ -825,7 +826,7 @@ namespace System.Linq.Expressions.Compiler
             Type nnTypeTo = typeTo.GetNonNullableType();
             il.EmitConvertToType(nnTypeFrom, nnTypeTo, isChecked, locals);
             // construct result type
-            ConstructorInfo ci = typeTo.GetConstructor(new Type[] { nnTypeTo })!;
+            ConstructorInfo ci = GetNullableConstructor(typeTo, nnTypeTo);
             il.Emit(OpCodes.Newobj, ci);
             labEnd = il.DefineLabel();
             il.Emit(OpCodes.Br_S, labEnd);
@@ -839,17 +840,26 @@ namespace System.Linq.Expressions.Compiler
             il.MarkLabel(labEnd);
         }
 
-
         private static void EmitNonNullableToNullableConversion(this ILGenerator il, Type typeFrom, Type typeTo, bool isChecked, ILocalCache locals)
         {
             Debug.Assert(!typeFrom.IsNullableType());
             Debug.Assert(typeTo.IsNullableType());
             Type nnTypeTo = typeTo.GetNonNullableType();
             il.EmitConvertToType(typeFrom, nnTypeTo, isChecked, locals);
-            ConstructorInfo ci = typeTo.GetConstructor(new Type[] { nnTypeTo })!;
+            ConstructorInfo ci = GetNullableConstructor(typeTo, nnTypeTo);
             il.Emit(OpCodes.Newobj, ci);
         }
 
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(Nullable<>))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Nullable<T> ctor will be preserved by the DynamicDependency.")]
+        private static ConstructorInfo GetNullableConstructor(Type nullableType, Type nonNullableType)
+        {
+            Debug.Assert(nullableType.IsNullableType());
+            Debug.Assert(!nonNullableType.IsNullableType() && nonNullableType.IsValueType);
+
+            return nullableType.GetConstructor(new Type[] { nonNullableType })!;
+        }
 
         private static void EmitNullableToNonNullableConversion(this ILGenerator il, Type typeFrom, Type typeTo, bool isChecked, ILocalCache locals)
         {
@@ -899,26 +909,38 @@ namespace System.Linq.Expressions.Compiler
                 il.EmitNonNullableToNullableConversion(typeFrom, typeTo, isChecked, locals);
         }
 
-
+        [DynamicDependency("get_HasValue", typeof(Nullable<>))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Nullable<T> method will be preserved by the DynamicDependency.")]
         internal static void EmitHasValue(this ILGenerator il, Type nullableType)
         {
+            Debug.Assert(nullableType.IsNullableType());
+
             MethodInfo mi = nullableType.GetMethod("get_HasValue", BindingFlags.Instance | BindingFlags.Public)!;
             Debug.Assert(nullableType.IsValueType);
             il.Emit(OpCodes.Call, mi);
         }
 
-
+        [DynamicDependency("get_Value", typeof(Nullable<>))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Nullable<T> method will be preserved by the DynamicDependency.")]
         internal static void EmitGetValue(this ILGenerator il, Type nullableType)
         {
+            Debug.Assert(nullableType.IsNullableType());
+
             MethodInfo mi = nullableType.GetMethod("get_Value", BindingFlags.Instance | BindingFlags.Public)!;
             Debug.Assert(nullableType.IsValueType);
             il.Emit(OpCodes.Call, mi);
         }
 
-
+        [DynamicDependency("GetValueOrDefault()", typeof(Nullable<>))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Nullable<T> method will be preserved by the DynamicDependency.")]
         internal static void EmitGetValueOrDefault(this ILGenerator il, Type nullableType)
         {
-            MethodInfo mi = nullableType.GetMethod("GetValueOrDefault", System.Type.EmptyTypes)!;
+            Debug.Assert(nullableType.IsNullableType());
+
+            MethodInfo mi = nullableType.GetMethod("GetValueOrDefault", Type.EmptyTypes)!;
             Debug.Assert(nullableType.IsValueType);
             il.Emit(OpCodes.Call, mi);
         }
@@ -965,6 +987,8 @@ namespace System.Linq.Expressions.Compiler
         /// The code assumes that bounds for all dimensions
         /// are already emitted.
         /// </summary>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Array ctor is dynamically constructed and is not included in IL. It is not subject to trimming.")]
         internal static void EmitArray(this ILGenerator il, Type arrayType)
         {
             Debug.Assert(arrayType != null);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -222,7 +223,10 @@ namespace System.Linq.Expressions
         /// The method finds the instance property with the specified name in a type. The property's type signature needs to be compatible with
         /// the arguments if it is a indexer. If the arguments is null or empty, we get a normal property.
         /// </summary>
-        private static PropertyInfo FindInstanceProperty(Type type, string propertyName, Expression[]? arguments)
+        private static PropertyInfo FindInstanceProperty(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] Type type,
+            string propertyName,
+            Expression[]? arguments)
         {
             // bind to public names first
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy;
@@ -262,7 +266,11 @@ namespace System.Linq.Expressions
             return argTypesStr.ToString();
         }
 
-        private static PropertyInfo? FindProperty(Type type, string propertyName, Expression[]? arguments, BindingFlags flags)
+        private static PropertyInfo? FindProperty(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] Type type,
+            string propertyName,
+            Expression[]? arguments,
+            BindingFlags flags)
         {
             PropertyInfo? property = null;
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -122,9 +122,6 @@ namespace System.Linq.Expressions.Interpreter
 #endif
         }
 
-        [DynamicDependency("GetValue", typeof(Array))]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "The GetValue methods will be preserved by the DynamicDependency.")]
         private static CallInstruction GetArrayAccessor(MethodInfo info, int argumentCount)
         {
             Type arrayType = info.DeclaringType!;
@@ -135,19 +132,19 @@ namespace System.Linq.Expressions.Interpreter
             {
                 case 1:
                     alternativeMethod = isGetter ?
-                        arrayType.GetMethod("GetValue", new[] { typeof(int) }) :
+                        typeof(Array).GetMethod("GetValue", new[] { typeof(int) }) :
                         typeof(CallInstruction).GetMethod(nameof(ArrayItemSetter1));
                     break;
 
                 case 2:
                     alternativeMethod = isGetter ?
-                        arrayType.GetMethod("GetValue", new[] { typeof(int), typeof(int) }) :
+                        typeof(Array).GetMethod("GetValue", new[] { typeof(int), typeof(int) }) :
                         typeof(CallInstruction).GetMethod(nameof(ArrayItemSetter2));
                     break;
 
                 case 3:
                     alternativeMethod = isGetter ?
-                        arrayType.GetMethod("GetValue", new[] { typeof(int), typeof(int), typeof(int) }) :
+                        typeof(Array).GetMethod("GetValue", new[] { typeof(int), typeof(int), typeof(int) }) :
                         typeof(CallInstruction).GetMethod(nameof(ArrayItemSetter3));
                     break;
             }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -122,6 +122,9 @@ namespace System.Linq.Expressions.Interpreter
 #endif
         }
 
+        [DynamicDependency("GetValue", typeof(Array))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "The GetValue methods will be preserved by the DynamicDependency.")]
         private static CallInstruction GetArrayAccessor(MethodInfo info, int argumentCount)
         {
             Type arrayType = info.DeclaringType!;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -146,18 +146,17 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class GetValueOrDefault : NullableMethodCallInstruction
         {
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
             private readonly Type _defaultValueType;
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2074:UnrecognizedReflectionPattern",
-                Justification = "_defaultValueType is a ValueType, so you can always create an instance of it.")]
             public GetValueOrDefault(MethodInfo mi)
             {
-                Debug.Assert(mi.ReturnType.IsValueType, "Nullable only allows on value types.");
+                Debug.Assert(mi.ReturnType.IsValueType, "Nullable is only allowed on value types.");
 
                 _defaultValueType = mi.ReturnType;
             }
 
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
+                Justification = "_defaultValueType is a ValueType. You can always create an instance of a ValueType.")]
             public override int Run(InterpretedFrame frame)
             {
                 if (frame.Peek() == null)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -146,19 +146,20 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class GetValueOrDefault : NullableMethodCallInstruction
         {
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
             private readonly Type _defaultValueType;
 
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2074:UnrecognizedReflectionPattern",
+                Justification = "_defaultValueType is a ValueType, so you can always create an instance of it.")]
             public GetValueOrDefault(MethodInfo mi)
             {
+                Debug.Assert(mi.ReturnType.IsValueType, "Nullable only allows on value types.");
+
                 _defaultValueType = mi.ReturnType;
             }
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
-                Justification = "_defaultValueType is a ValueType, so it will always have a default constructor.")]
             public override int Run(InterpretedFrame frame)
             {
-                Debug.Assert(_defaultValueType.IsValueType, "Nullable only allows on value types.");
-
                 if (frame.Peek() == null)
                 {
                     frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -152,8 +153,12 @@ namespace System.Linq.Expressions.Interpreter
                 _defaultValueType = mi.ReturnType;
             }
 
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
+                Justification = "_defaultValueType is a ValueType, so it will always have a default constructor.")]
             public override int Run(InterpretedFrame frame)
             {
+                Debug.Assert(_defaultValueType.IsValueType, "Nullable only allows on value types.");
+
                 if (frame.Peek() == null)
                 {
                     frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -173,7 +173,10 @@ namespace System.Linq.Expressions
         /// <param name="type">The <see cref="Type"/> containing the field.</param>
         /// <param name="fieldName">The field to be accessed.</param>
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
-        public static MemberExpression Field(Expression? expression, Type type, string fieldName)
+        public static MemberExpression Field(
+            Expression? expression,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] Type type,
+            string fieldName)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.RequiresNotNull(fieldName, nameof(fieldName));
@@ -220,7 +223,10 @@ namespace System.Linq.Expressions
         /// <param name="type">The <see cref="Type"/> containing the property.</param>
         /// <param name="propertyName">The property to be accessed.</param>
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
-        public static MemberExpression Property(Expression? expression, Type type, string propertyName)
+        public static MemberExpression Property(
+            Expression? expression,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties| DynamicallyAccessedMemberTypes.NonPublicProperties)] Type type,
+            string propertyName)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.RequiresNotNull(propertyName, nameof(propertyName));

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -1162,7 +1162,11 @@ namespace System.Linq.Expressions
         /// <exception cref="ArgumentNullException">
         /// <paramref name="type"/> or <paramref name="methodName"/> is null.</exception>
         /// <exception cref="InvalidOperationException">No method whose name is <paramref name="methodName"/>, whose type parameters match <paramref name="typeArguments"/>, and whose parameter types match <paramref name="arguments"/> is found in <paramref name="type"/> or its base types.-or-More than one method whose name is <paramref name="methodName"/>, whose type parameters match <paramref name="typeArguments"/>, and whose parameter types match <paramref name="arguments"/> is found in <paramref name="type"/> or its base types.</exception>
-        public static MethodCallExpression Call(Type type, string methodName, Type[]? typeArguments, params Expression[]? arguments)
+        public static MethodCallExpression Call(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type,
+            string methodName,
+            Type[]? typeArguments,
+            params Expression[]? arguments)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             ContractUtils.RequiresNotNull(methodName, nameof(methodName));
@@ -1287,7 +1291,12 @@ namespace System.Linq.Expressions
             return ExpressionUtils.TryQuote(parameterType, ref argument);
         }
 
-        private static MethodInfo? FindMethod(Type type, string methodName, Type[]? typeArgs, Expression[] args, BindingFlags flags)
+        private static MethodInfo? FindMethod(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type,
+            string methodName,
+            Type[]? typeArgs,
+            Expression[] args,
+            BindingFlags flags)
         {
             int count = 0;
             MethodInfo? method = null;
@@ -1392,6 +1401,8 @@ namespace System.Linq.Expressions
         /// <paramref name="array"/> or <paramref name="indexes"/> is null.</exception>
         /// <exception cref="ArgumentException">
         /// <paramref name="array"/>.Type does not represent an array type.-or-The rank of <paramref name="array"/>.Type does not match the number of elements in <paramref name="indexes"/>.-or-The <see cref="Expression.Type"/> property of one or more elements of <paramref name="indexes"/> does not represent the <see cref="int"/> type.</exception>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "The Array 'Get' method is dynamically constructed and are not included in IL. It is not subject to trimming.")]
         public static MethodCallExpression ArrayIndex(Expression array, IEnumerable<Expression> indexes)
         {
             ExpressionUtils.RequiresCanRead(array, nameof(array), -1);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -178,7 +179,8 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="type">A <see cref="Type"/> that has a constructor that takes no arguments.</param>
         /// <returns>A <see cref="NewExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.New"/> and the <see cref="NewExpression.Constructor"/> property set to the <see cref="ConstructorInfo"/> that represents the parameterless constructor of the specified type.</returns>
-        public static NewExpression New(Type type)
+        public static NewExpression New(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
             if (type == typeof(void))

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -280,7 +280,8 @@ namespace System.Runtime.CompilerServices
         }
 
 #if FEATURE_COMPILE
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(UpdateDelegates))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "UpdateDelegates methods don't have ILLink annotations.")]
 #endif
         internal T MakeUpdateDelegate()
         {
@@ -355,6 +356,8 @@ namespace System.Runtime.CompilerServices
         }
 #endif
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "CallSiteOps methods don't have ILLink annotations.")]
         private T CreateCustomUpdateDelegate(MethodInfo invoke)
         {
             Type returnType = invoke.GetReturnType();

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -357,7 +357,7 @@ namespace System.Runtime.CompilerServices
 #endif
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-            Justification = "CallSiteOps methods don't have ILLink annotations.")]
+            Justification = "CallSiteOps methods don't have trimming annotations.")]
         private T CreateCustomUpdateDelegate(MethodInfo invoke)
         {
             Type returnType = invoke.GetReturnType();

--- a/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -180,6 +180,7 @@
     <Compile Include="TestExtensions\PerCompilationTypeAttribute.cs" />
     <Compile Include="TestExtensions\TestOrderer.cs" />
     <Compile Include="TestExtensions\TestOrderAttribute.cs" />
+    <Compile Include="TrimCompatibilityTests.cs" />
     <Compile Include="TypeBinary\TypeBinaryTests.cs" />
     <Compile Include="TypeBinary\TypeEqual.cs" />
     <Compile Include="TypeBinary\TypeIs.cs" />

--- a/src/libraries/System.Linq.Expressions/tests/TrimCompatibilityTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TrimCompatibilityTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public static class TrimCompatibilityTests
+    {
+        /// <summary>
+        /// Verifies that the below Types don't have any DynamicallyAccessedMembers attributes,
+        /// so we can safely call MakeGenericMethod on their methods.
+        /// </summary>
+        [Fact]
+        public static void VerifyMethodsCalledWithMakeGenericMethod()
+        {
+            Assembly linqExpressions = typeof(Expression).Assembly;
+            Type[] types = new Type[]
+            {
+                linqExpressions.GetType("System.Dynamic.Utils.DelegateHelpers"),
+                linqExpressions.GetType("System.Dynamic.UpdateDelegates"),
+                linqExpressions.GetType("System.Runtime.CompilerServices.CallSiteOps"),
+            };
+
+            foreach (Type type in types)
+            {
+                foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+                {
+                    Type[] genericTypes = method.GetGenericArguments();
+                    if (genericTypes != null)
+                    {
+                        foreach (Type genericType in genericTypes)
+                        {
+                            Assert.Null(genericType.GetCustomAttribute<DynamicallyAccessedMembersAttribute>());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #45623

This is just round 1. At least one more round will be made where we start annotating APIs as `RequiresUnreferencedCode`.