### PR TITLE
Duplicate productVersion.txt with repo-specific name (#48018)

### DIFF
--- a/src/installer/publish/prepare-artifacts.proj
+++ b/src/installer/publish/prepare-artifacts.proj
@@ -86,6 +86,13 @@
       Lines="$(ProductVersionTxtContents)"
       Overwrite="true"
       Encoding="ASCII" />
+
+    <!-- Generate runtime-productVersion.txt containing the value of $(PackageVersion) -->
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)runtime-productVersion.txt"
+      Lines="$(ProductVersionTxtContents)"
+      Overwrite="true"
+      Encoding="ASCII" />
       
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
@@ -109,6 +116,11 @@
 
       <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
         <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
+      </ItemsToPush>
+
+      <ItemsToPush Include="$(ArtifactsShippingPackagesDir)runtime-productVersion.txt">
+        <RelativeBlobPath>$(InstallersRelativePath)runtime-productVersion.txt</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
 


### PR DESCRIPTION
In our efforts to unify the build access story using aka.ms links, we have found that there are certain files that share the same name in multiple different repositories, most importantly, productVersion.txt. As part of the work to move to aka.ms links, we will be flattening the short link paths, so rather than having a runtime-specific, aspnetcore-specific, etc. full path to the files generated by each of the repos, they will all go to the same short link location. This means that the path to productVersion.txt will collide in the aka.ms links (the backing locations are not changing and will be unaffected). To combat this, we will add a duplicate of each of the product repos productVersion.txt, renamed to indicate which product repo it came from, in this case runtime-productVersion.txt. The original will remane so that we do not break existing scenarios that do not use the aka.ms links.