### PR TITLE
Fix AV in NativeRuntimeEventSource QCalls

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -126,6 +126,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Debugger.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\EditAndContinueHelper.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipe.CoreCLR.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\NativeRuntimeEventSource.PortableThreadPool.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\ICustomDebuggerNotification.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\StackFrame.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\StackFrameHelper.cs" />

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -989,7 +989,7 @@ FCFuncStart(gStreamFuncs)
 FCFuncEnd()
 
 
-#if defined(FEATURE_EVENTSOURCE_XPLAT) 
+#if defined(FEATURE_EVENTSOURCE_XPLAT)
 FCFuncStart(gEventLogger)
     QCFuncElement("IsEventSourceLoggingEnabled", XplatEventSourceLogger::IsEventSourceLoggingEnabled)
     QCFuncElement("LogEventSource", XplatEventSourceLogger::LogEventSource)

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -989,13 +989,15 @@ FCFuncStart(gStreamFuncs)
 FCFuncEnd()
 
 
-#if defined(FEATURE_EVENTSOURCE_XPLAT) || defined(FEATURE_PERFTRACING)
+#if defined(FEATURE_EVENTSOURCE_XPLAT) 
 FCFuncStart(gEventLogger)
-#if defined(FEATURE_EVENTSOURCE_XPLAT)
     QCFuncElement("IsEventSourceLoggingEnabled", XplatEventSourceLogger::IsEventSourceLoggingEnabled)
     QCFuncElement("LogEventSource", XplatEventSourceLogger::LogEventSource)
+FCFuncEnd()
 #endif // defined(FEATURE_EVENTSOURCE_XPLAT)
+
 #if defined(FEATURE_PERFTRACING)
+FCFuncStart(gNativeEventLogger)
     QCFuncElement("LogThreadPoolWorkerThreadStart", NativeEventLogger::LogThreadPoolWorkerThreadStart)
     QCFuncElement("LogThreadPoolWorkerThreadStop", NativeEventLogger::LogThreadPoolWorkerThreadStop)
     QCFuncElement("LogThreadPoolWorkerThreadWait", NativeEventLogger::LogThreadPoolWorkerThreadWait)
@@ -1005,9 +1007,8 @@ FCFuncStart(gEventLogger)
     QCFuncElement("LogThreadPoolIOEnqueue", NativeEventLogger::LogThreadPoolIOEnqueue)
     QCFuncElement("LogThreadPoolIODequeue", NativeEventLogger::LogThreadPoolIODequeue)
     QCFuncElement("LogThreadPoolWorkingThreadCount", NativeEventLogger::LogThreadPoolWorkingThreadCount)
-#endif // defined(FEATURE_PERFTRACING)
 FCFuncEnd()
-#endif // defined(FEATURE_EVENTSOURCE_XPLAT) || defined(FEATURE_PERFTRACING)
+#endif // defined(FEATURE_PERFTRACING)
 
 #ifdef FEATURE_PERFTRACING
 FCFuncStart(gEventPipeInternalFuncs)
