### PR TITLE
rebuild certificate context if we use client cert from credential cache

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -591,6 +591,10 @@ namespace System.Net.Security
                     _credentialsHandle = cachedCredentialHandle;
                     _selectedClientCertificate = clientCertificate;
                     cachedCred = true;
+                    if (selectedCert != null)
+                    {
+                        _sslAuthenticationOptions.CertificateContext = SslStreamCertificateContext.Create(selectedCert!);
+                    }
                 }
                 else
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -367,7 +367,7 @@ namespace System.Net.Security.Tests
             // Make sure we can build chain before proceeding to ssl handshale
             using (var chain = new X509Chain())
             {
-                int count = 10;
+                int count = 25;
                 chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags;
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                 chain.ChainPolicy.DisableCertificateDownloads = false;
@@ -380,7 +380,7 @@ namespace System.Net.Security.Tests
                 }
 
                 // Verify we can construct full chain
-                Assert.Equal(clientChain.Count + 1, chain.ChainElements.Count);
+                Assert.Equal(clientChain.Count + 1, chain.ChainElements.Count, "chain cannot be built");
             }
 
             var clientOptions = new  SslClientAuthenticationOptions() { TargetHost = "localhost",  };
@@ -400,7 +400,7 @@ namespace System.Net.Security.Tests
                     _output.WriteLine("received {0}", c.Subject);
                 }
 
-                Assert.True(chain.ChainPolicy.ExtraStore.Count >= clientChain.Count - 1);
+                Assert.True(chain.ChainPolicy.ExtraStore.Count >= clientChain.Count - 1, "client did not sent expected chain");
                 return true;
             };
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -350,8 +350,8 @@ namespace System.Net.Security.Tests
             {
                 // Client should send chain without root CA. There is no good way how to know if the chain was built from certificates
                 // from wire or from system store. However, SslStream adds certificates from wire to ExtraStore in RemoteCertificateValidationCallback.
-                // So we verify the operation by checking the ExtraStore.
-                Assert.Equal(clientChain.Count - 1, chain.ChainPolicy.ExtraStore.Count);
+                // So we verify the operation by checking the ExtraStore. On Windows, that includes leaf itself.
+                Assert.True(chain.ChainPolicy.ExtraStore.Count >= clientChain.Count - 1);
                 return true;
             };
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -350,6 +350,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/46837", TestPlatforms.OSX)]
         public async Task SslStream_ClientCertificate_SendsChain()
         {
             List<SslStream> streams = new List<SslStream>();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -380,7 +380,7 @@ namespace System.Net.Security.Tests
                 }
 
                 // Verify we can construct full chain
-                Assert.Equal(clientChain.Count + 1, chain.ChainElements.Count, "chain cannot be built");
+                Assert.True(chain.ChainElements.Count > clientChain.Count, "chain cannot be built");
             }
 
             var clientOptions = new  SslClientAuthenticationOptions() { TargetHost = "localhost",  };

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -29,6 +29,14 @@ namespace System.Net.Security.Tests
                 },
                 false);
 
+        private static readonly X509EnhancedKeyUsageExtension s_tlsClientEku =
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection
+                {
+                    new Oid("1.3.6.1.5.5.7.3.2", null)
+                },
+                false);
+
         private static readonly X509BasicConstraintsExtension s_eeConstraints =
             new X509BasicConstraintsExtension(false, false, 0, false);
 
@@ -107,7 +115,7 @@ namespace System.Net.Security.Tests
             catch { };
         }
 
-        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, [CallerMemberName] string? testName = null, bool longChain = false)
+        internal static (X509Certificate2 certificate, X509Certificate2Collection) GenerateCertificates(string targetName, [CallerMemberName] string? testName = null, bool longChain = false, bool serverCertificate = true)
         {
             const int keySize = 2048;
             if (PlatformDetection.IsWindows && testName != null)
@@ -123,7 +131,7 @@ namespace System.Net.Security.Tests
             extensions.Add(builder.Build());
             extensions.Add(s_eeConstraints);
             extensions.Add(s_eeKeyUsage);
-            extensions.Add(s_tlsServerEku);
+            extensions.Add(serverCertificate ? s_tlsServerEku : s_tlsClientEku);
 
             CertificateAuthority.BuildPrivatePki(
                 PkiOptions.IssuerRevocationViaCrl,


### PR DESCRIPTION
This regression caused by #38364. We used to call X509Chain.Build inside of pal for each connection. We don't want to do that for the SslStreamCertificateContext so the change would also create context for client certificates to keep the pal simple. However, the context is not part of are cache so when get client certificate from cache it would not have the associated certificates and it would send only leave certificate. And some servers are sensitive to it. 

This is mini fix to get on par with 3.1. 
Longer term fix may be to make context part of the cache ... and possibly measure how much the cache actually saves and re-consider usefulness. That can be done later as per fix instead of functional change. 


The most digital part of this change is the test. Since the client side has no API to take certificate chain, only one way is to add intermediates to the CA store. With that, the server side can always construct full chain regardless of what client actually provided. Also intermediate certificate can be cached behind the scenes so the verification may be tricky. 

I eventually realized that VerifyRemoteCertificate add certificates from wire `chain.ChainPolicy.ExtraStore.AddRange(remoteCertificateStore)`. So I use that for fix validation.
I verified that without the fix only first round would work and that subsequent handshakes would have no extra certs - just like described in the linked issue. 

If somebody has better idea for validation please let me know. 

fixed  #47580


 