### PR TITLE
Add crossgen2 automated SuperPMI collection of Core_Root libraries

### DIFF
--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -101,9 +101,10 @@ jobs:
     platforms:
     # Linux tests are built on the OSX machines.
     # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
+    # TODO: Linux crossgen2 jobs crash during collection, and need to be investigated.
+    # - Linux_arm
+    # - Linux_arm64
+    # - Linux_x64
     - windows_x64
     - windows_x86
     - windows_arm64

--- a/eng/pipelines/coreclr/superpmi.yml
+++ b/eng/pipelines/coreclr/superpmi.yml
@@ -107,6 +107,27 @@ jobs:
     - windows_x64
     - windows_x86
     - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen2
+      collectionName: libraries
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
     - ${{ parameters.steps }}
   
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi-setup.py -source_directory $(Build.SourcesDirectory) -core_root_directory $(Core_Root_Dir) -arch $(archType) -mch_file_tag $(MchFileTag) -input_directory $(InputDirectory) -collection_name $(CollectionName) -max_size 50 # size in MB
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi-setup.py -source_directory $(Build.SourcesDirectory) -core_root_directory $(Core_Root_Dir) -arch $(archType) -mch_file_tag $(MchFileTag) -input_directory $(InputDirectory) -collection_name $(CollectionName) -collection_type $(CollectionType) -max_size 50 # size in MB
       displayName: ${{ format('SuperPMI setup ({0})', parameters.osGroup) }}
 
       # Run superpmi collection in helix

