### PR TITLE
Avoid unnecessary Range usage in TranscodingStream

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
@@ -484,11 +484,11 @@ namespace System.Text
                         out int charsWritten,
                         out decoderFinished);
 
-                    buffer = buffer[bytesConsumed..];
+                    buffer = buffer.Slice(bytesConsumed);
 
                     // convert chars -> bytes [inner]
 
-                    Span<char> decodedChars = scratchChars.AsSpan(..charsWritten);
+                    Span<char> decodedChars = scratchChars.AsSpan(0, charsWritten);
 
                     do
                     {
@@ -500,7 +500,7 @@ namespace System.Text
                             out int bytesWritten,
                             out encoderFinished);
 
-                        decodedChars = decodedChars[charsConsumed..];
+                        decodedChars = decodedChars.Slice(charsConsumed);
 
                         // It's more likely that the inner stream provides an optimized implementation of
                         // Write(byte[], ...) over Write(ROS<byte>), so we'll prefer the byte[]-based overloads.
@@ -560,7 +560,7 @@ namespace System.Text
                             out int charsWritten,
                             out decoderFinished);
 
-                        remainingOuterEncodedBytes = remainingOuterEncodedBytes[bytesConsumed..];
+                        remainingOuterEncodedBytes = remainingOuterEncodedBytes.Slice(bytesConsumed);
 
                         // convert chars -> bytes [inner]
 
@@ -576,7 +576,7 @@ namespace System.Text
                                 out int bytesWritten,
                                 out encoderFinished);
 
-                            decodedChars = decodedChars[charsConsumed..];
+                            decodedChars = decodedChars.Slice(charsConsumed);
                             await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(scratchBytes, 0, bytesWritten), cancellationToken).ConfigureAwait(false);
                         } while (!encoderFinished);
                     } while (!decoderFinished);


### PR DESCRIPTION
- Enables MemoryExtensions.AsSpan(T[], Range) to be trimmed in a default Blazor wasm app.
- Use of span.Slice(int) is more efficient than span[int..]
- Use of AsSpan(int, int) is more efficient than AsSpan(Range)

cc: @GrabYourPitchforks, @eerhardt 