### PR TITLE
Use 'AsSpan' over 'Substring' in 'System.Private.Xml'

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -283,7 +283,7 @@ namespace System.Xml.Serialization
             {
                 if (separator >= 0)
                 {
-                    sb.Append(originalIdentifier.AsSpan(separator, 1));
+                    sb.Append(originalIdentifier[separator]);
                 }
                 separator++;
                 separator += names[i].Length;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -283,7 +283,7 @@ namespace System.Xml.Serialization
             {
                 if (separator >= 0)
                 {
-                    sb.Append(originalIdentifier.Substring(separator, 1));
+                    sb.Append(originalIdentifier.AsSpan(separator, 1));
                 }
                 separator++;
                 separator += names[i].Length;


### PR DESCRIPTION
Fix violation found by the [Prefer 'AsSpan' over 'Substring'](https://github.com/dotnet/roslyn-analyzers/pull/4806) analyzer in `System.Private.Xml` ([issue](https://github.com/dotnet/runtime/issues/33784)).