### PR TITLE
IntPtr and UIntPtr were added as DisallowedTypes

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DisallowedTypeConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DisallowedTypeConverterFactory.cs
@@ -21,7 +21,9 @@ namespace System.Text.Json.Serialization.Converters
                 // Explicitly disallowing this type provides a clear exception when ctors with
                 // .ctor(SerializationInfo, StreamingContext) signatures are attempted to be used for deserialization.
                 // Invoking such ctors is not safe when used with untrusted user input.
-                type == typeof(SerializationInfo);
+                type == typeof(SerializationInfo) ||
+                type == typeof(IntPtr) ||
+                type == typeof(UIntPtr);
         }
 
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -525,8 +525,7 @@ namespace System.Text.Json.Serialization.Tests
 
             void RunTest<T>(string json)
             {
-                Type type = typeof(T);
-                string fullName = type.FullName;
+                string fullName = typeof(T).FullName;
 
                 NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<T>(json));
                 string exAsStr = ex.ToString();
@@ -541,7 +540,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Contains("$.Prop", exAsStr);
 
                 // NSE is not thrown because the serializer handles null.
-                if (!type.IsValueType)
+                if (!typeof(T).IsValueType)
                 {
                     Assert.Null(JsonSerializer.Deserialize<T>("null"));
 

--- a/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -518,12 +518,15 @@ namespace System.Text.Json.Serialization.Tests
             // Any test payload is fine.
             string json = @"""Some string""";
 
-            RunTest<Type>();
-            RunTest<SerializationInfo>();
+            RunTest<Type>(json);
+            RunTest<SerializationInfo>(json);
+            RunTest<IntPtr>(json);
+            RunTest<UIntPtr>(json);
 
-            void RunTest<T>()
+            void RunTest<T>(string json)
             {
-                string fullName = typeof(T).FullName;
+                Type type = typeof(T);
+                string fullName = type.FullName;
 
                 NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<T>(json));
                 string exAsStr = ex.ToString();
@@ -538,10 +541,13 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Contains("$.Prop", exAsStr);
 
                 // NSE is not thrown because the serializer handles null.
-                Assert.Null(JsonSerializer.Deserialize<T>("null"));
+                if (!type.IsValueType)
+                {
+                    Assert.Null(JsonSerializer.Deserialize<T>("null"));
 
-                ClassWithType<T> obj = JsonSerializer.Deserialize<ClassWithType<T>>(@"{""Prop"":null}");
-                Assert.Null(obj.Prop);
+                    ClassWithType<T> obj = JsonSerializer.Deserialize<ClassWithType<T>>(@"{""Prop"":null}");
+                    Assert.Null(obj.Prop);
+                }
             }
         }
 
@@ -550,18 +556,18 @@ namespace System.Text.Json.Serialization.Tests
         {
             RunTest<Type>(typeof(int));
             RunTest<SerializationInfo>(new SerializationInfo(typeof(Type), new FormatterConverter()));
+            RunTest<IntPtr>((IntPtr)123);
+            RunTest<UIntPtr>((UIntPtr)123);
 
             void RunTest<T>(T value)
             {
-                string fullName = typeof(T).FullName;
+                Type type = typeof(T);
+                string fullName = type.FullName;
 
                 NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(value));
                 string exAsStr = ex.ToString();
                 Assert.Contains(fullName, exAsStr);
                 Assert.Contains("$", exAsStr);
-
-                string serialized = JsonSerializer.Serialize((T)(object)null);
-                Assert.Equal("null", serialized);
 
                 ClassWithType<T> obj = new ClassWithType<T> { Prop = value };
 
@@ -570,12 +576,18 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Contains(fullName, exAsStr);
                 Assert.Contains("$.Prop", exAsStr);
 
-                obj.Prop = (T)(object)null;
-                serialized = JsonSerializer.Serialize(obj);
-                Assert.Equal(@"{""Prop"":null}", serialized);
+                if (!type.IsValueType)
+                {
+                    string serialized = JsonSerializer.Serialize((T)(object)null);
+                    Assert.Equal("null", serialized);
 
-                serialized = JsonSerializer.Serialize(obj, new JsonSerializerOptions { IgnoreNullValues = true });
-                Assert.Equal(@"{}", serialized);
+                    obj.Prop = (T)(object)null;
+                    serialized = JsonSerializer.Serialize(obj);
+                    Assert.Equal(@"{""Prop"":null}", serialized);
+
+                    serialized = JsonSerializer.Serialize(obj, new JsonSerializerOptions { IgnoreNullValues = true });
+                    Assert.Equal(@"{}", serialized);
+                }
             }
         }
 


### PR DESCRIPTION
NotSupportedException is fired when IntPtr/UIntPtr property is being serialized/deserialized

DeserializeUnsupportedType and SerializeUnsupportedType tests were modified for value types compatibility.

