### PR TITLE
Adding browser-wasm trimming test leg

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -193,7 +193,7 @@ jobs:
       targetRid: browser-wasm
       platform: Browser_wasm
       container:
-        image: ubuntu-18.04-webassembly-20210219200611-3852446
+        image: ubuntu-18.04-webassembly-20210223133559-4800846
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -193,7 +193,7 @@ jobs:
       targetRid: browser-wasm
       platform: Browser_wasm
       container:
-        image: ubuntu-18.04-webassembly-20210217201218-6f4d99e
+        image: ubuntu-18.04-webassembly-20210219200611-3852446
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -193,7 +193,7 @@ jobs:
       targetRid: browser-wasm
       platform: Browser_wasm
       container:
-        image: ubuntu-18.04-webassembly-20210111135621-8ac9b02
+        image: ubuntu-18.04-webassembly-20210217201218-6f4d99e
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -57,6 +57,7 @@ jobs:
     - windows_x64
     - OSX_x64
     - Linux_x64
+    - Browser_wasm
     jobParameters:
       testGroup: innerloop
       timeoutInMinutes: 120

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -57,10 +57,25 @@ jobs:
     - windows_x64
     - OSX_x64
     - Linux_x64
-    - Browser_wasm
     jobParameters:
       testGroup: innerloop
       timeoutInMinutes: 120
       nameSuffix: Runtime_Release
       buildArgs: -s clr+libs -c $(_BuildConfig)
+      extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
+
+#
+# Build Release config vertical for Browser-wasm
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    buildConfig: release
+    platforms:
+    - Browser_wasm
+    jobParameters:
+      testGroup: innerloop
+      timeoutInMinutes: 120
+      nameSuffix: Runtime_Release
+      buildArgs: -s mono+libs -c $(_BuildConfig)
       extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <IsTrimmingTest>true</IsTrimmingTest>
+    <UseDefaultBlazorWASMFeatureSwitches>false</UseDefaultBlazorWASMFeatureSwitches>
     <PublishTrimmed>true</PublishTrimmed>
     <SkipImportRepoLinkerTargets>true</SkipImportRepoLinkerTargets>
     <TrimMode>link</TrimMode>

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <SkipConfigureTrimming>true</SkipConfigureTrimming>
     <UseDefaultBlazorWASMFeatureSwitches>false</UseDefaultBlazorWASMFeatureSwitches>
     <PublishTrimmed>true</PublishTrimmed>
     <SkipImportRepoLinkerTargets>true</SkipImportRepoLinkerTargets>

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <IsTrimmingTest>true</IsTrimmingTest>
     <PublishTrimmed>true</PublishTrimmed>
     <SkipImportRepoLinkerTargets>true</SkipImportRepoLinkerTargets>
     <TrimMode>link</TrimMode>

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <PublishTrimmed>true</PublishTrimmed>
+    <SkipImportRepoLinkerTargets>true</SkipImportRepoLinkerTargets>
     <TrimMode>link</TrimMode>
     <TrimmerRemoveSymbols>false</TrimmerRemoveSymbols>
     <SelfContained>true</SelfContained>

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -42,7 +42,6 @@
           Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'" />
 
   <!-- Overriding these targets as these projects won't need to binplace -->
-  <Target Name="GetBinPlaceTargetFramework" />
   <Target Name="PublishTestAsSelfContained" />
 
 </Project>

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -32,7 +32,7 @@
   </Target>
 
   <Target Name="RootJavaScriptInteropAssembly"
-          BeforeTargets="_RunILLink"
+          BeforeTargets="PrepareForILLink"
           Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
     <ItemGroup>
       <TrimmerRootAssembly Include="%(ManagedAssemblyToLink.Identity)" Condition="'%(ManagedAssemblyToLink.FileName)' == 'System.Private.Runtime.InteropServices.JavaScript'" />

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -36,22 +36,12 @@
     </ItemGroup>
   </Target>
 
