### PR TITLE
[Release/5.0] Fix covariant returns when overriding method of non-parent ancestor

### DIFF
--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1169,6 +1169,12 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
             if (!pMD->RequiresCovariantReturnTypeChecking() && !pParentMD->RequiresCovariantReturnTypeChecking())
                 continue;
 
+            // Locate the MethodTable defining the pParentMD.
+            while (pParentMT->GetCanonicalMethodTable() != pParentMD->GetMethodTable())
+            {
+                pParentMT = pParentMT->GetParentMethodTable();
+            }
+
             SigTypeContext context1(pParentMT->GetInstantiation(), pMD->GetMethodInstantiation());
             MetaSig methodSig1(pParentMD);
             TypeHandle hType1 = methodSig1.GetReturnProps().GetTypeHandleThrowing(pParentMD->GetModule(), &context1, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);

--- a/src/tests/Regressions/coreclr/GitHub_45053/test45053.cs
+++ b/src/tests/Regressions/coreclr/GitHub_45053/test45053.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+public abstract class T<TR>
+{
+    public abstract TR GetA();
+}
+
+// This abstract causes the error - not overriding the base method cause the runtime to crash
+public abstract class TA : T<A> { }
+
+// This works
+// public abstract class TA : T<A>
+// {
+//  // Overriding in between fixes the problem
+//    public override A GetA() => new ();
+// }
+
+    // Overriden here, in the grandson
+public class TB : TA
+{
+    public override B GetA() => new ();
+}
+public class A { }
+
+public class B : A { }
+
+class Program
+{
+    static int Main()
+    {
+        System.Console.WriteLine((new TB() as T<A>).GetA().GetType().FullName);
+
+        return 100;
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_45053/test45053.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_45053/test45053.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test45053.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Port #47846 to release/5.0

There is a problem in the
ClassLoader::ValidateMethodsWithCovariantReturnTypes that results in
failed verification of valid override in case the return type of the
method being overriden is generic in canonical form and it is defined
in an ancestor class that is not the parent.

The problem is that we attempt to use instantiation of the parent class
instead of the ancestor class that contains definition of the method
being overriden.

This change fixes it by locating the proper ancestor MethodTable and
using it.

## Customer Impact
Valid application that uses multiple generic type arguments in covariant return override where some of them but not all are canonical crashes at runtime with System.TypeLoadException when attempting to use the underlying type.

## Testing
CoreCLR pri1 tests, including the new test added that specifically target the problematic cases (copy of the repro provided by our customer that have found the issue)

## Risk
Low

## Regression
No