### PR TITLE
Fix Use Span Based String Concat violations in System.Diagnostics.DiagnosticSource

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -162,9 +162,6 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 dotnet_code_quality.ca1822.api_surface = private, internal
 dotnet_code_quality.ca2208.api_surface = public
 
-# CA1841: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1841.severity = warning
-
 # License header
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -162,6 +162,9 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 dotnet_code_quality.ca1822.api_surface = private, internal
 dotnet_code_quality.ca2208.api_surface = public
 
+# CA1841: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1841.severity = warning
+
 # License header
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -19,7 +19,7 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.1' and '$(TargetFramework)' != 'netstandard1.3'">$(DefineConstants);EVENTSOURCE_ENUMERATE_SUPPORT</DefineConstants>
     <DefineConstants Condition="$(TargetFramework.StartsWith('net4'))">$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS;ENABLE_HTTP_HANDLER</DefineConstants>
     <ExcludeFromPackage Condition="'$(TargetFramework)' == 'netstandard2.0'">true</ExcludeFromPackage>
-    <DefineConstants Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">$(DefineConstants);W3C_DEFAULT_ID_FORMAT</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">$(DefineConstants);W3C_DEFAULT_ID_FORMAT;SPAN_BASED_STRING_CONCAT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1215,7 +1215,7 @@ namespace System.Diagnostics
             //generate overflow suffix
             string overflowSuffix = ((int)GetRandomNumber()).ToString("x8");
 #if SPAN_BASED_STRING_CONCAT
-            return string.Concat(parentId.AsSpan(0, trimPosition), overflowSuffix, stackalloc char[] { '#' });
+            return string.Concat(parentId.AsSpan(0, trimPosition), overflowSuffix, "#");
 #else
             return parentId.Substring(0, trimPosition) + overflowSuffix + '#';
 #endif

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1215,7 +1215,7 @@ namespace System.Diagnostics
             //generate overflow suffix
             string overflowSuffix = ((int)GetRandomNumber()).ToString("x8");
 #if SPAN_BASED_STRING_CONCAT
-            return string.Concat(parentId.AsSpan(0, trimPosition), overflowSuffix, '#'.ToString());
+            return string.Concat(parentId.AsSpan(0, trimPosition), overflowSuffix, stackalloc char[] { '#' });
 #else
             return parentId.Substring(0, trimPosition) + overflowSuffix + '#';
 #endif

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System;
 
 namespace System.Diagnostics
 {
@@ -1213,7 +1214,11 @@ namespace System.Diagnostics
 
             //generate overflow suffix
             string overflowSuffix = ((int)GetRandomNumber()).ToString("x8");
+#if SPAN_BASED_STRING_CONCAT
+            return string.Concat(parentId.AsSpan(0, trimPosition), overflowSuffix, '#'.ToString());
+#else
             return parentId.Substring(0, trimPosition) + overflowSuffix + '#';
+#endif
         }
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
         [System.Security.SecuritySafeCriticalAttribute]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using System;
 
 namespace System.Diagnostics
 {
@@ -628,7 +629,13 @@ namespace System.Diagnostics
                         if (specStartIdx < endIdx)
                         {
                             if (_eventSource.IsEnabled(EventLevel.Informational, Keywords.Messages))
+                            {
+#if SPAN_BASED_STRING_CONCAT
+                                _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), "'"));
+#else
                                 _eventSource.Message("DiagnosticSource: Parsing Explicit Transform '" + filterAndPayloadSpec.Substring(specStartIdx, endIdx - specStartIdx) + "'");
+#endif
+                            }
 
                             _explicitTransforms = new TransformSpec(filterAndPayloadSpec, specStartIdx, endIdx, _explicitTransforms);
                         }
@@ -736,7 +743,14 @@ namespace System.Diagnostics
                             if (specStartIdx < endIdx)
                             {
                                 if (_eventSource.IsEnabled(EventLevel.Informational, Keywords.Messages))
+                                {
+#if SPAN_BASED_STRING_CONCAT
+                                    _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), "'"));
+#else
                                     _eventSource.Message("DiagnosticSource: Parsing Explicit Transform '" + filterAndPayloadSpec.Substring(specStartIdx, endIdx - specStartIdx) + "'");
+#endif
+                                }
+
 
                                 _explicitTransforms = new TransformSpec(filterAndPayloadSpec, specStartIdx, endIdx, _explicitTransforms);
                             }
@@ -1011,7 +1025,7 @@ namespace System.Diagnostics
             }
 #endif // EVENTSOURCE_ACTIVITY_SUPPORT
 