-  <!-- This target is just a workaround while https://github.com/dotnet/runtime/issues/48522 gets fixed. Once it is, this whole target
-  should be removed. -->
-  <Target Name="RootJavaScriptInteropAssembly"
-          BeforeTargets="PrepareForILLink"
-          Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
-    <ItemGroup>
-      <TrimmerRootAssembly Include="%(ManagedAssemblyToLink.Identity)" Condition="'%(ManagedAssemblyToLink.FileName)' == 'System.Private.Runtime.InteropServices.JavaScript'" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="CreateTestWasmAppBundle"
           AfterTargets="Publish"
           DependsOnTargets="BundleTestWasmApp"
           Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'" />
 
-  <!-- Overriding this target as these projects won't need to binplace -->
+  <!-- Overriding these targets as these projects won't need to binplace -->
   <Target Name="GetBinPlaceTargetFramework" />
   <Target Name="PublishTestAsSelfContained" />
 

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -31,6 +31,8 @@
     </ItemGroup>
   </Target>
 
+  <!-- This target is just a workaround while https://github.com/dotnet/runtime/issues/48522 gets fixed. Once it is, this whole target
+  should be removed. -->
   <Target Name="RootJavaScriptInteropAssembly"
           BeforeTargets="PrepareForILLink"
           Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="$(RepositoryEngineeringDir)testing\tests.mobile.targets" Condition="'$(RuntimeIdentifier)' == 'browser-wasm'" />
+
   <Target Name="RemoveRuntimePackFromDownloadItem"
           AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
@@ -28,5 +30,22 @@
       <TrimmerRootAssembly Include="@(IntermediateAssembly)" />
     </ItemGroup>
   </Target>
+
+  <Target Name="RootJavaScriptInteropAssembly"
+          BeforeTargets="_RunILLink"
+          Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
+    <ItemGroup>
+      <TrimmerRootAssembly Include="%(ManagedAssemblyToLink.Identity)" Condition="'%(ManagedAssemblyToLink.FileName)' == 'System.Private.Runtime.InteropServices.JavaScript'" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Overriding this target as these projects won't need to binplace -->
+  <Target Name="GetBinPlaceTargetFramework" />
+  <Target Name="PublishTestAsSelfContained" />
+
+  <PropertyGroup>
+    <BundleDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutputPath)', 'AppBundle'))</BundleDir>
+    <WasmMainAssemblyFileName>project.dll</WasmMainAssemblyFileName>
+  </PropertyGroup>
 
 </Project>

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -1,6 +1,11 @@
 <Project>
   <Import Project="$(RepositoryEngineeringDir)testing\tests.mobile.targets" Condition="'$(RuntimeIdentifier)' == 'browser-wasm'" />
 
+  <PropertyGroup>
+    <BundleDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutputPath)', 'AppBundle'))</BundleDir>
+    <WasmMainAssemblyFileName>project.dll</WasmMainAssemblyFileName>
+  </PropertyGroup>
+
   <Target Name="RemoveRuntimePackFromDownloadItem"
           AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
@@ -14,7 +19,7 @@
   <Target Name="UpdateRuntimePack"
           AfterTargets="ResolveFrameworkReferences">
     <ItemGroup>
-      <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(MicrosoftNetCoreAppRuntimePackRidDir)/../../" />
+      <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(MicrosoftNetCoreAppRuntimePackRidDir)../../" />
       <ResolvedTargetingPack Update="@(ResolvedTargetingPack)" Path="$(TargetingPackDir)" />
     </ItemGroup>
   </Target>
@@ -41,13 +46,13 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="CreateTestWasmAppBundle"
+          AfterTargets="Publish"
+          DependsOnTargets="BundleTestWasmApp"
+          Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'" />
+
   <!-- Overriding this target as these projects won't need to binplace -->
   <Target Name="GetBinPlaceTargetFramework" />
   <Target Name="PublishTestAsSelfContained" />
-
-  <PropertyGroup>
-    <BundleDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutputPath)', 'AppBundle'))</BundleDir>
-    <WasmMainAssemblyFileName>project.dll</WasmMainAssemblyFileName>
-  </PropertyGroup>
 
 </Project>

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -14,7 +14,7 @@
   <Target Name="UpdateRuntimePack"
           AfterTargets="ResolveFrameworkReferences">
     <ItemGroup>
