### PR TITLE
PriorityQueue: Apply Comparer<T>.Default optimization

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -21,6 +21,11 @@ namespace System.Collections.Generic
         private (TElement Element, TPriority Priority)[] _nodes;
 
         /// <summary>
+        /// Custom comparer used to order the heap.
+        /// </summary>
+        private IComparer<TPriority>? _comparer;
+
+        /// <summary>
         /// Lazily-initialized collection used to expose the contents of the queue.
         /// </summary>
         private UnorderedItemsCollection? _unorderedItems;
@@ -96,7 +101,7 @@ namespace System.Collections.Generic
                 ? Array.Empty<(TElement, TPriority)>()
                 : new (TElement, TPriority)[initialCapacity];
 
-            Comparer = comparer ?? Comparer<TPriority>.Default;
+            _comparer = comparer;
         }
 
         /// <summary>
@@ -119,7 +124,7 @@ namespace System.Collections.Generic
             }
 
             _nodes = EnumerableHelpers.ToArray(items, out _size);
-            Comparer = comparer ?? Comparer<TPriority>.Default;
+            _comparer = comparer;
 
             if (_size > 1)
             {
@@ -135,7 +140,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Gets the priority comparer of the priority queue.
         /// </summary>
-        public IComparer<TPriority> Comparer { get; }
+        public IComparer<TPriority> Comparer => _comparer ?? Comparer<TPriority>.Default;
 
         /// <summary>
         /// Gets a collection that enumerates the elements of the queue.
@@ -157,7 +162,14 @@ namespace System.Collections.Generic
 
             // Restore the heap order
             int lastNodeIndex = GetLastNodeIndex();
-            MoveUp((element, priority), lastNodeIndex);
+            if (_comparer == null)
+            {
+                MoveUpDefaultComparer((element, priority), lastNodeIndex);
+            }
+            else
+            {
+                MoveUpCustomComparer((element, priority), lastNodeIndex);
+            }
         }
 
         /// <summary>
@@ -186,7 +198,7 @@ namespace System.Collections.Generic
             }
 
             TElement element = _nodes[RootIndex].Element;
-            Remove(RootIndex);
+            RemoveRootNode();
             return element;
         }
 
@@ -201,7 +213,7 @@ namespace System.Collections.Generic
             if (_size != 0)
             {
                 (element, priority) = _nodes[RootIndex];
-                Remove(RootIndex);
+                RemoveRootNode();
                 return true;
             }
 
@@ -237,15 +249,32 @@ namespace System.Collections.Generic
             if (_size != 0)
             {
                 (TElement Element, TPriority Priority) root = _nodes[RootIndex];
-                if (Comparer.Compare(priority, root.Priority) > 0)
+
+                if (_comparer == null)
                 {
-                    (TElement Element, TPriority Priority) newRoot = (element, priority);
-                    _nodes[RootIndex] = newRoot;
+                    if (Comparer<TPriority>.Default.Compare(priority, root.Priority) > 0)
+                    {
+                        (TElement Element, TPriority Priority) newRoot = (element, priority);
+                        _nodes[RootIndex] = newRoot;
 
-                    MoveDown(newRoot, RootIndex);
-                    _version++;
+                        MoveDownDefaultComparer(newRoot, RootIndex);
+                        _version++;
 
-                    return root.Element;
+                        return root.Element;
+                    }
+                }
+                else
+                {
+                    if (_comparer.Compare(priority, root.Priority) > 0)
+                    {
+                        (TElement Element, TPriority Priority) newRoot = (element, priority);
+                        _nodes[RootIndex] = newRoot;
+
+                        MoveDownCustomComparer(newRoot, RootIndex);
+                        _version++;
+
+                        return root.Element;
+                    }
                 }
             }
 
@@ -411,9 +440,9 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// Removes the node at the specified index.
+        /// Removes the node from the root of the heap
         /// </summary>
