### PR TITLE
New tests that JsonIncludeAttribute and JsonNumberHandlingAttribute are honored during deserialization

### DIFF
--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -837,11 +837,14 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task ArgumentDeserialization_Honors_JsonInclude()
         {
-            Point_MembersHave_JsonInclude point = new Point_MembersHave_JsonInclude(1, 2);
+            Point_MembersHave_JsonInclude point = new Point_MembersHave_JsonInclude(1, 2,3);
 
             string json = JsonSerializer.Serialize(point);
             Assert.Contains(@"""X"":1", json);
             Assert.Contains(@"""Y"":2", json);
+            //We should add another test for non-public members
+            //when https://github.com/dotnet/runtime/issues/31511 is implemented
+            Assert.Contains(@"""Z"":3", json);
 
             point = await Serializer.DeserializeWrapper<Point_MembersHave_JsonInclude>(json);
             point.Verify();

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -848,6 +848,20 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public async Task ArgumentDeserialization_Honors_JsonNumberHandling()
+        {
+            ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes obj = await Serializer.DeserializeWrapper<ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes>(ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes.s_json);
+            obj.Verify();
+
+            string json = JsonSerializer.Serialize(obj);
+            Assert.Contains(@"""A"":1", json);
+            Assert.Contains(@"""B"":""NaN""", json);
+            Assert.Contains(@"""C"":2", json);
+            Assert.Contains(@"""D"":""3""", json);
+            Assert.Contains(@"""E"":""4""", json);
+        }
+
+        [Fact]
         public async Task ArgumentDeserialization_Honors_JsonPropertyName()
         {
             Point_MembersHave_JsonPropertyName point = new Point_MembersHave_JsonPropertyName(1, 2);

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -835,6 +835,19 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public async Task ArgumentDeserialization_Honors_JsonInclude()
+        {
+            Point_MembersHave_JsonInclude point = new Point_MembersHave_JsonInclude(1, 2);
+
+            string json = JsonSerializer.Serialize(point);
+            Assert.Contains(@"""X"":1", json);
+            Assert.Contains(@"""Y"":2", json);
+
+            point = await Serializer.DeserializeWrapper<Point_MembersHave_JsonInclude>(json);
+            point.Verify();
+        }
+
+        [Fact]
         public async Task ArgumentDeserialization_Honors_JsonPropertyName()
         {
             Point_MembersHave_JsonPropertyName point = new Point_MembersHave_JsonPropertyName(1, 2);

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // Array size is the count of the following tests.
-            Task[] tasks = new Task[15];
+            Task[] tasks = new Task[16];
 
             // Simple models can be deserialized.
             tasks[0] = Task.Run(async () => await RunTestAsync<Parameterized_IndexViewModel_Immutable>(Parameterized_IndexViewModel_Immutable.s_data));
@@ -49,10 +49,11 @@ namespace System.Text.Json.Serialization.Tests
             tasks[9] = Task.Run(async () => await RunTestAsync<Point_MembersHave_JsonConverter>(Point_MembersHave_JsonConverter.s_data));
             tasks[10] = Task.Run(async () => await RunTestAsync<Point_MembersHave_JsonIgnore>(Point_MembersHave_JsonIgnore.s_data));
             tasks[11] = Task.Run(async () => await RunTestAsync<Point_MembersHave_JsonInclude>(Point_MembersHave_JsonInclude.s_data));
+            tasks[12] = Task.Run(async () => await RunTestAsync<ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes>(ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes.s_data));
             // Complex JSON as last argument works
-            tasks[12] = Task.Run(async () => await RunTestAsync<Point_With_Array>(Point_With_Array.s_data));
-            tasks[13] = Task.Run(async () => await RunTestAsync<Point_With_Dictionary>(Point_With_Dictionary.s_data));
-            tasks[14] = Task.Run(async () => await RunTestAsync<Point_With_Object>(Point_With_Object.s_data));
+            tasks[13] = Task.Run(async () => await RunTestAsync<Point_With_Array>(Point_With_Array.s_data));
+            tasks[14] = Task.Run(async () => await RunTestAsync<Point_With_Dictionary>(Point_With_Dictionary.s_data));
+            tasks[15] = Task.Run(async () => await RunTestAsync<Point_With_Object>(Point_With_Object.s_data));
 
             await Task.WhenAll(tasks);
         }

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Stream.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // Array size is the count of the following tests.
-            Task[] tasks = new Task[14];
+            Task[] tasks = new Task[15];
 
             // Simple models can be deserialized.
             tasks[0] = Task.Run(async () => await RunTestAsync<Parameterized_IndexViewModel_Immutable>(Parameterized_IndexViewModel_Immutable.s_data));
@@ -48,10 +48,11 @@ namespace System.Text.Json.Serialization.Tests
             tasks[8] = Task.Run(async () => await RunTestAsync<Point_MembersHave_JsonPropertyName>(Point_MembersHave_JsonPropertyName.s_data));
             tasks[9] = Task.Run(async () => await RunTestAsync<Point_MembersHave_JsonConverter>(Point_MembersHave_JsonConverter.s_data));
             tasks[10] = Task.Run(async () => await RunTestAsync<Point_MembersHave_JsonIgnore>(Point_MembersHave_JsonIgnore.s_data));
+            tasks[11] = Task.Run(async () => await RunTestAsync<Point_MembersHave_JsonInclude>(Point_MembersHave_JsonInclude.s_data));
             // Complex JSON as last argument works
-            tasks[11] = Task.Run(async () => await RunTestAsync<Point_With_Array>(Point_With_Array.s_data));
-            tasks[12] = Task.Run(async () => await RunTestAsync<Point_With_Dictionary>(Point_With_Dictionary.s_data));
-            tasks[13] = Task.Run(async () => await RunTestAsync<Point_With_Object>(Point_With_Object.s_data));
+            tasks[12] = Task.Run(async () => await RunTestAsync<Point_With_Array>(Point_With_Array.s_data));
+            tasks[13] = Task.Run(async () => await RunTestAsync<Point_With_Dictionary>(Point_With_Dictionary.s_data));
+            tasks[14] = Task.Run(async () => await RunTestAsync<Point_With_Object>(Point_With_Object.s_data));
 
             await Task.WhenAll(tasks);
         }

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
@@ -2066,19 +2066,23 @@ namespace System.Text.Json.Serialization.Tests
         public int X { get; }
 
         [JsonInclude]
-        public int Y { get; }
+        public int Y { get; private set; }
 
-        public Point_MembersHave_JsonInclude(int x, int y) => (X, Y) = (x, y);
+        public int Z { get; private set; }
+
+        public Point_MembersHave_JsonInclude(int x, int y, int z) => (X, Y, Z) = (x, y, z);
 
         public void Initialize() { }
 
-        public static readonly string s_json = @"{""X"":1,""Y"":2}";
+        public static readonly string s_json = @"{""X"":1,""Y"":2,""Z"":3}";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
+
         public void Verify()
         {
             Assert.Equal(1, X);
             Assert.Equal(2, Y);
+            Assert.Equal(3, Z);
         }
     }
 
@@ -2100,11 +2104,13 @@ namespace System.Text.Json.Serialization.Tests
         public int E { get; }
 
         public ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes(int a, float b, int c, int d, int e) => (A, B, C, D, E) = (a, b, c, d, e);
+
         public void Initialize() { }
 
         public static readonly string s_json = @"{""A"":1,""B"":""NaN"",""C"":""2"",""D"": 3,""E"":""4""}";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
+
         public void Verify()
         {
             Assert.Equal(1, A);

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
@@ -2060,6 +2060,28 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class Point_MembersHave_JsonInclude : ITestClass
+    {
+        [JsonInclude]
+        public int X { get; }
+
+        [JsonInclude]
+        public int Y { get; }
+
+        public Point_MembersHave_JsonInclude(int x, int y) => (X, Y) = (x, y);
+
+        public void Initialize() { }
+
+        public static readonly string s_json = @"{""X"":1,""Y"":2}";
+
+        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
+        public void Verify()
+        {
+            Assert.Equal(1, X);
+            Assert.Equal(2, Y);
+        }
+    }
+
     public class Point_MultipleMembers_BindTo_OneConstructorParameter
     {
         public int X { get; }

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
@@ -2059,7 +2059,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, Y); // We don't set parameter default value here.
         }
     }
-
+    
     public class Point_MembersHave_JsonInclude : ITestClass
     {
         [JsonInclude]
@@ -2079,6 +2079,39 @@ namespace System.Text.Json.Serialization.Tests
         {
             Assert.Equal(1, X);
             Assert.Equal(2, Y);
+        }
+    }
+
+    public class ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes : ITestClass
+    {
+        [JsonNumberHandling(JsonNumberHandling.Strict)]
+        public int A { get; }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+        public float B { get; }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+        public int C { get; }
+
+        [JsonNumberHandling(JsonNumberHandling.WriteAsString)]
+        public int D { get; }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+        public int E { get; }
+
+        public ClassWithFiveArgs_MembersHave_JsonNumberHandlingAttributes(int a, float b, int c, int d, int e) => (A, B, C, D, E) = (a, b, c, d, e);
+        public void Initialize() { }
+
+        public static readonly string s_json = @"{""A"":1,""B"":""NaN"",""C"":""2"",""D"": 3,""E"":""4""}";
+
+        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
+        public void Verify()
+        {
+            Assert.Equal(1, A);
+            Assert.Equal(float.NaN, B);
+            Assert.Equal(2, C);
+            Assert.Equal(3, D);
+            Assert.Equal(4, E);
         }
     }
 


### PR DESCRIPTION
I added two test for checking the attributes during parameterized ctor deserialization.
_ArgumentDeserialization_Honors_JsonNumberHandling_ test shows that _JsonIncludeAttribute_ is not necessary when the deserialization occurs via ctor mapping even though the properties don't have setters.
This is the only thing that bothers me. 

#47855