### PR TITLE
[wasm] Don't use MAP_32BIT, its not needed and newer emscripten versions don't define it.

### DIFF
--- a/src/mono/mono/utils/mono-mmap-wasm.c
+++ b/src/mono/mono/utils/mono-mmap-wasm.c
@@ -190,8 +190,6 @@ mono_file_map (size_t length, int flags, int fd, guint64 offset, void **ret_hand
 		mflags |= MAP_SHARED;
 	if (flags & MONO_MMAP_FIXED)
 		mflags |= MAP_FIXED;
-	if (flags & MONO_MMAP_32BIT)
-		mflags |= MAP_32BIT;
 
 	if (length == 0)
 		/* emscripten throws an exception on 0 length */


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20809,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>