### PR TITLE
Fix various test crashes and asserts when running the Algorithms test suite with the Android Crypto PAL

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp_cipher.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp_cipher.c
@@ -151,18 +151,22 @@ int32_t CryptoNative_EvpCipherSetKeyAndIV(CipherCtx* ctx, uint8_t* key, uint8_t*
 
     // CryptoNative_EvpCipherSetKeyAndIV can be called separately for key and iv
     // so we need to wait for both and do Init after.
-    if (key)
+    // TODO: What to do if key or iv is already set. Ignore or replace?
+    if (key && !ctx->key)
         SaveTo(key, &ctx->key, (size_t)keyLength);
-    if (iv)
+    if (iv && !ctx->iv)
         SaveTo(iv, &ctx->iv, (size_t)ctx->ivLength);
 
     if (!ctx->key || !ctx->iv)
         return SUCCESS;
 
-    // input:  0 for Decrypt, 1 for Encrypt
-    // Cipher: 2 for Decrypt, 1 for Encrypt
-    assert(enc == 0 || enc == 1);
-    ctx->encMode = enc == 0 ? CIPHER_DECRYPT_MODE : CIPHER_ENCRYPT_MODE;
+    // input:  0 for Decrypt, 1 for Encrypt, -1 leave untouched
+    // Cipher: 2 for Decrypt, 1 for Encrypt, N/A
+    if (enc != -1)
+    {
+        assert(enc == 0 || enc == 1);
+        ctx->encMode = enc == 0 ? CIPHER_DECRYPT_MODE : CIPHER_ENCRYPT_MODE;
+    }
 
     JNIEnv* env = GetJNIEnv();
 
@@ -213,7 +217,11 @@ CipherCtx* CryptoNative_EvpCipherCreate2(intptr_t type, uint8_t* key, int32_t ke
     if (CryptoNative_EvpCipherSetKeyAndIV(ctx, key, iv, enc) != SUCCESS)
         return FAIL;
     
-    assert(keyLength == GetAlgorithmWidth(type));
+    if (keyLength != GetAlgorithmWidth(type))
+    {
+        LOG_ERROR("Key length must match algorithm width.");
+        return FAIL;
+    }
     return ctx;
 }
 
@@ -225,6 +233,9 @@ int32_t CryptoNative_EvpCipherUpdate(CipherCtx* ctx, uint8_t* outm, int32_t* out
     if (!outl && !in)
         // it means caller wants us to record "inl" but we don't need it.
         return SUCCESS;
+
+    if (!in)
+        return FAIL;
 
     JNIEnv* env = GetJNIEnv();
     jbyteArray inDataBytes = (*env)->NewByteArray(env, inl);
@@ -265,6 +276,8 @@ int32_t CryptoNative_EvpCipherFinalEx(CipherCtx* ctx, uint8_t* outm, int32_t* ou
     int tagLength = (hasTag && !decrypt) ? TAG_MAX_LENGTH : 0;
 
     jbyteArray outBytes = (jbyteArray)(*env)->CallObjectMethod(env, ctx->cipher, g_cipherDoFinalMethod);
+    if (CheckJNIExceptions(env)) return FAIL;
+
     jsize outBytesLen = (*env)->GetArrayLength(env, outBytes);
 
     if (outBytesLen > tagLength)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp_cipher.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp_cipher.c
@@ -151,11 +151,10 @@ int32_t CryptoNative_EvpCipherSetKeyAndIV(CipherCtx* ctx, uint8_t* key, uint8_t*
 
     // CryptoNative_EvpCipherSetKeyAndIV can be called separately for key and iv
     // so we need to wait for both and do Init after.
-    // TODO: What to do if key or iv is already set. Ignore or replace?
     if (key && !ctx->key)
-        SaveTo(key, &ctx->key, (size_t)keyLength);
+        SaveTo(key, &ctx->key, (size_t)keyLength, /* overwrite */ true);
     if (iv && !ctx->iv)
-        SaveTo(iv, &ctx->iv, (size_t)ctx->ivLength);
+        SaveTo(iv, &ctx->iv, (size_t)ctx->ivLength, /* overwrite */ true);
 
     if (!ctx->key || !ctx->iv)
         return SUCCESS;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
@@ -32,6 +32,13 @@ jobject CryptoNative_HmacCreate(uint8_t* key, int32_t keyLen, intptr_t type)
     jbyteArray keyBytes = (*env)->NewByteArray(env, keyLen);
     (*env)->SetByteArrayRegion(env, keyBytes, 0, keyLen, (jbyte*)key);
     jobject sksObj = (*env)->NewObject(env, g_sksClass, g_sksCtor, keyBytes, macName);
+    if (CheckJNIExceptions(env))
+    {
+        (*env)->DeleteLocalRef(env, keyBytes);
+        (*env)->DeleteLocalRef(env, sksObj);
+        (*env)->DeleteLocalRef(env, macName);
+        return FAIL;
+    }
     assert(sksObj && "Unable to create an instance of SecretKeySpec");
     jobject macObj = ToGRef(env, (*env)->CallStaticObjectMethod(env, g_macClass, g_macGetInstanceMethod, macName));
     (*env)->CallVoidMethod(env, macObj, g_macInitMethod, sksObj);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -210,9 +210,13 @@ void AssertOnJNIExceptions(JNIEnv* env)
     assert(!CheckJNIExceptions(env));
 }
 
-void SaveTo(uint8_t* src, uint8_t** dst, size_t len)
+void SaveTo(uint8_t* src, uint8_t** dst, size_t len, bool overwrite)
 {
-    assert(!(*dst));
+    assert(overwrite || !(*dst));
+    if (overwrite)
+    {
+        free(*dst);
+    }
     *dst = (uint8_t*)malloc(len * sizeof(uint8_t));
     memcpy(*dst, src, len);
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -177,7 +177,7 @@ extern jclass    g_TrustManager;
 #define LOG_ERROR(fmt, ...) ((void)__android_log_print(ANDROID_LOG_ERROR, "DOTNET", "%s: " fmt, __FUNCTION__, ## __VA_ARGS__))
 #define JSTRING(str) ((jstring)(*env)->NewStringUTF(env, str))
 
-void SaveTo(uint8_t* src, uint8_t** dst, size_t len);
+void SaveTo(uint8_t* src, uint8_t** dst, size_t len, bool overwrite);
 jobject ToGRef(JNIEnv *env, jobject lref);
 jobject AddGRef(JNIEnv *env, jobject gref);
 void ReleaseGRef(JNIEnv *env, jobject gref);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.c
@@ -3,6 +3,8 @@
 
 #include "pal_rsa.h"
 
+#define RSA_FAIL -1
+
 PALEXPORT RSA* CryptoNative_RsaCreate()
 {
     RSA* rsa = malloc(sizeof(RSA));
@@ -41,7 +43,7 @@ PALEXPORT void CryptoNative_RsaDestroy(RSA* rsa)
 PALEXPORT int32_t CryptoNative_RsaPublicEncrypt(int32_t flen, uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
 {
     if (!rsa)
-        return FAIL;
+        return RSA_FAIL;
 
     JNIEnv* env = GetJNIEnv();
 
@@ -58,6 +60,12 @@ PALEXPORT int32_t CryptoNative_RsaPublicEncrypt(int32_t flen, uint8_t* from, uin
     jbyteArray fromBytes = (*env)->NewByteArray(env, flen);
     (*env)->SetByteArrayRegion(env, fromBytes, 0, flen, (jbyte*)from);
     jbyteArray encryptedBytes = (jbyteArray)(*env)->CallObjectMethod(env, cipher, g_cipherDoFinal2Method, fromBytes);
+    if (CheckJNIExceptions(env))
+    {
+        (*env)->DeleteLocalRef(env, fromBytes);
+        (*env)->DeleteLocalRef(env, cipher);
+        return RSA_FAIL;
+    }
     jsize encryptedBytesLen = (*env)->GetArrayLength(env, encryptedBytes);
     (*env)->GetByteArrayRegion(env, encryptedBytes, 0, encryptedBytesLen, (jbyte*) to);
 
@@ -111,7 +119,7 @@ PALEXPORT RSA* CryptoNative_DecodeRsaPublicKey(uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
-        return NULL;
+        return FAIL;
     }
 
     JNIEnv* env = GetJNIEnv();
@@ -134,31 +142,84 @@ PALEXPORT RSA* CryptoNative_DecodeRsaPublicKey(uint8_t* buf, int32_t len)
     (*env)->DeleteLocalRef(env, bytes);
     (*env)->DeleteLocalRef(env, x509keySpec);
 
+    if (CheckJNIExceptions(env))
+    {
+        CryptoNative_RsaDestroy(rsa);
+        return FAIL;
+    }
+
     return rsa;
 }
 
 PALEXPORT int32_t CryptoNative_RsaSignPrimitive(int32_t flen, uint8_t* from, uint8_t* to, RSA* rsa)
 {
-    // TODO:
-    return FAIL;
+    if (!rsa)
+        return RSA_FAIL;
+
+    JNIEnv* env = GetJNIEnv();
+
+    jobject algName = JSTRING("RSA/ECB/NoPadding");
+
+    jobject cipher = (*env)->CallStaticObjectMethod(env, g_cipherClass, g_cipherGetInstanceMethod, algName);
+    (*env)->CallVoidMethod(env, cipher, g_cipherInit2Method, CIPHER_ENCRYPT_MODE, rsa->privateKey);
+    jbyteArray fromBytes = (*env)->NewByteArray(env, flen);
+    (*env)->SetByteArrayRegion(env, fromBytes, 0, flen, (jbyte*)from);
+    jbyteArray encryptedBytes = (jbyteArray)(*env)->CallObjectMethod(env, cipher, g_cipherDoFinal2Method, fromBytes);
+    if (CheckJNIExceptions(env))
+    {
+        (*env)->DeleteLocalRef(env, cipher);
+        (*env)->DeleteLocalRef(env, fromBytes);
+        (*env)->DeleteLocalRef(env, algName);
+        return RSA_FAIL;
+    }
+    jsize encryptedBytesLen = (*env)->GetArrayLength(env, encryptedBytes);
+    (*env)->GetByteArrayRegion(env, encryptedBytes, 0, encryptedBytesLen, (jbyte*) to);
+
+    (*env)->DeleteLocalRef(env, cipher);
+    (*env)->DeleteLocalRef(env, fromBytes);
+    (*env)->DeleteLocalRef(env, encryptedBytes);
+    (*env)->DeleteLocalRef(env, algName);
+
+    return (int32_t)encryptedBytesLen;
 }
 
 PALEXPORT int32_t CryptoNative_RsaVerificationPrimitive(int32_t flen, uint8_t* from, uint8_t* to, RSA* rsa)
 {
-    // TODO:
-    return FAIL;
+    if (!rsa)
+        return RSA_FAIL;
+
+    JNIEnv* env = GetJNIEnv();
+
+    jobject algName = JSTRING("RSA/ECB/NoPadding");
+
+    jobject cipher = (*env)->CallStaticObjectMethod(env, g_cipherClass, g_cipherGetInstanceMethod, algName);
+    (*env)->CallVoidMethod(env, cipher, g_cipherInit2Method, CIPHER_DECRYPT_MODE, rsa->publicKey);
+    jbyteArray fromBytes = (*env)->NewByteArray(env, flen);
+    (*env)->SetByteArrayRegion(env, fromBytes, 0, flen, (jbyte*)from);
+    jbyteArray decryptedBytes = (jbyteArray)(*env)->CallObjectMethod(env, cipher, g_cipherDoFinal2Method, fromBytes);
+    jsize decryptedBytesLen = (*env)->GetArrayLength(env, decryptedBytes);
+    (*env)->GetByteArrayRegion(env, decryptedBytes, 0, decryptedBytesLen, (jbyte*) to);
+
+    (*env)->DeleteLocalRef(env, cipher);
+    (*env)->DeleteLocalRef(env, fromBytes);
+    (*env)->DeleteLocalRef(env, decryptedBytes);
+    (*env)->DeleteLocalRef(env, algName);
+
+    return (int32_t)decryptedBytesLen;
 }
 
 PALEXPORT int32_t CryptoNative_RsaSign(int32_t type, uint8_t* m, int32_t mlen, uint8_t* sigret, int32_t* siglen, RSA* rsa)
 {
     // TODO:
-    return FAIL;
+    LOG_ERROR("RSA signing NYI");
+    return RSA_FAIL;
 }
 
 PALEXPORT int32_t CryptoNative_RsaVerify(int32_t type, uint8_t* m, int32_t mlen, uint8_t* sigbuf, int32_t siglen, RSA* rsa)
 {
     // TODO:
-    return FAIL;
+    LOG_ERROR("RSA signing NYI");
+    return RSA_FAIL;
 }
 
 PALEXPORT int32_t CryptoNative_RsaGenerateKeyEx(RSA* rsa, int32_t bits, jobject pubExp)
@@ -232,9 +293,8 @@ PALEXPORT int32_t CryptoNative_GetRsaParameters(RSA* rsa,
         *dmq1 = ToGRef(env, (*env)->CallObjectMethod(env, privateKey, g_RSAPrivateCrtKeyPrimeExpQField));
         *iqmp = ToGRef(env, (*env)->CallObjectMethod(env, privateKey, g_RSAPrivateCrtKeyCrtCoefField));
     }
-    else
+    else if (publicKey)
     {
-        assert(publicKey);
         *e = ToGRef(env, (*env)->CallObjectMethod(env, publicKey, g_RSAPublicKeyGetPubExpMethod));
         *n = ToGRef(env, (*env)->CallObjectMethod(env, publicKey, g_RSAKeyGetModulus));
         *d = NULL;
@@ -243,6 +303,10 @@ PALEXPORT int32_t CryptoNative_GetRsaParameters(RSA* rsa,
         *dmp1 = NULL;
         *dmq1 = NULL;
         *iqmp = NULL;
+    }
+    else
+    {
+        return FAIL;
     }
 
     return CheckJNIExceptions(env) ? FAIL : SUCCESS;


### PR DESCRIPTION
There were a number of various assert failures and crashes when running the System.Security.Cryptography.Algorithms test suite while I was testing #48348.

This PR fixes almost all of the crashes (there was one related to a stack imbalance that I haven't had a chance to track down yet).

A number of the fixes are returning the right "failure" value to match OpenSSL's API.