### PR TITLE
Multicorejit unification

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -370,6 +370,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TrackDynamicMethodDebugInfo, W("TrackDynami
 
 RETAIL_CONFIG_STRING_INFO(INTERNAL_MultiCoreJitProfile, W("MultiCoreJitProfile"), "If set, use the file to store/control multi-core JIT.")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_MultiCoreJitProfileWriteDelay, W("MultiCoreJitProfileWriteDelay"), 12, "Set the delay after which the multi-core JIT profile will be written to disk.")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_MultiCoreJitMinNumCpus, W("MultiCoreJitMinNumCpus"), 2, "Minimum number of cpus that must be present to allow MultiCoreJit usage.")
 
 #endif
 

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -435,13 +435,7 @@ HRESULT MulticoreJitRecorder::WriteOutput(IStream * pStream)
         }
 
         memcpy(pSignature, pBlob, dwLength);
-
-        if (!m_JitInfoArray[i].PackSignatureForMethod(pSignature, dwLength))
-        {
-            _ASSERTE(m_JitInfoArray[i].GetRawMethodData2() == 0);
-            _ASSERTE(m_JitInfoArray[i].GetRawMethodSignature() == nullptr);
-            delete[] pSignature;
-        }
+        m_JitInfoArray[i].PackSignatureForMethod(pSignature, dwLength);
     }
 
     {
@@ -502,7 +496,7 @@ HRESULT MulticoreJitRecorder::WriteOutput(IStream * pStream)
         {
             // Method record
             DWORD data1 = m_JitInfoArray[i].GetRawMethodData1();
-            DWORD data2 = m_JitInfoArray[i].GetRawMethodData2();
+            unsigned short data2 = m_JitInfoArray[i].GetRawMethodData2();
             BYTE * pSignature = m_JitInfoArray[i].GetRawMethodSignature();
 
             if (pSignature == nullptr)

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -1459,7 +1459,8 @@ bool MulticoreJitManager::IsMethodSupported(MethodDesc * pMethod)
     }
     CONTRACTL_END;
 
-    return !pMethod->IsDynamicMethod() &&
+    return pMethod->HasILHeader() &&
+           !pMethod->IsDynamicMethod() &&
            !pMethod->GetLoaderAllocator()->IsCollectible();
 }
 

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -387,14 +387,10 @@ HRESULT MulticoreJitRecorder::WriteOutput(IStream * pStream)
     HRESULT hr = S_OK;
 
     // Preprocessing Methods
