### PR TITLE
ReadOnlySequence: Don't leak the flags that are on _startInteger and _endInteger.

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -248,7 +248,7 @@ namespace System.Buffers
                 int currentLength = startSegment.Memory.Length - startIndex;
 
                 // Position in start segment, defer to single segment seek
-                if (currentLength > offset)
+                if (currentLength > offset || offset == 0)
                     goto IsSingleSegment;
 
                 if (currentLength < 0)

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -62,7 +62,7 @@ namespace System.Buffers
         public SequencePosition Start
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => new SequencePosition(_startObject, _startInteger & ReadOnlySequence.IndexBitMask);
+            get => new SequencePosition(_startObject, GetIndex(_startInteger));
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace System.Buffers
         public SequencePosition End
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => new SequencePosition(_endObject, _endInteger & ReadOnlySequence.IndexBitMask);
+            get => new SequencePosition(_endObject, GetIndex(_endInteger));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -661,7 +661,7 @@ namespace System.Buffers
     internal static class ReadOnlySequence
     {
         /// <summary>
-        /// Flag that allow to encode the <see cref="ReadOnlySequence{T}.SequenceType"/>.
+        /// Flag that allows encoding the <see cref="ReadOnlySequence{T}.SequenceType"/>.
         /// </summary>
         /// <seealso cref="ReadOnlySequence{T}.GetSequenceType"/>
         public const int FlagBitMask = 1 << 31;

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -62,7 +62,7 @@ namespace System.Buffers
         public SequencePosition Start
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => new SequencePosition(_startObject, _startInteger);
+            get => new SequencePosition(_startObject, _startInteger & ReadOnlySequence.IndexBitMask);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace System.Buffers
         public SequencePosition End
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => new SequencePosition(_endObject, _endInteger);
+            get => new SequencePosition(_endObject, _endInteger & ReadOnlySequence.IndexBitMask);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -660,6 +660,10 @@ namespace System.Buffers
 
     internal static class ReadOnlySequence
     {
+        /// <summary>
+        /// Flag that allow to encode the <see cref="ReadOnlySequence{T}.SequenceType"/>.
+        /// </summary>
+        /// <seealso cref="ReadOnlySequence{T}.GetSequenceType"/>
         public const int FlagBitMask = 1 << 31;
         public const int IndexBitMask = ~FlagBitMask;
 

--- a/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -187,6 +187,29 @@ namespace System.Memory.Tests
             Assert.Equal(buffer.End, buffer.GetPosition(5));
         }
 
+        [Fact]
+        public void Start_EqualToGetPosition0()
+        {
+            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(5);
+            Assert.Equal(buffer.Start, buffer.GetPosition(0));
+        }
+
+        [Fact]
+        public void InnerPositionAreNotEqualToEnd()
+        {
+            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(3);
+            Assert.NotEqual(buffer.GetPosition(1), buffer.End);
+            Assert.NotEqual(buffer.GetPosition(2), buffer.End);
+        }
+
+        [Fact]
+        public void InnerPositionAreNotEqualToStart()
+        {
+            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(3);
+            Assert.NotEqual(buffer.GetPosition(1), buffer.Start);
+            Assert.NotEqual(buffer.GetPosition(2), buffer.Start);
+        }
+
         public static TheoryData<Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>>> ValidSliceCases => new TheoryData<Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>>>
         {
             b => b.Slice(5),

--- a/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -180,6 +180,13 @@ namespace System.Memory.Tests
             });
         }
 
+        [Fact]
+        public void End_EqualToGetPositionSize()
+        {
+            ReadOnlySequence<byte> buffer = Factory.CreateOfSize(5);
+            Assert.Equal(buffer.End, buffer.GetPosition(5));
+        }
+
         public static TheoryData<Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>>> ValidSliceCases => new TheoryData<Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>>>
         {
             b => b.Slice(5),


### PR DESCRIPTION
Fixes #42999.
Currently the ReadOnlySequence.End has sometimes a flag that causes odd behavior like:  
`GetPosition(size) != End`
`ReadOnlySequence<byte>.Empty.Start != ReadOnlySequence<byte>.Empty.End`  
This causes more odd behavior later on types relying on the ROSequence.

My fix simply removes the flags when we return a SequencePosition in .Start and .End.