### PR TITLE
Statically link System.Native into the final exe on ios, since the pinvoke mapping maps calls to it to __Internal.

### DIFF
--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -84,7 +84,7 @@ internal class Xcode
         {
             string libName = Path.GetFileNameWithoutExtension(lib);
             // libmono must always be statically linked, for other librarires we can use dylibs
-            bool dylibExists = libName != "libmonosgen-2.0" && dylibs.Any(dylib => Path.GetFileName(dylib) == libName + ".dylib");
+            bool dylibExists = libName != "libmonosgen-2.0" && libName != "libSystem.Native" && dylibs.Any(dylib => Path.GetFileName(dylib) == libName + ".dylib");
 
             if (!preferDylibs || !dylibExists)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/47581.