### PR TITLE
Completely get rid of "refonly" from Mono

### DIFF
--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1241,7 +1241,7 @@ mono_alc_load_file (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAs
 		if (status == MONO_IMAGE_IMAGE_INVALID)
 			mono_error_set_bad_image_by_name (error, filename, "Invalid Image: %s", filename);
 		else
-			mono_error_set_simple_file_not_found (error, filename, FALSE);
+			mono_error_set_simple_file_not_found (error, filename);
 	}
 
 leave:

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -691,12 +691,12 @@ leave:
 }
 
 static MonoArrayHandle
-get_assembly_array_from_domain (MonoDomain *domain, MonoBoolean refonly, MonoError *error)
+get_assembly_array_from_domain (MonoDomain *domain, MonoError *error)
 {
 	int i;
 	GPtrArray *assemblies;
 
-	assemblies = mono_domain_get_assemblies (domain, refonly);
+	assemblies = mono_domain_get_assemblies (domain);
 
 	MonoArrayHandle res = mono_array_new_handle (domain, mono_class_get_assembly_class (), assemblies->len, error);
 	goto_if_nok (error, leave);
@@ -714,7 +714,7 @@ MonoArrayHandle
 ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetLoadedAssemblies (MonoError *error)
 {
 	MonoDomain *domain = mono_domain_get ();
-	return get_assembly_array_from_domain (domain, FALSE, error);
+	return get_assembly_array_from_domain (domain, error);
 }
 
 MonoAssembly*

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -944,13 +944,6 @@ mono_domain_asmctx_from_path (const char *fname, MonoAssembly *requesting_assemb
 	return FALSE;
 }
 
-char *
-mono_make_shadow_copy (const char *filename, MonoError *error)
-{
-	error_init (error);
-	return (char *) filename;
-}
-
 /**
  * mono_domain_from_appdomain:
  */

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -104,7 +104,6 @@ static MonoAssembly *
 mono_domain_assembly_preload (MonoAssemblyLoadContext *alc,
 			      MonoAssemblyName *aname,
 			      gchar **assemblies_path,
-			      gboolean refonly,
 			      gpointer user_data,
 			      MonoError *error);
 
@@ -287,7 +286,7 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 	mono_gc_init_icalls ();
 
 	// We have to append here because otherwise this will run before the netcore hook (which is installed first), see https://github.com/dotnet/runtime/issues/34273
-	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (FALSE), FALSE, TRUE);
+	mono_install_assembly_preload_hook_v2 (mono_domain_assembly_preload, GUINT_TO_POINTER (FALSE), TRUE);
 	mono_install_assembly_search_hook_v2 (mono_domain_assembly_search, GUINT_TO_POINTER (FALSE), FALSE, FALSE);
 	mono_install_assembly_search_hook_v2 (mono_domain_assembly_postload_search, GUINT_TO_POINTER (FALSE), TRUE, FALSE);
 	mono_install_assembly_load_hook_v2 (mono_domain_fire_assembly_load, NULL, FALSE);
@@ -1078,7 +1077,6 @@ static MonoAssembly *
 mono_domain_assembly_preload (MonoAssemblyLoadContext *alc,
 			      MonoAssemblyName *aname,
 			      gchar **assemblies_path,
-			      gboolean refonly,
 			      gpointer user_data,
 			      MonoError *error)
 {
@@ -1087,7 +1085,6 @@ mono_domain_assembly_preload (MonoAssemblyLoadContext *alc,
 
 	g_assert (alc);
 	g_assert (domain == mono_domain_get ());
-	g_assert (!refonly);
 
 	MonoAssemblyCandidatePredicate predicate = NULL;
 	void* predicate_ud = NULL;

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -52,9 +52,9 @@ typedef gboolean (*MonoAssemblyAsmCtxFromPathFunc) (const char *absfname, MonoAs
 
 void mono_install_assembly_asmctx_from_path_hook (MonoAssemblyAsmCtxFromPathFunc func, gpointer user_data);
 
-typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gboolean refonly, gpointer user_data, MonoError *error);
+typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error);
 
-void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer user_data, gboolean refonly, gboolean append);
+void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer user_data, gboolean append);
 
 typedef MonoAssembly * (*MonoAssemblySearchFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean postload, gpointer user_data, MonoError *error);
 

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -56,10 +56,10 @@ typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *al
 
 void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer user_data, gboolean refonly, gboolean append);
 