-      <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(RuntimePackDir)" />
+      <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(MicrosoftNetCoreAppRuntimePackRidDir)/../../" />
       <ResolvedTargetingPack Update="@(ResolvedTargetingPack)" Path="$(TargetingPackDir)" />
     </ItemGroup>
   </Target>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -4,9 +4,9 @@
     <OutputType>Exe</OutputType>
     <MonoAOTCompilerDir>{MonoAOTCompilerDir}</MonoAOTCompilerDir>
     <MonoProjectRoot>{MonoProjectRoot}</MonoProjectRoot>
+    <EventSourceSupport>true</EventSourceSupport>
     <MonoAOTCompilerTasksAssemblyPath>{MonoAOTCompilerTasksAssemblyPath}</MonoAOTCompilerTasksAssemblyPath>
     <WasmAppBuilderTasksAssemblyPath>{WasmAppBuilderTasksAssemblyPath}</WasmAppBuilderTasksAssemblyPath>
-    <ILLinkTasksAssembly>{ILLinkTasksAssembly}</ILLinkTasksAssembly>
     <MicrosoftNetCoreAppRuntimePackRidDir>{MicrosoftNetCoreAppRuntimePackRidDir}</MicrosoftNetCoreAppRuntimePackRidDir>
     <RepositoryEngineeringDir>{RepositoryEngineeringDir}</RepositoryEngineeringDir>
     <TargetFramework>{NetCoreAppCurrent}</TargetFramework>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <MonoAOTCompilerDir>{MonoAOTCompilerDir}</MonoAOTCompilerDir>
     <MonoProjectRoot>{MonoProjectRoot}</MonoProjectRoot>
-    <EventSourceSupport>true</EventSourceSupport>
     <MonoAOTCompilerTasksAssemblyPath>{MonoAOTCompilerTasksAssemblyPath}</MonoAOTCompilerTasksAssemblyPath>
     <WasmAppBuilderTasksAssemblyPath>{WasmAppBuilderTasksAssemblyPath}</WasmAppBuilderTasksAssemblyPath>
     <MicrosoftNetCoreAppRuntimePackRidDir>{MicrosoftNetCoreAppRuntimePackRidDir}</MicrosoftNetCoreAppRuntimePackRidDir>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <MonoAOTCompilerDir>{MonoAOTCompilerDir}</MonoAOTCompilerDir>
+    <MonoProjectRoot>{MonoProjectRoot}</MonoProjectRoot>
+    <MonoAOTCompilerTasksAssemblyPath>{MonoAOTCompilerTasksAssemblyPath}</MonoAOTCompilerTasksAssemblyPath>
+    <WasmAppBuilderTasksAssemblyPath>{WasmAppBuilderTasksAssemblyPath}</WasmAppBuilderTasksAssemblyPath>
+    <ILLinkTasksAssembly>{ILLinkTasksAssembly}</ILLinkTasksAssembly>
+    <MicrosoftNetCoreAppRuntimePackRidDir>{MicrosoftNetCoreAppRuntimePackRidDir}</MicrosoftNetCoreAppRuntimePackRidDir>
+    <RepositoryEngineeringDir>{RepositoryEngineeringDir}</RepositoryEngineeringDir>
     <TargetFramework>{NetCoreAppCurrent}</TargetFramework>
     <RuntimeIdentifier>{RuntimeIdentifier}</RuntimeIdentifier>
     <RuntimePackDir>{RuntimePackDir}</RuntimePackDir>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -11,7 +11,6 @@
     <RepositoryEngineeringDir>{RepositoryEngineeringDir}</RepositoryEngineeringDir>
     <TargetFramework>{NetCoreAppCurrent}</TargetFramework>
     <RuntimeIdentifier>{RuntimeIdentifier}</RuntimeIdentifier>
-    <RuntimePackDir>{RuntimePackDir}</RuntimePackDir>
     <TargetingPackDir>{TargetingPackDir}</TargetingPackDir>
     <NETCoreAppMaximumVersion>{NetCoreAppMaximumVersion}</NETCoreAppMaximumVersion>
     <MicrosoftNETCoreAppVersion>{MicrosoftNETCoreAppVersion}</MicrosoftNETCoreAppVersion>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -93,16 +93,21 @@
     <Message Text="Generated $(_projectFile)" />
   </Target>
 
