### PR TITLE
Fix JIT disasm for xor reg, reg

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11531,6 +11531,10 @@ BYTE* emitter::emitOutputRR(BYTE* dst, instrDesc* id)
                 {
                     code = AddRexWPrefix(ins, code);
                 }
+                else
+                {
+                    id->idOpSize(EA_4BYTE);
+                }
 
                 // Set the 'w' bit to get the large version
                 code |= 0x1;


### PR DESCRIPTION
Fixes JIT disasm to correctly show the emitted reg size as 32-bit instead of 64-bit for xor with same registers.