### PR TITLE
Resolve ILLink warnings in System.Linq.Expressions (Round 2)

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
@@ -15,36 +15,6 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitGetArrayElement(System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitLift(System.Linq.Expressions.ExpressionType,System.Type,System.Linq.Expressions.MethodCallExpression,System.Linq.Expressions.ParameterExpression[],System.Linq.Expressions.Expression[])</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitLiftedBinaryArithmetic(System.Linq.Expressions.ExpressionType,System.Type,System.Type,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitSetArrayElement(System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitUnaryOperator(System.Linq.Expressions.ExpressionType,System.Type,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2072</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.Expression.ListInit(System.Linq.Expressions.NewExpression,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression})</property>
@@ -72,36 +42,6 @@
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Dynamic.Utils.TypeUtils.GetUserDefinedCoercionMethod(System.Type,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.AddressOf(System.Linq.Expressions.IndexExpression,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.AddressOf(System.Linq.Expressions.MethodCallExpression,System.Type)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitDynamicExpression(System.Linq.Expressions.Expression)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitInvocationExpression(System.Linq.Expressions.Expression,System.Linq.Expressions.Compiler.LambdaCompiler.CompilationFlags)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.LambdaCompiler.EmitUnary(System.Linq.Expressions.UnaryExpression,System.Linq.Expressions.Compiler.LambdaCompiler.CompilationFlags)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -138,60 +78,6 @@
       <argument>IL2075</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.ExpressionStringBuilder.VisitExtension(System.Linq.Expressions.Expression)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.LightCompiler.CompileAddress(System.Linq.Expressions.Expression,System.Int32)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.LightCompiler.CompileIndexAssignment(System.Linq.Expressions.BinaryExpression,System.Boolean)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.LightCompiler.CompileInvocationExpression(System.Linq.Expressions.Expression)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.LightCompiler.CompileMultiDimArrayAccess(System.Linq.Expressions.Expression,System.Linq.Expressions.IArgumentProvider,System.Int32)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.LightCompiler.EmitIndexGet(System.Linq.Expressions.IndexExpression)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2077</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.DefaultValueInstruction.Run(System.Linq.Expressions.Interpreter.InterpretedFrame)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2077</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.InitializeLocalInstruction.MutableBox.Run(System.Linq.Expressions.Interpreter.InterpretedFrame)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2077</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Interpreter.InitializeLocalInstruction.MutableValue.Run(System.Linq.Expressions.Interpreter.InterpretedFrame)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2080</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.Compiler.CompilerScope.ElementBoxStorage.#ctor(System.Linq.Expressions.Compiler.CompilerScope.Storage,System.Int32,System.Linq.Expressions.ParameterExpression)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
@@ -73,11 +73,5 @@
       <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.Expression.PropertyOrField(System.Linq.Expressions.Expression,System.String)</property>
     </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Linq.Expressions.ExpressionStringBuilder.VisitExtension(System.Linq.Expressions.Expression)</property>
-    </attribute>
   </assembly>
 </linker>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -29,6 +29,17 @@ namespace System.Dynamic.Utils
             return type;
         }
 
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(Nullable<>))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Nullable<T> ctor will be preserved by the DynamicDependency.")]
+        public static ConstructorInfo GetNullableConstructor(Type nullableType, Type nonNullableType)
+        {
+            Debug.Assert(nullableType.IsNullableType());
+            Debug.Assert(!nonNullableType.IsNullableType() && nonNullableType.IsValueType);
+
+            return nullableType.GetConstructor(new Type[] { nonNullableType })!;
+        }
+
         public static bool IsNullableType(this Type type) => type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
 
         public static bool IsNullableOrReferenceType(this Type type) => !type.IsValueType || IsNullableType(type);
@@ -934,5 +945,29 @@ namespace System.Dynamic.Utils
         }
 
 #endif
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Array 'Get' method is dynamically constructed and is not included in IL. It is not subject to trimming.")]
+        public static MethodInfo GetArrayGetMethod(Type arrayType)
+        {
+            Debug.Assert(arrayType.IsArray);
+            return arrayType.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance)!;
+        }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Array 'Set' method is dynamically constructed and is not included in IL. It is not subject to trimming.")]
+        public static MethodInfo GetArraySetMethod(Type arrayType)
+        {
+            Debug.Assert(arrayType.IsArray);
+            return arrayType.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance)!;
+        }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The Array 'Address' method is dynamically constructed and is not included in IL. It is not subject to trimming.")]
+        public static MethodInfo GetArrayAddressMethod(Type arrayType)
+        {
+            Debug.Assert(arrayType.IsArray);
+            return arrayType.GetMethod("Address", BindingFlags.Public | BindingFlags.Instance)!;
+        }
     }
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/CompilerScope.Storage.cs
@@ -110,8 +110,9 @@ namespace System.Linq.Expressions.Compiler
             {
                 _array = array;
                 _index = index;
-                _boxType = typeof(StrongBox<>).MakeGenericType(variable.Type);
-                _boxValueField = _boxType.GetField("Value")!;
+                Type boxType = typeof(StrongBox<>).MakeGenericType(variable.Type);
+                _boxValueField = boxType.GetField("Value")!;
+                _boxType = boxType;
             }
 
             internal override void EmitLoad()

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -485,7 +485,7 @@ namespace System.Linq.Expressions.Compiler
 
                 if (TryEmitILConstant(il, value, nonNullType))
                 {
-                    il.Emit(OpCodes.Newobj, GetNullableConstructor(type, nonNullType));
+                    il.Emit(OpCodes.Newobj, TypeUtils.GetNullableConstructor(type, nonNullType));
                     return true;
                 }
 
