### PR TITLE
SPMI fixes for missing info.

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -2636,8 +2636,11 @@ void MethodContext::repGetMethodSig(CORINFO_METHOD_HANDLE ftn, CORINFO_SIG_INFO*
     key.B = CastHandle(memberParent);
 
 
-    AssertCodeMsg(GetMethodSig != nullptr && GetMethodSig->GetIndex(key) != -1 , EXCEPTIONCODE_MC,
-        "Didn't find anything anything for ftn-%016llX prt-%016llX", key.A, key.B);
+    AssertCodeMsg(GetMethodSig != nullptr, EXCEPTIONCODE_MC,
+                  "Didn't find anything anything for ftn-%016llX prt-%016llX", key.A, key.B);
+
+    AssertCodeMsg(GetMethodSig->GetIndex(key) != -1, EXCEPTIONCODE_MC,
+                  "Didn't find anything anything for ftn-%016llX prt-%016llX", key.A, key.B);
 
     value = GetMethodSig->Get(key);
 
@@ -2696,12 +2699,11 @@ CORINFO_CLASS_HANDLE MethodContext::repGetArgClass(CORINFO_SIG_INFO*       sig,
     key.methodSignature        = CastPointer(sig->methodSignature);
     key.scope                  = CastHandle(sig->scope);
     key.args                   = CastHandle(args);
-
-    AssertCodeMsg(GetArgClass != nullptr, EXCEPTIONCODE_MC,
-        "Didn't find %016llx, %016llx.  probably a missing exception in getArgClass", key.scope, key.args);
-
     key.sigInst_classInst_Index = SpmiRecordsHelper::ContainsHandleMap(sig->sigInst.classInstCount, sig->sigInst.classInst, SigInstHandleMap);
     key.sigInst_methInst_Index  = SpmiRecordsHelper::ContainsHandleMap(sig->sigInst.methInstCount, sig->sigInst.methInst, SigInstHandleMap);
+
+    AssertCodeMsg(GetArgClass != nullptr, EXCEPTIONCODE_MC,
+                  "Didn't find %016llx, %016llx.  probably a missing exception in getArgClass", key.scope, key.args);
 
     AssertCodeMsg(GetArgClass->GetIndex(key) != -1, EXCEPTIONCODE_MC,
                   "Didn't find %016llx, %016llx.  probably a missing exception in getArgClass", key.scope, key.args);

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -2635,6 +2635,10 @@ void MethodContext::repGetMethodSig(CORINFO_METHOD_HANDLE ftn, CORINFO_SIG_INFO*
     key.A = CastHandle(ftn);
     key.B = CastHandle(memberParent);
 
+
+    AssertCodeMsg(GetMethodSig != nullptr && GetMethodSig->GetIndex(key) != -1 , EXCEPTIONCODE_MC,
+        "Didn't find anything anything for ftn-%016llX prt-%016llX", key.A, key.B);
+
     value = GetMethodSig->Get(key);
 
     *sig = SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(value, GetMethodSig, SigInstHandleMap);
@@ -2683,9 +2687,6 @@ CORINFO_CLASS_HANDLE MethodContext::repGetArgClass(CORINFO_SIG_INFO*       sig,
                                                    CORINFO_ARG_LIST_HANDLE args,
                                                    DWORD*                  exceptionCode)
 {
-    AssertCodeMsg(GetArgClass != nullptr, EXCEPTIONCODE_MC,
-                  "Didn't find %016llx, %016llx.  probably a missing exception in getArgClass", CastHandle(sig->scope), CastHandle(args));
-
     Agnostic_GetArgClass_Key key;
     ZeroMemory(&key, sizeof(Agnostic_GetArgClass_Key)); // We use the input structs as a key and use memcmp to compare.. so
                                                         // we need to zero out padding too
@@ -2695,6 +2696,9 @@ CORINFO_CLASS_HANDLE MethodContext::repGetArgClass(CORINFO_SIG_INFO*       sig,
     key.methodSignature        = CastPointer(sig->methodSignature);
     key.scope                  = CastHandle(sig->scope);
     key.args                   = CastHandle(args);
+
+    AssertCodeMsg(GetArgClass != nullptr, EXCEPTIONCODE_MC,
+        "Didn't find %016llx, %016llx.  probably a missing exception in getArgClass", key.scope, key.args);
 
     key.sigInst_classInst_Index = SpmiRecordsHelper::ContainsHandleMap(sig->sigInst.classInstCount, sig->sigInst.classInst, SigInstHandleMap);
     key.sigInst_methInst_Index  = SpmiRecordsHelper::ContainsHandleMap(sig->sigInst.methInstCount, sig->sigInst.methInst, SigInstHandleMap);

--- a/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -354,7 +354,7 @@ JitInstance::Result JitInstance::CompileMethod(MethodContext* MethodToCompile, i
     {
         SpmiException e(&param.exceptionPointers);
 
-        if (e.GetCode() == EXCEPTIONCODE_MC)
+        if (param.exceptionCode == EXCEPTIONCODE_MC) // Can't check e.GetCode() because of https://github.com/dotnet/runtime/issues/48356
         {
             char* message = e.GetExceptionMessage();
             LogMissing("Method context %d failed to replay: %s", mcIndex, message);

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -537,8 +537,12 @@ int __cdecl main(int argc, char* argv[])
         {
             failToReplayCount++;
 
+            // Methods that don't compile due to missing JIT-EE information
+            // should still be added to the failing MC list but we don't create MC repro for them.
             if (o.mclFilename != nullptr)
+            {
                 failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
+            }
 
             // The following only apply specifically to failures caused by errors (as opposed
             // to, for instance, failures caused by missing JIT-EE details).

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1285,6 +1285,8 @@ def print_superpmi_failure_code(return_code, coreclr_args):
         logging.warning("Compilation failures")
     elif return_code == 2:
         logging.warning("Asm diffs found")
+    elif return_code == 3:
+        logging.warning("SPMI misses found")
     elif return_code == 139 and coreclr_args.host_os != "windows":
         logging.error("Fatal error, SuperPMI has returned SIGSEGV (segmentation fault)")
     else:

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1286,7 +1286,7 @@ def print_superpmi_failure_code(return_code, coreclr_args):
     elif return_code == 2:
         logging.warning("Asm diffs found")
     elif return_code == 3:
-        logging.warning("SPMI misses found")
+        logging.warning("SuperPMI missing data encountered")
     elif return_code == 139 and coreclr_args.host_os != "windows":
         logging.error("Fatal error, SuperPMI has returned SIGSEGV (segmentation fault)")
     else:


### PR DESCRIPTION
Improve SPMI experience when there are misses, they could be due to stale collection or due to local changes.
It is useful to separate Jit asserts from such misses when working on big changes that could introduce misses but should not introduce Jit asserts.


Link https://github.com/dotnet/runtime/issues/48356.
Before:
```
Running SuperPMI replay of D:\Sergey\git\runtime\artifacts\spmi\mch\af37688b-d4e5-4a41-a7ee-701728a470aa.windows.x64\tests.pmi.windows.x64.checked.mch
Compilation failures

Repro .mc files created for failures:
D:\Sergey\git\runtime\artifacts\spmi\repro.windows.x64.Checked.20\repro-102534.mc
***
D:\Sergey\git\runtime\artifacts\spmi\repro.windows.x64.Checked.20\repro-74002.mc
D:\Sergey\git\runtime\artifacts\spmi\repro.windows.x64.Checked.20\repro-80696.mc

To run a specific failure (replace JIT path and .mc filename as needed):

D:\Sergey\git\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\superpmi.exe  D:\Sergey\git\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\clrjit.dll D:\Sergey\git\runtime\artifacts\spmi\repro.windows.x64.Checked.20\xxxxx.mc
```

After:
```
Running SuperPMI replay of D:\Sergey\git\runtime\artifacts\spmi\mch\af37688b-d4e5-4a41-a7ee-701728a470aa.windows.x64\libraries.pmi.windows.x64.checked.mch
SPMI misses found
Running SuperPMI replay of D:\Sergey\git\runtime\artifacts\spmi\mch\af37688b-d4e5-4a41-a7ee-701728a470aa.windows.x64\tests.pmi.windows.x64.checked.mch
SPMI misses found

```