+  <Target Name="GetTrimmingProjectsToRestore"
+          DependsOnTargets="GenerateProjects"
+          Returns="@(TestConsoleApps)" />
+
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
 
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Restore"
+             Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration)" />
 
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Publish"
-             Properties="Configuration=$(Configuration)" />
+             Properties="Configuration=$(Configuration);BuildProjectReferences=false" />
   </Target>
 
   <Target Name="ExecuteApplications"

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -82,7 +82,6 @@
                                                  .Replace('{MonoProjectRoot}', '$(MonoProjectRoot)')
                                                  .Replace('{MonoAOTCompilerTasksAssemblyPath}', '$(MonoAOTCompilerTasksAssemblyPath)')
                                                  .Replace('{WasmAppBuilderTasksAssemblyPath}', '$(WasmAppBuilderTasksAssemblyPath)')
-                                                 .Replace('{ILLinkTasksAssembly}', '$(ILLinkTasksAssembly)')
                                                  .Replace('{MicrosoftNetCoreAppRuntimePackRidDir}', '$(MicrosoftNetCoreAppRuntimePackRidDir)'))"
                       Overwrite="true" />
     <Copy SourceFiles="$(_projectSourceFile)"

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -29,8 +29,10 @@
       <!-- We need to separate Item metadata declaration in two in order to be able to use ProjectDir and TestRuntimeIdentifier bellow -->
       <TestConsoleAppSourceFiles>
         <ProjectFile>%(ProjectDir)project.csproj</ProjectFile>
-        <TestCommand>$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'publish', 'project'))</TestCommand>
-        <TestExecutionDirectory>$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'publish'))</TestExecutionDirectory>
+        <TestCommand Condition="'$(TargetArchitecture)' != 'wasm' Or '$(TargetOs)' != 'browser'">$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'publish', 'project'))</TestCommand>
+        <TestCommand Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'AppBundle', 'run-v8.sh'))</TestCommand>
+        <TestExecutionDirectory Condition="'$(TargetArchitecture)' != 'wasm' Or '$(TargetOs)' != 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'publish'))</TestExecutionDirectory>
+        <TestExecutionDirectory Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'AppBundle'))</TestExecutionDirectory>
         <RuntimePackDirectory>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.runtime.%(TestRuntimeIdentifier)', '$(Configuration)'))</RuntimePackDirectory>
       </TestConsoleAppSourceFiles>
     </ItemGroup>
@@ -76,7 +78,14 @@
                                                  .Replace('{RuntimeIdentifier}','%(TestConsoleApps.TestRuntimeIdentifier)')
                                                  .Replace('{MicrosoftNETILLinkTasksVersion}', '$(MicrosoftNETILLinkTasksVersion)')
                                                  .Replace('{ExtraTrimmerArgs}', '%(TestConsoleApps.ExtraTrimmerArgs)')
-                                                 .Replace('{AdditionalProjectReferences}', '$(_additionalProjectReferencesString)'))"
+                                                 .Replace('{AdditionalProjectReferences}', '$(_additionalProjectReferencesString)')
+                                                 .Replace('{RepositoryEngineeringDir}', '$(RepositoryEngineeringDir)')
+                                                 .Replace('{MonoAOTCompilerDir}', '$(MonoAOTCompilerDir)')
+                                                 .Replace('{MonoProjectRoot}', '$(MonoProjectRoot)')
+                                                 .Replace('{MonoAOTCompilerTasksAssemblyPath}', '$(MonoAOTCompilerTasksAssemblyPath)')
+                                                 .Replace('{WasmAppBuilderTasksAssemblyPath}', '$(WasmAppBuilderTasksAssemblyPath)')
+                                                 .Replace('{ILLinkTasksAssembly}', '$(ILLinkTasksAssembly)')
+                                                 .Replace('{MicrosoftNetCoreAppRuntimePackRidDir}', '$(MicrosoftNetCoreAppRuntimePackRidDir)'))"
                       Overwrite="true" />
     <Copy SourceFiles="$(_projectSourceFile)"
           DestinationFolder="$(_projectDir)" />
