### PR TITLE
Update incremental servicing condition for pkgs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -240,7 +240,7 @@
          Excluding .sfxprojs as they have their own incremental servicing infra. -->
     <GeneratePackage Condition="'$(GeneratePackage)' == ''">true</GeneratePackage>
     <GeneratePackage Condition="(('$(PreReleaseVersionLabel)' == 'servicing' or
-                                  '$(RepositoryName)' == 'runtimelab') and
+                                  '$(GitHubRepositoryName)' == 'runtimelab') and
                                  '$(MSBuildProjectExtension)' != '.sfxproj')">false</GeneratePackage>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -236,11 +236,12 @@
     <IsShippingAssembly Condition="$(IsExperimentalAssembly)">false</IsShippingAssembly>
     <!-- We don't want Private packages to be shipped to NuGet.org -->
     <IsShippingPackage Condition="($(MSBuildProjectName.Contains('Private')) or $(IsExperimentalAssembly)) and '$(MSBuildProjectExtension)' == '.pkgproj'">false</IsShippingPackage>
-    <!-- A package isn't generated (in traversal builds) if in servicing or in runtimelab. Intended to be overridden at project level. -->
+    <!-- A package isn't generated if in servicing or in runtimelab. Intended to be overridden at project level.
+         Excluding .sfxprojs as they have their own incremental servicing infra. -->
     <GeneratePackage Condition="'$(GeneratePackage)' == ''">true</GeneratePackage>
     <GeneratePackage Condition="(('$(PreReleaseVersionLabel)' == 'servicing' or
                                   '$(RepositoryName)' == 'runtimelab') and
-                                 '$(BuildAllProjects)' == 'true')">false</GeneratePackage>
+                                 '$(MSBuildProjectExtension)' != '.sfxproj')">false</GeneratePackage>
   </PropertyGroup>
 
 


### PR DESCRIPTION
Exclude .sfxproj from that mechanism as they have their own infra for handling incremental servicing and also removing the traversal check as that difference in behavior between a root build and an individual project's build is confusing and doesn't add value.

@safern if there's a way to identify runtimelab build I would be happy to update the condition to make it actually work for runtimelab.