### PR TITLE
Get rid of explicit protection change to RX on arm64 macOS in the exception handling

### DIFF
--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -249,10 +249,6 @@ PCODE TheUMEntryPrestubWorker(UMEntryThunk * pUMEntryThunk)
     if (pThread->IsAbortRequested())
         pThread->HandleThreadAbort();
 
-#if defined(HOST_OSX) && defined(HOST_ARM64)
-    auto jitWriteEnableHolder = PAL_JITWriteEnable(true);
-#endif // defined(HOST_OSX) && defined(HOST_ARM64)
-
     UMEntryThunk::DoRunTimeInit(pUMEntryThunk);
 
     return (PCODE)pUMEntryThunk->GetCode();
@@ -288,6 +284,11 @@ void STDCALL UMEntryThunk::DoRunTimeInit(UMEntryThunk* pUMEntryThunk)
 
     {
         GCX_PREEMP();
+
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+        auto jitWriteEnableHolder = PAL_JITWriteEnable(true);
+#endif // defined(HOST_OSX) && defined(HOST_ARM64)
+
         pUMEntryThunk->RunTimeInit();
     }
 

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3312,10 +3312,6 @@ DWORD_PTR ExceptionTracker::CallHandler(
         break;
     }
 
-#if defined(HOST_OSX) && defined(HOST_ARM64)
-    auto jitWriteEnableHolder = PAL_JITWriteEnable(false);
-#endif // defined(HOST_OSX) && defined(HOST_ARM64)
-
 #ifdef USE_FUNCLET_CALL_HELPER
     // Invoke the funclet. We pass throwable only when invoking the catch block.
     // Since the actual caller of the funclet is the assembly helper, pass the reference
@@ -3951,10 +3947,6 @@ void ExceptionTracker::ResumeExecution(
 
     EH_LOG((LL_INFO100, "resuming execution at 0x%p\n", GetIP(pContextRecord)));
     EH_LOG((LL_INFO100, "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"));
-
-#if defined(HOST_OSX) && defined(HOST_ARM64)
-    auto jitWriteEnableHolder = PAL_JITWriteEnable(false);
-#endif // defined(HOST_OSX) && defined(HOST_ARM64)
 
     RtlRestoreContext(pContextRecord, pExceptionRecord);
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1921,10 +1921,6 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
 
     ETWOnStartup(PrestubWorker_V1, PrestubWorkerEnd_V1);
 
-#if defined(HOST_OSX) && defined(HOST_ARM64)
-    auto jitWriteEnableHolder = PAL_JITWriteEnable(true);
-#endif // defined(HOST_OSX) && defined(HOST_ARM64)
-
     MAKE_CURRENT_THREAD_AVAILABLE();
 
     // Attempt to check what GC mode we are running under.
@@ -1994,7 +1990,13 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
         }
 
         GCX_PREEMP_THREAD_EXISTS(CURRENT_THREAD);
-        pbRetVal = pMD->DoPrestub(pDispatchingMT, CallerGCMode::Coop);
+        {
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+            auto jitWriteEnableHolder = PAL_JITWriteEnable(true);
+#endif // defined(HOST_OSX) && defined(HOST_ARM64)
+
+            pbRetVal = pMD->DoPrestub(pDispatchingMT, CallerGCMode::Coop);
+        }
 
         UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
         UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;


### PR DESCRIPTION
The need for explicit changing of protection to RX in the `ExceptionTracker::CallHandler` and `ExceptionTracker::ResumeExecution` was caused by a problematic placement of the `PAL_JITWriteEnable` holder in the `TheUMEntryPrestubWorker` and `PreStubWorker`. The problem is that the destructor of the holder is not being called when the lifetime of the holder ends after the `UNINSTALL_MANAGED_EXCEPTION_DISPATCHER` in methods called from managed code or asm helpers. This is a limitation of our exception handling on Unix. We let the `PAL_SEHException` exception representing a managed exception propagate through native code using standard c++ mechanism and then catch it at the boundary of managed code / asm helper. We directly call the `DispatchManagedException` from there and start unwinding the managed frames. That means that if object lifetime ends after that catch, the destructor is never called.