### PR TITLE
BigInteger parsing optimizations

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -464,7 +464,7 @@ namespace System.Numerics
             AssertValid();
         }
 
-        private BigInteger(int n, uint[]? rgu)
+        internal BigInteger(int n, uint[]? rgu)
         {
             _sign = n;
             _bits = rgu;
@@ -683,8 +683,7 @@ namespace System.Numerics
 
         public static BigInteger Parse(string value, NumberStyles style, IFormatProvider? provider)
         {
-            (int sign, uint[]? bits) = BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
-            return new BigInteger(sign, bits);
+            return BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
         }
 
         public static bool TryParse([NotNullWhen(true)] string? value, out BigInteger result)
@@ -694,17 +693,12 @@ namespace System.Numerics
 
         public static bool TryParse([NotNullWhen(true)] string? value, NumberStyles style, IFormatProvider? provider, out BigInteger result)
         {
-            bool success = BigNumber.TryParseBigInteger(
-                value, style, NumberFormatInfo.GetInstance(provider), out int sign, out uint[]? bits);
-
-            result = new BigInteger(sign, bits);
-            return success;
+            return BigNumber.TryParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
         public static BigInteger Parse(ReadOnlySpan<char> value, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null)
         {
-            (int sign, uint[]? bits) = BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
-            return new BigInteger(sign, bits);
+            return BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
         }
 
         public static bool TryParse(ReadOnlySpan<char> value, out BigInteger result)
@@ -714,11 +708,7 @@ namespace System.Numerics
 
         public static bool TryParse(ReadOnlySpan<char> value, NumberStyles style, IFormatProvider? provider, out BigInteger result)
         {
-            bool success = BigNumber.TryParseBigInteger(
-                value, style, NumberFormatInfo.GetInstance(provider), out int sign, out uint[]? bits);
-
-            result = new BigInteger(sign, bits);
-            return success;
+            return BigNumber.TryParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
         public static int Compare(BigInteger left, BigInteger right)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -683,7 +683,8 @@ namespace System.Numerics
 
         public static BigInteger Parse(string value, NumberStyles style, IFormatProvider? provider)
         {
-            return BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
+            (int sign, uint[]? bits) = BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
+            return new BigInteger(sign, bits);
         }
 
         public static bool TryParse([NotNullWhen(true)] string? value, out BigInteger result)
@@ -693,22 +694,31 @@ namespace System.Numerics
 
         public static bool TryParse([NotNullWhen(true)] string? value, NumberStyles style, IFormatProvider? provider, out BigInteger result)
         {
-            return BigNumber.TryParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider), out result);
+            bool success = BigNumber.TryParseBigInteger(
+                value, style, NumberFormatInfo.GetInstance(provider), out int sign, out uint[]? bits);
+
+            result = new BigInteger(sign, bits);
+            return success;
         }
 
         public static BigInteger Parse(ReadOnlySpan<char> value, NumberStyles style = NumberStyles.Integer, IFormatProvider? provider = null)
         {
-            return BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
+            (int sign, uint[]? bits) = BigNumber.ParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider));
+            return new BigInteger(sign, bits);
         }
 
         public static bool TryParse(ReadOnlySpan<char> value, out BigInteger result)
         {
-            return BigNumber.TryParseBigInteger(value, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out result);
+            return TryParse(value, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
         public static bool TryParse(ReadOnlySpan<char> value, NumberStyles style, IFormatProvider? provider, out BigInteger result)
         {
-            return BigNumber.TryParseBigInteger(value, style, NumberFormatInfo.GetInstance(provider), out result);
+            bool success = BigNumber.TryParseBigInteger(
+                value, style, NumberFormatInfo.GetInstance(provider), out int sign, out uint[]? bits);
+
+            result = new BigInteger(sign, bits);
+            return success;
         }
 
         public static int Compare(BigInteger left, BigInteger right)


### PR DESCRIPTION
Improves performance of BigInteger parsing from decimal and hex strings (both speed and memory allocations), according to the benchmark that I have included. The difference is particularly significant for large decimal strings, given that the current implementation allocates two BigInteger instances for each input digit.

#### Benchmark code
```csharp
using System.Collections.Generic;
using System.Globalization;
using System.Linq;
using BenchmarkDotNet.Attributes;

public class BigIntegerParseBenchmarks
{
    public IEnumerable<object> NumberStrings =>
        new string[]
        {
            "123",
            int.MinValue.ToString(),
            string.Concat(Enumerable.Repeat("1234567890", 20)),
            string.Concat(Enumerable.Repeat("654719003", 57)),
        };

    public IEnumerable<object> NumberStringsHex =>
        new string[]
        {
            "12A",
            int.MinValue.ToString("X"),
            string.Concat(Enumerable.Repeat("1234567890abcdefffff", 10)),
            string.Concat(Enumerable.Repeat("18a473f5d", 57)),
        };

    [Benchmark]
    [ArgumentsSource(nameof(NumberStrings))]
    public BigInteger Parse(string numberString) => BigInteger.Parse(numberString);

    [Benchmark]
    [ArgumentsSource(nameof(NumberStringsHex))]
    public BigInteger ParseHex(string numberString) => BigInteger.Parse(numberString, NumberStyles.HexNumber);
}
```

#### Benchmark results (on master branch)
``` ini

BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.18363.1316 (1909/November2019Update/19H2)
Intel Core i7-8550U CPU 1.80GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET SDK=5.0.102
  [Host]     : .NET 6.0.0 (6.0.21.10203), X64 RyuJIT
  Job-NSGODO : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  Toolchain=CoreRun  
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15  
WarmupCount=1  

```
|   Method |                        numberString |        Mean |     Error |    StdDev |      Median |         Min |         Max |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |------------------------------------ |------------:|----------:|----------:|------------:|------------:|------------:|--------:|------:|------:|----------:|
|    Parse |                                 123 |    186.5 ns |   3.43 ns |   2.87 ns |    187.0 ns |    181.9 ns |    192.6 ns |  0.0246 |     - |     - |     104 B |
|    Parse |                         -2147483648 |    418.0 ns |  16.69 ns |  18.55 ns |    419.0 ns |    359.6 ns |    442.6 ns |  0.0312 |     - |     - |     136 B |
|    Parse | 123456789012(...)901234567890 [200] | 17,866.9 ns | 193.43 ns | 180.93 ns | 17,901.3 ns | 17,527.7 ns | 18,163.3 ns | 13.1653 |     - |     - |  55,176 B |
|    Parse | 654719003654(...)003654719003 [513] | 69,284.7 ns | 643.04 ns | 536.97 ns | 69,112.3 ns | 68,447.0 ns | 70,545.0 ns | 65.5556 |     - |     - | 274,272 B |
| ParseHex |                                 12A |    121.8 ns |   0.64 ns |   0.50 ns |    121.7 ns |    121.3 ns |    123.2 ns |  0.0323 |     - |     - |     136 B |
| ParseHex |                            80000000 |    183.5 ns |   1.28 ns |   1.07 ns |    183.6 ns |    182.4 ns |    185.5 ns |  0.0319 |     - |     - |     136 B |
| ParseHex | 1234567890ab(...)90abcdefffff [200] |  2,520.9 ns |  17.84 ns |  14.90 ns |  2,511.0 ns |  2,505.7 ns |  2,544.7 ns |  0.2609 |     - |     - |   1,128 B |
| ParseHex | 18a473f5d18a(...)f5d18a473f5d [513] |  6,069.5 ns |  83.14 ns |  77.77 ns |  6,045.6 ns |  5,938.0 ns |  6,202.7 ns |  0.7287 |     - |     - |   3,128 B |

#### Results after changes
``` ini

BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.18363.1316 (1909/November2019Update/19H2)
Intel Core i7-8550U CPU 1.80GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET SDK=5.0.102
  [Host]     : .NET 6.0.0 (6.0.21.10203), X64 RyuJIT
  Job-WMUKDU : .NET 6.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  Toolchain=CoreRun  
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15  
WarmupCount=1  

```
|   Method |                        numberString |       Mean |    Error |   StdDev |     Median |        Min |        Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |------------------------------------ |-----------:|---------:|---------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
|    Parse |                                 123 |   126.0 ns |  1.81 ns |  1.51 ns |   125.8 ns |   123.7 ns |   128.9 ns | 0.0248 |     - |     - |     104 B |
|    Parse |                         -2147483648 |   176.5 ns |  3.55 ns |  3.65 ns |   174.7 ns |   171.9 ns |   182.6 ns | 0.0322 |     - |     - |     136 B |
|    Parse | 123456789012(...)901234567890 [200] | 1,843.5 ns | 21.83 ns | 20.42 ns | 1,843.6 ns | 1,819.9 ns | 1,875.5 ns | 0.2339 |     - |     - |     984 B |
|    Parse | 654719003654(...)003654719003 [513] | 5,197.3 ns | 23.14 ns | 20.51 ns | 5,206.4 ns | 5,134.6 ns | 5,210.8 ns | 0.6656 |     - |     - |   2,792 B |
| ParseHex |                                 12A |   116.3 ns |  1.23 ns |  1.09 ns |   116.2 ns |   114.9 ns |   118.8 ns | 0.0245 |     - |     - |     104 B |
| ParseHex |                            80000000 |   166.1 ns |  1.76 ns |  1.56 ns |   165.9 ns |   164.2 ns |   169.3 ns | 0.0320 |     - |     - |     136 B |
| ParseHex | 1234567890ab(...)90abcdefffff [200] | 1,705.1 ns | 10.51 ns |  8.77 ns | 1,703.0 ns | 1,692.7 ns | 1,715.7 ns | 0.2362 |     - |     - |   1,000 B |
| ParseHex | 18a473f5d18a(...)f5d18a473f5d [513] | 3,905.5 ns | 34.60 ns | 30.67 ns | 3,907.6 ns | 3,866.8 ns | 3,975.6 ns | 0.6660 |     - |     - |   2,840 B |
