### PR TITLE
Fix Numeric Test when Number Grouping is Empty

### DIFF
--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -127,6 +127,8 @@ namespace System.Numerics.Tests
             VerifyFormatParse("123&4567^ <", NumberStyles.Any, nfi, new BigInteger(-1234567));
         }
 
+        private static bool NoGrouping(int[] sizes) => sizes.Length == 0 || (sizes.Length == 1 && sizes[0] == 0);
+
         private static void VerifyDefaultParse(Random random)
         {
             // BasicTests
@@ -219,7 +221,14 @@ namespace System.Numerics.Tests
                 sizes = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSizes;
                 seperator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;
                 digits = GenerateGroups(sizes, seperator, random);
-                VerifyFailParseToString(digits, typeof(FormatException));
+                if (NoGrouping(sizes))
+                {
+                    VerifyParseToString(digits);
+                }
+                else
+                {
+                    VerifyFailParseToString(digits, typeof(FormatException));
+                }
             }
 
             // Exponent
@@ -341,7 +350,7 @@ namespace System.Numerics.Tests
                 sizes = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSizes;
                 seperator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;
                 digits = GenerateGroups(sizes, seperator, random);
-                VerifyParseToString(digits, ns, ((ns & NumberStyles.AllowThousands) != 0));
+                VerifyParseToString(digits, ns, NoGrouping(sizes) || ((ns & NumberStyles.AllowThousands) != 0));
             }
 
             // Exponent
@@ -726,6 +735,11 @@ namespace System.Numerics.Tests
             int total;
             int num_digits = random.Next(10, 100);
             string digits = string.Empty;
+
+            if (NoGrouping(sizes))
+            {
+                return GetDigitSequence(1, 100, random);
+            }
 
             total = 0;
             total_sizes.Add(0);


### PR DESCRIPTION
Fixes #47929