### PR TITLE
Add ILLinker warning suppressions

### DIFF
--- a/src/libraries/System.Data.Common/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Data.Common/src/ILLink/ILLink.Suppressions.xml
@@ -3,6 +3,12 @@
   <assembly fullname="System.Data.Common, PublicKeyToken=b03f5f7f11d50a3a">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Data.ColumnTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
       <argument>IL2057</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Data.Common.DataStorage.GetType(System.String)</property>

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Suppressions.xml
@@ -3,6 +3,12 @@
   <assembly fullname="System.Linq.Expressions, PublicKeyToken=b03f5f7f11d50a3a">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Linq.Expressions.Compiler.AssemblyGen.DefineDelegateType(System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Linq.Expressions.Expression.ApplyTypeArgs(System.Reflection.MethodInfo,System.Type[])</property>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
@@ -5,6 +5,12 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:System.Resources.ResourceReader.InitializeBinaryFormatter</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:Internal.Runtime.InteropServices.ComActivator.FindClassType(System.Guid,System.String,System.String,System.String)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">

--- a/src/libraries/System.Security.Cryptography.Primitives/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/ILLink/ILLink.Suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Security.Cryptography.Primitives, PublicKeyToken=b03f5f7f11d50a3a">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Security.Cryptography.CryptoConfigForwarder.BindCreateFromName</property>
+    </attribute>
+  </assembly>
+</linker>


### PR DESCRIPTION
This adds suppressions for the new  ILLinker warnings in https://github.com/dotnet/runtime/pull/47709. These new warnings are the result of an update made in the ILLinker that broadens the scenarios in which it recognizes the use of `RequiresUnreferencedCode` attribute.  