### PR TITLE
Miscellaneous fixes for big-endian systems

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -486,7 +486,14 @@ namespace System.Buffers.Text
             uint i2 = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 6) & 0x3F));
             uint i3 = Unsafe.Add(ref encodingMap, (IntPtr)(i & 0x3F));
 
-            return i0 | (i1 << 8) | (i2 << 16) | (i3 << 24);
+            if (BitConverter.IsLittleEndian)
+            {
+                return i0 | (i1 << 8) | (i2 << 16) | (i3 << 24);
+            }
+            else
+            {
+                return (i0 << 24) | (i1 << 16) | (i2 << 8) | i3;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -501,7 +508,14 @@ namespace System.Buffers.Text
             uint i1 = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 12) & 0x3F));
             uint i2 = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 6) & 0x3F));
 
-            return i0 | (i1 << 8) | (i2 << 16) | (EncodingPad << 24);
+            if (BitConverter.IsLittleEndian)
+            {
+                return i0 | (i1 << 8) | (i2 << 16) | (EncodingPad << 24);
+            }
+            else
+            {
+                return (i0 << 24) | (i1 << 16) | (i2 << 8) | EncodingPad;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -514,7 +528,14 @@ namespace System.Buffers.Text
             uint i0 = Unsafe.Add(ref encodingMap, (IntPtr)(i >> 10));
             uint i1 = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 4) & 0x3F));
 
-            return i0 | (i1 << 8) | (EncodingPad << 16) | (EncodingPad << 24);
+            if (BitConverter.IsLittleEndian)
+            {
+                return i0 | (i1 << 8) | (EncodingPad << 16) | (EncodingPad << 24);
+            }
+            else
+            {
+                return (i0 << 24) | (i1 << 16) | (EncodingPad << 8) | EncodingPad;
+            }
         }
 
         private const uint EncodingPad = '='; // '=', for padding

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
@@ -109,7 +109,7 @@ namespace System.Buffers.Text
             DecomposedGuid guidAsBytes = default;
             guidAsBytes.Guid = value;
 
-            // When a GUID is blitted, the first three components are little-endian, and the last component is big-endian.
+            // When a GUID is blitted, the first three components are native-endian, and the last component is big-endian.
 
             // The line below forces the JIT to hoist the bounds check for the following segment.
             // The JIT will optimize away the read, but it cannot optimize away the bounds check
@@ -117,10 +117,20 @@ namespace System.Buffers.Text
             // We use 8 instead of 7 so that we also capture the dash if we're asked to insert one.
 
             { _ = destination[8]; }
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte03, destination, 0, HexConverter.Casing.Lower);
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte02, destination, 2, HexConverter.Casing.Lower);
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte01, destination, 4, HexConverter.Casing.Lower);
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte00, destination, 6, HexConverter.Casing.Lower);
+            if (BitConverter.IsLittleEndian)
+            {
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte03, destination, 0, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte02, destination, 2, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte01, destination, 4, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte00, destination, 6, HexConverter.Casing.Lower);
+            }
+            else
+            {
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte00, destination, 0, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte01, destination, 2, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte02, destination, 4, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte03, destination, 6, HexConverter.Casing.Lower);
+            }
 
             if (flags < 0 /* use dash? */)
             {
@@ -133,8 +143,16 @@ namespace System.Buffers.Text
             }
 
             { _ = destination[4]; }
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte05, destination, 0, HexConverter.Casing.Lower);
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte04, destination, 2, HexConverter.Casing.Lower);
+            if (BitConverter.IsLittleEndian)
+            {
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte05, destination, 0, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte04, destination, 2, HexConverter.Casing.Lower);
+            }
+            else
+            {
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte04, destination, 0, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte05, destination, 2, HexConverter.Casing.Lower);
+            }
 
             if (flags < 0 /* use dash? */)
             {
@@ -147,8 +165,16 @@ namespace System.Buffers.Text
             }
 
             { _ = destination[4]; }
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte07, destination, 0, HexConverter.Casing.Lower);
-            HexConverter.ToBytesBuffer(guidAsBytes.Byte06, destination, 2, HexConverter.Casing.Lower);
+            if (BitConverter.IsLittleEndian)
+            {
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte07, destination, 0, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte06, destination, 2, HexConverter.Casing.Lower);
+            }
+            else
+            {
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte06, destination, 0, HexConverter.Casing.Lower);
+                HexConverter.ToBytesBuffer(guidAsBytes.Byte07, destination, 2, HexConverter.Casing.Lower);
+            }
 
             if (flags < 0 /* use dash? */)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryAccessor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryAccessor.cs
@@ -494,8 +494,8 @@ namespace System.IO
                 int* valuePtr = (int*)(&value);
                 int flags = *valuePtr;
                 int hi = *(valuePtr + 1);
