### PR TITLE
Probe libnuma.so.1.0.0 before its symlinks

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -284,10 +284,14 @@ void NUMASupportInitialize()
         return;
     }
 
-    g_numaHandle = dlopen("libnuma.so", RTLD_LAZY);
+    g_numaHandle = dlopen("libnuma.so.1", RTLD_LAZY);
     if (g_numaHandle == 0)
     {
-        g_numaHandle = dlopen("libnuma.so.1", RTLD_LAZY);
+        g_numaHandle = dlopen("libnuma.so.1.0.0", RTLD_LAZY);
+        if (g_numaHandle == 0)
+        {
+            g_numaHandle = dlopen("libnuma.so", RTLD_LAZY);
+        }
     }
     if (g_numaHandle != 0)
     {
@@ -887,10 +891,10 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
     if (cacheSize == 0)
     {
         //
-        // Fallback to retrieve cachesize via /sys/.. if sysconf was not available 
-        // for the platform. Currently musl and arm64 should be only cases to use  
+        // Fallback to retrieve cachesize via /sys/.. if sysconf was not available
+        // for the platform. Currently musl and arm64 should be only cases to use
         // this method to determine cache size.
-        // 
+        //
         size_t size;
 
         if (ReadMemoryValueFromFile("/sys/devices/system/cpu/cpu0/cache/index0/size", &size))

--- a/src/coreclr/pal/src/numa/numa.cpp
+++ b/src/coreclr/pal/src/numa/numa.cpp
@@ -116,10 +116,14 @@ NUMASupportInitialize()
         return TRUE;
     }
 
-    numaHandle = dlopen("libnuma.so", RTLD_LAZY);
+    numaHandle = dlopen("libnuma.so.1", RTLD_LAZY);
     if (numaHandle == 0)
     {
-        numaHandle = dlopen("libnuma.so.1", RTLD_LAZY);
+        numaHandle = dlopen("libnuma.so.1.0.0", RTLD_LAZY);
+        if (numaHandle == 0)
+        {
+            numaHandle = dlopen("libnuma.so", RTLD_LAZY);
+        }
     }
     if (numaHandle != 0)
     {


### PR DESCRIPTION
On Linux, libnuma.so{.1} are symlinks to libnuma.so.1.0.0.

When installed from default package manager; Ubuntu (libnuma-dev) and
Alpine (numactl-dev), found these two symlinks:
`{libnuma.so,libnuma.so.1} -> libnuma.so.1.0.0`

On Fedora (numactl-libs):
`libnuma.so.1 -> libnuma.so.1.0.0`
(there is no version-less variant)

PR adjusts probing fallback flow based on this info.