### PR TITLE
[mono] Developer convenience MSBuild property

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -52,6 +52,23 @@
     <MonoCxxCompiler Condition="'$(MonoCCompiler)' == 'gcc'">g++</MonoCxxCompiler>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(MonoCMakeUseLd)' != ''">
+    <_MonoCMakeArgs Include="-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=$(MonoCMakeUseLd)" />
+    <_MonoCMakeArgs Include="-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=$(MonoCMakeUseLd)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(MonoCMakeLd)' != ''">
+    <_MonoCMakeArgs Include="-DCMAKE_LINKER=$(MonoCMakeLd)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(MonoCMakeAr)' != ''">
+    <_MonoCMakeArgs Include="-DCMAKE_AR=$(MonoCMakeAr)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(MonoCMakeRanlib)' != ''">
+    <_MonoCMakeArgs Include="-DCMAKE_RANLIB=$(MonoCMakeRanlib)" />
+  </ItemGroup>
+
   <!-- default thread suspend for specific platforms -->
   <PropertyGroup>
     <MonoThreadSuspend Condition="'$(TargetswatchOS)' == 'true' and '$(MonoThreadSuspend)' == ''">coop</MonoThreadSuspend>
@@ -65,7 +82,7 @@
     <PackageReference Include="Microsoft.NETCore.Runtime.ICU.Transport" PrivateAssets="all" Version="$(MicrosoftNETCoreRuntimeICUTransportVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <!-- CI specific build options -->    
+  <!-- CI specific build options -->
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and ('$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true')">
     <_MonoCMakeArgs Include="-DENABLE_WERROR=1"/>
   </ItemGroup>
@@ -499,7 +516,7 @@
 
       <!-- thread suspend -->
       <MonoAOTCMakeArgs Include="-DGC_SUSPEND=$(MonoThreadSuspend)" />
-    </ItemGroup> 
+    </ItemGroup>
 
     <PropertyGroup>
       <_MonoAotCrossOffsetsCommand Condition="'$(MonoUseCrossTool)' == 'true'">python3 $(MonoProjectRoot)mono/tools/offsets-tool/offsets-tool.py @(MonoAotCrossOffsetsToolParams, ' ')</_MonoAotCrossOffsetsCommand>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -52,23 +52,6 @@
     <MonoCxxCompiler Condition="'$(MonoCCompiler)' == 'gcc'">g++</MonoCxxCompiler>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(MonoCMakeUseLd)' != ''">
-    <_MonoCMakeArgs Include="-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=$(MonoCMakeUseLd)" />
-    <_MonoCMakeArgs Include="-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=$(MonoCMakeUseLd)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(MonoCMakeLd)' != ''">
-    <_MonoCMakeArgs Include="-DCMAKE_LINKER=$(MonoCMakeLd)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(MonoCMakeAr)' != ''">
-    <_MonoCMakeArgs Include="-DCMAKE_AR=$(MonoCMakeAr)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(MonoCMakeRanlib)' != ''">
-    <_MonoCMakeArgs Include="-DCMAKE_RANLIB=$(MonoCMakeRanlib)" />
-  </ItemGroup>
-
   <!-- default thread suspend for specific platforms -->
   <PropertyGroup>
     <MonoThreadSuspend Condition="'$(TargetswatchOS)' == 'true' and '$(MonoThreadSuspend)' == ''">coop</MonoThreadSuspend>
@@ -373,7 +356,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_MonoCMakeConfigureCommand>cmake @(_MonoCMakeArgs, ' ') $(MonoProjectRoot)</_MonoCMakeConfigureCommand>
+      <_MonoCMakeConfigureCommand>cmake @(_MonoCMakeArgs, ' ') $(MonoCMakeExtraArgs) $(MonoProjectRoot)</_MonoCMakeConfigureCommand>
       <_MonoCMakeConfigureCommand Condition="'$(TargetsBrowser)' != 'true' and '$(_MonoRunInitCompiler)' != 'false' and '$(OS)' != 'Windows_NT'">bash -c 'source $(RepositoryEngineeringDir)native/init-compiler.sh $(Platform) $(MonoCCompiler) &amp;&amp; @(_MonoBuildEnv, ' ') $(_MonoCMakeConfigureCommand)'</_MonoCMakeConfigureCommand>
       <_MonoCMakeConfigureCommand Condition="'$(TargetsBrowser)' != 'true' and '$(_MonoRunInitCompiler)' != 'false' and '$(OS)' == 'Windows_NT'">set __repoRoot=&quot;$(RepoRoot)&quot; &amp;&amp; call &quot;$(RepositoryEngineeringDir)native\init-compiler-and-cmake.cmd&quot; $(Platform) &amp;&amp; cd /D &quot;$(MonoObjDir)&quot; &amp;&amp; @(_MonoBuildEnv, ' ') $(_MonoCMakeConfigureCommand)</_MonoCMakeConfigureCommand>
       <_MonoCMakeConfigureCommand Condition="'$(TargetsBrowser)' != 'true' and '$(_MonoRunInitCompiler)' == 'false'">$(_MonoCCOption) $(_MonoCXXOption) @(_MonoBuildEnv, ' ') $(_MonoCMakeConfigureCommand)</_MonoCMakeConfigureCommand>


### PR DESCRIPTION
Adds a property, named `MonoCMakeExtraArgs`, which is passed through to the CMake configure command invocation.

Example usage:
```
MonoCMakeExtraArgs="-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=$HOME/clang-9.x/out/bin/ld.lld -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=$HOME/clang-9.x/out/bin/ld.lld -DCMAKE_LINKER=$HOME/clang-9.x/out/bin/ld.lld -DCMAKE_AR=$HOME/clang-9.x/out/bin/llvm-ar -DCMAKE_RANLIB=$HOME/clang-9.x/out/bin/llvm-ranlib" \
./build.sh
    -configuration Release \
    --subset mono \
    /p:MonoLLVMUseCxx11Abi=true /p:MonoEnableLLVM=true \
    /p:MonoLLVMDir="$LLVM_PREFIX"
```

`touch src/mono/mono/mini/mini-llvm.c && time ninja -C
artifacts/obj/mono/Linux.x64.Release` reports 5.3 seconds when using lld,
llvm-ar, and llvm-ranlib; this takes 18 seconds when using GNU tools.

Note that GCC doesn't support full paths for fuse-ld, [unlike Clang](https://reviews.llvm.org/D17952).
