### PR TITLE
Simplify PriorityQueue enumerator, and fix tuple element names

### DIFF
--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -383,8 +383,8 @@ namespace System.Collections.Generic
     {
         public PriorityQueue() { }
         public PriorityQueue(System.Collections.Generic.IComparer<TPriority>? comparer) { }
-        public PriorityQueue(System.Collections.Generic.IEnumerable<(TElement element, TPriority priority)> items) { }
-        public PriorityQueue(System.Collections.Generic.IEnumerable<(TElement element, TPriority priority)> items, System.Collections.Generic.IComparer<TPriority>? comparer) { }
+        public PriorityQueue(System.Collections.Generic.IEnumerable<(TElement Element, TPriority Priority)> items) { }
+        public PriorityQueue(System.Collections.Generic.IEnumerable<(TElement Element, TPriority Priority)> items, System.Collections.Generic.IComparer<TPriority>? comparer) { }
         public PriorityQueue(int initialCapacity) { }
         public PriorityQueue(int initialCapacity, System.Collections.Generic.IComparer<TPriority>? comparer) { }
         public System.Collections.Generic.IComparer<TPriority> Comparer { get { throw null; } }
@@ -394,14 +394,14 @@ namespace System.Collections.Generic
         public TElement Dequeue() { throw null; }
         public void Enqueue(TElement element, TPriority priority) { }
         public TElement EnqueueDequeue(TElement element, TPriority priority) { throw null; }
-        public void EnqueueRange(System.Collections.Generic.IEnumerable<(TElement element, TPriority priority)> items) { }
+        public void EnqueueRange(System.Collections.Generic.IEnumerable<(TElement Element, TPriority Priority)> items) { }
         public void EnqueueRange(System.Collections.Generic.IEnumerable<TElement> elements, TPriority priority) { }
         public int EnsureCapacity(int capacity) { throw null; }
         public TElement Peek() { throw null; }
         public void TrimExcess() { }
         public bool TryDequeue([System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TElement element, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TPriority priority) { throw null; }
         public bool TryPeek([System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TElement element, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TPriority priority) { throw null; }
-        public sealed partial class UnorderedItemsCollection : System.Collections.Generic.IEnumerable<(TElement element, TPriority priority)>, System.Collections.Generic.IReadOnlyCollection<(TElement element, TPriority priority)>, System.Collections.ICollection, System.Collections.IEnumerable
+        public sealed partial class UnorderedItemsCollection : System.Collections.Generic.IEnumerable<(TElement Element, TPriority Priority)>, System.Collections.Generic.IReadOnlyCollection<(TElement Element, TPriority Priority)>, System.Collections.ICollection, System.Collections.IEnumerable
         {
             internal UnorderedItemsCollection(PriorityQueue<TElement, TPriority> queue) { }
             public int Count { get { throw null; } }
@@ -409,14 +409,14 @@ namespace System.Collections.Generic
             object System.Collections.ICollection.SyncRoot { get { throw null; } }
             void ICollection.CopyTo(System.Array array, int index) { }
             public System.Collections.Generic.PriorityQueue<TElement, TPriority>.UnorderedItemsCollection.Enumerator GetEnumerator() { throw null; }
-            System.Collections.Generic.IEnumerator<(TElement element, TPriority priority)> System.Collections.Generic.IEnumerable<(TElement element, TPriority priority)>.GetEnumerator() { throw null; }
+            System.Collections.Generic.IEnumerator<(TElement Element, TPriority Priority)> System.Collections.Generic.IEnumerable<(TElement Element, TPriority Priority)>.GetEnumerator() { throw null; }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<(TElement element, TPriority priority)>, System.Collections.IEnumerator, System.IDisposable
+            public partial struct Enumerator : System.Collections.Generic.IEnumerator<(TElement Element, TPriority Priority)>, System.Collections.IEnumerator, System.IDisposable
             {
-                (TElement element, TPriority priority) IEnumerator<(TElement element, TPriority priority)>.Current { get { throw null; } }
+                (TElement Element, TPriority Priority) IEnumerator<(TElement Element, TPriority Priority)>.Current { get { throw null; } }
                 public void Dispose() { }
                 public bool MoveNext() { throw null; }
-                public (TElement element, TPriority priority) Current { get { throw null; } }
+                public (TElement Element, TPriority Priority) Current { get { throw null; } }
                 object System.Collections.IEnumerator.Current { get { throw null; } }
                 void System.Collections.IEnumerator.Reset() { }
             }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -99,7 +99,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Creates a priority queue populated with the specified elements and priorities.
         /// </summary>
-        public PriorityQueue(IEnumerable<(TElement element, TPriority priority)> items)
+        public PriorityQueue(IEnumerable<(TElement Element, TPriority Priority)> items)
             : this(items, comparer: null)
         {
         }
@@ -108,7 +108,7 @@ namespace System.Collections.Generic
         /// Creates a priority queue populated with the specified elements and priorities,
         /// and with the specified priority comparer.
         /// </summary>
-        public PriorityQueue(IEnumerable<(TElement element, TPriority priority)> items, IComparer<TPriority>? comparer)
+        public PriorityQueue(IEnumerable<(TElement Element, TPriority Priority)> items, IComparer<TPriority>? comparer)
         {
             if (items is null)
             {
@@ -480,7 +480,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Moves a node up in the tree to restore heap order.
         /// </summary>
-        private void MoveUp((TElement element, TPriority priority) node, int nodeIndex)
+        private void MoveUp((TElement Element, TPriority Priority) node, int nodeIndex)
         {
             // Instead of swapping items all the way to the root, we will perform
             // a similar optimization as in the insertion sort.
@@ -490,7 +490,7 @@ namespace System.Collections.Generic
                 int parentIndex = GetParentIndex(nodeIndex);
                 (TElement Element, TPriority Priority) parent = _nodes[parentIndex];
 
-                if (Comparer.Compare(node.priority, parent.Priority) < 0)
+                if (Comparer.Compare(node.Priority, parent.Priority) < 0)
                 {
                     _nodes[nodeIndex] = parent;
                     nodeIndex = parentIndex;
@@ -507,7 +507,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Moves a node down in the tree to restore heap order.
         /// </summary>
-        private void MoveDown((TElement element, TPriority priority) node, int nodeIndex)
+        private void MoveDown((TElement Element, TPriority Priority) node, int nodeIndex)
         {
             // The node to move down will not actually be swapped every time.
             // Rather, values on the affected path will be moved up, thus leaving a free spot
@@ -534,7 +534,7 @@ namespace System.Collections.Generic
 
                 // In case no child needs to be extracted earlier than the current node,
                 // there is nothing more to do - the right spot was found.
-                if (Comparer.Compare(node.priority, topChild.Priority) <= 0)
+                if (Comparer.Compare(node.Priority, topChild.Priority) <= 0)
                 {
                     break;
                 }
@@ -548,7 +548,7 @@ namespace System.Collections.Generic
             _nodes[nodeIndex] = node;
         }
 
-        public sealed class UnorderedItemsCollection : IReadOnlyCollection<(TElement element, TPriority priority)>, ICollection
+        public sealed class UnorderedItemsCollection : IReadOnlyCollection<(TElement Element, TPriority Priority)>, ICollection
         {
             private readonly PriorityQueue<TElement, TPriority> _queue;
 
@@ -598,97 +598,54 @@ namespace System.Collections.Generic
                 }
             }
 
-            public struct Enumerator : IEnumerator<(TElement element, TPriority priority)>
+            public struct Enumerator : IEnumerator<(TElement Element, TPriority Priority)>
             {
                 private readonly PriorityQueue<TElement, TPriority> _queue;
                 private readonly int _version;
-
                 private int _index;
-                private (TElement element, TPriority priority)? _currentElement;
-
-                private const int FirstCallToEnumerator = -2;
-                private const int EndOfEnumeration = -1;
+                private (TElement, TPriority) _current;
 
                 internal Enumerator(PriorityQueue<TElement, TPriority> queue)
                 {
                     _queue = queue;
+                    _index = 0;
                     _version = queue._version;
-                    _index = FirstCallToEnumerator;
-                    _currentElement = default;
+                    _current = default;
                 }
 
-                public void Dispose()
-                {
-                    _index = EndOfEnumeration;
-                }
+                public void Dispose() { }
 
                 public bool MoveNext()
+                {
+                    PriorityQueue<TElement, TPriority> localQueue = _queue;
+
+                    if (_version == localQueue._version && ((uint)_index < (uint)localQueue._size))
+                    {
+                        _current = localQueue._nodes[_index];
+                        _index++;
+                        return true;
+                    }
+
+                    return MoveNextRare();
+                }
+
+                private bool MoveNextRare()
                 {
                     if (_version != _queue._version)
                     {
                         throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
                     }
 
-                    if (_index == FirstCallToEnumerator)
-                    {
-                        if (_queue._size > 0)
-                        {
-                            _index = 0;
-                            _currentElement = _queue._nodes[_index];
-                            return true;
-                        }
-                        else
-                        {
-                            _index = EndOfEnumeration;
-                            return false;
-                        }
-                    }
-
-                    if (_index == EndOfEnumeration)
-                    {
-                        return false;
-                    }
-
-                    // advance enumerator
-                    _index++;
-
-                    if (_index < _queue._size)
-                    {
-                        _currentElement = _queue._nodes[_index];
-                        return true;
-                    }
-                    else
-                    {
-                        _index = EndOfEnumeration;
-                        _currentElement = default;
-                        return false;
-                    }
+                    _index = _queue._size + 1;
+                    _current = default;
+                    return false;
                 }
 
-                public (TElement element, TPriority priority) Current
-                {
-                    get
-                    {
-                        if (_index < 0)
-                        {
-                            ThrowEnumerationNotStartedOrEnded();
-                        }
-                        return _currentElement!.Value;
-                    }
-                }
+                public (TElement Element, TPriority Priority) Current => _current;
 
-                private void ThrowEnumerationNotStartedOrEnded()
-                {
-                    Debug.Assert(_index == FirstCallToEnumerator || _index == EndOfEnumeration);
-
-                    string message = _index == FirstCallToEnumerator
-                        ? SR.InvalidOperation_EnumNotStarted
-                        : SR.InvalidOperation_EnumEnded;
-
-                    throw new InvalidOperationException(message);
-                }
-
-                object IEnumerator.Current => Current;
+                object IEnumerator.Current =>
+                    _index == 0 || _index == _queue._size + 1 ? throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen) :
+                    Current;
 
                 void IEnumerator.Reset()
                 {
@@ -697,19 +654,16 @@ namespace System.Collections.Generic
                         throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
                     }
 
-                    _index = FirstCallToEnumerator;
-                    _currentElement = default;
+                    _index = 0;
+                    _current = default;
                 }
             }
 
-            public Enumerator GetEnumerator()
-                => new Enumerator(_queue);
+            public Enumerator GetEnumerator() => new Enumerator(_queue);
 
-            IEnumerator<(TElement element, TPriority priority)> IEnumerable<(TElement element, TPriority priority)>.GetEnumerator()
-                => GetEnumerator();
+            IEnumerator<(TElement Element, TPriority Priority)> IEnumerable<(TElement Element, TPriority Priority)>.GetEnumerator() => GetEnumerator();
 
-            IEnumerator IEnumerable.GetEnumerator()
-                => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
- Rewritten to match `List<T>.Enumerator` line for line
- Tuples, according to our guidelines, use PascalCased element names

cc: @eiriktsarpalis 