### PR TITLE
Limit unique SNI to 63 chars in tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -127,7 +127,7 @@ namespace System.Net.Http.Functional.Tests
                 }
 
                 // Use a different SNI for each connection to prevent TLS 1.3 renegotiation issue: https://github.com/dotnet/runtime/issues/47378
-                client.DefaultRequestHeaders.Host = getTestSNIName();
+                client.DefaultRequestHeaders.Host = GetTestSNIName();
 
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -140,7 +140,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(1, count);
             }
 
-            string getTestSNIName()
+            string GetTestSNIName()
             {
                 return $"{nameof(GetAsync_AllowedSSLVersion_Succeeds)}_{acceptedProtocol}_{requestOnlyThisProtocol}";
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -362,7 +362,8 @@ namespace System.Net.Security.Tests
                     return true;
                 }))
             {
-                string serverName = _serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
+                // Use a different SNI for each connection to prevent TLS 1.3 renegotiation issue: https://github.com/dotnet/runtime/issues/47378
+                string serverName = TestHelper.GetTestSNIName(nameof(ServerAsyncSslHelper), clientSslProtocols, serverSslProtocols);
 
                 _log.WriteLine("Connected on {0} {1} ({2} {3})", clientStream.Socket.LocalEndPoint, clientStream.Socket.RemoteEndPoint, clientStream.Socket.Handle, serverStream.Socket.Handle);
                 _log.WriteLine("client SslStream#{0} server SslStream#{1}", sslClientStream.GetHashCode(),  sslServerStream.GetHashCode());

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -80,7 +80,7 @@ namespace System.Net.Security.Tests
             using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
             {
                 // Use a different SNI for each connection to prevent TLS 1.3 renegotiation issue: https://github.com/dotnet/runtime/issues/47378
-                string serverHost = getTestSNIName();
+                string serverHost = TestHelper.GetTestSNIName(nameof(ClientAndServer_OneOrBothUseDefault_Ok), clientProtocols, serverProtocols);
                 var clientCertificates = new X509CertificateCollection() { clientCertificate };
 
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
@@ -99,16 +99,6 @@ namespace System.Net.Security.Tests
                         _clientStream.HashAlgorithm == HashAlgorithmType.Sha512,
                         _clientStream.SslProtocol + " " + _clientStream.HashAlgorithm);
                 }
-            }
-
-            string getTestSNIName()
-            {
-                static string ProtocolToString(SslProtocols? protocol)
-                {
-                    return (protocol?.ToString() ?? "null").Replace(", ", "_");
-                }
-
-                return $"{nameof(ClientAndServer_OneOrBothUseDefault_Ok)}_{ProtocolToString(clientProtocols)}_{ProtocolToString(serverProtocols)}";
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.X509Certificates.Tests.Common;
@@ -157,7 +159,7 @@ namespace System.Net.Security.Tests
                     intermedPub3.Dispose();
                     CertificateAuthority intermediateAuthority3 = new CertificateAuthority(intermedCert3, null, null, null);
 
-                    RSA  eeKey = (RSA)endEntity.PrivateKey;
+                    RSA eeKey = (RSA)endEntity.PrivateKey;
                     endEntity = intermediateAuthority3.CreateEndEntity(
                         $"CN=\"A SSL Test\", O=\"testName\"",
                         eeKey,
@@ -211,6 +213,19 @@ namespace System.Net.Security.Tests
 
             Assert.Equal(s_pong, buffer);
             await t;
+        }
+
+        internal static string GetTestSNIName(string testMethodName, params SslProtocols?[] protocols)
+        {
+            static string ProtocolToString(SslProtocols? protocol)
+            {
+                return (protocol?.ToString() ?? "null").Replace(", ", "-");
+            }
+
+            var args = string.Join("-", protocols.Select(p => ProtocolToString(p)));
+            var name = $"{testMethodName}-{args}";
+
+            return name.Length > 63 ? name.Substring(0, 63) : name;
         }
     }
 }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -222,10 +222,10 @@ namespace System.Net.Security.Tests
                 return (protocol?.ToString() ?? "null").Replace(", ", "-");
             }
 
-            var args = string.Join("-", protocols.Select(p => ProtocolToString(p)));
-            var name = $"{testMethodName}-{args}";
+            var args = string.Join(".", protocols.Select(p => ProtocolToString(p)));
+            var name = testMethodName.Length > 63 ? testMethodName.Substring(0, 63) : testMethodName;
 
-            return name.Length > 63 ? name.Substring(0, 63) : name;
+            return $"{name}.{args}";
         }
     }
 }


### PR DESCRIPTION
The test generates SNI based on test name and argument to make it unique. However the SNI shouldn't be longer than 63 chars.
The PR also add another place when unique SNI is required for fix TLS1.3 test

Fixes #47378