### PR TITLE
Small pgo cleanup

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -904,17 +904,14 @@ public:
     {
         m_blockCount++;
         block->bbSparseProbeList = nullptr;
-        JITDUMP("node " FMT_BB "\n", block->bbNum);
     }
 
     void VisitTreeEdge(BasicBlock* source, BasicBlock* target) override
     {
-        JITDUMP("tree " FMT_BB " -> " FMT_BB "\n", source->bbNum, target->bbNum);
     }
 
     void VisitNonTreeEdge(BasicBlock* source, BasicBlock* target, SpanningTreeVisitor::EdgeKind kind) override
     {
-        JITDUMP("non-tree " FMT_BB " -> " FMT_BB "\n", source->bbNum, target->bbNum);
         switch (kind)
         {
             case EdgeKind::PostdominatesSource:

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -445,9 +445,7 @@ CONFIG_INTEGER(JitEnableGuardedDevirtualization, W("JitEnableGuardedDevirtualiza
 #if defined(DEBUG)
 // Various policies for GuardedDevirtualization
 CONFIG_STRING(JitGuardedDevirtualizationRange, W("JitGuardedDevirtualizationRange"))
-CONFIG_INTEGER(JitGuardedDevirtualizationGuessUniqueInterface, W("JitGuardedDevirtualizationGuessUniqueInterface"), 1)
 CONFIG_INTEGER(JitGuardedDevirtualizationGuessBestClass, W("JitGuardedDevirtualizationGuessBestClass"), 1)
-CONFIG_INTEGER(JitGuardedDeivrtualizationUseProfile, W("JitGuardedDevirtualizationUseProfile"), 0)
 #endif // DEBUG
 
 // Enable insertion of patchpoints into Tier0 methods with loops.

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -946,7 +946,7 @@ protected :
         ComputedPgoData* m_next = nullptr;
         MethodDesc *m_pMD;
         NewArrayHolder<BYTE> m_allocatedData;
-        PgoInstrumentationSchema* m_schema;
+        PgoInstrumentationSchema* m_schema = nullptr;
         UINT32 m_cSchemaElems;
         BYTE *m_pInstrumentationData = nullptr;
         HRESULT m_hr = E_NOTIMPL;


### PR DESCRIPTION
On the runtime side, intitialize the schema field so that the jit does not
internally think all optimized builds have pgo data with mismatched IL.

Quiet down some of the jit dumping when doing edge instrumentation.

Remove a few unused COMPlus vars from the jit.