-typedef MonoAssembly * (*MonoAssemblySearchFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
+typedef MonoAssembly * (*MonoAssemblySearchFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean postload, gpointer user_data, MonoError *error);
 
 void
-mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, gpointer user_data, gboolean refonly, gboolean postload, gboolean append);
+mono_install_assembly_search_hook_v2 (MonoAssemblySearchFuncV2 func, gpointer user_data, gboolean postload, gboolean append);
 
 typedef void (*MonoAssemblyLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssembly *assembly, gpointer user_data, MonoError *error);
 

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -136,7 +136,7 @@ gboolean
 mono_assembly_check_name_match (MonoAssemblyName *wanted_name, MonoAssemblyName *candidate_name);
 
 MonoAssembly *
-mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, gboolean refonly);
+mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname);
 
 MONO_PROFILER_API MonoAssemblyName*
 mono_assembly_get_name_internal (MonoAssembly *assembly);

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1961,7 +1961,6 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 	MonoAssembly *ass;
 	MonoImageOpenStatus def_status;
 	gchar *fname;
-	gchar *new_fname;
 	gboolean loaded_from_bundle;
 
 	MonoAssemblyLoadRequest load_req;

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2081,7 +2081,7 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 	}
 
 	if (!image)
-		image = mono_image_open_a_lot (load_req.alc, fname, status, FALSE, load_from_context);
+		image = mono_image_open_a_lot (load_req.alc, fname, status, load_from_context);
 
 	if (!image){
 		if (*status == MONO_IMAGE_OK)

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -3075,7 +3075,6 @@ mono_assembly_load_with_partial_name_internal (const char *name, MonoAssemblyLoa
 
 	res = invoke_assembly_preload_hook (alc, aname, assemblies_path);
 	if (res) {
-		res->in_gac = FALSE;
 		mono_assembly_name_free_internal (aname);
 		return res;
 	}

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1068,7 +1068,7 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	 * 10. Return NULL.
 	 */
 
-	reference = mono_assembly_loaded_internal (alc, aname, FALSE);
+	reference = mono_assembly_loaded_internal (alc, aname);
 	if (reference) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Assembly already loaded in the active ALC: '%s'.", aname->name);
 		goto leave;
@@ -1083,7 +1083,7 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	}
 
 	if (!is_default && !is_satellite) {
-		reference = mono_assembly_loaded_internal (mono_domain_default_alc (mono_alc_domain (alc)), aname, FALSE);
+		reference = mono_assembly_loaded_internal (mono_domain_default_alc (mono_alc_domain (alc)), aname);
 		if (reference) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Assembly already loaded in the default ALC: '%s'.", aname->name);
 			goto leave;
@@ -3099,7 +3099,7 @@ mono_assembly_load_with_partial_name_internal (const char *name, MonoAssemblyLoa
 	if ((aname->major | aname->minor | aname->build | aname->revision) == 0)
 		aname = mono_assembly_remap_version (aname, &mapped_aname);
 	
-	res = mono_assembly_loaded_internal (alc, aname, FALSE);
+	res = mono_assembly_loaded_internal (alc, aname);
 	if (res) {
 		mono_assembly_name_free_internal (aname);
 		return res;
@@ -3300,11 +3300,11 @@ mono_assembly_loaded_full (MonoAssemblyName *aname, gboolean refonly)
 	if (refonly)
 		return NULL;
 	MonoAssemblyLoadContext *alc = mono_domain_default_alc (mono_domain_get ());
-	return mono_assembly_loaded_internal (alc, aname, refonly);
+	return mono_assembly_loaded_internal (alc, aname);
 }
 
 MonoAssembly *
-mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, gboolean refonly)
+mono_assembly_loaded_internal (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname)
 {
 	MonoAssembly *res;
 	MonoAssemblyName mapped_aname;
@@ -3330,7 +3330,7 @@ mono_assembly_loaded (MonoAssemblyName *aname)
 {
 	MonoAssembly *res;
 	MONO_ENTER_GC_UNSAFE;
-	res = mono_assembly_loaded_internal (mono_domain_default_alc (mono_domain_get ()), aname, FALSE);
+	res = mono_assembly_loaded_internal (mono_domain_default_alc (mono_domain_get ()), aname);
 	MONO_EXIT_GC_UNSAFE;
 	return res;
 }

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -214,8 +214,7 @@ mono_class_from_typeref_checked (MonoImage *image, guint32 type_token, MonoError
 		
 		mono_assembly_get_assemblyref (image, idx - 1, &aname);
 		human_name = mono_stringify_assembly_name (&aname);
-		gboolean refonly = FALSE;
-		mono_error_set_simple_file_not_found (error, human_name, refonly);
+		mono_error_set_simple_file_not_found (error, human_name);
 		g_free (human_name);
 		return NULL;
 	}

--- a/src/mono/mono/metadata/coree.c
+++ b/src/mono/mono/metadata/coree.c
@@ -132,7 +132,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 			/* The process is terminating. */
 			return TRUE;
 		file_name = mono_get_module_file_name (hInst);
-		image = mono_image_loaded_internal (alc, file_name, FALSE);
+		image = mono_image_loaded_internal (alc, file_name);
 		if (image)
 			mono_image_close (image);
 

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -550,10 +550,10 @@ MonoImage *mono_assembly_open_from_bundle (MonoAssemblyLoadContext *alc,
 					   const char *culture);
 
 MonoAssembly *
-mono_try_assembly_resolve (MonoAssemblyLoadContext *alc, const char *fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
+mono_try_assembly_resolve (MonoAssemblyLoadContext *alc, const char *fname, MonoAssembly *requesting, MonoError *error);
 
 MonoAssembly *
-mono_domain_assembly_postload_search (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean refonly, gboolean postload, gpointer user_data, MonoError *error);
+mono_domain_assembly_postload_search (MonoAssemblyLoadContext *alc, MonoAssembly *requesting, MonoAssemblyName *aname, gboolean postload, gpointer user_data, MonoError *error);
 
 MonoJitInfo* mono_jit_info_table_find_internal (MonoDomain *domain, gpointer addr, gboolean try_aot, gboolean allow_trampolines);
 

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -476,9 +476,6 @@ mono_jit_info_get_generic_sharing_context (MonoJitInfo *ji);
 void
 mono_jit_info_set_generic_sharing_context (MonoJitInfo *ji, MonoGenericSharingContext *gsctx);
 
-char *
-mono_make_shadow_copy (const char *filename, MonoError *error);
-
 // TODO: remove these on netcore, we should always be explicit about allocating from ALCs
 //#ifndef ENABLE_NETCORE
 gpointer

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -574,7 +574,7 @@ gboolean
 mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoError *error);
 
 GPtrArray*
-mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly);
+mono_domain_get_assemblies (MonoDomain *domain);
 
 void
 mono_runtime_register_appctx_properties (int nprops, const char **keys,  const char **values);

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -1653,7 +1653,7 @@ mono_domain_unlock (MonoDomain *domain)
 }
 
 GPtrArray*
-mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly)
+mono_domain_get_assemblies (MonoDomain *domain)
 {
 	GSList *tmp;
 	GPtrArray *assemblies;
@@ -1663,8 +1663,6 @@ mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly)
 	mono_domain_assemblies_lock (domain);
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;
-		if (refonly != FALSE)
-			continue;
 		g_ptr_array_add (assemblies, ass);
 	}
 	mono_domain_assemblies_unlock (domain);

