### PR TITLE
[release/5.0] Linux-only fix for SOS with 5.0 singlefile apps

### DIFF
--- a/src/coreclr/src/debug/runtimeinfo/CMakeLists.txt
+++ b/src/coreclr/src/debug/runtimeinfo/CMakeLists.txt
@@ -9,3 +9,8 @@ add_library_clr(runtimeinfo STATIC ${RUNTIMEINFO_SOURCES})
 add_dependencies(runtimeinfo coreclr_module_index_header)
 add_dependencies(runtimeinfo mscordaccore_module_index_header)
 add_dependencies(runtimeinfo mscordbi_module_index_header)
+
+if (CLR_CMAKE_TARGET_LINUX)
+    # publish runtimeinfo lib
+    _install(TARGETS runtimeinfo DESTINATION lib)
+endif()

--- a/src/installer/corehost/cli/apphost/static/CMakeLists.txt
+++ b/src/installer/corehost/cli/apphost/static/CMakeLists.txt
@@ -90,6 +90,8 @@ elseif(CLR_CMAKE_TARGET_LINUX)
         ${CORECLR_STATIC_LIB_LOCATION}/libnativeresourcestring.a
     )
 
+    set(RUNTIMEINFO_LIB ${CORECLR_STATIC_LIB_LOCATION}/libruntimeinfo.a)
+
     # currently linking coreclr into the singlefilehost is only supported on linux
     # the following code here would be needed if/when BSD and OSX are supported too
     #
@@ -200,7 +202,8 @@ endif(NOT CLR_CMAKE_TARGET_LINUX)
 
 set_property(TARGET singlefilehost PROPERTY ENABLE_EXPORTS 1)
 
-target_link_libraries(singlefilehost
+target_link_libraries(
+    singlefilehost
     libhostcommon
     ${CORECLR_LIBRARIES}
 
@@ -209,6 +212,7 @@ target_link_libraries(singlefilehost
     ${NATIVE_LIBS_EXTRA}
 
     ${START_WHOLE_ARCHIVE}
+    ${RUNTIMEINFO_LIB}
     ${NATIVE_LIBS}
     ${END_WHOLE_ARCHIVE}
 )


### PR DESCRIPTION
## Customer Impact
Linux singlefile apps in 5.0 use new kind of static host with runtime statically linked into the executable. One consequence is that SOS debugging is broken for such apps.
This change adds the necessary export for `DotNetRuntimeInfo` symbol so that SOS could see the app as managed and work again.

## Testing
Verified that the `DotNetRuntimeInfo` symbol is indeed exported from the apps after the fix.
Verified manually that SOS works with such apps.

## Risk
Very low risk. There are no code changes, just exporting a symbol for a static field that SOS needs to examine.
