### PR TITLE
Clarify distro-agnostic OpenSSL 1.0 check and non-portable comment

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -117,7 +117,7 @@ static void DetectCiphersuiteConfiguration()
 
 #else
 
-    /// Produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x.
+    // OpenSSL 1.0 does not support CipherSuites so there is no way for caller to override default
     g_config_specified_ciphersuites = 1;
 
 #endif

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -43,13 +43,7 @@ static int32_t g_config_specified_ciphersuites = 0;
 
 static void DetectCiphersuiteConfiguration()
 {
-    // This routine will always produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x,
-    // so if we're building direct for 1.0.x (the only time NEED_OPENSSL_1_1 is undefined) then
-    // just omit all the code here.
-    //
-    // The method uses OpenSSL 1.0.x API, except for the fallback function SSL_CTX_config, to
-    // make the portable version easier.
-#ifdef NEED_OPENSSL_1_1
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
 
     if (API_EXISTS(SSL_state))
     {
@@ -58,6 +52,16 @@ static void DetectCiphersuiteConfiguration()
         g_config_specified_ciphersuites = 1;
         return;
     }
+
+#endif
+
+    // This routine will always produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x,
+    // so if we're building direct for 1.0.x (the only time NEED_OPENSSL_1_1 is undefined) then
+    // just omit all the code here.
+    //
+    // The method uses OpenSSL 1.0.x API, except for the fallback function SSL_CTX_config, to
+    // make the portable version easier.
+#ifdef NEED_OPENSSL_1_1
 
     // Check to see if there's a registered default CipherString. If not, we will use our own.
     SSL_CTX* ctx = SSL_CTX_new(TLS_method());
@@ -113,8 +117,7 @@ static void DetectCiphersuiteConfiguration()
 
 #else
 
-    // The Fedora, RHEL, and CentOS builds replace the normal defaults (with a configuration model).
-    // Consider their non-portable builds to always have specified ciphersuites in config.
+    /// Produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x.
     g_config_specified_ciphersuites = 1;
 
 #endif


### PR DESCRIPTION
Applying @tmds' suggestion from previous PR: https://github.com/dotnet/runtime/pull/48013#issuecomment-775951667

> ```
> if (API_EXISTS(SSL_state))
> ```
> 
> move this before `#ifdef NEED_OPENSSL_1_1` and guard it with `#ifdef FEATURE_DISTRO_AGNOSTIC_SSL`.
> 
> Replace this comment:
> 
> ```
> // The Fedora, RHEL, and CentOS builds replace the normal defaults (with a configuration model).
> // Consider their non-portable builds to always have specified ciphersuites in config.
> ```
> 
> by:
> 
> ```
> /// Produce g_config_specified_ciphersuites = 1 on OpenSSL 1.0.x.
> ```