### PR TITLE
Use live dependencies for netcoreapp3.0 depencies (#48176)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/Directory.Build.props
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/Directory.Build.props
@@ -5,5 +5,6 @@
     <NoWarn>$(NoWarn);PKG0001</NoWarn>
     <PackageVersion>5.0.1</PackageVersion>
     <AssemblyVersion Condition="$(TargetFramework.StartsWith('net4'))">5.0.0.1</AssemblyVersion>
+    <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/Directory.Build.props
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/Directory.Build.props
@@ -3,5 +3,7 @@
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);PKG0001</NoWarn>
+    <PackageVersion>5.0.1</PackageVersion>
+    <AssemblyVersion Condition="$(TargetFramework.StartsWith('net4'))">5.0.0.1</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
@@ -28,6 +28,11 @@
                         $(TargetFramework.StartsWith('net4'))">
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+  </ItemGroup>
+
+  <!-- Application tfms (.NETCoreApp, .NETFramework) need to use the same or higher version of .NETStandard's dependencies. -->
+  <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Json\src\System.Text.Json.csproj" />
   </ItemGroup>
 

--- a/src/libraries/Microsoft.Extensions.Primitives/Directory.Build.props
+++ b/src/libraries/Microsoft.Extensions.Primitives/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <PackageVersion>5.0.1</PackageVersion>
     <AssemblyVersion Condition="$(TargetFramework.StartsWith('net4'))">5.0.0.1</AssemblyVersion>
+    <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Primitives/Directory.Build.props
+++ b/src/libraries/Microsoft.Extensions.Primitives/Directory.Build.props
@@ -1,8 +1,7 @@
-﻿<Project>
+<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <StrongNameKeyId>Open</StrongNameKeyId>
     <PackageVersion>5.0.1</PackageVersion>
