### PR TITLE
Dispose of ClientWebSocket when it fails to connect

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -33,6 +33,12 @@ namespace System.Net.WebSockets.Client.Tests
                 }
                 Assert.Equal(WebSocketState.Closed, cws.State);
                 Assert.Equal(exceptionMessage, ex.Message);
+
+                // Other operations throw after failed connect
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => cws.ReceiveAsync(new byte[1], default));
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => cws.SendAsync(new byte[1], WebSocketMessageType.Binary, true, default));
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => cws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, default));
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => cws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, default));
             }
         }
 


### PR DESCRIPTION
Somehow when it was ported to .NET Core, the transition from connecting to connected was switched to being done before the connect rather than after.  As a result, if the connection fails and the websocket is never initialized, subsequent use (misuse) ends up null ref'ing.  This restores the .NET Framework behavior, which was to dispose of the instance if the connect fails; subsequent operations then throw ObjectDisposedException.

Fixes https://github.com/dotnet/runtime/issues/47582