@@ -826,7 +826,7 @@ namespace System.Linq.Expressions.Compiler
             Type nnTypeTo = typeTo.GetNonNullableType();
             il.EmitConvertToType(nnTypeFrom, nnTypeTo, isChecked, locals);
             // construct result type
-            ConstructorInfo ci = GetNullableConstructor(typeTo, nnTypeTo);
+            ConstructorInfo ci = TypeUtils.GetNullableConstructor(typeTo, nnTypeTo);
             il.Emit(OpCodes.Newobj, ci);
             labEnd = il.DefineLabel();
             il.Emit(OpCodes.Br_S, labEnd);
@@ -846,19 +846,8 @@ namespace System.Linq.Expressions.Compiler
             Debug.Assert(typeTo.IsNullableType());
             Type nnTypeTo = typeTo.GetNonNullableType();
             il.EmitConvertToType(typeFrom, nnTypeTo, isChecked, locals);
-            ConstructorInfo ci = GetNullableConstructor(typeTo, nnTypeTo);
+            ConstructorInfo ci = TypeUtils.GetNullableConstructor(typeTo, nnTypeTo);
             il.Emit(OpCodes.Newobj, ci);
-        }
-
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(Nullable<>))]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
-            Justification = "The Nullable<T> ctor will be preserved by the DynamicDependency.")]
-        private static ConstructorInfo GetNullableConstructor(Type nullableType, Type nonNullableType)
-        {
-            Debug.Assert(nullableType.IsNullableType());
-            Debug.Assert(!nonNullableType.IsNullableType() && nonNullableType.IsValueType);
-
-            return nullableType.GetConstructor(new Type[] { nonNullableType })!;
         }
 
         private static void EmitNullableToNonNullableConversion(this ILGenerator il, Type typeFrom, Type typeTo, bool isChecked, ILocalCache locals)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Address.cs
@@ -162,7 +162,6 @@ namespace System.Linq.Expressions.Compiler
             _ilg.Emit(OpCodes.Ldloca, temp);
         }
 
-
         private void AddressOf(MethodCallExpression node, Type type)
         {
             // An array index of a multi-dimensional array is represented by a call to Array.Get,
@@ -172,9 +171,9 @@ namespace System.Linq.Expressions.Compiler
             // this situation and replace it with a call to the Address method.
             if (!node.Method.IsStatic &&
                 node.Object!.Type.IsArray &&
-                node.Method == node.Object.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance))
+                node.Method == TypeUtils.GetArrayGetMethod(node.Object.Type))
             {
-                MethodInfo mi = node.Object.Type.GetMethod("Address", BindingFlags.Public | BindingFlags.Instance)!;
+                MethodInfo mi = TypeUtils.GetArrayAddressMethod(node.Object.Type);
 
                 EmitMethodCall(node.Object, mi, node);
             }