-    <AssemblyVersion>5.0.0.1</AssemblyVersion>
+    <AssemblyVersion Condition="$(TargetFramework.StartsWith('net4'))">5.0.0.1</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/Microsoft.Extensions.Primitives.csproj
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/Microsoft.Extensions.Primitives.csproj
@@ -20,6 +20,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or
                         $(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+  </ItemGroup>
+
+  <!-- NetCoreApp3.0 needs to use the same version of dependencies as .NETStandard. -->
+  <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
   </ItemGroup>
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
@@ -150,11 +150,9 @@
                         '$(TargetFramework)' == 'netcoreapp3.0'">
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
-    <Reference Include="System.Collections.Immutable" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Memory" />
-    <Reference Include="System.Reflection.Metadata" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
@@ -163,8 +161,22 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or
                         $(TargetFramework.StartsWith('net4'))">
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Reflection.Metadata\src\System.Reflection.Metadata.csproj" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
+  
+  <!-- Application tfms (.NETCoreApp, .NETFramework) need to use the same or higher version of .NETStandard's dependencies. -->
+  <Choose>
+    <When Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+      <ItemGroup>
+        <Reference Include="System.Collections.Immutable" />
+        <Reference Include="System.Reflection.Metadata" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ProjectReference Include="$(LibrariesProjectRoot)System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
+        <ProjectReference Include="$(LibrariesProjectRoot)System.Reflection.Metadata\src\System.Reflection.Metadata.csproj" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/src/libraries/System.Text.Json/Directory.Build.props
+++ b/src/libraries/System.Text.Json/Directory.Build.props
@@ -2,8 +2,8 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <PackageVersion>5.0.1</PackageVersion>
-    <AssemblyVersion Condition="$(TargetFramework.StartsWith('net4'))">5.0.0.1</AssemblyVersion>
+    <PackageVersion>5.0.2</PackageVersion>
+    <AssemblyVersion Condition="$(TargetFramework.StartsWith('net4'))">5.0.0.2</AssemblyVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -242,10 +242,8 @@
     <Reference Include="System.Reflection.Primitives" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.Encoding.Extensions" />
-    <Reference Include="System.Text.Encodings.Web" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
@@ -256,7 +254,22 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Numerics.Vectors" Version="$(SystemNumericsVectorsVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Encodings.Web\src\System.Text.Encodings.Web.csproj" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" Condition="'$(TargetFramework)' == 'net461'" />
   </ItemGroup>
+
+  <!-- Application tfms (.NETCoreApp, .NETFramework) need to use the same or higher version of .NETStandard's dependencies. -->
+  <Choose>
+    <When Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+      <ItemGroup>
+        <Reference Include="System.Runtime.CompilerServices.Unsafe" />
+        <Reference Include="System.Text.Encodings.Web" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
+        <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Encodings.Web\src\System.Text.Encodings.Web.csproj" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -319,7 +319,7 @@ namespace System.Text.Json
 
                 return memberInfo is PropertyInfo propertyInfo
                     ? propertyInfo.PropertyType
-                    : Unsafe.As<FieldInfo>(memberInfo).FieldType;
+                    : Unsafe.As<FieldInfo>(memberInfo)!.FieldType;
             }
 
             // Cache the lookup from object property name to JsonPropertyInfo using a case-insensitive comparer.
@@ -390,13 +390,13 @@ namespace System.Text.Json
             Debug.Assert(currentMember is PropertyInfo || currentMember is FieldInfo);
             PropertyInfo? currentPropertyInfo = currentMember as PropertyInfo;
             Type currentMemberType = currentPropertyInfo == null
-                ? Unsafe.As<FieldInfo>(currentMember).FieldType
+                ? Unsafe.As<FieldInfo>(currentMember)!.FieldType
                 : currentPropertyInfo.PropertyType;
 
             Debug.Assert(ignoredProperty is PropertyInfo || ignoredProperty is FieldInfo);
             PropertyInfo? ignoredPropertyInfo = ignoredProperty as PropertyInfo;
             Type ignoredPropertyType = ignoredPropertyInfo == null
-                ? Unsafe.As<FieldInfo>(ignoredProperty).FieldType
+                ? Unsafe.As<FieldInfo>(ignoredProperty)!.FieldType
                 : ignoredPropertyInfo.PropertyType;
 
             return currentMemberType == ignoredPropertyType &&

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -18,6 +18,10 @@
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" Condition="'$(BuildAllOOBPackages)' == 'true'" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\**\*.pkgproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\pkg\Microsoft.Extensions.Logging.EventSource.pkgproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Primitives\pkg\Microsoft.Extensions.Primitives.pkgproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\pkg\System.Reflection.MetadataLoadContext.pkgproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)System.Text.Json\pkg\System.Text.Json.pkgproj" />
     <!-- This is merge marker 1 to help automerge -->
     <!-- This is merge marker 2 to help automerge --> 
     <!-- This is merge marker 3 to help automerge --> 

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -18,10 +18,10 @@
     <ProjectReference Include="$(PkgDir)*\*.proj" Exclude="$(PkgDir)test\*" Condition="'$(BuildAllOOBPackages)' == 'true'" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\**\*.pkgproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\pkg\Microsoft.Extensions.Logging.EventSource.pkgproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Primitives\pkg\Microsoft.Extensions.Primitives.pkgproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\pkg\System.Reflection.MetadataLoadContext.pkgproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)System.Text.Json\pkg\System.Text.Json.pkgproj" />
+    <ProjectReference Condition="'$(BuildAllConfigurations)' == 'true'" Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\pkg\Microsoft.Extensions.Logging.EventSource.pkgproj" />
+    <ProjectReference Condition="'$(BuildAllConfigurations)' == 'true'" Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Primitives\pkg\Microsoft.Extensions.Primitives.pkgproj" />
+    <ProjectReference Condition="'$(BuildAllConfigurations)' == 'true'" Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\pkg\System.Reflection.MetadataLoadContext.pkgproj" />
+    <ProjectReference Condition="'$(BuildAllConfigurations)' == 'true'" Include="$(MSBuildThisFileDirectory)System.Text.Json\pkg\System.Text.Json.pkgproj" />
     <!-- This is merge marker 1 to help automerge -->
     <!-- This is merge marker 2 to help automerge --> 
     <!-- This is merge marker 3 to help automerge --> 

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -928,11 +928,13 @@
         "3.1.0",
         "3.1.1",
         "3.1.2",
