### PR TITLE
Add possibility to write ANSI color escape codes when the console output is redirected

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -39,6 +39,9 @@ namespace System
         private static int s_windowHeight;  // Cached WindowHeight, invalid when s_windowWidth == -1.
         private static int s_invalidateCachedSettings = 1; // Tracks whether we should invalidate the cached settings.
 
+        /// <summary>Whether to output ansi color strings.</summary>
+        private static volatile int s_emitAnsiColorCodes = -1;
+
         public static Stream OpenStandardInput()
         {
             return new UnixConsoleStream(SafeFileHandleHelper.Open(() => Interop.Sys.Dup(Interop.Sys.FileDescriptors.STDIN_FILENO)), FileAccess.Read,
@@ -779,8 +782,10 @@ namespace System
             // Changing the color involves writing an ANSI character sequence out to the output stream.
             // We only want to do this if we know that sequence will be interpreted by the output.
             // rather than simply displayed visibly.
-            if (!SupportsAnsiColor())
+            if (!EmitAnsiColorCodes)
+            {
                 return;
+            }
 
             // See if we've already cached a format string for this foreground/background
             // and specific color choice.  If we have, just output that format string again.
@@ -813,31 +818,50 @@ namespace System
         /// <summary>Writes out the ANSI string to reset colors.</summary>
         private static void WriteResetColorString()
         {
-            if (SupportsAnsiColor())
+            if (EmitAnsiColorCodes)
             {
                 WriteStdoutAnsiString(TerminalFormatStrings.Instance.Reset);
             }
         }
 
-        /// <summary>
-        /// Tests whether ANSI color codes should be emitted or not.
-        /// <para>
-        /// If the <c>DOTNET_CONSOLE_ANSI_COLOR</c> environment variable contains <c>true</c> (case insensitive) or <c>1</c>
-        /// then ANSI color codes are supported. If the <c>DOTNET_CONSOLE_ANSI_COLOR</c> environment variable is not defined
-        /// or contains a non truthy value, then ANSI color codes are supported if the console output is not redirected.
-        /// </para>
-        /// </summary>
-        /// <returns><c>true</c> if ANSI color escape codes must be emitted, <c>false</c> if they must not be emitted.</returns>
-        /// <remarks>This was discussed in https://github.com/dotnet/runtime/issues/33980</remarks>
-        private static bool SupportsAnsiColor()
+        /// <summary>Get whether to emit ANSI color codes.</summary>
+        private static bool EmitAnsiColorCodes
         {
-            string? consoleAnsiColor = Environment.GetEnvironmentVariable("DOTNET_CONSOLE_ANSI_COLOR");
-            if (consoleAnsiColor != null)
+            get
             {
-                return consoleAnsiColor == "1" || (bool.TryParse(consoleAnsiColor, out bool enabled) && enabled);
-            }
+                // The flag starts at -1.  If it's no longer -1, it's 0 or 1 to represent false or true.
+                int emitAnsiColorCodes = s_emitAnsiColorCodes;
+                if (emitAnsiColorCodes != -1)
+                {
+                    return Convert.ToBoolean(emitAnsiColorCodes);
+                }
 
-            return !Console.IsOutputRedirected;
+                // We've not yet computed whether to emit codes or not.  Do so now.  We may race with
+                // other threads, and that's ok; this is idempotent unless someone is currently changing
+                // the value of the relevant environment variables, in which case behavior here is undefined.
+
+                // By default, we emit ANSI color codes if output isn't redirected, and suppress them if output is redirected.
+                bool enabled = !Console.IsOutputRedirected;
+
+                if (enabled)
+                {
+                    // We subscribe to the informal standard from https://no-color.org/.  If we'd otherwise emit
+                    // ANSI color codes but the NO_COLOR environment variable is set, disable emitting them.
+                    enabled = Environment.GetEnvironmentVariable("NO_COLOR") is null;
+                }
+                else
+                {
+                    // We also support overriding in the other direction.  If we'd otherwise avoid emitting color
+                    // codes but the DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION environment variable is
+                    // set to 1 or true, enable color.
+                    string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
+                    enabled = envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
+                }
+
+                // Store and return the computed answer.
+                s_emitAnsiColorCodes = Convert.ToInt32(enabled);
+                return enabled;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This  introduces an opt-in mechanism to allow writing ANSI color escape codes even when the console output is redirected.

To enable ANSI color codes, the `DOTNET_CONSOLE_ANSI_COLOR` environment variable must be set to `true` (case insensitive) or `1`.

Fixes #33980