### PR TITLE
DefineDynamicAssembly API Extension

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -265,6 +265,21 @@ namespace System.Reflection.Emit
                                                  assemblyAttributes);
         }
 
+        [DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
+        public static AssemblyBuilder DefineDynamicAssembly(
+            AssemblyName name,
+            AssemblyBuilderAccess access,
+            AssemblyLoadContext assemblyLoadContext,
+            IEnumerable<CustomAttributeBuilder>? assemblyAttributes = null)
+        {
+            StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
+            return InternalDefineDynamicAssembly(name,
+                access,
+                ref stackMark,
+                assemblyLoadContext,
+                assemblyAttributes);
+        }
+
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void CreateDynamicAssembly(ObjectHandleOnStack name,
                                                          StackCrawlMarkHandle stackMark,

--- a/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
+++ b/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
@@ -23,6 +23,7 @@ namespace System.Reflection.Emit
         public override bool ReflectionOnly { get { throw null; } }
         public static System.Reflection.Emit.AssemblyBuilder DefineDynamicAssembly(System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access) { throw null; }
         public static System.Reflection.Emit.AssemblyBuilder DefineDynamicAssembly(System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access, System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder>? assemblyAttributes) { throw null; }
+        public static System.Reflection.Emit.AssemblyBuilder DefineDynamicAssembly(System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access, System.Runtime.Loader.AssemblyLoadContext assemblyLoadContext, System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder>? assemblyAttributes = null) { throw null; }
         public System.Reflection.Emit.ModuleBuilder DefineDynamicModule(string name) { throw null; }
         public override bool Equals(object? obj) { throw null; }
         public override object[] GetCustomAttributes(bool inherit) { throw null; }

--- a/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.csproj
+++ b/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.csproj
@@ -8,6 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.Loader\ref\System.Runtime.Loader.csproj" />
     <ProjectReference Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
     <ProjectReference Include="..\..\System.Reflection.Primitives\ref\System.Reflection.Primitives.csproj" />
     <ProjectReference Include="..\..\System.Reflection.Emit.ILGeneration\ref\System.Reflection.Emit.ILGeneration.csproj" />


### PR DESCRIPTION
Added an overload of the `DefineDynamicAssembly` method to explicitly specify the ALC used to host of dynamic assembly