### PR TITLE
Allow macOS chain building to use network if revocation checking is online

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
@@ -615,7 +615,7 @@ namespace Internal.Cryptography.Pal
             // There is no way to independently enable or disable online revocation checking
             // and AIA fetching. If the caller specifies they want Online revocation checking,
             // then we need to allow network operations (including AIA fetching.)
-            bool revocationRequiresNetwork = revocationMode == X509RevocationMode.Online;
+            bool revocationRequiresNetwork = revocationMode != X509RevocationMode.NoCheck;
 
             try
             {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
@@ -611,6 +611,12 @@ namespace Internal.Cryptography.Pal
 
             SecTrustChainPal chainPal = new SecTrustChainPal();
 
+            // The allowNetwork controls all network activity for macOS chain building.
+            // There is no way to independently enable or disable online revocation checking
+            // and AIA fetching. If the caller specifies they want Online revocation checking,
+            // then we need to allow network operations (including AIA fetching.)
+            bool revocationRequiresNetwork = revocationMode == X509RevocationMode.Online;
+
             try
             {
                 chainPal.OpenTrustHandle(
@@ -622,7 +628,7 @@ namespace Internal.Cryptography.Pal
 
                 chainPal.Execute(
                     verificationTime,
-                    !disableAia,
+                    allowNetwork: !disableAia || revocationRequiresNetwork,
                     applicationPolicy,
                     certificatePolicy,
                     revocationFlag);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -141,6 +141,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
         [Theory]
         [MemberData(nameof(AllViableRevocation))]
+        public static void RevokeLeafWithAiaFetchingDisabled(PkiOptions pkiOptions)
+        {
+            SimpleTest(
+                pkiOptions,
+                (root, intermediate, endEntity, holder, responder) =>
+                {
+                    DateTimeOffset now = DateTimeOffset.UtcNow;
+                    intermediate.Revoke(endEntity, now);
+                    holder.Chain.ChainPolicy.VerificationTime = now.AddSeconds(1).UtcDateTime;
+                    holder.Chain.ChainPolicy.DisableCertificateDownloads = true;
+
+                    SimpleRevocationBody(
+                        holder,
+                        endEntity,
+                        rootRevoked: false,
+                        issrRevoked: false,
+                        leafRevoked: true);
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(AllViableRevocation))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/31249", TestPlatforms.OSX)]
         public static void RevokeIntermediateAndEndEntity(PkiOptions pkiOptions)
         {


### PR DESCRIPTION
Fixes #47713 

The DisableCertificateDownloads property on the chain policy controls all
network activity when building a chain on macOS, not just AIA fetching. If
set to true, the (default) revocation policy would fail because the network
would be treated as unavailable. On macOS, as a work around, permit the
network activity if revocation checking is explicitly enabled.