### PR TITLE
Fix official build

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -304,34 +304,34 @@ stages:
       - windows_arm
       - windows_arm64
 
-- ${{ if eq(variables.isOfficialBuild, true) }}:
-  - template: /eng/pipelines/official/stages/publish.yml
+  #
+  # Build PGO CoreCLR release
+  #
+  - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
-      isOfficialBuild: ${{ variables.isOfficialBuild }}
-
-#
-# Build PGO CoreCLR release
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: release
-    platforms:
-    - windows_x64
-    jobParameters:
-      testGroup: innerloop
-      pgoType: 'PGO'
+      jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      buildConfig: release
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: innerloop
+        pgoType: 'PGO'
 
   #
   # PGO Build
   #
-- template: /eng/pipelines/installer/installer-matrix.yml
-  parameters:
-    buildConfig: Release
-    jobParameters:
+  - template: /eng/pipelines/installer/installer-matrix.yml
+    parameters:
+      buildConfig: Release
+      jobParameters:
+        isOfficialBuild: ${{ variables.isOfficialBuild }}
+        liveRuntimeBuildConfig: release
+        liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+        pgoType: 'PGO'
+      platforms:
+      - windows_x64
+
+- ${{ if eq(variables.isOfficialBuild, true) }}:
+  - template: /eng/pipelines/official/stages/publish.yml
+    parameters:
       isOfficialBuild: ${{ variables.isOfficialBuild }}
-      liveRuntimeBuildConfig: release
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      pgoType: 'PGO'
-    platforms:
-    - windows_x64


### PR DESCRIPTION
This was broken by: https://github.com/dotnet/runtime/commit/9962cfd2eee6b4aa7909ea0ea6e08151bbeed77f

The yml was wrong, these steps need to be before the prepare for publish stage. That is why the official build was failing to parse the yml file.

I tested it with: https://dnceng.visualstudio.com/internal/_build/results?buildId=989090&view=results

cc: @agocke @dotnet/runtime-infrastructure @jkoritzinsky 