### PR TITLE
Remove unused unicode header inclusion

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -19,7 +19,6 @@
 
 // All ICU headers need to be included here so that all function prototypes are
 // available before the function pointers are declared below.
-#include <unicode/uclean.h>
 #include <unicode/ucurr.h>
 #include <unicode/ucal.h>
 #include <unicode/uchar.h>


### PR DESCRIPTION
`unicode/uclean.h` was added in bdc8955 for `u_init()` when the PR was
WIP: https://github.com/dotnet/runtime/pull/37971/commits

By the time PR was merged, `u_init()` was removed, so this header is
not required by any configuration.

Fixes #47831