### PR TITLE
Remove string.Insert/Remove usage from Uri.GetCanonicalPath

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4421,17 +4421,18 @@ namespace System
                     //Note: we may produce non escaped Uri characters on the wire
                     if (InFact(Flags.E_PathNotCanonical) && NotAny(Flags.UserEscaped))
                     {
-                        string str = _string;
+                        ReadOnlySpan<char> str = _string;
 
                         // Check on not canonical disk designation like C|\, should be rare, rare case
                         if (dosPathIdx != 0 && str[dosPathIdx + _info.Offset.Path - 1] == '|')
                         {
-                            str = str.Remove(dosPathIdx + _info.Offset.Path - 1, 1);
-                            str = str.Insert(dosPathIdx + _info.Offset.Path - 1, ":");
+                            char[] chars = str.ToArray();
+                            chars[dosPathIdx + _info.Offset.Path - 1] = ':';
+                            str = chars;
                         }
 
                         UriHelper.EscapeString(
-                            str.AsSpan(_info.Offset.Path, _info.Offset.Query - _info.Offset.Path),
+                            str.Slice(_info.Offset.Path, _info.Offset.Query - _info.Offset.Path),
                             ref dest, checkExistingEscaped: !IsImplicitFile, '?', '#');
                     }
                     else


### PR DESCRIPTION
For a rare path, GetCanonicalPath is removing one character from a string and then inserting a replacement character.  Thanks to span, we can replace the two string allocations with a single char[] allocation and avoid these Remove/Insert calls, which are the only ones keeping string.Remove and string.Insert from being trimmed out of a default Blazor wasm app.

cc: @eerhardt, @tannergooding, @MihaZupan 