### PR TITLE
AssemblyLoadContext.CurrentContextualReflectionContext and instantiating AssemblyBuilder

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -240,6 +240,7 @@ namespace System.Reflection.Emit
                     assemblyName,
                     AssemblyBuilderAccess.Run,
                     ref stackMark,
+                    null,
                     null);
 
                 // this always gets the internal module.

--- a/src/coreclr/vm/appdomainnative.cpp
+++ b/src/coreclr/vm/appdomainnative.cpp
@@ -16,7 +16,7 @@
 using namespace clr::fs;
 
 // static
-void QCALLTYPE AppDomainNative::CreateDynamicAssembly(QCall::ObjectHandleOnStack assemblyName, QCall::StackCrawlMarkHandle stackMark, INT32 access, QCall::ObjectHandleOnStack retAssembly)
+void QCALLTYPE AppDomainNative::CreateDynamicAssembly(QCall::ObjectHandleOnStack assemblyName, QCall::StackCrawlMarkHandle stackMark, INT32 access, QCall::ObjectHandleOnStack assemblyLoadContext, QCall::ObjectHandleOnStack retAssembly)
 {
     QCALL_CONTRACT;
 
@@ -38,7 +38,17 @@ void QCALLTYPE AppDomainNative::CreateDynamicAssembly(QCall::ObjectHandleOnStack
     args.access                 = access;
     args.stackMark              = stackMark;
 
-    Assembly *pAssembly = Assembly::CreateDynamic(GetAppDomain(), &args);
+    Assembly*       pAssembly = nullptr;
+    ICLRPrivBinder* pBinderContext = nullptr;
+
+    if (assemblyLoadContext.Get() != NULL)
+    {
+        INT_PTR nativeAssemblyLoadContext = ((ASSEMBLYLOADCONTEXTREF)assemblyLoadContext.Get())->GetNativeAssemblyLoadContext();
+
+        pBinderContext = reinterpret_cast<ICLRPrivBinder*>(nativeAssemblyLoadContext);
+    }
+
+    pAssembly = Assembly::CreateDynamic(GetAppDomain(), pBinderContext, &args);
 
     retAssembly.Set(pAssembly->GetExposedObject());
 

--- a/src/coreclr/vm/appdomainnative.hpp
+++ b/src/coreclr/vm/appdomainnative.hpp
@@ -19,7 +19,7 @@
 class AppDomainNative
 {
 public:
-    static void QCALLTYPE CreateDynamicAssembly(QCall::ObjectHandleOnStack assemblyName, QCall::StackCrawlMarkHandle stackMark, INT32 access, QCall::ObjectHandleOnStack retAssembly);
+    static void QCALLTYPE CreateDynamicAssembly(QCall::ObjectHandleOnStack assemblyName, QCall::StackCrawlMarkHandle stackMark, INT32 access, QCall::ObjectHandleOnStack assemblyLoadContext, QCall::ObjectHandleOnStack retAssembly);
     static FCDECL0(Object*, GetLoadedAssemblies);
     static FCDECL1(Object*, GetOrInternString, StringObject* pStringUNSAFE);
     static FCDECL1(Object*, IsStringInterned, StringObject* pString);

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -90,7 +90,7 @@ public:
 
     BOOL IsSystem() { WRAPPER_NO_CONTRACT; return m_pManifestFile->IsSystem(); }
 
-    static Assembly *CreateDynamic(AppDomain *pDomain, CreateDynamicAssemblyArgs *args);
+    static Assembly *CreateDynamic(AppDomain *pDomain, ICLRPrivBinder* pBinderContext, CreateDynamicAssemblyArgs *args);
 
     MethodDesc *GetEntryPoint();
 

--- a/src/tests/Loader/ContextualReflection/ContextualReflection.cs
+++ b/src/tests/Loader/ContextualReflection/ContextualReflection.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using System.Runtime.Remoting;
@@ -724,6 +726,19 @@ namespace ContextualReflectionTest
             }
         }
 
+        void TestDefineDynamicAssembly(bool collectibleContext, AssemblyBuilderAccess assemblyBuilderAccess)
+        {
+            AssemblyLoadContext assemblyLoadContext = collectibleContext ? new AssemblyLoadContext("DynamicAssembly Collectable context", true) : AssemblyLoadContext.Default;
+            AssemblyName dynamicAssemblyName = new AssemblyName("DynamicAssembly");
+
+            using (assemblyLoadContext.EnterContextualReflection())
+            {
+                AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(dynamicAssemblyName, assemblyBuilderAccess);
+            }
+
+            Assert.IsTrue(assemblyLoadContext.Assemblies.Any(a => AssemblyName.ReferenceMatchesDefinition(a.GetName(), dynamicAssemblyName)));
+        }
+
         void TestMockAssemblyThrows()
         {
             Exception e = Assert.ThrowsArgumentException("activating", () => AssemblyLoadContext.EnterContextualReflection(new MockAssembly()));
@@ -736,6 +751,8 @@ namespace ContextualReflectionTest
             VerifyContextualReflectionProxy();
             VerifyUsingStatementContextualReflectionUsage();
             VerifyBadContextualReflectionUsage();
+            TestDynamicAssembly(true);
+            TestDynamicAssembly(false);
 
             RunTests(isolated : false);
             alcProgramInstance.RunTestsIsolated();
@@ -754,6 +771,12 @@ namespace ContextualReflectionTest
         {
             VerifyIsolationAlc();
             RunTests(isolated : true);
+        }
+
+        public void TestDynamicAssembly(bool collectibleContext)
+        {
+            TestDefineDynamicAssembly(collectibleContext, AssemblyBuilderAccess.Run);
+            TestDefineDynamicAssembly(collectibleContext, AssemblyBuilderAccess.RunAndCollect);
         }
     }
 }


### PR DESCRIPTION
Added the ability to manage the context of placing a dynamic assembly using AssemblyLoadContext.EnterContextualReflection
Issue: #29842