### PR TITLE
Remove a couple LINQ usages in Microsoft.Extensions

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Xml;
 
 namespace Microsoft.Extensions.Configuration.Xml
@@ -68,7 +67,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                             break;
 
                         case XmlNodeType.EndElement:
-                            if (prefixStack.Any())
+                            if (prefixStack.Count != 0)
                             {
                                 // If this EndElement node comes right after an Element node,
                                 // it means there is no text/CDATA node in current element
@@ -179,7 +178,7 @@ namespace Microsoft.Extensions.Configuration.Xml
             }
 
             // If current element is not root element
-            if (prefixStack.Any())
+            if (prefixStack.Count != 0)
             {
                 string lastPrefix = prefixStack.Pop();
                 prefixStack.Push(ConfigurationPath.Combine(lastPrefix, reader.Value));

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
 
 namespace Microsoft.Extensions.Configuration.Xml

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -201,8 +201,7 @@ namespace Microsoft.Extensions.Logging
             }
 
             // if the value implements IEnumerable, build a comma separated string.
-            var enumerable = value as IEnumerable;
-            if (enumerable != null)
+            if (value is IEnumerable enumerable)
             {
                 var vsb = new ValueStringBuilder(stackalloc char[256]);
                 bool first = true;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Globalization;
 using System.Text;
 
@@ -205,7 +204,19 @@ namespace Microsoft.Extensions.Logging
             var enumerable = value as IEnumerable;
             if (enumerable != null)
             {
-                return string.Join(", ", enumerable.Cast<object>().Select(o => o ?? NullValue));
+                var vsb = new ValueStringBuilder(stackalloc char[256]);
+                bool first = true;
+                foreach (object e in enumerable)
+                {
+                    if (!first)
+                    {
+                        vsb.Append(", ");
+                    }
+
+                    vsb.Append(e != null ? e.ToString() : NullValue);
+                    first = false;
+                }
+                return vsb.ToString();
             }
 
             return value;


### PR DESCRIPTION
Note that this was the only usage of `Enumerable.Cast` in a Blazor WASM default app. So this allows for that method to be trimmed. It is also faster and allocates less according to this benchmark:

```C#
    [MemoryDiagnoser]
    public class JoinBenchmark
    {
        private const string NullValue = "(null)";
        private static IEnumerable s_Enumerable = Enumerable.Range(1, 10);

        [Benchmark]
        public string OldWay()
        {
            return string.Join(", ", s_Enumerable.Cast<object>().Select(o => o ?? NullValue));
        }

        [Benchmark]
        public string NewWay()
        {
            var vsb = new ValueStringBuilder(stackalloc char[256]);
            bool first = true;
            foreach (object e in s_Enumerable)
            {
                if (!first)
                {
                    vsb.Append(", ");
                }

                vsb.Append(e != null ? e.ToString() : NullValue);
                first = false;
            }
            return vsb.ToString();
        }
    }
```

| Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| OldWay | 468.1 ns | 3.29 ns | 2.92 ns | 0.0798 |     - |     - |     504 B |
| NewWay | 222.2 ns | 2.72 ns | 2.27 ns | 0.0621 |     - |     - |     392 B |
