### PR TITLE
Process.WaitForExit: don't wait for standard streams when process was killed.

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.NonUap.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.NonUap.cs
@@ -25,6 +25,10 @@ namespace System.Diagnostics
 
                 if (result != null && result.Count != 0)
                     throw new AggregateException(SR.KillEntireProcessTree_TerminationIncomplete, result);
+
+                // Don't wait for output on WaitForExit.
+                _output?.CancelOperation(fakeEof: true);
+                _error?.CancelOperation(fakeEof: true);
             }
         }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -52,8 +52,7 @@ namespace System.Diagnostics
             throw new PlatformNotSupportedException(SR.ProcessStartWithPasswordAndDomainNotSupported);
         }
 
-        /// <summary>Terminates the associated process immediately.</summary>
-        public void Kill()
+        private void KillCore()
         {
             EnsureState(State.HaveId);
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -88,8 +88,7 @@ namespace System.Diagnostics
             SetPrivilege(Interop.Advapi32.SeDebugPrivilege, 0);
         }
 
-        /// <summary>Terminates the associated process immediately.</summary>
-        public void Kill()
+        private void KillCore()
         {
             using (SafeProcessHandle handle = GetProcessHandle(Interop.Advapi32.ProcessOptions.PROCESS_TERMINATE | Interop.Advapi32.ProcessOptions.PROCESS_QUERY_LIMITED_INFORMATION, throwIfExited: false))
             {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1077,6 +1077,16 @@ namespace System.Diagnostics
             return new Process(".", false, Environment.ProcessId, null);
         }
 
+        /// <summary>Terminates the associated process immediately.</summary>
+        public void Kill()
+        {
+            KillCore();
+
+            // Don't wait for output on WaitForExit.
+            _output?.CancelOperation(fakeEof: true);
+            _error?.CancelOperation(fakeEof: true);
+        }
+
         /// <devdoc>
         ///    <para>
         ///       Raises the <see cref='System.Diagnostics.Process.Exited'/> event.

--- a/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -13,6 +13,8 @@
              Link="Common\System\IO\StringParser.cs" />
     <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs"
              Link="Common\System\ShouldNotBeInvokedException.cs" />
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
+             Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
     <Compile Include="$(CommonTestPath)Microsoft\Win32\TempRegistryKey.cs"
              Link="Common\Microsoft\Win32\TempRegistryKey.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"


### PR DESCRIPTION
This is a common pattern:

```
process.Kill();
process.WaitForExit();
```

When the process has redirected standard output or standard error
`WaitForExit` will block until all descendants of the child process (that
inherited these streams) have also terminated.

This change will make `WaitForExit` no longer wait for these descendants
when the process was killed first.

Additionally, when the user has cancelled the reading by calling
`CancelOutputRead` and `CancelErrorRead`, `WaitForExit` will no longer
wait for the streams either.

@danmoseley @stephentoub @adamsitnik @eiriktsarpalis ptal