### PR TITLE
Enable reading of a performance counter running as an elevated process

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
@@ -1691,6 +1691,7 @@ namespace System.Diagnostics
                         throw new InvalidOperationException(SR.SetSecurityDescriptorFailed);
 
                     Interop.Kernel32.SECURITY_ATTRIBUTES securityAttributes = default;
+                    securityAttributes.lpSecurityDescriptor = securityDescriptorPointer.DangerousGetHandle();
                     securityAttributes.bInheritHandle = Interop.BOOL.FALSE;
 
                     //


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46851
source https://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/SharedPerformanceCounter.cs,1568

Tested locally using the local feed and local pacage