### PR TITLE
Revert "Use same code to DetectCiphersuiteConfiguration for portable and non-portable builds" to fix non-portable build

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -43,18 +43,21 @@ static int32_t g_config_specified_ciphersuites = 0;
 
 static void DetectCiphersuiteConfiguration()
 {
-    // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
-    // Always produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.
-#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+    // This routine will always produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x,
+    // so if we're building direct for 1.0.x (the only time NEED_OPENSSL_1_1 is undefined) then
+    // just omit all the code here.
+    //
+    // The method uses OpenSSL 1.0.x API, except for the fallback function SSL_CTX_config, to
+    // make the portable version easier.
+#ifdef NEED_OPENSSL_1_1
+
     if (API_EXISTS(SSL_state))
     {
+        // For portable builds NEED_OPENSSL_1_1 is always set.
+        // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
         g_config_specified_ciphersuites = 1;
         return;
     }
-#elif OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0_RTM
-    g_config_specified_ciphersuites = 1;
-    return;
-#endif
 
     // Check to see if there's a registered default CipherString. If not, we will use our own.
     SSL_CTX* ctx = SSL_CTX_new(TLS_method());
@@ -100,13 +103,21 @@ static void DetectCiphersuiteConfiguration()
     {
         ssl = SSL_new(ctx);
         assert(ssl != NULL);
-        int systemDefaultCount = sk_SSL_CIPHER_num(SSL_get_ciphers(ssl));
+        int after = sk_SSL_CIPHER_num(SSL_get_ciphers(ssl));
         SSL_free(ssl);
 
-        g_config_specified_ciphersuites = (allCount != systemDefaultCount);
+        g_config_specified_ciphersuites = (allCount != after);
     }
 
     SSL_CTX_free(ctx);
+
+#else
+
+    // The Fedora, RHEL, and CentOS builds replace the normal defaults (with a configuration model).
+    // Consider their non-portable builds to always have specified ciphersuites in config.
+    g_config_specified_ciphersuites = 1;
+
+#endif
 }
 
 void CryptoNative_EnsureLibSslInitialized()


### PR DESCRIPTION
This reverts commit 464010d9d0241bbdcbfbda25b32e78991ddf6093 (https://github.com/dotnet/runtime/pull/42812).

This fixes `./build.sh -c Release --subset libs.native /p:PortableBuild=false` for me. See https://github.com/dotnet/runtime/issues/48010:

```
/work/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c(94,10):
  error G69804242: implicit declaration of function 'SSL_CTX_config' is invalid in C99 [-Werror,-Wimplicit-function-declaration] [/work/src/libraries/Native/build-native.proj]
      if (!SSL_CTX_config(ctx, "system_default"))
           ^
  Failed to build "native libraries component".
/work/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c(60,20):
  error GB4859E72: code will never be executed [-Werror,-Wunreachable-code] [/work/src/libraries/Native/build-native.proj]
      SSL_CTX* ctx = SSL_CTX_new(TLS_method());
                     ^~~~~~~~~~~
```

It may be reasonable to fix this without reverting, but I'm not sure how. I'm submitting the revert as a PR in case it is ok to merge  to fix my build in the short term.