-        private void Remove(int indexOfNodeToRemove)
+        private void RemoveRootNode()
         {
             // The idea is to replace the specified node by the very last
             // node and shorten the array by one.
@@ -424,34 +453,17 @@ namespace System.Collections.Generic
             {
                 _nodes[lastNodeIndex] = default;
             }
+
             _size--;
             _version++;
 
-            // In case we wanted to remove the node that was the last one,
-            // we are done.
-
-            if (indexOfNodeToRemove == lastNodeIndex)
+            if (_comparer == null)
             {
-                return;
-            }
-
-            // Our last node was erased from the array and needs to be
-            // inserted again. Of course, we will overwrite the node we
-            // wanted to remove. After that operation, we will need
-            // to restore the heap property (in general).
-
-            (TElement Element, TPriority Priority) nodeToRemove = _nodes[indexOfNodeToRemove];
-
-            int relation = Comparer.Compare(lastNode.Priority, nodeToRemove.Priority);
-            _nodes[indexOfNodeToRemove] = lastNode;
-
-            if (relation < 0)
-            {
-                MoveUp(lastNode, indexOfNodeToRemove);
+                MoveDownDefaultComparer(lastNode, RootIndex);
             }
             else
             {
-                MoveDown(lastNode, indexOfNodeToRemove);
+                MoveDownCustomComparer(lastNode, RootIndex);
             }
         }
 
@@ -483,26 +495,67 @@ namespace System.Collections.Generic
             int lastNodeIndex = GetLastNodeIndex();
             int lastParentWithChildren = GetParentIndex(lastNodeIndex);
 
-            for (int index = lastParentWithChildren; index >= 0; --index)
+            if (_comparer == null)
             {
-                MoveDown(_nodes[index], index);
+                for (int index = lastParentWithChildren; index >= 0; --index)
+                {
+                    MoveDownDefaultComparer(_nodes[index], index);
+                }
+            }
+            else
+            {
+                for (int index = lastParentWithChildren; index >= 0; --index)
+                {
+                    MoveDownCustomComparer(_nodes[index], index);
+                }
             }
         }
 
         /// <summary>
         /// Moves a node up in the tree to restore heap order.
         /// </summary>
