### PR TITLE
Fix DisableAiaOptionWorks and remove ActiveIssue.

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
@@ -64,7 +64,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 cuCaStore.Open(OpenFlags.ReadWrite);
 
                 X509Chain chain = holder.Chain;
-                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+                // macOS combines revocation and AIA fetching in to a single flag. Both need to be disabled
+                // to prevent AIA fetches.
+                if (PlatformDetection.IsOSX)
+                {
+                    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                }
+
                 chain.ChainPolicy.DisableCertificateDownloads = true;
                 chain.ChainPolicy.CustomTrustStore.Add(rootCert);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
@@ -101,12 +108,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 Assert.Equal(1, chain.ChainElements.Count);
                 Assert.Contains(X509ChainStatusFlags.PartialChain, chain.ChainStatus.Select(s => s.Status));
                 holder.DisposeChainElements();
-
-                // macOS doesn't like our revocation responder, so disable revocation checks there.
-                if (PlatformDetection.IsOSX)
-                {
-                    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                }
 
                 chain.ChainPolicy.ExtraStore.Add(intermediateCert);
                 Assert.True(chain.Build(endEntity), "Chain build with intermediate, AIA disabled");

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
@@ -42,7 +42,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/47492", TestPlatforms.OSX)]
         public static void DisableAiaOptionWorks()
         {
             CertificateAuthority.BuildPrivatePki(
@@ -65,6 +64,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 cuCaStore.Open(OpenFlags.ReadWrite);
 
                 X509Chain chain = holder.Chain;
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                 chain.ChainPolicy.DisableCertificateDownloads = true;
                 chain.ChainPolicy.CustomTrustStore.Add(rootCert);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;


### PR DESCRIPTION
The underlying behavior fix that should allow restoring this test was done in #47718.

 Closes #47492 