--- a/src/mono/mono/metadata/exception-internals.h
+++ b/src/mono/mono/metadata/exception-internals.h
@@ -51,7 +51,7 @@ void
 mono_error_set_file_not_found (MonoError *oerror, const char *file_name, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_simple_file_not_found (MonoError *oerror, const char *assembly_name, gboolean refection_only);
+mono_error_set_simple_file_not_found (MonoError *oerror, const char *assembly_name);
 
 MonoExceptionHandle
 mono_corlib_exception_new_with_args (const char *name_space, const char *name, const char *arg_0, const char *arg_1, MonoError *error);

--- a/src/mono/mono/metadata/exception.c
+++ b/src/mono/mono/metadata/exception.c
@@ -1492,12 +1492,9 @@ mono_error_set_file_not_found (MonoError *error, const char *file_name, const ch
 }
 
 void
-mono_error_set_simple_file_not_found (MonoError *error, const char *file_name, gboolean refection_only)
+mono_error_set_simple_file_not_found (MonoError *error, const char *file_name)
 {
-	if (refection_only)
-		mono_error_set_file_not_found (error, file_name, "Cannot resolve dependency to assembly '%s' because it has not been preloaded. When using the ReflectionOnly APIs, dependent assemblies must be pre-loaded or loaded on demand through the ReflectionOnlyAssemblyResolve event.", file_name);
-	else
-		mono_error_set_file_not_found (error, file_name, "Could not load file or assembly '%s' or one of its dependencies.", file_name);
+	mono_error_set_file_not_found (error, file_name, "Could not load file or assembly '%s' or one of its dependencies.", file_name);
 }
 
 void

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -496,7 +496,7 @@ eventpipe_execute_rundown (
 		g_free (events_data.buffer);
 
 		// Iterate all assemblies in domain.
-		GPtrArray *assemblies = mono_domain_get_assemblies (root_domain, FALSE);
+		GPtrArray *assemblies = mono_domain_get_assemblies (root_domain);
 		if (assemblies) {
 			for (int i = 0; i < assemblies->len; ++i) {
 				MonoAssembly *assembly = (MonoAssembly *)g_ptr_array_index (assemblies, i);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -5209,8 +5209,7 @@ add_file_to_modules_array (MonoDomain *domain, MonoArrayHandle dest, int dest_id
 		goto_if_nok (error, leave);
 		if (!m) {
 			const char *filename = mono_metadata_string_heap (image, cols [MONO_FILE_NAME]);
-			gboolean refonly = FALSE;
-			mono_error_set_simple_file_not_found (error, filename, refonly);
+			mono_error_set_simple_file_not_found (error, filename);
 			goto leave;
 		}
 		MonoReflectionModuleHandle rm = mono_module_get_object_handle (domain, m, error);
@@ -5471,7 +5470,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 		if (status == MONO_IMAGE_IMAGE_INVALID)
 			mono_error_set_bad_image_by_name (error, filename, "Invalid Image: %s", filename);
 		else
-			mono_error_set_simple_file_not_found (error, filename, FALSE);
+			mono_error_set_simple_file_not_found (error, filename);
 		g_free (filename);
 		return;
 	}

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -5465,7 +5465,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "InternalGetAssemblyName (\"%s\")", filename);
 
 	MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
-	image = mono_image_open_a_lot (alc, filename, &status, FALSE, FALSE);
+	image = mono_image_open_a_lot (alc, filename, &status, FALSE);
 
 	if (!image){
 		if (status == MONO_IMAGE_IMAGE_INVALID)

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -5465,7 +5465,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "InternalGetAssemblyName (\"%s\")", filename);
 
 	MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
-	image = mono_image_open_a_lot (alc, filename, &status, TRUE, FALSE);
+	image = mono_image_open_a_lot (alc, filename, &status, FALSE, FALSE);
 
 	if (!image){
 		if (status == MONO_IMAGE_IMAGE_INVALID)

--- a/src/mono/mono/metadata/image-internals.h
+++ b/src/mono/mono/metadata/image-internals.h
@@ -13,7 +13,7 @@ char *
 mono_image_get_name_with_culture_if_needed (MonoImage *image);
 
 MonoImage*
-mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name, mono_bool refonly);
+mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name);
 
 MonoImage*
 mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError *error);
@@ -22,6 +22,6 @@ MonoImage*
 mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
 
 MonoImage *
-mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context);
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean load_from_context);
 
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/src/mono/mono/metadata/loaded-images-internals.h
+++ b/src/mono/mono/metadata/loaded-images-internals.h
@@ -18,10 +18,8 @@
  */
 enum {
 	MONO_LOADED_IMAGES_HASH_PATH = 0,
-	MONO_LOADED_IMAGES_HASH_PATH_REFONLY = 1,
-	MONO_LOADED_IMAGES_HASH_NAME = 2,
-	MONO_LOADED_IMAGES_HASH_NAME_REFONLY = 3,
-	MONO_LOADED_IMAGES_HASH_COUNT = 4
+	MONO_LOADED_IMAGES_HASH_NAME = 1,
+	MONO_LOADED_IMAGES_HASH_COUNT = 2
 };
 
 struct _MonoLoadedImages {
@@ -39,10 +37,10 @@ void
 mono_loaded_images_free (MonoLoadedImages *li);
 
 GHashTable *
-mono_loaded_images_get_hash (MonoLoadedImages *li, gboolean refonly);
+mono_loaded_images_get_hash (MonoLoadedImages *li);
 
 GHashTable *
-mono_loaded_images_get_by_name_hash (MonoLoadedImages *li, gboolean refonly);
+mono_loaded_images_get_by_name_hash (MonoLoadedImages *li);
 
 gboolean
 mono_loaded_images_remove_image (MonoImage *image);

--- a/src/mono/mono/metadata/loaded-images.c
+++ b/src/mono/mono/metadata/loaded-images.c
@@ -22,7 +22,7 @@ mono_loaded_images_cleanup (MonoLoadedImages *li, gboolean shutdown)
 
 		// If an assembly image is still loaded at shutdown, this could indicate managed code is still running.
 		// Reflection-only images being still loaded doesn't indicate anything as harmful, so we don't check for it.
-		g_hash_table_iter_init (&iter, mono_loaded_images_get_hash (li, FALSE));
+		g_hash_table_iter_init (&iter, mono_loaded_images_get_hash (li));
 		while (g_hash_table_iter_next (&iter, NULL, (void**)&image))
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly image '%s' [%p] still loaded at shutdown.", image->name, image);
 	}