-        private void MoveUp((TElement Element, TPriority Priority) node, int nodeIndex)
+        private void MoveUpDefaultComparer((TElement Element, TPriority Priority) node, int nodeIndex)
         {
             // Instead of swapping items all the way to the root, we will perform
             // a similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is null);
 
             while (nodeIndex > 0)
             {
                 int parentIndex = GetParentIndex(nodeIndex);
                 (TElement Element, TPriority Priority) parent = _nodes[parentIndex];
 
-                if (Comparer.Compare(node.Priority, parent.Priority) < 0)
+                if (Comparer<TPriority>.Default.Compare(node.Priority, parent.Priority) < 0)
+                {
+                    _nodes[nodeIndex] = parent;
+                    nodeIndex = parentIndex;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            _nodes[nodeIndex] = node;
+        }
+
+        /// <summary>
+        /// Moves a node up in the tree to restore heap order.
+        /// </summary>
+        private void MoveUpCustomComparer((TElement Element, TPriority Priority) node, int nodeIndex)
+        {
+            // Instead of swapping items all the way to the root, we will perform
+            // a similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is not null);
+
+            while (nodeIndex > 0)
+            {
+                int parentIndex = GetParentIndex(nodeIndex);
+                (TElement Element, TPriority Priority) parent = _nodes[parentIndex];
+
+                if (_comparer.Compare(node.Priority, parent.Priority) < 0)
                 {
                     _nodes[nodeIndex] = parent;
                     nodeIndex = parentIndex;
@@ -519,11 +572,13 @@ namespace System.Collections.Generic
         /// <summary>
         /// Moves a node down in the tree to restore heap order.
         /// </summary>
-        private void MoveDown((TElement Element, TPriority Priority) node, int nodeIndex)
+        private void MoveDownDefaultComparer((TElement Element, TPriority Priority) node, int nodeIndex)
         {
             // The node to move down will not actually be swapped every time.
             // Rather, values on the affected path will be moved up, thus leaving a free spot
             // for this value to drop in. Similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is null);
 
             int i;
             while ((i = GetFirstChildIndex(nodeIndex)) < _size)
@@ -537,7 +592,7 @@ namespace System.Collections.Generic
                 while (++i < childrenIndexesLimit)
                 {
                     (TElement Element, TPriority Priority) child = _nodes[i];
-                    if (Comparer.Compare(child.Priority, topChild.Priority) < 0)
+                    if (Comparer<TPriority>.Default.Compare(child.Priority, topChild.Priority) < 0)
                     {
                         topChild = child;
                         topChildIndex = i;
@@ -546,7 +601,53 @@ namespace System.Collections.Generic
 
                 // In case no child needs to be extracted earlier than the current node,
                 // there is nothing more to do - the right spot was found.
-                if (Comparer.Compare(node.Priority, topChild.Priority) <= 0)
+                if (Comparer<TPriority>.Default.Compare(node.Priority, topChild.Priority) <= 0)
+                {
+                    break;
+                }
+
+                // Move the top child up by one node and now investigate the
+                // node that was considered to be the top child (recursive).
+                _nodes[nodeIndex] = topChild;
+                nodeIndex = topChildIndex;
+            }
+
+            _nodes[nodeIndex] = node;
+        }
+
+        /// <summary>
+        /// Moves a node down in the tree to restore heap order.
+        /// </summary>
+        private void MoveDownCustomComparer((TElement Element, TPriority Priority) node, int nodeIndex)
+        {
+            // The node to move down will not actually be swapped every time.
+            // Rather, values on the affected path will be moved up, thus leaving a free spot
+            // for this value to drop in. Similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is not null);
+
+            int i;
+            while ((i = GetFirstChildIndex(nodeIndex)) < _size)
+            {
+                // Check if the current node (pointed by 'nodeIndex') should really be extracted
+                // first, or maybe one of its children should be extracted earlier.
+                (TElement Element, TPriority Priority) topChild = _nodes[i];
+                int childrenIndexesLimit = Math.Min(i + Arity, _size);
+                int topChildIndex = i;
+
+                while (++i < childrenIndexesLimit)
+                {
+                    (TElement Element, TPriority Priority) child = _nodes[i];
+                    if (_comparer.Compare(child.Priority, topChild.Priority) < 0)
+                    {
+                        topChild = child;
+                        topChildIndex = i;
+                    }
+                }
+
+                // In case no child needs to be extracted earlier than the current node,
+                // there is nothing more to do - the right spot was found.
+                if (_comparer.Compare(node.Priority, topChild.Priority) <= 0)
                 {
                     break;
                 }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -692,7 +692,7 @@ namespace System.Collections.Generic
             {
                 // Currently the JIT doesn't optimize direct Comparer<T>.Default.Compare
                 // calls for reference types, so we want to cache the comparer instance instead.
-                // TODO update if this changes in the future.
+                // TODO https://github.com/dotnet/runtime/issues/10050: Update if this changes in the future.
                 return comparer ?? Comparer<TPriority>.Default;
             }
         }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -99,10 +99,7 @@ namespace System.Collections.Generic
                     nameof(initialCapacity), initialCapacity, SR.ArgumentOutOfRange_NeedNonNegNum);
             }
 
-            _nodes = (initialCapacity == 0)
-                ? Array.Empty<(TElement, TPriority)>()
-                : new (TElement, TPriority)[initialCapacity];
-
+            _nodes = new (TElement, TPriority)[initialCapacity];
             _comparer = InitializeComparer(comparer);
         }
 

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -84,7 +84,7 @@ namespace System.Collections.Generic
         public PriorityQueue(IComparer<TPriority>? comparer)
         {
             _nodes = Array.Empty<(TElement, TPriority)>();
-            _comparer = InitializeComparer(null);
+            _comparer = InitializeComparer(comparer);
         }
 
         /// <summary>


### PR DESCRIPTION
Make direct calls to `Comparer<T>.Default.Compare` when no custom `IComparer<T>` instance is specified, taking advantage of the optimizations in #48160.

## Performance

Using benchmarks from https://github.com/dotnet/performance/pull/1665

### main

|         Method |   Size |            Mean |         Error |        StdDev |          Median |             Min |             Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |------- |----------------:|--------------:|--------------:|----------------:|----------------:|----------------:|------:|------:|------:|----------:|
|       HeapSort |     10 |        275.5 ns |       4.72 ns |       3.94 ns |        274.3 ns |        272.3 ns |        284.7 ns |     - |     - |     - |         - |
| K_Min_Elements |     10 |        188.2 ns |       1.43 ns |       1.34 ns |        188.1 ns |        186.4 ns |        190.5 ns |     - |     - |     - |         - |
|       HeapSort |    100 |      5,831.1 ns |      23.68 ns |      20.99 ns |      5,827.2 ns |      5,790.5 ns |      5,873.7 ns |     - |     - |     - |         - |
| K_Min_Elements |    100 |        835.3 ns |       5.56 ns |       4.64 ns |        835.9 ns |        825.7 ns |        842.4 ns |     - |     - |     - |         - |
|       HeapSort |   1000 |    104,618.2 ns |   1,297.35 ns |   1,213.54 ns |    104,295.8 ns |    103,134.7 ns |    107,482.9 ns |     - |     - |     - |         - |
| K_Min_Elements |   1000 |      5,109.5 ns |      84.29 ns |      74.72 ns |      5,082.6 ns |      5,035.9 ns |      5,285.3 ns |     - |     - |     - |         - |
|       HeapSort |  10000 |  1,382,286.0 ns |  17,339.01 ns |  14,478.85 ns |  1,378,520.1 ns |  1,364,851.3 ns |  1,418,781.0 ns |     - |     - |     - |       1 B |
| K_Min_Elements |  10000 |     43,600.4 ns |     655.10 ns |     547.04 ns |     43,470.5 ns |     42,982.0 ns |     44,965.3 ns |     - |     - |     - |         - |
|       HeapSort | 100000 | 17,338,945.6 ns | 127,125.13 ns | 106,155.24 ns | 17,342,100.0 ns | 17,143,023.1 ns | 17,486,884.6 ns |     - |     - |     - |      11 B |
| K_Min_Elements | 100000 |    461,078.6 ns |  18,155.17 ns |  20,907.53 ns |    458,911.1 ns |    428,690.8 ns |    492,106.5 ns |     - |     - |     - |         - |

### PR branch

|         Method |   Size |            Mean |         Error |        StdDev |          Median |             Min |             Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |------- |----------------:|--------------:|--------------:|----------------:|----------------:|----------------:|------:|------:|------:|----------:|
|       HeapSort |     10 |        208.9 ns |       6.34 ns |       6.79 ns |        208.6 ns |        191.8 ns |        217.7 ns |     - |     - |     - |         - |
| K_Min_Elements |     10 |        147.3 ns |       5.80 ns |       6.68 ns |        144.6 ns |        136.6 ns |        160.8 ns |     - |     - |     - |         - |
|       HeapSort |    100 |      3,553.9 ns |     120.23 ns |     133.63 ns |      3,583.6 ns |      3,261.7 ns |      3,751.3 ns |     - |     - |     - |         - |
| K_Min_Elements |    100 |        610.5 ns |      18.93 ns |      20.25 ns |        615.2 ns |        561.9 ns |        647.7 ns |     - |     - |     - |         - |
|       HeapSort |   1000 |     82,091.4 ns |   3,752.99 ns |   4,321.94 ns |     82,769.6 ns |     74,755.7 ns |     91,248.6 ns |     - |     - |     - |         - |
| K_Min_Elements |   1000 |      4,042.3 ns |     179.86 ns |     207.13 ns |      4,028.6 ns |      3,687.8 ns |      4,411.0 ns |     - |     - |     - |         - |
|       HeapSort |  10000 |  1,117,819.2 ns |  38,606.25 ns |  42,910.75 ns |  1,108,901.0 ns |  1,037,257.2 ns |  1,176,602.9 ns |     - |     - |     - |       1 B |
| K_Min_Elements |  10000 |     34,393.6 ns |   1,911.55 ns |   2,124.68 ns |     33,527.5 ns |     31,757.1 ns |     38,687.1 ns |     - |     - |     - |         - |
|       HeapSort | 100000 | 14,617,127.5 ns | 510,218.11 ns | 587,567.94 ns | 14,697,175.0 ns | 13,688,916.7 ns | 15,793,872.2 ns |     - |     - |     - |       8 B |
| K_Min_Elements | 100000 |    337,853.6 ns |  12,592.12 ns |  14,501.10 ns |    331,689.4 ns |    316,677.5 ns |    365,371.4 ns |     - |     - |     - |         - |