### PR TITLE
Improve error message when bundler fails due to duplicate entries

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -206,9 +206,11 @@ namespace Microsoft.NET.HostModel.Bundle
                 throw new ArgumentException("Invalid input specification: Must specify the host binary");
             }
 
-            if (fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1).Any())
+            var bundleRelativePathCollision = fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1).FirstOrDefault();
+            if (bundleRelativePathCollision != null)
             {
-                throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath");
+                string fileSpecPaths = string.Join(", ", bundleRelativePathCollision.Select(file => "'" + file.SourcePath + "'"));
+                throw new ArgumentException($"Invalid input specification: Found entries {fileSpecPaths} with the same BundleRelativePath '{bundleRelativePathCollision.Key}'");
             }
 
             string bundlePath = Path.Combine(OutputDir, HostName);

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -206,7 +206,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 throw new ArgumentException("Invalid input specification: Must specify the host binary");
             }
 
-            var bundleRelativePathCollision = fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1).FirstOrDefault();
+            var bundleRelativePathCollision = fileSpecs.GroupBy(file => file.BundleRelativePath).FirstOrDefault(g => g.Count() > 1);
             if (bundleRelativePathCollision != null)
             {
                 string fileSpecPaths = string.Join(", ", bundleRelativePathCollision.Select(file => "'" + file.SourcePath + "'"));

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -83,11 +83,14 @@ namespace Microsoft.NET.HostModel.Tests
             // Generate a file specification with duplicate entries
             var fileSpecs = new List<FileSpec>();
             fileSpecs.Add(new FileSpec(BundleHelper.GetHostPath(fixture), BundleHelper.GetHostName(fixture)));
-            fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
-            fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
+            fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "rel/app.repeat"));
+            fileSpecs.Add(new FileSpec(Path.Join(BundleHelper.GetPublishPath(fixture), "System.dll"), "rel/app.repeat"));
 
             Bundler bundler = new Bundler(hostName, bundleDir.FullName, targetOS: targetOS, targetArch: targetArch);
-            Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs));
+            Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs))
+                .Message
+                    .Should().Contain("rel/app.repeat")
+                    .And.Contain(BundleHelper.GetAppPath(fixture));
         }
 
         [Fact]


### PR DESCRIPTION
There are multiple possible cases which will make the bundler fail with duplicate entries. Currently there's no indication of which entries caused the problem, making it really hard to diagnose these failures.

This change prints out the source file paths and the colliding relative bundle path in the error message. This should help with diagnosing the failures.

Should help with #48112, https://github.com/dotnet/sdk/issues/10621 and https://github.com/dotnet/sdk/issues/3465