### PR TITLE
Return failure code when SafeHandle tests fail.

### DIFF
--- a/src/tests/Interop/PInvoke/SafeHandles/InvalidSafeHandleMarshallingTests.cs
+++ b/src/tests/Interop/PInvoke/SafeHandles/InvalidSafeHandleMarshallingTests.cs
@@ -12,9 +12,29 @@ namespace SafeHandleTests
     {
         public static void RunTest()
         {
-            Assert.Throws<InvalidOperationException>(() => SafeHandleNative.SafeHandle_Invalid(new TestSafeHandle()));
+            if (TestLibrary.Utilities.IsWindows)
+            {
+                // The interface marshaller is only available when COM interop is
+                // enabled. The interface marshaller is what initiates the COM
+                // interop system which is what subsequently defines defined exception
+                // type to throw - matches .NET Framework behavior. At present support
+                // is limited to Windows so we branch on that.
+                Assert.Throws<InvalidOperationException>(() => MarshalSafeHandleAsInterface());
+            }
+            else
+            {
+                // When the interface marshaller is not available we fallback to
+                // the marshalling system which will throw a different exception.
+                Assert.Throws<MarshalDirectiveException>(() => MarshalSafeHandleAsInterface());
+            }
+
             Assert.Throws<MarshalDirectiveException>(() => SafeHandleNative.SafeHandle_Invalid(new TestSafeHandle[1]));
             Assert.Throws<TypeLoadException>(() => SafeHandleNative.SafeHandle_Invalid(new SafeHandleNative.StructWithSafeHandleArray()));
+        }
+
+        static void MarshalSafeHandleAsInterface()
+        {
+            SafeHandleNative.SafeHandle_Invalid(new TestSafeHandle());
         }
     }
 }

--- a/src/tests/Interop/PInvoke/SafeHandles/Program.cs
+++ b/src/tests/Interop/PInvoke/SafeHandles/Program.cs
@@ -26,7 +26,9 @@ namespace SafeHandleTests
             catch (Exception ex)
             {
                 Console.WriteLine(ex.ToString());
+                return 101;
             }
+
             return 100;
         }
     }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1209,6 +1209,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Generics/GenericsTest/GenericsTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/SafeHandles/**">
+            <Issue>https://github.com/dotnet/runtime/issues/48084</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
For context see https://github.com/dotnet/runtime/pull/47944#discussion_r573249389

/cc @jkoritzinsky @elinor-fung 