@@ -41,20 +41,20 @@ mono_loaded_images_free (MonoLoadedImages *li)
 }
 
 GHashTable *
-mono_loaded_images_get_hash (MonoLoadedImages *li, gboolean refonly)
+mono_loaded_images_get_hash (MonoLoadedImages *li)
 {
 	g_assert (li != NULL);
 	GHashTable **loaded_images_hashes = &li->loaded_images_hashes[0];
-	int idx = refonly ? MONO_LOADED_IMAGES_HASH_PATH_REFONLY : MONO_LOADED_IMAGES_HASH_PATH;
+	int idx = MONO_LOADED_IMAGES_HASH_PATH;
 	return loaded_images_hashes [idx];
 }
 
 GHashTable *
-mono_loaded_images_get_by_name_hash (MonoLoadedImages *li, gboolean refonly)
+mono_loaded_images_get_by_name_hash (MonoLoadedImages *li)
 {
 	g_assert (li != NULL);
 	GHashTable **loaded_images_hashes = &li->loaded_images_hashes[0];
-	int idx = refonly ? MONO_LOADED_IMAGES_HASH_NAME_REFONLY : MONO_LOADED_IMAGES_HASH_NAME;
+	int idx = MONO_LOADED_IMAGES_HASH_NAME;
 	return loaded_images_hashes [idx];
 }
 
