### PR TITLE
Remove dead code

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -458,15 +458,7 @@ namespace System.Diagnostics.Tests
         public void TestUserCredentialsPropertiesOnWindows()
         {
             const string username = "testForDotnetRuntime";
-            string password;
-            using (RandomNumberGenerator rng = new RNGCryptoServiceProvider())
-            {
-                byte[] randomBytes = new byte[33];
-                rng.GetBytes(randomBytes);
-
-                // Add special chars to ensure it satisfies password requirements.
-               password = Convert.ToBase64String(randomBytes) + "_-As@!%*(1)4#2";
-           }
+            string password = Convert.ToBase64String(RandomNumberGenerator.GetBytes(33)) + "_-As@!%*(1)4#2";
 
             uint removalResult = Interop.NetUserDel(null, username);
             Assert.True(removalResult == Interop.ExitCodes.NERR_Success || removalResult == Interop.ExitCodes.NERR_UserNotFound);

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;
 using System.ComponentModel;
@@ -456,8 +457,16 @@ namespace System.Diagnostics.Tests
         [OuterLoop("Requires admin privileges")]
         public void TestUserCredentialsPropertiesOnWindows()
         {
-            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Unit test dummy credentials.")]
-            const string username = "testForDotnetRuntime", password = "PassWord123!!";
+            const string username = "testForDotnetRuntime";
+            string password;
+            using (RandomNumberGenerator rng = new RNGCryptoServiceProvider())
+            {
+                byte[] randomBytes = new byte[33];
+                rng.GetBytes(randomBytes);
+
+                // Add special chars to ensure it satisfies password requirements.
+               password = Convert.ToBase64String(randomBytes) + "_-As@!%*(1)4#2";
+           }
 
             uint removalResult = Interop.NetUserDel(null, username);
             Assert.True(removalResult == Interop.ExitCodes.NERR_Success || removalResult == Interop.ExitCodes.NERR_UserNotFound);

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2360,7 +2360,7 @@ namespace System.Diagnostics.Tests
         {
             string folderNameWithSpaces = "folder name with spaces"; // this needs escaping
             string fullPath = Path.Combine(TestDirectory, folderNameWithSpaces);
-            string[] arguments = new string[] { "/c", "mkdir", "-p", fullPath };
+            string[] arguments = new string[] { "/c", "mkdir", fullPath };
 
             if (Directory.Exists(fullPath))
             {

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalTest.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalTest.cs
@@ -15,9 +15,8 @@ namespace System.DirectoryServices.AccountManagement.Tests
 
         private void RefreshContext()
         {
-            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Unit test password.")]
-            string username = "Administrator", password = "Adrumble@6";
-
+            string username = "Administrator";
+            string password = Environment.GetEnvironmentVariable("TESTPASSWORD");
             string OU = "Tests";
             string baseDomain = WindowsIdentity.GetCurrent().Name.Split(new char[] { '\\' })[1] + "-TEST";
             string domain = $"{baseDomain}.nttest.microsoft.com";

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/UserPrincipalTest.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/UserPrincipalTest.cs
@@ -28,33 +28,5 @@ namespace System.DirectoryServices.AccountManagement.Tests
             UserPrincipal user = new UserPrincipal(DomainContext);
             user.Dispose();
         }
-
-        public void ComputedUACCheck()
-        {
-            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Unit test password.")]
-            string username = "Administrator", password = "Adrumble@6";
-            //TODO: don't assume it exists, create it if its not
-            string OU = "TestNull";
-            string baseDomain =WindowsIdentity.GetCurrent().Name.Split(new char[] { '\\' })[1] + "-TEST";
-            string domain = $"{baseDomain}.nttest.microsoft.com";
-            string container = $"ou={OU},dc={baseDomain},dc=nttest,dc=microsoft,dc=com";
-
-            PrincipalContext context = new PrincipalContext(ContextType.Domain, domain, container, username, password);
-            UserPrincipal user = UserPrincipal.FindByIdentity(context, IdentityType.SamAccountName, "good");
-
-            // set the wrong password to force account lockout
-            // Is there a way of doing it programmatically except for NetUserSetInfo? (managed code)
-            context.ValidateCredentials("good", "wrong password");
-
-            //verify that the account is locked out
-            Assert.True(user.IsAccountLockedOut(), "trying wrong credentials did not lock the account");
-
-            // if uac is not set correctly, this call might clear the lockout
-            user.SmartcardLogonRequired = false;
-            user.Save();
-
-            //verify that the account is still locked out
-            Assert.True(user.IsAccountLockedOut(), "the account is no longer locked out after writing setting SmartCardLogonRequired");
-        }
     }
 }


### PR DESCRIPTION
1. Remove dead creds from S.DS.AM. These were creds for some long gone local account on a long gone machine. This reduces credential scan noise.
2. Outerloop process tests create a temporary local account, when running elevated, then delete it. Change to a secure password. This also reduces credential scan noise.
3. Remove `-p` going to mkdir, apparently copied from Unix. Windows doesn't have this flag and it doesn't matter for the test.