-        "5.0.0"
+        "5.0.0",
+        "5.0.1"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "5.0.0.0": "5.0.0"
+        "5.0.0.0": "5.0.0",
+        "5.0.0.1": "5.0.1"
       }
     },
     "Microsoft.Extensions.Logging.TraceSource": {
@@ -1054,11 +1056,13 @@
         "3.1.0",
         "3.1.1",
         "3.1.2",
-        "5.0.0"
+        "5.0.0",
+        "5.0.1"
       ],
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "5.0.0.0": "5.0.0"
+        "5.0.0.0": "5.0.0",
+        "5.0.0.1": "5.0.1"
       }
     },
     "Microsoft.IO.Redist": {
@@ -4864,13 +4868,15 @@
     "System.Reflection.MetadataLoadContext": {
       "StableVersions": [
         "4.6.0",
-        "5.0.0"
+        "5.0.0",
+        "5.0.1"
       ],
-      "BaselineVersion": "5.0.0",
+      "BaselineVersion": "5.0.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0",
-        "5.0.0.0": "5.0.0"
+        "5.0.0.0": "5.0.0",
+        "5.0.0.1": "5.0.1"
       }
     },
     "System.Reflection.Primitives": {
@@ -6468,9 +6474,10 @@
       "StableVersions": [
         "4.6.0",
         "5.0.0",
-        "5.0.1"
+        "5.0.1",
+        "5.0.2"
       ],
-      "BaselineVersion": "5.0.0",
+      "BaselineVersion": "5.0.2",
       "InboxOn": {
         "netcoreapp3.0": "4.0.0.0",
         "net5.0": "5.0.0.0"
@@ -6478,7 +6485,8 @@
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0",
         "5.0.0.0": "5.0.0",
-        "5.0.0.1": "5.0.1"
+        "5.0.0.1": "5.0.1",
+        "5.0.0.2": "5.0.2"
       }
     },
     "System.Text.RegularExpressions": {

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -6457,7 +6457,7 @@
       "BaselineVersion": "5.0.1",
       "InboxOn": {
         "netcoreapp3.0": "4.0.4.0",
-        "net5.0": "5.0.0.1"
+        "net5.0": "5.0.0.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -931,6 +931,7 @@
         "5.0.0",
         "5.0.1"
       ],
+      "BaselineVersion": "5.0.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "5.0.0.0": "5.0.0",
@@ -1059,6 +1060,7 @@
         "5.0.0",
         "5.0.1"
       ],
+      "BaselineVersion": "5.0.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "5.0.0.0": "5.0.0",
@@ -1506,18 +1508,6 @@
         "net45": "4.0.0.0"
       }
     },
-    "runtime.native.System.Data.SqlClient.sni": {
-      "StableVersions": [
-        "4.0.0",
-        "4.3.0",
-        "4.4.0",
-        "4.5.0",
-        "4.6.0",
-        "4.7.0"
-      ],
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
-    },
     "runtime.linux-arm.runtime.native.System.IO.Ports": {
       "StableVersions": [
         "4.7.0",
@@ -1539,11 +1529,16 @@
       ],
       "InboxOn": {}
     },
-    "runtime.osx-x64.runtime.native.System.IO.Ports": {
+    "runtime.native.System.Data.SqlClient.sni": {
       "StableVersions": [
-        "4.7.0",
-        "5.0.0"
+        "4.0.0",
+        "4.3.0",
+        "4.4.0",
+        "4.5.0",
+        "4.6.0",
+        "4.7.0"
       ],
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "runtime.native.System.IO.Ports": {
@@ -1553,6 +1548,13 @@
         "5.0.1"
       ],
       "BaselineVersion": "5.0.1",
+      "InboxOn": {}
+    },
+    "runtime.osx-x64.runtime.native.System.IO.Ports": {
+      "StableVersions": [
+        "4.7.0",
+        "5.0.0"
+      ],
       "InboxOn": {}
     },
     "SMDiagnostics": {


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/commit/d77092decb2bbd7bc94cd548af925d801a032e9e.
Fixes https://github.com/dotnet/runtime/issues/45560

Users are hitting an issue with needing to add an explicit reference to `System.Text.Encodings.Web` when they have `System.Text.Json` 5.0.0 in a netcoreapp3.1 project.

This is because the build of System.Text.Json for `netcoreapp3.0` doesn't have a reference to the "live" built System.Text.Encoding.Web, instead it references the version from the shared framework.  This creates a compatibility problem because the `netstandard2.0` version references a higher version of the dependency than is inbox on `netcoreapp3.0`

Reported in https://github.com/dotnet/aspnetcore/issues/28354 and https://github.com/dotnet/aspnetcore/issues/28632. Documented in https://github.com/dotnet/AspNetCore.Docs/issues/21054.

## Customer Impact

Reported by customers who want to use the System.Text.Json 5.0.x package in a netcoreapp3.1 project and need to add an additional PackageReference to `System.Text.Encodings.Web`.

## Regression?

Regressed between preview8 and rc1 of the 5.0.0 package.

## Testing

Packages created locally and installed in a netcoreapp3.1 project. Transitive dependencies are coming along. NuSpec lists the dependencies.

## Risk

Low/Medium. NuSpec and assembly metadata change.