### PR TITLE
Fix errors when DispatchProxy is not public type

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -252,6 +252,8 @@ namespace System.Reflection
                 _fields.Add(tb.DefineField("_methodInfos", typeof(MethodInfo[]), FieldAttributes.Private));
 
                 _methodInfos = new List<MethodInfo>();
+
+                _assembly.EnsureTypeIsVisible(proxyBaseType);
             }
 
             private void Complete()

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -137,6 +137,60 @@ namespace DispatchProxyTests
         }
 
         [Fact]
+        public static void Create_Using_PrivateProxy()
+        {
+            Assert.NotNull(TestType_PrivateProxy.Proxy<TestType_IHelloService>());
+        }
+
+        [Fact]
+        public static void Create_Using_PrivateProxyAndInternalService()
+        {
+            Assert.NotNull(TestType_PrivateProxy.Proxy<TestType_InternalInterfaceService>());
+        }
+
+        [Fact]
+        public static void Create_Using_PrivateProxyAndInternalServiceWithExternalGenericArgument()
+        {
+            Assert.NotNull(TestType_PrivateProxy.Proxy<TestType_InternalInterfaceWithNonPublicExternalGenericArgument>());
+        }
+
+        [Fact]
+        public static void Create_Using_InternalProxy()
+        {
+            Assert.NotNull(DispatchProxy.Create<TestType_InternalInterfaceService, InternalInvokeProxy>());
+        }
+
+        [Fact]
+        public static void Create_Using_ExternalNonPublicService()
+        {
+            Assert.NotNull(DispatchProxy.Create<DispatchProxyTestDependency.TestType_IExternalNonPublicHiService, TestDispatchProxy>());
+        }
+
+        [Fact]
+        public static void Create_Using_InternalProxyWithExternalNonPublicBaseType()
+        {
+            Assert.NotNull(DispatchProxy.Create<TestType_IHelloService, TestType_InternalProxyInternalBaseType>());
+        }
+
+        [Fact]
+        public static void Create_Using_InternalServiceImplementingNonPublicExternalService()
+        {
+            Assert.NotNull(DispatchProxy.Create<TestType_InternalInterfaceImplementsNonPublicExternalType, TestDispatchProxy>());
+        }
+
+        [Fact]
+        public static void Create_Using_InternalServiceWithGenericArgumentBeingNonPublicExternalService()
+        {
+            Assert.NotNull(DispatchProxy.Create<TestType_InternalInterfaceWithNonPublicExternalGenericArgument, TestDispatchProxy>());
+        }
+
+        [Fact]
+        public static void Create_Using_InternalProxyWithBaseTypeImplementingServiceWithgenericArgumentBeingNonPublicExternalService()
+        {
+            Assert.NotNull(DispatchProxy.Create<TestType_IHelloService, TestType_InternalProxyImplementingInterfaceWithGenericArgumentBeingNonPublicExternalType>());
+        }
+
+        [Fact]
         public static void Invoke_Receives_Correct_MethodInfo_And_Arguments()
         {
             bool wasInvoked = false;

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -137,24 +137,28 @@ namespace DispatchProxyTests
         }
 
         [Fact]
+        [SkipOnMono("https://github.com/dotnet/runtime/issues/47989")]
         public static void Create_Using_PrivateProxy()
         {
             Assert.NotNull(TestType_PrivateProxy.Proxy<TestType_IHelloService>());
         }
 
         [Fact]
+        [SkipOnMono("https://github.com/dotnet/runtime/issues/47989")]
         public static void Create_Using_PrivateProxyAndInternalService()
         {
             Assert.NotNull(TestType_PrivateProxy.Proxy<TestType_InternalInterfaceService>());
         }
 
         [Fact]
+        [SkipOnMono("https://github.com/dotnet/runtime/issues/47989")]
         public static void Create_Using_PrivateProxyAndInternalServiceWithExternalGenericArgument()
         {
             Assert.NotNull(TestType_PrivateProxy.Proxy<TestType_InternalInterfaceWithNonPublicExternalGenericArgument>());
         }
 
         [Fact]
+        [SkipOnMono("https://github.com/dotnet/runtime/issues/47989")]
         public static void Create_Using_InternalProxy()
         {
             Assert.NotNull(DispatchProxy.Create<TestType_InternalInterfaceService, InternalInvokeProxy>());
@@ -167,6 +171,7 @@ namespace DispatchProxyTests
         }
 
         [Fact]
