### PR TITLE
[release/5.0] Backport Fix for Issue 46529 incorrect 64-bit shift result with cast to int

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -464,12 +464,26 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
                         // Don't try to optimize.
                         assert(!canPushCast);
                     }
-                    else if ((shiftAmountValue >= 32) && ((tree->gtFlags & GTF_ALL_EFFECT) == 0))
+                    else if (shiftAmountValue >= 32)
                     {
-                        // Result of the shift is zero.
-                        DEBUG_DESTROY_NODE(tree);
-                        GenTree* zero = gtNewZeroConNode(TYP_INT);
-                        return fgMorphTree(zero);
+                        // We know that we have a narrowing cast ([u]long -> [u]int)
+                        // and that we are casting to a 32-bit value, which will result in zero.
+                        //
+                        // Check to see if we have any side-effects that we must keep
+                        //
+                        if ((tree->gtFlags & GTF_ALL_EFFECT) == 0)
+                        {
+                            // Result of the shift is zero.
+                            DEBUG_DESTROY_NODE(tree);
+                            GenTree* zero = gtNewZeroConNode(TYP_INT);
+                            return fgMorphTree(zero);
+                        }
+                        else // We do have a side-effect
+                        {
+                            // We could create a GT_COMMA node here to keep the side-effect and return a zero
+                            // Instead we just don't try to optimize this case.
+                            canPushCast = false;
+                        }
                     }
                     else
                     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public unsafe class Test
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(byte* bytes) => (int)(((ulong)bytes[0]) << 56);
+
+    public static int Main()
+    {
+        byte p = 0xFF;
+        int result = Foo(&p);
+        if (result == 0)
+        {
+            Console.WriteLine("Passed");
+            return 100;
+        }
+        else
+        {
+            Console.WriteLine("Failed: {0:x}",result);
+            return 101;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_46529/Runtime_46529.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### Incorrect behavior a 64-bit long with shift of 32 or more combined with a cast to int 

The JIT generates incorrect code for this code pattern:

`(int) (X << C)`

where C >= 32 and
and  X is anything with a potential side-effect and is 64-bit integer type

## Customer Impact

Reported by customer who was migrating to .Net Core from the Desktop runtime.

## Regression?

This is a regression that was introduced in the .Net 3.X timeframe by 
https://github.com/dotnet/coreclr/pull/19899

## Testing

SuperPMI, new unit test, CLR outerloop,  asm diffs.

## Risk

Low

Fixes issue #47724