@@ -88,12 +97,17 @@
 
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
+
+    <PropertyGroup>
+      <_TrimmedProjectsPublishTargets>Publish</_TrimmedProjectsPublishTargets>
+      <_TrimmedProjectsPublishTargets Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$(_TrimmedProjectsPublishTargets);BundleTestWasmApp</_TrimmedProjectsPublishTargets>
+    </PropertyGroup>
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration)" />
 
     <MSBuild Projects="@(TestConsoleApps)"
-             Targets="Publish"
+             Targets="$(_TrimmedProjectsPublishTargets)"
              Properties="Configuration=$(Configuration)" />
   </Target>
 
@@ -108,7 +122,7 @@
       <Output TaskParameter="ExitCode" PropertyName="ExecutionExitCode" />
     </Exec>
 
-    <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems) The Command %(TestConsoleApps.TestCommand) return a non-success exit code." />
+    <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems) The Command %(TestConsoleApps.TestCommand) return a non-success exit code." ContinueOnError="ErrorAndContinue" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="ExecuteApplications" />

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -33,7 +33,6 @@
         <TestCommand Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'AppBundle', 'run-v8.sh'))</TestCommand>
         <TestExecutionDirectory Condition="'$(TargetArchitecture)' != 'wasm' Or '$(TargetOs)' != 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'publish'))</TestExecutionDirectory>
         <TestExecutionDirectory Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '$(NetCoreAppCurrent)', '%(TestRuntimeIdentifier)', 'AppBundle'))</TestExecutionDirectory>
-        <RuntimePackDirectory>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.runtime.%(TestRuntimeIdentifier)', '$(Configuration)'))</RuntimePackDirectory>
       </TestConsoleAppSourceFiles>
     </ItemGroup>
 
@@ -73,7 +72,6 @@
                                                  .Replace('{MicrosoftNETCoreAppVersion}', '$(MicrosoftNETCoreAppVersion)')
                                                  .Replace('{NetCoreAppCurrent}', '$(NetCoreAppCurrent)')
                                                  .Replace('{NetCoreAppMaximumVersion}', '$(NetCoreAppMaximumVersion)')
-                                                 .Replace('{RuntimePackDir}', '%(TestConsoleApps.RuntimePackDirectory)')
                                                  .Replace('{TargetingPackDir}','$(MicrosoftNetCoreAppRefPackDir)')
                                                  .Replace('{RuntimeIdentifier}','%(TestConsoleApps.TestRuntimeIdentifier)')
                                                  .Replace('{MicrosoftNETILLinkTasksVersion}', '$(MicrosoftNETILLinkTasksVersion)')

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -37,7 +37,7 @@
       </TestConsoleAppSourceFiles>
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="!$(SkipOnTestRuntimes.Contains('$(PackageRID)'))">
       <TestConsoleApps Include="@(TestConsoleAppSourceFiles->'%(ProjectFile)')" Condition="!$([System.String]::Copy('%(TestConsoleAppSourceFiles.SkipOnTestRuntimes)').Contains('$(PackageRID)'))">
         <ProjectCompileItems>%(Identity)</ProjectCompileItems>
       </TestConsoleApps>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -96,16 +96,12 @@
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
 
-    <PropertyGroup>
-      <_TrimmedProjectsPublishTargets>Publish</_TrimmedProjectsPublishTargets>
-      <_TrimmedProjectsPublishTargets Condition="'$(TargetArchitecture)' == 'wasm' And '$(TargetOs)' == 'browser'">$(_TrimmedProjectsPublishTargets);BundleTestWasmApp</_TrimmedProjectsPublishTargets>
-    </PropertyGroup>
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration)" />
 
     <MSBuild Projects="@(TestConsoleApps)"
-             Targets="$(_TrimmedProjectsPublishTargets)"
+             Targets="Publish"
              Properties="Configuration=$(Configuration)" />
   </Target>
 

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -10,7 +10,7 @@
     <PublishingTestsRun>true</PublishingTestsRun>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
