### PR TITLE
[mbr] Update samples to use hotreload-delta-gen

### DIFF
--- a/src/mono/netcore/sample/mbr/DeltaHelper.targets
+++ b/src/mono/netcore/sample/mbr/DeltaHelper.targets
@@ -1,23 +1,23 @@
 <Project>
-  <!-- Invoke roslynildiff to apply the DeltaScript to the output assembly to
+  <!-- Invoke hotreload-delta-gen to apply the DeltaScript to the output assembly to
        create the .dmeta, .dil and .dpdb files on the OutputPath -->
   <!-- Have to be careful about AfterTargets. If we happen to go after a design-time target, we could get into an infinite loop. -->
   <Target Name="CompileDiff" AfterTargets="Build">
-    <Message Importance="High" Condition="'$(RoslynILDiffFullPath)' == ''" Text="WARNING: RoslynILDiffFullPath property is unset.  Using default which may be wrong on your system" />
-    <Error Condition="'$(DeltaScript)' == ''" Text="DeltaScript property not set in project - don't know how to invoke roslynildiff" />
+    <Message Importance="High" Condition="'$(HotreloadDeltaGenFullPath)' == ''" Text="WARNING: HotreloadDeltaGenFullPath property is unset.  Will run 'hotreload-delta-gen' assuming it is on the PATH" />
+    <Error Condition="'$(DeltaScript)' == ''" Text="DeltaScript property not set in project - don't know how to invoke hotreload-delta-gen" />
     <PropertyGroup>
-      <RoslynILDiffFullPath Condition="'$(RoslynILDiffFullPath)' == ''">/Users/alklig/work/roslynildiff/roslynildiff</RoslynILDiffFullPath>
-      <RoslynILDiffArgs>-msbuild:$(MSBuildProjectFullPath)</RoslynILDiffArgs>
+      <HotreloadDeltaGenFullPath Condition="'$(HotreloadDeltaGenFullPath)' == ''">hotreload-delta-gen</HotreloadDeltaGenFullPath>
+      <HotreloadDeltaGenArgs>-msbuild:$(MSBuildProjectFullPath)</HotreloadDeltaGenArgs>
       <!-- HACK: have to pass config and RID  so that this target works for a 'dotnet publish' run.
-	   What other properties do  I need to pass? Maybe roslynildiff should just expose an MSBuild task so we can pass everything -->
-      <RoslynILDiffArgs Condition="'$(Configuration)' != ''">$(RoslynILDiffArgs) -p:Configuration=$(Configuration)</RoslynILDiffArgs>
-      <RoslynILDiffArgs Condition="'$(RuntimeIdentifier)' != ''">$(RoslynILDiffArgs) -p:RuntimeIdentifier=$(RuntimeIdentifier)</RoslynILDiffArgs>
-      <RoslynILDiffArgs>$(RoslynILDiffArgs) -script:$(DeltaScript)</RoslynILDiffArgs>
+	         What other properties do  I need to pass? Maybe hotreload-delta-gen should just expose an MSBuild task so we can pass everything -->
+      <HotreloadDeltaGenArgs Condition="'$(Configuration)' != ''">$(HotreloadDeltaGenArgs) -p:Configuration=$(Configuration)</HotreloadDeltaGenArgs>
+      <HotreloadDeltaGenArgs Condition="'$(RuntimeIdentifier)' != ''">$(HotreloadDeltaGenArgs) -p:RuntimeIdentifier=$(RuntimeIdentifier)</HotreloadDeltaGenArgs>
+      <HotreloadDeltaGenArgs>$(HotreloadDeltaGenArgs) -script:$(DeltaScript)</HotreloadDeltaGenArgs>
     </PropertyGroup>
-    <Exec Command="$(RoslynILDiffFullPath) $(RoslynILDiffArgs)"/>
+    <Exec Command="$(HotreloadDeltaGenFullPath) $(HotreloadDeltaGenArgs)"/>
   </Target>
 
-  <!-- Computes the names of the files that roslynildiff will produce, given the name of the base assembly and the
+  <!-- Computes the names of the files that hotreload-delta-gen will produce, given the name of the base assembly and the
        number of deltas -->
   <UsingTask TaskName="ComputeDeltaFileOutputNames" TaskFactory="RoslynCodeTaskFactory"
 	     AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >

--- a/src/mono/netcore/sample/mbr/README.md
+++ b/src/mono/netcore/sample/mbr/README.md
@@ -3,18 +3,21 @@
 
 ## Prerequisites
 
-To run the tests you will need to build a runtime with the Mono metadata update
-property set, and you will need the `roslynildiff` commandline tool.
+To run the tests you will need to:
 
-At this time there is only support for Mac and Linux.  No Windows.
+1. Build a runtime with the `MonoMetadataUpdate` property set to true: `/p:MonoMetadataUpdate=true`.
+2. Put the [hotreload-delta-gen](https://github.com/dotnet/hotreload-utils/tree/main/src/hotreload-delta-gen) command line tool somewhere on your `PATH`.
+
+   Build the tool with `dotnet publish --self-contained -r <RID>` and then add the `publish/hotreload-delta-gen` directory to your `PATH`.
+   If you don't want to add it to your `PATH`, you can set the `HotReloadDeltaGenFullPath` msbuild property in `DeltaHelper.targets` to the full path name of the published executable.
+
+The tool, runtime changes and samples should work on Mac and Linux.  Windows might work, but it hasn't been tested.
 
 ## Building
 
 Build the runtime with the `/p:MonoMetadataUpdate=true` option.
 
-Both Debug and Release configurations should work, although mixing a Release
-configuration with a Debug runtime configuration (or vice versa) is not
-supported.
+Both Debug and Release configurations should work.
 
 For desktop:
 
@@ -23,7 +26,7 @@ build.sh -s Mono+Libs /p:MonoMetadataUpdate=true
 ```
 
 
-For Wasm:
+For WebAssembly:
 
 Make sure `EMSDK_PATH` is set (see [workflow](../../../../../docs/workflow/building/libraries/webassembly-instructions.md))
 ```console
@@ -32,31 +35,18 @@ build.sh --os browser /p:MonoMetadataUpdate=true
 
 ## Running
 
-Edit [browser/WasmDelta.csproj](./browser/WasmDelta.csproj) or [console/ConsoleDelta.csproj](./console/ConsoleDelta.csproj) and set the `RoslynILDiffFullPath` property to the path to the `roslynildiff` shell script:
-
-```xml
-   <!-- Add this before the Import of DeltaHelper.targets -->
-   <PropertyGroup>
-     <RoslynILDiffFullPath>/home/user/tools/roslyn-ildiff/roslynildiff</RoslynILDiffFullPath>
-   </PropertyGroup>
-```
-
-(Make sure the configuration is the same as the runtime that you built)
-
-For console:
+For console (desktop):
 
 ```
-make MONO_CONFIG=Debug publish && make MONO_CONFIG=Debug run
+make CONFIG=Debug publish && make CONFIG=Debug run
 ```
 
 The output from `run` should print an old string, apply an update and then print a new string
 
-For wasm:
+For browser (WebAssembly):
 
 ```
 make CONFIG=Debug && make CONFIG=Debug run
 ```
 
 Then go to http://localhost:8000/ and click the button once or twice (the example has 2 updates prebuilt)
-
-


### PR DESCRIPTION
Update build and README to use `hotreload-delta-gen` from [hotreload-utils](https://github.com/dotnet/hotreload-utils)