### PR TITLE
Avoid race conditions when building linker tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,7 @@
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <!-- Opt-in/out repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
+    <UsingToolMicrosoftNetILLinkTasks>true</UsingToolMicrosoftNetILLinkTasks>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>
     <!--

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -19,19 +19,19 @@
                              TargetFramework="$(NetCoreAppCurrent)"
                              TargetingPackName="$(SharedFrameworkName).Ref"
                              TargetingPackVersion="$(ProductVersion)"
-                             Condition="'@(KnownFrameworkReference)' != '' and !@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
+                             Condition="'@(KnownFrameworkReference)' == '' or !@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
     <KnownAppHostPack Include="$(SharedFrameworkName)" 
                       AppHostPackNamePattern="$(SharedFrameworkName).Host.**RID**"
                       AppHostPackVersion="$(ProductVersion)"
                       AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
                       TargetFramework="$(NetCoreAppCurrent)"
-                      Condition="'@(KnownAppHostPack)' != '' and !@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
+                      Condition="'@(KnownAppHostPack)' == '' or !@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
     <KnownCrossgen2Pack Include="$(SharedFrameworkName).Crossgen2"
                         TargetFramework="$(NetCoreAppCurrent)"
                         Crossgen2PackNamePattern="$(SharedFrameworkName).Crossgen2.**RID**"
                         Crossgen2PackVersion="$(ProductVersion)"
                         Crossgen2RuntimeIdentifiers="linux-musl-x64;linux-x64;win-x64"
-                        Condition="'@(KnownCrossgen2Pack)' != '' and !@(KnownCrossgen2Pack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
+                        Condition="'@(KnownCrossgen2Pack)' == '' or !@(KnownCrossgen2Pack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
   </ItemGroup>
 
   <!-- .NETCoreApp 2.x DisableImplicitAssemblyReferences support. -->

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -7,6 +7,9 @@
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <PlatformManifestFile />
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Enable NuGet static graph evaluation to optimize incremental restore -->
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -1,20 +1,16 @@
 <Project>
-  <Target Name="RestoreProject">
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Properties="Configuration=$(Configuration);ForceEvaluation=true"
-             Targets="Restore" />
-  </Target>
-
   <Target Name="RemoveRuntimePackFromDownloadItem"
           AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <PackageDownload Remove="@(PackageDownload)"
-                       Condition="$([System.String]::Copy('%(Identity)').StartsWith('Microsoft.NETCore.App.Runtime'))" />
+                       Condition="'$(UsePackageDownload)' == 'true' and $([System.String]::Copy('%(Identity)').StartsWith('Microsoft.NETCore.App.Runtime'))" />
+      <PackageReference Remove="@(PackageReference)"
+                        Condition="'$(UsePackageDownload)' != 'true' and $([System.String]::Copy('%(Identity)').StartsWith('Microsoft.NETCore.App.Runtime'))" />
     </ItemGroup>
   </Target>
 
   <Target Name="UpdateRuntimePack"
-          DependsOnTargets="ResolveFrameworkReferences">
+          AfterTargets="ResolveFrameworkReferences">
     <ItemGroup>
       <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(RuntimePackDir)" />
       <ResolvedTargetingPack Update="@(ResolvedTargetingPack)" Path="$(TargetingPackDir)" />
@@ -33,8 +29,6 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishTrimmed" DependsOnTargets="ProcessFrameworkReferences;RestoreProject;UpdateRuntimePack;Publish" />
-
   <ItemGroup>
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
       DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppVersion)"
@@ -43,7 +37,7 @@
       RuntimeFrameworkName="Microsoft.NETCore.App"
       RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
       RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86;ios-arm64;ios-arm;ios-x64;ios-x86;tvos-arm64;tvos-x64;android-arm64;android-arm;android-x64;android-x86;browser-wasm"
-      TargetFramework="net6.0"
+      TargetFramework="$(TargetFramework)"
       TargetingPackName="Microsoft.NETCore.App.Ref"
       TargetingPackVersion="$(MicrosoftNETCoreAppVersion)" />
 
@@ -51,7 +45,7 @@
       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
       AppHostPackVersion="$(MicrosoftNETCoreAppVersion)"
       AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
-      TargetFramework="net6.0" />
+      TargetFramework="$(TargetFramework)" />
   </ItemGroup>
 
 </Project>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -92,15 +92,13 @@
 
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
-    <PropertyGroup>
-      <TestPublishTrimmedCommand>"$(DotNetTool)"</TestPublishTrimmedCommand>
-      <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) build /t:PublishTrimmed</TestPublishTrimmedCommand>
-      <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) /nr:false</TestPublishTrimmedCommand>
-      <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) /warnaserror</TestPublishTrimmedCommand>
-      <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) -p:configuration=$(Configuration)</TestPublishTrimmedCommand>
-    </PropertyGroup>
+    <MSBuild Projects="@(TestConsoleApps)"
+             Targets="Restore"
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);@(CliEnvironment)" />
 
-    <Exec Command="$(TestPublishTrimmedCommand) %(TestConsoleApps.AdditionalArgs)" EnvironmentVariables="@(CliEnvironment)" StandardOutputImportance="Low" WorkingDirectory="%(TestConsoleApps.ProjectDir)" />
+    <MSBuild Projects="@(TestConsoleApps)"
+             Targets="Publish"
+             Properties="Configuration=$(Configuration);@(CliEnvironment)" />
   </Target>
 
   <Target Name="ExecuteApplications"

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -11,10 +11,6 @@
     <TestSupportFiles Include="$(MSBuildThisFileDirectory)SupportFiles\Directory.Build.*">
       <DestinationFolder>$(TrimmingTestDir)</DestinationFolder>
     </TestSupportFiles>
-
-    <CliEnvironment Include="DOTNET_CLI_TELEMETRY_OPTOUT=1" />
-    <CliEnvironment Include="DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" />
-    <CliEnvironment Include="DOTNET_MULTILEVEL_LOOKUP=0" />
   </ItemGroup>
 
   <Target Name="CreateTestDir"
@@ -94,11 +90,11 @@
           DependsOnTargets="GenerateProjects">
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Restore"
-             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);@(CliEnvironment)" />
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration)" />
 
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Publish"
-             Properties="Configuration=$(Configuration);@(CliEnvironment)" />
+             Properties="Configuration=$(Configuration)" />
   </Target>
 
   <Target Name="ExecuteApplications"

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -264,7 +264,6 @@
                       Condition="'$(TestPackages)' == 'true'" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\tests\**\*.TrimmingTests.proj"
                       Exclude="@(ProjectExclusions)"
-                      BuildInParallel="false"
                       Condition="'$(TestTrimming)' == 'true'" />
   </ItemGroup>
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -11,7 +11,6 @@
     <TestAssemblies Condition="'$(TestAssemblies)' == ''">true</TestAssemblies>
     <TestPackages Condition="'$(TestPackages)' == ''">false</TestPackages>
     <TestTrimming Condition="'$(TestTrimming)' == ''">false</TestTrimming>
-    <ContinueOnError Condition="'$(TestTrimming)' == 'true'">true</ContinueOnError>
   </PropertyGroup>
   
   <!-- Projects that don't support code coverage measurement. -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/40398
Depends on https://github.com/dotnet/arcade/pull/6936

Changes:
- Use static graph restore for linker tests
- Use in-proc MSBuild task to publish linker test projects
- Enabled parallel building of linker tests
- Code clean up...

Filed https://github.com/dotnet/runtime/issues/48027 to fix an unnecessary excessive amount of NuGet invocation.