### PR TITLE
Use size_t for hostfxr info count members

### DIFF
--- a/src/native/corehost/hostfxr.h
+++ b/src/native/corehost/hostfxr.h
@@ -311,10 +311,10 @@ struct hostfxr_dotnet_environment_info
     const char_t* hostfxr_version;
     const char_t* hostfxr_commit_hash;
 
-    int32_t sdk_count;
+    size_t sdk_count;
     const hostfxr_dotnet_environment_sdk_info* sdks;
 
-    int32_t framework_count;
+    size_t framework_count;
     const hostfxr_dotnet_environment_framework_info* frameworks;
 };
 


### PR DESCRIPTION
Installer build with GCC failed:
```sh
  /runtime/src/native/corehost/fxr/hostfxr.cpp:456:35: error: narrowing conversion of 'environment_sdk_infos.std::vector<hostfxr_dotnet_environment_sdk_info>::size()' from 'std::vector<hostfxr_dotnet_environment_sdk_info>::size_type' {aka 'long unsigned int'} to 'int32_t' {aka 'int'} inside { } [-Werror=narrowing]
           environment_sdk_infos.size(),
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  /runtime/src/native/corehost/fxr/hostfxr.cpp:458:41: error: narrowing conversion of 'environment_framework_infos.std::vector<hostfxr_dotnet_environment_framework_info>::size()' from 'std::vector<hostfxr_dotnet_environment_framework_info>::size_type' {aka 'long unsigned int'} to 'int32_t' {aka 'int'} inside { } [-Werror=narrowing]
           environment_framework_infos.size(),
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

This PR fixes the build.