### PR TITLE
Remove use of string.GetHashCode(StringComparison)

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
@@ -272,7 +272,7 @@ namespace System.Net.Mail
 
         public override int GetHashCode()
         {
-            return ToString().GetHashCode(StringComparison.InvariantCultureIgnoreCase);
+            return StringComparer.InvariantCultureIgnoreCase.GetHashCode(ToString());
         }
 
         private static readonly EncodedStreamFactory s_encoderFactory = new EncodedStreamFactory();

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1542,7 +1542,7 @@ namespace System
 
                 if (IsUncOrDosPath)
                 {
-                    return remoteUrl.GetHashCode(StringComparison.OrdinalIgnoreCase);
+                    return StringComparer.OrdinalIgnoreCase.GetHashCode(remoteUrl);
                 }
                 else
                 {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -51,7 +51,7 @@ namespace System.Runtime.InteropServices
 
         public override int GetHashCode()
         {
-            return Name == null ? 0 : Name.GetHashCode(StringComparison.OrdinalIgnoreCase);
+            return Name == null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
         }
 
         public override string ToString()


### PR DESCRIPTION
All of our call sites to it pass in a const StringComparison; GetHashCode will then turn around and decide which property on StringComparer to use, and then call GetHashCode on the relevant instance... we may as well just pick the instance directly, which not only saves the lookup and enables devirtualization, it also enables better trimming, as string.GetHashCode(StringComparison) ends up rooting all of the StringComparer properties in case you pass in the appropriate StringComparison.  Changing this removes the remaining use of StringComparer.InvariantCulture and StringComparer.CurrentCultureIgnoreCase in a default Blazor wasm app.

cc: @eerhardt 