--- a/eng/pipelines/coreclr/templates/run-superpmi-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-job.yml
@@ -133,14 +133,14 @@ jobs:
       continueOnError: true
       condition: always()
 
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py merge-mch -pattern $(MchFilesLocation)$(CollectionName).$(CollectionType)*.mch  -output_mch_path $(MchFilesLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py merge-mch -log_level DEBUG -pattern $(MchFilesLocation)$(CollectionName).$(CollectionType)*.mch  -output_mch_path $(MchFilesLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch
       displayName: ${{ format('Merge {0}-{1} SuperPMI collections', parameters.collectionName, parameters.collectionType) }}
       continueOnError: true
       condition: always()
 
     # For now, we won't upload merged collection as an artifact.
 
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py upload -arch $(archType) -build_type $(buildConfig) -mch_files $(MchFilesLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch -core_root $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).x64.$(buildConfigUpper)
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi.py upload -log_level DEBUG -arch $(archType) -build_type $(buildConfig) -mch_files $(MchFilesLocation)$(CollectionName).$(CollectionType).$(MchFileTag).mch -core_root $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).x64.$(buildConfigUpper)
       displayName: ${{ format('Upload SuperPMI {0}-{1} collection to Azure Storage', parameters.collectionName, parameters.collectionType) }}
       env:
         CLRJIT_AZ_KEY: $(clrjit_key1) # secret key stored as variable in pipeline

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
@@ -259,8 +259,8 @@ inline void SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INST_HandleArray(
     {
         if (handleInstCount > 0)
         {
-            // This is really a VM/crossgen bug.
-            LogVerbose("(handleInstCount > 0) but (handleInstArray == nullptr)!");
+            // This is really a VM/crossgen2 bug (or, a by-design crossgen2 feature to avoid creating
+            // an array the JIT doesn't look at).
             handleInstCount = 0;
         }
 

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -50,9 +50,9 @@ parser.add_argument("-source_directory", help="path to source directory")
 parser.add_argument("-core_root_directory", help="path to core_root directory")
 parser.add_argument("-arch", help="Architecture")
 parser.add_argument("-mch_file_tag", help="Tag to be used to mch files")
-parser.add_argument("-collection_name", help="Name of the SPMI collection to be done")
-parser.add_argument("-input_directory", help="directory containing assemblies for which superpmi collection to "
-                                                  "be done")
+parser.add_argument("-collection_name", help="Name of the SPMI collection to be done (e.g., libraries, tests)")
+parser.add_argument("-collection_type", help="Type of the SPMI collection to be done (crossgen, crossgen2, pmi)")
+parser.add_argument("-input_directory", help="directory containing assemblies for which superpmi collection to be done")
 parser.add_argument("-max_size", help="Max size of each partition in MB")
 is_windows = platform.system() == "Windows"
 native_binaries_to_ignore = [
@@ -128,6 +128,11 @@ def setup_args(args):
                         "collection_name",
                         lambda unused: True,
                         "Unable to set collection_name")
+
+    coreclr_args.verify(args,
+                        "collection_type",
+                        lambda unused: True,
+                        "Unable to set collection_type")
 
     coreclr_args.verify(args,
                         "input_directory",
@@ -380,7 +385,7 @@ def main(main_args):
     pmiassemblies_directory = path.join(workitem_directory, "pmiAssembliesDirectory")
 
     # Copy ".dotnet" to correlation_payload_directory for crossgen2 job; it is needed to invoke crossgen2.dll
-    if coreclr_args.collection_name == "crossgen2":
+    if coreclr_args.collection_type == "crossgen2":
         dotnet_src_directory = path.join(source_directory, ".dotnet")
         dotnet_dst_directory = path.join(correlation_payload_directory, ".dotnet")
         print('Copying {} -> {}'.format(dotnet_src_directory, dotnet_dst_directory))
@@ -390,7 +395,7 @@ def main(main_args):
     input_artifacts = path.join(pmiassemblies_directory, coreclr_args.collection_name)
     exclude_directory = ['Core_Root'] if coreclr_args.collection_name == "tests" else []
     exclude_files = native_binaries_to_ignore
-    if coreclr_args.collection_name == "crossgen2":
+    if coreclr_args.collection_type == "crossgen2":
         # Currently, trying to crossgen2 R2RTest\Microsoft.Build.dll causes a pop-up failure, so exclude it.
         exclude_files += [ "Microsoft.Build.dll" ]
     partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory, exclude_files)

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -55,18 +55,35 @@ parser.add_argument("-collection_type", help="Type of the SPMI collection to be 
 parser.add_argument("-input_directory", help="directory containing assemblies for which superpmi collection to be done")
 parser.add_argument("-max_size", help="Max size of each partition in MB")
 is_windows = platform.system() == "Windows"
+
 native_binaries_to_ignore = [
     "System.IO.Compression.Native.dll",
     "clretwrc.dll",
     "clrgc.dll",
     "clrjit.dll",
+    "clrjit_unix_arm_arm.dll",
+    "clrjit_unix_arm_arm64.dll",
     "clrjit_unix_arm_x64.dll",
+    "clrjit_unix_arm_x86.dll",
+    "clrjit_unix_arm64_arm64.dll",
     "clrjit_unix_arm64_x64.dll",
+    "clrjit_unix_armel_x86.dll",
+    "clrjit_unix_osx_arm64_arm64.dll",
+    "clrjit_unix_osx_arm64_x64.dll",
+    "clrjit_unix_x64_arm64.dll",
     "clrjit_unix_x64_x64.dll",
+    "clrjit_win_arm_arm.dll",
+    "clrjit_win_arm_arm64.dll",
     "clrjit_win_arm_x64.dll",
+    "clrjit_win_arm_x86.dll",
+    "clrjit_win_arm64_arm64.dll",
     "clrjit_win_arm64_x64.dll",
+    "clrjit_win_x64_arm64.dll",
     "clrjit_win_x64_x64.dll",
+    "clrjit_win_x86_arm.dll",
+    "clrjit_win_x86_arm64.dll",
     "clrjit_win_x86_x64.dll",
+    "clrjit_win_x86_x86.dll",
     "coreclr.dll",
     "CoreConsole.exe",
     "coredistools.dll",
@@ -78,17 +95,19 @@ native_binaries_to_ignore = [
     "ilasm.exe",
     "ildasm.exe",
     "jitinterface_x64.dll",
-    "linuxnonjit.dll",
     "mcs.exe",
+    "Microsoft.DiaSymReader.Native.amd64.dll",
+    "Microsoft.DiaSymReader.Native.x86.dll",
     "mscordaccore.dll",
     "mscordbi.dll",
     "mscorrc.dll",
-    "protononjit.dll",
+    "msdia140.dll",
     "superpmi.exe",
     "superpmi-shim-collector.dll",
     "superpmi-shim-counter.dll",
     "superpmi-shim-simple.dll",
 ]
+
 MAX_FILES_COUNT = 1500
 
 def setup_args(args):

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -379,6 +379,13 @@ def main(main_args):
     workitem_directory = path.join(source_directory, "workitem")
     pmiassemblies_directory = path.join(workitem_directory, "pmiAssembliesDirectory")
 
+    # Copy ".dotnet" to correlation_payload_directory for crossgen2 job; it is needed to invoke crossgen2.dll
+    if coreclr_args.collection_name == "crossgen2":
+        dotnet_src_directory = path.join(source_directory, ".dotnet")
+        dotnet_dst_directory = path.join(correlation_payload_directory, ".dotnet")
+        print('Copying {} -> {}'.format(dotnet_src_directory, dotnet_dst_directory))
+        copy_directory(dotnet_src_directory, dotnet_dst_directory)
+
     # payload
     input_artifacts = path.join(pmiassemblies_directory, coreclr_args.collection_name)
     exclude_directory = ['Core_Root'] if coreclr_args.collection_name == "tests" else []

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -57,7 +57,6 @@ parser.add_argument("-max_size", help="Max size of each partition in MB")
 is_windows = platform.system() == "Windows"
 
 native_binaries_to_ignore = [
-    "System.IO.Compression.Native.dll",
     "clretwrc.dll",
     "clrgc.dll",
     "clrjit.dll",
@@ -94,7 +93,12 @@ native_binaries_to_ignore = [
     "dbgshim.dll",
     "ilasm.exe",
     "ildasm.exe",
+    "jitinterface_arm.dll",
+    "jitinterface_arm64.dll",
     "jitinterface_x64.dll",
+    "jitinterface_x86.dll",
+    "KernelTraceControl.dll",
+    "KernelTraceControl.Win61.dll",
     "mcs.exe",
     "Microsoft.DiaSymReader.Native.amd64.dll",
     "Microsoft.DiaSymReader.Native.x86.dll",
@@ -106,6 +110,8 @@ native_binaries_to_ignore = [
     "superpmi-shim-collector.dll",
     "superpmi-shim-counter.dll",
     "superpmi-shim-simple.dll",
+    "System.IO.Compression.Native.dll",
+    "ucrtbase.dll",
 ]
 
 MAX_FILES_COUNT = 1500
@@ -388,7 +394,6 @@ def main(main_args):
         # Need to accept files without any extension, which is how executable filesnames look.
         acceptable_copy = lambda path: (os.path.basename(path).find(".") == -1) or any(path.endswith(extension) for extension in [".py", ".dll", ".so", ".json"])
 
-    print("is_windows {}".format(is_windows))
     print('Copying {} -> {}'.format(coreclr_args.core_root_directory, superpmi_dst_directory))
     copy_directory(coreclr_args.core_root_directory, superpmi_dst_directory, match_func=acceptable_copy)
 

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -416,12 +416,16 @@ def main(main_args):
     workitem_directory = path.join(source_directory, "workitem")
     pmiassemblies_directory = path.join(workitem_directory, "pmiAssembliesDirectory")
 
-    # Copy ".dotnet" to correlation_payload_directory for crossgen2 job; it is needed to invoke crossgen2.dll
-    if coreclr_args.collection_type == "crossgen2":
-        dotnet_src_directory = path.join(source_directory, ".dotnet")
-        dotnet_dst_directory = path.join(correlation_payload_directory, ".dotnet")
-        print('Copying {} -> {}'.format(dotnet_src_directory, dotnet_dst_directory))
-        copy_directory(dotnet_src_directory, dotnet_dst_directory, verbose_output=False)
+    # NOTE: we can't use the build machine ".dotnet" to run on all platforms. E.g., the Windows x86 build uses a
+    # Windows x64 .dotnet\dotnet.exe that can't load a 32-bit shim. Thus, we always use corerun from Core_Root to invoke crossgen2.
+    # The following will copy .dotnet to the correlation payload in case we change our mind, and need or want to use it for some scenarios.
+
+    # # Copy ".dotnet" to correlation_payload_directory for crossgen2 job; it is needed to invoke crossgen2.dll
+    # if coreclr_args.collection_type == "crossgen2":
+    #     dotnet_src_directory = path.join(source_directory, ".dotnet")
+    #     dotnet_dst_directory = path.join(correlation_payload_directory, ".dotnet")
+    #     print('Copying {} -> {}'.format(dotnet_src_directory, dotnet_dst_directory))
+    #     copy_directory(dotnet_src_directory, dotnet_dst_directory, verbose_output=False)
 
     # payload
     input_artifacts = path.join(pmiassemblies_directory, coreclr_args.collection_name)

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -264,17 +264,17 @@ def run_command(command_to_run, _cwd=None):
             print(stderr.decode("utf-8"))
 
 
-def copy_directory(src_path, dst_path):
+def copy_directory(src_path, dst_path, verbose_output=True, match_func=lambda path: True):
     """Copies directory in 'src_path' to 'dst_path' maintaining the directory
     structure. https://docs.python.org/3.5/library/shutil.html#shutil.copytree can't
     be used in this case because it expects the destination directory should not
     exist, however we do call copy_directory() to copy files to same destination directory.
 
-    It only copied *.dll, *.exe and *.py files.
-
     Args:
         src_path (string): Path of source directory that need to be copied.
         dst_path (string): Path where directory should be copied.
+        verbose_output (bool): True to print every copy or skipped file.
+        match_func (str -> bool) : Criteria function determining if a file is copied.
     """
     if not os.path.exists(dst_path):
         os.makedirs(dst_path)
@@ -282,16 +282,15 @@ def copy_directory(src_path, dst_path):
         src_item = os.path.join(src_path, item)
         dst_item = os.path.join(dst_path, item)
         if os.path.isdir(src_item):
-            copy_directory(src_item, dst_item)
+            copy_directory(src_item, dst_item, verbose_output, match_func)
         else:
-            should_copy_file = dst_item.endswith('.dll') or dst_item.endswith('.py')
-            if is_windows:
-                should_copy_file = should_copy_file or dst_item.endswith('.exe')
+            if match_func(src_item):
+                if verbose_output:
+                    print("> copy {0} => {1}".format(src_item, dst_item))
+                shutil.copy2(src_item, dst_item)
             else:
-                should_copy_file = should_copy_file or dst_item.endswith('.so') or item.find(".") == -1
-            if not should_copy_file:
-                continue
-            shutil.copy2(src_item, dst_item)
+                if verbose_output:
+                    print("> skipping {0}".format(src_item))
 
 
 def copy_files(src_path, dst_path, file_names):
@@ -381,9 +380,17 @@ def main(main_args):
 
     # create superpmi directory
     print('Copying {} -> {}'.format(superpmi_src_directory, superpmi_dst_directory))
-    copy_directory(superpmi_src_directory, superpmi_dst_directory)
+    copy_directory(superpmi_src_directory, superpmi_dst_directory, match_func=lambda path: any(path.endswith(extension) for extension in [".py"]))
+
+    if is_windows:
+        acceptable_copy = lambda path: any(path.endswith(extension) for extension in [".py", ".dll", ".exe", ".json"])
+    else:
+        # Need to accept files without any extension, which is how executable filesnames look.
+        acceptable_copy = lambda path: (os.path.basename(path).find(".") == -1) or any(path.endswith(extension) for extension in [".py", ".dll", ".so", ".json"])
+
+    print("is_windows {}".format(is_windows))
     print('Copying {} -> {}'.format(coreclr_args.core_root_directory, superpmi_dst_directory))
-    copy_directory(coreclr_args.core_root_directory, superpmi_dst_directory)
+    copy_directory(coreclr_args.core_root_directory, superpmi_dst_directory, match_func=acceptable_copy)
 
     # Clone and build jitutils
     try:
@@ -409,7 +416,7 @@ def main(main_args):
         dotnet_src_directory = path.join(source_directory, ".dotnet")
         dotnet_dst_directory = path.join(correlation_payload_directory, ".dotnet")
         print('Copying {} -> {}'.format(dotnet_src_directory, dotnet_dst_directory))
-        copy_directory(dotnet_src_directory, dotnet_dst_directory)
+        copy_directory(dotnet_src_directory, dotnet_dst_directory, verbose_output=False)
 
     # payload
     input_artifacts = path.join(pmiassemblies_directory, coreclr_args.collection_name)

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -309,6 +309,7 @@ def partition_files(src_directory, dst_directory, max_size, exclude_directories=
         exclude_files ([string]): List of files names to be excluded.
     """
 
+    print('Partitioning files from {0} to {1}'.format(src_directory, dst_directory))
     sorted_by_size = get_files_sorted_by_size(src_directory, exclude_directories, exclude_files)
     partitions = first_fit(sorted_by_size, max_size)
 
@@ -396,6 +397,7 @@ def main(main_args):
     exclude_directory = ['Core_Root'] if coreclr_args.collection_name == "tests" else []
     exclude_files = native_binaries_to_ignore
     if coreclr_args.collection_type == "crossgen2":
+        print('Adding exclusions for crossgen2')
         # Currently, trying to crossgen2 R2RTest\Microsoft.Build.dll causes a pop-up failure, so exclude it.
         exclude_files += [ "Microsoft.Build.dll" ]
     partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory, exclude_files)

--- a/src/coreclr/scripts/superpmi-setup.py
+++ b/src/coreclr/scripts/superpmi-setup.py
@@ -382,7 +382,11 @@ def main(main_args):
     # payload
     input_artifacts = path.join(pmiassemblies_directory, coreclr_args.collection_name)
     exclude_directory = ['Core_Root'] if coreclr_args.collection_name == "tests" else []
-    partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory)
+    exclude_files = native_binaries_to_ignore
+    if coreclr_args.collection_name == "crossgen2":
+        # Currently, trying to crossgen2 R2RTest\Microsoft.Build.dll causes a pop-up failure, so exclude it.
+        exclude_files += [ "Microsoft.Build.dll" ]
+    partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory, exclude_files)
 
     # Set variables
     print('Setting pipeline variables:')

--- a/src/coreclr/scripts/superpmi.proj
+++ b/src/coreclr/scripts/superpmi.proj
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(AGENT_OS)' == 'Windows_NT' ">
-    <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet;%PATH%" Condition=" '$(CollectionType)' == 'crossgen2' "/>
+    <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet%3B%PATH%" Condition=" '$(CollectionType)' == 'crossgen2' "/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(AGENT_OS)' != 'Windows_NT' ">

--- a/src/coreclr/scripts/superpmi.proj
+++ b/src/coreclr/scripts/superpmi.proj
@@ -22,7 +22,6 @@
     <PmiAssembliesDirectory>%HELIX_WORKITEM_PAYLOAD%\binaries</PmiAssembliesDirectory>
     <SuperPMIDirectory>%HELIX_CORRELATION_PAYLOAD%\superpmi</SuperPMIDirectory>
     <OutputMchPath>%HELIX_WORKITEM_UPLOAD_ROOT%</OutputMchPath>
-    <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet;%PATH%" Condition=" '$(CollectionType)' == 'crossgen2' "/>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
     <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll </WorkItemCommand>
@@ -33,7 +32,6 @@
     <PmiAssembliesDirectory>$HELIX_WORKITEM_PAYLOAD/binaries</PmiAssembliesDirectory>
     <SuperPMIDirectory>$HELIX_CORRELATION_PAYLOAD/superpmi</SuperPMIDirectory>
     <OutputMchPath>$HELIX_WORKITEM_UPLOAD_ROOT</OutputMchPath>
-    <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/.dotnet:$PATH" Condition=" '$(CollectionType)' == 'crossgen2' "/>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)/artifacts/helixresults</HelixResultsDestinationDir>
     <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll </WorkItemCommand>
@@ -47,6 +45,18 @@
     <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
     <EnableXUnitReporter>false</EnableXUnitReporter>
     <WorkItemTimeout>5:00</WorkItemTimeout>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(AGENT_OS)' == 'Windows_NT' ">
+    <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet;%PATH%" Condition=" '$(CollectionType)' == 'crossgen2' "/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(AGENT_OS)' != 'Windows_NT' ">
+    <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/.dotnet:$PATH" Condition=" '$(CollectionType)' == 'crossgen2' "/>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/scripts/superpmi.proj
+++ b/src/coreclr/scripts/superpmi.proj
@@ -22,6 +22,7 @@
     <PmiAssembliesDirectory>%HELIX_WORKITEM_PAYLOAD%\binaries</PmiAssembliesDirectory>
     <SuperPMIDirectory>%HELIX_CORRELATION_PAYLOAD%\superpmi</SuperPMIDirectory>
     <OutputMchPath>%HELIX_WORKITEM_UPLOAD_ROOT%</OutputMchPath>
+    <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet;%PATH%" />
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
     <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll </WorkItemCommand>
@@ -32,6 +33,7 @@
     <PmiAssembliesDirectory>$HELIX_WORKITEM_PAYLOAD/binaries</PmiAssembliesDirectory>
     <SuperPMIDirectory>$HELIX_CORRELATION_PAYLOAD/superpmi</SuperPMIDirectory>
     <OutputMchPath>$HELIX_WORKITEM_UPLOAD_ROOT</OutputMchPath>
+    <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/.dotnet:$PATH" />
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)/artifacts/helixresults</HelixResultsDestinationDir>
     <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll </WorkItemCommand>

--- a/src/coreclr/scripts/superpmi.proj
+++ b/src/coreclr/scripts/superpmi.proj
@@ -24,7 +24,7 @@
     <OutputMchPath>%HELIX_WORKITEM_UPLOAD_ROOT%</OutputMchPath>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
-    <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll </WorkItemCommand>
+    <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll </WorkItemCommand>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <Python>$HELIX_PYTHONPATH</Python>
@@ -34,7 +34,7 @@
     <OutputMchPath>$HELIX_WORKITEM_UPLOAD_ROOT</OutputMchPath>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)/artifacts/helixresults</HelixResultsDestinationDir>
-    <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll </WorkItemCommand>
+    <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll </WorkItemCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WorkItemCommand)' != ''">

--- a/src/coreclr/scripts/superpmi.proj
+++ b/src/coreclr/scripts/superpmi.proj
@@ -22,7 +22,7 @@
     <PmiAssembliesDirectory>%HELIX_WORKITEM_PAYLOAD%\binaries</PmiAssembliesDirectory>
     <SuperPMIDirectory>%HELIX_CORRELATION_PAYLOAD%\superpmi</SuperPMIDirectory>
     <OutputMchPath>%HELIX_WORKITEM_UPLOAD_ROOT%</OutputMchPath>
-    <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet;%PATH%" />
+    <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet;%PATH%" Condition=" '$(CollectionType)' == 'crossgen2' "/>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
     <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll </WorkItemCommand>
@@ -33,7 +33,7 @@
     <PmiAssembliesDirectory>$HELIX_WORKITEM_PAYLOAD/binaries</PmiAssembliesDirectory>
     <SuperPMIDirectory>$HELIX_CORRELATION_PAYLOAD/superpmi</SuperPMIDirectory>
     <OutputMchPath>$HELIX_WORKITEM_UPLOAD_ROOT</OutputMchPath>
-    <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/.dotnet:$PATH" />
+    <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/.dotnet:$PATH" Condition=" '$(CollectionType)' == 'crossgen2' "/>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)/artifacts/helixresults</HelixResultsDestinationDir>
     <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll </WorkItemCommand>

--- a/src/coreclr/scripts/superpmi.proj
+++ b/src/coreclr/scripts/superpmi.proj
@@ -47,6 +47,8 @@
     <WorkItemTimeout>5:00</WorkItemTimeout>
   </PropertyGroup>
 
+  <!-- We're currently not using .dotnet on the Helix agents -->
+  <!--
   <ItemGroup Condition=" '$(AGENT_OS)' == 'Windows_NT' ">
     <HelixPreCommand Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\.dotnet%3B%PATH%" Condition=" '$(CollectionType)' == 'crossgen2' "/>
   </ItemGroup>
@@ -58,6 +60,7 @@
   <PropertyGroup>
     <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
   </PropertyGroup>
+  -->
 
   <ItemGroup>
     <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1712,7 +1712,7 @@ class SuperPMIReplayAsmDiffs:
                         path_var = os.environ.get("PATH")
                         if path_var is not None:
                             jit_analyze_file = "jit-analyze.bat" if platform.system() == "Windows" else "jit-analyze.sh"
-                            jit_analyze_path = find_file(jit_analyze_file, path_var.split(";"))
+                            jit_analyze_path = find_file(jit_analyze_file, path_var.split(os.pathsep))
                             if jit_analyze_path is not None:
                                 # It appears we have a built jit-analyze on the path, so try to run it.
                                 command = [ jit_analyze_path, "-r", "--base", base_asm_location, "--diff", diff_asm_location ]
@@ -1838,7 +1838,7 @@ def determine_pmi_location(coreclr_args):
         logging.info("Using PMI at %s", pmi_location)
     else:
         path_var = os.environ.get("PATH")
-        pmi_location = find_file("pmi.dll", path_var.split(";")) if path_var is not None else None
+        pmi_location = find_file("pmi.dll", path_var.split(os.pathsep)) if path_var is not None else None
         if pmi_location is not None:
             logging.info("Using PMI found on PATH at %s", pmi_location)
         else:
@@ -1914,7 +1914,7 @@ def find_tool(coreclr_args, tool_name, search_core_root=True, search_product_loc
     if search_path:
         path_var = os.environ.get("PATH")
         if path_var is not None:
-            tool_path = find_file(tool_name, path_var.split(";"))
+            tool_path = find_file(tool_name, path_var.split(os.pathsep))
             if tool_path is not None:
                 logging.debug("Using %s from PATH: %s", tool_name, tool_path)
                 return tool_path

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2095,6 +2095,7 @@ def determine_jit_ee_version(coreclr_args):
                 match_obj = re.search(r'^constexpr GUID JITEEVersionIdentifier *= *{ */\* *([^ ]*) *\*/', line)
                 if match_obj is not None:
                     jiteeversionguid_h_jit_ee_version = match_obj.group(1)
+                    jiteeversionguid_h_jit_ee_version = jiteeversionguid_h_jit_ee_version.lower()
                     logging.info("Using JIT/EE Version from jiteeversionguid.h: %s", jiteeversionguid_h_jit_ee_version)
                     return jiteeversionguid_h_jit_ee_version
             logging.warning("Warning: couldn't find JITEEVersionIdentifier in %s; is the file corrupt?", jiteeversionguid_h_path)
@@ -2106,6 +2107,7 @@ def determine_jit_ee_version(coreclr_args):
     return_code = proc.returncode
     if return_code == 0:
         mcs_jit_ee_version = stdout_jit_ee_version.decode('utf-8').strip()
+        mcs_jit_ee_version = mcs_jit_ee_version.lower()
         logging.info("Using JIT/EE Version from mcs: %s", mcs_jit_ee_version)
         return mcs_jit_ee_version
 


### PR DESCRIPTION
Add a superpmi.py collect `-exclude` option to avoid collecting
assemblies known to fail (and cause pop-up failures: see #47552).

Use `-exclude` to exclude R2RTest\Microsoft.Build.dll.

Depends on #47779

Fixes #47541