### PR TITLE
Do not align cloned loops

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9232,6 +9232,12 @@ void emitter::emitDispIns(
             break;
 
         case IF_NONE:
+#if FEATURE_LOOP_ALIGN
+            if (ins == INS_align)
+            {
+                printf("[%d bytes]", id->idCodeSize());
+            }
+#endif
             break;
 
         default:

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5321,6 +5321,9 @@ void Compiler::optCloneLoop(unsigned loopInd, LoopCloneContext* context)
         noway_assert(cloneOk);
 
 #if FEATURE_LOOP_ALIGN
+        // If the original loop is aligned, do not align the cloned loop because cloned loop will be executed in
+        // rare scenario. Additionally, having to align cloned loop will force us to disable some VEX prefix encoding
+        // and adding compensation for over-estimated instructions.
         if (blk->isLoopAlign())
         {
             newBlk->bbFlags &= ~BBF_LOOP_ALIGN;

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5319,6 +5319,15 @@ void Compiler::optCloneLoop(unsigned loopInd, LoopCloneContext* context)
         // checked them to guarantee they are clonable.
         bool cloneOk = BasicBlock::CloneBlockState(this, newBlk, blk);
         noway_assert(cloneOk);
+
+#if FEATURE_LOOP_ALIGN
+        if (blk->isLoopAlign())
+        {
+            newBlk->bbFlags &= ~BBF_LOOP_ALIGN;
+            JITDUMP("Removing LOOP_ALIGN flag from cloned loop in " FMT_BB "\n", newBlk->bbNum);
+        }
+#endif
+
         // TODO-Cleanup: The above clones the bbNatLoopNum, which is incorrect.  Eventually, we should probably insert
         // the cloned loop in the loop table.  For now, however, we'll just make these blocks be part of the surrounding
         // loop, if one exists -- the parent of the loop we're cloning.


### PR DESCRIPTION
In my benchmark stability analysis post "loop alignment" work, I found out an interesting case where we were not removing the `align` flag from cloned loop if it has calls. More details can be seen in https://github.com/dotnet/runtime/issues/43227#issuecomment-772914110. However, after careful thought, we should never align cloned loop because they are slower loops that will execute only in rare scenarios. Cloned loops are inserted in the flowgraph after the actual loop. With nested loop or in presence of conditions, its instruction group can stretch inside the method. Now if we decide to align the loop, we need to add the over-estimation compensation `NOP` or disable VEX prefix encoding until we reach the instruction group having cloned loop. (Details about the compensation code / VEX prefix disabling can be seen in PR description of https://github.com/dotnet/runtime/pull/44370). Addition of over-estimation compensation can be expensive specially if they get inserted in hot code or loops. Hence, reduce the possibility of adding such compensation by not aligning cloned loop.

Also, with `COMPlus_JitDiffableDasm`, it is hard to understand how much padding was added by `align` instruction. Hence output the no. of bytes we padded.

Contributes to https://github.com/dotnet/runtime/issues/43227.