### PR TITLE
Move statics to POH

### DIFF
--- a/src/coreclr/src/gc/gcpriv.h
+++ b/src/coreclr/src/gc/gcpriv.h
@@ -93,7 +93,7 @@ inline void FATAL_GC_ERROR()
 
 #define CARD_BUNDLE         //enable card bundle feature.(requires WRITE_WATCH)
 
-// #define ALLOW_REFERENCES_IN_POH  //Allow POH objects to contain references.
+#define ALLOW_REFERENCES_IN_POH  //Allow POH objects to contain references.
 
 #ifdef BACKGROUND_GC
 #define BGC_SERVO_TUNING

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -143,14 +143,14 @@ LargeHeapHandleBucket::LargeHeapHandleBucket(LargeHeapHandleBucket *pNext, DWORD
 
     // Allocate the array in the large object heap.
     OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
-    HandleArrayObj = (PTRARRAYREF)AllocateObjectArray(Size, g_pObjectClass, TRUE);
+    HandleArrayObj = (PTRARRAYREF)AllocateObjectArray(Size, g_pObjectClass, /* bAllocateInPinnedHeap = */TRUE);
 
     // Retrieve the pointer to the data inside the array. This is legal since the array
     // is located in the large object heap and is guaranteed not to move.
     m_pArrayDataPtr = (OBJECTREF *)HandleArrayObj->GetDataPtr();
 
     // Store the array in a strong handle to keep it alive.
-    m_hndHandleArray = pDomain->CreatePinningHandle((OBJECTREF)HandleArrayObj);
+    m_hndHandleArray = pDomain->CreateStrongHandle((OBJECTREF)HandleArrayObj);
 }
 
 
@@ -166,7 +166,7 @@ LargeHeapHandleBucket::~LargeHeapHandleBucket()
 
     if (m_hndHandleArray)
     {
-        DestroyPinningHandle(m_hndHandleArray);
+        DestroyStrongHandle(m_hndHandleArray);
         m_hndHandleArray = NULL;
     }
 }
@@ -517,7 +517,7 @@ ThreadStaticHandleBucket::ThreadStaticHandleBucket(ThreadStaticHandleBucket *pNe
 
     // Allocate the array on the GC heap.
     OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
-    HandleArrayObj = (PTRARRAYREF)AllocateObjectArray(Size, g_pObjectClass, FALSE);
+    HandleArrayObj = (PTRARRAYREF)AllocateObjectArray(Size, g_pObjectClass);
 
     // Store the array in a strong handle to keep it alive.
     m_hndHandleArray = pDomain->CreateStrongHandle((OBJECTREF)HandleArrayObj);

--- a/src/coreclr/src/vm/gchelpers.cpp
+++ b/src/coreclr/src/vm/gchelpers.cpp
@@ -803,7 +803,7 @@ OBJECTREF   DupArrayForCloning(BASEARRAYREF pRef)
 //
 // Helper for parts of the EE which are allocating arrays
 //
-OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle elementType, BOOL bAllocateInLargeHeap)
+OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle elementType, BOOL bAllocateInPinnedHeap)
 {
     CONTRACTL {
         THROWS;
@@ -823,7 +823,7 @@ OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle elementType, BOOL bAll
     _ASSERTE(arrayType.GetInternalCorElementType() == ELEMENT_TYPE_SZARRAY);
 #endif //_DEBUG
 
-    GC_ALLOC_FLAGS flags = bAllocateInLargeHeap ? GC_ALLOC_LARGE_OBJECT_HEAP : GC_ALLOC_NO_FLAGS;
+    GC_ALLOC_FLAGS flags = bAllocateInPinnedHeap ? GC_ALLOC_PINNED_OBJECT_HEAP : GC_ALLOC_NO_FLAGS;
     return AllocateSzArray(arrayType, (INT32) cElements, flags);
 }
 

--- a/src/coreclr/src/vm/gchelpers.h
+++ b/src/coreclr/src/vm/gchelpers.h
@@ -31,7 +31,7 @@ OBJECTREF AllocateArrayEx(TypeHandle  arrayType, INT32 *pArgs, DWORD dwNumArgs, 
 OBJECTREF AllocatePrimitiveArray(CorElementType type, DWORD cElements);
 
 // Allocate SD array of object types given an element type
-OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle ElementType, BOOL bAllocateInLargeHeap = FALSE);
+OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle ElementType, BOOL bAllocateInPinnedHeap = FALSE);
 
 // Allocate a string
 STRINGREF AllocateString( DWORD cchStringLength );


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/48136
Fix in master: https://github.com/dotnet/runtime/pull/47651

This change moved the array for holding the statics from LOH to POH. This change should reduce LOH fragmentation.

# Customer Impact
Customer observed that after a few days of running their services memory consumption would begin to rise and in some cases get as high as 700-800 MB. They share hosting machines with other services and are required to remain under 300 MB. They cannot proceed with their migration to .NET 5 until this memory consumption is brought under control.


# Testing
Customer setup an environment where the fragmentation issue reproduced and confirmed that with the fix all static initializers moved to the POH and there was no fragmentation in the LOH after the fix.

Based on the results in their test environment this fix is expected to reduce their memory consumption by as much as 200 MB.

Other causes for their increased memory consumption have been identified and the .NET team is also assisting in a couple of those investigations. This fix is a big step towards meeting their requirement.

For functional correctness, I have run the CoreCLR tests on both debug and release build on Windows locally, and the CI is running on all platforms.

# Risk
At a glance, the key risk here is that the code under `ALLOW_REFERENCES_IN_POH` was not activated and therefore they could be wrong. According to @Maoni0, the code under the `ALLOW_REFERENCES_IN_POH` was tested just like the code without when the pinned object heap feature was checked in, therefore that risk is mitigated. 

One additional risk vector is that objects are now going to be allocated on POH, so if there are specific configs reducing sizes there might be some concern. 

# Regression
It is not a regression. 