### PR TITLE
Ensure mono_gc_thread_detach is always called

### DIFF
--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -3572,13 +3572,12 @@ thread_detach (MonoThreadInfo *info)
 	g_assert (info);
 	g_assert (mono_thread_info_is_current (info));
 
-	if (!mono_thread_info_try_get_internal_thread_gchandle (info, &gchandle))
-		return;
+	if (mono_thread_info_try_get_internal_thread_gchandle (info, &gchandle)) {
+		internal = (MonoInternalThread*)mono_gchandle_get_target_internal (gchandle);
+		g_assert (internal);
 
-	internal = (MonoInternalThread*) mono_gchandle_get_target_internal (gchandle);
-	g_assert (internal);
-
-	mono_thread_detach_internal (internal);
+		mono_thread_detach_internal (internal);
+	}
 
 	mono_gc_thread_detach (info);
 }


### PR DESCRIPTION
The previous logic would not call `mono_gc_thread_detach` for a number of scenarios. One example:
```
start_wrapper
- mono_thread_info_attach - thread is now live in mono threads layer
- start_wrapper_internal
-- mono_thread_attach_internal - mono attached to vm thread layer. GC handle is set via mono_thread_info_set_internal_thread_gchandle
-- mono_thread_detach_internal - detached from vm thread layer. GC handle cleared via call to mono_thread_info_unset_internal_thread_gchandle
- mono_thread_info_exit
-- mono_thread_info_detach
--- unregister_thread
---- thread_detach callback - checks if gc handle is valid and returns if not via mono_thread_info_try_get_internal_thread_gchandle. We've already cleared above so we never call mono_gc_thread_detach.
```

This change ensures `mono_gc_thread_detach` is always called even the GC handle for the thread has already been cleared.