### PR TITLE
Make assertion show the actual flags in EmptyAiaResponseIsIgnored

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
@@ -37,7 +37,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 Assert.False(chain.Build(endEntity));
-                Assert.True(chain.AllStatusFlags().HasFlag(X509ChainStatusFlags.PartialChain), "expected partial chain");
+                X509ChainStatusFlags chainFlags = chain.AllStatusFlags();
+                Assert.True(chainFlags.HasFlag(X509ChainStatusFlags.PartialChain), $"expected partial chain flags, got {chainFlags}");
             }
         }
 


### PR DESCRIPTION
Contributes to #48223.

I can't get this to fail locally, but if it does again it would be helpful to know what the actual chain flags are so we can improve the test.