### PR TITLE
Add ability to update the friend assembly set of an assembly with Reflection Emit

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -594,8 +594,7 @@ namespace System.Reflection.Emit
                 _manifestModuleBuilder,     // pass in the in-memory assembly module
                 AssemblyBuilderData.AssemblyDefToken,
                 _manifestModuleBuilder.GetConstructorToken(con),
-                binaryAttribute,
-                false);
+                binaryAttribute);
         }
 
         /// <summary>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -595,8 +595,7 @@ namespace System.Reflection.Emit
                 AssemblyBuilderData.AssemblyDefToken,
                 _manifestModuleBuilder.GetConstructorToken(con),
                 binaryAttribute,
-                false,
-                typeof(DebuggableAttribute) == con.DeclaringType);
+                false);
         }
 
         /// <summary>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -533,8 +533,7 @@ namespace System.Reflection.Emit
         /// </summary>
         internal void CreateCustomAttribute(ModuleBuilder mod, int tkOwner, int tkAttrib, bool toDisk)
         {
-            TypeBuilder.DefineCustomAttribute(mod, tkOwner, tkAttrib, m_blob, toDisk,
-                                                      typeof(System.Diagnostics.DebuggableAttribute) == m_con.DeclaringType);
+            TypeBuilder.DefineCustomAttribute(mod, tkOwner, tkAttrib, m_blob, toDisk);
         }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -519,21 +519,10 @@ namespace System.Reflection.Emit
             }
         }
 
-
-
-
         // return the byte interpretation of the custom attribute
         internal void CreateCustomAttribute(ModuleBuilder mod, int tkOwner)
         {
-            CreateCustomAttribute(mod, tkOwner, mod.GetConstructorToken(m_con), false);
-        }
-
-        /// <summary>
-        /// Call this function with toDisk=1, after on disk module has been snapped.
-        /// </summary>
-        internal void CreateCustomAttribute(ModuleBuilder mod, int tkOwner, int tkAttrib, bool toDisk)
-        {
-            TypeBuilder.DefineCustomAttribute(mod, tkOwner, tkAttrib, m_blob, toDisk);
+            TypeBuilder.DefineCustomAttribute(mod, tkOwner, mod.GetConstructorToken(m_con), m_blob);
         }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/EventBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/EventBuilder.cs
@@ -97,7 +97,7 @@ namespace System.Reflection.Emit
                 m_evToken,
                 m_module.GetConstructorToken(con),
                 binaryAttribute,
-                false, false);
+                false);
         }
 
         // Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/EventBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/EventBuilder.cs
@@ -96,8 +96,7 @@ namespace System.Reflection.Emit
                 m_module,
                 m_evToken,
                 m_module.GetConstructorToken(con),
-                binaryAttribute,
-                false);
+                binaryAttribute);
         }
 
         // Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.cs
@@ -172,7 +172,7 @@ namespace System.Reflection.Emit
             m_typeBuilder.ThrowIfCreated();
 
             TypeBuilder.DefineCustomAttribute(module,
-                m_fieldTok, module.GetConstructorToken(con), binaryAttribute, false);
+                m_fieldTok, module.GetConstructorToken(con), binaryAttribute);
         }
 
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.cs
@@ -172,7 +172,7 @@ namespace System.Reflection.Emit
             m_typeBuilder.ThrowIfCreated();
 
             TypeBuilder.DefineCustomAttribute(module,
-                m_fieldTok, module.GetConstructorToken(con), binaryAttribute, false, false);
+                m_fieldTok, module.GetConstructorToken(con), binaryAttribute, false);
         }
 
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -775,8 +775,7 @@ namespace System.Reflection.Emit
 
             TypeBuilder.DefineCustomAttribute(m_module, MetadataToken,
                 ((ModuleBuilder)m_module).GetConstructorToken(con),
-                binaryAttribute,
-                false);
+                binaryAttribute);
 
             if (IsKnownCA(con))
                 ParseCA(con);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -776,7 +776,7 @@ namespace System.Reflection.Emit
             TypeBuilder.DefineCustomAttribute(m_module, MetadataToken,
                 ((ModuleBuilder)m_module).GetConstructorToken(con),
                 binaryAttribute,
-                false, false);
+                false);
 
             if (IsKnownCA(con))
                 ParseCA(con);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -1559,7 +1559,7 @@ namespace System.Reflection.Emit
                 1,                                          // This is hard coding the module token to 1
                 GetConstructorToken(con),
                 binaryAttribute,
-                false, false);
+                false);
         }
 
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -1558,8 +1558,7 @@ namespace System.Reflection.Emit
                 this,
                 1,                                          // This is hard coding the module token to 1
                 GetConstructorToken(con),
-                binaryAttribute,
-                false);
+                binaryAttribute);
         }
 
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.cs
@@ -34,7 +34,7 @@ namespace System.Reflection.Emit
                 _token,
                 ((ModuleBuilder)_methodBuilder.GetModule()).GetConstructorToken(con),
                 binaryAttribute,
-                false, false);
+                false);
         }
 
         // Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.cs
@@ -33,8 +33,7 @@ namespace System.Reflection.Emit
                 _methodBuilder.GetModuleBuilder(),
                 _token,
                 ((ModuleBuilder)_methodBuilder.GetModule()).GetConstructorToken(con),
-                binaryAttribute,
-                false);
+                binaryAttribute);
         }
 
         // Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
@@ -117,8 +117,7 @@ namespace System.Reflection.Emit
                 m_moduleBuilder,
                 m_tkProperty,
                 m_moduleBuilder.GetConstructorToken(con),
-                binaryAttribute,
-                false);
+                binaryAttribute);
         }
 
         // Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
@@ -118,7 +118,7 @@ namespace System.Reflection.Emit
                 m_tkProperty,
                 m_moduleBuilder.GetConstructorToken(con),
                 binaryAttribute,