@@ -1165,6 +1166,9 @@ FCClassElement("ModuleBuilder", "System.Reflection.Emit", gCOMModuleBuilderFuncs
 FCClassElement("ModuleHandle", "System", gCOMModuleHandleFuncs)
 FCClassElement("Monitor", "System.Threading", gMonitorFuncs)
 FCClassElement("NativeLibrary", "System.Runtime.InteropServices", gInteropNativeLibraryFuncs)
+#if defined(FEATURE_PERFTRACING)
+FCClassElement("NativeRuntimeEventSource", "System.Diagnostics.Tracing", gNativeEventLogger)
+#endif //defined(FEATURE_PERFTRACING)
 #ifdef FEATURE_COMINTEROP
 FCClassElement("OAVariantLib", "Microsoft.Win32", gOAVariantFuncs)
 #endif
@@ -1213,7 +1217,7 @@ FCClassElement("WeakReference`1", "System", gWeakReferenceOfTFuncs)
 FCClassElement("X86Base", "System.Runtime.Intrinsics.X86", gX86BaseFuncs)
 #endif // defined(TARGET_X86) || defined(TARGET_AMD64)
 
-#if defined(FEATURE_EVENTSOURCE_XPLAT) || defined(FEATURE_PERFTRACING)
+#if defined(FEATURE_EVENTSOURCE_XPLAT)
 FCClassElement("XplatEventLogger", "System.Diagnostics.Tracing", gEventLogger)
 #endif //defined(FEATURE_EVENTSOURCE_XPLAT)
 

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1960,7 +1960,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPool.Portable.cs" Condition="'$(FeatureCoreCLR)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPoolBoundHandle.PlatformNotSupported.cs" Condition="'$(FeatureCoreCLR)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\NativeRuntimeEventSource.PortableThreadPool.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\NativeRuntimeEventSource.PortableThreadPool.cs" Condition="'$(FeatureCoreCLR)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.GateThread.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.HillClimbing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.HillClimbing.Complex.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1283,7 +1283,15 @@ namespace System.Diagnostics.Tracing
 #endif // FEATURE_MANAGED_ETW
 
                     if (m_Dispatchers != null && m_eventData[eventId].EnabledForAnyListener)
+                    {
+#if MONO
+                        // On Mono, managed events from NativeRuntimeEventSource are written using WriteEventCore which can be
+                        // written doubly because EventPipe tries to pump it back up to EventListener via NativeRuntimeEventSource.ProcessEvents.
+                        // So we need to prevent this from getting written directly to the Listeners.
+                        if (typeof(this) != typeof(NativeRuntimeEventSource))
+#endif // MONO
                         WriteToAllListeners(eventId, pActivityId, relatedActivityId, eventDataCount, data);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1284,12 +1284,12 @@ namespace System.Diagnostics.Tracing
 
                     if (m_Dispatchers != null && m_eventData[eventId].EnabledForAnyListener)
                     {
-#if MONO
+#if MONO && !TARGET_BROWSER
                         // On Mono, managed events from NativeRuntimeEventSource are written using WriteEventCore which can be
                         // written doubly because EventPipe tries to pump it back up to EventListener via NativeRuntimeEventSource.ProcessEvents.
                         // So we need to prevent this from getting written directly to the Listeners.
                         if (this.GetType() != typeof(NativeRuntimeEventSource))
-#endif // MONO
+#endif // MONO && !TARGET_BROWSER
                             WriteToAllListeners(eventId, pActivityId, relatedActivityId, eventDataCount, data);
                     }
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1288,9 +1288,9 @@ namespace System.Diagnostics.Tracing
                         // On Mono, managed events from NativeRuntimeEventSource are written using WriteEventCore which can be
                         // written doubly because EventPipe tries to pump it back up to EventListener via NativeRuntimeEventSource.ProcessEvents.
                         // So we need to prevent this from getting written directly to the Listeners.
-                        if (typeof(this) != typeof(NativeRuntimeEventSource))
+                        if (this.GetType() != typeof(NativeRuntimeEventSource))
 #endif // MONO
-                        WriteToAllListeners(eventId, pActivityId, relatedActivityId, eventDataCount, data);
+                            WriteToAllListeners(eventId, pActivityId, relatedActivityId, eventDataCount, data);
                     }
                 }
                 catch (Exception ex)

--- a/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.cs
+++ b/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using Microsoft.Diagnostics.Tracing;
+using Tracing.Tests.Common;
+
+namespace Tracing.Tests.GCFinalizers
+{
+    public class ProviderValidation
+    {
+        public static int Main(string[] args)
+        {
+            var providers = new List<Provider>()
+            {
+                new Provider("Microsoft-DotNETCore-SampleProfiler"),
+                //ThreadingKeyword (0x10000)
+                new Provider("Microsoft-Windows-DotNETRuntime", 0x10000, EventLevel.Verbose)
+            };
+            
+            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesTraceContainEvents);
+        }
+
+        private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+        {
+            { "Microsoft-Windows-DotNETRuntime", -1 },
+            { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
+            { "Microsoft-DotNETCore-SampleProfiler", -1 }
+        };
+
+        private static Action _eventGeneratingAction = () => 
+        {
+            Task[] tasks = new Task[50];
+            for (int i = 0; i < 50; i++)
+            {
+                tasks[i] = Task.Run(async () => {
+                    long total = 0;
+                    await Task.Delay(10);
+                    var rnd = new Random();
+                    for (int n = 1; n <= 100; n++)
+                        total += rnd.Next(0, 100);
+                    return total;
+                });
+            }
+        };
+
+        private static Func<EventPipeEventSource, Func<int>> _DoesTraceContainEvents = (source) => 
+        {
+            int threadPoolEventsCount = 0;
+            source.Clr.ThreadPoolWorkerThreadStart += (_) => threadPoolEventsCount += 1;
+            source.Clr.ThreadPoolWorkerThreadWait += (_) => threadPoolEventsCount += 1;
+            source.Clr.ThreadPoolWorkerThreadStop += (_) => threadPoolEventsCount += 1;
+            source.Clr.ThreadPoolWorkerThreadAdjustmentSample += (_) => threadPoolEventsCount += 1;
+            source.Clr.ThreadPoolWorkerThreadAdjustmentAdjustment += (_) => threadPoolEventsCount += 1;
+            return () => {
+                Logger.logger.Log("Event counts validation");
+                return threadPoolEventsCount >= 50 ? 100 : -1;
+            };
+        };
+    }
+}

--- a/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.csproj
+++ b/src/tests/tracing/eventpipe/eventsvalidation/ThreadPool.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>1</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ThreadPool.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/48407 and https://github.com/dotnet/runtime/issues/48368.

There was a error in the last commit I made as part of #47829 where I moved around some of the QCalls from XplatEventLogger to NativeRuntimeEventSource that wasn't properly reflected in ecalllist.h that causes an AV to occur. 

This PR fixes ecalllist.h to properly reflect where the QCalls are getting called from, and adds a regression test that checks for the ThreadPool events. 

cc @brianrob 