### PR TITLE
Optimize Matrix.Elements

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
@@ -82,24 +82,18 @@ namespace System.Drawing.Drawing2D
             return new Matrix(clonedMatrix);
         }
 
-        public float[] Elements
+        public unsafe float[] Elements
         {
             get
             {
-                IntPtr buf = Marshal.AllocHGlobal(6 * 8); // 6 elements x 8 bytes (float)
+                float[] elements = new float[6];
 
-                try
+                fixed (float* m = elements)
                 {
-                    Gdip.CheckStatus(Gdip.GdipGetMatrixElements(new HandleRef(this, NativeMatrix), buf));
+                    Gdip.CheckStatus(Gdip.GdipGetMatrixElements(new HandleRef(this, NativeMatrix), m));
+                }
 
-                    float[] m = new float[6];
-                    Marshal.Copy(buf, m, 0, 6);
-                    return m;
-                }
-                finally
-                {
-                    Marshal.FreeHGlobal(buf);
-                }
+                return elements;
             }
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -800,7 +800,7 @@ namespace System.Drawing
             internal static extern int GdipVectorTransformMatrixPointsI(HandleRef matrix, Point* pts, int count);
 
             [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetMatrixElements(HandleRef matrix, IntPtr m);
+            internal static extern unsafe int GdipGetMatrixElements(HandleRef matrix, float* m);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipIsMatrixInvertible(HandleRef matrix, out int boolean);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -697,9 +697,7 @@ namespace System.Drawing
 
             if (!cumulTransform.IsIdentity)
             {
-                float[] elements = cumulTransform.Elements;
-                currentOffset.X = elements[4];
-                currentOffset.Y = elements[5];
+                currentOffset = cumulTransform.Offset;
             }
 
             GraphicsContext? context = _previousContext;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GraphicsContext.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GraphicsContext.cs
@@ -49,9 +49,7 @@ namespace System.Drawing
             Matrix transform = g.Transform;
             if (!transform.IsIdentity)
             {
-                float[] elements = transform.Elements;
-                _transformOffset.X = elements[4];
-                _transformOffset.Y = elements[5];
+                _transformOffset = transform.Offset;
             }
             transform.Dispose();
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -381,7 +381,6 @@ namespace System.Drawing
             finally
             {
                 RestoreClipRgn(dc, hSaveRgn);
-                Interop.Gdi32.DeleteObject(hSaveRgn);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Internal;
 using System.IO;
@@ -380,6 +381,7 @@ namespace System.Drawing
             finally
             {
                 RestoreClipRgn(dc, hSaveRgn);
+                Interop.Gdi32.DeleteObject(hSaveRgn);
             }
         }
 
@@ -416,8 +418,11 @@ namespace System.Drawing
         internal void Draw(Graphics graphics, Rectangle targetRect)
         {
             Rectangle copy = targetRect;
-            copy.X += (int)graphics.Transform.OffsetX;
-            copy.Y += (int)graphics.Transform.OffsetY;
+
+            using Matrix transform = graphics.Transform;
+            PointF offset = transform.Offset;
+            copy.X += (int)offset.X;
+            copy.Y += (int)offset.Y;
 
             using (WindowsGraphics wg = WindowsGraphics.FromGraphics(graphics, ApplyGraphicsProperties.Clipping))
             {
@@ -433,8 +438,10 @@ namespace System.Drawing
         internal void DrawUnstretched(Graphics graphics, Rectangle targetRect)
         {
             Rectangle copy = targetRect;
-            copy.X += (int)graphics.Transform.OffsetX;
-            copy.Y += (int)graphics.Transform.OffsetY;
+            using Matrix transform = graphics.Transform;
+            PointF offset = transform.Offset;
+            copy.X += (int)offset.X;
+            copy.Y += (int)offset.Y;
 
             using (WindowsGraphics wg = WindowsGraphics.FromGraphics(graphics, ApplyGraphicsProperties.Clipping))
             {

--- a/src/libraries/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
+++ b/src/libraries/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
@@ -54,7 +54,8 @@ namespace System.Drawing.Internal
             Debug.Assert(g != null, "null Graphics object.");
 
             WindowsRegion? wr = null;
-            float[]? elements = null;
+
+            PointF offset = default;
 
             Region? clipRgn = null;
             Matrix? worldTransf = null;
@@ -71,7 +72,7 @@ namespace System.Drawing.Internal
                 {
                     if ((properties & ApplyGraphicsProperties.TranslateTransform) != 0)
                     {
-                        elements = worldTransf.Elements;
+                        offset = worldTransf.Offset;
                     }
 
                     worldTransf.Dispose();
@@ -110,10 +111,10 @@ namespace System.Drawing.Internal
                 }
             }
 
-            if (elements != null)
+            if (offset != default)
             {
                 // elements (XFORM) = [eM11, eM12, eM21, eM22, eDx, eDy], eDx/eDy specify the translation offset.
-                wg.DeviceContext.TranslateTransform((int)elements[4], (int)elements[5]);
+                wg.DeviceContext.TranslateTransform((int)offset.X, (int)offset.Y);
             }
 
             return wg;


### PR DESCRIPTION
Just pin the array. There is no need to allocate native memory and copy.