### PR TITLE
Fix timeout in ThreadLocalTests

### DIFF
--- a/src/libraries/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/libraries/System.Threading/tests/ThreadLocalTests.cs
@@ -134,7 +134,7 @@ namespace System.Threading.Tests
                 GC.WaitForPendingFinalizers();
                 GC.Collect();
                 return mres.IsSet;
-            }, 5000);
+            }, ThreadTestHelpers.UnexpectedTimeoutMilliseconds);
 
             Assert.True(mres.IsSet);
         }
@@ -329,7 +329,7 @@ namespace System.Threading.Tests
                     GC.WaitForPendingFinalizers();
                     GC.Collect();
                     return mres.IsSet;
-                }, 5000);
+                }, ThreadTestHelpers.UnexpectedTimeoutMilliseconds);
 
                 Assert.True(mres.IsSet, "RunThreadLocalTest8_Values: Expected thread local to release the object and for it to be finalized");
             }


### PR DESCRIPTION
This caused a flaky failure in https://github.com/dotnet/runtime/pull/47084

Change to use UnexpectedTimeoutMilliseconds (30 seconds) like the other tests. Note that a passing test will take much less time.