### PR TITLE
For Reverse P/Invokes, call TraceCall with the entrypoint to the target method.

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5447,14 +5447,14 @@ void F_CALL_CONV HCCALL3(JIT_ReversePInvokeEnterTrackTransitions, ReversePInvoke
         {
             // If we're in an IL stub, we want to trace the address of the target method,
             // not the next instruction in the stub.
-            JIT_ReversePInvokeEnterRare2(frame, pMD->IsILStub() && secretArg != NULL ? (void*)frame->pMD->GetMultiCallableAddrOfCode() : _ReturnAddress());
+            JIT_ReversePInvokeEnterRare2(frame, pMD->IsILStub() && secretArg != NULL ? (void*)((UMEntryThunk*)secretArg)->GetManagedTarget() : _ReturnAddress());
         }
     }
     else
     {
         // If we're in an IL stub, we want to trace the address of the target method,
         // not the next instruction in the stub.
-        JIT_ReversePInvokeEnterRare(frame, pMD->IsILStub() && secretArg != NULL ? (void*)frame->pMD->GetMultiCallableAddrOfCode() : _ReturnAddress());
+        JIT_ReversePInvokeEnterRare(frame, pMD->IsILStub() && secretArg != NULL ? (void*)((UMEntryThunk*)secretArg)->GetManagedTarget() : _ReturnAddress());
     }
 
 #ifndef FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5447,14 +5447,14 @@ void F_CALL_CONV HCCALL3(JIT_ReversePInvokeEnterTrackTransitions, ReversePInvoke
         {
             // If we're in an IL stub, we want to trace the address of the target method,
             // not the next instruction in the stub.
-            JIT_ReversePInvokeEnterRare2(frame, _ReturnAddress(), pMD->IsILStub() ? (UMEntryThunk*)secretArg : (UMEntryThunk*)NULL);
+            JIT_ReversePInvokeEnterRare2(frame, _ReturnAddress(), GetMethod(handle)->IsILStub() ? (UMEntryThunk*)secretArg : (UMEntryThunk*)NULL);
         }
     }
     else
     {
         // If we're in an IL stub, we want to trace the address of the target method,
         // not the next instruction in the stub.
-        JIT_ReversePInvokeEnterRare(frame, _ReturnAddress(), pMD->IsILStub() ? (UMEntryThunk*)secretArg  : (UMEntryThunk*)NULL);
+        JIT_ReversePInvokeEnterRare(frame, _ReturnAddress(), GetMethod(handle)->IsILStub() ? (UMEntryThunk*)secretArg  : (UMEntryThunk*)NULL);
     }
 
 #ifndef FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5445,12 +5445,16 @@ void F_CALL_CONV HCCALL3(JIT_ReversePInvokeEnterTrackTransitions, ReversePInvoke
         thread->m_fPreemptiveGCDisabled.StoreWithoutBarrier(1);
         if (g_TrapReturningThreads.LoadWithoutBarrier() != 0)
         {
-            JIT_ReversePInvokeEnterRare2(frame, _ReturnAddress());
+            // If we're in an IL stub, we want to trace the address of the target method,
+            // not the next instruction in the stub.
+            JIT_ReversePInvokeEnterRare2(frame, pMD->IsILStub() && secretArg != NULL ? (void*)frame->pMD->GetMultiCallableAddrOfCode() : _ReturnAddress());
         }
     }
     else
     {
-        JIT_ReversePInvokeEnterRare(frame, _ReturnAddress());
+        // If we're in an IL stub, we want to trace the address of the target method,
+        // not the next instruction in the stub.
+        JIT_ReversePInvokeEnterRare(frame, pMD->IsILStub() && secretArg != NULL ? (void*)frame->pMD->GetMultiCallableAddrOfCode() : _ReturnAddress());
     }
 
 #ifndef FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5389,7 +5389,7 @@ NOINLINE static void JIT_ReversePInvokeEnterRare(ReversePInvokeFrame* frame, voi
     // Increment/DecrementTraceCallCount() will bump
     // g_TrapReturningThreads for us.
     if (CORDebuggerTraceCall())
-        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)traceAddr);
+        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)returnAddr);
 #endif // DEBUGGING_SUPPORTED
 }
 
@@ -5403,7 +5403,7 @@ NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, vo
     // Increment/DecrementTraceCallCount() will bump
     // g_TrapReturningThreads for us.
     if (CORDebuggerTraceCall())
