### PR TITLE
Special-case Enumerable.SequenceEqual for byte[]

### DIFF
--- a/src/libraries/System.Linq/tests/SequenceEqualTests.cs
+++ b/src/libraries/System.Linq/tests/SequenceEqualTests.cs
@@ -214,5 +214,37 @@ namespace System.Linq.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("second", () => first.SequenceEqual(second));
         }
+
+        [Fact]
+        public void ByteArrays_SpecialCasedButExpectedBehavior()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("first", () => ((byte[])null).SequenceEqual(new byte[1]));
+            AssertExtensions.Throws<ArgumentNullException>("second", () => new byte[1].SequenceEqual(null));
+
+            Assert.False(new byte[1].SequenceEqual(new byte[0]));
+            Assert.False(new byte[0].SequenceEqual(new byte[1]));
+
+            var r = new Random();
+            for (int i = 0; i < 32; i++)
+            {
+                byte[] arr = new byte[i];
+                r.NextBytes(arr);
+
+                byte[] same = (byte[])arr.Clone();
+                Assert.True(arr.SequenceEqual(same));
+                Assert.True(same.SequenceEqual(arr));
+                Assert.True(same.SequenceEqual(arr.ToList()));
+                Assert.True(same.ToList().SequenceEqual(arr));
+                Assert.True(same.ToList().SequenceEqual(arr.ToList()));
+
+                if (i > 0)
+                {
+                    byte[] diff = (byte[])arr.Clone();
+                    diff[^1]++;
+                    Assert.False(arr.SequenceEqual(diff));
+                    Assert.False(diff.SequenceEqual(arr));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
```C#
[Params(1, 100, 1_000_000)]
public int Count { get; set; }

private byte[] _arr1, _arr2;

[GlobalSetup]
public void Setup()
{
    _arr1 = RandomNumberGenerator.GetBytes(Count);
    _arr2 = (byte[])_arr1.Clone();
}

[Benchmark]
public bool SequenceEquals() => _arr1.SequenceEqual(_arr2);
```

|         Method |           Toolchain |   Count |             Mean | Ratio |
|--------------- |-------------------- |-------- |-----------------:|------:|
| SequenceEquals | \master\corerun.exe |       1 |        44.769 ns |  1.00 |
| SequenceEquals |     \pr\corerun.exe |       1 |         7.577 ns |  0.17 |
|                |                     |         |                  |       |
| SequenceEquals | \master\corerun.exe |     100 |       622.219 ns |  1.00 |
| SequenceEquals |     \pr\corerun.exe |     100 |         9.766 ns |  0.02 |
|                |                     |         |                  |       |
| SequenceEquals | \master\corerun.exe | 1000000 | 5,882,686.440 ns | 1.000 |
| SequenceEquals |     \pr\corerun.exe | 1000000 |    32,118.099 ns | 0.005 |