### PR TITLE
Only use ninja on Windows for Mono cross AOT compiler build

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -153,6 +153,28 @@ stages:
       buildConfig: release
       platforms:
       - Linux_x64
+      jobParameters:
+        buildArgs: -s mono+packs -c $(_BuildConfig)
+                   /p:MonoCrossAOTTargetOS=Android+Browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
+        nameSuffix: CrossAOT_Mono
+        runtimeVariant: crossaot
+        dependsOn:
+        - mono_android_offsets
+        - mono_browser_offsets
+        monoCrossAOTTargetOS:
+        - Android
+        - Browser
+        isOfficialBuild: ${{ variables.isOfficialBuild }}
+        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+        extraStepsParameters:
+          name: MonoRuntimePacks
+
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
       - Windows_x64
       jobParameters:
         buildArgs: -s mono+packs -c $(_BuildConfig)

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -8,7 +8,7 @@
     <OverridePackageId>Microsoft.NETCore.App.Runtime.AOT.$(RuntimeIdentifier).Cross.$(TargetCrossRid)</OverridePackageId>
     <ArchiveName>dotnet-monocrossaot</ArchiveName>
     <SharedFrameworkHostFileNameOverride>monocrossaot</SharedFrameworkHostFileNameOverride>
-    <RuntimeIdentifiers>linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;osx-x64;win-x64</RuntimeIdentifiers>
     <GenerateInstallers>false</GenerateInstallers>
     <PublishReadyToRun>false</PublishReadyToRun>
     <HostJsonTargetPath>tools/</HostJsonTargetPath>


### PR DESCRIPTION
Ninja isn't installed on the CentOS Linux Docker image we're using, this broke the official build. Caused by  https://github.com/dotnet/runtime/pull/47589.