+  <PropertyGroup Condition="'$(TargetOS)' == 'Browser' And '$(IsTrimmingTest)' != 'true'">
     <!-- We need to set this in order to get extensibility on xunit category traits and other arguments we pass down to xunit via MSBuild properties -->
     <RunScriptCommand Condition="'$(IsFunctionalTest)' != 'true'">$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js --output-directory=$XHARNESS_OUT --  $(RunTestsJSArguments) --run WasmTestRunner.dll $(AssemblyName).dll</RunScriptCommand>
     <RunScriptCommand Condition="'$(IsFunctionalTest)' == 'true'">$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js --output-directory=$XHARNESS_OUT --expected-exit-code=$(ExpectedExitCode) --  $(RunTestsJSArguments) --run $(AssemblyName).dll --testing</RunScriptCommand>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -10,7 +10,7 @@
     <PublishingTestsRun>true</PublishingTestsRun>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetOS)' == 'Browser' And '$(IsTrimmingTest)' != 'true'">
+  <PropertyGroup Condition="'$(TargetOS)' == 'Browser' And '$(UseDefaultBlazorWASMFeatureSwitches)' != 'false'">
     <!-- We need to set this in order to get extensibility on xunit category traits and other arguments we pass down to xunit via MSBuild properties -->
     <RunScriptCommand Condition="'$(IsFunctionalTest)' != 'true'">$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js --output-directory=$XHARNESS_OUT --  $(RunTestsJSArguments) --run WasmTestRunner.dll $(AssemblyName).dll</RunScriptCommand>
     <RunScriptCommand Condition="'$(IsFunctionalTest)' == 'true'">$HARNESS_RUNNER wasm $XHARNESS_COMMAND  --app=. --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js --output-directory=$XHARNESS_OUT --expected-exit-code=$(ExpectedExitCode) --  $(RunTestsJSArguments) --run $(AssemblyName).dll --testing</RunScriptCommand>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -245,5 +245,5 @@
           AfterTargets="Build"
           DependsOnTargets="Publish;BundleTestAppleApp;BundleTestAndroidApp;BundleTestWasmApp;ArchiveTests" />
 
-  <Import Project="$(RepositoryEngineeringDir)illink.targets" />
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(SkipImportRepoLinkerTargets)' != 'true'" />
 </Project>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -162,7 +162,9 @@
 
   </Target>
 
-  <Target Name="ConfigureTrimming" Condition="'$(EnableAggressiveTrimming)' == 'true'" AfterTargets="AddTestRunnersToPublishedFiles">
+  <!-- This .targets file is also imported by the runtime Trimming tests, and we want to be able to manually configure trimming in them so this
+  should be considered if we ever want to change the Condition of the ConfigureTrimming target -->
+  <Target Name="ConfigureTrimming" Condition="'$(EnableAggressiveTrimming)' == 'true' And '$(SkipConfigureTrimming)' != 'true'" AfterTargets="AddTestRunnersToPublishedFiles">
     <PropertyGroup>
       <TrimMode>link</TrimMode>
     </PropertyGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/Microsoft.Extensions.Logging.Console.TrimmingTests.proj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/Microsoft.Extensions.Logging.Console.TrimmingTests.proj
@@ -6,7 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="AddConsoleFormatterTests.cs" />
+    <TestConsoleAppSourceFiles Include="AddConsoleFormatterTests.cs">
+      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: This depends on ConsoleLogger.Processor which requires System.Threading.Thread.Start() which throws PNSE on wasm. -->
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/Microsoft.Extensions.Logging.Console.TrimmingTests.proj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/Microsoft.Extensions.Logging.Console.TrimmingTests.proj
@@ -3,12 +3,11 @@
 
   <PropertyGroup>
     <AdditionalProjectReferences>Microsoft.Extensions.Logging.Console</AdditionalProjectReferences>
+    <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: This depends on ConsoleLogger.Processor which requires System.Threading.Thread.Start() which throws PNSE on wasm. -->
   </PropertyGroup>
   
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="AddConsoleFormatterTests.cs">
-      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: This depends on ConsoleLogger.Processor which requires System.Threading.Thread.Start() which throws PNSE on wasm. -->
-    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="AddConsoleFormatterTests.cs" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/System.Net.HttpListener/tests/TrimmingTests/System.Net.HttpListener.TrimmingTests.proj
+++ b/src/libraries/System.Net.HttpListener/tests/TrimmingTests/System.Net.HttpListener.TrimmingTests.proj
@@ -1,18 +1,19 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
+  <PropertyGroup>
+    <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: HttpListener.ctor() throws PNSE on wasm -->
+  </PropertyGroup>
+
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="CookieExtensionsTest.Clone.cs">
       <AdditionalSourceFiles>CookieExtensionsTest.Helper.cs</AdditionalSourceFiles>