-                int lo = *(valuePtr + 2);
-                int mid = *(valuePtr + 3);
+                int lo = *(valuePtr + (BitConverter.IsLittleEndian ? 2 : 3));
+                int mid = *(valuePtr + (BitConverter.IsLittleEndian ? 3 : 2));
 
                 byte* pointer = null;
                 try

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
@@ -380,10 +380,7 @@ namespace System.Resources
                     if (_ums.Position > _ums.Length - byteLen)
                         throw new BadImageFormatException(SR.Format(SR.BadImageFormat_ResourcesIndexTooLong, index));
 
-                    string? s = null;
-                    char* charPtr = (char*)_ums.PositionPointer;
-
-                    s = new string(charPtr, 0, byteLen / 2);
+                    string s = Encoding.Unicode.GetString(_ums.PositionPointer, byteLen);
 
                     _ums.Position += byteLen;
                     dataOffset = _store.ReadInt32();

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -956,10 +956,9 @@ namespace System.Reflection.Metadata
             }
             else
             {
-                byte[] bytes = Encoding.Unicode.GetBytes(value);
-                fixed (byte* ptr = &bytes[0])
+                for (int i = 0; i < value.Length; i++)
                 {
-                    WriteBytesUnchecked((byte*)ptr, bytes.Length);
+                    WriteUInt16((ushort)value[i]);
                 }
             }
         }
@@ -990,10 +989,9 @@ namespace System.Reflection.Metadata
             }
             else
             {
-                byte[] bytes = Encoding.Unicode.GetBytes(value);
-                fixed (byte* ptr = bytes)
+                for (int i = 0; i < value.Length; i++)
                 {
-                    WriteBytesUnchecked((byte*)ptr, bytes.Length);
+                    WriteUInt16((ushort)value[i]);
                 }
             }
         }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
@@ -77,6 +77,24 @@ namespace System.Reflection.Metadata
             guidPtr[7] = (byte)((guidPtr[7] & 0x0f) | (4 << 4));
             guidPtr[8] = (byte)((guidPtr[8] & 0x3f) | (2 << 6));
 
+            // the code above assumed the host is little-endian; if this is not the case,
+            // we need to fix up the first three fields (int, short, short)
+            if (!BitConverter.IsLittleEndian)
+            {
+                byte tmp = guidPtr[0];
+                guidPtr[0] = guidPtr[3];
+                guidPtr[3] = tmp;
+                tmp = guidPtr[1];
+                guidPtr[1] = guidPtr[2];
+                guidPtr[2] = tmp;
+                tmp = guidPtr[4];
+                guidPtr[4] = guidPtr[5];
+                guidPtr[5] = tmp;
+                tmp = guidPtr[6];
+                guidPtr[6] = guidPtr[7];
+                guidPtr[7] = tmp;
+            }
+
             // compute a random-looking stamp from the remaining bits, but with the upper bit set
             uint stamp = 0x80000000u | ((uint)hashCode[19] << 24 | (uint)hashCode[18] << 16 | (uint)hashCode[17] << 8 | hashCode[16]);
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -381,9 +381,19 @@ namespace System.Reflection.Metadata
                 return;
             }
 
-            fixed (char* ptr = &value[0])
+            if (BitConverter.IsLittleEndian)
             {
-                WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                fixed (char* ptr = &value[0])
+                {
+                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                }
+            }
+            else
+            {
+                for (int i = 0; i < value.Length; i++)
+                {
+                    WriteUInt16((ushort)value[i]);
+                }
             }
         }
 
@@ -398,9 +408,19 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(value));
             }
 
-            fixed (char* ptr = value)
+            if (BitConverter.IsLittleEndian)
             {
-                WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                fixed (char* ptr = value)
+                {
+                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
+                }
+            }
+            else
+            {
+                for (int i = 0; i < value.Length; i++)
+                {
+                    WriteUInt16((ushort)value[i]);
+                }
             }
         }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
@@ -549,7 +549,8 @@ namespace System.Reflection.PortableExecutable
 
                     while (ptr < end)
                     {
-                        checksum = AggregateChecksum(checksum, *(ushort*)ptr);
+                        // little-endian encoding:
+                        checksum = AggregateChecksum(checksum, (ushort)(ptr[1] << 8 | ptr[0]));
                         ptr += sizeof(ushort);
                     }
                 }


### PR DESCRIPTION
* Base64Encoder needs to take byte order into accout
  when packing characters into an int.

* First three fields of GUID data structure are held in
  native byte order (not always little-endian).

* UnmanagedMemoryAccessor needs to access internal fields
  of decimal type correctly in native byte order.

* When accessing a memory-mapped resource file, strings
  may need to be converted to native byte order.

* The metadata blob writer did not handle writing UTF16
  characters correctly on big-endian systems.

* Endian bug in PEBuilder checksum computation.