### PR TITLE
Re-enable iOS AOT functional test

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -271,10 +271,8 @@
   <ItemGroup Condition="'$(ArchiveTests)' == 'true' and ('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS')">
     <ProjectReference Include="$(MonoProjectRoot)sample\iOS\Program.csproj"
                       BuildInParallel="false" />
-                      <!-- TODO: remove Exclude after "tests.mobile.targets(107,5): error : Unable to compile method" fixed -->
     <ProjectReference Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\**\*.Test.csproj"
-                      BuildInParallel="false"
-                      Exclude="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\AOT\iOS.Simulator.Aot.Test.csproj"/>
+                      BuildInParallel="false" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(ArchiveTests)' == 'true' and '$(TargetOS)' == 'Android'">


### PR DESCRIPTION
- [x] `Unable to compile method` issue was addressed in https://github.com/dotnet/runtime/pull/47033.
- [x] The problem with AOT test hanging on a simulator was addressed in https://github.com/dotnet/runtime/pull/48004.
- [x] https://github.com/dotnet/runtime/issues/47581#issuecomment-776474465 


 