-      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: HttpListener.ctor() throws PNSE on wasm -->
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="CookieExtensionsTest.InternalAdd.cs">
       <AdditionalSourceFiles>CookieExtensionsTest.Helper.cs</AdditionalSourceFiles>
-      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: HttpListener.ctor() throws PNSE on wasm -->
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="CookieExtensionsTest.ToServerString.cs">
       <AdditionalSourceFiles>CookieExtensionsTest.Helper.cs</AdditionalSourceFiles>
-      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: HttpListener.ctor() throws PNSE on wasm -->
     </TestConsoleAppSourceFiles>
   </ItemGroup>
 

--- a/src/libraries/System.Net.HttpListener/tests/TrimmingTests/System.Net.HttpListener.TrimmingTests.proj
+++ b/src/libraries/System.Net.HttpListener/tests/TrimmingTests/System.Net.HttpListener.TrimmingTests.proj
@@ -4,12 +4,15 @@
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="CookieExtensionsTest.Clone.cs">
       <AdditionalSourceFiles>CookieExtensionsTest.Helper.cs</AdditionalSourceFiles>
+      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: HttpListener.ctor() throws PNSE on wasm -->
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="CookieExtensionsTest.InternalAdd.cs">
       <AdditionalSourceFiles>CookieExtensionsTest.Helper.cs</AdditionalSourceFiles>
+      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: HttpListener.ctor() throws PNSE on wasm -->
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="CookieExtensionsTest.ToServerString.cs">
       <AdditionalSourceFiles>CookieExtensionsTest.Helper.cs</AdditionalSourceFiles>
+      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: HttpListener.ctor() throws PNSE on wasm -->
     </TestConsoleAppSourceFiles>
   </ItemGroup>
 

--- a/src/libraries/System.Reflection.DispatchProxy/tests/TrimmingTests/DispatchProxyTest.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/TrimmingTests/DispatchProxyTest.cs
@@ -26,7 +26,7 @@ class Program
     }
 }
 
-interface IFoo
+public interface IFoo
 {
     public int Property1 { get; set; }
     public int UnusedProperty { get; set; }
@@ -46,7 +46,7 @@ class Foo : IFoo
     public void UnusedMethod3() { }
 }
 
