### PR TITLE
Trim assembly level attributes which are not useful and can contain 

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
@@ -65,6 +65,29 @@
     </type>
 
     <!-- System.Runtime.CompilerServices -->
+    <type fullname="System.Reflection.AssemblyCompanyAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Reflection.AssemblyConfigurationAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Reflection.AssemblyCopyrightAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Reflection.AssemblyDefaultAliasAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Reflection.AssemblyDescriptionAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Reflection.AssemblyProductAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Reflection.AssemblyTitleAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+
+    <!-- System.Runtime.CompilerServices -->
     <type fullname="System.Runtime.CompilerServices.AsyncMethodBuilderAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>


### PR DESCRIPTION
very long string value