-                false, false);
+                false);
         }
 
         // Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -51,7 +51,7 @@ namespace System.Reflection.Emit
                 {
                     Debug.Assert(m_con != null);
                     DefineCustomAttribute(module, token, module.GetConstructorToken(m_con),
-                        m_binaryAttribute, false);
+                        m_binaryAttribute);
                 }
                 else
                 {
@@ -178,10 +178,10 @@ namespace System.Reflection.Emit
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void DefineCustomAttribute(QCallModule module, int tkAssociate, int tkConstructor,
-            byte[]? attr, int attrLength, bool toDisk);
+            byte[]? attr, int attrLength);
 
         internal static void DefineCustomAttribute(ModuleBuilder module, int tkAssociate, int tkConstructor,
-            byte[]? attr, bool toDisk)
+            byte[]? attr)
         {
             byte[]? localAttr = null;
 
@@ -192,7 +192,7 @@ namespace System.Reflection.Emit
             }
 
             DefineCustomAttribute(new QCallModule(ref module), tkAssociate, tkConstructor,
-                localAttr, (localAttr != null) ? localAttr.Length : 0, toDisk);
+                localAttr, (localAttr != null) ? localAttr.Length : 0);
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -2159,7 +2159,7 @@ namespace System.Reflection.Emit
                 throw new ArgumentNullException(nameof(binaryAttribute));
 
             DefineCustomAttribute(m_module, m_tdType, ((ModuleBuilder)m_module).GetConstructorToken(con),
-                binaryAttribute, false);
+                binaryAttribute);
         }
 
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -51,7 +51,7 @@ namespace System.Reflection.Emit
                 {
                     Debug.Assert(m_con != null);
                     DefineCustomAttribute(module, token, module.GetConstructorToken(m_con),
-                        m_binaryAttribute, false, false);
+                        m_binaryAttribute, false);
                 }
                 else
                 {
@@ -178,10 +178,10 @@ namespace System.Reflection.Emit
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void DefineCustomAttribute(QCallModule module, int tkAssociate, int tkConstructor,
-            byte[]? attr, int attrLength, bool toDisk, bool updateCompilerFlags);
+            byte[]? attr, int attrLength, bool toDisk);
 
         internal static void DefineCustomAttribute(ModuleBuilder module, int tkAssociate, int tkConstructor,
-            byte[]? attr, bool toDisk, bool updateCompilerFlags)
+            byte[]? attr, bool toDisk)
         {
             byte[]? localAttr = null;
 
@@ -192,7 +192,7 @@ namespace System.Reflection.Emit
             }
 
             DefineCustomAttribute(new QCallModule(ref module), tkAssociate, tkConstructor,
-                localAttr, (localAttr != null) ? localAttr.Length : 0, toDisk, updateCompilerFlags);
+                localAttr, (localAttr != null) ? localAttr.Length : 0, toDisk);
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -2159,7 +2159,7 @@ namespace System.Reflection.Emit
                 throw new ArgumentNullException(nameof(binaryAttribute));
 
             DefineCustomAttribute(m_module, m_tdType, ((ModuleBuilder)m_module).GetConstructorToken(con),
-                binaryAttribute, false, false);
+                binaryAttribute, false);
         }
 
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)

--- a/src/coreclr/dlls/mscorrc/mscorrc.rc
+++ b/src/coreclr/dlls/mscorrc/mscorrc.rc
@@ -502,7 +502,6 @@ BEGIN
     IDS_EE_VARARG_NOT_SUPPORTED             "Vararg calling convention not supported."
 
     IDS_EE_INVALID_CA                       "Invalid custom attribute provided."
-    IDS_EE_INVALID_CA_EX                    "Invalid custom attribute provided: '%1'"
 
     IDS_EE_THREADSTART_STATE                "Thread is running or terminated; it cannot restart."
     IDS_EE_THREAD_CANNOT_GET                "Unable to retrieve thread information."

--- a/src/coreclr/dlls/mscorrc/resource.h
+++ b/src/coreclr/dlls/mscorrc/resource.h
@@ -244,7 +244,6 @@
 #define IDS_EE_VARARG_NOT_SUPPORTED             0x1a0f
 
 #define IDS_EE_INVALID_CA                       0x1a10
-#define IDS_EE_INVALID_CA_EX                    0x1a11
 
 #define IDS_EE_THREADSTART_STATE                0x1a12
 

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -1796,11 +1796,15 @@ typedef enum CorAttributeTargets
 #define FORWARD_INTEROP_STUB_METHOD_TYPE        "System.Runtime.InteropServices.ManagedToNativeComInteropStubAttribute"
 
 #define FRIEND_ASSEMBLY_TYPE_W                  W("System.Runtime.CompilerServices.InternalsVisibleToAttribute")
-#define FRIEND_ASSEMBLY_TYPE                     "System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+#define FRIEND_ASSEMBLY_TYPE                    "System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+#define FRIEND_ASSEMBLY_TYPE_NAMESPACE          "System.Runtime.CompilerServices"
+#define FRIEND_ASSEMBLY_TYPE_NAME               "InternalsVisibleToAttribute"
 #define FRIEND_ASSEMBLY_SIG                     {IMAGE_CEE_CS_CALLCONV_DEFAULT_HASTHIS, 2, ELEMENT_TYPE_VOID, ELEMENT_TYPE_STRING, ELEMENT_TYPE_BOOLEAN}
 
 #define SUBJECT_ASSEMBLY_TYPE_W                 W("System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute")
-#define SUBJECT_ASSEMBLY_TYPE                    "System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute"
+#define SUBJECT_ASSEMBLY_TYPE                   "System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute"
+#define SUBJECT_ASSEMBLY_TYPE_NAMESPACE         "System.Runtime.CompilerServices"
+#define SUBJECT_ASSEMBLY_TYPE_NAME              "IgnoresAccessChecksToAttribute"
 #define SUBJECT_ASSEMBLY_SIG                    {IMAGE_CEE_CS_CALLCONV_DEFAULT_HASTHIS, 1, ELEMENT_TYPE_VOID, ELEMENT_TYPE_STRING}
 
 #define DISABLED_PRIVATE_REFLECTION_TYPE_W      W("System.Runtime.CompilerServices.DisablePrivateReflectionAttribute")
@@ -1817,6 +1821,12 @@ typedef enum CorAttributeTargets
 
 #define NONVERSIONABLE_TYPE_W                   W("System.Runtime.Versioning.NonVersionableAttribute")
 #define NONVERSIONABLE_TYPE                      "System.Runtime.Versioning.NonVersionableAttribute"
