### PR TITLE
Add more sources to tasks.proj build semaphore

### DIFF
--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -49,7 +49,7 @@
     <!-- Include both the project file and its sources as an input. -->
     <ItemGroup>
       <TasksSrc Include="%(ProjectReferenceWithConfiguration.Identity)" />
-      <TasksSrc Include="%(ProjectReferenceWithConfiguration.RelativeDir)%(ProjectReferenceWithConfiguration.RecursiveDir)**\*.cs" />
+      <TasksSrc Include="%(ProjectReferenceWithConfiguration.RelativeDir)%(ProjectReferenceWithConfiguration.RecursiveDir)**\*" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -48,7 +48,6 @@
 
     <!-- Include both the project file and its sources as an input. -->
     <ItemGroup>
-      <TasksSrc Include="%(ProjectReferenceWithConfiguration.Identity)" />
       <TasksSrc Include="%(ProjectReferenceWithConfiguration.RelativeDir)%(ProjectReferenceWithConfiguration.RecursiveDir)**\*" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
With the Apple/AndroidAppBuilders we now have additional sources besides *.cs so we need to add them to the semaphore,
otherwise changes in these files wouldn't cause a rebuild.

See also https://github.com/dotnet/runtime/issues/37783