### PR TITLE
Fix some valgrind warnings about jumps based on uninitialized values.

### DIFF
--- a/src/coreclr/binder/assemblyname.cpp
+++ b/src/coreclr/binder/assemblyname.cpp
@@ -141,7 +141,7 @@ namespace BINDER_SPACE
         }
 
         // Set public key and/or public key token (if we have it)
-        if (pvPublicKeyToken && dwPublicKeyToken)
+        if (dwPublicKeyToken && pvPublicKeyToken)
         {
             SBuffer publicKeyOrTokenBLOB((const BYTE *) pvPublicKeyToken, dwPublicKeyToken);
 

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -2600,6 +2600,7 @@ CPalThread::FreeSignalAlternateStack()
         // ss_size is >= MINSIGSTKSZ even in this case.
         ss.ss_size = MINSIGSTKSZ;
         ss.ss_flags = SS_DISABLE;
+        ss.ss_sp = NULL;
         int st = sigaltstack(&ss, &oss);
         if ((st == 0) && (oss.ss_flags != SS_DISABLE))
         {

--- a/src/coreclr/vm/amd64/gmsamd64.cpp
+++ b/src/coreclr/vm/amd64/gmsamd64.cpp
@@ -22,7 +22,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     }
     CONTRACTL_END;
 
-    CONTEXT                         ctx;
+    CONTEXT                         ctx = { 0 };
     KNONVOLATILE_CONTEXT_POINTERS   nonVolRegPtrs;
 
     ctx.Rip = baseState->m_CaptureRip;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46905

@janvorli ptal.