-    // - Add ModuleDependency to JITInfo
-    // - Increment MethodCount in Module
     LONG skipped = 0;
 
     for (LONG i = 0 ; i < m_JitInfoCount; i++)
     {
-        SigBuilder sigBuilder;
-
         if (m_JitInfoArray[i].IsModuleInfo())
         {
             // Module records don't need preprocessing
@@ -405,6 +401,8 @@ HRESULT MulticoreJitRecorder::WriteOutput(IStream * pStream)
 
         if (m_JitInfoArray[i].IsGenericMethodInfo())
         {
+            SigBuilder sigBuilder;
+
             BOOL fSuccess = false;
             EX_TRY
             {

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -1139,7 +1139,9 @@ void MulticoreJitManager::SetProfileRoot(const WCHAR * pProfilePath)
 
 #endif
 
-    if (g_SystemInfo.dwNumberOfProcessors >= 2)
+    unsigned minNumCpus = (unsigned)CLRConfig::GetConfigValue(CLRConfig::INTERNAL_MultiCoreJitMinNumCpus);
+
+    if (g_SystemInfo.dwNumberOfProcessors >= minNumCpus)
     {
         if (InterlockedCompareExchange(& m_fSetProfileRootCalled, SETPROFILEROOTCALLED, 0) == 0) // Only allow the first call per appdomain
         {
@@ -1169,8 +1171,8 @@ void MulticoreJitManager::StartProfile(AppDomain * pDomain, ICLRPrivBinder *pBin
         return;
     }
 
-    // Need extra processor for multicore JIT feature
-    _ASSERTE(g_SystemInfo.dwNumberOfProcessors >= 2);
+    // Check if need extra processor for multicore JIT feature
+    _ASSERTE(g_SystemInfo.dwNumberOfProcessors >= (unsigned)CLRConfig::GetConfigValue(CLRConfig::INTERNAL_MultiCoreJitMinNumCpus));
 
 #ifdef PROFILING_SUPPORTED
 

--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -20,49 +20,39 @@
 
 #endif
 
-// Make sure a record can fit within 2048 bytes, 511 methods now
+// Bits 0xff0000 are reserved method flags. Currently only first bit is used.
+const unsigned METHOD_FLAGS_MASK       = 0xff0000;
+const unsigned JIT_BY_APP_THREAD_TAG   = 0x10000;   // tag, that indicates whether method is jitted by application thread(1) or background thread(0)
+// Tags 0xfe0000 are currently free
 
-const int      MAX_RECORD_SIZE   = 2048;
-const unsigned MAX_JIT_COUNT     = (MAX_RECORD_SIZE - sizeof(unsigned)) / sizeof(unsigned);
+const unsigned RECORD_TYPE_OFFSET      = 24;        // offset of type of record
+
+const unsigned MAX_MODULES             = 0x10000;   // maximum allowed number of modules (2^16 values)
+
+const unsigned MODULE_LEVEL_OFFSET     = 16;        // offset of module load level
+const unsigned MAX_MODULE_LEVELS       = 0x100;     // maximum allowed number of module levels (2^8 values)
+
+const unsigned MAX_METHODS             = 0x4000;    // Maximum allowed number of methods (2^14 values) (in principle this is also limited by "unsigned short" counters)
+
+const unsigned SIGNATURE_LENGTH_OFFSET = 16;        // offset of signature length
+const unsigned MAX_SIGNATURE_LENGTH    = 0x10000;   // maximum allowed signature length (2^16 values)
 
 const int      HEADER_W_COUNTER  = 14;              // Extra 16-bit counters in header for statistics: 28
 const int      HEADER_D_COUNTER  = 3;               // Extra 32-bit counters in header for statistics: 12
-const unsigned MAX_MODULES       = 512;             // Maximum number of modules
-
-const unsigned MAX_METHOD_ARRAY  = 16384;           // Maximum number of methods
 
 const int      MULTICOREJITLIFE  = 60 * 1000;       // 60 seconds
-
-const int      MULTICOREJITBLOCKLIMIT = 10 * 1000;  // 10 seconds
-
-const unsigned MAX_GENERIC_ARRAY  = 16384;          // Maximum number of generics
-                                                    //  8-bit module index
-
-                                                    // Method JIT information: 8-bit module 4-bit flag 20-bit method index
-const unsigned MODULE_DEPENDENCY = 0x800000;        //  1-bit module dependency mask
-const unsigned JIT_BY_APP_THREAD = 0x400000;        //  1-bit application thread
-
-const unsigned METHODINDEX_MASK  = 0x0FFFFF;        // 20-bit method index
-
-                                                    // Dependendy information: 8-bit module 4-bit flag 4-bit unused 8-bit level 8-bit module
-const unsigned LEVEL_SHIFT       = 8;
-const unsigned LEVEL_MASK        = 0xFF;            //  8-bit file load level
-const unsigned MODULE_MASK       = 0xFF;            //  8-bit dependent module index
-
 const int      MAX_WALKBACK      = 128;
-
-const unsigned SIGNATURELENGTH_MASK  = 0x0FFFFFF;        // 24-bit signature length
 
 enum
 {
-    MULTICOREJIT_PROFILE_VERSION   = 101,
+    MULTICOREJIT_PROFILE_VERSION   = 102,
 
+    // These should be powers of 2 in order to implement fast check for rec type
     MULTICOREJIT_HEADER_RECORD_ID          = 1,
     MULTICOREJIT_MODULE_RECORD_ID          = 2,
-    MULTICOREJIT_JITINF_RECORD_ID          = 3,
-    MULTICOREJIT_GENERICINF_RECORD_ID      = 4
+    MULTICOREJIT_MODULEINF_RECORD_ID       = 4,
+    MULTICOREJIT_METHODINF_RECORD_ID       = 8
 };
-
 
 inline unsigned Pack8_24(unsigned up, unsigned low)
 {
@@ -71,33 +61,63 @@ inline unsigned Pack8_24(unsigned up, unsigned low)
     return (up << 24) + low;
 }
 
-// Multicore JIT profile format
-
+// Multicore JIT profile format.
+//
 // <profile>::= <HeaderRecord> { <ModuleRecord> | <JitInfRecord> }
 //
 //  1. Each record is DWORD aligned
-//  2. Each record starts with a DWORD <recordID> with Pack8_24(record type, record size)
+//  2. Each record starts with a DWORD with tag in higher 8 bits
 //  3. Counter are just statistical information gathed (mainly during play back), good for quick diagnosis, not used to guide playback
-//  4  Maximum number of modules supported is 256
-//  5  Simple module name stored
-//  6  Maximum method index: 20-bit, could extend to 22 bits
-//  7  JIT_BY_APP_THREAD is for diagnosis only
-
+//  4. Maximum number of modules supported is MAX_MODULES
+//  5. Maximum number of methods supported is MAX_METHODS
+//  5. Simple module name stored
+//  7. Method flag JIT_BY_APP_THREAD is for diagnosis only
+//
 // <HeaderRecord>::= <recordID> <version> <timeStamp> <moduleCount> <methodCount> <DependencyCount> <unsigned short counter>*14 <unsigned counter>*3
 // <ModuleRecord>::= <recordID> <ModuleVersion> <JitMethodCount> <loadLevel> <lenModuleName> char*lenModuleName <padding>
-// <JifInfRecord>::= <recordID> { <moduleDependency> | <methodJitInfo> }
-
-// <moduleDependency>::
-//    8-bit source module index,  current always 0 until we track per module dependency
-//    8-bit flag                  MODULE_DEPENDENCY is 1
-//    8-bit load level
-//    8-bit target module index
-
-// <methodJitInfo>::
-//    8-bit module index,         current always 0 until we track per module dependency
-//    4-bit flag                  MODULE_DEPENDENCY is 0, JIT_BY_APP_THREAD could be 1
-//   20-bit method index
-
+// JifInfRecord is described below.
+//
+//
+// Actual profile has two representations: internal and the one, that is stored in file.
+//
+// I. Internal profile
+//
+//   Internal profile representation is stored in m_JitInfoArray and is used during profile gathering.
+//   m_JitInfoArray is an array of RecorderInfo (12 bytes on 32-bit systems, 16 bytes on 64-bit systems), with MAX_METHODS elements.
+//
+//   1. Modules.
+//     For modules RecorderInfo::data2 and RecorderInfo::ptr are set to 0. RecorderInfo::ptr == 0 is also a flag that RecorderInfo correponds to module.
+//     RecorderInfo::data1 is non-zero and represents info for module.
+//
+//     Info for module includes module index and requested load level, with some additional data in higher bits (MULTICOREJIT_MODULEINF_RECORD_ID tag).
+//     - bits 0-15 store module index
+//     - bits 16-23 store load level
+//     - bits 24-31 store tag (MULTICOREJIT_MODULEINF_RECORD_ID)
+//
+//   2. Methods.
+//     For methods RecorderInfo::data2 is set to 0.
+//     RecorderInfo::ptr is set to pointer to MethodDesc.
+//     RecorderInfo::data1 is non-zero and represents additional info for method.
+//
+//     Info for method includes module index and method flags (like JIT_BY_APP_THREAD_TAG, etc.), with some additional data in higher bits (MULTICOREJIT_METHODINF_RECORD_ID tag).
+//     - bits 0-15 store module index
+//     - bits 16-23 store method flags
+//     - bits 24-31 store tag (MULTICOREJIT_METHODINF_RECORD_ID).
+//
+// II. Profile in file
+//
+//   Preprocessing is performed right before profile saving to file.
+//
+//   1. Modules.
+//     For modules, no preprocessing of RecorderInfo is required, RecorderInfo::data1 is written to file as JifInfRecord.
+//
+//   2. Methods.
+//     For methods, binary signature is computed and RecorderInfo contents are changed.
+//     a) RecorderInfo::data1 doesn't change.
+//     b) RecorderInfo::data2 stores binary sizes, bits 0-15 store signature length, bits 16-31 store overall record length.
+//     c) RecorderInfo::ptr is replaced with pointer to method's binary signature.
+//
+//     File write order: RecorderInfo::data1, RecorderInfo::data2, signature, extra alignment (this is optional). All of these represent JitInfRecord.
 
 struct HeaderRecord
 {
@@ -263,22 +283,17 @@ private:
 
     int                                m_nLoadedModuleCount;
 
-    unsigned                           m_busyWith;
-
     unsigned                           m_headerModuleCount;
     unsigned                           m_moduleCount;
     PlayerModuleInfo                 * m_pModules;
 
-    void JITMethod(Module * pModule, unsigned methodIndex);
-
-    HRESULT HandleModuleRecord(const ModuleRecord * pModule);
-    HRESULT HandleMethodRecord(unsigned * buffer, int count);
-    HRESULT HandleGenericMethodRecord(unsigned moduleIndex, BYTE * signature, unsigned length);
+    HRESULT HandleModuleRecord(const ModuleRecord * pMod);
+    HRESULT HandleModuleInfoRecord(unsigned moduleTo, unsigned level);
+    HRESULT HandleMethodInfoRecord(unsigned moduleIndex, BYTE * signature, unsigned length);
+    void CompileMethodInfoRecord(Module *pModule, MethodDesc *pMethod);
 
     bool CompileMethodDesc(Module * pModule, MethodDesc * pMD);
     HRESULT PlayProfile();
-
-    bool GroupWaitForModuleLoad(int pos);
 
     bool ShouldAbort(bool fast) const;
 
@@ -289,8 +304,6 @@ private:
     void TraceSummary();
 
     HRESULT UpdateModuleInfo();
-
-    bool HandleModuleDependency(unsigned jitInfo);
 
     HRESULT ReadCheckFile(const WCHAR * pFileName);
 
@@ -333,17 +346,52 @@ struct RecorderModuleInfo
     bool SetModule(Module * pModule);
 };
 
-struct RecorderGenericInfo
+struct RecorderInfo
 {
-    unsigned        genericInfo;
-    BYTE *          genericSignature;
+    unsigned data1;
+    unsigned data2;
+    BYTE *   ptr;
 
-    RecorderGenericInfo()
+    RecorderInfo()
     {
         LIMITED_METHOD_CONTRACT;
 
-        genericInfo      = 0;
-        genericSignature = nullptr;
+        data1 = 0;
+        data2 = 0;
+        ptr  = nullptr;
+    }
+
+    static bool isMethod(unsigned data)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return (data & ((unsigned) MULTICOREJIT_METHODINF_RECORD_ID << RECORD_TYPE_OFFSET)) != 0;
+    }
+
+    static unsigned packMethod(unsigned moduleIndex, bool application)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        _ASSERTE(moduleIndex < MAX_MODULES);
+        unsigned data = Pack8_24(MULTICOREJIT_METHODINF_RECORD_ID, moduleIndex);
+
+        if (application)
+        {
+             // Jitted by application threads, not background thread
+            data |= JIT_BY_APP_THREAD_TAG;
+        }
+
+        return data;
+    }
+
+    static unsigned packModule(FileLoadLevel needLevel, unsigned moduleIndex)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        _ASSERTE(moduleIndex < MAX_MODULES);
+        _ASSERTE(((unsigned) needLevel) < MAX_MODULE_LEVELS);
+        unsigned data = Pack8_24(MULTICOREJIT_MODULEINF_RECORD_ID, ((unsigned) needLevel << MODULE_LEVEL_OFFSET) | moduleIndex);
+        return data;
     }
 };
 
@@ -359,11 +407,8 @@ private:
     unsigned                  m_ModuleCount;
     unsigned                  m_ModuleDepCount;
 
-    unsigned                  m_JitInfoArray[MAX_METHOD_ARRAY];
+    RecorderInfo            * m_JitInfoArray;
     LONG                      m_JitInfoCount;
-
-    MethodDesc*               m_GenericInfoArray[MAX_GENERIC_ARRAY];
-    LONG                      m_GenericInfoCount;
 
     bool                      m_fFirstMethod;
     bool                      m_fAborted;
@@ -378,8 +423,9 @@ private:
 
     HRESULT WriteModuleRecord(IStream * pStream,  const RecorderModuleInfo & module);
 
-    void RecordJitInfo(unsigned module, unsigned method);
-    void RecordGenericInfo(MethodDesc * pMethod);
+    void RecordMethodInfo(unsigned moduleIndex, MethodDesc * pMethod, bool application);
+    unsigned RecordModuleInfo(Module * pModule);
+    void RecordOrUpdateModuleInfo(FileLoadLevel needLevel, unsigned moduleIndex);
 
     void AddAllModulesInAsm(DomainAssembly * pAssembly);
 
@@ -402,10 +448,11 @@ public:
 
         m_pDomain           = pDomain;
         m_pBinderContext    = pBinderContext;
-        m_JitInfoCount      = 0;
         m_ModuleCount       = 0;
         m_ModuleDepCount    = 0;
-        m_GenericInfoCount  = 0;
+
+        m_JitInfoArray      = new (nothrow) RecorderInfo[MAX_METHODS];
+        m_JitInfoCount      = 0;
 
         m_fFirstMethod      = true;
         m_fAborted          = false;
@@ -431,21 +478,24 @@ public:
 
         return true;
     }
+#endif // !TARGET_UNIX
 
     ~MulticoreJitRecorder()
     {
         LIMITED_METHOD_CONTRACT;
 
+        delete[] m_JitInfoArray;
+
+#ifndef TARGET_UNIX
         CloseTimer();
-    }
 #endif // !TARGET_UNIX
+    }
 
     bool IsAtFullCapacity() const
     {
         LIMITED_METHOD_CONTRACT;
 
-        return (m_JitInfoCount >= (LONG) MAX_METHOD_ARRAY) ||
-               (m_GenericInfoCount >= (LONG) MAX_GENERIC_ARRAY) ||
+        return (m_JitInfoCount >= (LONG) MAX_METHODS) ||
                (m_ModuleCount  >= MAX_MODULES);
     }
 
@@ -500,4 +550,3 @@ void MulticoreJitFireEtwMethodCodeReturned(MethodDesc * pMethod);
 #define _FireEtwMulticoreJit(String1, String2, Int1, Int2, Int3)  if (PrivateEtwEnabled()) MulticoreJitFireEtw (String1, String2, Int1, Int2, Int3)
 #define _FireEtwMulticoreJitA(String1, String2, Int1, Int2, Int3) if (PrivateEtwEnabled()) MulticoreJitFireEtwA(String1, String2, Int1, Int2, Int3)
 #define _FireEtwMulticoreJitMethodCodeReturned(pMethod) if(PrivateEtwEnabled()) MulticoreJitFireEtwMethodCodeReturned(pMethod)
-

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -940,14 +940,6 @@ void MulticoreJitProfilePlayer::CompileMethodInfoRecord(Module *pModule, MethodD
                 return;
             }
         }
