### PR TITLE
Remove exclusion of the UnitTest_GVM

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -925,9 +925,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
             <Issue>Not compatible with crossgen2</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/UnitTest_GVM/*">
-            <Issue>https://github.com/dotnet/runtime/issues/42924</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/coverage/importer/refanytype1/*">
             <Issue>https://github.com/dotnet/runtime/issues/43460</Issue>
         </ExcludeList>


### PR DESCRIPTION
The test was disabled because it was failign with crossgen2. I am
removing the exclusion because the test is passing now.

Close #42924