### PR TITLE
Add example for installing/launching emulator to Android test doc

### DIFF
--- a/docs/workflow/testing/libraries/testing-android.md
+++ b/docs/workflow/testing/libraries/testing-android.md
@@ -42,9 +42,9 @@ unzip ~/andk.zip -d $(dirname ${ANDROID_NDK_ROOT}) && rm -rf ~/andk.zip
 # platform-tools, platforms and build-tools
 export ANDROID_SDK_ROOT=~/android-sdk
 curl https://dl.google.com/android/repository/commandlinetools-${HOST_OS_SHORT}-${SDK_VER}.zip -L --output ~/asdk.zip
-unzip ~/asdk.zip -d ${ANDROID_SDK_ROOT} && rm -rf ~/asdk.zip
-yes | ${ANDROID_SDK_ROOT}/tools/bin/./sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --licenses
-${ANDROID_SDK_ROOT}/tools/bin/./sdkmanager --sdk_root=${ANDROID_SDK_ROOT} "platform-tools" "platforms;android-${SDK_API_LEVEL}" "build-tools;${SDK_BUILD_TOOLS}"
+mkdir ${ANDROID_SDK_ROOT} && unzip ~/asdk.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && rm -rf ~/asdk.zip
+yes | ${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --licenses
+${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} "platform-tools" "platforms;android-${SDK_API_LEVEL}" "build-tools;${SDK_BUILD_TOOLS}"
 
 # We also need to download precompiled binaries and headers for OpenSSL from maven, this step is a temporary hack
 # and will be removed once we figure out how to integrate OpenSSL properly as a dependency
@@ -65,7 +65,7 @@ and even run tests one by one for each library:
 ```
 ./build.sh libs.tests -os Android -arch x64 -test
 ```
-Make sure an emulator is booted (see `AVD Manager`) or a device is plugged in and unlocked.
+Make sure an emulator is booted (see [`AVD Manager`](#avd-manager)) or a device is plugged in and unlocked.
 `AVD Manager` tool recommends to install `x86` images by default so if you follow that recommendation make sure `-arch x86` was used for the build script.
 
 ### Running individual test suites
@@ -84,6 +84,31 @@ XHarness for Android doesn't talk much and only saves test results to a file. Ho
 adb logcat -s "DOTNET"
 ```
 Or simply open `logcat` window in Android Studio or Visual Stuido.
+
+### AVD Manager
+If Android Studio is installed, [AVD Manager](https://developer.android.com/studio/run/managing-avds) can be used from the IDE to create and start Android virtual devices. Otherwise, the Android SDK provides the [`avdmanager` command line tool](https://developer.android.com/studio/command-line/avdmanager).
+
+Example of installing, creating, and launching emulators from the command line (where `SDK_API_LEVEL` matches the installed Android SDK and `EMULATOR_NAME_X86`/`EMULATOR_NAME_X64` are names of your choice):
+```bash
+# Install x86 image
+${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager "system-images;android-${SDK_API_LEVEL};default;x86"
+
+# Create x86 image
+${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/avdmanager create avd --name ${EMULATOR_NAME_X86} --package "system-images;android-${SDK_API_LEVEL};default;x86"
+
+# Launch emulator with x86 image
+${ANDROID_SDK_ROOT}/emulator/emulator -avd ${EMULATOR_NAME_X86} &
+
+# Install x64 image
+${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager "system-images;android-${SDK_API_LEVEL};default;x86_64"
+
+# Create x64 image
+${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/avdmanager create avd --name ${EMULATOR_NAME_X64} --package "system-images;android-${SDK_API_LEVEL};default;x86_64"
+
+# Launch emulator with x64 image
+${ANDROID_SDK_ROOT}/emulator/emulator -avd ${EMULATOR_NAME_X64} &
+```
+The emulator can be launched with a variety of options. Run `emulator -help` to see the full list.
 
 ### Existing Limitations
 - `-os Android` is not supported for Windows yet (`WSL` can be used instead)


### PR DESCRIPTION
- Make sample script for installing SDK unzip to cmdline-tools - seems to work better with the expected structure for the SDK (based on https://developer.android.com/studio/command-line#tools-sdk and trying to use command line tools)
- Add example for creating AVD and launching emulator from command line