### PR TITLE
Remove trimming attributes from any assembly.

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
@@ -15,19 +15,10 @@
     </type>
 
     <!-- System.Diagnostics.CodeAnalysis -->
-    <type fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
     <type fullname="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="System.Diagnostics.CodeAnalysis.AllowNullAttribute">
@@ -145,6 +136,19 @@
   <!-- Internal attributes shared as implementation, so they could be in any assembly -->
   <assembly fullname="*">
     <type fullname="System.Runtime.Versioning.NonVersionableAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+  </assembly>
+
+  <!-- Attributes that are allowed to be in any assembly -->
+  <assembly fullname="*">
+    <type fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
   </assembly>

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
@@ -21,39 +21,6 @@
     <type fullname="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.AllowNullAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.DisallowNullAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.MaybeNullAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.NotNullAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.MemberNotNullAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
 
     <!-- System.Runtime.CompilerServices -->
     <type fullname="System.Reflection.AssemblyCompanyAttribute">
@@ -149,6 +116,39 @@
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.AllowNullAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.DisallowNullAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.MaybeNullAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.NotNullAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.MemberNotNullAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
   </assembly>


### PR DESCRIPTION
These attributes are allowed to be in any assembly, for assemblies that are built using older TFMs where the attributes didn't exist.

Fix #48399