### PR TITLE
Handle NativeLibrary.GetExport/Free on libs not loaded through NativeLibrary.*Load* on Mono.

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/IconTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/IconTests.cs
@@ -500,7 +500,7 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34591", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47759", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void Save_NullOutputStreamNoIconData_ThrowsArgumentNullException()
         {
             using (var source = new Icon(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico")))
@@ -526,6 +526,7 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47759", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Save_ClosedOutputStreamNoIconData_DoesNothing()
         {
@@ -688,7 +689,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34591", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47759", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void FromHandle_IconHandleOneTime_Success()
         {
             using (var icon1 = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
@@ -701,7 +702,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34591", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47759", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void FromHandle_IconHandleMultipleTime_Success()
         {
             using (var icon1 = new Icon(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico")))
@@ -722,7 +723,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34591", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47759", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void FromHandle_BitmapHandleOneTime_Success()
         {
             IntPtr handle;
@@ -739,7 +740,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34591", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47759", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void FromHandle_BitmapHandleMultipleTime_Success()
         {
             IntPtr handle;

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -1578,16 +1578,19 @@ ves_icall_System_Runtime_InteropServices_NativeLibrary_FreeLib (gpointer lib, Mo
 	native_library_lock ();
 
 	module = netcore_handle_lookup (lib);
-	if (!module)
-		goto leave;
+	if (module) {
+		ref_count = mono_refcount_dec (module);
+		if (ref_count > 0)
+			goto leave;
 
-	ref_count = mono_refcount_dec (module);
-	if (ref_count > 0)
-		goto leave;
-
-	g_hash_table_remove (native_library_module_map, module->handle);
-	g_hash_table_add (native_library_module_blocklist, module);
-	mono_dl_close (module);
+		g_hash_table_remove (native_library_module_map, module->handle);
+		g_hash_table_add (native_library_module_blocklist, module);
+		mono_dl_close (module);
+	} else {
+		MonoDl raw_module = { 0 };
+		raw_module.handle = lib;
+		mono_dl_close (&raw_module);
+	}
 
 leave:
 	native_library_unlock ();
@@ -1610,28 +1613,18 @@ ves_icall_System_Runtime_InteropServices_NativeLibrary_GetSymbol (gpointer lib, 
 	native_library_lock ();
 
 	module = netcore_handle_lookup (lib);
-	if (!module) {
-#ifdef HOST_WIN32
-		// netcore calls NativeLibrary.GetExport on Windows system libraries loaded directly using Interop.Kernel32.LoadLibraryEx.
-		// Fallback accepting NativeLibrary.GetExport calls on libraries loaded directly by Interop.Kernel32.LoadLibraryEx.
-		// https://github.com/dotnet/runtime/pull/47013.
-		symbol = GetProcAddress ((HMODULE)lib, symbol_name);
-		if (!symbol)
-			mono_error_set_generic_error (error, "System", "EntryPointNotFoundException", "%p: %s", lib, symbol_name);
-#else
-		mono_error_set_generic_error (error, "System", "DllNotFoundException", "%p: %s", lib, symbol_name);
-#endif
-	}
-	goto_if_nok (error, leave);
-
-	if (!symbol) {
+	if (module) {
 		mono_dl_symbol (module, symbol_name, &symbol);
 		if (!symbol)
 			mono_error_set_generic_error (error, "System", "EntryPointNotFoundException", "%s: %s", module->full_name, symbol_name);
-		goto_if_nok (error, leave);
+	} else {
+		MonoDl raw_module = { 0 };
+		raw_module.handle = lib;
+		mono_dl_symbol (&raw_module, symbol_name, &symbol);
+		if (!symbol)
+			mono_error_set_generic_error (error, "System", "EntryPointNotFoundException", "%p: %s", lib, symbol_name);
 	}
 
-leave:
 	native_library_unlock ();
 
 leave_nolock:


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/47013 changed how kernel32.dll and Ws2_32.dll gets loaded on Windows. Instead of loading using NativeLibrary.Load these system libraries are now loaded directly using LoadLibraryEx, but symbols are still handled through NativeLibrary. This short-circuits some logic in Mono that assumes all libraries gets loaded through NativeLibrary.Load.

Fix adds ability to use OS handle in calls to NativeLibrary.GetExport/Free regardless if that handle was retrieved through a call to NativeLibrary.*Load* or not. Fix is not platform specific since the same scenarios can apply to all platforms.