### PR TITLE
Fix issue #48345

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -66,6 +66,18 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             _stringResource2 = s;
         }
 
+        private static void StoreLiteralAndArgument(string s1)
+        {
+            _stringResource = s1;
+            _stringResource2 = "1";
+        }
+
+        private static string Issue48345(string s)
+        {
+            _stringResource = $"s: {s} length: {s?.Length}";
+            return "1";
+        }
+
         internal static string _marshalledString;
         private static string InvokeMarshalString()
         {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -66,7 +66,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             _stringResource2 = s;
         }
 
-        private static string Issue48345(string s)
+        private static string StoreArgumentAndReturnLiteral(string s)
         {
             _stringResource = $"s: {s} length: {s?.Length}";
             return "1";

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -66,12 +66,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             _stringResource2 = s;
         }
 
-        private static void StoreLiteralAndArgument(string s1)
-        {
-            _stringResource = s1;
-            _stringResource2 = "1";
-        }
-
         private static string Issue48345(string s)
         {
             _stringResource = $"s: {s} length: {s?.Length}";

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -841,5 +841,19 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Equal(HelperMarshal._stringResource, HelperMarshal._stringResource2);
             Assert.True(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
         }
+
+        [Fact]
+        public static void Issue48345()
+        {
+            HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
+            var fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:Issue48345";
+            Runtime.InvokeJS(
+                $"var a = BINDING.bind_static_method('{fqn}')('test');\r\n" +
+                $"var b = BINDING.bind_static_method('{fqn}')(a);\r\n" +
+                "App.call_test_method ('InvokeString2', [ b ]);"
+            );
+            Assert.Equal("s: 1 length: 1", HelperMarshal._stringResource);
+            Assert.Equal("1", HelperMarshal._stringResource2);
+        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -843,10 +843,10 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        public static void Issue48345()
+        public static void InternedStringReturnValuesWork()
         {
             HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
-            var fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:Issue48345";
+            var fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:StoreArgumentAndReturnLiteral";
             Runtime.InvokeJS(
                 $"var a = BINDING.bind_static_method('{fqn}')('test');\r\n" +
                 $"var b = BINDING.bind_static_method('{fqn}')(a);\r\n" +

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -171,6 +171,8 @@ var BindingSupportLib = {
 		_store_string_in_intern_table: function (string, ptr, internIt) {
 			if (!ptr)
 				throw new Error ("null pointer passed to _store_string_in_intern_table");
+			else if (typeof (ptr) !== "number")
+				throw new Error (`non-pointer passed to _store_string_in_intern_table: ${typeof(ptr)} ${ptr}, for string '${string}'`);
 
 			var originalArg = ptr;
 			
@@ -300,13 +302,13 @@ var BindingSupportLib = {
 
 			var arrayRoot = MONO.mono_wasm_new_root (mono_array);
 			try {
-				return this._mono_array_to_js_array_rooted (arrayRoot);
+				return this._mono_array_root_to_js_array (arrayRoot);
 			} finally {
 				arrayRoot.release();
 			}
 		},
 
-		_mono_array_to_js_array_rooted: function (arrayRoot) {
+		_mono_array_root_to_js_array: function (arrayRoot) {
 			if (arrayRoot.value === 0)
 				return null;
 
@@ -320,9 +322,9 @@ var BindingSupportLib = {
 					elemRoot.value = this.mono_array_get (arrayRoot.value, i);
 
 					if (this.is_nested_array (elemRoot.value))
-						res[i] = this._mono_array_to_js_array_rooted (elemRoot);
+						res[i] = this._mono_array_root_to_js_array (elemRoot);
 					else
-						res[i] = this._unbox_mono_obj_rooted (elemRoot);
+						res[i] = this._unbox_mono_obj_root (elemRoot);
 				}
 			} finally {
 				elemRoot.release ();
@@ -353,7 +355,7 @@ var BindingSupportLib = {
 
 			var root = MONO.mono_wasm_new_root (mono_obj);
 			try {
-				return this._unbox_mono_obj_rooted (root);
+				return this._unbox_mono_obj_root (root);
 			} finally {
 				root.release();
 			}
@@ -447,7 +449,7 @@ var BindingSupportLib = {
 			}
 		},
 
-		_unbox_mono_obj_rooted: function (root) {
+		_unbox_mono_obj_root: function (root) {
 			var mono_obj = root.value;
 			if (mono_obj === 0)
 				return undefined;
@@ -1295,7 +1297,7 @@ var BindingSupportLib = {
 			this._handle_exception_for_call (converter, buffer, resultRoot, exceptionRoot, argsRootBuffer);
 
 			if (is_result_marshaled)
-				result = this._unbox_mono_obj_rooted (resultRoot);
+				result = this._unbox_mono_obj_root (resultRoot);
 			else
 				result = resultRoot.value;
 
@@ -1428,7 +1430,7 @@ var BindingSupportLib = {
 				"    case 28:", // char
 				"        result = String.fromCharCode(Module.HEAP32[buffer / 4]); break;",
 				"    default:",
-				"        result = binding_support._unbox_mono_obj_rooted_with_known_nonprimitive_type (resultRoot, resultType); break;",
+				"        result = binding_support._unbox_mono_obj_rooted_with_known_nonprimitive_type (resultRoot.value, resultType); break;",
 				"    }",
 				"}",
 				"",

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -172,9 +172,7 @@ var BindingSupportLib = {
 			if (!ptr)
 				throw new Error ("null pointer passed to _store_string_in_intern_table");
 			else if (typeof (ptr) !== "number")
-				throw new Error (`non-pointer passed to _store_string_in_intern_table: ${typeof(ptr)} ${ptr}, for string '${string}'`);
-
-			var originalArg = ptr;
+				throw new Error (`non-pointer passed to _store_string_in_intern_table: ${typeof(ptr)}`);
 			
 			const internBufferSize = 8192;
 
@@ -1430,7 +1428,7 @@ var BindingSupportLib = {
 				"    case 28:", // char
 				"        result = String.fromCharCode(Module.HEAP32[buffer / 4]); break;",
 				"    default:",
-				"        result = binding_support._unbox_mono_obj_rooted_with_known_nonprimitive_type (resultRoot.value, resultType); break;",
+				"        result = binding_support._unbox_mono_obj_rooted_with_known_nonprimitive_type (resultPtr, resultType); break;",
 				"    }",
 				"}",
 				"",


### PR DESCRIPTION
The return value marshaling for bound static methods accidentally passed a root object to the conversion APIs instead of passing the pointer stored inside the root. This would work for many scenarios (intentionally) but not here.

Also renamed _unbox_mono_obj_rooted and _mono_array_to_js_array_rooted to make it clearer what argument type they expect (roots) and separate them from the other _rooted APIs (which do expect raw pointers).