### PR TITLE
Revert "Support marshalling of null SafeHandle."

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1241,8 +1241,7 @@ namespace System.StubHelpers
         {
             if (pHandle == null)
             {
-                success = false;
-                return IntPtr.Zero;
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pHandle, ExceptionResource.ArgumentNull_SafeHandle);
             }
 
             pHandle.DangerousAddRef(ref success);
@@ -1252,7 +1251,11 @@ namespace System.StubHelpers
         // Releases the SH (to be called from finally block).
         internal static void SafeHandleRelease(SafeHandle pHandle)
         {
-            Debug.Assert(pHandle != null);
+            if (pHandle == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pHandle, ExceptionResource.ArgumentNull_SafeHandle);
+            }
+
             pHandle.DangerousRelease();
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1742,19 +1742,7 @@ namespace Internal.TypeSystem.Interop
                 if (IsManagedByRef)
                     PropagateFromByRefArg(marshallingCodeStream, _managedHome);
 
-                // Boolean by-ref for DangerousAddRef().
                 var vAddRefed = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Boolean));
-                marshallingCodeStream.EmitLdc(0);
-                marshallingCodeStream.EmitStLoc(vAddRefed);
-
-                // Initialize native value to null.
-                marshallingCodeStream.EmitLdc(0);
-                marshallingCodeStream.Emit(ILOpcode.conv_i);
-                StoreNativeValue(marshallingCodeStream);
-
-                ILCodeLabel lHandleIsNull = emitter.NewCodeLabel();
-                LoadManagedValue(marshallingCodeStream);
-                marshallingCodeStream.Emit(ILOpcode.brfalse, lHandleIsNull);
                 LoadManagedValue(marshallingCodeStream);
                 marshallingCodeStream.EmitLdLoca(vAddRefed);
                 marshallingCodeStream.Emit(ILOpcode.call, emitter.NewToken(
@@ -1767,7 +1755,6 @@ namespace Internal.TypeSystem.Interop
                     safeHandleType.GetKnownMethod("DangerousGetHandle",
                         new MethodSignature(0, 0, Context.GetWellKnownType(WellKnownType.IntPtr), TypeDesc.EmptyTypes))));
                 StoreNativeValue(marshallingCodeStream);
-                marshallingCodeStream.EmitLabel(lHandleIsNull);
 
                 ILCodeLabel lNotAddrefed = emitter.NewCodeLabel();
                 cleanupCodeStream.EmitLdLoc(vAddRefed);

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.Export.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKeyRef.Export.cs
@@ -12,11 +12,13 @@ internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
+        private static readonly SafeCreateHandle s_nullExportString = new SafeCreateHandle();
+
         [DllImport(Libraries.AppleCryptoNative)]
         private static extern int AppleCryptoNative_SecKeyExport(
             SafeSecKeyRefHandle? key,
             int exportPrivate,
-            SafeCreateHandle? cfExportPassphrase,
+            SafeCreateHandle cfExportPassphrase,
             out SafeCFDataHandle cfDataOut,
             out int pOSStatus);
 
@@ -25,9 +27,9 @@ internal static partial class Interop
             bool exportPrivate,
             ReadOnlySpan<char> password)
         {
-            SafeCreateHandle? exportPassword = exportPrivate
+            SafeCreateHandle exportPassword = exportPrivate
                 ? CoreFoundation.CFStringCreateFromSpan(password)
-                : null;
+                : s_nullExportString;
 
             int ret;
             SafeCFDataHandle cfData;
@@ -44,7 +46,10 @@ internal static partial class Interop
             }
             finally
             {
-                exportPassword?.Dispose();
+                if (exportPassword != s_nullExportString)
+                {
+                    exportPassword.Dispose();
+                }
             }
 
             if (ret == 1)

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.TransmitFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.TransmitFile.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Mswsock, SetLastError = true)]
         internal static extern unsafe bool TransmitFile(
             SafeHandle socket,
-            SafeHandle? fileHandle,
+            IntPtr fileHandle,
             int numberOfBytesToWrite,
             int numberOfBytesPerSend,
             NativeOverlapped* overlapped,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -1052,9 +1052,27 @@ namespace System.Net.Sockets
                 transmitFileBuffers.TailLength = postBufferLength;
             }
 