+
+#define DEBUGGABLE_ATTRIBUTE_TYPE_W             W("System.Diagnostics.DebuggableAttribute")
+#define DEBUGGABLE_ATTRIBUTE_TYPE               "System.Diagnostics.DebuggableAttribute"
+#define DEBUGGABLE_ATTRIBUTE_TYPE_NAMESPACE     "System.Diagnostics"
+#define DEBUGGABLE_ATTRIBUTE_TYPE_NAME          "DebuggableAttribute"
+
 
 // Keep in sync with CompilationRelaxations.cs
 typedef enum CompilationRelaxationsEnum

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -1300,7 +1300,7 @@ void Assembly::UpdateCachedFriendAssemblyInfo()
     }
 }
 
-ReleaseHolder<FriendAssemblyDescriptor> Assembly::GetFriendAssemblyInfo(bool *pfNoFriendAssemblies)
+ReleaseHolder<FriendAssemblyDescriptor> Assembly::GetFriendAssemblyInfo()
 {
     CacheFriendAssemblyInfo();
 
@@ -1317,45 +1317,21 @@ bool Assembly::GrantsFriendAccessTo(Assembly *pAccessingAssembly, FieldDesc *pFD
 {
     WRAPPER_NO_CONTRACT;
 
-    bool noFriendAssemblies = false;
-    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
-
-    if (noFriendAssemblies)
-    {
-        return false;
-    }
-
-    return friendAssemblyInfo->GrantsFriendAccessTo(pAccessingAssembly, pFD);
+    return GetFriendAssemblyInfo()->GrantsFriendAccessTo(pAccessingAssembly, pFD);
 }
 
 bool Assembly::GrantsFriendAccessTo(Assembly *pAccessingAssembly, MethodDesc *pMD)
 {
     WRAPPER_NO_CONTRACT;
 
-    bool noFriendAssemblies = false;
-    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
-
-    if (noFriendAssemblies)
-    {
-        return false;
-    }
-
-    return friendAssemblyInfo->GrantsFriendAccessTo(pAccessingAssembly, pMD);
+    return GetFriendAssemblyInfo()->GrantsFriendAccessTo(pAccessingAssembly, pMD);
 }
 
 bool Assembly::GrantsFriendAccessTo(Assembly *pAccessingAssembly, MethodTable *pMT)
 {
     WRAPPER_NO_CONTRACT;
 
-    bool noFriendAssemblies = false;
-    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
-
-    if (noFriendAssemblies)
-    {
-        return false;
-    }
-
-    return friendAssemblyInfo->GrantsFriendAccessTo(pAccessingAssembly, pMT);
+    return GetFriendAssemblyInfo()->GrantsFriendAccessTo(pAccessingAssembly, pMT);
 }
 
 bool Assembly::IgnoresAccessChecksTo(Assembly *pAccessedAssembly)
@@ -1368,21 +1344,12 @@ bool Assembly::IgnoresAccessChecksTo(Assembly *pAccessedAssembly)
     }
     CONTRACTL_END;
 
-    bool noFriendAssemblies = false;
-    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
-
-    if (noFriendAssemblies)
-    {
-        return false;
-    }
-
-
     if (pAccessedAssembly->IsDisabledPrivateReflection())
     {
         return false;
     }
 
-    return friendAssemblyInfo->IgnoresAccessChecksTo(pAccessedAssembly);
+    return GetFriendAssemblyInfo()->IgnoresAccessChecksTo(pAccessedAssembly);
 }
 
 

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -1247,7 +1247,6 @@ void Assembly::CacheFriendAssemblyInfo()
         if (m_pFriendAssemblyDescriptor == NULL)
         {
             m_pFriendAssemblyDescriptor = pFriendAssemblies.Extract();
-            pFriendAssemblies.SuppressRelease();
         }
     }
 } // void Assembly::CacheFriendAssemblyInfo()
@@ -1287,7 +1286,6 @@ void Assembly::UpdateCachedFriendAssemblyInfo()
                     m_pFriendAssemblyDescriptor->Release();
 
                 m_pFriendAssemblyDescriptor = pFriendAssemblies.Extract();
-                pFriendAssemblies.SuppressRelease();
                 return;
             }
             else
@@ -2437,8 +2435,7 @@ ReleaseHolder<FriendAssemblyDescriptor> FriendAssemblyDescriptor::CreateFriendAs
         }
     }
 
-    pFriendAssemblies.SuppressRelease();
-    return pFriendAssemblies.Extract();
+    return pFriendAssemblies;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -94,7 +94,12 @@ enum ReasonForNotSharing
     ReasonForNotSharing_ClosureComparisonFailed = 0x8,
 };
 
-#define NO_FRIEND_ASSEMBLIES_MARKER ((FriendAssemblyDescriptor *)S_FALSE)
+static CrstStatic g_friendAssembliesCrst;
+
+void Assembly::Initialize()
+{
+    g_friendAssembliesCrst.Init(CrstLeafLock);
+}
 
 //----------------------------------------------------------------------------------------------
 // The ctor's job is to initialize the Assembly enough so that the dtor can safely run.
@@ -255,8 +260,8 @@ Assembly::~Assembly()
 
     Terminate();
 
-    if (m_pFriendAssemblyDescriptor != NULL && m_pFriendAssemblyDescriptor != NO_FRIEND_ASSEMBLIES_MARKER)
-        delete m_pFriendAssemblyDescriptor;
+    if (m_pFriendAssemblyDescriptor != NULL)
+        m_pFriendAssemblyDescriptor->Release();
 
     if (m_pManifestFile)
     {
@@ -1234,25 +1239,79 @@ void Assembly::CacheFriendAssemblyInfo()
 
     if (m_pFriendAssemblyDescriptor == NULL)
     {
-        FriendAssemblyDescriptor *pFriendAssemblies = FriendAssemblyDescriptor::CreateFriendAssemblyDescriptor(this->GetManifestFile());
-        if (pFriendAssemblies == NULL)
-        {
-            pFriendAssemblies = NO_FRIEND_ASSEMBLIES_MARKER;
-        }
+        ReleaseHolder<FriendAssemblyDescriptor> pFriendAssemblies = FriendAssemblyDescriptor::CreateFriendAssemblyDescriptor(this->GetManifestFile());
+        _ASSERTE(pFriendAssemblies != NULL);
 
-        void *pvPreviousDescriptor = InterlockedCompareExchangeT(&m_pFriendAssemblyDescriptor,
-                                                                 pFriendAssemblies,
-                                                                 NULL);
+        CrstHolder friendDescriptorLock(&g_friendAssembliesCrst);
 
-        if (pvPreviousDescriptor != NULL && pFriendAssemblies != NO_FRIEND_ASSEMBLIES_MARKER)
+        if (m_pFriendAssemblyDescriptor == NULL)
         {
-            if (pFriendAssemblies != NO_FRIEND_ASSEMBLIES_MARKER)
-            {
-                delete pFriendAssemblies;
-            }
+            m_pFriendAssemblyDescriptor = pFriendAssemblies.Extract();
+            pFriendAssemblies.SuppressRelease();
         }
     }
 } // void Assembly::CacheFriendAssemblyInfo()
