### PR TITLE
[release/5.0] Take SuppressGCTransition into account in IL stub caching

### DIFF
--- a/src/coreclr/src/vm/dllimport.h
+++ b/src/coreclr/src/vm/dllimport.h
@@ -150,7 +150,8 @@ enum NDirectStubFlags
 #ifdef FEATURE_COMINTEROP
     NDIRECTSTUB_FL_FIELDGETTER              = 0x00002000, // COM->CLR field getter
     NDIRECTSTUB_FL_FIELDSETTER              = 0x00004000, // COM->CLR field setter
-    // unused                               = 0x00008000,
+#endif // FEATURE_COMINTEROP
+    NDIRECTSTUB_FL_SUPPRESSGCTRANSITION     = 0x00008000,
     // unused                               = 0x00010000,
     // unused                               = 0x00020000,
     // unused                               = 0x00080000,
@@ -158,7 +159,6 @@ enum NDirectStubFlags
     // unused                               = 0x00200000,
     // unused                               = 0x00400000,
     // unused                               = 0x00800000,
-#endif // FEATURE_COMINTEROP
 
     // internal flags -- these won't ever show up in an NDirectStubHashBlob
     NDIRECTSTUB_FL_FOR_NUMPARAMBYTES        = 0x10000000,   // do just enough to return the right value from Marshal.NumParamBytes

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionNative.cpp
@@ -21,3 +21,15 @@ BOOL DLL_EXPORT NextUInt(/* out */ uint32_t *n)
     *n = (++_n);
     return TRUE;
 }
+
+typedef int (STDMETHODVCALLTYPE *CALLBACKPROC)(int n);
+
+extern "C"
+BOOL DLL_EXPORT STDMETHODVCALLTYPE InvokeCallback(CALLBACKPROC cb, int* n)
+{
+    if (cb == nullptr || n == nullptr)
+        return FALSE;
+
+    *n = cb((++_n));
+    return TRUE;
+}

