### PR TITLE
[release/5.0] Support Async DNS lookup on older Windows from impersonificated conte…

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoExW.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoExW.cs
@@ -11,6 +11,8 @@ internal static partial class Interop
 {
     internal static partial class Winsock
     {
+        internal const int WSA_E_CANCELLED = 10111;
+
         internal const string GetAddrInfoExCancelFunctionName = "GetAddrInfoExCancel";
 
         internal const int NS_ALL = 0;

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -166,14 +166,13 @@ namespace System.Net
             SocketError errorCode = (SocketError)Interop.Winsock.GetAddrInfoExW(
                 hostName, null, Interop.Winsock.NS_ALL, IntPtr.Zero, &hints, &context->Result, IntPtr.Zero, &context->Overlapped, s_getAddrInfoExCallback, &context->CancelHandle);
 
-
-            if (errorCode == SocketError.TryAgain)
+            if (errorCode == SocketError.TryAgain || (int)errorCode == Interop.Winsock.WSA_E_CANCELLED)
             {
                 // WSATRY_AGAIN indicates possible problem with reachability according to docs.
                 // However, if servers are really unreachable, we would still get IOPending here
                 // and final result would be posted via overlapped IO.
                 // synchronous failure here may signal issue when GetAddrInfoExW does not work from
-                // impersonated context.
+                // impersonated context. Windows 8 and Server 2012 fail for same reason with different errorCode.
                 GetAddrInfoExContext.FreeContext(context);
                 return null;
             }

--- a/src/libraries/System.Security.Principal.Windows/tests/WindowsIdentityImpersonatedTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Principal.Windows/tests/WindowsIdentityImpersonatedTests.netcoreapp.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Principal;
@@ -56,6 +58,42 @@ public class WindowsIdentityImpersonatedTests : IClassFixture<WindowsIdentityFix
             Assert.Equal(_fixture.TestAccount.AccountName, WindowsIdentity.GetCurrent().Name);
             Assert.NotEqual(currentWindowsIdentity.Name, WindowsIdentity.GetCurrent().Name);
         }
+    }
+
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+    [OuterLoop]
+    public void RunImpersonated_NameResolution()
+    {
+        WindowsIdentity currentWindowsIdentity = WindowsIdentity.GetCurrent();
+
+        WindowsIdentity.RunImpersonated(_fixture.TestAccount.AccountTokenHandle, () =>
+        {
+            Assert.Equal(_fixture.TestAccount.AccountName, WindowsIdentity.GetCurrent().Name);
+
+            IPAddress[] a1 = Dns.GetHostAddressesAsync("").GetAwaiter().GetResult();
+            IPAddress[] a2 = Dns.GetHostAddresses("");
+
+            Assert.True(a1.Length > 0);
+            Assert.True(a1.SequenceEqual(a2));
+        });
+    }
+
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+    [OuterLoop]
+    public async Task RunImpersonatedAsync_NameResolution()
+    {
+        WindowsIdentity currentWindowsIdentity = WindowsIdentity.GetCurrent();
+
+        await WindowsIdentity.RunImpersonatedAsync(_fixture.TestAccount.AccountTokenHandle, async () =>
+        {
+            Assert.Equal(_fixture.TestAccount.AccountName, WindowsIdentity.GetCurrent().Name);
+
+            IPAddress[] a1 = await Dns.GetHostAddressesAsync("");
+            IPAddress[] a2 = Dns.GetHostAddresses("");
+
+            Assert.True(a1.Length > 0);
+            Assert.True(a1.SequenceEqual(a2));
+        });
     }
 }
 


### PR DESCRIPTION
Fixes #45165

Technically this is continuation of #29935 which we fixed in 5.0.3 (PR #46897) and turned out to be only partial fix. This issue is specific to Win8 and Win 2012 (as reported in #45165).
The original issue #29935 didn't have test (because we didn't know how), but we came up with idea later. The test discovered the same problem on Win8 and Win 2012 as the reported issue #45165.

## Customer Impact

Asynchronous name resolution and services depending on that (like HttpClient) do not work when running from impersonate context on Win8 and Win 2012 (ie . user other than owner of the process)
At least 1 customer hit this on Win 2012 in #45165.
The issue has been present for some time, but is now blocking migration from Framework to .NET Core.

## Regression?

Yes. This works in .NET Framework and was broken in .NET Core 2.1 by https://github.com/dotnet/corefx/pull/26850 when we began supporting async name resolution. As part of this we changed to use GetAddrInfoExW which has a bug in that it does not flow the impersonated token.
We worked around the OS bug in #29935, but we missed the case for Win8 and Win 2012, which we are fixing in this PR.

## Testing

Added 2 automated tests to cover NameResolution from impersonificated context.

#### Performance

This only adds one more error code check to existing code. No neccesary.

## Risk

Small. The fix is to retry synchronous API on thread pool if async resolution fails with certain error codes.
The logic already exists, we are just using it for more OS error codes.