@@ -200,7 +199,7 @@ namespace System.Linq.Expressions.Compiler
             }
             else
             {
-                MethodInfo address = node.Object!.Type.GetMethod("Address", BindingFlags.Public | BindingFlags.Instance)!;
+                MethodInfo address = TypeUtils.GetArrayAddressMethod(node.Object!.Type);
                 EmitMethodCall(node.Object, address, node);
             }
         }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Binary.cs
@@ -475,10 +475,12 @@ namespace System.Linq.Expressions.Compiler
             FreeLocal(locLeft);
             FreeLocal(locRight);
 
-            EmitBinaryOperator(op, leftType.GetNonNullableType(), rightType.GetNonNullableType(), resultType.GetNonNullableType(), liftedToNull: false);
+            Type resultNonNullableType = resultType.GetNonNullableType();
+
+            EmitBinaryOperator(op, leftType.GetNonNullableType(), rightType.GetNonNullableType(), resultNonNullableType, liftedToNull: false);
 
             // construct result type
-            ConstructorInfo ci = resultType.GetConstructor(new Type[] { resultType.GetNonNullableType() })!;
+            ConstructorInfo ci = TypeUtils.GetNullableConstructor(resultType, resultNonNullableType);
             _ilg.Emit(OpCodes.Newobj, ci);
             _ilg.Emit(OpCodes.Stloc, locResult);
             _ilg.Emit(OpCodes.Br_S, labEnd);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -4,9 +4,11 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Compiler
 {
@@ -183,7 +185,7 @@ namespace System.Linq.Expressions.Compiler
             if (typeof(LambdaExpression).IsAssignableFrom(expr.Type))
             {
                 // if the invoke target is a lambda expression tree, first compile it into a delegate
-                expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Type.EmptyTypes)!);
+                expr = Expression.Call(expr, LambdaExpression.GetCompileMethod(expr.Type));
             }
 
             EmitMethodCall(expr, expr.Type.GetInvokeMethod(), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
@@ -311,7 +313,7 @@ namespace System.Linq.Expressions.Compiler
             else
             {
                 // Multidimensional arrays, call get
-                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance)!);
+                _ilg.Emit(OpCodes.Call, TypeUtils.GetArrayGetMethod(arrayType));
             }
         }
 
@@ -339,7 +341,7 @@ namespace System.Linq.Expressions.Compiler
             else
             {
                 // Multidimensional arrays, call set
-                _ilg.Emit(OpCodes.Call, arrayType.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance)!);
+                _ilg.Emit(OpCodes.Call, TypeUtils.GetArraySetMethod(arrayType));
             }
         }
 
@@ -602,13 +604,22 @@ namespace System.Linq.Expressions.Compiler
             _ilg.Emit(OpCodes.Dup);
             LocalBuilder siteTemp = GetLocal(siteType);
             _ilg.Emit(OpCodes.Stloc, siteTemp);
-            _ilg.Emit(OpCodes.Ldfld, siteType.GetField("Target")!);
+            _ilg.Emit(OpCodes.Ldfld, GetCallSiteTargetField(siteType));
             _ilg.Emit(OpCodes.Ldloc, siteTemp);
             FreeLocal(siteTemp);
 
             List<WriteBack>? wb = EmitArguments(invoke, node, 1);
             _ilg.Emit(OpCodes.Callvirt, invoke);
             EmitWriteBack(wb);
