### PR TITLE
Change C# names of P/Invokes of objc_msgSend to be call-site specific.

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
@@ -28,8 +28,8 @@ internal static partial class Interop
         private static extern IntPtr objc_getClass(string className);
         [DllImport(Libraries.libobjc)]
         private static extern IntPtr sel_getUid(string selector);
-        [DllImport(Libraries.libobjc)]
-        private static extern IntPtr objc_msgSend(IntPtr basePtr, IntPtr selector);
+        [DllImport(Libraries.libobjc, EntryPoint = "objc_msgSend")]
+        private static extern IntPtr get_ProcessInfo(IntPtr basePtr, IntPtr selector);
 
         internal static Version GetOperatingSystemVersion()
         {
@@ -37,7 +37,7 @@ internal static partial class Interop
             int minor = 0;
             int patch = 0;
 
-            IntPtr processInfo = objc_msgSend(objc_getClass("NSProcessInfo"), sel_getUid("processInfo"));
+            IntPtr processInfo = get_ProcessInfo(objc_getClass("NSProcessInfo"), sel_getUid("processInfo"));
 
             if (processInfo != IntPtr.Zero)
             {

--- a/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
@@ -36,9 +36,9 @@ internal static partial class Interop
             if (processInfo != IntPtr.Zero)
             {
 #if TARGET_ARM64
-                NSOperatingSystemVersion osVersion = osversion_objc_msgSend(processInfo, sel_getUid("operatingSystemVersion"));
+                NSOperatingSystemVersion osVersion = NSOperatingSystemVersion_objc_msgSend(processInfo, sel_getUid("operatingSystemVersion"));
 #else
-                objc_msgSend_stret_rosversion(out NSOperatingSystemVersion osVersion, processInfo, sel_getUid("operatingSystemVersion"));
+                NSOperatingSystemVersion_objc_msgSend_stret(out NSOperatingSystemVersion osVersion, processInfo, sel_getUid("operatingSystemVersion"));
 #endif
                 checked
                 {
@@ -61,9 +61,9 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.libobjc, EntryPoint = "obj_msgSend")]
-        private static extern NSOperatingSystemVersion osversion_objc_msgSend(IntPtr basePtr, IntPtr selector);
+        private static extern NSOperatingSystemVersion NSOperatingSystemVersion_objc_msgSend(IntPtr basePtr, IntPtr selector);
 
         [DllImport(Libraries.libobjc, EntryPoint = "obj_msgSend_stret")]
-        private static extern void objc_msgSend_stret_rosversion(out NSOperatingSystemVersion osVersion, IntPtr basePtr, IntPtr selector);
+        private static extern void NSOperatingSystemVersion_objc_msgSend_stret(out NSOperatingSystemVersion osVersion, IntPtr basePtr, IntPtr selector);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
@@ -29,7 +29,7 @@ internal static partial class Interop
         [DllImport(Libraries.libobjc)]
         private static extern IntPtr sel_getUid(string selector);
         [DllImport(Libraries.libobjc, EntryPoint = "objc_msgSend")]
-        private static extern IntPtr get_ProcessInfo(IntPtr basePtr, IntPtr selector);
+        private static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector);
 
         internal static Version GetOperatingSystemVersion()
         {
@@ -37,7 +37,7 @@ internal static partial class Interop
             int minor = 0;
             int patch = 0;
 
-            IntPtr processInfo = get_ProcessInfo(objc_getClass("NSProcessInfo"), sel_getUid("processInfo"));
+            IntPtr processInfo = intptr_objc_msgSend(objc_getClass("NSProcessInfo"), sel_getUid("processInfo"));
 
             if (processInfo != IntPtr.Zero)
             {

--- a/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.libobjc.cs
@@ -60,10 +60,10 @@ internal static partial class Interop
             return new Version(major, minor, patch);
         }
 
-        [DllImport(Libraries.libobjc, EntryPoint = "obj_msgSend")]
+        [DllImport(Libraries.libobjc, EntryPoint = "objc_msgSend")]
         private static extern NSOperatingSystemVersion osversion_objc_msgSend(IntPtr basePtr, IntPtr selector);
 
-        [DllImport(Libraries.libobjc, EntryPoint = "obj_msgSend_stret")]
+        [DllImport(Libraries.libobjc, EntryPoint = "objc_msgSend_stret")]
         private static extern void objc_msgSend_stret_rosversion(out NSOperatingSystemVersion osVersion, IntPtr basePtr, IntPtr selector);
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
@@ -71,11 +71,10 @@ namespace System.Drawing
         {
             IntPtr graphicsContext = intptr_objc_msgSend(objc_getClass("NSGraphicsContext"), sel_registerName("currentContext"));
             IntPtr ctx = intptr_objc_msgSend(graphicsContext, sel_registerName("graphicsPort"));
-            Rect bounds = default;
 
             CGContextSaveGState(ctx);
 
-            void_objc_msgSend_stret_rrect(ref bounds, handle, sel_registerName("bounds"));
+            void_objc_msgSend_stret_rrect(out Rect bounds, handle, sel_registerName("bounds"));
 
             var isFlipped = bool_objc_msgSend(handle, sel_registerName("isFlipped"));
             if (isFlipped)
@@ -214,7 +213,7 @@ namespace System.Drawing
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
         public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend_stret")]
-        public static extern void void_objc_msgSend_stret_rrect(ref Rect arect, IntPtr basePtr, IntPtr selector);
+        public static extern void void_objc_msgSend_stret_rrect(out Rect arect, IntPtr basePtr, IntPtr selector);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
         [return:MarshalAs(UnmanagedType.U1)]
         public static extern bool bool_objc_msgSend(IntPtr handle, IntPtr selector);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
@@ -69,15 +69,15 @@ namespace System.Drawing
 
         internal static CocoaContext GetCGContextForNSView(IntPtr handle)
         {
-            IntPtr graphicsContext = objc_msgSend(objc_getClass("NSGraphicsContext"), sel_registerName("currentContext"));
-            IntPtr ctx = objc_msgSend(graphicsContext, sel_registerName("graphicsPort"));
+            IntPtr graphicsContext = get_currentContext(objc_getClass("NSGraphicsContext"), sel_registerName("currentContext"));
+            IntPtr ctx = get_graphicsPort(graphicsContext, sel_registerName("graphicsPort"));
             Rect bounds = default;
 
             CGContextSaveGState(ctx);
 
-            objc_msgSend_stret(ref bounds, handle, sel_registerName("bounds"));
+            get_bounds(ref bounds, handle, sel_registerName("bounds"));
 
-            var isFlipped = bool_objc_msgSend(handle, sel_registerName("isFlipped"));
+            var isFlipped = get_isFlipped(handle, sel_registerName("isFlipped"));
             if (isFlipped)
             {
                 CGContextTranslateCTM(ctx, bounds.origin.x, bounds.size.height);
@@ -211,14 +211,14 @@ namespace System.Drawing
         #region Cocoa Methods
         [DllImport("libobjc.dylib")]
         public static extern IntPtr objc_getClass(string className);
-        [DllImport("libobjc.dylib")]
-        public static extern IntPtr objc_msgSend(IntPtr basePtr, IntPtr selector, string argument);
-        [DllImport("libobjc.dylib")]
-        public static extern IntPtr objc_msgSend(IntPtr basePtr, IntPtr selector);
-        [DllImport("libobjc.dylib")]
-        public static extern void objc_msgSend_stret(ref Rect arect, IntPtr basePtr, IntPtr selector);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
-        public static extern bool bool_objc_msgSend(IntPtr handle, IntPtr selector);
+        public static extern IntPtr get_currentContext(IntPtr basePtr, IntPtr selector);
+        [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+        public static extern IntPtr get_graphicsPort(IntPtr basePtr, IntPtr selector);
+        [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend_stret")]
+        public static extern void get_bounds(ref Rect arect, IntPtr basePtr, IntPtr selector);
+        [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+        public static extern bool get_isFlipped(IntPtr handle, IntPtr selector);
         [DllImport("libobjc.dylib")]
         public static extern IntPtr sel_registerName(string selectorName);
         #endregion

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
@@ -69,15 +69,15 @@ namespace System.Drawing
 
         internal static CocoaContext GetCGContextForNSView(IntPtr handle)
         {
-            IntPtr graphicsContext = get_currentContext(objc_getClass("NSGraphicsContext"), sel_registerName("currentContext"));
-            IntPtr ctx = get_graphicsPort(graphicsContext, sel_registerName("graphicsPort"));
+            IntPtr graphicsContext = intptr_objc_msgSend(objc_getClass("NSGraphicsContext"), sel_registerName("currentContext"));
+            IntPtr ctx = intptr_objc_msgSend(graphicsContext, sel_registerName("graphicsPort"));
             Rect bounds = default;
 
             CGContextSaveGState(ctx);
 
-            get_bounds(ref bounds, handle, sel_registerName("bounds"));
+            void_objc_msgSend_stret_rrect(ref bounds, handle, sel_registerName("bounds"));
 
-            var isFlipped = get_isFlipped(handle, sel_registerName("isFlipped"));
+            var isFlipped = bool_objc_msgSend(handle, sel_registerName("isFlipped"));
             if (isFlipped)
             {
                 CGContextTranslateCTM(ctx, bounds.origin.x, bounds.size.height);
@@ -212,13 +212,12 @@ namespace System.Drawing
         [DllImport("libobjc.dylib")]
         public static extern IntPtr objc_getClass(string className);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
-        public static extern IntPtr get_currentContext(IntPtr basePtr, IntPtr selector);
-        [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
-        public static extern IntPtr get_graphicsPort(IntPtr basePtr, IntPtr selector);
+        public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend_stret")]
-        public static extern void get_bounds(ref Rect arect, IntPtr basePtr, IntPtr selector);
+        public static extern void void_objc_msgSend_stret_rrect(ref Rect arect, IntPtr basePtr, IntPtr selector);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
-        public static extern bool get_isFlipped(IntPtr handle, IntPtr selector);
+        [return:MarshalAs(UnmanagedType.U1)]
+        public static extern bool bool_objc_msgSend(IntPtr handle, IntPtr selector);
         [DllImport("libobjc.dylib")]
         public static extern IntPtr sel_registerName(string selectorName);
         #endregion

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
@@ -74,7 +74,7 @@ namespace System.Drawing
 
             CGContextSaveGState(ctx);
 
-            void_objc_msgSend_stret_rrect(out Rect bounds, handle, sel_registerName("bounds"));
+            Rect_objc_msgSend_stret(out Rect bounds, handle, sel_registerName("bounds"));
 
             var isFlipped = bool_objc_msgSend(handle, sel_registerName("isFlipped"));
             if (isFlipped)
@@ -213,7 +213,7 @@ namespace System.Drawing
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
         public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend_stret")]
-        public static extern void void_objc_msgSend_stret_rrect(out Rect arect, IntPtr basePtr, IntPtr selector);
+        public static extern void Rect_objc_msgSend_stret(out Rect arect, IntPtr basePtr, IntPtr selector);
         [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
         [return:MarshalAs(UnmanagedType.U1)]
         public static extern bool bool_objc_msgSend(IntPtr handle, IntPtr selector);


### PR DESCRIPTION
As requested in https://github.com/dotnet/runtime/pull/47592#discussion_r566486393, I've renamed all instances of objc_msgSend P/Invokes to have call-site specific names since objc_msgSend has callsite-specific signatures.