### PR TITLE
Add MCS verb to dump jit flags histogram

### DIFF
--- a/src/coreclr/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/coreclr/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MCS_SOURCES
     verbdumpmap.cpp
     verbdumptoc.cpp
     verbfracture.cpp
+    verbjitflags.cpp
     verbildump.cpp
     verbinteg.cpp
     verbmerge.cpp

--- a/src/coreclr/ToolBox/superpmi/mcs/commandline.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/commandline.cpp
@@ -130,6 +130,10 @@ void CommandLine::DumpHelp(const char* program)
     printf("     to the mch file.\n");
     printf("     e.g. '-toc a.mch' creates a.mch.mct\n");
     printf("\n");
+    printf(" -jitflags inputfile\n");
+    printf("     Summarize interesting jitflags for the method contexts\n");
+    printf("     e.g. '-jitflags a.mch'\n");
+    printf("\n");
     printf("Range descriptions are either a single number, or a text file with .mcl extension\n");
     printf("containing a sorted list of line delimited numbers.\n");
     printf("     e.g. -strip 2 a.mc b.mc\n");
@@ -234,6 +238,12 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                 tempLen          = strlen(argv[i]);
                 foundVerb        = true;
                 o->actionDumpToc = true;
+            }
+            else if ((_strnicmp(&argv[i][1], "jitflags", argLen) == 0))
+            {
+                tempLen           = strlen(argv[i]);
+                foundVerb         = true;
+                o->actionJitFlags = true;
             }
             else if ((_strnicmp(&argv[i][1], "ildump", argLen) == 0))
             {
@@ -546,6 +556,16 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         if (!foundFile1)
         {
             LogError("CommandLine::Parse() '-dumpToc' needs one input.");
+            DumpHelp(argv[0]);
+            return false;
+        }
+        return true;
+    }
+    if (o->actionJitFlags)
+    {
+        if (!foundFile1)
+        {
+            LogError("CommandLine::Parse() '-jitFlags' needs one input.");
             DumpHelp(argv[0]);
             return false;
         }

--- a/src/coreclr/ToolBox/superpmi/mcs/commandline.h
+++ b/src/coreclr/ToolBox/superpmi/mcs/commandline.h
@@ -23,6 +23,7 @@ public:
             , actionDumpMap(false)
             , actionDumpToc(false)
             , actionFracture(false)
+            , actionJitFlags(false)
             , actionILDump(false)
             , actionInteg(false)
             , actionMerge(false)
@@ -51,6 +52,7 @@ public:
         bool  actionDumpMap;
         bool  actionDumpToc;
         bool  actionFracture;
+        bool  actionJitFlags;
         bool  actionILDump;
         bool  actionInteg;
         bool  actionMerge;

--- a/src/coreclr/ToolBox/superpmi/mcs/mcs.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/mcs.cpp
@@ -12,6 +12,7 @@
 #include "verbfracture.h"
 #include "verbdumpmap.h"
 #include "verbdumptoc.h"
+#include "verbjitflags.h"
 #include "verbildump.h"
 #include "verbtoc.h"
 #include "verbremovedup.h"
@@ -101,6 +102,10 @@ int __cdecl main(int argc, char* argv[])
     if (o.actionPrintJITEEVersion)
     {
         exitCode = verbPrintJITEEVersion::DoWork();
+    }
+    if (o.actionJitFlags)
+    {
+        exitCode = verbJitFlags::DoWork(o.nameOfFile1);
     }
 
     Logger::Shutdown();

--- a/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.cpp
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.cpp
@@ -1,0 +1,111 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#include "standardpch.h"
+#include "verbjitflags.h"
+#include "methodcontext.h"
+#include "methodcontextiterator.h"
+#include "errorhandling.h"
+#include "corjitflags.h"
+
+int verbJitFlags::DoWork(const char* nameOfInput)
+{
+    MethodContextIterator mci;
+    if (!mci.Initialize(nameOfInput))
+        return -1;
+
+    LightWeightMap<unsigned long long, unsigned> flagMap;
+
+    while (mci.MoveNext())
+    {
+        MethodContext* mc = mci.Current();
+        CORJIT_FLAGS corJitFlags;
+        mc->repGetJitFlags(&corJitFlags, sizeof(corJitFlags));
+        unsigned long long rawFlags = corJitFlags.GetFlagsRaw();
+
+        int index = flagMap.GetIndex(rawFlags);
+        if (index == -1)
+        {
+            flagMap.Add(rawFlags, 1);
+        }
+        else
+        {
+            int oldVal = flagMap.GetItem(index);
+            flagMap.Update(index, oldVal + 1);
+        }
+    }
+
+    if (!mci.Destroy())
+        return -1;
+
+    printf("%16s,%8s, parsed\n", "bits", "count");
+
+    const unsigned int count = flagMap.GetCount();
+    unsigned long long* pFlag = flagMap.GetRawKeys();
+    for (unsigned int i = 0; i < count; i++)
+    {
+        const unsigned long long flag = *pFlag++;
+        const int index = flagMap.GetIndex(flag);
+
+        printf("%016llx,%8u", flag, flagMap.GetItem(index));
+
+        for (int flagBit = 63; flagBit >= 0; flagBit--)
+        {
+            if (((flag >> flagBit) & 1ull) == 1ull)
+            {
+                switch (flagBit)
+                {
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_SPEED_OPT: printf(", SPEED_OPT"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_SIZE_OPT: printf(", SIZE_OPT"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_DEBUG_CODE: printf(", DEBUG_CODE"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_DEBUG_EnC: printf(", DEBUG_EnC"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_DEBUG_INFO: printf(", DEBUG_INFO"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_MIN_OPT: printf(", MIN_OPT"); break;
+
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_MCJIT_BACKGROUND: printf(", MCJIT_BACKGROUND"); break;
+
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_OSR: printf(", OSR"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_ALT_JIT: printf(", ALT_JIT"); break;
+
+                    case 17: printf(", FEATURE_SIMD"); break;
+
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_MAKEFINALCODE: printf(", MAKEFINALCODE"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_READYTORUN: printf(", READYTORUN"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_PROF_ENTERLEAVE: printf(", PROF_ENTERLEAVE"); break;
+
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_PROF_NO_PINVOKE_INLINE: printf(", NO_PINVOKE_INLINE"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_SKIP_VERIFICATION: printf(", SKIP_VERIFICATION"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_PREJIT: printf(", PREJIT"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_RELOC: printf(", RELOC"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_IMPORT_ONLY: printf(", IMPORT_ONLY"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_IL_STUB: printf(", IL_STUB"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_PROCSPLIT: printf(", PROCSPLIT"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_BBINSTR: printf(", BBINSTR"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_BBOPT: printf(", BBOPT"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_FRAMED: printf(", FRAMED"); break;
+
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_PUBLISH_SECRET_PARAM: printf(", PUBLISH_SECRET_PARAM"); break;
+
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_SAMPLING_JIT_BACKGROUND: printf(", SAMPLING_JIT_BACKGROUND"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_USE_PINVOKE_HELPERS: printf(", USE_PINVOKE_HELPERS"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_REVERSE_PINVOKE: printf(", REVERSE_PINVOKE"); break;                    
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_TRACK_TRANSITIONS: printf(", TRACK_TRANSITIONS"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_TIER0: printf(", TIER0"); break;
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_TIER1: printf(", TIER1"); break;
+
+                    case CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_NO_INLINING: printf(", NO_INLINING"); break;
+                    default:
+                        printf(", ?_%02u_?", flagBit);
+                        break;
+                }
+            }
+        }
+
+        printf("\n");
+    }
+
+    return 0;
+}
+

--- a/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.h
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.h
@@ -1,0 +1,18 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// verbJitFlags.h - verb that prints sumary of jit flags values
+//----------------------------------------------------------
+#ifndef _verbJitFlags
+#define _verbJitFlags
+
+class verbJitFlags
+{
+public:
+    static int DoWork(const char* nameOfInput);
+};
+
+#endif

--- a/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.h
+++ b/src/coreclr/ToolBox/superpmi/mcs/verbjitflags.h
@@ -4,7 +4,7 @@
 //
 
 //----------------------------------------------------------
-// verbJitFlags.h - verb that prints sumary of jit flags values
+// verbJitFlags.h - verb that prints summary of jit flags values
 //----------------------------------------------------------
 #ifndef _verbJitFlags
 #define _verbJitFlags

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -206,3 +206,91 @@ std::string SpmiDumpHelper::DumpCorInfoFlag(CorInfoFlag flags)
 
     return s;
 }
+
+std::string SpmiDumpHelper::DumpJitFlags(CORJIT_FLAGS corJitFlags)
+{
+    return DumpJitFlags(corJitFlags.GetFlagsRaw());
+}
+
+std::string SpmiDumpHelper::DumpJitFlags(unsigned long long flags)
+{
+    std::string s("");
+
+#define AddFlag(__name)\
+    if (flags & (1ull << CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_ ## __name)) { \
+       s += std::string(" ") + std::string(#__name); \
+       flags &= ~(1ull << CORJIT_FLAGS::CorJitFlag::CORJIT_FLAG_ ## __name); }
+
+    // Note some flags are target dependent, but we want to
+    // be target-agnostic. So we use numbers for the few
+    // flags that are not universally defined.
+
+#define AddFlagNumeric(__name, __val)\
+    if (flags & (1ull << __val)) { \
+       s += std::string(" ") + std::string(#__name); \
+       flags &= ~(1ull <<__val); }
+
+    AddFlag(SPEED_OPT);
+    AddFlag(SIZE_OPT);
+    AddFlag(DEBUG_CODE);
+    AddFlag(DEBUG_EnC);
+    AddFlag(DEBUG_INFO);
+    AddFlag(MIN_OPT);
+
+    AddFlag(MCJIT_BACKGROUND);
+
+    // x86 only
+    //
+    AddFlagNumeric(PINVOKE_RESTORE_ESP, 8);
+    AddFlagNumeric(TARGET_P4, 9);
+    AddFlagNumeric(USE_FCOMI, 10);
+    AddFlagNumeric(USE_CMOV, 11);
+
+    AddFlag(OSR);
+    AddFlag(ALT_JIT);
+
+    AddFlagNumeric(FEATURE_SIMD, 17);
+
+    AddFlag(MAKEFINALCODE);
+    AddFlag(READYTORUN);
+    AddFlag(PROF_ENTERLEAVE);
+
+    AddFlag(PROF_NO_PINVOKE_INLINE);
+    AddFlag(SKIP_VERIFICATION);
+    AddFlag(PREJIT);
+    AddFlag(RELOC);
+    AddFlag(IMPORT_ONLY);
+    AddFlag(IL_STUB);
+    AddFlag(PROCSPLIT);
+    AddFlag(BBINSTR);
+    AddFlag(BBOPT);
+    AddFlag(FRAMED);
+
+    AddFlag(PUBLISH_SECRET_PARAM);
+
+    AddFlag(SAMPLING_JIT_BACKGROUND);
+    AddFlag(USE_PINVOKE_HELPERS);
+    AddFlag(REVERSE_PINVOKE);
+    AddFlag(TRACK_TRANSITIONS);
+    AddFlag(TIER0);
+    AddFlag(TIER1);
+
+    // arm32 only
+    //
+    AddFlagNumeric(RELATIVE_CODE_RELOCS, 41);
+
+    AddFlag(NO_INLINING);
+
+#undef AddFlag
+#undef AddFlagNumeric
+
+    if (flags != 0)
+    {
+        char buffer[MAX_BUFFER_SIZE];
+        sprintf_s(buffer, MAX_BUFFER_SIZE, " Unknown jit flags-%016llX", flags);
+        s += std::string(buffer);
+    }
+
+    return s;
+}
+

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
@@ -49,6 +49,9 @@ public:
 
     static std::string DumpCorInfoFlag(CorInfoFlag flags);
 
+    static std::string DumpJitFlags(CORJIT_FLAGS corJitFlags);
+    static std::string DumpJitFlags(unsigned long long rawFlags);
+
 private:
 
     static void FormatAgnostic_CORINFO_SIG_INST_Element(


### PR DESCRIPTION
Useful for determining what sorts of jit compilations are found in an SPMI
collection.