### PR TITLE
fix configuration binder cannot bind a array instance

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.Configuration
             {
                 var options = new BinderOptions();
                 configureOptions?.Invoke(options);
-                BindInstance(instance.GetType(), instance, configuration, options);
+                instance = BindInstance(instance.GetType(), instance, configuration, options);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1001,6 +1001,25 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("val_2", options.IReadOnlyDictionary["def"]);
             Assert.Equal("val_3", options.IReadOnlyDictionary["ghi"]);
         }
+        
+        [Fact]
+        public void CanBindArray()
+        {
+            var input = new[] {"abc", "def", "ghi"};
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = Array.Empty<string>();
+            config.Bind(options);
+
+            Assert.Equal(3, options.Count);
+
+            Assert.Equal("abc", options[0]);
+            Assert.Equal("def", options[1]);
+            Assert.Equal("ghi", options[2]);
+        }
 
         private class UnintializedCollectionsOptions
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1019,7 +1019,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var options = Array.Empty<string>();
             config.Bind(options);
 
-            Assert.Equal(3, options.Count);
+            Assert.Equal(3, options.Length);
 
             Assert.Equal("abc", options[0]);
             Assert.Equal("def", options[1]);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1005,7 +1005,12 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         [Fact]
         public void CanBindArray()
         {
-            var input = new[] {"abc", "def", "ghi"};
+            var input = new Dictionary<string, string>
+            {
+                {"0", "abc"},
+                {"1", "def"},
+                {"2", "ghi"}
+            };
 
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(input);


### PR DESCRIPTION
I find the configuration binder cannot bind an array instance, because the references of the `BindInstance` result is different with its passed-in array instance.