### PR TITLE
Fix failure with `reimportSpillClique=true`. 

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6325,6 +6325,7 @@ GenTreeCall* Compiler::gtNewCallNode(
 
 GenTree* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs))
 {
+    assert(type != TYP_VOID);
     // We need to ensure that all struct values are normalized.
     // It might be nice to assert this in general, but we have assignments of int to long.
     if (varTypeIsStruct(type))
@@ -6607,6 +6608,7 @@ GenTree* Compiler::gtArgNodeByLateArgInx(GenTreeCall* call, unsigned lateArgInx)
 
 GenTreeOp* Compiler::gtNewAssignNode(GenTree* dst, GenTree* src)
 {
+    assert(!src->TypeIs(TYP_VOID));
     /* Mark the target as being assigned */
 
     if ((dst->gtOper == GT_LCL_VAR) || (dst->OperGet() == GT_LCL_FLD))

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13620,7 +13620,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         }
                         else
                         {
-                            op1->gtBashToNOP();
+                            // Can't bash to NOP here because op1 can be referenced from `currentBlock->bbEntryState`,
+                            // if we ever need to reimport we need a valid LCL_VAR on it.
+                            op1 = gtNewNothingNode();
                         }
                     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_47308/Runtime_47308.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_47308/Runtime_47308.il
@@ -1,12 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// That was a repro for a wrong IL stack optimization that happen when all conditions were met:
+//   - debug code, so we spill entries often,
+//   - we reimport blocks, `reimportSpillClique = true`,
+//   - there is a value that is popped and we were bashing it to nop(wrong optimization);
+//   - during reimportation we were asked to spill 'nop' value to the stack.
+
 .assembly extern System.Console {}
 
 .assembly Test1 {}
 .assembly extern mscorlib{auto}
 .class FullProof {
-.method static int32 Test() {
+.method static void Test() {
 .maxstack 500
 
 IL_352:       ldc.i8 1
@@ -37,6 +43,7 @@ IL_457:       add
 IL_490:       pop
 IL_491:       conv.ovf.i8.un
               pop
+              pop
 IL_500:       ret
 }
 
@@ -46,8 +53,7 @@ IL_500:       ret
 .maxstack 3
    .try
    {
-      call int32 FullProof::Test()
-      pop
+      call void FullProof::Test()
       leave.s WithoutEH
    }
    catch [mscorlib]System.Exception 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_47308/Runtime_47308.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_47308/Runtime_47308.il
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Console {}
+
+.assembly Test1 {}
+.assembly extern mscorlib{auto}
+.class FullProof {
+.method static int32 Test() {
+.maxstack 500
+
+IL_352:       ldc.i8 1
+IL_353:       conv.ovf.u8.un
+
+IL_417:       ldc.i8 1
+
+IL_428:       conv.ovf.u8.un
+IL_429:       ldc.r8 -55.5
+IL_434:       conv.r4
+IL_435:       nop
+IL_436:       ldc.r4 55.5
+IL_437:       ldc.r4 55.5
+IL_438:       ldc.r8 0.0
+IL_439:       nop
+IL_440:       beq IL_457
+IL_441:       conv.r8
+IL_450:       nop
+IL_451:       pop
+IL_452:       pop
+IL_453:       conv.ovf.u8
+IL_454:       ldc.r8 -55.5
+IL_455:       ldc.r4 -0.0
+IL_456:       nop
+IL_457:       add
+
+
+IL_490:       pop
+IL_491:       conv.ovf.i8.un
+              pop
+IL_500:       ret
+}
+
+.method public static int32  Main()
+{
+.entrypoint
+.maxstack 3
+   .try
+   {
+      call int32 FullProof::Test()
+      pop
+      leave.s WithoutEH
+   }
+   catch [mscorlib]System.Exception 
+   {
+      call       void [System.Console]System.Console::WriteLine(object)
+      leave.s AfterEH
+   }
+   
+WithoutEH:
+   ldstr      "PASS"
+   call       void [System.Console]System.Console::WriteLine(string)
+   ldc.i4.s   100
+   br RETURN
+   
+AfterEH:
+
+   ldstr      "FAIL"
+   call       void [System.Console]System.Console::WriteLine(string)
+   ldc.i4.s   101
+   br RETURN
+
+RETURN:
+
+   ret
+}
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_47308/Runtime_47308.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_47308/Runtime_47308.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Runtime_47308.il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The optimization added in https://github.com/dotnet/runtime/pull/31677 could cause a failure in tricky conditions.

The test reproduces the failure without crossgen2, it fails on 5.0.

We needed:
- `<DebugType>Full</DebugType>`;
- `reimportSpillClique = true`, by creating blocks like:
```
A: leave r4 on the stack;
B: leave r8 on the stack;
C: merge block for A, B, sees one incoming as r4, another as r8, sets reimportSpillClique = true.
```
- a CEE_POP that triggers optimization bashToNop from 31677;
- another stack entry after the poped one to force another spill stack call.

when all the conditions were met we were creating a tree like:
```
ASG(LCL_VAR void, NOP void)
```
and failing with assert during local visitor phase, with a noway assert in codegen, then with invalid program exception (in 5.0 release).


The stack when we `bashToNop`:
```
dump EE stacks:
depth: 3
               [000044] ------------              *  LCL_VAR   long   V07 tmp7
               [000045] ------------              *  LCL_VAR   long   V08 tmp8
               [000046] ------------              *  LCL_VAR   float  V09 tmp9 <- we would pop it from the current and bash to nop.

block number: 2, depth: 4
               [000044] ------------              *  LCL_VAR   long   V07 tmp7
               [000045] ------------              *  LCL_VAR   long   V08 tmp8
               [000046] ------------              *  LCL_VAR   float  V09 tmp9 <- this is reference saved in `block->bbEntryState`, it will become invalid.
               [000047] ------------              *  LCL_VAR   float  V10 tmp10
```
so during reimportation, we will try to use the invalid reference during `impSpillStackEntry`.


Fixes https://github.com/dotnet/runtime/issues/47308.