### PR TITLE
Rename LargeHeapHandle* to PinnedHeapHandle* to reflect what it actually does

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -122,8 +122,8 @@ ULONG               SystemDomain::s_dNumAppDomains = 0;
 DWORD               SystemDomain::m_dwLowestFreeIndex        = 0;
 
 #ifndef CROSSGEN_COMPILE
-// Constructor for the LargeHeapHandleBucket class.
-LargeHeapHandleBucket::LargeHeapHandleBucket(LargeHeapHandleBucket *pNext, DWORD Size, BaseDomain *pDomain)
+// Constructor for the PinnedHeapHandleBucket class.
+PinnedHeapHandleBucket::PinnedHeapHandleBucket(PinnedHeapHandleBucket *pNext, DWORD Size, BaseDomain *pDomain)
 : m_pNext(pNext)
 , m_ArraySize(Size)
 , m_CurrentPos(0)
@@ -154,8 +154,8 @@ LargeHeapHandleBucket::LargeHeapHandleBucket(LargeHeapHandleBucket *pNext, DWORD
 }
 
 
-// Destructor for the LargeHeapHandleBucket class.
-LargeHeapHandleBucket::~LargeHeapHandleBucket()
+// Destructor for the PinnedHeapHandleBucket class.
+PinnedHeapHandleBucket::~PinnedHeapHandleBucket()
 {
     CONTRACTL
     {
@@ -173,7 +173,7 @@ LargeHeapHandleBucket::~LargeHeapHandleBucket()
 
 
 // Allocate handles from the bucket.
-OBJECTREF *LargeHeapHandleBucket::AllocateHandles(DWORD nRequested)
+OBJECTREF *PinnedHeapHandleBucket::AllocateHandles(DWORD nRequested)
 {
     CONTRACTL
     {
@@ -194,7 +194,7 @@ OBJECTREF *LargeHeapHandleBucket::AllocateHandles(DWORD nRequested)
 }
 
 // look for a free item embedded in the table
-OBJECTREF *LargeHeapHandleBucket::TryAllocateEmbeddedFreeHandle()
+OBJECTREF *PinnedHeapHandleBucket::TryAllocateEmbeddedFreeHandle()
 {
     CONTRACTL
     {
@@ -224,7 +224,7 @@ OBJECTREF *LargeHeapHandleBucket::TryAllocateEmbeddedFreeHandle()
 }
 
 // enumerate the handles in the bucket
-void LargeHeapHandleBucket::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
+void PinnedHeapHandleBucket::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
 {
     for (int i = 0; i < m_CurrentPos; i++)
     {
@@ -239,8 +239,8 @@ void LargeHeapHandleBucket::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
 
 #define MAX_BUCKETSIZE (16384 - 4)
 
-// Constructor for the LargeHeapHandleTable class.
-LargeHeapHandleTable::LargeHeapHandleTable(BaseDomain *pDomain, DWORD InitialBucketSize)
+// Constructor for the PinnedHeapHandleTable class.
+PinnedHeapHandleTable::PinnedHeapHandleTable(BaseDomain *pDomain, DWORD InitialBucketSize)
 : m_pHead(NULL)
 , m_pDomain(pDomain)
 , m_NextBucketSize(InitialBucketSize)
@@ -263,8 +263,8 @@ LargeHeapHandleTable::LargeHeapHandleTable(BaseDomain *pDomain, DWORD InitialBuc
 }
 
 
-// Destructor for the LargeHeapHandleTable class.
-LargeHeapHandleTable::~LargeHeapHandleTable()
+// Destructor for the PinnedHeapHandleTable class.
+PinnedHeapHandleTable::~PinnedHeapHandleTable()
 {
     CONTRACTL
     {
@@ -276,7 +276,7 @@ LargeHeapHandleTable::~LargeHeapHandleTable()
     // Delete the buckets.
     while (m_pHead)
     {
-        LargeHeapHandleBucket *pOld = m_pHead;
+        PinnedHeapHandleBucket *pOld = m_pHead;
         m_pHead = pOld->GetNext();
         delete pOld;
     }
@@ -294,7 +294,7 @@ LargeHeapHandleTable::~LargeHeapHandleTable()
 // thread notions.
 //
 // The instance in question is
-// There are two locations you can find a LargeHeapHandleTable
+// There are two locations you can find a PinnedHeapHandleTable
 // 1) there is one in every BaseDomain, it is used to keep track of the static members
 //     in that domain
 // 2) there is one in the System Domain that is used for the GlobalStringLiteralMap
@@ -315,7 +315,7 @@ LargeHeapHandleTable::~LargeHeapHandleTable()
 // Each BaseDomain has its own critical section
 //
 // BaseDomain::AllocateObjRefPtrsInLargeTable takes a lock with
-//        CrstHolder ch(&m_LargeHeapHandleTableCrst);
+//        CrstHolder ch(&m_PinnedHeapHandleTableCrst);
 //
 // it does this before it calls AllocateHandles which suffices.  It does not call ReleaseHandles
 // at any time (although ReleaseHandles may be called via AllocateHandles if the request
@@ -336,7 +336,7 @@ LargeHeapHandleTable::~LargeHeapHandleTable()
 //
 // AppDomainStringLiteralMap::GetStringLiteral
 // leads to calls to
-//     LargeHeapHandleBlockHolder constructor
+//     PinnedHeapHandleBlockHolder constructor
 //     leads to calls to
 //          m_Data = pOwner->AllocateHandles(nCount);
 //
@@ -377,7 +377,7 @@ LargeHeapHandleTable::~LargeHeapHandleTable()
 
 
 // Allocate handles from the large heap handle table.
-OBJECTREF* LargeHeapHandleTable::AllocateHandles(DWORD nRequested)
+OBJECTREF* PinnedHeapHandleTable::AllocateHandles(DWORD nRequested)
 {
     CONTRACTL
     {
@@ -447,7 +447,7 @@ OBJECTREF* LargeHeapHandleTable::AllocateHandles(DWORD nRequested)
         // We need a block big enough to hold the requested handles
         DWORD NewBucketSize = max(m_NextBucketSize, nRequested);
 
-        m_pHead = new LargeHeapHandleBucket(m_pHead, NewBucketSize, m_pDomain);
+        m_pHead = new PinnedHeapHandleBucket(m_pHead, NewBucketSize, m_pDomain);
 
         m_NextBucketSize = min(m_NextBucketSize * 2, MAX_BUCKETSIZE);
     }
@@ -457,7 +457,7 @@ OBJECTREF* LargeHeapHandleTable::AllocateHandles(DWORD nRequested)
 
 //*****************************************************************************
 // Release object handles allocated using AllocateHandles().
-void LargeHeapHandleTable::ReleaseHandles(OBJECTREF *pObjRef, DWORD nReleased)
+void PinnedHeapHandleTable::ReleaseHandles(OBJECTREF *pObjRef, DWORD nReleased)
 {
     CONTRACTL
     {
@@ -490,9 +490,9 @@ void LargeHeapHandleTable::ReleaseHandles(OBJECTREF *pObjRef, DWORD nReleased)
 }
 
 // enumerate the handles in the handle table
-void LargeHeapHandleTable::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
+void PinnedHeapHandleTable::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
 {
-    for (LargeHeapHandleBucket *pBucket = m_pHead; pBucket != nullptr; pBucket = pBucket->GetNext())
+    for (PinnedHeapHandleBucket *pBucket = m_pHead; pBucket != nullptr; pBucket = pBucket->GetNext())
     {
         pBucket->EnumStaticGCRefs(fn, sc);
     }
@@ -635,7 +635,7 @@ BaseDomain::BaseDomain()
     m_pTPABinderContext = NULL;
 
     // Make sure the container is set to NULL so that it gets loaded when it is used.
-    m_pLargeHeapHandleTable = NULL;
+    m_pPinnedHeapHandleTable = NULL;
 
 #ifndef CROSSGEN_COMPILE
     // Note that m_handleStore is overridden by app domains
@@ -702,8 +702,8 @@ void BaseDomain::Init()
     m_ILStubGenLock.Init(CrstILStubGen, CrstFlags(CRST_REENTRANCY), TRUE);
     m_NativeTypeLoadLock.Init(CrstInteropData, CrstFlags(CRST_REENTRANCY), TRUE);
 
-    // Large heap handle table CRST.
-    m_LargeHeapHandleTableCrst.Init(CrstAppDomainHandleTable);
+    // Pinned heap handle table CRST.
+    m_PinnedHeapHandleTableCrst.Init(CrstAppDomainHandleTable);
 
     m_crstLoaderAllocatorReferences.Init(CrstLoaderAllocatorReferences);
     // Has to switch thread to GC_NOTRIGGER while being held (see code:BaseDomain#AssemblyListLock)
@@ -883,7 +883,7 @@ OBJECTREF* BaseDomain::AllocateObjRefPtrsInLargeTable(int nRequested, OBJECTREF*
 
     // Enter preemptive state, take the lock and go back to cooperative mode.
     {
-        CrstHolder ch(&m_LargeHeapHandleTableCrst);
+        CrstHolder ch(&m_PinnedHeapHandleTableCrst);
         GCX_COOP();
 
         if (ppLazyAllocate && *ppLazyAllocate)
@@ -893,11 +893,11 @@ OBJECTREF* BaseDomain::AllocateObjRefPtrsInLargeTable(int nRequested, OBJECTREF*
         }
 
         // Make sure the large heap handle table is initialized.
-        if (!m_pLargeHeapHandleTable)
-            InitLargeHeapHandleTable();
+        if (!m_pPinnedHeapHandleTable)
+            InitPinnedHeapHandleTable();
 
         // Allocate the handles.
-        OBJECTREF* result = m_pLargeHeapHandleTable->AllocateHandles(nRequested);
+        OBJECTREF* result = m_pPinnedHeapHandleTable->AllocateHandles(nRequested);
 
         if (ppLazyAllocate)
         {
@@ -983,22 +983,22 @@ STRINGREF *BaseDomain::GetOrInternString(STRINGREF *pString)
     return GetLoaderAllocator()->GetOrInternString(pString);
 }
 
-void BaseDomain::InitLargeHeapHandleTable()
+void BaseDomain::InitPinnedHeapHandleTable()
 {
     CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        PRECONDITION(m_pLargeHeapHandleTable==NULL);
+        PRECONDITION(m_pPinnedHeapHandleTable==NULL);
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
 
-    m_pLargeHeapHandleTable = new LargeHeapHandleTable(this, STATIC_OBJECT_TABLE_BUCKET_SIZE);
+    m_pPinnedHeapHandleTable = new PinnedHeapHandleTable(this, STATIC_OBJECT_TABLE_BUCKET_SIZE);
 
 #ifdef _DEBUG
-    m_pLargeHeapHandleTable->RegisterCrstDebug(&m_LargeHeapHandleTableCrst);
+    m_pPinnedHeapHandleTable->RegisterCrstDebug(&m_PinnedHeapHandleTableCrst);
 #endif
 }
 
@@ -5067,9 +5067,9 @@ void AppDomain::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
              IsGCSpecialThread());
 
 #ifndef CROSSGEN_COMPILE
-    if (m_pLargeHeapHandleTable != nullptr)
+    if (m_pPinnedHeapHandleTable != nullptr)
     {
-        m_pLargeHeapHandleTable->EnumStaticGCRefs(fn, sc);
+        m_pPinnedHeapHandleTable->EnumStaticGCRefs(fn, sc);
     }
 #endif // CROSSGEN_COMPILE
 

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -478,17 +478,17 @@ public:
 #endif
 
 
-// The large heap handle bucket class is used to contain handles allocated
-// from an array contained in the large heap.
-class LargeHeapHandleBucket
+// The pinned heap handle bucket class is used to contain handles allocated
+// from an array contained in the pinned heap.
+class PinnedHeapHandleBucket
 {
 public:
     // Constructor and desctructor.
-    LargeHeapHandleBucket(LargeHeapHandleBucket *pNext, DWORD Size, BaseDomain *pDomain);
-    ~LargeHeapHandleBucket();
+    PinnedHeapHandleBucket(PinnedHeapHandleBucket *pNext, DWORD Size, BaseDomain *pDomain);
+    ~PinnedHeapHandleBucket();
 
     // This returns the next bucket.
-    LargeHeapHandleBucket *GetNext()
+    PinnedHeapHandleBucket *GetNext()
     {
         LIMITED_METHOD_CONTRACT;
 
@@ -523,7 +523,7 @@ public:
     void EnumStaticGCRefs(promote_func* fn, ScanContext* sc);
 
 private:
-    LargeHeapHandleBucket *m_pNext;
+    PinnedHeapHandleBucket *m_pNext;
     int m_ArraySize;
     int m_CurrentPos;
     int m_CurrentEmbeddedFreePos;
@@ -533,16 +533,16 @@ private:
 
 
 
-// The large heap handle table is used to allocate handles that are pointers
-// to objects stored in an array in the large object heap.
-class LargeHeapHandleTable
+// The pinned heap handle table is used to allocate handles that are pointers
+// to objects stored in an array in the pinned object heap.
+class PinnedHeapHandleTable
 {
 public:
     // Constructor and desctructor.
-    LargeHeapHandleTable(BaseDomain *pDomain, DWORD InitialBucketSize);
-    ~LargeHeapHandleTable();
+    PinnedHeapHandleTable(BaseDomain *pDomain, DWORD InitialBucketSize);
+    ~PinnedHeapHandleTable();
 
-    // Allocate handles from the large heap handle table.
+    // Allocate handles from the pinned heap handle table.
     OBJECTREF* AllocateHandles(DWORD nRequested);
 
     // Release object handles allocated using AllocateHandles().
@@ -552,22 +552,22 @@ public:
 
 private:
     // The buckets of object handles.
-    LargeHeapHandleBucket *m_pHead;
+    PinnedHeapHandleBucket *m_pHead;
 
     // We need to know the containing domain so we know where to allocate handles
     BaseDomain *m_pDomain;
 
-    // The size of the LargeHeapHandleBuckets.
+    // The size of the PinnedHeapHandleBucket.
     DWORD m_NextBucketSize;
 
     // for finding and re-using embedded free items in the list
-    LargeHeapHandleBucket *m_pFreeSearchHint;
+    PinnedHeapHandleBucket *m_pFreeSearchHint;
     DWORD m_cEmbeddedFree;
 
 #ifdef _DEBUG
 
     // these functions are present to enforce that there is a locking mechanism in place
-    // for each LargeHeapHandleTable even though the code itself does not do the locking
+    // for each PinnedHeapHandleTable even though the code itself does not do the locking
     // you must tell the table which lock you intend to use and it will verify that it has
     // in fact been taken before performing any operations
 
@@ -590,18 +590,18 @@ private:
 
 };
 
-class LargeHeapHandleBlockHolder;
-void LargeHeapHandleBlockHolder__StaticFree(LargeHeapHandleBlockHolder*);
+class PinnedHeapHandleBlockHolder;
+void PinnedHeapHandleBlockHolder__StaticFree(PinnedHeapHandleBlockHolder*);
 
 
-class LargeHeapHandleBlockHolder:public Holder<LargeHeapHandleBlockHolder*,DoNothing,LargeHeapHandleBlockHolder__StaticFree>
+class PinnedHeapHandleBlockHolder:public Holder<PinnedHeapHandleBlockHolder*,DoNothing,PinnedHeapHandleBlockHolder__StaticFree>
 
 {
-    LargeHeapHandleTable* m_pTable;
+    PinnedHeapHandleTable* m_pTable;
     DWORD m_Count;
     OBJECTREF* m_Data;
 public:
-    FORCEINLINE LargeHeapHandleBlockHolder(LargeHeapHandleTable* pOwner, DWORD nCount)
+    FORCEINLINE PinnedHeapHandleBlockHolder(PinnedHeapHandleTable* pOwner, DWORD nCount)
     {
         WRAPPER_NO_CONTRACT;
         m_Data = pOwner->AllocateHandles(nCount);
@@ -624,7 +624,7 @@ public:
     }
 };
 
-FORCEINLINE  void LargeHeapHandleBlockHolder__StaticFree(LargeHeapHandleBlockHolder* pHolder)
+FORCEINLINE  void PinnedHeapHandleBlockHolder__StaticFree(PinnedHeapHandleBlockHolder* pHolder)
 {
     WRAPPER_NO_CONTRACT;
     pHolder->FreeData();
@@ -1129,7 +1129,7 @@ protected:
 
     //****************************************************************************************
     // Helper method to initialize the large heap handle table.
-    void InitLargeHeapHandleTable();
+    void InitPinnedHeapHandleTable();
 
     //****************************************************************************************
     //
@@ -1158,11 +1158,11 @@ protected:
 
     IGCHandleStore* m_handleStore;
 
-    // The large heap handle table.
-    LargeHeapHandleTable        *m_pLargeHeapHandleTable;
+    // The pinned heap handle table.
+    PinnedHeapHandleTable       *m_pPinnedHeapHandleTable;
 
-    // The large heap handle table critical section.
-    CrstExplicitInit             m_LargeHeapHandleTableCrst;
+    // The pinned heap handle table critical section.
+    CrstExplicitInit             m_PinnedHeapHandleTableCrst;
 
 #ifdef FEATURE_COMINTEROP
     // Information regarding the managed standard interfaces.

--- a/src/coreclr/vm/stringliteralmap.cpp
+++ b/src/coreclr/vm/stringliteralmap.cpp
@@ -289,7 +289,7 @@ GlobalStringLiteralMap::GlobalStringLiteralMap()
 : m_StringToEntryHashTable(NULL)
 , m_MemoryPool(NULL)
 , m_HashTableCrstGlobal(CrstGlobalStrLiteralMap)
-, m_LargeHeapHandleTable(SystemDomain::System(), GLOBAL_STRING_TABLE_BUCKET_SIZE)
+, m_PinnedHeapHandleTable(SystemDomain::System(), GLOBAL_STRING_TABLE_BUCKET_SIZE)
 {
     CONTRACTL
     {
@@ -299,7 +299,7 @@ GlobalStringLiteralMap::GlobalStringLiteralMap()
     CONTRACTL_END;
 
 #ifdef _DEBUG
-    m_LargeHeapHandleTable.RegisterCrstDebug(&m_HashTableCrstGlobal);
+    m_PinnedHeapHandleTable.RegisterCrstDebug(&m_HashTableCrstGlobal);
 #endif
 }
 
@@ -487,7 +487,7 @@ StringLiteralEntry *GlobalStringLiteralMap::AddStringLiteral(EEStringData *pStri
     StringLiteralEntry *pRet;
 
     {
-    LargeHeapHandleBlockHolder pStrObj(&m_LargeHeapHandleTable,1);
+    PinnedHeapHandleBlockHolder pStrObj(&m_PinnedHeapHandleTable,1);
     // Create the COM+ string object.
     STRINGREF strObj = AllocateStringObject(pStringData);
 
@@ -528,7 +528,7 @@ StringLiteralEntry *GlobalStringLiteralMap::AddInternedString(STRINGREF *pString
     StringLiteralEntry *pRet;
 
     {
-    LargeHeapHandleBlockHolder pStrObj(&m_LargeHeapHandleTable,1);
+    PinnedHeapHandleBlockHolder pStrObj(&m_PinnedHeapHandleTable,1);
     SetObjectReference(pStrObj[0], (OBJECTREF) *pString);
 
     // Since the allocation might have caused a GC we need to re-get the
@@ -583,7 +583,7 @@ void GlobalStringLiteralMap::RemoveStringLiteralEntry(StringLiteralEntry *pEntry
 
         // Release the object handle that the entry was using.
         STRINGREF *pObjRef = pEntry->GetStringObject();
-        m_LargeHeapHandleTable.ReleaseHandles((OBJECTREF*)pObjRef, 1);
+        m_PinnedHeapHandleTable.ReleaseHandles((OBJECTREF*)pObjRef, 1);
     }
 
     // We do not delete the StringLiteralEntry itself that will be done in the

--- a/src/coreclr/vm/stringliteralmap.h
+++ b/src/coreclr/vm/stringliteralmap.h
@@ -113,8 +113,8 @@ private:
 
     Crst                        m_HashTableCrstGlobal;
 
-    // The large heap handle table.
-    LargeHeapHandleTable        m_LargeHeapHandleTable;
+    // The pinned heap handle table.
+    PinnedHeapHandleTable        m_PinnedHeapHandleTable;
 
 };
 


### PR DESCRIPTION
This is the cleanup work after https://github.com/dotnet/runtime/pull/47651