### PR TITLE
Fix for small bug in the profile statistics writer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -282,7 +282,7 @@ namespace ILCompiler.DependencyAnalysis
                     EmitObjectData(r2rPeBuilder, nodeContents, nodeIndex, name, node.Section);
                     lastWrittenObjectNode = node;
 
-                    if ((_generatePdbFile || _generatePerfMapFile) && node is MethodWithGCInfo methodNode)
+                    if (_outputInfoBuilder != null && node is MethodWithGCInfo methodNode)
                     {
                         _outputInfoBuilder.AddMethod(methodNode, nodeContents.DefinedSymbols[0]);
                     }


### PR DESCRIPTION
During my experimentation with callchain optimizations I noticed
that the profile map only contains meaningful information when
we're generating PDB or PerfMap at the same time - apparently I
had the PDB generation turned on during debugging so I overlooked
this.

Thanks

Tomas

/cc @dotnet/crossgen-contrib