-        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)traceAddr);
+        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)returnAddr);
 #endif // DEBUGGING_SUPPORTED
 }
 

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5360,7 +5360,7 @@ EXCEPTION_HANDLER_DECL(FastNExportExceptHandler);
 #endif
 
 // This is a slower version of the reverse PInvoke enter function.
-NOINLINE static void JIT_ReversePInvokeEnterRare(ReversePInvokeFrame* frame, void* traceAddr)
+NOINLINE static void JIT_ReversePInvokeEnterRare(ReversePInvokeFrame* frame, void* returnAddr, UMEntryThunk* pThunk = NULL)
 {
     _ASSERTE(frame != NULL);
 
@@ -5389,11 +5389,11 @@ NOINLINE static void JIT_ReversePInvokeEnterRare(ReversePInvokeFrame* frame, voi
     // Increment/DecrementTraceCallCount() will bump
     // g_TrapReturningThreads for us.
     if (CORDebuggerTraceCall())
-        g_pDebugInterface->TraceCall((const BYTE*)traceAddr);
+        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)traceAddr);
 #endif // DEBUGGING_SUPPORTED
 }
 
-NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, void* traceAddr)
+NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, void* returnAddr, UMEntryThunk* pThunk = NULL)
 {
     frame->currentThread->RareDisablePreemptiveGC();
 #ifdef DEBUGGING_SUPPORTED
@@ -5403,7 +5403,7 @@ NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, vo
     // Increment/DecrementTraceCallCount() will bump
     // g_TrapReturningThreads for us.
     if (CORDebuggerTraceCall())
-        g_pDebugInterface->TraceCall((const BYTE*)traceAddr);
+        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)traceAddr);
 #endif // DEBUGGING_SUPPORTED
 }
 
@@ -5447,14 +5447,14 @@ void F_CALL_CONV HCCALL3(JIT_ReversePInvokeEnterTrackTransitions, ReversePInvoke
         {
             // If we're in an IL stub, we want to trace the address of the target method,
             // not the next instruction in the stub.
-            JIT_ReversePInvokeEnterRare2(frame, pMD->IsILStub() && secretArg != NULL ? (void*)((UMEntryThunk*)secretArg)->GetManagedTarget() : _ReturnAddress());
+            JIT_ReversePInvokeEnterRare2(frame, _ReturnAddress(), pMD->IsILStub() ? (UMEntryThunk*)secretArg : (UMEntryThunk*)NULL);
         }
     }
     else
     {
         // If we're in an IL stub, we want to trace the address of the target method,
         // not the next instruction in the stub.
-        JIT_ReversePInvokeEnterRare(frame, pMD->IsILStub() && secretArg != NULL ? (void*)((UMEntryThunk*)secretArg)->GetManagedTarget() : _ReturnAddress());
+        JIT_ReversePInvokeEnterRare(frame, _ReturnAddress(), pMD->IsILStub() ? (UMEntryThunk*)secretArg  : (UMEntryThunk*)NULL);
     }
 
 #ifndef FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12680,7 +12680,7 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
 
         // If we're a reverse IL stub, we need to use the TrackTransitions variant
         // so we have the target MethodDesc entrypoint to tell the debugger about.
-        if (CORProfilerTrackTransitions() || flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB))
+        if (CORProfilerTrackTransitions() || ftn->IsILStub())
         {
             flags.Set(CORJIT_FLAGS::CORJIT_FLAG_TRACK_TRANSITIONS);
         }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12677,7 +12677,10 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
             COMDelegate::ThrowIfInvalidUnmanagedCallersOnlyUsage(ftn);
 
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE);
-        if (CORProfilerTrackTransitions())
+
+        // If we're a reverse IL stub, we need to use the TrackTransitions variant
+        // so we have the target MethodDesc entrypoint to tell the debugger about.
+        if (CORProfilerTrackTransitions() || flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB))
         {
             flags.Set(CORJIT_FLAGS::CORJIT_FLAG_TRACK_TRANSITIONS);
         }


### PR DESCRIPTION
Since we're in an IL stub, we don't need to support breakpoints in the stub itself. The debugger will try to resolve the target method and move the breakpoint there. In actuality, that's the part that's failing. Somewhere in the ReversePInvoke helper call chain, we're touching the secret arg register. As a result, when the debugger tries to move the breakpoint, it crashes. By doing the same work ourselves, the debugger doesn't need to resolve the stub secret arg since it never sees a breakpoint in the stub itself.

Fixes #47421 
Fixes #47376 