### PR TITLE
[POC] Add configure methods for configuring services built by generic host builder

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostBuilder.cs
@@ -38,6 +38,13 @@ namespace Microsoft.Extensions.Hosting
         IHostBuilder ConfigureAppConfiguration(Action<HostBuilderContext, IConfigurationBuilder> configureDelegate);
 
         /// <summary>
+        /// Configures services added to the container. This can be called multiple times and the results will be additive.
+        /// </summary>
+        /// <param name="configureDelegate">The delegate for configuring the <see cref="IServiceProvider"/>.</param>
+        /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
+        IHostBuilder Configure(Action<HostBuilderContext, IServiceProvider> configureDelegate);
+
+        /// <summary>
         /// Adds services to the container. This can be called multiple times and the results will be additive.
         /// </summary>
         /// <param name="configureDelegate">The delegate for configuring the <see cref="IServiceCollection"/> that will be used


### PR DESCRIPTION
For now seems there's no convenient way for **generic host** (For web host we can use `Startup.Configure`) to access built service provider **before** host is started.
One workaround to achieve this is to create an `IHostedService` class, consumes [IHostApplicationLifetime](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-5.0#ihostapplicationlifetime) service and register corresponding lifetime events.
Is there any possibility to provide an interface on `IHostBuilder` like what I implemeted in this PR so devs can achieve such goal in below way:

```cs
public static IHostBuilder CreateHostBuilder(string[] args)
    => Host.CreateDefaultBuilder(args)
    .Configure((context, serviceProvider) =>
    {
        // Do whatever they like to do with built service provider,
        // this callback will be called right after service provider
        // was built
    });
```