### PR TITLE
Add SZArrayHelper to CoreCLR linker descriptor

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLinkTrim.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLinkTrim.xml
@@ -24,5 +24,10 @@
     <type fullname="System.Collections.Generic.IReadOnlyCollection`1" />
     <type fullname="System.Collections.Generic.IList`1" />
     <type fullname="System.Collections.Generic.IReadOnlyList`1" />
+
+    <!-- Indicator for illink that all instance methods are instantiated -->
+    <type fullname="System.SZArrayHelper">
+      <method name=".ctor" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
It's strictly speaking not required but the type is handled by
JIT specially and illink would need to recognize this one of case.