### PR TITLE
Remove some linker warnings from NullableTypeInfo

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.Shared.xml
@@ -53,12 +53,6 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Diagnostics.Tracing.NullableTypeInfo.#ctor(System.Type,System.Collections.Generic.List{System.Type})</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2070</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Diagnostics.Tracing.TypeAnalysis.#ctor(System.Type,System.Diagnostics.Tracing.EventDataAttribute,System.Collections.Generic.List{System.Type})</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -66,12 +60,6 @@
       <argument>IL2072</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Diagnostics.Tracing.EventSource.EnsureDescriptorsInitialized</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2072</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Diagnostics.Tracing.NullableTypeInfo.WriteData(System.Diagnostics.Tracing.PropertyValue)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -261,8 +261,6 @@ namespace System.Diagnostics.Tracing
         }
     }
 
-#nullable enable
-
     /// <summary>
     /// TraceLogging: Type handler for Nullable.
     /// </summary>
@@ -296,7 +294,7 @@ namespace System.Diagnostics.Tracing
             bool hasValue = refVal is not null;
             TraceLoggingDataCollector.AddScalar(hasValue);
             PropertyValue val = valueInfo.PropertyValueFactory(hasValue
-                ? value
+                ? refVal
                 : Activator.CreateInstance(valueInfo.DataType));
             this.valueInfo.WriteData(val);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -299,7 +299,11 @@ namespace System.Diagnostics.Tracing
             TraceLoggingDataCollector.AddScalar(hasValue);
             PropertyValue val = valueInfo.PropertyValueFactory(hasValue
                 ? refVal
-                : RuntimeHelpers.GetUninitializedObject(valueInfo.DataType));
+#if ES_BUILD_STANDALONE
+                : FormatterServices.GetUninitializedObject(t);
+ #else
+                : RuntimeHelpers.GetUninitializedObject(t);
+ #endif
             this.valueInfo.WriteData(val);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -6,7 +6,9 @@ using System;
 using System.Diagnostics;
 #endif
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
@@ -286,16 +288,16 @@ namespace System.Diagnostics.Tracing
             this.valueInfo.WriteMetadata(group, "Value", format);
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
+                Justification = "The underlying type of Nullable<T> must be defaultable")]
         public override void WriteData(PropertyValue value)
         {
-            // It's not currently possible to get the HasValue property of a nullable type through reflection when the
-            // value is null. Instead, we simply check that the nullable is not null.
             object? refVal = value.ReferenceValue;
             bool hasValue = refVal is not null;
             TraceLoggingDataCollector.AddScalar(hasValue);
             PropertyValue val = valueInfo.PropertyValueFactory(hasValue
                 ? refVal
-                : Activator.CreateInstance(valueInfo.DataType));
+                : RuntimeHelpers.GetUninitializedObject(valueInfo.DataType));
             this.valueInfo.WriteData(val);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -300,9 +300,9 @@ namespace System.Diagnostics.Tracing
             PropertyValue val = valueInfo.PropertyValueFactory(hasValue
                 ? refVal
 #if ES_BUILD_STANDALONE
-                : FormatterServices.GetUninitializedObject(t));
+                : FormatterServices.GetUninitializedObject(valueInfo.DataType));
  #else
-                : RuntimeHelpers.GetUninitializedObject(t));
+                : RuntimeHelpers.GetUninitializedObject(valueInfo.DataType));
  #endif
             this.valueInfo.WriteData(val);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -288,8 +288,10 @@ namespace System.Diagnostics.Tracing
             this.valueInfo.WriteMetadata(group, "Value", format);
         }
 
+#if !ES_BUILD_STANDALONE
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
                 Justification = "The underlying type of Nullable<T> must be defaultable")]
+#endif
         public override void WriteData(PropertyValue value)
         {
             object? refVal = value.ReferenceValue;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -300,9 +300,9 @@ namespace System.Diagnostics.Tracing
             PropertyValue val = valueInfo.PropertyValueFactory(hasValue
                 ? refVal
 #if ES_BUILD_STANDALONE
-                : FormatterServices.GetUninitializedObject(t);
+                : FormatterServices.GetUninitializedObject(t));
  #else
-                : RuntimeHelpers.GetUninitializedObject(t);
+                : RuntimeHelpers.GetUninitializedObject(t));
  #endif
             this.valueInfo.WriteData(val);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -4,6 +4,7 @@
 #if ES_BUILD_STANDALONE
 using System;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 #endif
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
I couldn't get rid of the use of Activator.CreateInstance, but
by boxing we can avoid calling the `.Value` property on Nullable,
which otherwise produces a warning.