### PR TITLE
Update build-runtime to disable PGO when not building release

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -273,6 +273,11 @@ if %__SkipCrossArchNative% EQU 0 (
 
 REM Set the remaining variables based upon the determined build configuration
 
+REM PGO optimization is only applied to release builds (see pgosupport.cmake). Disable PGO by default if not building release.
+if NOT "%__BuildType%"=="Release" (
+    set __PgoOptimize=0
+)
+
 if %__PgoOptimize%==0 (
     set __RestoreOptData=0
 )


### PR DESCRIPTION
Seemed unnecessary for the script to still do the prep (e.g. restoring, getting the version) when the actual build won't do anything on non-Release.