### PR TITLE
[release/5.0] Fix FC_NO_TAILCALL with newer compilers

### DIFF
--- a/src/coreclr/src/vm/ecall.cpp
+++ b/src/coreclr/src/vm/ecall.cpp
@@ -222,7 +222,7 @@ void ECall::PopulateManagedCastHelpers()
 static CrstStatic gFCallLock;
 
 // This variable is used to force the compiler not to tailcall a function.
-int FC_NO_TAILCALL;
+RAW_KEYWORD(volatile) int FC_NO_TAILCALL;
 
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/src/vm/fcall.h
+++ b/src/coreclr/src/vm/fcall.h
@@ -926,7 +926,7 @@ void HCallAssert(void*& cache, void* target);
 // might do, which would otherwise confuse the epilog walker.
 //
 // * See #FC_INNER for more
-extern int FC_NO_TAILCALL;
+extern RAW_KEYWORD(volatile) int FC_NO_TAILCALL;
 #define FC_INNER_RETURN(type, expr)                                                        \
     type __retVal = expr;                                                                  \
     while (0 == FC_NO_TAILCALL) { }; /* side effect the compile can't remove */            \


### PR DESCRIPTION
Port #45999 to release/5.0

## Customer Impact
Once we move to the new MSVC toolset, we will see intermittent runtime crashes during GC without this fix.

The new MSVC  toolset performs more optimizations that violate invariants in the low-level runtime code. This change is suppressing the optimization in a specific situation.

## Testing
The fix was tested and merged in master. This is a port of the fix.

## Risk
Master branch had this fix for some time now. Based on that the risk is low.