-        else if (pMethod->IsNDirect())
-        {
-            // NDirect Stub
-            if (GetStubForInteropMethod(pMethod))
-            {
-                return;
-            }
-        }
     }
 
     m_stats.m_nFilteredMethods++;

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -1161,7 +1161,7 @@ HRESULT MulticoreJitProfilePlayer::PlayProfile()
         unsigned data1 = * (const unsigned *) pBuffer;
         unsigned rcdTyp = data1 >> RECORD_TYPE_OFFSET;
         unsigned rcdLen = 0;
-        
+
         if (rcdTyp == MULTICOREJIT_MODULE_RECORD_ID)
         {
             rcdLen = data1 & 0xFFFFFF;    
@@ -1176,6 +1176,12 @@ HRESULT MulticoreJitProfilePlayer::PlayProfile()
         }
         else if (rcdTyp == MULTICOREJIT_GENERICMETHOD_RECORD_ID)
         {
+            if (nSize < sizeof(unsigned) + sizeof(unsigned short))
+            {
+                hr = COR_E_BADIMAGEFORMAT;
+                break;
+            }
+
             unsigned signatureLength = * (const unsigned short *) (((const unsigned *) pBuffer) + 1);
             DWORD dataSize = signatureLength + sizeof(DWORD) + sizeof(unsigned short);
             dataSize = AlignUp(dataSize, sizeof(DWORD));

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -389,8 +389,6 @@ MulticoreJitProfilePlayer::MulticoreJitProfilePlayer(ICLRPrivBinder * pBinderCon
     m_pFileBuffer        = NULL;
     m_nFileSize          = 0;
 
-    m_busyWith           = EmptyToken;
-
     m_nStartTime         = GetTickCount();
 }
 
@@ -601,89 +599,6 @@ bool MulticoreJitProfilePlayer::CompileMethodDesc(Module * pModule, MethodDesc *
     return false;
 }
 
-
-// Conditional JIT of a method
-void MulticoreJitProfilePlayer::JITMethod(Module * pModule, unsigned methodIndex)
-{
-    STANDARD_VM_CONTRACT;
-
-	// Ensure non-null module
-	if (pModule == NULL)
-	{
-		if (ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context, TRACE_LEVEL_VERBOSE, CLR_PRIVATEMULTICOREJIT_KEYWORD))
-		{
-			_FireEtwMulticoreJitA(W("NULLMODULEPOINTER"), NULL, methodIndex, 0, 0);
-		}
-		return;
-	}
-
-    methodIndex &= METHODINDEX_MASK; // 20-bit
-
-    unsigned token = TokenFromRid(methodIndex, mdtMethodDef);
-
-    // Similar to Module::FindMethod + Module::FindMethodThrowing,
-    // except it calls GetMethodDescFromMemberDefOrRefOrSpec with strictMetadataChecks=FALSE to allow generic instantiation
-    MethodDesc * pMethod = MemberLoader::GetMethodDescFromMemberDefOrRefOrSpec(pModule, token, NULL, FALSE, FALSE);
-    if (pMethod != NULL && !pMethod->IsDynamicMethod())
-    {
-        if (pMethod->HasILHeader())
-        {
-            // MethodDesc::FindOrCreateTypicalSharedInstantiation is expensive, avoid calling it unless the method or class has generic arguments
-            if (pMethod->HasClassOrMethodInstantiation())
-            {
-                pMethod = pMethod->FindOrCreateTypicalSharedInstantiation();
-
-                if (pMethod == NULL)
-                {
-                    goto BadMethod;
-                }
-
-                pModule = pMethod->GetModule_NoLogging();
-            }
-
-            if (pMethod->GetNativeCode() != NULL) // last check before
-            {
-                m_stats.m_nHasNativeCode ++;
-
-                return;
-            }
-            else
-            {
-                m_busyWith = methodIndex;
-
-                bool rslt = CompileMethodDesc(pModule, pMethod);
-
-                m_busyWith = EmptyToken;
-
-                if (rslt)
-                {
-                    return;
-                }
-            }
-        }
-        else if (pMethod->IsNDirect())
-        {
-            // NDirect Stub
-            if (GetStubForInteropMethod(pMethod))
-            {
-                return;
-            }
-        }
-    }
-
-BadMethod:
-
-    m_stats.m_nFilteredMethods ++;
-
-    MulticoreJitTrace(("Filtered out methods: pModule:[%s] token:[%x]", pModule->GetSimpleName(), token));
-
-    if (ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context, TRACE_LEVEL_VERBOSE, CLR_PRIVATEMULTICOREJIT_KEYWORD))
-    {
-        _FireEtwMulticoreJitA(W("FILTERMETHOD-GENERIC"), pModule->GetSimpleName(), token, 0, 0);
-    }
-}
-
-
 class MulticoreJitPlayerModuleEnumerator : public MulticoreJitModuleEnumerator
 {
     MulticoreJitProfilePlayer * m_pPlayer;
@@ -847,94 +762,26 @@ bool MulticoreJitProfilePlayer::ShouldAbort(bool fast) const
     return false;
 }
 