+        }
+
+        [DynamicDependency("Target", typeof(CallSite<>))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The 'Target' field will be preserved by the DynamicDependency.")]
+        private static FieldInfo GetCallSiteTargetField(Type siteType)
+        {
+            Debug.Assert(siteType.IsGenericType && siteType.GetGenericTypeDefinition() == typeof(CallSite<>));
+            return siteType.GetField("Target")!;
         }
 
         private void EmitNewExpression(Expression expr)
@@ -1160,7 +1171,7 @@ namespace System.Linq.Expressions.Compiler
                         EmitMethodCallExpression(mc);
                         if (resultType.IsNullableType() && !TypeUtils.AreEquivalent(resultType, mc.Type))
                         {
-                            ConstructorInfo ci = resultType.GetConstructor(new Type[] { mc.Type })!;
+                            ConstructorInfo ci = TypeUtils.GetNullableConstructor(resultType, mc.Type);
                             _ilg.Emit(OpCodes.Newobj, ci);
                         }
                         _ilg.Emit(OpCodes.Br_S, exit);
@@ -1264,7 +1275,7 @@ namespace System.Linq.Expressions.Compiler
                         EmitMethodCallExpression(mc);
                         if (resultType.IsNullableType() && !TypeUtils.AreEquivalent(resultType, mc.Type))
                         {
-                            ConstructorInfo ci = resultType.GetConstructor(new Type[] { mc.Type })!;
+                            ConstructorInfo ci = TypeUtils.GetNullableConstructor(resultType, mc.Type);
                             _ilg.Emit(OpCodes.Newobj, ci);
                         }
                         _ilg.Emit(OpCodes.Br_S, exit);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Unary.cs
@@ -94,7 +94,7 @@ namespace System.Linq.Expressions.Compiler
                     EmitBinaryOperator(ExpressionType.SubtractChecked, nnType, nnType, nnType, liftedToNull: false);
 
                     // construct result
-                    _ilg.Emit(OpCodes.Newobj, type.GetConstructor(new Type[] { nnType })!);
+                    _ilg.Emit(OpCodes.Newobj, TypeUtils.GetNullableConstructor(type, nnType));
                     _ilg.Emit(OpCodes.Br_S, end);
 
                     // if null then push back on stack
@@ -164,7 +164,7 @@ namespace System.Linq.Expressions.Compiler
                         EmitUnaryOperator(op, nnOperandType, nnOperandType);
 
                         // construct result
-                        ConstructorInfo ci = resultType.GetConstructor(new Type[] { nnOperandType })!;
+                        ConstructorInfo ci = TypeUtils.GetNullableConstructor(resultType, nnOperandType);
                         _ilg.Emit(OpCodes.Newobj, ci);
                         _ilg.Emit(OpCodes.Br_S, labEnd);
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionStringBuilder.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -786,6 +787,8 @@ namespace System.Linq.Expressions
             return node;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "The 'ToString' method cannot be trimmed on any Expression type because we are calling Expression.ToString() in this method.")]
         protected internal override Expression VisitExtension(Expression node)
         {
             // Prefer an overridden ToString, if available.

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 
 namespace System.Linq.Expressions.Interpreter
@@ -21,6 +22,8 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "DefaultValue";
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
+            Justification = "_type is a ValueType. You can always create an instance of a ValueType.")]
         public override int Run(InterpretedFrame frame)
         {
             frame.Push(Activator.CreateInstance(_type));

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -593,7 +593,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             else if (index.ArgumentCount != 1)
             {
-                _instructions.EmitCall(index.Object!.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance)!);
+                _instructions.EmitCall(TypeUtils.GetArrayGetMethod(index.Object!.Type));
             }
             else
             {
@@ -632,7 +632,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             else if (index.ArgumentCount != 1)
             {
-                _instructions.EmitCall(index.Object!.Type.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance)!);
+                _instructions.EmitCall(TypeUtils.GetArraySetMethod(index.Object!.Type));
             }
             else
             {
@@ -2343,7 +2343,7 @@ namespace System.Linq.Expressions.Interpreter
                         var call = (MethodCallExpression)node;
                         if (!call.Method.IsStatic &&
                             call.Object!.Type.IsArray &&
-                            call.Method == call.Object.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance))
+                            call.Method == TypeUtils.GetArrayGetMethod(call.Object.Type))
                         {
                             return CompileMultiDimArrayAccess(
                                 call.Object,
@@ -2380,9 +2380,9 @@ namespace System.Linq.Expressions.Interpreter
                 indexLocals[i] = argTmp;
             }
 
-            _instructions.EmitCall(array.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance)!);
+            _instructions.EmitCall(TypeUtils.GetArrayGetMethod(array.Type));
 