+
+void Assembly::UpdateCachedFriendAssemblyInfo()
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        INJECT_FAULT(COMPlusThrowOM(););
+    }
+    CONTRACTL_END
+
+    ReleaseHolder<FriendAssemblyDescriptor> pOldFriendAssemblyDescriptor;
+    
+    {
+        CrstHolder friendDescriptorLock(&g_friendAssembliesCrst);
+        if (m_pFriendAssemblyDescriptor != NULL)
+        {
+            m_pFriendAssemblyDescriptor->AddRef();
+            pOldFriendAssemblyDescriptor = m_pFriendAssemblyDescriptor;
+        }
+    }
+
+    while (true)
+    {
+        ReleaseHolder<FriendAssemblyDescriptor> pFriendAssemblies = FriendAssemblyDescriptor::CreateFriendAssemblyDescriptor(this->GetManifestFile());
+        FriendAssemblyDescriptor* pFriendAssemblyDescriptorNextLoop = NULL;
+
+        {
+            CrstHolder friendDescriptorLock(&g_friendAssembliesCrst);
+
+            if (m_pFriendAssemblyDescriptor == pOldFriendAssemblyDescriptor)
+            {
+                if (m_pFriendAssemblyDescriptor != NULL)
+                    m_pFriendAssemblyDescriptor->Release();
+
+                m_pFriendAssemblyDescriptor = pFriendAssemblies.Extract();
+                pFriendAssemblies.SuppressRelease();
+                return;
+            }
+            else
+            {
+                m_pFriendAssemblyDescriptor->AddRef();
+                pFriendAssemblyDescriptorNextLoop = m_pFriendAssemblyDescriptor;
+            }
+        }
+
+        // Initialize this here to avoid calling Release on the previous value of pOldFriendAssemblyDescriptor while holding the lock
+        pOldFriendAssemblyDescriptor = pFriendAssemblyDescriptorNextLoop;
+    }
+}
+
+ReleaseHolder<FriendAssemblyDescriptor> Assembly::GetFriendAssemblyInfo(bool *pfNoFriendAssemblies)
+{
+    CacheFriendAssemblyInfo();
+
+    CrstHolder friendDescriptorLock(&g_friendAssembliesCrst);
+    m_pFriendAssemblyDescriptor->AddRef();
+    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyDescriptor(m_pFriendAssemblyDescriptor);
+
+    return friendAssemblyDescriptor;
+}
 
 //*****************************************************************************
 // Is the given assembly a friend of this assembly?
@@ -1260,42 +1319,45 @@ bool Assembly::GrantsFriendAccessTo(Assembly *pAccessingAssembly, FieldDesc *pFD
 {
     WRAPPER_NO_CONTRACT;
 
-    CacheFriendAssemblyInfo();
+    bool noFriendAssemblies = false;
+    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
 
-    if (m_pFriendAssemblyDescriptor == NO_FRIEND_ASSEMBLIES_MARKER)
+    if (noFriendAssemblies)
     {
         return false;
     }
 
-    return m_pFriendAssemblyDescriptor->GrantsFriendAccessTo(pAccessingAssembly, pFD);
+    return friendAssemblyInfo->GrantsFriendAccessTo(pAccessingAssembly, pFD);
 }
 
 bool Assembly::GrantsFriendAccessTo(Assembly *pAccessingAssembly, MethodDesc *pMD)
 {
     WRAPPER_NO_CONTRACT;
 
-    CacheFriendAssemblyInfo();
+    bool noFriendAssemblies = false;
+    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
 
-    if (m_pFriendAssemblyDescriptor == NO_FRIEND_ASSEMBLIES_MARKER)
+    if (noFriendAssemblies)
     {
         return false;
     }
 
-    return m_pFriendAssemblyDescriptor->GrantsFriendAccessTo(pAccessingAssembly, pMD);
+    return friendAssemblyInfo->GrantsFriendAccessTo(pAccessingAssembly, pMD);
 }
 
 bool Assembly::GrantsFriendAccessTo(Assembly *pAccessingAssembly, MethodTable *pMT)
 {
     WRAPPER_NO_CONTRACT;
 
-    CacheFriendAssemblyInfo();
+    bool noFriendAssemblies = false;
+    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
 
-    if (m_pFriendAssemblyDescriptor == NO_FRIEND_ASSEMBLIES_MARKER)
+    if (noFriendAssemblies)
     {
         return false;
     }
 
-    return m_pFriendAssemblyDescriptor->GrantsFriendAccessTo(pAccessingAssembly, pMT);
+    return friendAssemblyInfo->GrantsFriendAccessTo(pAccessingAssembly, pMT);
 }
 
 bool Assembly::IgnoresAccessChecksTo(Assembly *pAccessedAssembly)
@@ -1308,19 +1370,21 @@ bool Assembly::IgnoresAccessChecksTo(Assembly *pAccessedAssembly)
     }
     CONTRACTL_END;
 
-    CacheFriendAssemblyInfo();
+    bool noFriendAssemblies = false;
+    ReleaseHolder<FriendAssemblyDescriptor> friendAssemblyInfo = GetFriendAssemblyInfo(&noFriendAssemblies);
 
-    if (m_pFriendAssemblyDescriptor == NO_FRIEND_ASSEMBLIES_MARKER)
+    if (noFriendAssemblies)
     {
         return false;
     }
+
 
     if (pAccessedAssembly->IsDisabledPrivateReflection())
     {
         return false;
     }
 
-    return m_pFriendAssemblyDescriptor->IgnoresAccessChecksTo(pAccessedAssembly);
+    return friendAssemblyInfo->IgnoresAccessChecksTo(pAccessedAssembly);
 }
 
 
