### PR TITLE
change platform version from 0.0 to 1.0 in orfer to consume 6.0 sdk

### DIFF
--- a/eng/targetframeworksuffix.props
+++ b/eng/targetframeworksuffix.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup Condition="'$(TargetFrameworkSuffix)' != '' and '$(TargetFrameworkSuffix)' != 'windows'">
     <TargetPlatformIdentifier>$(TargetFrameworkSuffix)</TargetPlatformIdentifier>
-    <TargetPlatformVersion>0.0</TargetPlatformVersion>
+    <TargetPlatformVersion>1.0</TargetPlatformVersion>
     <TargetPlatformMoniker>$(TargetFrameworkSuffix),Version=$(TargetPlatformVersion)</TargetPlatformMoniker>
   </PropertyGroup>
   


### PR DESCRIPTION
Nuget changed on how it run validation for 0.0 or empty platform version for 6.0.
This is a redundant string so we can use any number here.
This will enable developers to use 6.0 sdk 
Tested the change locally 

cc @pgovind 
