### PR TITLE
Re-remove NetEventSource.IsEnabled property

### DIFF
--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -10,7 +10,6 @@
 #nullable enable
 using System.Collections;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -99,7 +98,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
+            if (Log.IsEnabled()) Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
         }
 
         /// <summary>Logs an information message.</summary>
@@ -111,7 +110,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(InfoEventId, Level = EventLevel.Informational, Keywords = Keywords.Default)]
@@ -129,7 +128,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
         }
 
         /// <summary>Logs an error message.</summary>
@@ -141,7 +140,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(ErrorEventId, Level = EventLevel.Error, Keywords = Keywords.Default)]
@@ -159,7 +158,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
         }
 
         /// <summary>Logs an info at verbose mode.</summary>
@@ -171,7 +170,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.VerboseMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.VerboseMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(ErrorEventId, Level = EventLevel.Verbose, Keywords = Keywords.Default)]
@@ -199,7 +198,7 @@ namespace System.Net
         [NonEvent]
         public static void DumpBuffer(object? thisOrContextObject, byte[] buffer, int offset, int count, [CallerMemberName] string? memberName = null)
         {
-            if (IsEnabled && offset >= 0 && offset <= buffer.Length - count)
+            if (Log.IsEnabled() && offset >= 0 && offset <= buffer.Length - count)
             {
                 count = Math.Min(count, MaxDumpSize);
 
@@ -225,7 +224,7 @@ namespace System.Net
             Debug.Assert(bufferPtr != IntPtr.Zero);
             Debug.Assert(count >= 0);
 
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 var buffer = new byte[Math.Min(count, MaxDumpSize)];
                 fixed (byte* targetPtr = buffer)
@@ -251,7 +250,7 @@ namespace System.Net
         {
             DebugValidateArg(first);
             DebugValidateArg(second);
-            if (IsEnabled) Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
+            if (Log.IsEnabled()) Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
         }
 
         /// <summary>Logs a relationship between two objects.</summary>
@@ -265,7 +264,7 @@ namespace System.Net
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(first);
             DebugValidateArg(second);
-            if (IsEnabled) Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
+            if (Log.IsEnabled()) Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
         }
 
         [Event(AssociateEventId, Level = EventLevel.Informational, Keywords = Keywords.Default, Message = "[{2}]<-->[{3}]")]
@@ -278,7 +277,7 @@ namespace System.Net
         [Conditional("DEBUG_NETEVENTSOURCE_MISUSE")]
         private static void DebugValidateArg(object? arg)
         {
-            if (!IsEnabled)
+            if (!Log.IsEnabled())
             {
                 Debug.Assert(!(arg is ValueType), $"Should not be passing value type {arg?.GetType()} to logging without IsEnabled check");
                 Debug.Assert(!(arg is FormattableString), $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
@@ -288,11 +287,8 @@ namespace System.Net
         [Conditional("DEBUG_NETEVENTSOURCE_MISUSE")]
         private static void DebugValidateArg(FormattableString? arg)
         {
-            Debug.Assert(IsEnabled || arg == null, $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
+            Debug.Assert(Log.IsEnabled() || arg == null, $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
         }
-
-        public static new bool IsEnabled =>
-            Log.IsEnabled();
 
         [NonEvent]
         public static string IdOf(object? value) => value != null ? value.GetType().Name + "#" + GetHashCode(value) : NullInstance;
@@ -381,7 +377,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string? arg1, string? arg2, string? arg3, string? arg4)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
                 if (arg2 == null) arg2 = "";
@@ -425,7 +421,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string? arg1, string? arg2, byte[]? arg3)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
                 if (arg2 == null) arg2 = "";
@@ -468,7 +464,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string? arg1, int arg2, int arg3, int arg4)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
 
@@ -506,7 +502,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string? arg1, int arg2, string? arg3)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
                 if (arg3 == null) arg3 = "";
@@ -541,7 +537,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string? arg1, string? arg2, int arg3)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
                 if (arg2 == null) arg2 = "";
@@ -576,7 +572,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string? arg1, string? arg2, string? arg3, int arg4)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
                 if (arg2 == null) arg2 = "";
@@ -618,7 +614,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
 
@@ -676,7 +672,7 @@ namespace System.Net
         [NonEvent]
         private unsafe void WriteEvent(int eventId, string arg1, string arg2, int arg3, int arg4, int arg5)
         {
-            if (IsEnabled())
+            if (Log.IsEnabled())
             {
                 if (arg1 == null) arg1 = "";
                 if (arg2 == null) arg2 = "";


### PR DESCRIPTION
We'd removed this almost a year ago, but it came back almost immediately and accidentally as a result of two PRs that raced with each other.

cc: @eerhardt 