### PR TITLE
Use 'AsSpan' over 'Substring' in 'System.Private.DataContractSerialization'

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1550,7 +1550,7 @@ namespace System.Runtime.Serialization
                 if (endIndex < 0)
                 {
                     if (localName != null)
-                        localName.Append(typeName.Substring(startIndex));
+                        localName.Append(typeName.AsSpan(startIndex));
                     nestedParamCounts.Add(0);
                     break;
                 }


### PR DESCRIPTION
Fix violation found by the [Prefer 'AsSpan' over 'Substring'](https://github.com/dotnet/roslyn-analyzers/pull/4806) analyzer in `System.Private.DataContractSerialization` ([issue](https://github.com/dotnet/runtime/issues/33784)).