### PR TITLE
Fix violations system private xml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -162,9 +162,6 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 dotnet_code_quality.ca1822.api_surface = private, internal
 dotnet_code_quality.ca2208.api_surface = public
 
-# CA1841: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1841.severity = warning
-
 # License header
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -162,6 +162,9 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 dotnet_code_quality.ca1822.api_surface = private, internal
 dotnet_code_quality.ca2208.api_surface = public
 
+# CA1841: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1841.severity = warning
+
 # License header
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILTrace.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILTrace.cs
@@ -182,19 +182,19 @@ namespace System.Xml.Xsl.IlGen
             string s = Enum.GetName(typeof(XmlILOptimization), opt)!;
             if (s.StartsWith("Introduce", StringComparison.Ordinal))
             {
-                return s.Substring(9) + " introduction";
+                return string.Concat(s.AsSpan(9), " introduction");
             }
             else if (s.StartsWith("Eliminate", StringComparison.Ordinal))
             {
-                return s.Substring(9) + " elimination";
+                return string.Concat(s.AsSpan(9), " elimination");
             }
             else if (s.StartsWith("Commute", StringComparison.Ordinal))
             {
-                return s.Substring(7) + " commutation";
+                return string.Concat(s.AsSpan(7), " commutation");
             }
             else if (s.StartsWith("Fold", StringComparison.Ordinal))
             {
-                return s.Substring(4) + " folding";
+                return string.Concat(s.AsSpan(4), " folding");
             }
             else if (s.StartsWith("Misc", StringComparison.Ordinal))
             {


### PR DESCRIPTION
While working on [this analyzer PR](https://github.com/dotnet/roslyn-analyzers/pull/4764) for [issue #33777](https://github.com/dotnet/runtime/issues/33777) I found 4 violations in `System.Private.Xml`. I've fixed them here. 