@@ -2270,11 +2334,11 @@ FriendAssemblyDescriptor::~FriendAssemblyDescriptor()
 //    pAssembly - assembly to get friend assembly information for
 //
 // Return Value:
-//    A friend assembly descriptor if the assembly declares any friend assemblies, otherwise NULL
+//    A friend assembly descriptor if the assembly declares any friend assemblies
 //
 
 // static
-FriendAssemblyDescriptor *FriendAssemblyDescriptor::CreateFriendAssemblyDescriptor(PEAssembly *pAssembly)
+ReleaseHolder<FriendAssemblyDescriptor> FriendAssemblyDescriptor::CreateFriendAssemblyDescriptor(PEAssembly *pAssembly)
 {
     CONTRACTL
     {
@@ -2284,7 +2348,7 @@ FriendAssemblyDescriptor *FriendAssemblyDescriptor::CreateFriendAssemblyDescript
     }
     CONTRACTL_END
 
-    NewHolder<FriendAssemblyDescriptor> pFriendAssemblies = new FriendAssemblyDescriptor;
+    ReleaseHolder<FriendAssemblyDescriptor> pFriendAssemblies = new FriendAssemblyDescriptor;
 
     // We're going to do this twice, once for InternalsVisibleTo and once for IgnoresAccessChecks
     ReleaseHolder<IMDInternalImport> pImport(pAssembly->GetMDImportWithRef());

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -86,6 +86,7 @@ public:
     void Terminate( BOOL signalProfiler = TRUE );
 
     static Assembly *Create(BaseDomain *pDomain, PEAssembly *pFile, DebuggerAssemblyControlFlags debuggerFlags, BOOL fIsCollectible, AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocator);
+    static void Initialize();
 
     BOOL IsSystem() { WRAPPER_NO_CONTRACT; return m_pManifestFile->IsSystem(); }
 
@@ -557,6 +558,12 @@ private:
     void CacheManifestFiles();
 
     void CacheFriendAssemblyInfo();
+#ifndef DACCESS_COMPILE
+    ReleaseHolder<FriendAssemblyDescriptor> GetFriendAssemblyInfo(bool *pfNoFriendAssemblies);
+#endif
+public:
+    void UpdateCachedFriendAssemblyInfo();
+private:
 
 
     PTR_BaseDomain        m_pDomain;        // Parent Domain
@@ -608,14 +615,14 @@ typedef Assembly::ModuleIterator ModuleIterator;
 // FriendSecurityDescriptor contains information on which assemblies are friends of an assembly, as well as
 // which individual internals are visible to those friend assemblies.
 //
-
 class FriendAssemblyDescriptor
 {
+    friend class Assembly;
 public:
     ~FriendAssemblyDescriptor();
 
     static
-    FriendAssemblyDescriptor *CreateFriendAssemblyDescriptor(PEAssembly *pAssembly);
+    ReleaseHolder<FriendAssemblyDescriptor> CreateFriendAssemblyDescriptor(PEAssembly *pAssembly);
 
     //---------------------------------------------------------------------------------------
     //
@@ -653,12 +660,26 @@ public:
         return IsAssemblyOnList(pAccessedAssembly, m_subjectAssemblies);
     }
 
+    void AddRef()
+    {
+        InterlockedIncrement(&m_refCount);
+    }
+
+    void Release()
+    {
+        if (InterlockedDecrement(&m_refCount) == 0)
+        {
+            delete this;
+        }
+    }
+
 private:
     typedef AssemblySpec FriendAssemblyName_t;
     typedef NewHolder<AssemblySpec> FriendAssemblyNameHolder;
 
     ArrayList                  m_alFullAccessFriendAssemblies;      // Friend assemblies which have access to all internals
     ArrayList                  m_subjectAssemblies;                 // Subject assemblies which we will not perform access checks against
+    LONG                       m_refCount = 1;
 
     FriendAssemblyDescriptor();
 

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -559,7 +559,7 @@ private:
 
     void CacheFriendAssemblyInfo();
 #ifndef DACCESS_COMPILE
-    ReleaseHolder<FriendAssemblyDescriptor> GetFriendAssemblyInfo(bool *pfNoFriendAssemblies);
+    ReleaseHolder<FriendAssemblyDescriptor> GetFriendAssemblyInfo();
 #endif
 public:
     void UpdateCachedFriendAssemblyInfo();

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -992,6 +992,8 @@ void EEStartupHelper()
 
 #endif // CROSSGEN_COMPILE
 
+        Assembly::Initialize();
+
 #if defined(HOST_OSX) && defined(HOST_ARM64)
         PAL_JITWriteEnable(true);
 #endif // defined(HOST_OSX) && defined(HOST_ARM64)

--- a/src/coreclr/vm/comdynamic.cpp
+++ b/src/coreclr/vm/comdynamic.cpp
@@ -887,7 +887,7 @@ void UpdateRuntimeStateForAssemblyCustomAttribute(Module* pModule, mdToken tkCus
         }
     }
 
