### PR TITLE
Check whether EventSource is supported before initializing RuntimeEventSource

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
@@ -31,8 +32,11 @@ namespace System
             if (!IsSupported)
                 return;
 
-            // Initialize tracing before any user code can be called.
-            System.Diagnostics.Tracing.RuntimeEventSource.Initialize();
+            // Initialize tracing before any user code can be called if EventSource is enabled.
+            if (EventSource.IsSupported)
+            {
+                System.Diagnostics.Tracing.RuntimeEventSource.Initialize();
+            }
 
             string? startupHooksVariable = AppContext.GetData("STARTUP_HOOKS") as string;
             if (startupHooksVariable == null)


### PR DESCRIPTION
Before we call RuntimeEventSource.Initialize we should check if EventSource feature switch is on. If the switch is off the Initialization path will eventually fail while trying to initialize the EventSource but we should just check it from the caller side anyway.