-class CountingProxy : DispatchProxy
+public class CountingProxy : DispatchProxy
 {
     private IFoo _inner;
     public int InvocationCount { get; private set; }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -20,7 +20,8 @@
       <AdditionalArgs>/p:DebugType=Embedded</AdditionalArgs>
       <!-- Justification: The implementation of StackFrame for Mono doesn't use
        StackFrameHelper to get line information which is what is being annotated
-       and tested with this test. -->
+       and tested with this test. Issue https://github.com/dotnet/runtime/issues/48849 is
+       tracking investigation on why this test is failing if not skipped. -->
       <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="VerifyResourcesGetTrimmedTest.cs">

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -18,6 +18,10 @@
       as a workaround while the linker bug is fixed. This bug has been logged in the
       linker repo here: https://github.com/mono/linker/issues/1285 -->
       <AdditionalArgs>/p:DebugType=Embedded</AdditionalArgs>
+      <!-- Justification: The implementation of StackFrame for Mono doesn't use
+       StackFrameHelper to get line information which is what is being annotated
+       and tested with this test. -->
+      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="VerifyResourcesGetTrimmedTest.cs">
       <!-- Setting the Trimming feature switch to make sure that the Resources get trimmed by the linker

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -4,7 +4,7 @@
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="AppDomainGetThreadGenericPrincipalTest.cs" />
     <TestConsoleAppSourceFiles Include="AppDomainGetThreadWindowsPrincipalTest.cs">
-      <SkipOnTestRuntimes>osx-x64;linux-x64</SkipOnTestRuntimes>
+      <SkipOnTestRuntimes>osx-x64;linux-x64;browser-wasm</SkipOnTestRuntimes>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="DebuggerTypeProxyAttributeTests.cs" />
     <TestConsoleAppSourceFiles Include="DefaultValueAttributeCtorTest.cs" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/TrimmingTests/System.Security.Cryptography.Algorithms.TrimmingTests.proj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/TrimmingTests/System.Security.Cryptography.Algorithms.TrimmingTests.proj
@@ -1,10 +1,12 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
+  <PropertyGroup>
+    <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: System.Security.Cryptography.RSA.Create() throws PNSE on wasm -->
+  </PropertyGroup>
+
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="RSAXmlTest.cs">
-      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: System.Security.Cryptography.RSA.Create() throws PNSE on wasm -->
-    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="RSAXmlTest.cs" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/TrimmingTests/System.Security.Cryptography.Algorithms.TrimmingTests.proj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/TrimmingTests/System.Security.Cryptography.Algorithms.TrimmingTests.proj
@@ -2,7 +2,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="RSAXmlTest.cs" />
+    <TestConsoleAppSourceFiles Include="RSAXmlTest.cs">
+      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: System.Security.Cryptography.RSA.Create() throws PNSE on wasm -->
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/System.Security.Cryptography.Csp/tests/TrimmingTests/System.Security.Cryptography.Csp.TrimmingTests.proj
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/TrimmingTests/System.Security.Cryptography.Csp.TrimmingTests.proj
@@ -2,7 +2,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="PasswordDeriveBytesTest.cs" />
+    <TestConsoleAppSourceFiles Include="PasswordDeriveBytesTest.cs">
+      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: System.Security.Cryptography.DeriveBytes..ctor() throws PNSE on wasm -->
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/System.Security.Cryptography.Csp/tests/TrimmingTests/System.Security.Cryptography.Csp.TrimmingTests.proj
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/TrimmingTests/System.Security.Cryptography.Csp.TrimmingTests.proj
@@ -1,10 +1,12 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
+  <PropertyGroup>
+    <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: System.Security.Cryptography.DeriveBytes..ctor() throws PNSE on wasm -->
+  </PropertyGroup>
+
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="PasswordDeriveBytesTest.cs">
-      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes> <!-- Justification: System.Security.Cryptography.DeriveBytes..ctor() throws PNSE on wasm -->
-    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="PasswordDeriveBytesTest.cs" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -261,9 +261,11 @@
                       Condition="'$(TestAssemblies)' == 'true'" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)pkg\test\testPackages.proj"
                       Condition="'$(TestPackages)' == 'true'" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\tests\**\*.TrimmingTests.proj"
+    <TrimmingTestProjects Include="$(MSBuildThisFileDirectory)*\tests\**\*.TrimmingTests.proj"
                       Exclude="@(ProjectExclusions)"
-                      Condition="'$(TestTrimming)' == 'true'" />
+                      Condition="'$(TestTrimming)' == 'true'"
+                      AdditionalProperties="%(AdditionalProperties);SkipTrimmingProjectsRestore=true" />
+    <ProjectReference Include="@(TrimmingTestProjects)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ArchiveTests)' == 'true' and '$(TargetOS)' == 'iOS'">
@@ -297,5 +299,20 @@
           DependsOnTargets="GenerateCoverageReport"
           Condition="'$(TestAssemblies)' == 'true' and
                      '$(Coverage)' == 'true'" />
+
+  <!-- Restoring all trimming test projects upfront in one single call to RestoreTrimmingProjects
+  so as to avoid possible race conditions that could happen if we restore each individually. -->
+  <Target Name="RestoreTrimmingProjects"
+          BeforeTargets="Build"
+          Condition="'$(TestTrimming)' == 'true'">
+    <MSBuild Projects="@(TrimmingTestProjects)"
+             Targets="GetTrimmingProjectsToRestore">
+      <Output TaskParameter="TargetOutputs" ItemName="_TrimmingProjectsToRestore" />
+    </MSBuild>
+
+    <MSBuild Projects="@(_TrimmingProjectsToRestore)"
+             Targets="Restore"
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration)" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/48027

cc: @eerhardt @safern @marek-safar 

contributes to https://github.com/dotnet/runtime/issues/39274

This will add the execution of browser-wasm trimming tests. I have tested this locally and only have 4 remaining failing tests which I have to investigate, but I'm sending the PR in the meantime to start getting some feedback.
