### PR TITLE
Optimize readonly char[] in System.Text.Encodings.Web

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
@@ -235,12 +235,12 @@ namespace System.Text.Encodings.Web
         // surrogate pairs in the output.
         public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
 
-        private static readonly char[] s_b = new char[] { '\\', 'b' };
-        private static readonly char[] s_t = new char[] { '\\', 't' };
-        private static readonly char[] s_n = new char[] { '\\', 'n' };
-        private static readonly char[] s_f = new char[] { '\\', 'f' };
-        private static readonly char[] s_r = new char[] { '\\', 'r' };
-        private static readonly char[] s_back = new char[] { '\\', '\\' };
+        private static ReadOnlySpan<byte> s_b => new byte[] { (byte)'\\', (byte)'b' };
+        private static ReadOnlySpan<byte> s_t => new byte[] { (byte)'\\', (byte)'t' };
+        private static ReadOnlySpan<byte> s_n => new byte[] { (byte)'\\', (byte)'n' };
+        private static ReadOnlySpan<byte> s_f => new byte[] { (byte)'\\', (byte)'f' };
+        private static ReadOnlySpan<byte> s_r => new byte[] { (byte)'\\', (byte)'r' };
+        private static ReadOnlySpan<byte> s_back => new byte[] { (byte)'\\', (byte)'\\' };
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -263,12 +263,13 @@ namespace System.Text.Encodings.Web
             // be written out as numeric entities for defense-in-depth.
             // See UnicodeEncoderBase ctor comments for more info.
 
+            Span<char> destination = new Span<char>(buffer, bufferLength);
             if (!WillEncode(unicodeScalar))
             {
-                return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten);
             }
 
-            char[] toCopy;
+            ReadOnlySpan<byte> toCopy;
             switch (unicodeScalar)
             {
                 case '\b': toCopy = s_b; break;
@@ -279,7 +280,7 @@ namespace System.Text.Encodings.Web
                 case '\\': toCopy = s_back; break;
                 default: return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
-            return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
+            return TryCopyAsciiCharacters(toCopy, destination, out numberOfCharactersWritten);
         }
     }
 }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
@@ -235,12 +235,12 @@ namespace System.Text.Encodings.Web
         // surrogate pairs in the output.
         public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
 
-        private static ReadOnlySpan<byte> s_b => new byte[] { (byte)'\\', (byte)'b' };
-        private static ReadOnlySpan<byte> s_t => new byte[] { (byte)'\\', (byte)'t' };
-        private static ReadOnlySpan<byte> s_n => new byte[] { (byte)'\\', (byte)'n' };
-        private static ReadOnlySpan<byte> s_f => new byte[] { (byte)'\\', (byte)'f' };
-        private static ReadOnlySpan<byte> s_r => new byte[] { (byte)'\\', (byte)'r' };
-        private static ReadOnlySpan<byte> s_back => new byte[] { (byte)'\\', (byte)'\\' };
+        private const string s_b = "\\b";
+        private const string s_t = "\\t";
+        private const string s_n = "\\n";
+        private const string s_f = "\\f";
+        private const string s_r = "\\r";
+        private const string s_back = "\\\\";
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -269,7 +269,7 @@ namespace System.Text.Encodings.Web
                 return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten);
             }
 
-            ReadOnlySpan<byte> toCopy;
+            string toCopy;
             switch (unicodeScalar)
             {
                 case '\b': toCopy = s_b; break;
@@ -280,7 +280,7 @@ namespace System.Text.Encodings.Web
                 case '\\': toCopy = s_back; break;
                 default: return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
-            return TryCopyAsciiCharacters(toCopy, destination, out numberOfCharactersWritten);
+            return TryCopyCharacters(toCopy, destination, out numberOfCharactersWritten);
         }
     }
 }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -389,12 +389,12 @@ namespace System.Text.Encodings.Web
         // surrogate pairs in the output.
         public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
 
-        private static ReadOnlySpan<byte> s_b => new byte[] { (byte)'\\', (byte)'b' };
-        private static ReadOnlySpan<byte> s_t => new byte[] { (byte)'\\', (byte)'t' };
-        private static ReadOnlySpan<byte> s_n => new byte[] { (byte)'\\', (byte)'n' };
-        private static ReadOnlySpan<byte> s_f => new byte[] { (byte)'\\', (byte)'f' };
-        private static ReadOnlySpan<byte> s_r => new byte[] { (byte)'\\', (byte)'r' };
-        private static ReadOnlySpan<byte> s_back => new byte[] { (byte)'\\', (byte)'\\' };
+        private const string s_b = "\\b";
+        private const string s_t = "\\t";
+        private const string s_n = "\\n";
+        private const string s_f = "\\f";
+        private const string s_r = "\\r";
+        private const string s_back = "\\\\";
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -423,7 +423,7 @@ namespace System.Text.Encodings.Web
                 return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten);
             }
 
