### PR TITLE
Fixes for SuperPMI collection of crossgen2

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -1204,8 +1204,19 @@ void MethodContext::recResolveToken(CORINFO_RESOLVED_TOKEN* pResolvedToken, DWOR
     key = SpmiRecordsHelper::CreateAgnostic_CORINFO_RESOLVED_TOKENin(pResolvedToken);
 
     ResolveTokenValue value;
-    value.tokenOut      = SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKENout(pResolvedToken, ResolveToken);
-    value.exceptionCode = (DWORD)exceptionCode;
+    if (exceptionCode != ERROR_SUCCESS)
+    {
+        // The output token memory might be corrupt or uninitialized, so just zero it out.
+        // (Set indexes to -1, indicating no buffer).
+        ZeroMemory(&value.tokenOut, sizeof(value.tokenOut));
+        value.tokenOut.pTypeSpec_Index   = (DWORD)-1;
+        value.tokenOut.pMethodSpec_Index = (DWORD)-1;
+    }
+    else
+    {
+        value.tokenOut = SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKENout(pResolvedToken, ResolveToken);
+    }
+    value.exceptionCode = exceptionCode;
 
     ResolveToken->Add(key, value);
     DEBUG_REC(dmpResolveToken(key, value));


### PR DESCRIPTION
1. Use superpmi.py parallelism (per assembly), not crossgen2 parallelism.
This is both faster, and it avoids a problem I was seeing of sharing
violations opening the method context file during collection.
2. Work around https://github.com/dotnet/runtime/issues/47554:
crossgen2 doesn't like EnableExtraSuperPmiQueries=1, so disable it
for crossgen2 collections.
3. Fix issue when `resolveToken` throws an exception: the resulting
resolved token structure could be corrupt (it was for crossgen2 in
a case I saw that led to SPMI crashing), so zero it out and record
that instead.

With this, there is only one crashing issue for collecting Core_Root
libraries (Windows x64 Checked), but there are 77835 compilation
failures on replay (see https://github.com/dotnet/runtime/issues/47540).