### PR TITLE
Inline platform package version

### DIFF
--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -11,9 +11,6 @@
     <!-- We're currently not building a "live" baseline, instead we're using .NETCore 1.0 RTM stable versions as the baseline -->
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
     <PackageVersion Condition="'$(PackageVersion)' == ''">6.0.0</PackageVersion>
-    <!-- major.minor.release version of the platforms package we're currently building
-         Pre-release will be appended during build -->
-    <PlatformPackageVersion>$(ProductVersion)</PlatformPackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>

--- a/src/libraries/Microsoft.NETCore.Platforms/pkg/Microsoft.NETCore.Platforms.pkgproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/pkg/Microsoft.NETCore.Platforms.pkgproj
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <PropertyGroup>
-    <PackageVersion>$(PlatformPackageVersion)</PackageVersion>
+    <PackageVersion>$(ProductVersion)</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>


### PR DESCRIPTION
The platform package version doesn't need to be defined centrally anymore.