### PR TITLE
Fix flaky EventLog tests

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
@@ -67,7 +67,7 @@ namespace System.Diagnostics.Tests
 
                 EventLog.CreateEventSource(log);
                 string message = $"Hello {Guid.NewGuid()}";
-                EventLog.WriteEntry(log.Source, message);
+                Helpers.Retry(() => EventLog.WriteEntry(log.Source, message));
 
                 using (EventLogReader reader = new EventLogReader(new EventLogQuery("Application", PathType.LogName, $"*[System/Provider/@Name=\"{log.Source}\"]")))
                 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogSessionTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogSessionTests.cs
@@ -93,7 +93,7 @@ namespace System.Diagnostics.Tests
                     using (EventLog eventLog = new EventLog())
                     {
                         eventLog.Source = source;
-                        eventLog.WriteEntry("Writing to event log.");
+                        Helpers.Retry(() => eventLog.WriteEntry("Writing to event log."));
                         Assert.NotEqual(0, Helpers.Retry((() => eventLog.Entries.Count)));
                         session.ClearLog(logName: log);
                         Assert.Equal(0,  Helpers.Retry((() => eventLog.Entries.Count)));


### PR DESCRIPTION
Fix #45847

There were two places where we do not do retries around EventLog.WriteEntry and those are the two failing tests.