-    // Debuggable attribute processing
+    // InternalsVisibleTo and IgnoresAccessChecksTo attribute processing
     if (((strcmp(szNamespace, FRIEND_ASSEMBLY_TYPE_NAMESPACE) == 0) && (strcmp(szName, FRIEND_ASSEMBLY_TYPE_NAME) == 0)) ||
         ((strcmp(szNamespace, SUBJECT_ASSEMBLY_TYPE_NAMESPACE) == 0) && (strcmp(szName, SUBJECT_ASSEMBLY_TYPE_NAME) == 0)))
     {
@@ -929,15 +929,6 @@ void QCALLTYPE COMDynamicWrite::DefineCustomAttribute(QCall::ModuleHandle pModul
 
     if (FAILED(hr))
     {
-        // See if the metadata engine gave us any error information.
-        SafeComHolderPreemp<IErrorInfo> pIErrInfo;
-        BSTRHolder bstrMessage;
-        if (SafeGetErrorInfo(&pIErrInfo) == S_OK)
-        {
-            if (SUCCEEDED(pIErrInfo->GetDescription(&bstrMessage)) && bstrMessage != NULL)
-                COMPlusThrow(kArgumentException, IDS_EE_INVALID_CA_EX, bstrMessage);
-        }
-
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_CA);
     }
 

--- a/src/coreclr/vm/comdynamic.cpp
+++ b/src/coreclr/vm/comdynamic.cpp
@@ -818,52 +818,29 @@ void QCALLTYPE COMDynamicWrite::SetClassLayout(QCall::ModuleHandle pModule, INT3
     END_QCALL;
 }
 
-void QCALLTYPE COMDynamicWrite::DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob, BOOL toDisk, BOOL updateCompilerFlags)
+// Helper function for COMDynamicWrite::DefineCustomAttribute
+void UpdateRuntimeStateForAssemblyCustomAttribute(Module* pModule, mdToken tkCustomAttribute, mdToken token, mdToken conTok, LPCBYTE pBlob, INT32 cbBlob)
 {
-    QCALL_CONTRACT;
+    WRAPPER_NO_CONTRACT;
 
-    BEGIN_QCALL;
+    LPCUTF8 szNamespace;
+    LPCUTF8 szName;
 
-    RefClassWriter* pRCW = pModule->GetReflectionModule()->GetClassWriter();
-    _ASSERTE(pRCW);
-
-    HRESULT hr;
-    mdCustomAttribute retToken;
-
-    if (toDisk && pRCW->GetOnDiskEmitter())
-    {
-        hr = pRCW->GetOnDiskEmitter()->DefineCustomAttribute(
-                token,
-                conTok,
-                pBlob,
-                cbBlob,
-                &retToken);
-    }
-    else
-    {
-        hr = pRCW->GetEmitter()->DefineCustomAttribute(
-                token,
-                conTok,
-                pBlob,
-                cbBlob,
-                &retToken);
-    }
-
+    HRESULT hr = pModule->GetMDImport()->GetNameOfCustomAttribute(tkCustomAttribute, &szNamespace, &szName);
     if (FAILED(hr))
     {
-        // See if the metadata engine gave us any error information.
-        SafeComHolderPreemp<IErrorInfo> pIErrInfo;
-        BSTRHolder bstrMessage;
-        if (SafeGetErrorInfo(&pIErrInfo) == S_OK)
-        {
-            if (SUCCEEDED(pIErrInfo->GetDescription(&bstrMessage)) && bstrMessage != NULL)
-                COMPlusThrow(kArgumentException, IDS_EE_INVALID_CA_EX, bstrMessage);
-        }
-
-        COMPlusThrow(kArgumentException, IDS_EE_INVALID_CA);
+        // If the type name cannot be acquired, then this isn't an interesting CustomAttribute
+        return;
     }
 
-    if (updateCompilerFlags)
+    if (szNamespace == NULL || szName == NULL)
+    {
+        // If either of the namespace or name are NULL, then this isn't an interesting attribute
+        return;
+    }
+
+    // Debuggable attribute processing
+    if ((strcmp(szNamespace, DEBUGGABLE_ATTRIBUTE_TYPE_NAMESPACE) == 0) && (strcmp(szName, DEBUGGABLE_ATTRIBUTE_TYPE_NAME) == 0))
     {
         DWORD flags     = 0;
         DWORD mask      = ~(DACF_OBSOLETE_TRACK_JIT_INFO | DACF_IGNORE_PDBS | DACF_ALLOW_JIT_OPTS) & DACF_CONTROL_FLAGS_MASK;
@@ -908,6 +885,65 @@ void QCALLTYPE COMDynamicWrite::DefineCustomAttribute(QCall::ModuleHandle pModul
             actualFlags = ((DWORD)(i.GetModule()->GetDebuggerInfoBits()) & mask) | flags;
             i.GetModule()->SetDebuggerInfoBits((DebuggerAssemblyControlFlags)actualFlags);
         }
+    }
+
+    // Debuggable attribute processing
+    if (((strcmp(szNamespace, FRIEND_ASSEMBLY_TYPE_NAMESPACE) == 0) && (strcmp(szName, FRIEND_ASSEMBLY_TYPE_NAME) == 0)) ||
+        ((strcmp(szNamespace, SUBJECT_ASSEMBLY_TYPE_NAMESPACE) == 0) && (strcmp(szName, SUBJECT_ASSEMBLY_TYPE_NAME) == 0)))
+    {
+        Assembly* pAssembly = pModule->GetAssembly();
+        pAssembly->UpdateCachedFriendAssemblyInfo();
+    }
+}
+
+void QCALLTYPE COMDynamicWrite::DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob, BOOL toDisk)
+{
+    QCALL_CONTRACT;
+
+    BEGIN_QCALL;
+
+    RefClassWriter* pRCW = pModule->GetReflectionModule()->GetClassWriter();
+    _ASSERTE(pRCW);
+
+    HRESULT hr;
+    mdCustomAttribute retToken;
+
+    if (toDisk && pRCW->GetOnDiskEmitter())
+    {
+        hr = pRCW->GetOnDiskEmitter()->DefineCustomAttribute(
+                token,
+                conTok,
+                pBlob,
+                cbBlob,
+                &retToken);
+    }
+    else
+    {
+        hr = pRCW->GetEmitter()->DefineCustomAttribute(
+                token,
+                conTok,
+                pBlob,
+                cbBlob,
+                &retToken);
+    }
+
+    if (FAILED(hr))
+    {
+        // See if the metadata engine gave us any error information.
+        SafeComHolderPreemp<IErrorInfo> pIErrInfo;
+        BSTRHolder bstrMessage;
+        if (SafeGetErrorInfo(&pIErrInfo) == S_OK)
+        {
+            if (SUCCEEDED(pIErrInfo->GetDescription(&bstrMessage)) && bstrMessage != NULL)
+                COMPlusThrow(kArgumentException, IDS_EE_INVALID_CA_EX, bstrMessage);
+        }
+
+        COMPlusThrow(kArgumentException, IDS_EE_INVALID_CA);
+    }
+
+    if (token == TokenFromRid(1, mdtAssembly))
+    {
+        UpdateRuntimeStateForAssemblyCustomAttribute(pModule, retToken, token, conTok, pBlob, cbBlob);
     }
 
     END_QCALL;

--- a/src/coreclr/vm/comdynamic.cpp
+++ b/src/coreclr/vm/comdynamic.cpp
@@ -896,7 +896,7 @@ void UpdateRuntimeStateForAssemblyCustomAttribute(Module* pModule, mdToken tkCus
     }
 }
 
