### PR TITLE
Tweak dependency injection's StackGuard

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/StackGuard.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/StackGuard.cs
@@ -14,9 +14,14 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private int _executionStackCount;
 
-
         public bool TryEnterOnCurrentStack()
         {
+#if NETCOREAPP || NETSTANDARD2_1
+            if (RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return true;
+            }
+#else
             try
             {
                 RuntimeHelpers.EnsureSufficientExecutionStack();
@@ -25,6 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             catch (InsufficientExecutionStackException)
             {
             }
+#endif
 
             if (_executionStackCount < MaxExecutionStackCount)
             {
@@ -36,11 +42,20 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public TR RunOnEmptyStack<T1, T2, TR>(Func<T1, T2, TR> action, T1 arg1, T2 arg2)
         {
-            return RunOnEmptyStackCore(s =>
+            // Prefer ValueTuple when available to reduce dependencies on Tuple
+#if NETCOREAPP
+            return RunOnEmptyStackCore(static s =>
+            {
+                var t = ((Func<T1, T2, TR>, T1, T2))s;
+                return t.Item1(t.Item2, t.Item3);
+            }, (action, arg1, arg2));
+#else
+            return RunOnEmptyStackCore(static s =>
             {
                 var t = (Tuple<Func<T1, T2, TR>, T1, T2>)s;
                 return t.Item1(t.Item2, t.Item3);
             }, Tuple.Create(action, arg1, arg2));
+#endif
         }
 
         private R RunOnEmptyStackCore<R>(Func<object, R> action, object state)
@@ -52,17 +67,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // Using default scheduler rather than picking up the current scheduler.
                 Task<R> task = Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
-                TaskAwaiter<R> awaiter = task.GetAwaiter();
-
                 // Avoid AsyncWaitHandle lazy allocation of ManualResetEvent in the rare case we finish quickly.
-                if (!awaiter.IsCompleted)
+                if (!task.IsCompleted)
                 {
                     // Task.Wait has the potential of inlining the task's execution on the current thread; avoid this.
                     ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
                 }
 
-                // Using awaiter here to unwrap AggregateException.
-                return awaiter.GetResult();
+                // Using awaiter here to propagate original exception
+                return task.GetAwaiter().GetResult();
             }
             finally
             {


### PR DESCRIPTION
- Use TryEnsureSufficientExecutionStack rather than EnsureSufficientExecutionStack, allowing the latter to be trimmed in a default Blazor wasm app.
- Use ValueTuple instead of Tuple, allowing the latter to be trimmed in a default Blazor wasm app
- Clean up awaiter usage in RunOnEmptyStackCore

cc: @eerhardt 