-            return Interop.Mswsock.TransmitFile(
-                socket, fileHandle, 0, 0, overlapped,
-                needTransmitFileBuffers ? &transmitFileBuffers : null, flags);
+            bool releaseRef = false;
+            IntPtr fileHandlePtr = IntPtr.Zero;
+            try
+            {
+                if (fileHandle != null)
+                {
+                    fileHandle.DangerousAddRef(ref releaseRef);
+                    fileHandlePtr = fileHandle.DangerousGetHandle();
+                }
+
+                return Interop.Mswsock.TransmitFile(
+                    socket, fileHandlePtr, 0, 0, overlapped,
+                    needTransmitFileBuffers ? &transmitFileBuffers : null, flags);
+            }
+            finally
+            {
+                if (releaseRef)
+                {
+                    fileHandle!.DangerousRelease();
+                }
+            }
         }
 
         public static unsafe SocketError SendFileAsync(SafeSocketHandle handle, FileStream? fileStream, byte[]? preBuffer, byte[]? postBuffer, TransmitFileOptions flags, TransmitFileAsyncResult asyncResult)

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1585,6 +1585,9 @@
   <data name="ArgumentNull_Path" xml:space="preserve">
     <value>Path cannot be null.</value>
   </data>
+  <data name="ArgumentNull_SafeHandle" xml:space="preserve">
+    <value>SafeHandle cannot be null.</value>
+  </data>
   <data name="ArgumentNull_Stream" xml:space="preserve">
     <value>Stream cannot be null.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -831,6 +831,8 @@ namespace System
                     return SR.ArgumentException_OtherNotArrayOfCorrectLength;
                 case ExceptionResource.ArgumentNull_Array:
                     return SR.ArgumentNull_Array;
+                case ExceptionResource.ArgumentNull_SafeHandle:
+                    return SR.ArgumentNull_SafeHandle;
                 case ExceptionResource.ArgumentOutOfRange_EndIndexStartIndex:
                     return SR.ArgumentOutOfRange_EndIndexStartIndex;
                 case ExceptionResource.ArgumentOutOfRange_Enum:
@@ -1027,6 +1029,7 @@ namespace System
         Task_WaitMulti_NullTask,
         ArgumentException_OtherNotArrayOfCorrectLength,
         ArgumentNull_Array,
+        ArgumentNull_SafeHandle,
         ArgumentOutOfRange_EndIndexStartIndex,
         ArgumentOutOfRange_Enum,
         ArgumentOutOfRange_HugeArrayNotSupported,

--- a/src/tests/Interop/PInvoke/SafeHandles/SafeHandleTests.cs
+++ b/src/tests/Interop/PInvoke/SafeHandles/SafeHandleTests.cs
@@ -16,22 +16,13 @@ namespace SafeHandleTests
         {
             var testHandle = new TestSafeHandle(initialValue);
             Assert.IsTrue(SafeHandleNative.SafeHandleByValue(testHandle, initialValue));
-            Assert.IsTrue(SafeHandleNative.SafeHandleByValue(null, IntPtr.Zero));
 
             Assert.IsTrue(SafeHandleNative.SafeHandleByRef(ref testHandle, initialValue, newValue));
-            Assert.AreEqual(newValue, testHandle.DangerousGetHandle());
-
-            testHandle = null;
-            Assert.IsTrue(SafeHandleNative.SafeHandleByRef(ref testHandle, IntPtr.Zero, newValue));
             Assert.AreEqual(newValue, testHandle.DangerousGetHandle());
 
             AbstractDerivedSafeHandle abstrHandle = new AbstractDerivedSafeHandleImplementation(initialValue);
             Assert.IsTrue(SafeHandleNative.SafeHandleInByRef(abstrHandle, initialValue));
             Assert.Throws<MarshalDirectiveException>(() => SafeHandleNative.SafeHandleByRef(ref abstrHandle, initialValue, newValue));
-
-            abstrHandle = null;
-            Assert.IsTrue(SafeHandleNative.SafeHandleInByRef(abstrHandle, IntPtr.Zero));
-            Assert.AreEqual(null, abstrHandle);
 
             NoDefaultConstructorSafeHandle noDefaultCtorHandle = new NoDefaultConstructorSafeHandle(initialValue);
             Assert.Throws<MissingMethodException>(() => SafeHandleNative.SafeHandleByRef(ref noDefaultCtorHandle, initialValue, newValue));


### PR DESCRIPTION
Reverts dotnet/runtime#47944

Reasons for revert: https://github.com/dotnet/runtime/pull/47944#issuecomment-777804161 and https://github.com/dotnet/runtime/pull/47944#issuecomment-777720578

/cc @jkotas @stephentoub 