### PR TITLE
Update AppleRunnerTemplate.sh 

### DIFF
--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -55,7 +55,7 @@ else
     HARNESS_RUNNER="dotnet xharness"
 fi
 
-$HARNESS_RUNNER ios $XHARNESS_CMD    \
+$HARNESS_RUNNER apple $XHARNESS_CMD    \
     --app="$EXECUTION_DIR/$TEST_NAME/$SCHEME_SDK/$TEST_NAME.app" \
     --targets="$TARGET" \
     --xcode="$XCODE_PATH"   \


### PR DESCRIPTION
Since the `ios` xharness command was renamed to `apple` in https://github.com/dotnet/xharness/pull/428,  it makes sense to update AppleRunnerTemplate.sh. 