### PR TITLE
Add missing logging to gtFoldExpr

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4716,13 +4716,9 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             break;
 
         default:
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("unexpected operator in this tree:\n");
-                gtDispTree(tree);
-            }
-#endif
+            JITDUMP("unexpected operator in this tree:\n");
+            DISPTREE(tree);
+
             NO_WAY("unexpected operator");
     }
 
@@ -12495,13 +12491,10 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
                 {
                     fgWalkTreePre(&colon_op2, gtClearColonCond);
                 }
-#ifdef DEBUG
-                if (verbose)
-                {
-                    printf("\nIdentical GT_COLON trees! ");
-                    gtDispTree(op2);
-                }
-#endif
+
+                JITDUMP("\nIdentical GT_COLON trees! ");
+                DISPTREE(op2);
+
                 GenTree* op;
                 if (sideEffList == nullptr)
                 {
@@ -12511,13 +12504,9 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
                 }
                 else
                 {
-#ifdef DEBUG
-                    if (verbose)
-                    {
-                        printf("Extracting side effects...\n");
-                        gtDispTree(sideEffList);
-                    }
-#endif
+                    JITDUMP("Extracting side effects...\n");
+                    DISPTREE(sideEffList);
+
                     // Change the GT_COLON into a GT_COMMA node with the side-effects
                     op2->ChangeOper(GT_COMMA);
                     op2->gtFlags |= (sideEffList->gtFlags & GTF_ALL_EFFECT);
@@ -12526,12 +12515,9 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
                     JITDUMP("Transformed GT_COLON into GT_COMMA:\n");
                     op = op2;
                 }
-#ifdef DEBUG
-                if (verbose)
-                {
-                    gtDispTree(op);
-                }
-#endif
+
+                DISPTREE(op);
+
                 return op;
             }
         }
@@ -12705,14 +12691,10 @@ GenTree* Compiler::gtFoldExprCompare(GenTree* tree)
             return tree;
     }
 
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("\nFolding comparison with identical operands:\n");
-        gtDispTree(tree);
-    }
-#endif
     /* The node has beeen folded into 'cons' */
+
+    JITDUMP("\nFolding comparison with identical operands:\n");
+    DISPTREE(tree);
 
     if (fgGlobalMorph)
     {
@@ -12724,13 +12706,8 @@ GenTree* Compiler::gtFoldExprCompare(GenTree* tree)
         cons->gtPrev = tree->gtPrev;
     }
 
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("Bashed to %s:\n", cons->AsIntConCommon()->IconValue() ? "true" : "false");
-        gtDispTree(cons);
-    }
-#endif
+    JITDUMP("Bashed to %s:\n", cons->AsIntConCommon()->IconValue() ? "true" : "false");
+    DISPTREE(cons);
 
     return cons;
 }
@@ -13417,15 +13394,10 @@ DONE_FOLD:
         op->gtFlags &= ~(GTF_VAR_USEASG | GTF_VAR_DEF);
     }
 
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("\nFolding binary operator with a constant operand:\n");
-        gtDispTree(tree);
-        printf("Transformed into:\n");
-        gtDispTree(op);
-    }
-#endif
+    JITDUMP("\nFolding binary operator with a constant operand:\n");
+    DISPTREE(tree);
+    JITDUMP("Transformed into:\n");
+    DISPTREE(op);
 
     return op;
 }
@@ -14520,13 +14492,9 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     // We only fold a GT_ADD that involves a null reference.
                     if (((op1->TypeGet() == TYP_REF) && (i1 == 0)) || ((op2->TypeGet() == TYP_REF) && (i2 == 0)))
                     {
-#ifdef DEBUG
-                        if (verbose)
-                        {
-                            printf("\nFolding operator with constant nodes into a constant:\n");
-                            gtDispTree(tree);
-                        }
-#endif
+                        JITDUMP("\nFolding operator with constant nodes into a constant:\n");
+                        DISPTREE(tree);
+
                         // Fold into GT_IND of null byref
                         tree->ChangeOperConst(GT_CNS_INT);
                         tree->gtType                 = TYP_BYREF;
@@ -14536,13 +14504,10 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         {
                             fgValueNumberTreeConst(tree);
                         }
-#ifdef DEBUG
-                        if (verbose)
-                        {
-                            printf("\nFolded to null byref:\n");
-                            gtDispTree(tree);
-                        }
-#endif
+
+                        JITDUMP("\nFolded to null byref:\n");
+                        DISPTREE(tree);
+
                         goto DONE;
                     }
                     break;
@@ -14791,13 +14756,8 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
         CNS_INT:
         FOLD_COND:
 
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("\nFolding operator with constant nodes into a constant:\n");
-                gtDispTree(tree);
-            }
-#endif
+            JITDUMP("\nFolding operator with constant nodes into a constant:\n");
+            DISPTREE(tree);
 
 #ifdef TARGET_64BIT
             // Some operations are performed as 64 bit instead of 32 bit so the upper 32 bits
