### PR TITLE
Annotate framework assemblies as trimmable

### DIFF
--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -20,6 +20,9 @@
     <AssemblyMetadata Include="PreferInbox">
       <Value>True</Value>
     </AssemblyMetadata>
+    <AssemblyMetadata Include="IsTrimmable">
+      <Value>True</Value>
+    </AssemblyMetadata>
   </ItemGroup>
 
   <!-- Adds SupportedOSPlatform attribute for Windows Specific libraries -->

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -20,7 +20,7 @@
     <AssemblyMetadata Include="PreferInbox">
       <Value>True</Value>
     </AssemblyMetadata>
-    <AssemblyMetadata Include="IsTrimmable">
+    <AssemblyMetadata Include="IsTrimmable" Condition="'$(SetIsTrimmable)' != 'false'">
       <Value>True</Value>
     </AssemblyMetadata>
   </ItemGroup>
@@ -86,7 +86,7 @@
       </AssemblyAttribute>
 
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata"
-                         Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true' and '@(AssemblyMetadata)' != ''">
+                         Condition="'@(AssemblyMetadata)' != ''">
         <_Parameter1>%(AssemblyMetadata.Identity)</_Parameter1>
         <_Parameter2>%(AssemblyMetadata.Value)</_Parameter2>
       </AssemblyAttribute>

--- a/src/libraries/System.Private.CoreLib/src/Internal/AssemblyAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/AssemblyAttributes.cs
@@ -22,5 +22,6 @@ using System.Resources;
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: AssemblyMetadata("IsTrimmable", "True")]
 
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
This will opt them into trimming with the behavior described at https://github.com/mono/linker/blob/main/docs/design/trimmed-assemblies.md#assemblymetadataistrimmable-true.

The linker part of this change is happening in https://github.com/mono/linker/pull/1839.

@marek-safar @eerhardt @vitek-karas