### PR TITLE
Fix number parsing with negative sign

### DIFF
--- a/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -350,7 +350,7 @@ namespace System.Globalization
             private static unsafe char* MatchNegativeSignChars(char* p, char* pEnd, string negativeSign, bool allowHyphenDuringParsing)
             {
                 char *ret = MatchChars(p, pEnd, negativeSign);
-                if (ret == null && allowHyphenDuringParsing && p <= pEnd && *p == '-')
+                if (ret == null && allowHyphenDuringParsing && p < pEnd && *p == '-')
                 {
                     ret = p + 1;
                 }

--- a/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -328,6 +329,35 @@ namespace System.Globalization
                 return null;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static unsafe bool AllowHyphenDuringParsing(NumberFormatInfo info)
+            {
+                string negativeSign = info.NegativeSign;
+                return negativeSign.Length == 1 &&
+                       negativeSign[0] switch {
+                           '\u2012' or         // Figure Dash
+                           '\u207B' or         // Superscript Minus
+                           '\u208B' or         // Subscript Minus
+                           '\u2212' or         // Minus Sign
+                           '\u2796' or         // Heavy Minus Sign
+                           '\uFE63' or         // Small Hyphen-Minus
+                           '\uFF0D' => true,   // Fullwidth Hyphen-Minus
+                           _ => false
+                       };
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static unsafe char* MatchNegativeSignChars(char* p, char* pEnd, string negativeSign, bool allowHyphenDuringParsing)
+            {
+                char *ret = MatchChars(p, pEnd, negativeSign);
+                if (ret == null && allowHyphenDuringParsing && p <= pEnd && *p == '-')
+                {
+                    ret = p + 1;
+                }
+
+                return ret;
+            }
+
             private static unsafe bool ParseNumber(ref char* str, char* strEnd, NumberStyles options, ref NumberBuffer number, StringBuilder? sb, NumberFormatInfo numfmt, bool parseDecimal)
             {
                 Debug.Assert(str != null);
@@ -345,7 +375,9 @@ namespace System.Globalization
                 number.sign = false;
                 string decSep;                  // Decimal separator from NumberFormatInfo.
                 string groupSep;                // Group separator from NumberFormatInfo.
-                string? currSymbol = null;       // Currency symbol from NumberFormatInfo.
+                string? currSymbol = null;      // Currency symbol from NumberFormatInfo.
+
+                bool allowHyphenDuringParsing = AllowHyphenDuringParsing(numfmt);
 
                 bool parsingCurrency = false;
                 if ((options & NumberStyles.AllowCurrencySymbol) != 0)
@@ -379,7 +411,7 @@ namespace System.Globalization
                     // "-Kr 1231.47" is legal but "- 1231.47" is not.
                     if (!IsWhite(ch) || (options & NumberStyles.AllowLeadingWhite) == 0 || ((state & StateSign) != 0 && ((state & StateCurrency) == 0 && numfmt.NumberNegativePattern != 2)))
                     {
-                        if ((((options & NumberStyles.AllowLeadingSign) != 0) && (state & StateSign) == 0) && ((next = MatchChars(p, strEnd, numfmt.PositiveSign)) != null || ((next = MatchChars(p, strEnd, numfmt.NegativeSign)) != null && (number.sign = true))))
+                        if ((((options & NumberStyles.AllowLeadingSign) != 0) && (state & StateSign) == 0) && ((next = MatchChars(p, strEnd, numfmt.PositiveSign)) != null || ((next = MatchNegativeSignChars(p, strEnd, numfmt.NegativeSign, allowHyphenDuringParsing)) != null && (number.sign = true))))
                         {
                             state |= StateSign;
                             p = next - 1;
@@ -475,7 +507,7 @@ namespace System.Globalization
                         {
                             ch = (p = next) < strEnd ? *p : '\0';
                         }
-                        else if ((next = MatchChars(p, strEnd, numfmt.NegativeSign)) != null)
+                        else if ((next = MatchNegativeSignChars(p, strEnd, numfmt.NegativeSign, allowHyphenDuringParsing)) != null)
                         {
                             ch = (p = next) < strEnd ? *p : '\0';
                             negExp = true;
@@ -512,7 +544,7 @@ namespace System.Globalization
                     {
                         if (!IsWhite(ch) || (options & NumberStyles.AllowTrailingWhite) == 0)
                         {
-                            if (((options & NumberStyles.AllowTrailingSign) != 0 && ((state & StateSign) == 0)) && ((next = MatchChars(p, strEnd, numfmt.PositiveSign)) != null || (((next = MatchChars(p, strEnd, numfmt.NegativeSign)) != null) && (number.sign = true))))
+                            if (((options & NumberStyles.AllowTrailingSign) != 0 && ((state & StateSign) == 0)) && ((next = MatchChars(p, strEnd, numfmt.PositiveSign)) != null || (((next = MatchNegativeSignChars(p, strEnd, numfmt.NegativeSign, allowHyphenDuringParsing)) != null) && (number.sign = true))))
                             {
                                 state |= StateSign;
                                 p = next - 1;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Globalization
 {
     /// <remarks>
@@ -73,8 +71,8 @@ namespace System.Globalization
 
         private bool _hasInvariantNumberSigns = true;
 
-        // When _allowHyphenDuringParsing is set to true, will allow the number parser to accept the hyphen `-` U+002D as a negative sign even if the culture
-        // negative sign is not the hyphen. Good example of that is Swedish culture (e.g. "sv-SE") which has U+2212 as negative sign.
+        // When _allowHyphenDuringParsing is set to true, we'll allow the number parser to accept the hyphen `-` U+002D as a negative sign even if the culture
+        // negative sign is not the hyphen. For example, the Swedish culture (e.g. "sv-SE") has U+2212 as the negative sign.
         private bool _allowHyphenDuringParsing;
 
         public NumberFormatInfo()
@@ -163,10 +161,13 @@ namespace System.Globalization
         internal bool HasInvariantNumberSigns => _hasInvariantNumberSigns;
         internal bool AllowHyphenDuringParsing => _allowHyphenDuringParsing;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void InitializeInvariantAndNegativeSignFlags()
         {
             _hasInvariantNumberSigns = _positiveSign == "+" && _negativeSign == "-";
+
+            // The list of the Minus characters are picked up from the CLDR parse lenient data.
+            // e.g. https://github.com/unicode-org/cldr/blob/feb602b06bd18ba7333464bd648b68292e8aa54d/common/main/sw.xml#L1001
+
             _allowHyphenDuringParsing = _negativeSign.Length == 1 &&
                                         _negativeSign[0] switch {
                                             '\u2012' or         // Figure Dash

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -1757,7 +1757,7 @@ namespace System
             return ParsingStatus.OK;
         }
 
-        internal static bool SpanStartsWith(ReadOnlySpan<char> span, char c) => span.Length > 0 && span[0] == c;
+        internal static bool SpanStartsWith(ReadOnlySpan<char> span, char c) => !span.IsEmpty && span[0] == c;
 
         internal static unsafe bool TryParseDouble(ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out double result)
         {
@@ -2003,7 +2003,7 @@ namespace System
         private static unsafe char* MatchNegativeSignChars(char* p, char* pEnd, NumberFormatInfo info)
         {
             char *ret = MatchChars(p, pEnd, info.NegativeSign);
-            if (ret == null && info.AllowHyphenDuringParsing && p <= pEnd && *p == '-')
+            if (ret == null && info.AllowHyphenDuringParsing && p < pEnd && *p == '-')
             {
                 ret = p + 1;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -295,7 +295,7 @@ namespace System
                 // "-Kr 1231.47" is legal but "- 1231.47" is not.
                 if (!IsWhite(ch) || (styles & NumberStyles.AllowLeadingWhite) == 0 || ((state & StateSign) != 0 && ((state & StateCurrency) == 0 && info.NumberNegativePattern != 2)))
                 {
-                    if ((((styles & NumberStyles.AllowLeadingSign) != 0) && (state & StateSign) == 0) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || ((next = MatchChars(p, strEnd, info.NegativeSign)) != null && (number.IsNegative = true))))
+                    if ((((styles & NumberStyles.AllowLeadingSign) != 0) && (state & StateSign) == 0) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || ((next = MatchNegativeSignChars(p, strEnd, info)) != null && (number.IsNegative = true))))
                     {
                         state |= StateSign;
                         p = next - 1;
@@ -393,7 +393,7 @@ namespace System
                     {
                         ch = (p = next) < strEnd ? *p : '\0';
                     }
-                    else if ((next = MatchChars(p, strEnd, info._negativeSign)) != null)
+                    else if ((next = MatchNegativeSignChars(p, strEnd, info)) != null)
                     {
                         ch = (p = next) < strEnd ? *p : '\0';
                         negExp = true;
@@ -430,7 +430,7 @@ namespace System
                 {
                     if (!IsWhite(ch) || (styles & NumberStyles.AllowTrailingWhite) == 0)
                     {
-                        if ((styles & NumberStyles.AllowTrailingSign) != 0 && ((state & StateSign) == 0) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || (((next = MatchChars(p, strEnd, info.NegativeSign)) != null) && (number.IsNegative = true))))
+                        if ((styles & NumberStyles.AllowTrailingSign) != 0 && ((state & StateSign) == 0) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || (((next = MatchNegativeSignChars(p, strEnd, info)) != null) && (number.IsNegative = true))))
                         {
                             state |= StateSign;
                             p = next - 1;
@@ -554,6 +554,14 @@ namespace System
                             goto FalseExit;
                         num = value[index];
                     }
+                }
+                else if (info.AllowHyphenDuringParsing && num == '-')
+                {
+                    sign = -1;
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
                 }
                 else
                 {
@@ -725,6 +733,14 @@ namespace System
                             goto FalseExit;
                         num = value[index];
                     }
+                }
+                else if (info.AllowHyphenDuringParsing && num == '-')
+                {
+                    sign = -1;
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
                 }
                 else
                 {
@@ -969,6 +985,14 @@ namespace System
                             goto FalseExit;
                         num = value[index];
                     }
+                }
+                else if (info.AllowHyphenDuringParsing && num == '-')
+                {
+                    overflow = true;
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
                 }
                 else
                 {
@@ -1297,6 +1321,14 @@ namespace System
                             goto FalseExit;
                         num = value[index];
                     }
+                }
+                else if (info.AllowHyphenDuringParsing && num == '-')
+                {
+                    overflow = true;
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
                 }
                 else
                 {
@@ -1725,6 +1757,8 @@ namespace System
             return ParsingStatus.OK;
         }
 
+        internal static bool SpanStartsWith(ReadOnlySpan<char> span, char c) => span.Length > 0 && span[0] == c;
+
         internal static unsafe bool TryParseDouble(ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out double result)
         {
             byte* pDigits = stackalloc byte[DoubleNumberBufferLength];
@@ -1768,8 +1802,8 @@ namespace System
                         return false;
                     }
                 }
-                else if (valueTrim.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
-                        valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                else if ((valueTrim.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) && valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol)) ||
+                        (info.AllowHyphenDuringParsing && SpanStartsWith(valueTrim, '-') && valueTrim.Slice(1).EqualsOrdinalIgnoreCase(info.NaNSymbol)))
                 {
                     result = double.NaN;
                 }
@@ -1840,6 +1874,11 @@ namespace System
                 {
                     result = Half.NaN;
                 }
+                else if (info.AllowHyphenDuringParsing && SpanStartsWith(valueTrim, '-') && !info.NaNSymbol.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
+                         !info.NaNSymbol.StartsWith('-') && valueTrim.Slice(1).EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                {
+                    result = Half.NaN;
+                }
                 else
                 {
                     result = (Half)0;
@@ -1907,6 +1946,11 @@ namespace System
                 {
                     result = float.NaN;
                 }
+                else if (info.AllowHyphenDuringParsing && SpanStartsWith(valueTrim, '-') && !info.NaNSymbol.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
+                         !info.NaNSymbol.StartsWith('-') && valueTrim.Slice(1).EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                {
+                    result = float.NaN;
+                }
                 else
                 {
                     result = 0;
@@ -1954,6 +1998,18 @@ namespace System
         }
 
         private static bool IsSpaceReplacingChar(char c) => c == '\u00a0' || c == '\u202f';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe char* MatchNegativeSignChars(char* p, char* pEnd, NumberFormatInfo info)
+        {
+            char *ret = MatchChars(p, pEnd, info.NegativeSign);
+            if (ret == null && info.AllowHyphenDuringParsing && p <= pEnd && *p == '-')
+            {
+                ret = p + 1;
+            }
+
+            return ret;
+        }
 
         private static unsafe char* MatchChars(char* p, char* pEnd, string value)
         {

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -713,5 +713,14 @@ namespace System.Tests
             double result = double.Parse(value.ToString("R"));
             Assert.Equal(BitConverter.DoubleToInt64Bits(value), BitConverter.DoubleToInt64Bits(result));
         }
+
+        [Fact]
+        public static void TestNegativeNumberParsingWithHyphen()
+        {
+            // CLDR data for Swedish culture has negative sign U+2212. This test ensure parsing with the hyphen with such cultures will succeed.
+            CultureInfo ci = CultureInfo.GetCultureInfo("sv-SE");
+            string s = string.Format(ci, "{0}", 158.68);
+            Assert.Equal(-158.68, double.Parse("-" + s, NumberStyles.Number, ci));
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.cs
@@ -834,5 +834,13 @@ namespace System.Tests
                 Assert.Equal(expected.ToLowerInvariant(), new string(actual));
             }
         }
+
+        [Fact]
+        public static void TestNegativeNumberParsingWithHyphen()
+        {
+            // CLDR data for Swedish culture has negative sign U+2212. This test ensure parsing with the hyphen with such cultures will succeed.
+            CultureInfo ci = CultureInfo.GetCultureInfo("sv-SE");
+            Assert.Equal(-158, int.Parse("-158", NumberStyles.Integer, ci));
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.cs
@@ -842,5 +842,29 @@ namespace System.Tests
             CultureInfo ci = CultureInfo.GetCultureInfo("sv-SE");
             Assert.Equal(-158, int.Parse("-158", NumberStyles.Integer, ci));
         }
+
+        [Fact]
+        public static void TestParseLenientData()
+        {
+            NumberFormatInfo nfi = new CultureInfo("en-US").NumberFormat;
+
+            string [] negativeSigns = new string []
+            {
+                "\u2012", // Figure Dash
+                "\u207B", // Superscript Minus
+                "\u208B", // Subscript Minus
+                "\u2212", // Minus Sign
+                "\u2796", // Heavy Minus Sign
+                "\uFE63", // Small Hyphen-Minus
+            };
+
+            foreach (string negativeSign in negativeSigns)
+            {
+                nfi.NegativeSign = negativeSign;
+                Assert.Equal(negativeSign, nfi.NegativeSign);
+                Assert.Equal(-9670, int.Parse("-9670", NumberStyles.Integer, nfi));
+            }
+        }
+
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.cs
@@ -439,5 +439,13 @@ namespace System.Tests
                 Assert.Equal(expected.ToLowerInvariant(), new string(actual));
             }
         }
+
+        [Fact]
+        public static void TestNegativeNumberParsingWithHyphen()
+        {
+            // CLDR data for Swedish culture has negative sign U+2212. This test ensure parsing with the hyphen with such cultures will succeed.
+            CultureInfo ci = CultureInfo.GetCultureInfo("sv-SE");
+            Assert.Equal(-15868, long.Parse("-15868", NumberStyles.Number, ci));
+        }
     }
 }


### PR DESCRIPTION
Fixes #47524

This change allow parsing negative numbers written with the hyphen character `-` when using cultures with negative sign not hyphen but it is one of the alternative Unicode minus sign characters. 
I have done some basic perf testing with this change and didn't notice any noticeable change.