### PR TITLE
XCode.cs: Statically link libraries when forcing AOT

### DIFF
--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -84,9 +84,9 @@ internal class Xcode
         {
             string libName = Path.GetFileNameWithoutExtension(lib);
             // libmono must always be statically linked, for other librarires we can use dylibs
-            bool dylibExists = libName != "libmonosgen-2.0" && libName != "libSystem.Native" && dylibs.Any(dylib => Path.GetFileName(dylib) == libName + ".dylib");
+            bool dylibExists = libName != "libmonosgen-2.0" && dylibs.Any(dylib => Path.GetFileName(dylib) == libName + ".dylib");
 
-            if (!preferDylibs || !dylibExists)
+            if (forceAOT || !(preferDylibs && dylibExists))
             {
                 // these libraries are pinvoked
                 // -force_load will be removed once we enable direct-pinvokes for AOT


### PR DESCRIPTION
The fix in https://github.com/dotnet/runtime/pull/48135 wasn't fully correct since it just fixed the problem for libSystem.Native but not the other libraries.

The real problem is that we're setting `preferDylib` to true via `!isDevice` but still generate the pinvoke mapping to `__Internal` for all files where an `.a` file is found.

The reason why this works in the simulator on non-AOT cases is because we only call the `register_dllmap` function when we're actually forcing AOT on the simulator: https://github.com/dotnet/runtime/blob/42009d1f33b52e40e5471d5c0d3ff4a8d5b2b83a/src/tasks/AppleAppBuilder/Templates/runtime.m#L239-L240

The better fix is to extend the check to always apply when forceAOT is true.