-            ReadOnlySpan<byte> toCopy;
+            string toCopy;
             switch (unicodeScalar)
             {
                 case '\b':
@@ -447,7 +447,7 @@ namespace System.Text.Encodings.Web
                 default:
                     return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
-            return TryCopyAsciiCharacters(toCopy, destination, out numberOfCharactersWritten);
+            return TryCopyCharacters(toCopy, destination, out numberOfCharactersWritten);
         }
 
         private static ReadOnlySpan<byte> AllowList => new byte[byte.MaxValue + 1]

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -389,12 +389,12 @@ namespace System.Text.Encodings.Web
         // surrogate pairs in the output.
         public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
 
-        private static readonly char[] s_b = new char[] { '\\', 'b' };
-        private static readonly char[] s_t = new char[] { '\\', 't' };
-        private static readonly char[] s_n = new char[] { '\\', 'n' };
-        private static readonly char[] s_f = new char[] { '\\', 'f' };
-        private static readonly char[] s_r = new char[] { '\\', 'r' };
-        private static readonly char[] s_back = new char[] { '\\', '\\' };
+        private static ReadOnlySpan<byte> s_b => new byte[] { (byte)'\\', (byte)'b' };
+        private static ReadOnlySpan<byte> s_t => new byte[] { (byte)'\\', (byte)'t' };
+        private static ReadOnlySpan<byte> s_n => new byte[] { (byte)'\\', (byte)'n' };
+        private static ReadOnlySpan<byte> s_f => new byte[] { (byte)'\\', (byte)'f' };
+        private static ReadOnlySpan<byte> s_r => new byte[] { (byte)'\\', (byte)'r' };
+        private static ReadOnlySpan<byte> s_back => new byte[] { (byte)'\\', (byte)'\\' };
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -417,12 +417,13 @@ namespace System.Text.Encodings.Web
             // be written out as numeric entities for defense-in-depth.
             // See UnicodeEncoderBase ctor comments for more info.
 
+            Span<char> destination = new Span<char>(buffer, bufferLength);
             if (!WillEncode(unicodeScalar))
             {
-                return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten);
             }
 
-            char[] toCopy;
+            ReadOnlySpan<byte> toCopy;
             switch (unicodeScalar)
             {
                 case '\b':
@@ -446,7 +447,7 @@ namespace System.Text.Encodings.Web
                 default:
                     return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
-            return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
+            return TryCopyAsciiCharacters(toCopy, destination, out numberOfCharactersWritten);
         }
 
         private static ReadOnlySpan<byte> AllowList => new byte[byte.MaxValue + 1]

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -96,10 +96,10 @@ namespace System.Text.Encodings.Web
             get { return 10; } // "&#x10FFFF;" is the longest encoded form
         }
 
-        private static readonly char[] s_quote = "&quot;".ToCharArray();
-        private static readonly char[] s_ampersand = "&amp;".ToCharArray();
-        private static readonly char[] s_lessthan = "&lt;".ToCharArray();
-        private static readonly char[] s_greaterthan = "&gt;".ToCharArray();
+        private static ReadOnlySpan<byte> s_quote => new byte[] { (byte)'&', (byte)'q', (byte)'u', (byte)'o', (byte)'t', (byte)';' };
+        private static ReadOnlySpan<byte> s_ampersand => new byte[] { (byte)'&', (byte)'a', (byte)'m', (byte)'p', (byte)';' };
+        private static ReadOnlySpan<byte> s_lessthan => new byte[] { (byte)'&', (byte)'l', (byte)'t', (byte)';' };
+        private static ReadOnlySpan<byte> s_greaterthan => new byte[] { (byte)'&', (byte)'g', (byte)'t', (byte)';' };
 
         public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
         {
@@ -108,11 +108,12 @@ namespace System.Text.Encodings.Web
                 throw new ArgumentNullException(nameof(buffer));
             }
 
-            if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\"') { return TryCopyCharacters(s_quote, buffer, bufferLength, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '&') { return TryCopyCharacters(s_ampersand, buffer, bufferLength, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '<') { return TryCopyCharacters(s_lessthan, buffer, bufferLength, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '>') { return TryCopyCharacters(s_greaterthan, buffer, bufferLength, out numberOfCharactersWritten); }
+            Span<char> destination = new Span<char>(buffer, bufferLength);
+            if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\"') { return TryCopyAsciiCharacters(s_quote, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '&') { return TryCopyAsciiCharacters(s_ampersand, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '<') { return TryCopyAsciiCharacters(s_lessthan, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '>') { return TryCopyAsciiCharacters(s_greaterthan, destination, out numberOfCharactersWritten); }
             else { return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
         }
 

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -96,10 +96,10 @@ namespace System.Text.Encodings.Web
             get { return 10; } // "&#x10FFFF;" is the longest encoded form
         }
 
