### PR TITLE
Add Mono EventPipe Sample Profiler support.

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -426,6 +426,7 @@ typedef char* (*ep_rt_mono_get_os_cmd_line_func)(void);
 typedef char* (*ep_rt_mono_get_managed_cmd_line_func)(void);
 typedef gboolean (*ep_rt_mono_execute_rundown_func)(ep_rt_mono_fire_domain_rundown_events_func domain_events_func, ep_rt_mono_fire_assembly_rundown_events_func assembly_events_func, ep_rt_mono_fire_method_rundown_events_func methods_events_func);
 typedef gboolean (*ep_rt_mono_walk_managed_stack_for_thread_func)(ep_rt_thread_handle_t thread, EventPipeStackContents *stack_contents);
+typedef gboolean (*ep_rt_mono_sample_profiler_write_sampling_event_for_threads_func)(ep_rt_thread_handle_t sampling_thread, EventPipeEvent *sampling_event);
 typedef gboolean (*ep_rt_mono_method_get_simple_assembly_name_func)(ep_rt_method_desc_t *method, ep_char8_t *name, size_t name_len);
 typedef gboolean (*ep_rt_mono_method_get_full_name_func)(ep_rt_method_desc_t *method, ep_char8_t *name, size_t name_len);
 
@@ -458,6 +459,7 @@ typedef struct _EventPipeMonoFuncTable {
 	ep_rt_mono_get_managed_cmd_line_func ep_rt_mono_get_managed_cmd_line;
 	ep_rt_mono_execute_rundown_func ep_rt_mono_execute_rundown;
 	ep_rt_mono_walk_managed_stack_for_thread_func ep_rt_mono_walk_managed_stack_for_thread;
+	ep_rt_mono_sample_profiler_write_sampling_event_for_threads_func ep_rt_mono_sample_profiler_write_sampling_event_for_threads;
 	ep_rt_mono_method_get_simple_assembly_name_func ep_rt_mono_method_get_simple_assembly_name;
 	ep_rt_mono_method_get_full_name_func ep_rt_mono_method_get_full_name;
 } EventPipeMonoFuncTable;
@@ -1079,17 +1081,14 @@ static
 void
 ep_rt_sample_profiler_write_sampling_event_for_threads (ep_rt_thread_handle_t sampling_thread, EventPipeEvent *sampling_event)
 {
-	// TODO: Implement.
-	// Suspend threads.
-	// Stack walk each thread, write sample event.
-	// Resume threads.
+	ep_rt_mono_func_table_get ()->ep_rt_mono_sample_profiler_write_sampling_event_for_threads (sampling_thread, sampling_event);
 }
 
 static
 void
 ep_rt_notify_profiler_provider_created (EventPipeProvider *provider)
 {
-	// TODO: Not supported.
+	;
 }
 
 /*

--- a/src/mono/mono/metadata/boehm-gc.c
+++ b/src/mono/mono/metadata/boehm-gc.c
@@ -290,15 +290,15 @@ mono_gc_collection_count (int generation)
 }
 
 void
-mono_gc_stop_world ()
+mono_stop_world (MonoThreadInfoFlags flags)
 {
-	g_assert ("mono_gc_stop_world is not supported in Boehm");
+	g_assert ("mono_stop_world is not supported in Boehm");
 }
 
 void
-mono_gc_restart_world ()
+mono_restart_world (MonoThreadInfoFlags flags)
 {
-	g_assert ("mono_gc_restart_world is not supported in Boehm");
+	g_assert ("mono_restart_world is not supported in Boehm");
 }
 
 /**

--- a/src/mono/mono/metadata/gc-internals.h
+++ b/src/mono/mono/metadata/gc-internals.h
@@ -430,4 +430,11 @@ extern gboolean mono_do_not_finalize;
 /* List of names of classes not to finalize. */
 extern gchar **mono_do_not_finalize_class_names;
 
+/*
+ * Unified runtime stop/restart world, SGEN Only.
+ * Will take and release the LOCK_GC.
+ */
+void mono_stop_world (MonoThreadInfoFlags flags);
+void mono_restart_world (MonoThreadInfoFlags flags);
+
 #endif /* __MONO_METADATA_GC_INTERNAL_H__ */

