### PR TITLE
Refactor TranscodeUtf8 to allow trimming of Vector128<T>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -882,7 +882,8 @@ namespace System.Text.Unicode
             // vector is only used in those code paths, we leave it uninitialized if SSE4.1
             // is not enabled.
 
-            Unsafe.SkipInit(out Vector128<short> nonAsciiUtf16DataMask);
+            Vector128<short> nonAsciiUtf16DataMask;
+
             if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian))
             {
                 nonAsciiUtf16DataMask = Vector128.Create(unchecked((short)0xFF80)); // mask of non-ASCII bits in a UTF-16 char
@@ -950,6 +951,10 @@ namespace System.Text.Unicode
                         Vector128<short> utf16Data;
                         for (i = 0; (uint)i < maxIters; i++)
                         {
+                            // The linker won't trim out nonAsciiUtf16DataMask unless this is in the loop.
+                            // Luckily, this is a nop and will be elided by the JIT
+                            Unsafe.SkipInit(out nonAsciiUtf16DataMask);
+
                             utf16Data = Unsafe.ReadUnaligned<Vector128<short>>(pInputBuffer);
 
                             if (AdvSimd.IsSupported)


### PR DESCRIPTION
This resolves #47860 by moving where `Unsafe.SkipInit` is called so we can trim out `Vector128<short>` in the default blazor_wasm template.

I logged https://github.com/mono/linker/issues/1805 to track the linker not understanding things like `SkipInit` (which are `NonVersionable`) and https://github.com/mono/linker/issues/1808 to track the linker not trimming out a local when its only usage is it being initialized via `initobj`

CC. @eerhardt, @stephentoub 