### PR TITLE
 Update the analyzer version in runtime and enable the TFM attributes on browser build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
     <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
   </ItemGroup>
   <PropertyGroup>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview1.21054.10</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview1.21101.7</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.8.0-4.20503.2</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <!-- Arcade dependencies -->
     <MicrosoftDotNetApiCompatVersion>6.0.0-beta.21062.10</MicrosoftDotNetApiCompatVersion>

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -157,13 +157,13 @@
       WriteOnlyWhenDifferent="true" />
 
   </Target>
-
-  <!-- Removes assembly level attributes for Browser. -->
-  <Target Name="RemoveSupportedPlatformAssemblyAttributeForBrowser" AfterTargets="GetAssemblyAttributes" Condition="'$(TargetFrameworkSuffix)' == 'Browser' or '$(IsTestProject)' == 'true'">
+  
+  <!-- Removes assembly level attributes from test projects. -->
+  <Target Name="RemoveSupportedOSPlatformAttributeFromTestProjects" AfterTargets="GetAssemblyAttributes" Condition="'$(IsTestProject)' == 'true'">
     <ItemGroup>
       <AssemblyAttribute Remove="System.Runtime.Versioning.SupportedOSPlatformAttribute" />
       <AssemblyAttribute Remove="System.Runtime.Versioning.TargetPlatformAttribute" />
     </ItemGroup>
   </Target>
-
+  
 </Project>

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -157,7 +157,7 @@
       WriteOnlyWhenDifferent="true" />
 
   </Target>
-  
+
   <!-- Removes assembly level attributes from test projects. -->
   <Target Name="RemoveSupportedOSPlatformAttributeFromTestProjects" AfterTargets="GetAssemblyAttributes" Condition="'$(IsTestProject)' == 'true'">
     <ItemGroup>
@@ -165,5 +165,5 @@
       <AssemblyAttribute Remove="System.Runtime.Versioning.TargetPlatformAttribute" />
     </ItemGroup>
   </Target>
-  
+
 </Project>


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/issues/44231#issuecomment-772077132 and https://github.com/dotnet/runtime/issues/44257

By design, SDK adds `SupportedOSPlatofrm("targetPlatform")` attribute into `AssemblyInfo.cs` for multi-targeted projects build in runtime which causing CA1416 warnings mostly on `.net5-Browser` targeted builds. 

We decided to suppress those warnings at the analyzer level, the work is done and [merged into roslyn-analyzers repo](https://github.com/dotnet/roslyn-analyzers/pull/4740) and now we can dogfood that change. This PR:
1. Updates the analyzer version to dogfood that change
2. Update the logic which is removing `SupportedOSPlatofrm("Browser")` attribute added my MSBuild from `AssemblyInfo`

