### PR TITLE
Fix for Crossgen2 crash in SuperPMI compilation (issue #47554)

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2889,6 +2889,13 @@ void Compiler::makeExtraStructQueries(CORINFO_CLASS_HANDLE structHandle, int lev
     }
     assert(structHandle != NO_CLASS_HANDLE);
     (void)typGetObjLayout(structHandle);
+    DWORD typeFlags = info.compCompHnd->getClassAttribs(structHandle);
+    if (StructHasNoPromotionFlagSet(typeFlags))
+    {
+        // In AOT ReadyToRun compilation, don't query fields of types
+        // outside of the current version bubble.
+        return;
+    }
     unsigned fieldCnt = info.compCompHnd->getClassNumInstanceFields(structHandle);
     impNormStructType(structHandle);
 #ifdef TARGET_ARMARCH


### PR DESCRIPTION
Based on Andy's advice I propose to harden makeExtraStructQueries
against drilling into types outside of the current compilation
version bubble similar to what we're already doing when promoting
struct fields. I have locally verified that it fixes the crash
Bruce described in the issue.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/47554

/cc @dotnet/crossgen-contrib, @dotnet/jit-contrib