### PR TITLE
Refactor lookup of dictionary key converters

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
@@ -17,6 +17,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteBooleanValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override bool ReadWithQuotes(ref Utf8JsonReader reader)
         {
             ReadOnlySpan<byte> propertyName = reader.GetSpan();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override byte ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetByteWithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
@@ -28,6 +28,8 @@ namespace System.Text.Json.Serialization.Converters
                 );
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override char ReadWithQuotes(ref Utf8JsonReader reader)
             => Read(ref reader, default!, default!);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
@@ -15,6 +15,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override DateTime ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetDateTimeNoValidation();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
@@ -15,6 +15,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override DateTimeOffset ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetDateTimeOffsetNoValidation();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override decimal ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetDecimalWithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override double ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetDoubleWithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -302,6 +302,8 @@ namespace System.Text.Json.Serialization.Converters
             return converted;
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override T ReadWithQuotes(ref Utf8JsonReader reader)
         {
             string? enumString = reader.GetString();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
@@ -15,6 +15,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override Guid ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetGuidNoValidation();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
@@ -21,6 +21,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override short ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetInt16WithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
@@ -21,6 +21,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override int ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetInt32WithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override long ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetInt64WithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Serialization.Converters
             throw new InvalidOperationException();
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override object ReadWithQuotes(ref Utf8JsonReader reader)
         {
             ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override sbyte ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetSByteWithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
@@ -21,6 +21,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override float ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetSingleWithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
@@ -23,6 +23,8 @@ namespace System.Text.Json.Serialization.Converters
             }
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override string ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetString()!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
@@ -21,6 +21,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override ushort ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetUInt16WithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
@@ -21,6 +21,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((ulong)value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override uint ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetUInt32WithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
+        internal override bool SupportsQuotedNumbers => true;
+
         internal override ulong ReadWithQuotes(ref Utf8JsonReader reader)
         {
             return reader.GetUInt64WithQuotes();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -33,6 +33,8 @@ namespace System.Text.Json.Serialization
 
         internal bool CanBePolymorphic { get; set; }
 
+        internal virtual bool SupportsQuotedNumbers => false;
+
         internal abstract JsonPropertyInfo CreateJsonPropertyInfo();
 
         internal abstract JsonParameterInfo CreateJsonParameterInfo();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -76,67 +76,13 @@ namespace System.Text.Json
 
         internal JsonConverter GetDictionaryKeyConverter(Type keyType)
         {
-            _dictionaryKeyConverters ??= GetDictionaryKeyConverters();
-
-            if (!_dictionaryKeyConverters.TryGetValue(keyType, out JsonConverter? converter))
+            JsonConverter converter = GetConverter(keyType);
+            if (!converter.SupportsQuotedNumbers)
             {
-                if (keyType.IsEnum)
-                {
-                    converter = GetEnumConverter();
-                    _dictionaryKeyConverters[keyType] = converter;
-                }
-                else
-                {
-                    ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(keyType);
-                }
+                ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(keyType);
             }
 
             return converter!;
-
-            // Use factory pattern to generate an EnumConverter with AllowStrings and AllowNumbers options for dictionary keys.
-            // There will be one converter created for each enum type.
-            JsonConverter GetEnumConverter()
-                => (JsonConverter)Activator.CreateInstance(
-                        typeof(EnumConverter<>).MakeGenericType(keyType),
-                        BindingFlags.Instance | BindingFlags.Public,
-                        binder: null,
-                        new object[] { EnumConverterOptions.AllowStrings | EnumConverterOptions.AllowNumbers, this },
-                        culture: null)!;
-        }
-
-        private ConcurrentDictionary<Type, JsonConverter>? _dictionaryKeyConverters;
-
-        private static ConcurrentDictionary<Type, JsonConverter> GetDictionaryKeyConverters()
-        {
-            const int NumberOfConverters = 18;
-            var converters = new ConcurrentDictionary<Type, JsonConverter>(Environment.ProcessorCount, NumberOfConverters);
-
-            // When adding to this, update NumberOfConverters above.
-            Add(s_defaultSimpleConverters[typeof(bool)]);
-            Add(s_defaultSimpleConverters[typeof(byte)]);
-            Add(s_defaultSimpleConverters[typeof(char)]);
-            Add(s_defaultSimpleConverters[typeof(DateTime)]);
-            Add(s_defaultSimpleConverters[typeof(DateTimeOffset)]);
-            Add(s_defaultSimpleConverters[typeof(double)]);
-            Add(s_defaultSimpleConverters[typeof(decimal)]);
-            Add(s_defaultSimpleConverters[typeof(Guid)]);
-            Add(s_defaultSimpleConverters[typeof(short)]);
-            Add(s_defaultSimpleConverters[typeof(int)]);
-            Add(s_defaultSimpleConverters[typeof(long)]);
-            Add(s_defaultSimpleConverters[typeof(object)]);
-            Add(s_defaultSimpleConverters[typeof(sbyte)]);
-            Add(s_defaultSimpleConverters[typeof(float)]);
-            Add(s_defaultSimpleConverters[typeof(string)]);
-            Add(s_defaultSimpleConverters[typeof(ushort)]);
-            Add(s_defaultSimpleConverters[typeof(uint)]);
-            Add(s_defaultSimpleConverters[typeof(ulong)]);
-
-            Debug.Assert(NumberOfConverters == converters.Count);
-
-            return converters;
-
-            void Add(JsonConverter converter) =>
-                converters[converter.TypeToConvert] = converter;
         }
 
         /// <summary>


### PR DESCRIPTION
Removed the separate cached dictionary to contain the converters that support number handling and replaced with a virtual method `SupportsQuotedNumbers` that returns true for the appropriate built-in converters.

This improves maintainbility especially for non-trivial converters like Enum and for other work that I'm prototyping. In the future, this would also be useful if we want to enable custom converters to add their own number handling.