-void QCALLTYPE COMDynamicWrite::DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob, BOOL toDisk)
+void QCALLTYPE COMDynamicWrite::DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob)
 {
     QCALL_CONTRACT;
 
@@ -908,24 +908,12 @@ void QCALLTYPE COMDynamicWrite::DefineCustomAttribute(QCall::ModuleHandle pModul
     HRESULT hr;
     mdCustomAttribute retToken;
 
-    if (toDisk && pRCW->GetOnDiskEmitter())
-    {
-        hr = pRCW->GetOnDiskEmitter()->DefineCustomAttribute(
-                token,
-                conTok,
-                pBlob,
-                cbBlob,
-                &retToken);
-    }
-    else
-    {
-        hr = pRCW->GetEmitter()->DefineCustomAttribute(
-                token,
-                conTok,
-                pBlob,
-                cbBlob,
-                &retToken);
-    }
+    hr = pRCW->GetEmitter()->DefineCustomAttribute(
+            token,
+            conTok,
+            pBlob,
+            cbBlob,
+            &retToken);
 
     if (FAILED(hr))
     {

--- a/src/coreclr/vm/comdynamic.h
+++ b/src/coreclr/vm/comdynamic.h
@@ -114,7 +114,7 @@ public:
 
     // Set a custom attribute
     static
-    void QCALLTYPE DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob, BOOL toDisk);
+    void QCALLTYPE DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob);
 
     // functions to set ParamInfo
     static

--- a/src/coreclr/vm/comdynamic.h
+++ b/src/coreclr/vm/comdynamic.h
@@ -114,7 +114,7 @@ public:
 
     // Set a custom attribute
     static
-    void QCALLTYPE DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob, BOOL toDisk, BOOL updateCompilerFlags);
+    void QCALLTYPE DefineCustomAttribute(QCall::ModuleHandle pModule, INT32 token, INT32 conTok, LPCBYTE pBlob, INT32 cbBlob, BOOL toDisk);
 
     // functions to set ParamInfo
     static

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -1838,14 +1838,6 @@ BOOL DomainAssembly::CheckZapDependencyIdentities(PEImage *pNativeImage)
 }
 #endif // FEATURE_PREJIT
 
-
-
-
-
-// <TODO>@todo Find a better place for these</TODO>
-#define DE_CUSTOM_VALUE_NAMESPACE        "System.Diagnostics"
-#define DE_DEBUGGABLE_ATTRIBUTE_NAME     "DebuggableAttribute"
-
 // <TODO>@todo .INI file is a temporary workaround for Beta 1</TODO>
 #define DE_INI_FILE_SECTION_NAME          W(".NET Framework Debugging Control")
 #define DE_INI_FILE_KEY_TRACK_INFO        W("GenerateTrackingInfo")
@@ -2080,9 +2072,7 @@ HRESULT DomainAssembly::GetDebuggingCustomAttributes(DWORD *pdwFlags)
         mdAssembly asTK = TokenFromRid(mdtAssembly, 1);
 
         hr = mdImport->GetCustomAttributeByName(asTK,
-                                                DE_CUSTOM_VALUE_NAMESPACE
-                                                NAMESPACE_SEPARATOR_STR
-                                                DE_DEBUGGABLE_ATTRIBUTE_NAME,
+                                                DEBUGGABLE_ATTRIBUTE_TYPE,
                                                 (const void**)&blob,
                                                 &size);
 
@@ -2131,7 +2121,7 @@ HRESULT DomainAssembly::GetDebuggingCustomAttributes(DWORD *pdwFlags)
                 }
 
                 LOG((LF_CORDB, LL_INFO10, "Assembly %S: has %s=%d,%d bits = 0x%x\n", GetDebugName(),
-                     DE_DEBUGGABLE_ATTRIBUTE_NAME,
+                     DEBUGGABLE_ATTRIBUTE_TYPE_NAME,
                      blob[2], blob[3], *pdwFlags));
             }
         }

--- a/src/coreclr/vm/reflectclasswriter.cpp
+++ b/src/coreclr/vm/reflectclasswriter.cpp
@@ -113,9 +113,4 @@ RefClassWriter::~RefClassWriter()
         m_pCeeGen->Release();
         m_pCeeGen = NULL;
     }
-
-    if (m_pOnDiskEmitter) {
-        m_pOnDiskEmitter->Release();
-        m_pOnDiskEmitter = NULL;
-    }
 }

--- a/src/coreclr/vm/reflectclasswriter.h
+++ b/src/coreclr/vm/reflectclasswriter.h
@@ -23,12 +23,10 @@ protected:
 	IMetaDataEmitHelper*	m_pEmitHelper;
 	ULONG					m_ulResourceSize;
     mdFile                  m_tkFile;
-    IMetaDataEmit*          m_pOnDiskEmitter;
 
 public:
     RefClassWriter() {
         LIMITED_METHOD_CONTRACT;
-        m_pOnDiskEmitter = NULL;
     }
 
 	HRESULT		Init(ICeeGen *pCeeGen, IUnknown *pUnk, LPCWSTR szName);
@@ -67,29 +65,6 @@ public:
         LIMITED_METHOD_CONTRACT;
 		return m_ceeFile;
 	}
-
-    IMetaDataEmit* GetOnDiskEmitter() {
-        LIMITED_METHOD_CONTRACT;
-        return m_pOnDiskEmitter;
-    }
-
-    void SetOnDiskEmitter(IMetaDataEmit *pOnDiskEmitter) {
-        CONTRACTL {
-            NOTHROW;
-            GC_TRIGGERS;
-            // we know that the com implementation is ours so we use mode-any to simplify
-            // having to switch mode
-            MODE_ANY;
-            FORBID_FAULT;
-        }
-        CONTRACTL_END;
-        if (pOnDiskEmitter)
-            pOnDiskEmitter->AddRef();
-        if (m_pOnDiskEmitter)
-            m_pOnDiskEmitter->Release();
-        m_pOnDiskEmitter = pOnDiskEmitter;
-    }
-
 
 	~RefClassWriter();
 };

