### PR TITLE
Shared properties for COM tests

### DIFF
--- a/src/tests/Interop/COM/Activator/Activator.csproj
+++ b/src/tests/Interop/COM/Activator/Activator.csproj
@@ -3,8 +3,6 @@
     <OutputType>Exe</OutputType>
     <ReferenceSystemPrivateCoreLib>true</ReferenceSystemPrivateCoreLib>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- The test fails casting from ClassFromA from the default ALC to type IGetTypeFromC from a custom ALC -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/tests/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
+++ b/src/tests/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
@@ -2,14 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <UseManagedCOMServer>true</UseManagedCOMServer>
+    <IsManagedCOMClient>true</IsManagedCOMClient>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests.csproj
@@ -2,14 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <UseManagedCOMServer>true</UseManagedCOMServer>
+    <IsManagedCOMClient>true</IsManagedCOMClient>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/Directory.Build.props
+++ b/src/tests/Interop/COM/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <!-- COM tests are unsupported outside of Windows -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/Interop/COM/Directory.Build.targets
+++ b/src/tests/Interop/COM/Directory.Build.targets
@@ -1,0 +1,17 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Managed clients include a app manifest, making them incompatible with some test scenarios -->
+  <PropertyGroup Condition="'$(IsManagedCOMClient)' == 'true'">
+    <!-- Tests would require the runincontext.exe to include a manifest describing the COM interfaces -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseManagedCOMServer)' == 'true'">
+    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
+    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+</Project>

--- a/src/tests/Interop/COM/Directory.Build.targets
+++ b/src/tests/Interop/COM/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Managed clients include a app manifest, making them incompatible with some test scenarios -->
+  <!-- Managed clients include an app manifest, making them incompatible with some test scenarios -->
   <PropertyGroup Condition="'$(IsManagedCOMClient)' == 'true'">
     <!-- Tests would require the runincontext.exe to include a manifest describing the COM interfaces -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Interop/COM/Dynamic/Dynamic.csproj
+++ b/src/tests/Interop/COM/Dynamic/Dynamic.csproj
@@ -2,12 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <IsManagedCOMClient>true</IsManagedCOMClient>
     <!-- This test is very slow under some GCStress variations, especially with COMPlus_HeapVerify=1, so disable it under GCStress to avoid test timeouts in the CI.
          Issue: https://github.com/dotnet/runtime/issues/39584
     -->

--- a/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
@@ -2,14 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <UseManagedCOMServer>true</UseManagedCOMServer>
     <!--  Suppress warning about conflicting type names. This occurs because of the reference to NETServer.
           The reference is only to ensure the project is built and properly copied. The test itself uses
           COM to activate the server rather than typical class activation via 'new' -->

--- a/src/tests/Interop/COM/NETClients/Directory.Build.props
+++ b/src/tests/Interop/COM/NETClients/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <IsManagedCOMClient>true</IsManagedCOMClient>
+  </PropertyGroup>
+</Project>

--- a/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
+++ b/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
+++ b/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
+++ b/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestInALC.cs" />

--- a/src/tests/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/src/tests/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />

--- a/src/tests/Interop/COM/NativeClients/Directory.Build.props
+++ b/src/tests/Interop/COM/NativeClients/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <UseManagedCOMServer>true</UseManagedCOMServer>
+    <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
+    <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/src/tests/Interop/COM/NativeClients/Dispatch.csproj
+++ b/src/tests/Interop/COM/NativeClients/Dispatch.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />

--- a/src/tests/Interop/COM/NativeClients/Events.csproj
+++ b/src/tests/Interop/COM/NativeClients/Events.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />

--- a/src/tests/Interop/COM/NativeClients/Licensing.csproj
+++ b/src/tests/Interop/COM/NativeClients/Licensing.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />

--- a/src/tests/Interop/COM/NativeClients/Primitives.csproj
+++ b/src/tests/Interop/COM/NativeClients/Primitives.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
-    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
-    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />


### PR DESCRIPTION
Add `UseManagedCOMServer` and `IsManagedCOMClient` to make it a bit simpler to specify all the right test properties for COM tests.

cc @AaronRobinsonMSFT @jkoritzinsky 