--- a/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
+++ b/src/tests/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
@@ -24,6 +24,34 @@ static class SuppressGCTransitionNative
     [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "NextUInt")]
     public static extern unsafe bool NextUInt_NoInline_GCTransition(int* n);
 
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe int InvokeCallbackFuncPtr_Inline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe int InvokeCallbackFuncPtr_Inline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe int InvokeCallbackVoidPtr_Inline_NoGCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe int InvokeCallbackVoidPtr_Inline_GCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_NoGCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_GCTransition(void* cb, int* n);
+
     public static IntPtr GetNextUIntFunctionPointer()
     {
         IntPtr mod = GetNativeLibrary();
@@ -146,8 +174,79 @@ unsafe class SuppressGCTransitionTest
         Assert.AreEqual(expected, n);
         return n + 1;
     }
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static int ReturnInt(int value)
+    {
+        return value;
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int ILStubCache_NoGCTransition_GCTransition(int expected)
+    {
+        // This test uses a callback marked UnmanagedCallersOnly as a way to verify that
+        // SuppressGCTransition is taken into account when caching IL stubs.
+        // It calls functions with the same signature, differing only in SuppressGCTransition.
+        // When calling an UnmanagedCallersOnly method, the runtime validates that the GC is in
+        // pre-emptive mode. If not, it throws a fatal error that cannot be caught and crashes.
+        // If the stub for the p/invoke with the transition suppressed is incorrectly reused for
+        // the p/invoke without the suppression, invoking the callback would produce a fatal error.
+        Console.WriteLine($"{nameof(ILStubCache_NoGCTransition_GCTransition)} ({expected}) ...");
 
-    public static int Main()
+        int n;
+
+        // Call function that has SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_Inline_NoGCTransition(null, null);
+
+        // Call function with same (blittable) signature, but without SuppressGCTransition.
+        // IL stub should not be re-used, GC transition should occur, and callback should be invoked.
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_Inline_GCTransition(&ReturnInt, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function that has SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_NoInline_NoGCTransition(null, null);
+
+        // Call function with same (non-blittable) signature, but without SuppressGCTransition
+        // IL stub should not be re-used, GC transition should occur, and callback should be invoked.
+        SuppressGCTransitionNative.InvokeCallbackFuncPtr_NoInline_GCTransition(&ReturnInt, &n);
+        Assert.AreEqual(expected++, n);
+
+        return n + 1;
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int ILStubCache_GCTransition_NoGCTransition(int expected)
+    {
+        // This test uses a callback marked UnmanagedCallersOnly as a way to verify that
+        // SuppressGCTransition is taken into account when caching IL stubs.
+        // It calls functions with the same signature, differing only in SuppressGCTransition.
+        // When calling an UnmanagedCallersOnly method, the runtime validates that the GC is in
+        // pre-emptive mode. If not, it throws a fatal error that cannot be caught and crashes.
+        Console.WriteLine($"{nameof(ILStubCache_GCTransition_NoGCTransition)} ({expected}) ...");
+
+        int n;
+
+        void* cb = (delegate* unmanaged[Cdecl]<int, int>)&ReturnInt;
+
+        // Call function that does not have SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_GCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function with same (blittable) signature, but with SuppressGCTransition.
+        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_NoGCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function that does not have SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_GCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        // Call function with same (non-blittable) signature, but with SuppressGCTransition
+        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
+        expected = n + 1;
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_NoGCTransition(cb, &n);
+        Assert.AreEqual(expected++, n);
+
+        return n + 1;
+    }
+    public static int Main(string[] args)
     {
         try
         {
@@ -159,6 +258,13 @@ unsafe class SuppressGCTransitionTest
             n = Mixed(n);
             n = Mixed_TightLoop(n);
             n = CallAsFunctionPointer(n);
+            n = ILStubCache_NoGCTransition_GCTransition(n);
+
+            if (args.Length != 0 && args[0].Equals("ILStubCache", StringComparison.OrdinalIgnoreCase))
+            {
+                // This test intentionally results in a fatal error, so only run when manually specified
+                n = ILStubCache_GCTransition_NoGCTransition(n);
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Issue: #46184
Fix in master: #47320

This is a stripped down version of the fix that went into master and the change it depended on: adds the `NDIRECTSTUB_FL_SUPPRESSGCTRANSITION` flag, updates the P/Invoke stub flags based on `SuppressGCTransition`, and uses the updated flags in the IL stub cache.

## Customer Impact

When this issue results in the runtime suppressing the GC transition for P/Invokes that should not have them suppressed, users may hit GC starvation, data corruption, or runtime termination. When the runtime doesn't suppress the transition when it should, users will miss getting the performance benefits expected from suppressing the transition.

This is difficult to diagnose and does not have a reasonable workaround (only options would be to never use `SuppressGCTransition` or to re-work P/Invokes such that they do not have the same signature).

Example based on the customer-reported issue:
```C#
private class NativeLib
{
    [SuppressGCTransition]
    [DllImport(nameof(NativeLib), CallingConvention = CallingConvention.Cdecl)]
    public static extern bool set_callback(void* callback);

    [DllImport(nameof(NativeLib), CallingConvention = CallingConvention.Cdecl)]
    public static extern bool invoke_callback(void* args);
}

[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
private static void Callback(IntPtr args) { ... }

static void Main(string[] _)
{
    NativeLib.set_callback((delegate* unmanaged[Cdecl]<IntPtr, void>)&Callback);

    // IL stub from set_callback is reused. GC transition is suppressed. Fatal error occurs trying to invoke callback. 
    NativeLib.invoke_callback(IntPtr.Zero.ToPointer());
}
```
```C++
typedef void (__cdecl *CALLBACK_FN)(void *args);
CALLBACK_FN g_cb;

extern "C" BOOL __declspec(dllexport) set_callback(CALLBACK_FN cb)
{
    g_cb = cb;
    return TRUE;
}

extern "C" BOOL __declspec(dllexport) invoke_callback(void* args)
{
    if (g_cb == nullptr)
        return FALSE;

    g_cb(args);
    return TRUE;
}
```
## Testing
Tests added to verify that P/Invokes with the same signature, differing only in `SuppressGCTransition`, do not re-use the same IL stub.

## Risk
This is a fairly targeted fix, but it does affect IL stub caching and the stub flags used during generation,

## Regression
No. `SuppressGCTransition` was introduced in 5.0.