### PR TITLE
Add debug checking of the loop table

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5439,6 +5439,7 @@ public:
     void fgDebugCheckStmtsList(BasicBlock* block, bool morphTrees);
     void fgDebugCheckNodeLinks(BasicBlock* block, Statement* stmt);
     void fgDebugCheckNodesUniqueness();
+    void fgDebugCheckLoopTable();
 
     void fgDebugCheckFlags(GenTree* tree);
     void fgDebugCheckDispFlags(GenTree* tree, unsigned dispFlags, unsigned debugFlags);

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -1617,13 +1617,8 @@ Compiler::fgWalkResult Compiler::fgStress64RsltMulCB(GenTree** pTree, fgWalkData
         return WALK_CONTINUE;
     }
 
-#ifdef DEBUG
-    if (pComp->verbose)
-    {
-        printf("STRESS_64RSLT_MUL before:\n");
-        pComp->gtDispTree(tree);
-    }
-#endif // DEBUG
+    JITDUMP("STRESS_64RSLT_MUL before:\n");
+    DISPTREE(tree);
 
     // To ensure optNarrowTree() doesn't fold back to the original tree.
     tree->AsOp()->gtOp1 = pComp->gtNewCastNode(TYP_LONG, tree->AsOp()->gtOp1, false, TYP_LONG);
@@ -1633,13 +1628,8 @@ Compiler::fgWalkResult Compiler::fgStress64RsltMulCB(GenTree** pTree, fgWalkData
     tree->gtType        = TYP_LONG;
     *pTree              = pComp->gtNewCastNode(TYP_INT, tree, false, TYP_INT);
 
-#ifdef DEBUG
-    if (pComp->verbose)
-    {
-        printf("STRESS_64RSLT_MUL after:\n");
-        pComp->gtDispTree(*pTree);
-    }
-#endif // DEBUG
+    JITDUMP("STRESS_64RSLT_MUL after:\n");
+    DISPTREE(*pTree);
 
     return WALK_SKIP_SUBTREES;
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12521,7 +12521,7 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
                     fgWalkTreePre(&colon_op2, gtClearColonCond);
                 }
 
-                JITDUMP("\nIdentical GT_COLON trees! ");
+                JITDUMP("\nIdentical GT_COLON trees!\n");
                 DISPTREE(op2);
 
                 GenTree* op;

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -3832,7 +3832,6 @@ void Compiler::optUnrollLoops()
                     }
                     // Block weight should no longer have the loop multiplier
                     newBlock->modifyBBWeight(newBlock->bbWeight / BB_LOOP_WEIGHT_SCALE);
-
                     // Jump dests are set in a post-pass; make sure CloneBlockState hasn't tried to set them.
                     assert(newBlock->bbJumpDest == nullptr);
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -3832,6 +3832,7 @@ void Compiler::optUnrollLoops()
                     }
                     // Block weight should no longer have the loop multiplier
                     newBlock->modifyBBWeight(newBlock->bbWeight / BB_LOOP_WEIGHT_SCALE);
+
                     // Jump dests are set in a post-pass; make sure CloneBlockState hasn't tried to set them.
                     assert(newBlock->bbJumpDest == nullptr);
 
@@ -3949,7 +3950,7 @@ void Compiler::optUnrollLoops()
             /* Make sure to update loop table */
 
             /* Use the LPFLG_REMOVED flag and update the bbLoopMask accordingly
-                * (also make head and bottom NULL - to hit an assert or GPF) */
+                * (also make head and bottom NULL - to hit an assert or an access violation) */
 
             optLoopTable[lnum].lpFlags |= LPFLG_REMOVED;
             optLoopTable[lnum].lpHead = optLoopTable[lnum].lpBottom = nullptr;
@@ -4576,6 +4577,8 @@ void Compiler::optOptimizeLoops()
                 printf("\n");
             }
         }
+
+        fgDebugCheckLoopTable();
 #endif
         optLoopsMarked = true;
     }
@@ -5194,6 +5197,8 @@ void Compiler::optCloneLoops()
         printf("\nAfter loop cloning:\n");
         fgDispBasicBlocks(/*dumpTrees*/ true);
     }
+
+    fgDebugCheckLoopTable();
 #endif
 }
 


### PR DESCRIPTION
Partially addresses #8944.

I decided to extract this into its own function as only a handful of phases maintain the invariants it checks right now.

These are some issues/`TODO`s that I've encountered/noticed while working on this:

There are at least three places where where the `fgDebugCheck*` methods are called right now:
  - `phase.cpp`, where for some select phases most of the checks are called.
  - `Compiler::compCompile`.
  - Various phase methods themselves.

Comments in `phase.cpp` indicate that it's "the place" for placing these debug checks going forward, but I found it difficult to fit the new method there, as it introduces a check that only a few phases guarantee and those phases are not in the allow-list. I would love to clean this all up and replace with a system where phases declare their pre-conditions and post-conditions, all consolidated in `phase.cpp`. I've left this for a future PR.

Removing loops from the table is not done consistently: `optUnrollLoops` nulls-out some fields "for good measure", `optUpdateLoopsBeforeRemoveBlock` doesn't, neither does `fgFoldConditional`. At the same time `optUpdateLoopsBeforeRemoveBlock` does not update the "needs alignment" flag for the first block, while the two other methods do. It would be nice to consolidate this code into one function. It is not trivial though, because of the following issue.

`bbNatLoopNum` is not maintained well for blocks. For example, `optUnrollLoops` leaves behind some blocks with it set after it unrolls. This is closely related to the above problem and complicated by the fact that if we remove the inner loop, some blocks could presumably become part of the outer loop, and I suspect that there are a lot of edge cases to the logic that will have to be written to account for that, so I excluded `optUnrollLoops` from the checks in this PR.

Logging is not performed consistently between `#ifdef DEBUG` + `printf`s and `JITDUMP`s. I've cleaned this up a little for `fgdiagnostic.cpp`, but decided to leave a much larger commit for `optimizer.cpp` out. Also, functions headers in `fgdiagnostic.cpp` do not conform to the standard pattern.

This change survives the diff of the framework with crossgen (no results as expected), but I expect there will be CI failures to resolve. I may be a little slow to respond in the next couple of days.

Edit: given the CI is green'ish, marking this ready for review.

cc @BruceForstall 