--- a/src/mono/mono/metadata/mono-gc.h
+++ b/src/mono/mono/metadata/mono-gc.h
@@ -126,12 +126,6 @@ MONO_API int    mono_gc_walk_heap        (int flags, MonoGCReferences callback, 
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_gc_init_finalizer_thread (void);
 
-/*
- * Only supported under SGen. These two with Sgen will take and release the LOCK_GC
- */
-void mono_gc_stop_world (void);
-void mono_gc_restart_world (void);
-
 MONO_END_DECLS
 
 #endif /* __METADATA_MONO_GC_H__ */

--- a/src/mono/mono/metadata/null-gc.c
+++ b/src/mono/mono/metadata/null-gc.c
@@ -86,15 +86,15 @@ mono_gc_collection_count (int generation)
 }
 
 void
-mono_gc_stop_world ()
+mono_stop_world (MonoThreadInfoFlags flags)
 {
-	g_assert ("mono_gc_stop_world is not supported in null GC");
+	g_assert ("mono_stop_world is not supported in null GC");
 }
 
 void
-mono_gc_restart_world ()
+mono_restart_world (MonoThreadInfoFlags flags)
 {
-	g_assert ("mono_gc_restart_world is not supported in null GC");
+	g_assert ("mono_restart_world is not supported in null GC");
 }
 
 void

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -840,20 +840,6 @@ sgen_finish_concurrent_work (const char *reason, gboolean stw)
 	sgen_major_collector.finish_sweeping ();
 }
 
-void
-mono_gc_stop_world ()
-{
-	LOCK_GC;
-	sgen_stop_world (0, FALSE);
-}
-
-void
-mono_gc_restart_world ()
-{
-	sgen_restart_world (0, FALSE);
-	UNLOCK_GC;
-}
-
 /*
  * When appdomains are unloaded we can easily remove objects that have finalizers,
  * but all the others could still be present in random places on the heap.

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7441,7 +7441,7 @@ interp_invalidate_transformed (MonoDomain *domain)
 	gboolean need_stw_restart = FALSE;
 #ifdef ENABLE_METADATA_UPDATE
 	need_stw_restart = TRUE;
-	mono_gc_stop_world ();
+	mono_stop_world (MONO_THREAD_INFO_FLAGS_NO_GC);
 	metadata_update_prepare_to_invalidate (domain);
 #endif
 	MonoJitDomainInfo *info = domain_jit_info (domain);
@@ -7450,7 +7450,7 @@ interp_invalidate_transformed (MonoDomain *domain)
 	mono_domain_jit_code_hash_unlock (domain);
 
 	if (need_stw_restart)
-		mono_gc_restart_world ();
+		mono_restart_world (MONO_THREAD_INFO_FLAGS_NO_GC);
 }
 
 static void


### PR DESCRIPTION
Implement support for EventPipe Sample Profiler on Mono inline with CoreClr Sample Profiler behaviour.  By default CoreClr sample profiler tries to run at 1000 hertz (every ms) and on each sample it will stop runtime, snap callstacks for all managed threads, submit EventPipe sample profile events and resume runtime. Doing a full stop/restart of the runtime on every sample could be quite invasive, but is probably the most portable way of implementing it working on most platforms.

This PR implements the same logic, but on Mono runtime, stopping the runtime, record all callstacks for all managed threads that should be sampled, restart runtime and then write all sample profile events into EventPipe. Note that events are written after the runtime has resumed since all code executed when runtime is stopped needs to be async safe (needed when running in preemptive mode) so we can't call into EventPipe at that point.

Going forward we should investigate alternative ways to do sample profiling depending on underlying platform and OS support. Currently implementation will work on all supported platforms, but it will not be as accurate as it could be (especially when using safe points and coop enabled runtime) and impacts measured target. Mono's profiler uses Signals/SuspendThread and for platforms supporting these API's, that could be an alternative implementation. It could also be worth to look into CPU hardware counters using ETW kernel log session on Windows and perf_event_open on Linux.