+        [SkipOnMono("https://github.com/dotnet/runtime/issues/47989")]
         public static void Create_Using_InternalProxyWithExternalNonPublicBaseType()
         {
             Assert.NotNull(DispatchProxy.Create<TestType_IHelloService, TestType_InternalProxyInternalBaseType>());
@@ -185,6 +190,7 @@ namespace DispatchProxyTests
         }
 
         [Fact]
+        [SkipOnMono("https://github.com/dotnet/runtime/issues/47989")]
         public static void Create_Using_InternalProxyWithBaseTypeImplementingServiceWithgenericArgumentBeingNonPublicExternalService()
         {
             Assert.NotNull(DispatchProxy.Create<TestType_IHelloService, TestType_InternalProxyImplementingInterfaceWithGenericArgumentBeingNonPublicExternalType>());

--- a/src/libraries/System.Reflection.DispatchProxy/tests/TestDependency/InternalsVisibleTo.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/TestDependency/InternalsVisibleTo.cs
@@ -1,0 +1,6 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("System.Reflection.DispatchProxy.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]

--- a/src/libraries/System.Reflection.DispatchProxy/tests/TestDependency/System.Reflection.DispatchProxy.TestDependency.csproj
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/TestDependency/System.Reflection.DispatchProxy.TestDependency.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="DispatchProxyTests.cs" />
+    <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="TestTypes.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="TestDependency\System.Reflection.DispatchProxy.TestDependency.csproj" />
-  </ItemGroup>
-  
 </Project>

--- a/src/libraries/System.Reflection.DispatchProxy/tests/TestDependency/TestTypes.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/TestDependency/TestTypes.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+
+namespace DispatchProxyTestDependency
+{
+    internal interface TestType_IExternalNonPublicHiService
+    {
+        string Hi(string message);
+    }
+
+    internal class TestType_ExternalNonPublicBaseClassForProxy : DispatchProxy
+    {
+        protected override object Invoke(MethodInfo targetMethod, object[] args) => null;
+    }
+}

--- a/src/libraries/System.Reflection.DispatchProxy/tests/TestTypes.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/TestTypes.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using DispatchProxyTestDependency;
 
 
 // Test types used to make proxies.
@@ -91,6 +92,20 @@ internal interface TestType_PublicInterfaceService_Implements_Internal : TestTyp
     string Echo2(string message);
 }
 
+internal interface TestType_InternalInterfaceImplementsNonPublicExternalType : TestType_IExternalNonPublicHiService
+{
+    string Hi2(string message);
+}
+
+internal interface TestType_ServiceWithGenericArgument<T>
+{
+    T GetInnerService();
+}
+
+internal interface TestType_InternalInterfaceWithNonPublicExternalGenericArgument : TestType_ServiceWithGenericArgument<TestType_IExternalNonPublicHiService>
+{
+}
+
 public interface TypeType_GenericMethod
 {
     T Echo<T>(T messages);
@@ -109,6 +124,35 @@ public sealed class Sealed_TestDispatchProxy : DispatchProxy
     {
         throw new InvalidOperationException();
     }
+}
+
+public class TestType_PrivateProxy
+{
+    public static T Proxy<T>() => DispatchProxy.Create<T, InvokeProxy<T>>();
+
+    private class InvokeProxy<T> : DispatchProxy
+    {
+        protected override object Invoke(MethodInfo targetMethod, object[] args) => null;
+    }
+}
+
+internal class TestType_InternalProxyInternalBaseType : TestType_ExternalNonPublicBaseClassForProxy
+{
+}
+
+internal class TestType_InternalProxyImplementingInterfaceWithGenericArgumentBeingNonPublicExternalType : DispatchProxy, TestType_InternalInterfaceWithNonPublicExternalGenericArgument
+{
+    public TestType_IExternalNonPublicHiService GetInnerService() => throw new InvalidOperationException();
+
+    protected override object Invoke(MethodInfo targetMethod, object[] args)
+    {
+        throw new InvalidOperationException();
+    }
+}
+
+internal class InternalInvokeProxy : DispatchProxy
+{
+    protected override object Invoke(MethodInfo targetMethod, object[] args) => null;
 }
 
 // This test double creates a proxy instance for the requested 'ProxyT' type.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/30917
Fixes: https://github.com/dotnet/runtime/issues/43685

This PR along with https://github.com/dotnet/runtime/pull/47784 fixes the issues above.

Technically this PR only adds tests to #43685 - https://github.com/dotnet/runtime/pull/47784 actually fixed the issue.

Also extra test cases for scenarios mentioned in both issues.

cc: @davidwrighton