### PR TITLE
Allow GlobalizationMode.Invariant = false to be substituted by the trimmer.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -8,6 +8,7 @@
     </type>
     <type fullname="System.Globalization.GlobalizationMode">
       <method signature="System.Boolean get_Invariant()" body="stub" value="true" feature="System.Globalization.Invariant" featurevalue="true" />
+      <method signature="System.Boolean get_Invariant()" body="stub" value="false" feature="System.Globalization.Invariant" featurevalue="false" />
     </type>
     <type fullname="System.LocalAppContextSwitches">
       <method signature="System.Boolean get_EnableUnsafeUTF7Encoding()" body="stub" value="false" feature="System.Text.Encoding.EnableUnsafeUTF7Encoding" featurevalue="false" />


### PR DESCRIPTION
This allows a Blazor WASM app to trim unused Invariant code when Invariant mode isn't enabled.

From my local measurements, this allows for a size savings of 3.7 KB .br compressed (10.7 KB uncompressed) in a default Blazor WASM app. An incomplete list of the public and internal members that can be trimmed when explicitly set (ApiReviewer wasn't able to show private members for some reason):

![image](https://user-images.githubusercontent.com/8291187/107256388-0c5e0f80-69ff-11eb-8bee-eb796acb877b.png)

This will also require explicitly defaulting `<InvariantGlobalization>false</InvariantGlobalization>` in the Blazor WASM SDK, when it is not already set by the developer's project.

cc @stephentoub