-
-// Basic delay unit
-const int DelayUnit          = 1;     //  1 ms delay
-const int MissingModuleDelay = 10;    // 10 ms for each missing module
-
-
-// Wait for all the module loading and level requests to be fullfilled
-// This allows for longer delay based on number of mismatches, to reduce CPU usage
-
-// Return true blocking count is 0, false if aborted
-bool MulticoreJitProfilePlayer::GroupWaitForModuleLoad(int pos)
+HRESULT MulticoreJitProfilePlayer::HandleModuleInfoRecord(unsigned moduleTo, unsigned level)
 {
     STANDARD_VM_CONTRACT;
+    
+    HRESULT hr = S_OK;
 
-    MulticoreJitTrace(("Enter GroupWaitForModuleLoad(pos=%4d): %d modules loaded, blocking count=%d", pos, m_nLoadedModuleCount, m_nBlockingCount));
+    MulticoreJitTrace(("ModuleRecord(%u) start module load",
+        moduleTo));
 
-    _FireEtwMulticoreJit(W("GROUPWAIT"), W("Enter"), m_nLoadedModuleCount, m_nBlockingCount, pos);
-
-    bool rslt = false;
-
-    // Ensure that we don't block in this particular case for longer than the block limit.
-    // This limit is smaller than the overall MULTICOREJITLIFE and ensures that we don't sit for the
-    // full player lifetime waiting for a module when the app behavior has changed.
-    DWORD currentModuleBlockStart = GetTickCount();
-
-    // Only allow module blocking to occur a certain number of times.
-
-    while (! ShouldAbort(false))
+    if (moduleTo >= m_moduleCount)
     {
-        if (FAILED(UpdateModuleInfo()))
-        {
-            break;
-        }
-
-        if (m_nBlockingCount == 0)
-        {
-            rslt = true;
-            break;
-        }
-
-        if(GetTickCount() - currentModuleBlockStart > MULTICOREJITBLOCKLIMIT)
-        {
-            MulticoreJitTrace(("MulticoreJitProfilePlayer::GroupWaitForModuleLoad timeout exceeded."));
-            _FireEtwMulticoreJit(W("ABORTPLAYER"), W("GroupWaitForModuleLoad timeout exceeded."), 0, 0, 0);
-
-            break;
-        }
-
-        // Heuristic for reducing CPU usage: delay longer when there are more blocking modules
-        unsigned delay = min((m_nMissingModule * MissingModuleDelay + m_nBlockingCount) * DelayUnit, 50);
-
-        MulticoreJitTrace(("Delay: %d ms", delay));
-
-        if (ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context, TRACE_LEVEL_VERBOSE, CLR_PRIVATEMULTICOREJIT_KEYWORD))
-        {
-            _FireEtwMulticoreJit(W("GROUPWAIT"), W("Delay"), delay, 0, 0);
-        }
-
-        ClrSleepEx(delay, FALSE);
-
-        m_stats.m_nTotalDelay += (unsigned short) delay;
-        m_stats.m_nDelayCount ++;
+        m_stats.m_nMissingModuleSkip++;
+        hr = COR_E_BADIMAGEFORMAT;
     }
