### PR TITLE
[Bug Fixed] Modify the exception handling when reading the status of /proc/ (Issue: #47566)

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.TryReadStatusFile.cs
+++ b/src/libraries/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.TryReadStatusFile.cs
@@ -181,7 +181,7 @@ internal static partial class Interop
                     }
                 }
             }
-            catch (IOException)
+            catch (Exception ex) when (ex is IOException || ex.InnerException is IOException)
             {
                 contents = null;
                 return false;


### PR DESCRIPTION
Fixed a catch block that throws an exception when reading the state under ```/proc/```.

Fixes: #47566 