-            return new IndexMethodByRefUpdater(objTmp, indexLocals, array.Type.GetMethod("Set", BindingFlags.Public | BindingFlags.Instance)!, index);
+            return new IndexMethodByRefUpdater(objTmp, indexLocals, TypeUtils.GetArraySetMethod(array.Type), index);
         }
 
         private void CompileNewExpression(Expression expr)
@@ -2671,7 +2671,7 @@ namespace System.Linq.Expressions.Interpreter
 
             if (typeof(LambdaExpression).IsAssignableFrom(node.Expression.Type))
             {
-                MethodInfo compMethod = node.Expression.Type.GetMethod("Compile", Type.EmptyTypes)!;
+                MethodInfo compMethod = LambdaExpression.GetCompileMethod(node.Expression.Type);
                 CompileMethodCallExpression(
                     Expression.Call(
                         node.Expression,

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -373,9 +374,13 @@ namespace System.Linq.Expressions.Interpreter
             internal MutableValue(int index, Type type)
                 : base(index)
             {
+                Debug.Assert(type.IsValueType, "MutableValue only supports value types.");
+
                 _type = type;
             }
 
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
+                Justification = "_type is a ValueType. You can always create an instance of a ValueType.")]
             public override int Run(InterpretedFrame frame)
             {
                 try
@@ -406,9 +411,13 @@ namespace System.Linq.Expressions.Interpreter
             internal MutableBox(int index, Type type)
                 : base(index)
             {
+                Debug.Assert(type.IsValueType, "MutableBox only supports value types.");
+
                 _type = type;
             }
 
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
+                Justification = "_type is a ValueType. You can always create an instance of a ValueType.")]
             public override int Run(InterpretedFrame frame)
             {
                 object? value;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -102,6 +102,21 @@ namespace System.Linq.Expressions
             }
         }
 
+        [DynamicDependency("Compile()", typeof(LambdaExpression))]
+        [DynamicDependency("Compile()", typeof(Expression<>))]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+            Justification = "The 'Compile' methods will be preserved by the DynamicDependency.")]
+        internal static MethodInfo GetCompileMethod(Type lambdaExpressionType)
+        {
+            Debug.Assert(lambdaExpressionType.IsAssignableTo(typeof(LambdaExpression)));
+
+            MethodInfo result = lambdaExpressionType.GetMethod("Compile", Type.EmptyTypes)!;
+            Debug.Assert(result.DeclaringType == typeof(LambdaExpression) ||
+                (result.DeclaringType!.IsGenericType && result.DeclaringType.GetGenericTypeDefinition() == typeof(Expression<>)));
+
+            return result;
+        }
+
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
         /// </summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -1401,8 +1401,6 @@ namespace System.Linq.Expressions
         /// <paramref name="array"/> or <paramref name="indexes"/> is null.</exception>
         /// <exception cref="ArgumentException">
         /// <paramref name="array"/>.Type does not represent an array type.-or-The rank of <paramref name="array"/>.Type does not match the number of elements in <paramref name="indexes"/>.-or-The <see cref="Expression.Type"/> property of one or more elements of <paramref name="indexes"/> does not represent the <see cref="int"/> type.</exception>
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "The Array 'Get' method is dynamically constructed and are not included in IL. It is not subject to trimming.")]
         public static MethodCallExpression ArrayIndex(Expression array, IEnumerable<Expression> indexes)
         {
             ExpressionUtils.RequiresCanRead(array, nameof(array), -1);
@@ -1431,7 +1429,7 @@ namespace System.Linq.Expressions
                 }
             }
 
-            MethodInfo mi = array.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance)!;
+            MethodInfo mi = TypeUtils.GetArrayGetMethod(array.Type);
             return Call(array, mi, indexList);
         }
 


### PR DESCRIPTION
Contributes to #45623

I believe this is the last round of being able to resolve / suppress warnings in this assembly. The remaining warnings will all need `[RequiresUnreferencedCode]` attributes on a bunch of public APIs. I'll do this in the 3rd and final round.