### PR TITLE
Fix to release memory allocated by AllocHGlobal

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
@@ -194,7 +194,7 @@ namespace System.Net.NetworkInformation
                             }
                         }
                     }
-                    catch
+                    finally
                     {
                         Marshal.FreeHGlobal(buffer);
                     }


### PR DESCRIPTION
A memory leak has occurred because the memory allocated for calling API has not been free.
This memory needs to free in finally block, not in catch block.