### PR TITLE
Make symbolsPath similar to default symbols path

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -12,6 +12,7 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
+    <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
     <NoWarn Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0')))">$(NoWarn);nullable</NoWarn>
     <NoWarn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(NoWarn);nullable</NoWarn>
     <!-- Ignore Obsolete errors within the generated shims that type-forward types.


### PR DESCRIPTION
This is part of ongoing effort to move things towards dotnet pack.
Currently we put the symbols into a special folder packageOutputPath/symbols, but nuget pack doesnt provide any hook to change the symbols path  so we are moving the symbols similar to the default behavior