@@ -14817,13 +14777,10 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             {
                 fgValueNumberTreeConst(tree);
             }
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("Bashed to int constant:\n");
-                gtDispTree(tree);
-            }
-#endif
+
+            JITDUMP("Bashed to int constant:\n");
+            DISPTREE(tree);
+
             goto DONE;
 
         /* This operation is going to cause an overflow exception. Morph into
@@ -14849,7 +14806,6 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             // for global morphing phase.
             //
             // TODO-CQ: Once fgMorphArgs() is fixed this restriction could be removed.
-            CLANG_FORMAT_COMMENT_ANCHOR;
 
             if (!fgGlobalMorph)
             {
@@ -14891,13 +14847,10 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             goto OVF;
 
         OVF:
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("\nFolding binary operator with constant nodes into a comma throw:\n");
-                gtDispTree(tree);
-            }
-#endif
+
+            JITDUMP("\nFolding binary operator with constant nodes into a comma throw:\n");
+            DISPTREE(tree);
+
             /* We will change the cast to a GT_COMMA and attach the exception helper as AsOp()->gtOp1.
              * The constant expression zero becomes op2. */
 
@@ -15211,13 +15164,9 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                 return tree;
             }
 
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("\nFolding long operator with constant nodes into a constant:\n");
-                gtDispTree(tree);
-            }
-#endif
+            JITDUMP("\nFolding long operator with constant nodes into a constant:\n");
+            DISPTREE(tree);
+
             assert((GenTree::s_gtNodeSizes[GT_CNS_NATIVELONG] == TREE_NODE_SZ_SMALL) ||
                    (tree->gtDebugFlags & GTF_DEBUG_NODE_LARGE));
 
@@ -15228,13 +15177,9 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                 fgValueNumberTreeConst(tree);
             }
 
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("Bashed to long constant:\n");
-                gtDispTree(tree);
-            }
-#endif
+            JITDUMP("Bashed to long constant:\n");
+            DISPTREE(tree);
+
             goto DONE;
 
         /*-------------------------------------------------------------------------
@@ -15263,12 +15208,8 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             if (_isnan(d1) || _isnan(d2))
             {
-#ifdef DEBUG
-                if (verbose)
-                {
-                    printf("Double operator(s) is NaN\n");
-                }
-#endif
+                JITDUMP("Double operator(s) is NaN\n");
+
                 if (tree->OperKind() & GTK_RELOP)
                 {
                     if (tree->gtFlags & GTF_RELOP_NAN_UN)
@@ -15382,13 +15323,8 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
         CNS_DOUBLE:
 
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("\nFolding fp operator with constant nodes into a fp constant:\n");
-                gtDispTree(tree);
-            }
-#endif
+            JITDUMP("\nFolding fp operator with constant nodes into a fp constant:\n");
+            DISPTREE(tree);
 
             assert((GenTree::s_gtNodeSizes[GT_CNS_DBL] == TREE_NODE_SZ_SMALL) ||
                    (tree->gtDebugFlags & GTF_DEBUG_NODE_LARGE));
@@ -15399,13 +15335,10 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             {
                 fgValueNumberTreeConst(tree);
             }
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("Bashed to fp constant:\n");
-                gtDispTree(tree);
-            }
-#endif
+
+            JITDUMP("Bashed to fp constant:\n");
+            DISPTREE(tree);
+
             goto DONE;
 
         default:
@@ -16021,12 +15954,7 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
                     if (node->OperIs(GT_ADDR) && node->gtGetOp1()->OperIsIndir() &&
                         (node->gtGetOp1()->TypeGet() == TYP_STRUCT))
                     {
-#ifdef DEBUG
-                        if (m_compiler->verbose)
-                        {
-                            printf("Keep the GT_ADDR and GT_IND together:\n");
-                        }
-#endif
+                        JITDUMP("Keep the GT_ADDR and GT_IND together:\n");
                         m_sideEffects.Push(node);
                         return Compiler::WALK_SKIP_SUBTREES;
                     }


### PR DESCRIPTION
Partially resolves #43348.

The first commit covers the logging for all paths in `gtFoldExpr`. Other `gtFold*` functions seem to already have the necessary logging so I did not touch them. I followed the existing (in `gtFoldExprConst`) "fine-grained" approach instead of e. g. checking at the end of `gtFoldExpr` if the node has changed.

I did not add calls to `DEBUG_DESTROY_NODE` as it looks like the function is little used (only 65 hits across the entire codebase) and the printing for it is commented out... Please let me know if that's still desirable, but it would potentially result in a lot of churn if done properly for all folding functions.

Edit: will add `DEBUG_DESTROY_NODE`s in a separate PR.

One thing I've noticed is that it would potentially be useful to have something like `gtDebugDisp*` wrappers so that all non-trivial calls wouldn't have to be wrapped in `#ifdef DEBUG` + `if (verbose)`, which adds quite a bit of noise. Please let me know if that's something desirable (potentially as a future PR) or the existing approach is fine as is.

I have verified this is a no-diff change across the framework assemblies when crossgening.

cc @sandreenko