### PR TITLE
Add typeforwards for Stack<T> and Queue<T> to mscorlib shim

### DIFF
--- a/src/libraries/shims/manual/mscorlib.forwards.cs
+++ b/src/libraries/shims/manual/mscorlib.forwards.cs
@@ -19,3 +19,6 @@
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.OrdinalComparer))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.UnitySerializationHolder))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Diagnostics.Contracts.ContractException))]
+// This is required for back-compatibility with legacy Xamarin which had Stack<T> and Queue<T> in mscorlib
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.Stack<>))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Collections.Generic.Queue<>))]


### PR DESCRIPTION
Old Xamarin implemented these types in mscorlib so we need to add typeforwarders for them.

Fixes https://github.com/dotnet/runtime/issues/48242