### PR TITLE
[wasm] Silence more warnings in the wasm runtime build

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -694,6 +694,10 @@ if(TARGET_IOS OR TARGET_ANDROID)
 else()
   set(DISABLE_DLLMAP 1)
 endif()
+if (TARGET_BROWSER)
+  # sys/errno.h exists, but just emits a warning and includes errno.h
+  unset(HAVE_SYS_ERRNO_H)
+endif()
 ### End of OS specific checks
 
 add_subdirectory(mono)

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -91,13 +91,13 @@ gboolean mono_using_xdebug;
 /* Counters */
 static guint32 discarded_code;
 static gint64 discarded_jit_time;
-static guint32 jinfo_try_holes_size;
 
 #define mono_jit_lock() mono_os_mutex_lock (&jit_mutex)
 #define mono_jit_unlock() mono_os_mutex_unlock (&jit_mutex)
 static mono_mutex_t jit_mutex;
 
 #ifndef DISABLE_JIT
+static guint32 jinfo_try_holes_size;
 static MonoBackend *current_backend;
 
 gpointer


### PR DESCRIPTION
Fix a couple more warnings.  This should be everything but a System.Globalization.Native problem that needs more work.