### PR TITLE
Clarify the behavior of FilePatternMatch Path and Stem

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/FilePatternMatch.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/FilePatternMatch.cs
@@ -12,21 +12,20 @@ namespace Microsoft.Extensions.FileSystemGlobbing
     public struct FilePatternMatch : IEquatable<FilePatternMatch>
     {
         /// <summary>
-        /// The path to the file matched
+        /// The path to the file matched, relative to the beginning of the matching search pattern
         /// </summary>
         /// <remarks>
-        /// If the matcher searched for "**/*.cs" using "src/Project" as the directory base and the pattern matcher found
+        /// If the matcher searched for "src/Project/**/*.cs" and the pattern matcher found
         /// "src/Project/Interfaces/IFile.cs", then Stem = "Interfaces/IFile.cs" and Path = "src/Project/Interfaces/IFile.cs".
         /// </remarks>
         public string Path { get; }
 
         /// <summary>
-        /// The subpath to the matched file under the base directory searched
+        /// The subpath to the file matched, relative to the first wildcard in the matching search pattern
         /// </summary>
         /// <remarks>
-        /// If the matcher searched for "**/*.cs" using "src/Project" as the directory base and the pattern matcher found
-        /// "src/Project/Interfaces/IFile.cs",
-        /// then Stem = "Interfaces/IFile.cs" and Path = "src/Project/Interfaces/IFile.cs".
+        /// If the matcher searched for "src/Project/**/*.cs" and the pattern matcher found
+        /// "src/Project/Interfaces/IFile.cs", then Stem = "Interfaces/IFile.cs" and Path = "src/Project/Interfaces/IFile.cs".
         /// </remarks>
         public string Stem { get; }
 
@@ -34,7 +33,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         /// Initializes new instance of <see cref="FilePatternMatch" />
         /// </summary>
         /// <param name="path">The path to the matched file</param>
-        /// <param name="stem">The stem</param>
+        /// <param name="stem">The stem path, relative to the first wildcard</param>
         public FilePatternMatch(string path, string stem)
         {
             Path = path;

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/FilePatternMatch.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/FilePatternMatch.cs
@@ -12,28 +12,28 @@ namespace Microsoft.Extensions.FileSystemGlobbing
     public struct FilePatternMatch : IEquatable<FilePatternMatch>
     {
         /// <summary>
-        /// The path to the file matched, relative to the beginning of the matching search pattern
+        /// The path to the file matched, relative to the beginning of the matching search pattern.
         /// </summary>
         /// <remarks>
-        /// If the matcher searched for "src/Project/**/*.cs" and the pattern matcher found
-        /// "src/Project/Interfaces/IFile.cs", then Stem = "Interfaces/IFile.cs" and Path = "src/Project/Interfaces/IFile.cs".
+        /// If the matcher searched for "src/Project/**/*.cs" and the pattern matcher found "src/Project/Interfaces/IFile.cs",
+        /// then <see cref="Stem" /> = "Interfaces/IFile.cs" and <see cref="Path" /> = "src/Project/Interfaces/IFile.cs".
         /// </remarks>
         public string Path { get; }
 
         /// <summary>
-        /// The subpath to the file matched, relative to the first wildcard in the matching search pattern
+        /// The subpath to the file matched, relative to the first wildcard in the matching search pattern.
         /// </summary>
         /// <remarks>
-        /// If the matcher searched for "src/Project/**/*.cs" and the pattern matcher found
-        /// "src/Project/Interfaces/IFile.cs", then Stem = "Interfaces/IFile.cs" and Path = "src/Project/Interfaces/IFile.cs".
+        /// If the matcher searched for "src/Project/**/*.cs" and the pattern matcher found "src/Project/Interfaces/IFile.cs",
+        /// then <see cref="Stem" /> = "Interfaces/IFile.cs" and <see cref="Path" /> = "src/Project/Interfaces/IFile.cs".
         /// </remarks>
         public string Stem { get; }
 
         /// <summary>
         /// Initializes new instance of <see cref="FilePatternMatch" />
         /// </summary>
-        /// <param name="path">The path to the matched file</param>
-        /// <param name="stem">The stem path, relative to the first wildcard</param>
+        /// <param name="path">The path to the file matched, relative to the beginning of the matching search pattern.</param>
+        /// <param name="stem">The subpath to the file matched, relative to the first wildcard in the matching search pattern.</param>
         public FilePatternMatch(string path, string stem)
         {
             Path = path;

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -445,10 +445,203 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             AssertExtensions.CollectionEqual(expected, actual, StringComparer.OrdinalIgnoreCase);
         }
 
+        [Theory] // rootDir, includePattern, expectedPath
+        [InlineData(@"root", @"*.0",         @"test.0")]
+        [InlineData(@"root", @"**/*.0",      @"test.0")]
+        public void PathIncludesAllSegmentsFromPattern_RootDirectory(string root, string includePattern, string expectedPath)
+        {
+            var fileToFind = @"root/test.0";
+
+            var matcher = new Matcher();
+            matcher.AddInclude(includePattern);
+
+            var results = matcher.Match(root, new[] { fileToFind });
+            var actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
+
+            Assert.Equal(expectedPath, actualPath);
+
+            // Also test all scenarios with the `./` current directory prefix
+            matcher = new Matcher();
+            matcher.AddInclude("./" + includePattern);
+
+            results = matcher.Match(root, new[] { fileToFind });
+            actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
+
+            Assert.Equal(expectedPath, actualPath);
+        }
+
+        [Theory] // rootDir,      includePattern,    expectedPath
+        [InlineData(@"root/dir1", @"*.1",            @"test.1")]
+        [InlineData(@"root/dir1", @"**/*.1",         @"test.1")]
+        [InlineData(@"root",      @"dir1/*.1",       @"dir1/test.1")]
+        [InlineData(@"root",      @"dir1/**/*.1",    @"dir1/test.1")]
+        [InlineData(@"root",      @"**/dir1/*.1",    @"dir1/test.1")]
+        [InlineData(@"root",      @"**/dir1/**/*.1", @"dir1/test.1")]
+        [InlineData(@"root",      @"**/*.1",         @"dir1/test.1")]
+        public void PathIncludesAllSegmentsFromPattern_OneDirectoryDeep(string root, string includePattern, string expectedPath)
+        {
+            var fileToFind = @"root/dir1/test.1";
+
+            var matcher = new Matcher();
+            matcher.AddInclude(includePattern);
+
+            var results = matcher.Match(root, new[] { fileToFind });
+            var actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
+
+            Assert.Equal(expectedPath, actualPath);
+
+            // Also test all scenarios with the `./` current directory prefix
+            matcher = new Matcher();
+            matcher.AddInclude("./" + includePattern);
+
+            results = matcher.Match(root, new[] { fileToFind });
+            actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
+
+            Assert.Equal(expectedPath, actualPath);
+        }
+
+        [Theory] // rootDir,           includePattern,            expectedPath
+        [InlineData(@"root/dir1/dir2", @"*.2",                    @"test.2")]
+        [InlineData(@"root/dir1/dir2", @"**/*.2",                 @"test.2")]
+        [InlineData(@"root/dir1",      @"dir2/*.2",               @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"dir2/**/*.2",            @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"**/dir2/*.2",            @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"**/dir2/**/*.2",         @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"**/*.2",                 @"dir2/test.2")]
+        [InlineData(@"root",           @"dir1/dir2/*.2",          @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"dir1/dir2/**/*.2",       @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/dir2/**/*.2",    @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/dir2/*.2",    @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/dir2/**/*.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"dir1/**/*.2",            @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/*.2",         @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir2/*.2",            @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir2/**/*.2",         @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/*.2",                 @"dir1/dir2/test.2")]
+        public void PathIncludesAllSegmentsFromPattern_TwoDirectoriesDeep(string root, string includePattern, string expectedPath)
+        {
+            var fileToFind = @"root/dir1/dir2/test.2";
+
+            var matcher = new Matcher();
+            matcher.AddInclude(includePattern);
+
+            var results = matcher.Match(root, new[] { fileToFind });
+            var actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
+
+            Assert.Equal(expectedPath, actualPath);
+
+            // Also test all scenarios with the `./` current directory prefix
+            matcher = new Matcher();
+            matcher.AddInclude("./" + includePattern);
+
+            results = matcher.Match(root, new[] { fileToFind });
+            actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
+
+            Assert.Equal(expectedPath, actualPath);
+        }
+
+        [Theory] // rootDir, includePattern, expectedStem
+        [InlineData(@"root", @"*.0",         @"test.0")]
+        [InlineData(@"root", @"**/*.0",      @"test.0")]
+        public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_RootDirectory(string root, string includePattern, string expectedStem)
+        {
+            var fileToFind = @"root/test.0";
+
+            var matcher = new Matcher();
+            matcher.AddInclude(includePattern);
+
+            var results = matcher.Match(root, new[] { fileToFind });
+            var actualStem = results.Files.Select(file => file.Stem).SingleOrDefault();
+
+            Assert.Equal(expectedStem, actualStem);
+
+            // Also test all scenarios with the `./` current directory prefix
+            matcher = new Matcher();
+            matcher.AddInclude("./" + includePattern);
+
+            results = matcher.Match(root, new[] { fileToFind });
+            actualStem = results.Files.Select(file => file.Stem).SingleOrDefault();
+
+            Assert.Equal(expectedStem, actualStem);
+        }
+
+        [Theory] // rootDir,      includePattern,    expectedStem
+        [InlineData(@"root/dir1", @"*.1",            @"test.1")]
+        [InlineData(@"root/dir1", @"**/*.1",         @"test.1")]
+        [InlineData(@"root",      @"dir1/*.1",       @"test.1")]
+        [InlineData(@"root",      @"dir1/**/*.1",    @"test.1")]
+        [InlineData(@"root",      @"**/dir1/*.1",    @"dir1/test.1")]
+        [InlineData(@"root",      @"**/dir1/**/*.1", @"dir1/test.1")]
+        [InlineData(@"root",      @"**/*.1",         @"dir1/test.1")]
+        public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_OneDirectoryDeep(string root, string includePattern, string expectedStem)
+        {
+            var fileToFind = @"root/dir1/test.1";
+
+            var matcher = new Matcher();
+            matcher.AddInclude(includePattern);
+
+            var results = matcher.Match(root, new[] { fileToFind });
+            var actualStem = results.Files.Select(file => file.Stem).SingleOrDefault();
+
+            Assert.Equal(expectedStem, actualStem);
+
+            // Also test all scenarios with the `./` current directory prefix
+            matcher = new Matcher();
+            matcher.AddInclude("./" + includePattern);
+
+            results = matcher.Match(root, new[] { fileToFind });
+            actualStem = results.Files.Select(file => file.Stem).SingleOrDefault();
+
+            Assert.Equal(expectedStem, actualStem);
+        }
+
+        [Theory] // rootDir,           includePattern,            expectedStem
+        [InlineData(@"root/dir1/dir2", @"*.2",                    @"test.2")]
+        [InlineData(@"root/dir1/dir2", @"**/*.2",                 @"test.2")]
+        [InlineData(@"root/dir1",      @"dir2/*.2",               @"test.2")]
+        [InlineData(@"root/dir1",      @"dir2/**/*.2",            @"test.2")]
+        [InlineData(@"root/dir1",      @"**/dir2/*.2",            @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"**/dir2/**/*.2",         @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"**/*.2",                 @"dir2/test.2")]
+        [InlineData(@"root",           @"dir1/dir2/*.2",          @"test.2")]
+        [InlineData(@"root",           @"dir1/dir2/**/*.2",       @"test.2")]
+        [InlineData(@"root",           @"**/dir1/dir2/**/*.2",    @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/dir2/*.2",    @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/dir2/**/*.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"dir1/**/*.2",            @"dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/*.2",         @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir2/*.2",            @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir2/**/*.2",         @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/*.2",                 @"dir1/dir2/test.2")]
+        public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_TwoDirectoriesDeep(string root, string includePattern, string expectedStem)
+        {
+            var fileToFind = @"root/dir1/dir2/test.2";
+
+            var matcher = new Matcher();
+            matcher.AddInclude(includePattern);
+
+            var results = matcher.Match(root, new[] { fileToFind });
+            var actualStem = results.Files.Select(file => file.Stem).SingleOrDefault();
+
+            Assert.Equal(expectedStem, actualStem);
+
+            // Also test all scenarios with the `./` current directory prefix
+            matcher = new Matcher();
+            matcher.AddInclude("./" + includePattern);
+
+            results = matcher.Match(root, new[] { fileToFind });
+            actualStem = results.Files.Select(file => file.Stem).SingleOrDefault();
+
+            Assert.Equal(expectedStem, actualStem);
+        }
+
         private List<string> GetFileList()
         {
             return new List<string>
             {
+                "root/test.0",
+                "root/dir1/test.1",
+                "root/dir1/dir2/test.2",
                 "src/project/source1.cs",
                 "src/project/sub/source2.cs",
                 "src/project/sub/source3.cs",


### PR DESCRIPTION
Resolves #36092 by clarifying the behavior of the `Path` and `Stem` properties on `FilePatternMatch`. The current documentation and `///` comments can be interpreted differently from what is implemented. Additionally, I found the existing unit tests left this behavior ambiguous. This adds some new `[Theory]` tests that illustrate the behavior clearly and updates the `///` comments to reflect the implementation more precisely.

Once we lock in the right verbiage for the comments, I'll follow up with a PR in `dotnet/dotnet-api-docs` to fix the documentation too.