-
-    MulticoreJitTrace(("Leave GroupWaitForModuleLoad(pos=%4d): blocking count=%d (rslt=%d)", pos, m_nBlockingCount, rslt));
-
-    _FireEtwMulticoreJit(W("GROUPWAIT"), W("Leave"), m_nLoadedModuleCount, m_nBlockingCount, rslt);
-
-    return rslt;
-}
-
-
-bool MulticoreJitProfilePlayer::HandleModuleDependency(unsigned jitInfo)
-{
-    STANDARD_VM_CONTRACT;
-
-    // depends on moduleTo, which may not loaded yet
-
-    unsigned moduleTo = jitInfo & MODULE_MASK;
-
-    if (moduleTo < m_moduleCount)
+    else
     {
-        unsigned level = (jitInfo >> LEVEL_SHIFT) & LEVEL_MASK;
-
         PlayerModuleInfo & mod = m_pModules[moduleTo];
 
         // Load the module if necessary.
-        if (!mod.m_pModule)
+        if (!mod.IsModuleLoaded())
         {
             // Update loaded module status.
             AppDomain * pAppDomain = GetAppDomain();
@@ -961,24 +808,32 @@ bool MulticoreJitProfilePlayer::HandleModuleDependency(unsigned jitInfo)
                     if (mod.m_pModule == NULL)
                     {
                         // Unable to load the assembly, so abort.
-                        return false;
+                        m_stats.m_nMissingModuleSkip++;
+                        hr = E_ABORT;
                     }
                 }
                 else
                 {
                     // Unable to load the assembly, so abort.
-                    return false;
+                    m_stats.m_nMissingModuleSkip++;
+                    hr = E_ABORT;
                 }
             }
         }
 
