### PR TITLE
JIT: fix interaction of PGO and jitstress

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5539,6 +5539,7 @@ protected:
     ICorJitInfo::PgoInstrumentationSchema* fgPgoSchema;
     BYTE*                                  fgPgoData;
     UINT32                                 fgPgoSchemaCount;
+    HRESULT                                fgPgoQueryResult;
     UINT32                                 fgNumProfileRuns;
     UINT32                                 fgPgoBlockCounts;
     UINT32                                 fgPgoClassProfiles;

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2251,6 +2251,10 @@ void Compiler::fgFindBasicBlocks()
     {
         printf("*************** In fgFindBasicBlocks() for %s\n", info.compFullName);
     }
+
+    // Call this here so any dump printing it inspires doesn't appear in the bb table.
+    //
+    fgStressBBProf();
 #endif
 
     // Allocate the 'jump target' bit vector


### PR DESCRIPTION
We always need to run the profile data phase so that jit stress can inject
random profile counts if it so chooses.

Also, clean up a few dumping nits -- don't dump the profile query status until
we get around to trying to incorporate counts; summarize schema records before
asserting that we must have block counts, etc.

Closes #47839