### PR TITLE
Refactor ForbidHtmlCharacters to allow for more trimming.

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
@@ -39,7 +39,7 @@ namespace System.Text.Encodings.Web
             // it's unfortunately common for developers to
             // forget to HTML-encode a string once it has been JS-encoded,
             // so this offers extra protection.
-            DefaultHtmlEncoder.ForbidHtmlCharacters(_allowedCharacters);
+            HtmlEncoderHelper.ForbidHtmlCharacters(_allowedCharacters);
 
             // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
             // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -33,7 +33,7 @@ namespace System.Text.Encodings.Web
             // it's unfortunately common for developers to
             // forget to HTML-encode a string once it has been JS-encoded,
             // so this offers extra protection.
-            DefaultHtmlEncoder.ForbidHtmlCharacters(allowedCharacters);
+            HtmlEncoderHelper.ForbidHtmlCharacters(allowedCharacters);
 
             // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
             // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Internal;
@@ -62,17 +61,7 @@ namespace System.Text.Encodings.Web
             // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
             _allowedCharacters.ForbidUndefinedCharacters();
 
-            ForbidHtmlCharacters(_allowedCharacters);
-        }
-
-        internal static void ForbidHtmlCharacters(AllowedCharactersBitmap allowedCharacters)
-        {
-            allowedCharacters.ForbidCharacter('<');
-            allowedCharacters.ForbidCharacter('>');
-            allowedCharacters.ForbidCharacter('&');
-            allowedCharacters.ForbidCharacter('\''); // can be used to escape attributes
-            allowedCharacters.ForbidCharacter('\"'); // can be used to escape attributes
-            allowedCharacters.ForbidCharacter('+'); // technically not HTML-specific, but can be used to perform UTF7-based attacks
+            HtmlEncoderHelper.ForbidHtmlCharacters(_allowedCharacters);
         }
 
         public DefaultHtmlEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
@@ -161,6 +150,23 @@ namespace System.Text.Encodings.Web
             buffer += numberOfHexCharacters + 1;
             *buffer = ';';
             return true;
+        }
+    }
+
+    /// <summary>
+    /// Separates static methods from HtmlEncoder and DefaultHtmlEncoder so those classes can be trimmed
+    /// when only these static methods are needed.
+    /// </summary>
+    internal static class HtmlEncoderHelper
+    {
+        internal static void ForbidHtmlCharacters(AllowedCharactersBitmap allowedCharacters)
+        {
+            allowedCharacters.ForbidCharacter('<');
+            allowedCharacters.ForbidCharacter('>');
+            allowedCharacters.ForbidCharacter('&');
+            allowedCharacters.ForbidCharacter('\''); // can be used to escape attributes
+            allowedCharacters.ForbidCharacter('\"'); // can be used to escape attributes
+            allowedCharacters.ForbidCharacter('+'); // technically not HTML-specific, but can be used to perform UTF7-based attacks
         }
     }
 }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
@@ -74,7 +74,7 @@ namespace System.Text.Encodings.Web
             // it's unfortunately common for developers to
             // forget to HTML-encode a string once it has been URL-encoded,
             // so this offers extra protection.
-            DefaultHtmlEncoder.ForbidHtmlCharacters(_allowedCharacters);
+            HtmlEncoderHelper.ForbidHtmlCharacters(_allowedCharacters);
 
             // Per RFC 3987, Sec. 2.2, we want encodings that are safe for
             // four particular components: 'isegment', 'ipath-noscheme',


### PR DESCRIPTION
Having a static method on an uninstanstiated class is causing the class to be preserved along with its base hierarchy. And any overriden methods to satisfy abstract base methods.

This isn't a large savings (~500 bytes .br compressed), but it stuck out when looking through this assembly as something that doesn't need to be here.

Before this change:
![image](https://user-images.githubusercontent.com/8291187/107674572-b686a300-6c5c-11eb-8813-3b1c5a4e8bb5.png)

After:
![image](https://user-images.githubusercontent.com/8291187/107674663-cbfbcd00-6c5c-11eb-88a7-535d36c84cfb.png)