--- a/src/tests/reflection/RefEmit/Dependency.cs
+++ b/src/tests/reflection/RefEmit/Dependency.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("EmittingIgnoresAccessChecksToAttributeIsRespected")]
+
+internal class BaseClass2
+{
+}

--- a/src/tests/reflection/RefEmit/Dependency.csproj
+++ b/src/tests/reflection/RefEmit/Dependency.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Dependency.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/reflection/RefEmit/EmittingIgnoresAccessChecksToAttributeIsRespected.cs
+++ b/src/tests/reflection/RefEmit/EmittingIgnoresAccessChecksToAttributeIsRespected.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+class BaseClass1 { }
+
+class Test
+{
+
+    public static int Main()
+    {
+        AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("testassembly"), AssemblyBuilderAccess.Run);
+        ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("testmodule");
+        ConstructorInfo ignoreAccessChecksToAttributeCtor = DefineIgnoresAccessChecksToAttribute(moduleBuilder);
+
+        {
+            Type type = typeof(BaseClass1);
+            AddInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, ignoreAccessChecksToAttributeCtor, type.Assembly);
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("DerivedTypeFor" + type.Name, TypeAttributes.Public, type);
+            typeBuilder.CreateType();
+        }
+
+        {
+            Type type = typeof(BaseClass2);
+            AddInstanceOfIgnoresAccessChecksToAttribute(assemblyBuilder, ignoreAccessChecksToAttributeCtor, type.Assembly);
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("DerivedTypeFor" + type.Name, TypeAttributes.Public, type);
+            typeBuilder.CreateType();
+        }
+        Console.WriteLine("PASS");
+        return 100;
+    }
+
+    static void AddInstanceOfIgnoresAccessChecksToAttribute(AssemblyBuilder assemblyBuilder, ConstructorInfo ignoreAccessChecksToAttributeCtor, Assembly assembly)
+    {
+        // Add this assembly level attribute:
+        // [assembly: System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute(assemblyName)]
+        ConstructorInfo attributeConstructor = ignoreAccessChecksToAttributeCtor;
+        CustomAttributeBuilder customAttributeBuilder =
+            new CustomAttributeBuilder(attributeConstructor, new object[] { assembly.GetName().Name });
+        assemblyBuilder.SetCustomAttribute(customAttributeBuilder);
+    }
+
+    static ConstructorInfo DefineIgnoresAccessChecksToAttribute(ModuleBuilder mb)
+    {
+        TypeBuilder attributeTypeBuilder =
+            mb.DefineType("System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute",
+                           TypeAttributes.Public | TypeAttributes.Class,
+                           typeof(Attribute));
+
+        // Create backing field as:
+        // private string assemblyName;
+        FieldBuilder assemblyNameField =
+            attributeTypeBuilder.DefineField("assemblyName", typeof(string), FieldAttributes.Private);
+
+        // Create ctor as:
+        // public IgnoresAccessChecksToAttribute(string)
+        ConstructorBuilder constructorBuilder = attributeTypeBuilder.DefineConstructor(MethodAttributes.Public,
+                                                     CallingConventions.HasThis,
+                                                     new Type[] { assemblyNameField.FieldType });
+
+        ILGenerator il = constructorBuilder.GetILGenerator();
+
+        // Create ctor body as:
+        // this.assemblyName = {ctor parameter 0}
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg, 1);
+        il.Emit(OpCodes.Stfld, assemblyNameField);
+
+        // return
+        il.Emit(OpCodes.Ret);
+
+        // Define property as:
+        // public string AssemblyName {get { return this.assemblyName; } }
+        PropertyBuilder propertyBuilder = attributeTypeBuilder.DefineProperty(
+                "AssemblyName",
+                PropertyAttributes.None,
+                CallingConventions.HasThis,
+                returnType: typeof(string),
+                parameterTypes: null);
+
+        MethodBuilder getterMethodBuilder = attributeTypeBuilder.DefineMethod(
+                                               "get_AssemblyName",
+                                               MethodAttributes.Public,
+                                               CallingConventions.HasThis,
+                                               returnType: typeof(string),
+                                               parameterTypes: null);
+        propertyBuilder.SetGetMethod(getterMethodBuilder);
+
+        // Generate body:
+        // return this.assemblyName;
+        il = getterMethodBuilder.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, assemblyNameField);
+        il.Emit(OpCodes.Ret);
+
+        // Generate the AttributeUsage attribute for this attribute type:
+        // [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+        TypeInfo attributeUsageTypeInfo = typeof(AttributeUsageAttribute).GetTypeInfo();
+
+        // Find the ctor that takes only AttributeTargets
+        ConstructorInfo attributeUsageConstructorInfo =
+            attributeUsageTypeInfo.DeclaredConstructors
+                .Single(c => c.GetParameters().Length == 1 &&
+                             c.GetParameters()[0].ParameterType == typeof(AttributeTargets));
+
+        // Find the property to set AllowMultiple
+        PropertyInfo allowMultipleProperty =
+            attributeUsageTypeInfo.DeclaredProperties
+                .Single(f => string.Equals(f.Name, "AllowMultiple"));
+
+        // Create a builder to construct the instance via the ctor and property
+        CustomAttributeBuilder customAttributeBuilder =
+            new CustomAttributeBuilder(attributeUsageConstructorInfo,
+                                        new object[] { AttributeTargets.Assembly },
+                                        new PropertyInfo[] { allowMultipleProperty },
+                                        new object[] { true });
+
+        // Attach this attribute instance to the newly defined attribute type
+        attributeTypeBuilder.SetCustomAttribute(customAttributeBuilder);
+
+        // Make the TypeInfo real so the constructor can be used.
+        return attributeTypeBuilder.CreateTypeInfo()!.DeclaredConstructors.Single();
+    }
+}
+
+

--- a/src/tests/reflection/RefEmit/EmittingIgnoresAccessChecksToAttributeIsRespected.csproj
+++ b/src/tests/reflection/RefEmit/EmittingIgnoresAccessChecksToAttributeIsRespected.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="EmittingIgnoresAccessChecksToAttributeIsRespected.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="Dependency.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Add routine/lock for updating friend assemblies
- Unify all assembly handling custom attribute updates in the runtime
  - This adjusts the handling of the DebuggableAttribute, which in the past would have worked even if it was applied to anything via the CustomAttributeBuilder apis

Fixes the runtime level changes needed to address issues #43685 and #30917