### PR TITLE
Expand PriorityQueue test coverage

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -23,7 +23,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Custom comparer used to order the heap.
         /// </summary>
-        private IComparer<TPriority>? _comparer;
+        private readonly IComparer<TPriority>? _comparer;
 
         /// <summary>
         /// Lazily-initialized collection used to expose the contents of the queue.

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
@@ -3,36 +3,34 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Xunit;
 
 namespace System.Collections.Tests
 {
-    public abstract class PriorityQueue_Generic_Tests<TElement, TPriority> : TestBase<(TElement, TPriority)>
+    public abstract class PriorityQueue_Generic_Tests<TElement, TPriority> : TestBase<TPriority>
     {
-        #region Helper methods
+        protected abstract TElement CreateElement(int seed);
 
-        protected IEnumerable<(TElement, TPriority)> GenericIEnumerableFactory(int count)
+        #region Helper methods
+        protected IEnumerable<(TElement, TPriority)> CreateItems(int count)
         {
             const int MagicValue = 34;
             int seed = count * MagicValue;
             for (int i = 0; i < count; i++)
             {
-                yield return CreateT(seed++);
+                yield return (CreateElement(seed++), CreateT(seed++));
             }
         }
 
-        protected PriorityQueue<TElement, TPriority> GenericPriorityQueueFactory(
+        protected PriorityQueue<TElement, TPriority> CreateEmptyPriorityQueue(int initialCapacity = 0)
+            => new PriorityQueue<TElement, TPriority>(initialCapacity, GetIComparer());
+
+        protected PriorityQueue<TElement, TPriority> CreatePriorityQueue(
             int initialCapacity, int countOfItemsToGenerate, out List<(TElement element, TPriority priority)> generatedItems)
         {
-            generatedItems = this.GenericIEnumerableFactory(countOfItemsToGenerate).ToList();
-
-            var queue = new PriorityQueue<TElement, TPriority>(initialCapacity);
-            foreach (var (element, priority) in generatedItems)
-            {
-                queue.Enqueue(element, priority);
-            }
-
+            generatedItems = CreateItems(countOfItemsToGenerate).ToList();
+            var queue = new PriorityQueue<TElement, TPriority>(initialCapacity, GetIComparer());
+            queue.EnqueueRange(generatedItems);
             return queue;
         }
 
@@ -41,9 +39,9 @@ namespace System.Collections.Tests
         #region Constructors
 
         [Fact]
-        public void PriorityQueue_Generic_Constructor()
+        public void PriorityQueue_DefaultConstructor_ComparerEqualsDefaultComparer()
         {
-            var queue = new PriorityQueue<TElement, TPriority>();
+            var queue = new PriorityQueue<TPriority, TPriority>();
 
             Assert.Equal(expected: 0, queue.Count);
             Assert.Empty(queue.UnorderedItems);
@@ -52,114 +50,90 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void PriorityQueue_Generic_Constructor_int(int initialCapacity)
+        public void PriorityQueue_EmptyCollection_UnorderedItemsIsEmpty(int initialCapacity)
         {
             var queue = new PriorityQueue<TElement, TPriority>(initialCapacity);
-
             Assert.Empty(queue.UnorderedItems);
         }
 
         [Fact]
-        public void PriorityQueue_Generic_Constructor_int_Negative_ThrowsArgumentOutOfRangeException()
+        public void PriorityQueue_ComparerConstructor_ComparerShouldEqualParameter()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("initialCapacity", () => new PriorityQueue<TElement, TPriority>(-1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("initialCapacity", () => new PriorityQueue<TElement, TPriority>(int.MinValue));
-        }
-
-        [Fact]
-        public void PriorityQueue_Generic_Constructor_IComparer()
-        {
-            IComparer<TPriority> comparer = Comparer<TPriority>.Default;
+            IComparer<TPriority> comparer = GetIComparer();
             var queue = new PriorityQueue<TElement, TPriority>(comparer);
-
             Assert.Equal(comparer, queue.Comparer);
         }
 
         [Fact]
-        public void PriorityQueue_Generic_Constructor_IComparer_Null()
+        public void PriorityQueue_ComparerConstructorNull_ComparerShouldEqualDefaultComparer()
         {
-            var queue = new PriorityQueue<TElement, TPriority>((IComparer<TPriority>)null);
+            var queue = new PriorityQueue<TElement, TPriority>(comparer: null);
+            Assert.Equal(0, queue.Count);
             Assert.Equal(Comparer<TPriority>.Default, queue.Comparer);
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void PriorityQueue_Generic_Constructor_int_IComparer(int initialCapacity)
+        public void PriorityQueue_CapacityConstructor_ComparerShouldEqualDefaultComparer(int initialCapacity)
         {
-            IComparer<TPriority> comparer = Comparer<TPriority>.Default;
             var queue = new PriorityQueue<TElement, TPriority>(initialCapacity);
-
             Assert.Empty(queue.UnorderedItems);
-            Assert.Equal(comparer, queue.Comparer);
+            Assert.Equal(Comparer<TPriority>.Default, queue.Comparer);
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void PriorityQueue_Generic_Constructor_IEnumerable(int count)
+        public void PriorityQueue_EnumerableConstructor_ShouldContainAllElements(int count)
         {
-            HashSet<(TElement, TPriority)> itemsToEnqueue = this.GenericIEnumerableFactory(count).ToHashSet();
+            var itemsToEnqueue = CreateItems(count).ToArray();
             PriorityQueue<TElement, TPriority> queue = new PriorityQueue<TElement, TPriority>(itemsToEnqueue);
-            Assert.True(itemsToEnqueue.SetEquals(queue.UnorderedItems));
+            Assert.Equal(itemsToEnqueue.Length, queue.Count);
+            AssertExtensions.CollectionEqual(itemsToEnqueue, queue.UnorderedItems, EqualityComparer<(TElement, TPriority)>.Default);
         }
 
         #endregion
 
-        #region Enqueue, Dequeue, Peek
+        #region Enqueue, Dequeue, Peek, EnqueueDequeue
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void PriorityQueue_Generic_Enqueue(int count)
+        public void PriorityQueue_Enqueue_IEnumerable(int count)
         {
-            PriorityQueue<TElement, TPriority> queue = GenericPriorityQueueFactory(count, count, out var generatedItems);
-            HashSet<(TElement, TPriority)> expectedItems = generatedItems.ToHashSet();
+            var itemsToEnqueue = CreateItems(count).ToArray();
+            PriorityQueue<TElement, TPriority> queue = CreateEmptyPriorityQueue();
 
-            Assert.Equal(count, queue.Count);
-            var actualItems = queue.UnorderedItems.ToArray();
-            Assert.True(expectedItems.SetEquals(actualItems));
-        }
+            foreach (var (element, priority) in itemsToEnqueue)
+            {
+                queue.Enqueue(element, priority);
+            }
 
-        [Fact]
-        public void PriorityQueue_Generic_Dequeue_EmptyCollection()
-        {
-            var queue = new PriorityQueue<TElement, TPriority>();
-
-            Assert.False(queue.TryDequeue(out _, out _));
-            Assert.Throws<InvalidOperationException>(() => queue.Dequeue());
-        }
-
-        [Fact]
-        public void PriorityQueue_Generic_Peek_EmptyCollection()
-        {
-            var queue = new PriorityQueue<TElement, TPriority>();
-
-            Assert.False(queue.TryPeek(out _, out _));
-            Assert.Throws<InvalidOperationException>(() => queue.Peek());
+            AssertExtensions.CollectionEqual(itemsToEnqueue, queue.UnorderedItems, EqualityComparer<(TElement, TPriority)>.Default);
         }
 
         [Theory]
         [MemberData(nameof(ValidPositiveCollectionSizes))]
-        public void PriorityQueue_Generic_Peek_PositiveCount(int count)
+        public void PriorityQueue_Peek_ShouldReturnMinimalElement(int count)
         {
-            IReadOnlyCollection<(TElement, TPriority)> itemsToEnqueue = this.GenericIEnumerableFactory(count).ToArray();
-            (TElement element, TPriority priority) expectedPeek = itemsToEnqueue.First();
-            PriorityQueue<TElement, TPriority> queue = new PriorityQueue<TElement, TPriority>();
+            IReadOnlyCollection<(TElement, TPriority)> itemsToEnqueue = CreateItems(count).ToArray();
+            PriorityQueue<TElement, TPriority> queue = CreateEmptyPriorityQueue();
+            (TElement Element, TPriority Priority) minItem = itemsToEnqueue.First();
 
             foreach (var (element, priority) in itemsToEnqueue)
             {
-                if (queue.Comparer.Compare(priority, expectedPeek.priority) < 0)
+                if (queue.Comparer.Compare(priority, minItem.Priority) < 0)
                 {
-                    expectedPeek = (element, priority);
+                    minItem = (element, priority);
                 }
 
                 queue.Enqueue(element, priority);
 
                 var actualPeekElement = queue.Peek();
-                var actualTryPeekSuccess = queue.TryPeek(out TElement actualTryPeekElement, out TPriority actualTryPeekPriority);
+                Assert.Equal(minItem.Element, actualPeekElement);
 
-                Assert.Equal(expectedPeek.element, actualPeekElement);
+                var actualTryPeekSuccess = queue.TryPeek(out TElement actualTryPeekElement, out TPriority actualTryPeekPriority);
                 Assert.True(actualTryPeekSuccess);
-                Assert.Equal(expectedPeek.element, actualTryPeekElement);
-                Assert.Equal(expectedPeek.priority, actualTryPeekPriority);
+                Assert.Equal(minItem.Element, actualTryPeekElement);
+                Assert.Equal(minItem.Priority, actualTryPeekPriority);
             }
         }
 
@@ -167,9 +141,9 @@ namespace System.Collections.Tests
         [InlineData(0, 5)]
         [InlineData(1, 1)]
         [InlineData(3, 100)]
-        public void PriorityQueue_Generic_PeekAndDequeue(int initialCapacity, int count)
+        public void PriorityQueue_PeekAndDequeue(int initialCapacity, int count)
         {
-            PriorityQueue<TElement, TPriority> queue = this.GenericPriorityQueueFactory(initialCapacity, count, out var generatedItems);
+            PriorityQueue<TElement, TPriority> queue = CreatePriorityQueue(initialCapacity, count, out var generatedItems);
 
             var expectedPeekPriorities = generatedItems
                 .Select(x => x.priority)
@@ -196,14 +170,31 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void PriorityQueue_Generic_EnqueueRange_IEnumerable(int count)
+        public void PriorityQueue_EnqueueRange_IEnumerable(int count)
         {
-            HashSet<(TElement, TPriority)> itemsToEnqueue = this.GenericIEnumerableFactory(count).ToHashSet();
-            PriorityQueue<TElement, TPriority> queue = new PriorityQueue<TElement, TPriority>();
+            (TElement, TPriority)[] itemsToEnqueue = CreateItems(count).ToArray();
+            PriorityQueue<TElement, TPriority> queue = CreateEmptyPriorityQueue();
 
             queue.EnqueueRange(itemsToEnqueue);
 
-            Assert.True(itemsToEnqueue.SetEquals(queue.UnorderedItems));
+            AssertExtensions.CollectionEqual(itemsToEnqueue, queue.UnorderedItems, EqualityComparer<(TElement, TPriority)>.Default);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void PriorityQueue_EnqueueDequeue(int count)
+        {
+            (TElement Element, TPriority Priority)[] itemsToEnqueue = CreateItems(2 * count).ToArray();
+            PriorityQueue<TElement, TPriority> queue = CreateEmptyPriorityQueue();
+            queue.EnqueueRange(itemsToEnqueue.Take(count));
+
+            foreach ((TElement element, TPriority priority) in itemsToEnqueue.Skip(count))
+            {
+                queue.EnqueueDequeue(element, priority);
+            }
+
+            var expectedItems = itemsToEnqueue.OrderByDescending(x => x.Priority, queue.Comparer).Take(count);
+            AssertExtensions.CollectionEqual(expectedItems, queue.UnorderedItems, EqualityComparer<(TElement, TPriority)>.Default);
         }
 
         #endregion
@@ -212,97 +203,15 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void PriorityQueue_Generic_Clear(int count)
+        public void PriorityQueue_Clear(int count)
         {
-            PriorityQueue<TElement, TPriority> queue = this.GenericPriorityQueueFactory(initialCapacity: 0, count, out _);
-
+            PriorityQueue<TElement, TPriority> queue = CreatePriorityQueue(initialCapacity: 0, count, out _);
             Assert.Equal(count, queue.Count);
+
             queue.Clear();
+
             Assert.Equal(expected: 0, queue.Count);
-        }
-
-        #endregion
-
-        #region EnsureCapacity, TrimExcess
-
-        [Fact]
-        public void PriorityQueue_Generic_EnsureCapacity_Negative()
-        {
-            PriorityQueue<TElement, TPriority> queue = new PriorityQueue<TElement, TPriority>();
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => queue.EnsureCapacity(-1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => queue.EnsureCapacity(int.MinValue));
-        }
-
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(0, 5)]
-        [InlineData(1, 1)]
-        [InlineData(3, 100)]
-        public void PriorityQueue_Generic_TrimExcess_ValidQueueThatHasntBeenRemovedFrom(int initialCapacity, int count)
-        {
-            PriorityQueue<TElement, TPriority> queue = this.GenericPriorityQueueFactory(initialCapacity, count, out _);
-            queue.TrimExcess();
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void PriorityQueue_Generic_TrimExcess_Repeatedly(int count)
-        {
-            PriorityQueue<TElement, TPriority> queue = this.GenericPriorityQueueFactory(initialCapacity: 0, count, out _);
-
-            Assert.Equal(count, queue.Count);
-            queue.TrimExcess();
-            queue.TrimExcess();
-            queue.TrimExcess();
-            Assert.Equal(count, queue.Count);
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidPositiveCollectionSizes))]
-        public void PriorityQueue_Generic_EnsureCapacityAndTrimExcess(int count)
-        {
-            IReadOnlyCollection<(TElement, TPriority)> itemsToEnqueue = this.GenericIEnumerableFactory(count).ToArray();
-            PriorityQueue<TElement, TPriority> queue = new PriorityQueue<TElement, TPriority>();
-            int expectedCount = 0;
-            Random random = new Random(Seed: 34);
-            int getNextEnsureCapacity() => random.Next(0, count * 2);
-            void trimAndEnsureCapacity()
-            {
-                queue.TrimExcess();
-
-                int capacityAfterEnsureCapacity = queue.EnsureCapacity(getNextEnsureCapacity());
-                Assert.Equal(capacityAfterEnsureCapacity, GetUnderlyingBufferCapacity(queue));
-
-                int capacityAfterTrimExcess = (queue.Count < (int)(capacityAfterEnsureCapacity * 0.9)) ? queue.Count : capacityAfterEnsureCapacity;
-                queue.TrimExcess();
-                Assert.Equal(capacityAfterTrimExcess, GetUnderlyingBufferCapacity(queue));
-            };
-
-            foreach (var (element, priority) in itemsToEnqueue)
-            {
-                trimAndEnsureCapacity();
-                queue.Enqueue(element, priority);
-                expectedCount++;
-                Assert.Equal(expectedCount, queue.Count);
-            }
-
-            while (expectedCount > 0)
-            {
-                queue.Dequeue();
-                trimAndEnsureCapacity();
-                expectedCount--;
-                Assert.Equal(expectedCount, queue.Count);
-            }
-
-            trimAndEnsureCapacity();
-            Assert.Equal(0, queue.Count);
-        }
-
-        private static int GetUnderlyingBufferCapacity(PriorityQueue<TElement, TPriority> queue)
-        {
-            FieldInfo nodesType = queue.GetType().GetField("_nodes", BindingFlags.NonPublic | BindingFlags.Instance);
-            var nodes = ((TElement Element, TPriority Priority)[])nodesType.GetValue(queue);
-            return nodes.Length;
+            Assert.False(queue.TryPeek(out _, out _));
         }
 
         #endregion
@@ -313,42 +222,13 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidPositiveCollectionSizes))]
         public void PriorityQueue_Enumeration_OrderingIsConsistent(int count)
         {
-            PriorityQueue<TElement, TPriority> queue = this.GenericPriorityQueueFactory(initialCapacity: 0, count, out _);
+            PriorityQueue<TElement, TPriority> queue = CreatePriorityQueue(initialCapacity: 0, count, out _);
 
             (TElement, TPriority)[] firstEnumeration = queue.UnorderedItems.ToArray();
             (TElement, TPriority)[] secondEnumeration = queue.UnorderedItems.ToArray();
 
             Assert.Equal(firstEnumeration.Length, count);
             Assert.True(firstEnumeration.SequenceEqual(secondEnumeration));
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidPositiveCollectionSizes))]
-        public void PriorityQueue_Enumeration_InvalidationOnModifiedCollection(int count)
-        {
-            IReadOnlyCollection<(TElement, TPriority)> itemsToEnqueue = this.GenericIEnumerableFactory(count).ToArray();
-            PriorityQueue<TElement, TPriority> queue = new PriorityQueue<TElement, TPriority>();
-            queue.EnqueueRange(itemsToEnqueue.Take(count - 1));
-            var enumerator = queue.UnorderedItems.GetEnumerator();
-
-            (TElement element, TPriority priority) = itemsToEnqueue.Last();
-            queue.Enqueue(element, priority);
-            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidPositiveCollectionSizes))]
-        public void PriorityQueue_Enumeration_InvalidationOnModifiedCapacity(int count)
-        {
-            PriorityQueue<TElement, TPriority> queue = this.GenericPriorityQueueFactory(initialCapacity: 0, count, out _);
-            var enumerator = queue.UnorderedItems.GetEnumerator();
-
-            int capacityBefore = GetUnderlyingBufferCapacity(queue);
-            queue.EnsureCapacity(count * 2 + 4);
-            int capacityAfter = GetUnderlyingBufferCapacity(queue);
-
-            Assert.NotEqual(capacityBefore, capacityAfter);
-            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
         }
 
         #endregion

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.Tests.cs
@@ -41,7 +41,7 @@ namespace System.Collections.Tests
         [Fact]
         public void PriorityQueue_DefaultConstructor_ComparerEqualsDefaultComparer()
         {
-            var queue = new PriorityQueue<TPriority, TPriority>();
+            var queue = new PriorityQueue<TElement, TPriority>();
 
             Assert.Equal(expected: 0, queue.Count);
             Assert.Empty(queue.UnorderedItems);
@@ -69,7 +69,7 @@ namespace System.Collections.Tests
         {
             var queue = new PriorityQueue<TElement, TPriority>(comparer: null);
             Assert.Equal(0, queue.Count);
-            Assert.Equal(Comparer<TPriority>.Default, queue.Comparer);
+            Assert.Same(Comparer<TPriority>.Default, queue.Comparer);
         }
 
         [Theory]
@@ -78,14 +78,14 @@ namespace System.Collections.Tests
         {
             var queue = new PriorityQueue<TElement, TPriority>(initialCapacity);
             Assert.Empty(queue.UnorderedItems);
-            Assert.Equal(Comparer<TPriority>.Default, queue.Comparer);
+            Assert.Same(Comparer<TPriority>.Default, queue.Comparer);
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void PriorityQueue_EnumerableConstructor_ShouldContainAllElements(int count)
         {
-            var itemsToEnqueue = CreateItems(count).ToArray();
+            (TElement, TPriority)[] itemsToEnqueue = CreateItems(count).ToArray();
             PriorityQueue<TElement, TPriority> queue = new PriorityQueue<TElement, TPriority>(itemsToEnqueue);
             Assert.Equal(itemsToEnqueue.Length, queue.Count);
             AssertExtensions.CollectionEqual(itemsToEnqueue, queue.UnorderedItems, EqualityComparer<(TElement, TPriority)>.Default);
@@ -99,10 +99,10 @@ namespace System.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void PriorityQueue_Enqueue_IEnumerable(int count)
         {
-            var itemsToEnqueue = CreateItems(count).ToArray();
+            (TElement, TPriority)[] itemsToEnqueue = CreateItems(count).ToArray();
             PriorityQueue<TElement, TPriority> queue = CreateEmptyPriorityQueue();
 
-            foreach (var (element, priority) in itemsToEnqueue)
+            foreach ((TElement element, TPriority priority) in itemsToEnqueue)
             {
                 queue.Enqueue(element, priority);
             }
@@ -118,7 +118,7 @@ namespace System.Collections.Tests
             PriorityQueue<TElement, TPriority> queue = CreateEmptyPriorityQueue();
             (TElement Element, TPriority Priority) minItem = itemsToEnqueue.First();
 
-            foreach (var (element, priority) in itemsToEnqueue)
+            foreach ((TElement element, TPriority priority) in itemsToEnqueue)
             {
                 if (queue.Comparer.Compare(priority, minItem.Priority) < 0)
                 {
@@ -127,10 +127,10 @@ namespace System.Collections.Tests
 
                 queue.Enqueue(element, priority);
 
-                var actualPeekElement = queue.Peek();
+                TElement actualPeekElement = queue.Peek();
                 Assert.Equal(minItem.Element, actualPeekElement);
 
-                var actualTryPeekSuccess = queue.TryPeek(out TElement actualTryPeekElement, out TPriority actualTryPeekPriority);
+                bool actualTryPeekSuccess = queue.TryPeek(out TElement actualTryPeekElement, out TPriority actualTryPeekPriority);
                 Assert.True(actualTryPeekSuccess);
                 Assert.Equal(minItem.Element, actualTryPeekElement);
                 Assert.Equal(minItem.Priority, actualTryPeekPriority);
@@ -143,19 +143,19 @@ namespace System.Collections.Tests
         [InlineData(3, 100)]
         public void PriorityQueue_PeekAndDequeue(int initialCapacity, int count)
         {
-            PriorityQueue<TElement, TPriority> queue = CreatePriorityQueue(initialCapacity, count, out var generatedItems);
+            PriorityQueue<TElement, TPriority> queue = CreatePriorityQueue(initialCapacity, count, out List<(TElement element, TPriority priority)> generatedItems);
 
-            var expectedPeekPriorities = generatedItems
+            TPriority[] expectedPeekPriorities = generatedItems
                 .Select(x => x.priority)
                 .OrderBy(x => x, queue.Comparer)
                 .ToArray();
 
-            for (var i = 0; i < count; ++i)
+            for (int i = 0; i < count; ++i)
             {
-                var expectedPeekPriority = expectedPeekPriorities[i];
+                TPriority expectedPeekPriority = expectedPeekPriorities[i];
 
-                var actualTryPeekSuccess = queue.TryPeek(out TElement actualTryPeekElement, out TPriority actualTryPeekPriority);
-                var actualTryDequeueSuccess = queue.TryDequeue(out TElement actualTryDequeueElement, out TPriority actualTryDequeuePriority);
+                bool actualTryPeekSuccess = queue.TryPeek(out TElement actualTryPeekElement, out TPriority actualTryPeekPriority);
+                bool actualTryDequeueSuccess = queue.TryDequeue(out TElement actualTryDequeueElement, out TPriority actualTryDequeuePriority);
 
                 Assert.True(actualTryPeekSuccess);
                 Assert.True(actualTryDequeueSuccess);
@@ -193,7 +193,7 @@ namespace System.Collections.Tests
                 queue.EnqueueDequeue(element, priority);
             }
 
-            var expectedItems = itemsToEnqueue.OrderByDescending(x => x.Priority, queue.Comparer).Take(count);
+            IEnumerable<(TElement Element, TPriority Priority)> expectedItems = itemsToEnqueue.OrderByDescending(x => x.Priority, queue.Comparer).Take(count);
             AssertExtensions.CollectionEqual(expectedItems, queue.UnorderedItems, EqualityComparer<(TElement, TPriority)>.Default);
         }
 

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Generic.cs
@@ -1,16 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace System.Collections.Tests
 {
     public class PriorityQueue_Generic_Tests_string_string : PriorityQueue_Generic_Tests<string, string>
     {
-        protected override (string, string) CreateT(int seed)
-        {
-            var element = this.CreateString(seed);
-            var priority = this.CreateString(seed);
-            return (element, priority);
-        }
+        protected override string CreateT(int seed) => CreateString(seed);
+        protected override string CreateElement(int seed) => CreateString(seed);
 
         protected string CreateString(int seed)
         {
@@ -24,13 +22,19 @@ namespace System.Collections.Tests
 
     public class PriorityQueue_Generic_Tests_int_int : PriorityQueue_Generic_Tests<int, int>
     {
-        protected override (int, int) CreateT(int seed)
-        {
-            var element = this.CreateInt(seed);
-            var priority = this.CreateInt(seed);
-            return (element, priority);
-        }
+        protected override int CreateT(int seed) => CreateInt(seed);
+        protected override int CreateElement(int seed) => CreateInt(seed);
 
         protected int CreateInt(int seed) => new Random(seed).Next();
+    }
+
+    public class PriorityQueue_Generic_Tests_string_string_CustomComparer : PriorityQueue_Generic_Tests_string_string
+    {
+        protected override IComparer<string> GetIComparer() => StringComparer.InvariantCultureIgnoreCase;
+    }
+
+    public class PriorityQueue_Generic_Tests_int_int_CustomComparer : PriorityQueue_Generic_Tests_int_int
+    {
+        protected override IComparer<int> GetIComparer() => Comparer<int>.Create((x, y) => -x.CompareTo(y));
     }
 }

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public static class PriorityQueue_PropertyTests
+    {
+        const int MaxTest = 100;
+
+        private readonly static IComparer<string> s_stringComparer = StringComparer.Ordinal;
+        
+        [Property(MaxTest = MaxTest)]
+        public static void HeapSort_Heapify_String(string[] elements)
+        {
+            var expected = elements.OrderBy(e => e, s_stringComparer);
+            var actual = HeapSort_Heapify(elements, s_stringComparer);
+            Assert.Equal(expected, actual);
+        }
+
+        [Property(MaxTest = MaxTest)]
+        public static void HeapSort_Heapify_Int(int[] elements)
+        {
+            var expected = elements.OrderBy(e => e);
+            var actual = HeapSort_Heapify(elements);
+            Assert.Equal(expected, actual);
+        }
+
+        private static IEnumerable<TElement> HeapSort_Heapify<TElement>(IEnumerable<TElement> inputs, IComparer<TElement>? comparer = null)
+        {
+            var queue = new PriorityQueue<TElement, TElement>(inputs.Select(e => (e, e)), comparer);
+            foreach ((TElement element, TElement priority) in DrainHeap(queue))
+            {
+                Assert.Equal(element, priority);
+                yield return element;
+            }
+        }
+
+        [Property(MaxTest = MaxTest)]
+        public static void HeapSort_EnqueueRange_String(string[] elements)
+        {
+            var expected = elements.OrderBy(e => e, s_stringComparer);
+            var actual = HeapSort_EnqueueRange(elements, s_stringComparer);
+            Assert.Equal(expected, actual);
+        }
+
+        [Property(MaxTest = MaxTest)]
+        public static void HeapSort_EnqueueRange_Int(int[] elements)
+        {
+            var expected = elements.OrderBy(e => e);
+            var actual = HeapSort_EnqueueRange(elements);
+            Assert.Equal(expected, actual);
+        }
+
+        private static IEnumerable<TElement> HeapSort_EnqueueRange<TElement>(IEnumerable<TElement> inputs, IComparer<TElement>? comparer = null)
+        {
+            var queue = new PriorityQueue<TElement, TElement>(comparer);
+            queue.EnqueueRange(inputs.Select(e => (e, e)));
+            foreach ((TElement element, TElement priority) in DrainHeap(queue))
+            {
+                Assert.Equal(element, priority);
+                yield return element;
+            }
+        }
+
+        [Property(MaxTest = MaxTest)]
+        public static void HeapSort_Enqueue_String(string[] elements)
+        {
+            var expected = elements.OrderBy(e => e, s_stringComparer);
+            var actual = HeapSort_Enqueue(elements, s_stringComparer);
+            Assert.Equal(expected, actual);
+        }
+
+        [Property(MaxTest = MaxTest)]
+        public static void HeapSort_Enqueue_Int(int[] elements)
+        {
+            var expected = elements.OrderBy(e => e);
+            var actual = HeapSort_Enqueue(elements);
+            Assert.Equal(expected, actual);
+        }
+
+        private static IEnumerable<TElement> HeapSort_Enqueue<TElement>(IEnumerable<TElement> inputs, IComparer<TElement>? comparer = null)
+        {
+            var queue = new PriorityQueue<TElement, TElement>(comparer);
+
+            foreach (var input in inputs)
+            {
+                queue.Enqueue(input, input);
+            }
+
+            foreach ((TElement element, TElement priority) in DrainHeap(queue))
+            {
+                Assert.Equal(element, priority);
+                yield return element;
+            }
+        }
+
+        [Property(MaxTest = MaxTest)]
+        public static void KMaxElements_String(string[] elements, NonNegativeInt k)
+        {
+            var expected = elements.OrderByDescending(e => e, s_stringComparer).Take(k.Get);
+            var actual = KMaxElements(elements, k.Get, s_stringComparer);
+            Assert.Equal(expected, actual);
+        }
+
+        [Property(MaxTest = MaxTest)]
+        public static void KMaxElements_Int(int[] elements, NonNegativeInt k)
+        {
+            var expected = elements.OrderByDescending(e => e).Take(k.Get);
+            var actual = KMaxElements(elements, k.Get);
+            Assert.Equal(expected, actual);
+        }
+
+        private static IEnumerable<TElement> KMaxElements<TElement>(TElement[] elements, int k, IComparer<TElement>? comparer = null)
+        {
+            var queue = new PriorityQueue<TElement, TElement>(comparer);
+            comparer = queue.Comparer;
+
+            int heapSize = Math.Min(k, elements.Length);
+            for (int i = 0; i < heapSize; i++)
+            {
+                TElement element = elements[i];
+                queue.Enqueue(element, element);
+            }
+
+            for (int i = k; i < elements.Length; i++)
+            {
+                TElement element = elements[i];
+                TElement dequeued = queue.EnqueueDequeue(element, element);
+                Assert.True(comparer.Compare(dequeued, element) <= 0);
+                Assert.Equal(k, queue.Count);
+            }
+
+            foreach ((TElement element, TElement priority) in DrainHeap(queue).Reverse())
+            {
+                Assert.Equal(element, priority);
+                yield return element;
+            }
+        }
+
+        private static IEnumerable<(TElement Element, TPriority Priority)> DrainHeap<TElement, TPriority>(PriorityQueue<TElement, TPriority> queue)
+        {
+            while (queue.Count > 0)
+            {
+                Assert.True(queue.TryPeek(out TElement element, out TPriority priority));
+                Assert.True(queue.TryDequeue(out TElement element2, out TPriority priority2));
+                Assert.Equal(element, element2);
+                Assert.Equal(priority, priority2);
+                yield return (element, priority);
+            }
+
+            Assert.False(queue.TryPeek(out _, out _));
+        }
+    }
+}

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
@@ -12,10 +12,11 @@ namespace System.Collections.Tests
     public static class PriorityQueue_PropertyTests
     {
         const int MaxTest = 100;
+        const string Seed = "(0,0)";
 
         private readonly static IComparer<string> s_stringComparer = StringComparer.Ordinal;
         
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Heapify_String(string[] elements)
         {
             var expected = elements.OrderBy(e => e, s_stringComparer);
@@ -23,7 +24,7 @@ namespace System.Collections.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Heapify_Int(int[] elements)
         {
             var expected = elements.OrderBy(e => e);
@@ -41,7 +42,7 @@ namespace System.Collections.Tests
             }
         }
 
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_EnqueueRange_String(string[] elements)
         {
             var expected = elements.OrderBy(e => e, s_stringComparer);
@@ -49,7 +50,7 @@ namespace System.Collections.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_EnqueueRange_Int(int[] elements)
         {
             var expected = elements.OrderBy(e => e);
@@ -68,7 +69,7 @@ namespace System.Collections.Tests
             }
         }
 
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Enqueue_String(string[] elements)
         {
             var expected = elements.OrderBy(e => e, s_stringComparer);
@@ -76,7 +77,7 @@ namespace System.Collections.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Enqueue_Int(int[] elements)
         {
             var expected = elements.OrderBy(e => e);
@@ -100,7 +101,7 @@ namespace System.Collections.Tests
             }
         }
 
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void KMaxElements_String(string[] elements, NonNegativeInt k)
         {
             var expected = elements.OrderByDescending(e => e, s_stringComparer).Take(k.Get);
@@ -108,7 +109,7 @@ namespace System.Collections.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest)]
+        [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void KMaxElements_Int(int[] elements, NonNegativeInt k)
         {
             var expected = elements.OrderByDescending(e => e).Take(k.Get);

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using FsCheck;
-using FsCheck.Xunit;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -12,11 +10,12 @@ namespace System.Collections.Tests
     public static class PriorityQueue_PropertyTests
     {
         const int MaxTest = 100;
-        const string Seed = "(0,0)";
+        const int Seed = 42;
 
         private readonly static IComparer<string> s_stringComparer = StringComparer.Ordinal;
-        
-        [Property(MaxTest = MaxTest, Replay = Seed)]
+
+        [Theory]
+        [MemberData(nameof(GetRandomStringArrays))]
         public static void HeapSort_Heapify_String(string[] elements)
         {
             IEnumerable<string> expected = elements.OrderBy(e => e, s_stringComparer);
@@ -24,7 +23,8 @@ namespace System.Collections.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest, Replay = Seed)]
+        [Theory]
+        [MemberData(nameof(GetRandomIntArrays))]
         public static void HeapSort_Heapify_Int(int[] elements)
         {
             IEnumerable<int> expected = elements.OrderBy(e => e);
@@ -42,7 +42,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Property(MaxTest = MaxTest, Replay = Seed)]
+        [Theory]
+        [MemberData(nameof(GetRandomStringArrays))]
         public static void HeapSort_EnqueueRange_String(string[] elements)
         {
             IEnumerable<string> expected = elements.OrderBy(e => e, s_stringComparer);
@@ -50,7 +51,8 @@ namespace System.Collections.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest, Replay = Seed)]
+        [Theory]
+        [MemberData(nameof(GetRandomIntArrays))]
         public static void HeapSort_EnqueueRange_Int(int[] elements)
         {
             IEnumerable<int> expected = elements.OrderBy(e => e);
@@ -69,7 +71,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Property(MaxTest = MaxTest, Replay = Seed)]
+        [Theory]
+        [MemberData(nameof(GetRandomStringArrays))]
         public static void HeapSort_Enqueue_String(string[] elements)
         {
             IEnumerable<string> expected = elements.OrderBy(e => e, s_stringComparer);
@@ -77,7 +80,8 @@ namespace System.Collections.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest, Replay = Seed)]
+        [Theory]
+        [MemberData(nameof(GetRandomIntArrays))]
         public static void HeapSort_Enqueue_Int(int[] elements)
         {
             IEnumerable<int> expected = elements.OrderBy(e => e);
@@ -101,19 +105,23 @@ namespace System.Collections.Tests
             }
         }
 
-        [Property(MaxTest = MaxTest, Replay = Seed)]
-        public static void KMaxElements_String(string[] elements, NonNegativeInt k)
+        [Theory]
+        [MemberData(nameof(GetRandomStringArrays))]
+        public static void KMaxElements_String(string[] elements)
         {
-            IEnumerable<string> expected = elements.OrderByDescending(e => e, s_stringComparer).Take(k.Get);
-            IEnumerable<string> actual = KMaxElements(elements, k.Get, s_stringComparer);
+            const int k = 5;
+            IEnumerable<string> expected = elements.OrderByDescending(e => e, s_stringComparer).Take(k);
+            IEnumerable<string> actual = KMaxElements(elements, k, s_stringComparer);
             Assert.Equal(expected, actual);
         }
 
-        [Property(MaxTest = MaxTest, Replay = Seed)]
-        public static void KMaxElements_Int(int[] elements, NonNegativeInt k)
+        [Theory]
+        [MemberData(nameof(GetRandomIntArrays))]
+        public static void KMaxElements_Int(int[] elements)
         {
-            IEnumerable<int> expected = elements.OrderByDescending(e => e).Take(k.Get);
-            IEnumerable<int> actual = KMaxElements(elements, k.Get);
+            const int k = 5;
+            IEnumerable<int> expected = elements.OrderByDescending(e => e).Take(k);
+            IEnumerable<int> actual = KMaxElements(elements, k);
             Assert.Equal(expected, actual);
         }
 
@@ -156,6 +164,42 @@ namespace System.Collections.Tests
             }
 
             Assert.False(queue.TryPeek(out _, out _));
+        }
+
+        public static IEnumerable<object[]> GetRandomStringArrays() => GenerateMemberData(random => GenArray(GenString, random));
+        public static IEnumerable<object[]> GetRandomIntArrays() => GenerateMemberData(random => GenArray(GenInt, random));
+
+        private static IEnumerable<object[]> GenerateMemberData<T>(Func<Random, T> genElement)
+        {
+            var random = new Random(Seed);
+            for (int i = 0; i < MaxTest; i++)
+            {
+                yield return new object[] { genElement(random) };
+            };
+        }
+
+        private static T[] GenArray<T>(Func<Random, T> genElement, Random random)
+        {
+            const int MaxArraySize = 100;
+            int arraySize = random.Next(MaxArraySize);
+            var array = new T[arraySize];
+            for (int i = 0; i < arraySize; i++)
+            {
+                array[i] = genElement(random);
+            }
+
+            return array;
+        }
+
+        private static int GenInt(Random random) => random.Next();
+
+        private static string GenString(Random random)
+        {
+            const int MaxSize = 50;
+            int size = random.Next(MaxSize);
+            var buffer = new byte[size];
+            random.NextBytes(buffer);
+            return Convert.ToBase64String(buffer);
         }
     }
 }

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.PropertyTests.cs
@@ -19,16 +19,16 @@ namespace System.Collections.Tests
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Heapify_String(string[] elements)
         {
-            var expected = elements.OrderBy(e => e, s_stringComparer);
-            var actual = HeapSort_Heapify(elements, s_stringComparer);
+            IEnumerable<string> expected = elements.OrderBy(e => e, s_stringComparer);
+            IEnumerable<string> actual = HeapSort_Heapify(elements, s_stringComparer);
             Assert.Equal(expected, actual);
         }
 
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Heapify_Int(int[] elements)
         {
-            var expected = elements.OrderBy(e => e);
-            var actual = HeapSort_Heapify(elements);
+            IEnumerable<int> expected = elements.OrderBy(e => e);
+            IEnumerable<int> actual = HeapSort_Heapify(elements);
             Assert.Equal(expected, actual);
         }
 
@@ -45,16 +45,16 @@ namespace System.Collections.Tests
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_EnqueueRange_String(string[] elements)
         {
-            var expected = elements.OrderBy(e => e, s_stringComparer);
-            var actual = HeapSort_EnqueueRange(elements, s_stringComparer);
+            IEnumerable<string> expected = elements.OrderBy(e => e, s_stringComparer);
+            IEnumerable<string> actual = HeapSort_EnqueueRange(elements, s_stringComparer);
             Assert.Equal(expected, actual);
         }
 
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_EnqueueRange_Int(int[] elements)
         {
-            var expected = elements.OrderBy(e => e);
-            var actual = HeapSort_EnqueueRange(elements);
+            IEnumerable<int> expected = elements.OrderBy(e => e);
+            IEnumerable<int> actual = HeapSort_EnqueueRange(elements);
             Assert.Equal(expected, actual);
         }
 
@@ -72,16 +72,16 @@ namespace System.Collections.Tests
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Enqueue_String(string[] elements)
         {
-            var expected = elements.OrderBy(e => e, s_stringComparer);
-            var actual = HeapSort_Enqueue(elements, s_stringComparer);
+            IEnumerable<string> expected = elements.OrderBy(e => e, s_stringComparer);
+            IEnumerable<string> actual = HeapSort_Enqueue(elements, s_stringComparer);
             Assert.Equal(expected, actual);
         }
 
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void HeapSort_Enqueue_Int(int[] elements)
         {
-            var expected = elements.OrderBy(e => e);
-            var actual = HeapSort_Enqueue(elements);
+            IEnumerable<int> expected = elements.OrderBy(e => e);
+            IEnumerable<int> actual = HeapSort_Enqueue(elements);
             Assert.Equal(expected, actual);
         }
 
@@ -89,7 +89,7 @@ namespace System.Collections.Tests
         {
             var queue = new PriorityQueue<TElement, TElement>(comparer);
 
-            foreach (var input in inputs)
+            foreach (TElement input in inputs)
             {
                 queue.Enqueue(input, input);
             }
@@ -104,16 +104,16 @@ namespace System.Collections.Tests
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void KMaxElements_String(string[] elements, NonNegativeInt k)
         {
-            var expected = elements.OrderByDescending(e => e, s_stringComparer).Take(k.Get);
-            var actual = KMaxElements(elements, k.Get, s_stringComparer);
+            IEnumerable<string> expected = elements.OrderByDescending(e => e, s_stringComparer).Take(k.Get);
+            IEnumerable<string> actual = KMaxElements(elements, k.Get, s_stringComparer);
             Assert.Equal(expected, actual);
         }
 
         [Property(MaxTest = MaxTest, Replay = Seed)]
         public static void KMaxElements_Int(int[] elements, NonNegativeInt k)
         {
-            var expected = elements.OrderByDescending(e => e).Take(k.Get);
-            var actual = KMaxElements(elements, k.Get);
+            IEnumerable<int> expected = elements.OrderByDescending(e => e).Take(k.Get);
+            IEnumerable<int> actual = KMaxElements(elements, k.Get);
             Assert.Equal(expected, actual);
         }
 

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Tests.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.Collections.Tests
 {
     public class PriorityQueue_NonGeneric_Tests : TestBase
     {
-        protected PriorityQueue<string, int> SmallPriorityQueueFactory(out HashSet<(string, int)> items)
+        protected PriorityQueue<string, int> CreateSmallPriorityQueue(out HashSet<(string, int)> items)
         {
             items = new HashSet<(string, int)>
             {
@@ -19,6 +21,17 @@ namespace System.Collections.Tests
             var queue = new PriorityQueue<string, int>(items);
 
             return queue;
+        }
+
+        protected PriorityQueue<int, int> CreatePriorityQueue(int initialCapacity, int count)
+        {
+            var pq = new PriorityQueue<int, int>(initialCapacity);
+            for (int i = 0; i < count; i++)
+            {
+                pq.Enqueue(i, i);
+            }
+
+            return pq;
         }
 
         [Fact]
@@ -33,7 +46,7 @@ namespace System.Collections.Tests
         [Fact]
         public void PriorityQueue_Generic_EnqueueDequeue_SmallerThanMin()
         {
-            PriorityQueue<string, int> queue = SmallPriorityQueueFactory(out HashSet<(string, int)> enqueuedItems);
+            PriorityQueue<string, int> queue = CreateSmallPriorityQueue(out HashSet<(string, int)> enqueuedItems);
 
             string actualElement = queue.EnqueueDequeue("zero", 0);
 
@@ -44,7 +57,7 @@ namespace System.Collections.Tests
         [Fact]
         public void PriorityQueue_Generic_EnqueueDequeue_LargerThanMin()
         {
-            PriorityQueue<string, int> queue = SmallPriorityQueueFactory(out HashSet<(string, int)> enqueuedItems);
+            PriorityQueue<string, int> queue = CreateSmallPriorityQueue(out HashSet<(string, int)> enqueuedItems);
 
             string actualElement = queue.EnqueueDequeue("four", 4);
 
@@ -57,7 +70,7 @@ namespace System.Collections.Tests
         [Fact]
         public void PriorityQueue_Generic_EnqueueDequeue_EqualToMin()
         {
-            PriorityQueue<string, int> queue = SmallPriorityQueueFactory(out HashSet<(string, int)> enqueuedItems);
+            PriorityQueue<string, int> queue = CreateSmallPriorityQueue(out HashSet<(string, int)> enqueuedItems);
 
             string actualElement = queue.EnqueueDequeue("one-not-to-enqueue", 1);
 
@@ -104,5 +117,166 @@ namespace System.Collections.Tests
 
             Assert.Equal("not null", queue.Dequeue());
         }
+
+        [Fact]
+        public void PriorityQueue_Constructor_int_Negative_ThrowsArgumentOutOfRangeException()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("initialCapacity", () => new PriorityQueue<int, int>(-1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("initialCapacity", () => new PriorityQueue<int, int>(int.MinValue));
+        }
+
+        [Fact]
+        public void PriorityQueue_Constructor_Enumerable_null_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("items", () => new PriorityQueue<int, int>(items: null));
+            AssertExtensions.Throws<ArgumentNullException>("items", () => new PriorityQueue<int, int>(items: null, comparer: Comparer<int>.Default));
+        }
+
+        [Fact]
+        public void PriorityQueue_EnqueueRange_null_ThrowsArgumentNullException()
+        {
+            var queue = new PriorityQueue<int, int>();
+            AssertExtensions.Throws<ArgumentNullException>("items", () => queue.EnqueueRange(null));
+        }
+
+        [Fact]
+        public void PriorityQueue_EmptyCollection_Dequeue_ShouldThrowException()
+        {
+            var queue = new PriorityQueue<int, int>();
+
+            Assert.Equal(0, queue.Count);
+            Assert.False(queue.TryDequeue(out _, out _));
+            Assert.Throws<InvalidOperationException>(() => queue.Dequeue());
+        }
+
+        [Fact]
+        public void PriorityQueue_EmptyCollection_Peek_ShouldReturnFalse()
+        {
+            var queue = new PriorityQueue<int, int>();
+
+            Assert.False(queue.TryPeek(out _, out _));
+            Assert.Throws<InvalidOperationException>(() => queue.Peek());
+        }
+
+        #region EnsureCapacity, TrimExcess
+
+        [Fact]
+        public void PriorityQueue_EnsureCapacity_Negative_ShouldThrowException()
+        {
+            PriorityQueue<int, int> queue = new PriorityQueue<int, int>();
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => queue.EnsureCapacity(-1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => queue.EnsureCapacity(int.MinValue));
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 5)]
+        [InlineData(1, 1)]
+        [InlineData(3, 100)]
+        public void PriorityQueue_TrimExcess_ShouldNotChangeCount(int initialCapacity, int count)
+        {
+            PriorityQueue<int, int> queue = CreatePriorityQueue(initialCapacity, count);
+
+            Assert.Equal(count, queue.Count);
+            queue.TrimExcess();
+            Assert.Equal(count, queue.Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidPositiveCollectionSizes))]
+        public void PriorityQueue_TrimExcess_Repeatedly_ShouldNotChangeCount(int count)
+        {
+            PriorityQueue<int, int> queue = CreatePriorityQueue(initialCapacity: count, count);
+
+            Assert.Equal(count, queue.Count);
+            queue.TrimExcess();
+            queue.TrimExcess();
+            queue.TrimExcess();
+            Assert.Equal(count, queue.Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidPositiveCollectionSizes))]
+        public void PriorityQueue_Generic_EnsureCapacityAndTrimExcess(int count)
+        {
+            IReadOnlyCollection<(int, int)> itemsToEnqueue = Enumerable.Range(1, count).Select(i => (i, i)).ToArray();
+            PriorityQueue<int, int> queue = new PriorityQueue<int, int>();
+            int expectedCount = 0;
+            Random random = new Random(Seed: 34);
+            int getNextEnsureCapacity() => random.Next(0, count * 2);
+            void trimAndEnsureCapacity()
+            {
+                queue.TrimExcess();
+
+                int capacityAfterEnsureCapacity = queue.EnsureCapacity(getNextEnsureCapacity());
+                Assert.Equal(capacityAfterEnsureCapacity, GetUnderlyingBufferCapacity(queue));
+
+                int capacityAfterTrimExcess = (queue.Count < (int)(capacityAfterEnsureCapacity * 0.9)) ? queue.Count : capacityAfterEnsureCapacity;
+                queue.TrimExcess();
+                Assert.Equal(capacityAfterTrimExcess, GetUnderlyingBufferCapacity(queue));
+            };
+
+            foreach (var (element, priority) in itemsToEnqueue)
+            {
+                trimAndEnsureCapacity();
+                queue.Enqueue(element, priority);
+                expectedCount++;
+                Assert.Equal(expectedCount, queue.Count);
+            }
+
+            while (expectedCount > 0)
+            {
+                queue.Dequeue();
+                trimAndEnsureCapacity();
+                expectedCount--;
+                Assert.Equal(expectedCount, queue.Count);
+            }
+
+            trimAndEnsureCapacity();
+            Assert.Equal(0, queue.Count);
+        }
+
+        private static int GetUnderlyingBufferCapacity<TPriority, TElement>(PriorityQueue<TPriority, TElement> queue)
+        {
+            FieldInfo nodesField = queue.GetType().GetField("_nodes", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(nodesField);
+            var nodes = ((TElement Element, TPriority Priority)[])nodesField.GetValue(queue);
+            return nodes.Length;
+        }
+
+        #endregion
+
+        [Theory]
+        [MemberData(nameof(ValidPositiveCollectionSizes))]
+        public void PriorityQueue_Enumeration_InvalidateOnModifiedCollection(int count)
+        {
+            IReadOnlyCollection<(int, int)> itemsToEnqueue = Enumerable.Range(1, count).Select(i => (i, i)).ToArray();
+            PriorityQueue<int, int> queue = new PriorityQueue<int, int>();
+            queue.EnqueueRange(itemsToEnqueue.Take(count - 1));
+            var enumerator = queue.UnorderedItems.GetEnumerator();
+
+            (int element, int priority) = itemsToEnqueue.Last();
+            queue.Enqueue(element, priority);
+            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+        }
+
+        #region Enumeration
+
+        [Theory]
+        [MemberData(nameof(ValidPositiveCollectionSizes))]
+        public void PriorityQueue_Enumeration_InvalidationOnModifiedCapacity(int count)
+        {
+            PriorityQueue<int, int> queue = CreatePriorityQueue(initialCapacity: 0, count);
+            var enumerator = queue.UnorderedItems.GetEnumerator();
+
+            int capacityBefore = GetUnderlyingBufferCapacity(queue);
+            queue.EnsureCapacity(count * 2 + 4);
+            int capacityAfter = GetUnderlyingBufferCapacity(queue);
+
+            Assert.NotEqual(capacityBefore, capacityAfter);
+            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+        }
+
+        #endregion
     }
 }

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Tests.cs
@@ -200,7 +200,7 @@ namespace System.Collections.Tests
         public void PriorityQueue_Generic_EnsureCapacityAndTrimExcess(int count)
         {
             IReadOnlyCollection<(int, int)> itemsToEnqueue = Enumerable.Range(1, count).Select(i => (i, i)).ToArray();
-            PriorityQueue<int, int> queue = new PriorityQueue<int, int>();
+            var queue = new PriorityQueue<int, int>();
             int expectedCount = 0;
             Random random = new Random(Seed: 34);
             int getNextEnsureCapacity() => random.Next(0, count * 2);
@@ -216,7 +216,7 @@ namespace System.Collections.Tests
                 Assert.Equal(capacityAfterTrimExcess, GetUnderlyingBufferCapacity(queue));
             };
 
-            foreach (var (element, priority) in itemsToEnqueue)
+            foreach ((int element, int priority) in itemsToEnqueue)
             {
                 trimAndEnsureCapacity();
                 queue.Enqueue(element, priority);

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
+    <!-- Referenced assembly 'FsCheck' does not have a strong name.-->
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- Common Collections tests -->
@@ -97,6 +99,7 @@
     <Compile Include="Generic\List\List.Generic.Tests.Sort.cs" />
     <Compile Include="Generic\PriorityQueue\PriorityQueue.Generic.cs" />
     <Compile Include="Generic\PriorityQueue\PriorityQueue.Generic.Tests.cs" />
+    <Compile Include="Generic\PriorityQueue\PriorityQueue.PropertyTests.cs" />
     <Compile Include="Generic\PriorityQueue\PriorityQueue.Tests.cs" />
     <Compile Include="Generic\Queue\Queue.Generic.cs" />
     <Compile Include="Generic\Queue\Queue.Generic.Tests.cs" />
@@ -128,5 +131,9 @@
              Link="Common\System\Collections\IDictionary.Generic.Tests.netcoreapp.cs" />
     <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs"
              Link="Common\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
+    <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
-    <!-- Referenced assembly 'FsCheck' does not have a strong name.-->
-    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- Common Collections tests -->
@@ -131,9 +129,5 @@
              Link="Common\System\Collections\IDictionary.Generic.Tests.netcoreapp.cs" />
     <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs"
              Link="Common\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
-    <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Extends PriorityQueue test coverage in the following ways:

* Abstracts the `IComparer<TPriority>` parameter in the PriorityQueue generic test class so that all code paths added in #48346 are exercised.
* Adds a few missing unit tests.
* Minor refactorings and rearrangements of existing tests.
* Adds property tests for PriorityQueue, a form of structured fuzzing already used in the Cbor project.