### PR TITLE
Add Fedora 35 RID

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/pkg/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/pkg/runtime.compatibility.json
@@ -2513,6 +2513,38 @@
     "any",
     "base"
   ],
+  "fedora.35": [
+    "fedora.35",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.35-arm64": [
+    "fedora.35-arm64",
+    "fedora.35",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.35-x64": [
+    "fedora.35-x64",
+    "fedora.35",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",

--- a/src/libraries/Microsoft.NETCore.Platforms/pkg/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/pkg/runtime.json
@@ -991,6 +991,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.35": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.35-arm64": {
+      "#import": [
+        "fedora.35",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.35-x64": {
+      "#import": [
+        "fedora.35",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"

--- a/src/libraries/Microsoft.NETCore.Platforms/pkg/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/pkg/runtimeGroups.props
@@ -66,7 +66,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31;32;33;34</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
Fedora rawhide now uses the fedora.35-x64 RID:

    $ podman run -it registry.fedoraproject.org/fedora:rawhide /bin/bash -c 'cat /etc/os-release'
    NAME=Fedora
    VERSION="35 (Container Image Prerelease)"
    ID=fedora
    VERSION_ID=35
    VERSION_CODENAME=""
    PLATFORM_ID="platform:f35"
    PRETTY_NAME="Fedora 35 (Container Image Prerelease)"
    ANSI_COLOR="0;38;2;60;110;180"
    LOGO=fedora-logo-icon
    CPE_NAME="cpe:/o:fedoraproject:fedora:35"
    HOME_URL="https://fedoraproject.org/"
    DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/"
    SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
    BUG_REPORT_URL="https://bugzilla.redhat.com/"
    REDHAT_BUGZILLA_PRODUCT="Fedora"
    REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide
    REDHAT_SUPPORT_PRODUCT="Fedora"
    REDHAT_SUPPORT_PRODUCT_VERSION=rawhide
    PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
    VARIANT="Container Image"
    VARIANT_ID=container