-            private void Dispose()
+                                    private void Dispose()
             {
                 if (_diagnosticsListenersSubscription != null)
                 {
@@ -1105,7 +1119,7 @@ namespace System.Diagnostics
             internal ActivitySamplingResult SamplingResult { get; set; }
 #endif // EVENTSOURCE_ACTIVITY_SUPPORT
 
-            #region private
+#region private
 
             // Given a type generate all the implicit transforms for type (that is for every field
             // generate the spec that fetches it).
@@ -1144,7 +1158,7 @@ namespace System.Diagnostics
             private ConcurrentDictionary<Type, TransformSpec?>? _implicitTransformsTable; // If there is more than one object type for an implicit transform, they go here.
             private readonly TransformSpec? _explicitTransforms;             // payload to include because the user explicitly indicated how to fetch the field.
             private readonly DiagnosticSourceEventSource _eventSource;      // Where the data is written to.
-            #endregion
+#endregion
         }
 
         // This olds one the implicit transform for one type of object.
@@ -1219,7 +1233,7 @@ namespace System.Diagnostics
             /// </summary>
             public TransformSpec? Next;
 
-            #region private
+#region private
             /// <summary>
             /// A PropertySpec represents information needed to fetch a property from
             /// and efficiently. Thus it represents a '.PROP' in a TransformSpec
@@ -1271,7 +1285,7 @@ namespace System.Diagnostics
                 /// </summary>
                 public PropertySpec? Next;
 
-                #region private
+#region private
                 /// <summary>
                 /// PropertyFetch is a helper class. It takes a PropertyInfo and then knows how
                 /// to efficiently fetch that property from a .NET object (See Fetch method).
@@ -1369,7 +1383,7 @@ namespace System.Diagnostics
                     /// </summary>
                     public virtual object? Fetch(object? obj) { return null; }
 
-                    #region private
+#region private
 
                     private sealed class RefTypedFetchProperty<TObject, TProperty> : PropertyFetch
                     {
@@ -1435,17 +1449,17 @@ namespace System.Diagnostics
                             return string.Join(",", (IEnumerable<ElementType>)obj);
                         }
                     }
-                    #endregion
+#endregion
                 }
 
                 private readonly string _propertyName;
                 private volatile PropertyFetch? _fetchForExpectedType;
-                #endregion
+#endregion
             }
 
             private readonly string _outputName = null!;
             private readonly PropertySpec? _fetches;
-            #endregion
+#endregion
         }
 
         /// <summary>
@@ -1458,13 +1472,13 @@ namespace System.Diagnostics
         {
             public CallbackObserver(Action<T> callback) { _callback = callback; }
 
-            #region private
+#region private
             public void OnCompleted() { }
             public void OnError(Exception error) { }
             public void OnNext(T value) { _callback(value); }
 
             private readonly Action<T> _callback;
-            #endregion
+#endregion
         }
 
         // A linked list of IObservable subscriptions (which are IDisposable).
@@ -1481,13 +1495,13 @@ namespace System.Diagnostics
             public Subscriptions? Next;
         }
 
-        #endregion
+#endregion
 
         private FilterAndTransform? _specs;                 // Transformation specifications that indicate which sources/events are forwarded.
 #if EVENTSOURCE_ACTIVITY_SUPPORT
         private FilterAndTransform? _activitySourceSpecs;   // ActivitySource Transformation specifications that indicate which sources/events are forwarded.
         private ActivityListener? _activityListener;
 #endif // EVENTSOURCE_ACTIVITY_SUPPORT
-        #endregion
+#endregion
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -631,7 +631,7 @@ namespace System.Diagnostics
                             if (_eventSource.IsEnabled(EventLevel.Informational, Keywords.Messages))
                             {
 #if SPAN_BASED_STRING_CONCAT
-                                _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), stackalloc char[] { '\'' }));
+                                _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), "'"));
 #else
                                 _eventSource.Message("DiagnosticSource: Parsing Explicit Transform '" + filterAndPayloadSpec.Substring(specStartIdx, endIdx - specStartIdx) + "'");
 #endif
@@ -745,7 +745,7 @@ namespace System.Diagnostics
                                 if (_eventSource.IsEnabled(EventLevel.Informational, Keywords.Messages))
                                 {
 #if SPAN_BASED_STRING_CONCAT
-                                    _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), stackalloc char[] { '\'' }));
+                                    _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), "'"));
 #else
                                     _eventSource.Message("DiagnosticSource: Parsing Explicit Transform '" + filterAndPayloadSpec.Substring(specStartIdx, endIdx - specStartIdx) + "'");
 #endif

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -631,7 +631,7 @@ namespace System.Diagnostics
                             if (_eventSource.IsEnabled(EventLevel.Informational, Keywords.Messages))
                             {
 #if SPAN_BASED_STRING_CONCAT
-                                _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), "'"));
+                                _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), stackalloc char[] { '\'' }));
 #else
                                 _eventSource.Message("DiagnosticSource: Parsing Explicit Transform '" + filterAndPayloadSpec.Substring(specStartIdx, endIdx - specStartIdx) + "'");
 #endif
@@ -745,7 +745,7 @@ namespace System.Diagnostics
                                 if (_eventSource.IsEnabled(EventLevel.Informational, Keywords.Messages))
                                 {
 #if SPAN_BASED_STRING_CONCAT
-                                    _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), "'"));
+                                    _eventSource.Message(string.Concat("DiagnosticSource: Parsing Explicit Transform '", filterAndPayloadSpec.AsSpan(specStartIdx, endIdx - specStartIdx), stackalloc char[] { '\'' }));
 #else
                                     _eventSource.Message("DiagnosticSource: Parsing Explicit Transform '" + filterAndPayloadSpec.Substring(specStartIdx, endIdx - specStartIdx) + "'");
 #endif


### PR DESCRIPTION
While working on [this analyzer PR](https://github.com/dotnet/roslyn-analyzers/pull/4764) for [#issue 33777](https://github.com/dotnet/runtime/issues/33777) I found 3 violations in `System.Diagnostics.DiagnosticSource`.