@@ -100,8 +100,8 @@ mono_loaded_images_remove_image (MonoImage *image)
 	GHashTable *loaded_images, *loaded_images_by_name;
 	MonoImage *image2;
 
-	loaded_images         = mono_loaded_images_get_hash (li, image->ref_only);
-	loaded_images_by_name = mono_loaded_images_get_by_name_hash (li, image->ref_only);
+	loaded_images         = mono_loaded_images_get_hash (li);
+	loaded_images_by_name = mono_loaded_images_get_by_name_hash (li);
 
 	name = image->name;
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -361,9 +361,6 @@ struct _MonoImage {
 	/* Whenever this is a dynamically emitted module */
 	guint8 dynamic : 1;
 
-	/* Whenever this is a reflection only image */
-	guint8 ref_only : 1;
-
 	/* Whenever this image contains uncompressed metadata */
 	guint8 uncompressed_metadata : 1;
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -220,7 +220,6 @@ struct _MonoAssembly {
 	MonoImage *image;
 	GSList *friend_assembly_names; /* Computed by mono_assembly_load_friends () */
 	guint8 friend_assembly_names_inited;
-	guint8 in_gac;
 	guint8 dynamic;
 	MonoAssemblyContext context;
 	guint8 wrap_non_exception_throws;

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1946,7 +1946,7 @@ int
 mono_runtime_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc);
 
 MonoAssembly*
-mono_try_assembly_resolve_handle (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
+mono_try_assembly_resolve_handle (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAssembly *requesting, MonoError *error);
 
 gboolean
 mono_runtime_object_init_handle (MonoObjectHandle this_obj, MonoError *error);

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1934,7 +1934,7 @@ _mono_reflection_get_type_from_info (MonoAssemblyLoadContext *alc, MonoTypeNameP
 	error_init (error);
 
 	if (info->assembly.name) {
-		MonoAssembly *assembly = mono_assembly_loaded_internal (alc, &info->assembly, FALSE);
+		MonoAssembly *assembly = mono_assembly_loaded_internal (alc, &info->assembly);
 		if (!assembly && image && image->assembly && mono_assembly_check_name_match (&info->assembly, &image->assembly->aname))
 			/* 
 			 * This could happen in the AOT compiler case when the search hook is not

--- a/src/mono/mono/metadata/verify.c
+++ b/src/mono/mono/metadata/verify.c
@@ -6126,7 +6126,7 @@ gboolean
 mono_verifier_is_enabled_for_class (MonoClass *klass)
 {
 	MonoImage *image = m_class_get_image (klass);
-	return verify_all || (verifier_mode > MONO_VERIFIER_PE_ONLY && !(image->assembly && image->assembly->in_gac) && image != mono_defaults.corlib);
+	return verify_all || (verifier_mode > MONO_VERIFIER_PE_ONLY && image != mono_defaults.corlib);
 }
 
 gboolean
@@ -6163,11 +6163,10 @@ gboolean
 mono_verifier_is_class_full_trust (MonoClass *klass)
 {
 	MonoImage *image = m_class_get_image (klass);
-	gboolean trusted_location = (image->assembly && image->assembly->in_gac);
 
 	if (verify_all && verifier_mode == MONO_VERIFIER_MODE_OFF)
-		return trusted_location || image == mono_defaults.corlib;
-	return verifier_mode < MONO_VERIFIER_MODE_VERIFIABLE || trusted_location || image == mono_defaults.corlib;
+		return image == mono_defaults.corlib;
+	return verifier_mode < MONO_VERIFIER_MODE_VERIFIABLE || image == mono_defaults.corlib;
 }
 
 GSList*

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12853,7 +12853,7 @@ resolve_profile_data (MonoAotCompile *acfg, ProfileData *data, MonoAssembly* cur
 		return;
 
 	/* Images */
-	GPtrArray *assemblies = mono_domain_get_assemblies (mono_get_root_domain (), FALSE);
+	GPtrArray *assemblies = mono_domain_get_assemblies (mono_get_root_domain ());
 	g_hash_table_iter_init (&iter, data->images);
 	while (g_hash_table_iter_next (&iter, &key, &value)) {
 		ImageProfileData *idata = (ImageProfileData*)value;

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -946,7 +946,7 @@ mini_assembly_can_skip_verification (MonoDomain *domain, MonoMethod *method)
 	MonoAssembly *assembly = m_class_get_image (method->klass)->assembly;
 	if (method->wrapper_type != MONO_WRAPPER_NONE && method->wrapper_type != MONO_WRAPPER_DYNAMIC_METHOD)
 		return FALSE;
-	if (assembly->in_gac || assembly->image == mono_defaults.corlib)
+	if (assembly->image == mono_defaults.corlib)
 		return FALSE;
 	return mono_assembly_has_skip_verification (assembly);
 }

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -100,7 +100,7 @@ parse_lookup_paths (const char *search_path)
 }
 
 static MonoAssembly*
-mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gboolean refonly, gpointer user_data, MonoError *error)
+mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error)
 {
 	MonoAssembly *result = NULL;
 	MonoCoreTrustedPlatformAssemblies *a = (MonoCoreTrustedPlatformAssemblies *)user_data;
@@ -114,7 +114,6 @@ mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, c
 
 	g_assert (aname);
 	g_assert (aname->name);
-	g_assert (!refonly);
 	/* alc might be a user ALC - we get here from alc.LoadFromAssemblyName(), but we should load TPA assemblies into the default alc */
 	MonoAssemblyLoadContext *default_alc;
 	default_alc = mono_domain_default_alc (mono_alc_domain (alc));
@@ -159,7 +158,7 @@ leave:
 static void
 install_assembly_loader_hooks (void)
 {
-	mono_install_assembly_preload_hook_v2 (mono_core_preload_hook, (void*)trusted_platform_assemblies, FALSE, FALSE);
+	mono_install_assembly_preload_hook_v2 (mono_core_preload_hook, (void*)trusted_platform_assemblies, FALSE);
 }
 
 static gboolean


### PR DESCRIPTION
Except legacy API functions that generally return `FALSE` or `NULL` and set `MONO_IMAGE_IMAGE_INVALID` whenever there's a `MonoImageOpenStatus` out-arg available.

There's one additional change here to an actual netcore icall: `InternalGetAssemblyName` will now open the image normally.  It was initially switched to `refonly` in order to be able to get the name from "problematic" images in https://github.com/dotnet/runtime/commit/d64b25aabeb8581a27be4968ca3517217290dd8b
But we don't have "problematic" images in netcore mono, so this makes no difference now.