-        private static ReadOnlySpan<byte> s_quote => new byte[] { (byte)'&', (byte)'q', (byte)'u', (byte)'o', (byte)'t', (byte)';' };
-        private static ReadOnlySpan<byte> s_ampersand => new byte[] { (byte)'&', (byte)'a', (byte)'m', (byte)'p', (byte)';' };
-        private static ReadOnlySpan<byte> s_lessthan => new byte[] { (byte)'&', (byte)'l', (byte)'t', (byte)';' };
-        private static ReadOnlySpan<byte> s_greaterthan => new byte[] { (byte)'&', (byte)'g', (byte)'t', (byte)';' };
+        private const string s_quote = "&quot;";
+        private const string s_ampersand = "&amp;";
+        private const string s_lessthan = "&lt;";
+        private const string s_greaterthan = "&gt;";
 
         public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
         {
@@ -110,10 +110,10 @@ namespace System.Text.Encodings.Web
 
             Span<char> destination = new Span<char>(buffer, bufferLength);
             if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '\"') { return TryCopyAsciiCharacters(s_quote, destination, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '&') { return TryCopyAsciiCharacters(s_ampersand, destination, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '<') { return TryCopyAsciiCharacters(s_lessthan, destination, out numberOfCharactersWritten); }
-            else if (unicodeScalar == '>') { return TryCopyAsciiCharacters(s_greaterthan, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '\"') { return TryCopyCharacters(s_quote, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '&') { return TryCopyCharacters(s_ampersand, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '<') { return TryCopyCharacters(s_lessthan, destination, out numberOfCharactersWritten); }
+            else if (unicodeScalar == '>') { return TryCopyCharacters(s_greaterthan, destination, out numberOfCharactersWritten); }
             else { return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
         }
 

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -900,7 +900,7 @@ namespace System.Text.Encodings.Web
 
         internal static bool TryCopyCharacters(string source, Span<char> destination, out int numberOfCharactersWritten)
         {
-            Debug.Assert(source.Length > 0);
+            Debug.Assert(!string.IsNullOrEmpty(source));
 
             if (destination.Length < source.Length)
             {
@@ -921,7 +921,7 @@ namespace System.Text.Encodings.Web
         internal static bool TryWriteScalarAsChar(int unicodeScalar, Span<char> destination, out int numberOfCharactersWritten)
         {
             Debug.Assert(unicodeScalar < ushort.MaxValue);
-            if (destination.Length < 1)
+            if (destination.IsEmpty)
             {
                 numberOfCharactersWritten = 0;
                 return false;

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -898,11 +898,11 @@ namespace System.Text.Encodings.Web
             }
         }
 
-        internal static unsafe bool TryCopyCharacters(char[] source, char* destination, int destinationLength, out int numberOfCharactersWritten)
+        internal static bool TryCopyAsciiCharacters(ReadOnlySpan<byte> source, Span<char> destination, out int numberOfCharactersWritten)
         {
-            Debug.Assert(source != null && destination != null && destinationLength >= 0);
+            Debug.Assert(source.Length > 0);
 
-            if (destinationLength < source.Length)
+            if (destination.Length < source.Length)
             {
                 numberOfCharactersWritten = 0;
                 return false;
@@ -910,7 +910,7 @@ namespace System.Text.Encodings.Web
 
             for (int i = 0; i < source.Length; i++)
             {
-                destination[i] = source[i];
+                destination[i] = (char)source[i];
             }
 
             numberOfCharactersWritten = source.Length;
@@ -918,17 +918,15 @@ namespace System.Text.Encodings.Web
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe bool TryWriteScalarAsChar(int unicodeScalar, char* destination, int destinationLength, out int numberOfCharactersWritten)
+        internal static bool TryWriteScalarAsChar(int unicodeScalar, Span<char> destination, out int numberOfCharactersWritten)
         {
-            Debug.Assert(destination != null && destinationLength >= 0);
-
             Debug.Assert(unicodeScalar < ushort.MaxValue);
-            if (destinationLength < 1)
+            if (destination.Length < 1)
             {
                 numberOfCharactersWritten = 0;
                 return false;
             }
-            *destination = (char)unicodeScalar;
+            destination[0] = (char)unicodeScalar;
             numberOfCharactersWritten = 1;
             return true;
         }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -898,7 +898,7 @@ namespace System.Text.Encodings.Web
             }
         }
 
-        internal static bool TryCopyAsciiCharacters(ReadOnlySpan<byte> source, Span<char> destination, out int numberOfCharactersWritten)
+        internal static bool TryCopyCharacters(string source, Span<char> destination, out int numberOfCharactersWritten)
         {
             Debug.Assert(source.Length > 0);
 
@@ -910,7 +910,7 @@ namespace System.Text.Encodings.Web
 
             for (int i = 0; i < source.Length; i++)
             {
-                destination[i] = (char)source[i];
+                destination[i] = source[i];
             }
 
             numberOfCharactersWritten = source.Length;

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
@@ -301,13 +301,13 @@ namespace System.Text.Encodings.Web
         // surrogate pairs in the output.
         public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
 
-        private static readonly char[] s_b = new char[] { '\\', 'b' };
-        private static readonly char[] s_t = new char[] { '\\', 't' };
-        private static readonly char[] s_n = new char[] { '\\', 'n' };
-        private static readonly char[] s_f = new char[] { '\\', 'f' };
-        private static readonly char[] s_r = new char[] { '\\', 'r' };
-        private static readonly char[] s_back = new char[] { '\\', '\\' };
-        private static readonly char[] s_doubleQuote = new char[] { '\\', '"' };
+        private static ReadOnlySpan<byte> s_b => new byte[] { (byte)'\\', (byte)'b' };
+        private static ReadOnlySpan<byte> s_t => new byte[] { (byte)'\\', (byte)'t' };
+        private static ReadOnlySpan<byte> s_n => new byte[] { (byte)'\\', (byte)'n' };
+        private static ReadOnlySpan<byte> s_f => new byte[] { (byte)'\\', (byte)'f' };
+        private static ReadOnlySpan<byte> s_r => new byte[] { (byte)'\\', (byte)'r' };
+        private static ReadOnlySpan<byte> s_back => new byte[] { (byte)'\\', (byte)'\\' };
+        private static ReadOnlySpan<byte> s_doubleQuote => new byte[] { (byte)'\\', (byte)'"' };
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -330,12 +330,13 @@ namespace System.Text.Encodings.Web
             // be written out as numeric entities for defense-in-depth.
             // See UnicodeEncoderBase ctor comments for more info.
 
+            Span<char> destination = new Span<char>(buffer, bufferLength);
             if (!WillEncode(unicodeScalar))
             {
-                return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten);
             }
 
-            char[] toCopy;
+            ReadOnlySpan<byte> toCopy;
             switch (unicodeScalar)
             {
                 case '\"':
@@ -362,7 +363,7 @@ namespace System.Text.Encodings.Web
                 default:
                     return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
-            return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
+            return TryCopyAsciiCharacters(toCopy, destination, out numberOfCharactersWritten);
         }
     }
 }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
@@ -301,13 +301,13 @@ namespace System.Text.Encodings.Web
         // surrogate pairs in the output.
         public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
 
-        private static ReadOnlySpan<byte> s_b => new byte[] { (byte)'\\', (byte)'b' };
-        private static ReadOnlySpan<byte> s_t => new byte[] { (byte)'\\', (byte)'t' };
-        private static ReadOnlySpan<byte> s_n => new byte[] { (byte)'\\', (byte)'n' };
-        private static ReadOnlySpan<byte> s_f => new byte[] { (byte)'\\', (byte)'f' };
-        private static ReadOnlySpan<byte> s_r => new byte[] { (byte)'\\', (byte)'r' };
-        private static ReadOnlySpan<byte> s_back => new byte[] { (byte)'\\', (byte)'\\' };
-        private static ReadOnlySpan<byte> s_doubleQuote => new byte[] { (byte)'\\', (byte)'"' };
+        private const string s_b = "\\b";
+        private const string s_t = "\\t";
+        private const string s_n = "\\n";
+        private const string s_f = "\\f";
+        private const string s_r = "\\r";
+        private const string s_back = "\\\\";
+        private const string s_doubleQuote = "\\\"";
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -336,7 +336,7 @@ namespace System.Text.Encodings.Web
                 return TryWriteScalarAsChar(unicodeScalar, destination, out numberOfCharactersWritten);
             }
 
-            ReadOnlySpan<byte> toCopy;
+            string toCopy;
             switch (unicodeScalar)
             {
                 case '\"':
@@ -363,7 +363,7 @@ namespace System.Text.Encodings.Web
                 default:
                     return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
-            return TryCopyAsciiCharacters(toCopy, destination, out numberOfCharactersWritten);
+            return TryCopyCharacters(toCopy, destination, out numberOfCharactersWritten);
         }
     }
 }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UrlEncoder.cs
@@ -161,7 +161,7 @@ namespace System.Text.Encodings.Web
                 throw new ArgumentNullException(nameof(buffer));
             }
 
-            if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
+            if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, new Span<char>(buffer, bufferLength), out numberOfCharactersWritten); }
 
             numberOfCharactersWritten = 0;
 


### PR DESCRIPTION
Also replace some unsafe code with Span.

Follow up from https://github.com/dotnet/runtime/pull/48172#issuecomment-777675790