### PR TITLE
Fix ILLink descriptors filename

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -110,7 +110,7 @@
 
     <ItemGroup Condition="'$(ILLinkTrimXml)' != ''">
       <EmbeddedResource Include="$(ILLinkTrimXml)">
-        <LogicalName>$(AssemblyName).xml</LogicalName>
+        <LogicalName>ILLink.Descriptors.xml</LogicalName>
       </EmbeddedResource>
     </ItemGroup>
 


### PR DESCRIPTION
Embedded descriptors need to be named `ILLink.Descriptors.xml` in order to be processed by the ILLinker.