### PR TITLE
JIT: fix issues with profile incorporation phase

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2206,35 +2206,6 @@ unsigned Compiler::fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, F
         curBBdesc->bbCodeOffs    = curBBoffs;
         curBBdesc->bbCodeOffsEnd = nxtBBoffs;
 
-        BasicBlock::weight_t profileWeight;
-
-        if (fgGetProfileWeightForBasicBlock(curBBoffs, &profileWeight))
-        {
-            if (compIsForInlining())
-            {
-                if (impInlineInfo->profileScaleState == InlineInfo::ProfileScaleState::KNOWN)
-                {
-                    double scaledWeight = impInlineInfo->profileScaleFactor * profileWeight;
-                    profileWeight       = (BasicBlock::weight_t)scaledWeight;
-                }
-            }
-
-            curBBdesc->setBBProfileWeight(profileWeight);
-
-            if (profileWeight == 0)
-            {
-                curBBdesc->bbSetRunRarely();
-            }
-            else
-            {
-                // Note that bbNewBasicBlock (called from fgNewBasicBlock) may have
-                // already marked the block as rarely run.  In that case (and when we know
-                // that the block profile weight is non-zero) we want to unmark that.
-
-                curBBdesc->bbFlags &= ~BBF_RUN_RARELY;
-            }
-        }
-
         switch (jmpKind)
         {
             case BBJ_SWITCH:


### PR DESCRIPTION
Change #47646 did not remove the code in `fgMakeBasicBlocks` that set profile
data. That masked some flaws in `fgIncorporateProfileData`:
* it should process all blocks; nothing has been imported yet
* it must honor a constraint that some handler blocks can't be rare.

This fixes the above, and removes the early profile setting.