### PR TITLE
EmptyAiaResponseIsIgnored should use incomplete chain.

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -820,8 +820,9 @@ SingleResponse ::= SEQUENCE {
             PkiOptions pkiOptions,
             out RevocationResponder responder,
             out CertificateAuthority rootAuthority,
-            out CertificateAuthority intermediateAuthority,
+            out CertificateAuthority[] intermediateAuthorities,
             out X509Certificate2 endEntityCert,
+            int intermediateAuthorityCount,
             string testName = null,
             bool registerAuthorities = true,
             bool pkiOptionsInSubject = false,
@@ -841,14 +842,10 @@ SingleResponse ::= SEQUENCE {
                     endEntityRevocationViaCrl || endEntityRevocationViaOcsp,
                 "At least one revocation mode is enabled");
 
-            if (extensions == null)
-            {
-                // default to client
-                extensions = new X509ExtensionCollection() { s_eeConstraints, s_eeKeyUsage, s_tlsClientEku };
-            }
+            // default to client
+            extensions ??= new X509ExtensionCollection() { s_eeConstraints, s_eeKeyUsage, s_tlsClientEku };
 
             using (RSA rootKey = RSA.Create(keySize))
-            using (RSA intermedKey = RSA.Create(keySize))
             using (RSA eeKey = RSA.Create(keySize))
             {
                 var rootReq = new CertificateRequest(
@@ -882,35 +879,45 @@ SingleResponse ::= SEQUENCE {
                     issuerRevocationViaCrl ? cdpUrl : null,
                     issuerRevocationViaOcsp ? ocspUrl : null);
 
-                // Don't dispose this, it's being transferred to the CertificateAuthority
-                X509Certificate2 intermedCert;
+                CertificateAuthority issuingAuthority = rootAuthority;
+                intermediateAuthorities = new CertificateAuthority[intermediateAuthorityCount];
 
+                for (int intermediateIndex = 0; intermediateIndex < intermediateAuthorityCount; intermediateIndex++)
                 {
-                    X509Certificate2 intermedPub = rootAuthority.CreateSubordinateCA(
-                        BuildSubject("A Revocation Test CA", testName, pkiOptions, pkiOptionsInSubject),
-                        intermedKey);
+                    using RSA intermediateKey = RSA.Create(keySize);
 
-                    intermedCert = intermedPub.CopyWithPrivateKey(intermedKey);
-                    intermedPub.Dispose();
+                    // Don't dispose this, it's being transferred to the CertificateAuthority
+                    X509Certificate2 intermedCert;
+
+                    {
+                        X509Certificate2 intermedPub = issuingAuthority.CreateSubordinateCA(
+                            BuildSubject($"A Revocation Test CA {intermediateIndex}", testName, pkiOptions, pkiOptionsInSubject),
+                            intermediateKey);
+                        intermedCert = intermedPub.CopyWithPrivateKey(intermediateKey);
+                        intermedPub.Dispose();
+                    }
+
+                    X509SubjectKeyIdentifierExtension intermedSkid =
+                        intermedCert.Extensions.OfType<X509SubjectKeyIdentifierExtension>().Single();
+
+                    certUrl = $"{responder.UriPrefix}cert/{intermedSkid.SubjectKeyIdentifier}.cer";
+                    cdpUrl = $"{responder.UriPrefix}crl/{intermedSkid.SubjectKeyIdentifier}.crl";
+                    ocspUrl = $"{responder.UriPrefix}ocsp/{intermedSkid.SubjectKeyIdentifier}";
+
+                    CertificateAuthority intermediateAuthority = new CertificateAuthority(
+                        intermedCert,
+                        issuerDistributionViaHttp ? certUrl : null,
+                        endEntityRevocationViaCrl ? cdpUrl : null,
+                        endEntityRevocationViaOcsp ? ocspUrl : null);
+
+                    issuingAuthority = intermediateAuthority;
+                    intermediateAuthorities[intermediateIndex] = intermediateAuthority;
                 }
 
-                X509SubjectKeyIdentifierExtension intermedSkid =
-                    intermedCert.Extensions.OfType<X509SubjectKeyIdentifierExtension>().Single();
-
-                certUrl = $"{responder.UriPrefix}cert/{intermedSkid.SubjectKeyIdentifier}.cer";
-                cdpUrl = $"{responder.UriPrefix}crl/{intermedSkid.SubjectKeyIdentifier}.crl";
-                ocspUrl = $"{responder.UriPrefix}ocsp/{intermedSkid.SubjectKeyIdentifier}";
-
-                intermediateAuthority = new CertificateAuthority(
-                    intermedCert,
-                    issuerDistributionViaHttp ? certUrl : null,
-                    endEntityRevocationViaCrl ? cdpUrl : null,
-                    endEntityRevocationViaOcsp ? ocspUrl : null);
-
-                endEntityCert = intermediateAuthority.CreateEndEntity(
-                        BuildSubject(subjectName ?? "A Revocation Test Cert", testName, pkiOptions, pkiOptionsInSubject),
-                        eeKey,
-                        extensions);
+                endEntityCert = issuingAuthority.CreateEndEntity(
+                    BuildSubject(subjectName ?? "A Revocation Test Cert", testName, pkiOptions, pkiOptionsInSubject),
+                    eeKey,
+                    extensions);
 
                 endEntityCert = endEntityCert.CopyWithPrivateKey(eeKey);
             }
@@ -918,8 +925,43 @@ SingleResponse ::= SEQUENCE {
             if (registerAuthorities)
             {
                 responder.AddCertificateAuthority(rootAuthority);
-                responder.AddCertificateAuthority(intermediateAuthority);
+
+                foreach (CertificateAuthority authority in intermediateAuthorities)
+                {
+                    responder.AddCertificateAuthority(authority);
+                }
             }
+        }
+
+        internal static void BuildPrivatePki(
+            PkiOptions pkiOptions,
+            out RevocationResponder responder,
+            out CertificateAuthority rootAuthority,
+            out CertificateAuthority intermediateAuthority,
+            out X509Certificate2 endEntityCert,
+            string testName = null,
+            bool registerAuthorities = true,
+            bool pkiOptionsInSubject = false,
+            string subjectName = null,
+            int keySize = DefaultKeySize,
+            X509ExtensionCollection extensions = null)
+        {
+
+            BuildPrivatePki(
+                pkiOptions,
+                out responder,
+                out rootAuthority,
+                out CertificateAuthority[] intermediateAuthorities,
+                out endEntityCert,
+                intermediateAuthorityCount: 1,
+                testName: testName,
+                registerAuthorities: registerAuthorities,
+                pkiOptionsInSubject: pkiOptionsInSubject,
+                subjectName: subjectName,
+                keySize: keySize,
+                extensions: extensions);
+
+            intermediateAuthority = intermediateAuthorities.Single();
         }
 
         private static string BuildSubject(

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/AiaTests.cs
@@ -19,15 +19,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 out CertificateAuthority[] intermediates,
                 out X509Certificate2 endEntity,
                 intermediateAuthorityCount: 2,
-                pkiOptionsInSubject: false);
-
-            CertificateAuthority intermediate1 = intermediates[0];
-            CertificateAuthority intermediate2 = intermediates[1];
+                pkiOptionsInSubject: false,
+                testName: nameof(EmptyAiaResponseIsIgnored));
 
             using (responder)
             using (root)
-            using (intermediate1)
-            using (intermediate2)
+            using (CertificateAuthority intermediate1 = intermediates[0])
+            using (CertificateAuthority intermediate2 = intermediates[1])
             using (endEntity)
             using (ChainHolder holder = new ChainHolder())
             using (X509Certificate2 intermediate2Cert = intermediate2.CloneIssuerCert())
@@ -57,7 +55,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 out CertificateAuthority root,
                 out CertificateAuthority intermediate,
                 out X509Certificate2 endEntity,
-                pkiOptionsInSubject: false);
+                pkiOptionsInSubject: false,
+                testName: nameof(DisableAiaOptionWorks));
 
             using (responder)
             using (root)


### PR DESCRIPTION
This changes the test to build a partial chain using two intermediates.
The leaf's issuing intermediate is added to the ExtraStore and the
second intermediate is expected to be fetched by AIA (and fail with
an empty response).

This is to help coerce chain builders treat it as a partial chain,
and can actually make some progress, as opposed to the leaf being
treated as an invalid root.

Fixes #48223

---------

Easier to review with "Hide whitespace changes".