-        if (mod.UpdateNeedLevel((FileLoadLevel) level))
+        if ((SUCCEEDED(hr)) && mod.UpdateNeedLevel((FileLoadLevel) level))
         {
-            m_nBlockingCount ++;
+            m_nBlockingCount++;
         }
     }
 
-    return true;
+    MulticoreJitTrace(("ModuleRecord(%d) end module load, hr=%x",
+        moduleTo,
+        hr));
+
+    TraceSummary();
+
+    return hr;
 }
 
 DomainAssembly * MulticoreJitProfilePlayer::LoadAssembly(SString & assemblyName)
@@ -1010,157 +865,26 @@ DomainAssembly * MulticoreJitProfilePlayer::LoadAssembly(SString & assemblyName)
         FALSE); // Don't throw on FileNotFound.
 }
 
-
-inline bool MethodJifInfo(unsigned inst)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return ((inst & MODULE_DEPENDENCY) == 0);
-}
-
-
-// Process a block of methodDef, call JIT if not blocked
-HRESULT MulticoreJitProfilePlayer::HandleMethodRecord(unsigned * buffer, int count)
+HRESULT MulticoreJitProfilePlayer::HandleMethodInfoRecord(unsigned moduleIndex, BYTE * signature, unsigned length)
 {
     STANDARD_VM_CONTRACT;
 
     HRESULT hr = E_ABORT;
 
-    MulticoreJitTrace(("MethodRecord(%d) start %d methods, %d mod loaded", m_stats.m_nTotalMethod, count, m_nLoadedModuleCount));
-
-    MulticoreJitManager & manager = GetAppDomain()->GetMulticoreJitManager();
-
-#ifdef MULTICOREJIT_LOGGING
-
-    MulticoreJitCodeStorage & curStorage = manager.GetMulticoreJitCodeStorage();
-
-    int lastCompiled = curStorage.GetStored();
-
-#endif
-
-    int pos = 0;
-
-    while (! ShouldAbort(true) && (pos < count))
-    {
-        unsigned jitInfo = buffer[pos]; // moduleIndex + methodIndex
-
-        unsigned moduleIndex = jitInfo >> 24;
-
-        if (moduleIndex < m_moduleCount)
-        {
-            if (jitInfo & MODULE_DEPENDENCY) // Module depedency information
-            {
-                if (! HandleModuleDependency(jitInfo))
-                {
-                    goto Abort;
-                }
-            }
-            else
-            {
-                PlayerModuleInfo & info = m_pModules[moduleIndex];
-
-                m_stats.m_nTotalMethod ++;
-
-                // If module is disabled for Jitting, just skip method without even waiting
-                if (! info.m_enableJit)
-                {
-                    m_stats.m_nFilteredMethods ++;
-                }
-                else
-                {
-
-                    //  To reduce contention with foreground thread, walk backward within the group of methods Jittable methods, not broken apart by dependency
-                    {
-                        int run = 1; // size of the group
-
-                        while (((pos + run) < count) && MethodJifInfo(buffer[pos + run]))
-                        {
-                            run ++;
-
-                            // If walk-back run is too long, lots of methods in the front will be missed by background thread
-                            if (run > MAX_WALKBACK)
-                            {
-                                break;
-                            }
-                        }
-
-                        if (run > 1)
-                        {
-                            MulticoreJitTrace(("Jit backwards %d methods",  run));
-                        }
-
-                        // Walk backwards within the same group, may be from different modules
-                        for (int p = pos + run - 1; p >= pos; p --)
-                        {
-                            unsigned inst = buffer[p];
-
-                            _ASSERTE(MethodJifInfo(inst));
-
-                            PlayerModuleInfo & mod = m_pModules[inst >> 24];
-
-                            if (mod.IsModuleLoaded() && mod.m_enableJit)
-                            {
-                                JITMethod(mod.m_pModule, inst);
-                            }
-                            else
-                            {
-                                m_stats.m_nFilteredMethods ++;
-                            }
-                        }
-
-                        m_stats.m_nWalkBack    += (short) (run - 1);
-                        m_stats.m_nTotalMethod += (short) (run - 1);
-
-                        pos += run - 1; // Skip the group
-                    }
-                }
-            }
-        }
-        else
-        {
-            hr = COR_E_BADIMAGEFORMAT;
-            goto Abort;
-        }
-
-        pos ++;
-    }
-
-    // Mark success
-    hr = S_OK;
-
-Abort:
-
-    m_stats.m_nMissingModuleSkip += (short) (count - pos);
-
-    MulticoreJitTrace(("MethodRecord(%d) end %d compiled, %d aborted / %d methods, hr=%x",
-        m_stats.m_nTotalMethod,
-        curStorage.GetStored() - lastCompiled,
-        count - pos, count, hr));
-
-    TraceSummary();
-
-    return hr;
-}
-
-HRESULT MulticoreJitProfilePlayer::HandleGenericMethodRecord(unsigned moduleIndex, BYTE * signature, unsigned length)
-{
-    STANDARD_VM_CONTRACT;
-
-    HRESULT hr = E_ABORT;
-
-    MulticoreJitTrace(("MethodRecord(%d) start a generic method, %d mod loaded", m_stats.m_nTotalMethod, m_nLoadedModuleCount));
+    MulticoreJitTrace(("MethodRecord(%d) start method compilation, %d mod loaded", m_stats.m_nTotalMethod, m_nLoadedModuleCount));
 
     if (moduleIndex >= m_moduleCount)
     {
-        m_stats.m_nMissingModuleSkip += 1;
+        m_stats.m_nMissingModuleSkip++;
+        hr = COR_E_BADIMAGEFORMAT;
     }
     else
     {
         PlayerModuleInfo & mod = m_pModules[moduleIndex];
+        m_stats.m_nTotalMethod++;
+
         if (mod.IsModuleLoaded() && mod.m_enableJit)
         {
-            m_stats.m_nTotalMethod ++;
-
             Module * pModule = mod.m_pModule;
 
             SigTypeContext typeContext;   // empty type context
@@ -1175,25 +899,58 @@ HRESULT MulticoreJitProfilePlayer::HandleGenericMethodRecord(unsigned moduleInde
             }
             EX_END_CATCH(SwallowAllExceptions);
 
-            if (pMethod && !pMethod->IsDynamicMethod() && pMethod->HasILHeader() && pMethod->GetNativeCode() == NULL)
-            {
-                CompileMethodDesc(pModule, pMethod);
-            }
-            else
-            {
-                m_stats.m_nFilteredMethods ++;
-            }
+            CompileMethodInfoRecord(pModule, pMethod);
+        }
+        else
+        {
+            m_stats.m_nFilteredMethods++;
         }
 
         hr = S_OK;
     }
 
-    MulticoreJitTrace(("MethodRecord(%d) end a generic method compiled, hr=%x",
+    MulticoreJitTrace(("MethodRecord(%d) end method compilation, filtered %d methods, hr=%x",
         m_stats.m_nTotalMethod,
+        m_stats.m_nFilteredMethods,
         hr));
 
     TraceSummary();
+
     return hr;
+}
+
+void MulticoreJitProfilePlayer::CompileMethodInfoRecord(Module *pModule, MethodDesc *pMethod)
+{
+    STANDARD_VM_CONTRACT;
+
+    if (pMethod != NULL && !pMethod->IsDynamicMethod())
+    {
+        if (pMethod->HasILHeader())
+        {
+            if (pMethod->GetNativeCode() == NULL)
+            {
+                if (CompileMethodDesc(pModule, pMethod))
+                {
+                    return;
+                }
+            }
+            else
+            {
+                m_stats.m_nHasNativeCode++;
+                return;
+            }
+        }
+        else if (pMethod->IsNDirect())
+        {
+            // NDirect Stub
+            if (GetStubForInteropMethod(pMethod))
+            {
+                return;
+            }
+        }
+    }
+
+    m_stats.m_nFilteredMethods++;
 }
 
 void MulticoreJitProfilePlayer::TraceSummary()
@@ -1266,7 +1023,7 @@ HRESULT MulticoreJitProfilePlayer::ReadCheckFile(const WCHAR * pFileName)
 
             MulticoreJitTrace(("HeaderRecord(version=%d, module=%d, method=%d)", header.version, m_headerModuleCount, header.methodCount));
 
-            if ((header.version != MULTICOREJIT_PROFILE_VERSION) || (header.moduleCount > MAX_MODULES) || (header.methodCount > MAX_METHOD_ARRAY) ||
+            if ((header.version != MULTICOREJIT_PROFILE_VERSION) || (header.moduleCount > MAX_MODULES) || (header.methodCount > MAX_METHODS) ||
                 (header.recordID != Pack8_24(MULTICOREJIT_HEADER_RECORD_ID, sizeof(HeaderRecord))))
             {
                 hr = COR_E_BADIMAGEFORMAT;
@@ -1349,53 +1106,149 @@ HRESULT MulticoreJitProfilePlayer::PlayProfile()
 
     while ((SUCCEEDED(hr)) && (nSize > sizeof(unsigned)))
     {
-        unsigned data   = * (const unsigned *) pBuffer;
-        unsigned rcdLen = data & 0xFFFFFF;
-        unsigned rcdTyp = data >> 24;
+        unsigned data1 = * (const unsigned *) pBuffer;
+        unsigned data2 = 0;
+        unsigned rcdTyp = data1 >> RECORD_TYPE_OFFSET;
+        unsigned rcdLen = 0;
+        
+        if (rcdTyp == MULTICOREJIT_MODULE_RECORD_ID)
+        {
+            rcdLen = data1 & 0xFFFFFF;    
+        }
+        else if (rcdTyp == MULTICOREJIT_MODULEINF_RECORD_ID)
+        {
+            rcdLen = sizeof(unsigned);
+        }
+        else if (rcdTyp == MULTICOREJIT_METHODINF_RECORD_ID)
+        {
+            data2 = * (((const unsigned *) pBuffer) + 1);
+            rcdLen = data2 >> SIGNATURE_LENGTH_OFFSET;
+        }
+        else
+        {
+            hr = COR_E_BADIMAGEFORMAT;
+            break;
+        }
 
         if ((rcdLen > nSize) || (rcdLen & 3)) // Better DWORD align
         {
             hr = COR_E_BADIMAGEFORMAT;
+            break;
         }
-        else
+
+        if (rcdTyp == MULTICOREJIT_MODULE_RECORD_ID)
         {
-            if (rcdTyp == MULTICOREJIT_MODULE_RECORD_ID)
-            {
-                const ModuleRecord * pRec = (const ModuleRecord * ) pBuffer;
+            const ModuleRecord * pRec = (const ModuleRecord * ) pBuffer;
 
-                if (((unsigned)(pRec->lenModuleName
-                    + pRec->lenAssemblyName
-                    ) > (rcdLen - sizeof(ModuleRecord))) ||
-                    (m_moduleCount >= m_headerModuleCount))
-                {
-                    hr = COR_E_BADIMAGEFORMAT;
-                }
-                else
-                {
-                    hr = HandleModuleRecord(pRec);
-                }
-            }
-            else if (rcdTyp == MULTICOREJIT_JITINF_RECORD_ID)
-            {
-                int mCount = (rcdLen - sizeof(unsigned)) / sizeof(unsigned);
-
-                hr = HandleMethodRecord((unsigned *) (pBuffer + sizeof(unsigned)), mCount);
-            }
-            else if (rcdTyp == MULTICOREJIT_GENERICINF_RECORD_ID)
-            {
-                unsigned info = *(unsigned *)(pBuffer + sizeof(unsigned));
-                unsigned moduleIndex = info >> 24;
-                unsigned signatureLength = info & SIGNATURELENGTH_MASK;
-                hr = HandleGenericMethodRecord(moduleIndex, (BYTE *) (pBuffer + sizeof(unsigned) * 2), signatureLength);
-            }
-            else
+            if (((unsigned)(pRec->lenModuleName
+                + pRec->lenAssemblyName
+                ) > (rcdLen - sizeof(ModuleRecord))) ||
+                (m_moduleCount >= m_headerModuleCount))
             {
                 hr = COR_E_BADIMAGEFORMAT;
             }
-
-            pBuffer += rcdLen;
-            nSize -= rcdLen;
+            else
+            {
+                hr = HandleModuleRecord(pRec);
+            }
         }
+        else if (rcdTyp == MULTICOREJIT_MODULEINF_RECORD_ID)
+        {
+            unsigned moduleIndex = data1 & (MAX_MODULES - 1);
+            unsigned level = (data1 & ((MAX_MODULE_LEVELS - 1) << MODULE_LEVEL_OFFSET)) >> MODULE_LEVEL_OFFSET;
+
+            hr = HandleModuleInfoRecord(moduleIndex, level);
+        }
+        else if (rcdTyp == MULTICOREJIT_METHODINF_RECORD_ID)
+        {
+            // Find all subsequent methods and jit/load them reversed if reversed order is required
+            bool reversedOrder = true;
+
+            if (reversedOrder)
+            {
+                bool isMethod = true;
+                const BYTE * pCurBuf = pBuffer;
+                unsigned curSize = nSize;
+
+                unsigned sizes[MAX_WALKBACK] = {0};
+                int count = 0;
+
+                do
+                {
+                    unsigned curdata2 = * (((const unsigned *) pCurBuf) + 1);
+                    unsigned currcdLen = curdata2 >> SIGNATURE_LENGTH_OFFSET;
+
+                    if (currcdLen > curSize)
+                    {
+                        hr = COR_E_BADIMAGEFORMAT;
+                        break;
+                    }
+
+                    sizes[count] = currcdLen;
+                    count++;
+
+                    pCurBuf += currcdLen;
+                    curSize -= currcdLen;
+
+                    if (curSize == 0)
+                    {
+                        break;
+                    }
+
+                    unsigned curdata1 = * (const unsigned *) pCurBuf;
+                    isMethod = RecorderInfo::isMethod(curdata1);
+                }
+                while (isMethod && count < MAX_WALKBACK);
+
+                _ASSERTE(count > 0);
+                if (count > 1)
+                {
+                    MulticoreJitTrace(("Jit backwards %d methods",  count));
+                }
+
+                int i = count - 1;
+                for (; (SUCCEEDED(hr)) && i >= 0; --i)
+                {
+                    pCurBuf -= sizes[i];
+
+                    unsigned curdata1 = * (const unsigned *) pCurBuf;
+                    unsigned curmoduleIndex = curdata1 & (MAX_MODULES - 1);
+                    unsigned curflags = curdata1 & METHOD_FLAGS_MASK;
+
+                    unsigned curdata2 = * (((const unsigned *) pCurBuf) + 1);
+                    unsigned cursignatureLength = curdata2 & MAX_SIGNATURE_LENGTH;
+
+                    hr = HandleMethodInfoRecord(curmoduleIndex, (BYTE *) (pCurBuf + sizeof(unsigned) * 2), cursignatureLength);
+
+                    if (SUCCEEDED(hr) && ShouldAbort(false))
+                    {
+                        hr = E_ABORT;
+                    }
+                }
+
+                m_stats.m_nWalkBack += (short) count;
+                m_stats.m_nFilteredMethods += (short) (i + 1);
+
+                rcdLen = nSize - curSize;
+            }
+            else
+            {
+                unsigned moduleIndex = data1 & (MAX_MODULES - 1);
+                unsigned flags = data1 & METHOD_FLAGS_MASK;
+
+                unsigned signatureLength = data2 & MAX_SIGNATURE_LENGTH;
+                rcdLen = data2 >> SIGNATURE_LENGTH_OFFSET;
+
+                hr = HandleMethodInfoRecord(moduleIndex, (BYTE *) (pBuffer + sizeof(unsigned) * 2), signatureLength);
+            }
+        }
+        else
+        {
+            hr = COR_E_BADIMAGEFORMAT;
+        }
+        
+        pBuffer += rcdLen;
+        nSize -= rcdLen;
 
         if (SUCCEEDED(hr) && ShouldAbort(false))
         {
@@ -1553,4 +1406,3 @@ Module * MulticoreJitProfilePlayer::GetModuleFromIndex(DWORD ix) const
     }
     return NULL;
 }
-


### PR DESCRIPTION
This PR unifies non-generic/shared-generic methods with generic methods in multicorejit, allowing to keep the original jit order. This is required as part of https://github.com/dotnet/runtime/issues/45748 change (specifically, https://github.com/dotnet/runtime/issues/45748#issuecomment-750889697), goal of which is to enable background type preloading using multicorejit. 

Generic methods are stored in profile using their binary signature and non-generics methods are stored using method tokens. However, for non-generic methods record size has double (8 bytes now), which allowed to fit additional data. Thus, there's no limit on method token now (previously there was `METHODINDEX_MASK`). Also, limit for module index has increased from 512 (MAX_MODULES) to 4096. Additional info can be stored for each method like JIT_BY_APP_THREAD_TAG or NO_JIT_TAG (NO_JIT_TAG will be added in further changes).

Additionally, NDirect methods are removed, because their current implementation leads to asserts and exceptions. Also, few checks for number of cpus are configurable with env variables now, thus, allowing to use multicorejit on arm with cpu hotplug.

cc @alpencolt