### PR TITLE
Fix GDI handle leak in Icon.DrawImage

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
@@ -10,5 +10,13 @@ internal static partial class Interop
     {
         [DllImport(Libraries.Gdi32, SetLastError = true, ExactSpelling = true)]
         public static extern RegionType SelectClipRgn(IntPtr hdc, IntPtr hrgn);
+
+        public static RegionType SelectClipRgn(HandleRef hdc, HandleRef hrgn)
+        {
+            RegionType result = SelectClipRgn(hdc.Handle, hrgn.Handle);
+            GC.KeepAlive(hdc.Wrapper);
+            GC.KeepAlive(hrgn.Wrapper);
+            return result;
+        }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
@@ -10,20 +10,5 @@ internal static partial class Interop
     {
         [DllImport(Libraries.Gdi32, SetLastError = true, ExactSpelling = true)]
         public static extern RegionType SelectClipRgn(IntPtr hdc, IntPtr hrgn);
-
-        public static RegionType SelectClipRgn(HandleRef hdc, IntPtr hrgn)
-        {
-            RegionType result = SelectClipRgn(hdc.Handle, hrgn);
-            GC.KeepAlive(hdc.Wrapper);
-            return result;
-        }
-
-        public static RegionType SelectClipRgn(HandleRef hdc, HandleRef hrgn)
-        {
-            RegionType result = SelectClipRgn(hdc.Handle, hrgn.Handle);
-            GC.KeepAlive(hdc.Wrapper);
-            GC.KeepAlive(hrgn.Wrapper);
-            return result;
-        }
     }
 }

--- a/src/libraries/Common/tests/System/Drawing/Helpers.cs
+++ b/src/libraries/Common/tests/System/Drawing/Helpers.cs
@@ -182,6 +182,9 @@ namespace System.Drawing
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr GetForegroundWindow();
 
+        [DllImport("user32.dll", ExactSpelling = true, SetLastError = true)]
+        public static extern int GetGuiResources(IntPtr hProcess, uint flags);
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr GetDC(IntPtr hWnd);
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -379,7 +379,7 @@ namespace System.Drawing
             }
             finally
             {
-                Interop.Gdi32.SelectClipRgn(hDC, hRgn);
+                Interop.Gdi32.SelectClipRgn(dc, hSaveRgn);
                 // We need to delete the region handle after restoring the region as GDI+ uses a copy of the handle.
                 Interop.Gdi32.DeleteObject(hSaveRgn);
             }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -379,7 +379,9 @@ namespace System.Drawing
             }
             finally
             {
-                RestoreClipRgn(dc, hSaveRgn);
+                Interop.Gdi32.SelectClipRgn(hDC, hRgn);
+                // We need to delete the region handle after restoring the region as GDI+ uses a copy of the handle.
+                Interop.Gdi32.DeleteObject(hSaveRgn);
             }
         }
 
@@ -394,13 +396,13 @@ namespace System.Drawing
                 hSaveRgn = hTempRgn;
                 hTempRgn = IntPtr.Zero;
             }
+            else
+            {
+                // if we fail to get the clip region delete the handle.
+                Interop.Gdi32.DeleteObject(hTempRgn);
+            }
 
             return hSaveRgn;
-        }
-
-        private static void RestoreClipRgn(IntPtr hDC, IntPtr hRgn)
-        {
-            Interop.Gdi32.SelectClipRgn(new HandleRef(null, hDC), new HandleRef(null, hRgn));
         }
 
         internal void Draw(Graphics graphics, int x, int y)

--- a/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
@@ -20,12 +20,16 @@ namespace System.Drawing.Tests
             RemoteExecutor.Invoke(() =>
             {
                 const int handleTreshold = 1;
-                Bitmap bmp = new(100, 100);
-                Icon ico = new(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico"));
+                using Bitmap bmp = new(100, 100);
+                using Icon ico = new(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico"));
+
                 IntPtr hdc = Helpers.GetDC(Helpers.GetForegroundWindow());
                 using Graphics graphicsFromHdc = Graphics.FromHdc(hdc);
 
-                int initialHandles = Helpers.GetGuiResources(Process.GetCurrentProcess().Handle, 0);
+                using Process currentProcess = Process.GetCurrentProcess();
+                IntPtr processHandle = currentProcess.Handle;
+
+                int initialHandles = Helpers.GetGuiResources(processHandle, 0);
                 ValidateNoWin32Error(initialHandles);
 
                 for (int i = 0; i < 5000; i++)
@@ -33,7 +37,7 @@ namespace System.Drawing.Tests
                     graphicsFromHdc.DrawIcon(ico, 100, 100);
                 }
 
-                int finalHandles = Helpers.GetGuiResources(Process.GetCurrentProcess().Handle, 0);
+                int finalHandles = Helpers.GetGuiResources(processHandle, 0);
                 ValidateNoWin32Error(finalHandles);
 
                 Assert.InRange(finalHandles, initialHandles, initialHandles + handleTreshold);

--- a/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.Drawing.Tests
+{
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public static class GdiPlusHandlesTests
+    {
+        public static bool IsDrawingAndRemoteExecutorSupported => Helpers.GetIsDrawingSupported() && RemoteExecutor.IsSupported;
+
+        [ConditionalFact(nameof(IsDrawingAndRemoteExecutorSupported))]
+        public static void GraphicsDrawIconDoesNotLeakHandles()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                const int handleTreshold = 1;
+                Bitmap bmp = new(100, 100);
+                Icon ico = new(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico"));
+                IntPtr currentProcessHandle = Process.GetCurrentProcess().Handle;
+                IntPtr hdc = Helpers.GetDC(Helpers.GetForegroundWindow());
+                using Graphics graphicsFromHdc = Graphics.FromHdc(hdc);
+
+                int initialHandles = Helpers.GetGuiResources(currentProcessHandle, 0);
+
+                for (int i = 0; i < 5000; i++)
+                {
+                    graphicsFromHdc.DrawIcon(ico, 100, 100);
+                }
+
+                int finalHandles = Helpers.GetGuiResources(currentProcessHandle, 0);
+
+                Assert.InRange(finalHandles, initialHandles, initialHandles + handleTreshold);
+            }).Dispose();
+
+        }
+
+    }
+}

--- a/src/libraries/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/libraries/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="DrawingTest.cs" />
     <Compile Include="FontTests.cs" />
     <Compile Include="FontFamilyTests.cs" />
+    <Compile Include="GdiPlusHandlesTests.cs" />
     <Compile Include="GdiplusTests.cs" />
     <Compile Include="GraphicsTests.cs" />
     <Compile Include="Graphics_DrawBezierTests.cs" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/46789

This was a regression from 3.1 -> 5.0 caused in: https://github.com/dotnet/corefx/commit/f807df691a3007cea9c7aa169f18be4cd9540758

I will need to port this to 5.0 as this is affecting winforms costumers directly and apps could just die if we exceed the GDI+ handle limit.