### PR TITLE
Disable BinaryFormatter as the default (de)serializer 

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -219,7 +219,7 @@ namespace System.ComponentModel
     }
     public partial class ComponentConverter : System.ComponentModel.ReferenceConverter
     {
-        public ComponentConverter(System.Type type) : base (default(System.Type)) { }
+        public ComponentConverter(System.Type type) : base(default(System.Type)) { }
         public override System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext context, object value, System.Attribute[] attributes) { throw null; }
         public override bool GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext context) { throw null; }
     }
@@ -415,9 +415,9 @@ namespace System.ComponentModel
     }
     public abstract partial class EventDescriptor : System.ComponentModel.MemberDescriptor
     {
-        protected EventDescriptor(System.ComponentModel.MemberDescriptor descr) : base (default(System.ComponentModel.MemberDescriptor)) { }
-        protected EventDescriptor(System.ComponentModel.MemberDescriptor descr, System.Attribute[] attrs) : base (default(System.ComponentModel.MemberDescriptor)) { }
-        protected EventDescriptor(string name, System.Attribute[] attrs) : base (default(System.ComponentModel.MemberDescriptor)) { }
+        protected EventDescriptor(System.ComponentModel.MemberDescriptor descr) : base(default(System.ComponentModel.MemberDescriptor)) { }
+        protected EventDescriptor(System.ComponentModel.MemberDescriptor descr, System.Attribute[] attrs) : base(default(System.ComponentModel.MemberDescriptor)) { }
+        protected EventDescriptor(string name, System.Attribute[] attrs) : base(default(System.ComponentModel.MemberDescriptor)) { }
         public abstract System.Type ComponentType { get; }
         public abstract System.Type EventType { get; }
         public abstract bool IsMulticast { get; }
@@ -705,7 +705,7 @@ namespace System.ComponentModel
         protected LicenseProvider() { }
         public abstract System.ComponentModel.License GetLicense(System.ComponentModel.LicenseContext context, System.Type type, object instance, bool allowExceptions);
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public sealed partial class LicenseProviderAttribute : System.Attribute
     {
         public static readonly System.ComponentModel.LicenseProviderAttribute Default;
@@ -1011,9 +1011,9 @@ namespace System.ComponentModel
     }
     public abstract partial class PropertyDescriptor : System.ComponentModel.MemberDescriptor
     {
-        protected PropertyDescriptor(System.ComponentModel.MemberDescriptor descr) : base (default(System.ComponentModel.MemberDescriptor)) { }
-        protected PropertyDescriptor(System.ComponentModel.MemberDescriptor descr, System.Attribute[] attrs) : base (default(System.ComponentModel.MemberDescriptor)) { }
-        protected PropertyDescriptor(string name, System.Attribute[] attrs) : base (default(System.ComponentModel.MemberDescriptor)) { }
+        protected PropertyDescriptor(System.ComponentModel.MemberDescriptor descr) : base(default(System.ComponentModel.MemberDescriptor)) { }
+        protected PropertyDescriptor(System.ComponentModel.MemberDescriptor descr, System.Attribute[] attrs) : base(default(System.ComponentModel.MemberDescriptor)) { }
+        protected PropertyDescriptor(string name, System.Attribute[] attrs) : base(default(System.ComponentModel.MemberDescriptor)) { }
         public abstract System.Type ComponentType { get; }
         public virtual System.ComponentModel.TypeConverter Converter { get { throw null; } }
         public virtual bool IsLocalizable { get { throw null; } }
@@ -1115,7 +1115,7 @@ namespace System.ComponentModel
         Document = 2,
         Component = 3,
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true)]
     public sealed partial class ProvidePropertyAttribute : System.Attribute
     {
         public ProvidePropertyAttribute(string propertyName, string receiverTypeName) { }
@@ -1222,7 +1222,7 @@ namespace System.ComponentModel
         public override int GetHashCode() { throw null; }
         public override bool IsDefaultAttribute() { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public sealed partial class ToolboxItemFilterAttribute : System.Attribute
     {
         public ToolboxItemFilterAttribute(string filterString) { }
@@ -1285,8 +1285,8 @@ namespace System.ComponentModel
         protected System.ComponentModel.PropertyDescriptorCollection SortProperties(System.ComponentModel.PropertyDescriptorCollection props, string[] names) { throw null; }
         protected abstract partial class SimplePropertyDescriptor : System.ComponentModel.PropertyDescriptor
         {
-            protected SimplePropertyDescriptor(System.Type componentType, string name, System.Type propertyType) : base (default(System.ComponentModel.MemberDescriptor)) { }
-            protected SimplePropertyDescriptor(System.Type componentType, string name, System.Type propertyType, System.Attribute[] attributes) : base (default(System.ComponentModel.MemberDescriptor)) { }
+            protected SimplePropertyDescriptor(System.Type componentType, string name, System.Type propertyType) : base(default(System.ComponentModel.MemberDescriptor)) { }
+            protected SimplePropertyDescriptor(System.Type componentType, string name, System.Type propertyType, System.Attribute[] attributes) : base(default(System.ComponentModel.MemberDescriptor)) { }
             public override System.Type ComponentType { get { throw null; } }
             public override bool IsReadOnly { get { throw null; } }
             public override System.Type PropertyType { get { throw null; } }
@@ -1609,8 +1609,8 @@ namespace System.ComponentModel.Design
     public delegate void DesignerTransactionCloseEventHandler(object sender, System.ComponentModel.Design.DesignerTransactionCloseEventArgs e);
     public partial class DesignerVerb : System.ComponentModel.Design.MenuCommand
     {
-        public DesignerVerb(string text, System.EventHandler handler) : base (default(System.EventHandler), default(System.ComponentModel.Design.CommandID)) { }
-        public DesignerVerb(string text, System.EventHandler handler, System.ComponentModel.Design.CommandID startCommandID) : base (default(System.EventHandler), default(System.ComponentModel.Design.CommandID)) { }
+        public DesignerVerb(string text, System.EventHandler handler) : base(default(System.EventHandler), default(System.ComponentModel.Design.CommandID)) { }
+        public DesignerVerb(string text, System.EventHandler handler, System.ComponentModel.Design.CommandID startCommandID) : base(default(System.EventHandler), default(System.ComponentModel.Design.CommandID)) { }
         public string Description { get { throw null; } set { } }
         public string Text { get { throw null; } }
         public override string ToString() { throw null; }
@@ -1634,6 +1634,14 @@ namespace System.ComponentModel.Design
         protected override void OnValidate(object value) { }
         public void Remove(System.ComponentModel.Design.DesignerVerb value) { }
     }
+//    public class RuntimeLicenseContext : System.ComponentModel.LicenseContext
+//    {
+//#pragma warning disable CS3008 // Identifier is not CLS-compliant
+//        public System.Collections.Hashtable _savedLicenseKeys;
+//#pragma warning restore CS3008 // Identifier is not CLS-compliant
+//        public override string GetSavedLicenseKey(System.Type type, System.Reflection.Assembly resourceAssembly) { throw null; }
+//    }
+
     public partial class DesigntimeLicenseContext : System.ComponentModel.LicenseContext
     {
         public DesigntimeLicenseContext() { }
@@ -1645,6 +1653,7 @@ namespace System.ComponentModel.Design
     {
         internal DesigntimeLicenseContextSerializer() { }
         public static void Serialize(System.IO.Stream o, string cryptoKey, System.ComponentModel.Design.DesigntimeLicenseContext context) { }
+        //public static void Deserialize(System.IO.Stream o, string cryptoKey, System.ComponentModel.Design.RuntimeLicenseContext context) { }
     }
     public enum HelpContextType
     {
@@ -1653,7 +1662,7 @@ namespace System.ComponentModel.Design
         Selection = 2,
         ToolWindowSelection = 3,
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple = false, Inherited = false)]
     public sealed partial class HelpKeywordAttribute : System.Attribute
     {
         public static readonly System.ComponentModel.Design.HelpKeywordAttribute Default;
@@ -2030,7 +2039,7 @@ namespace System.ComponentModel.Design.Serialization
         public object Pop() { throw null; }
         public void Push(object context) { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited = false)]
     public sealed partial class DefaultSerializationProviderAttribute : System.Attribute
     {
         public DefaultSerializationProviderAttribute(string providerTypeName) { }
@@ -2132,7 +2141,7 @@ namespace System.ComponentModel.Design.Serialization
         public object Value { get { throw null; } set { } }
     }
     public delegate void ResolveNameEventHandler(object sender, System.ComponentModel.Design.Serialization.ResolveNameEventArgs e);
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = true, Inherited = true)]
     [System.ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)). https://go.microsoft.com/fwlink/?linkid=14202")]
     public sealed partial class RootDesignerSerializerAttribute : System.Attribute
     {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
@@ -15,6 +15,7 @@
     <Compile Include="System\ComponentModel\DateTimeConverter.cs" />
     <Compile Include="System\ComponentModel\DateTimeOffsetConverter.cs" />
     <Compile Include="System\ComponentModel\DecimalConverter.cs" />
+    <Compile Include="System\ComponentModel\Design\LocalAppContextSwitches.cs" />
     <Compile Include="System\ComponentModel\DoubleConverter.cs" />
     <Compile Include="System\ComponentModel\EnumConverter.cs" />
     <Compile Include="System\ComponentModel\GuidConverter.cs" />
@@ -232,6 +233,9 @@
     <Compile Include="System\ComponentModel\Design\Serialization\RootDesignerSerializerAttribute.cs" />
     <Compile Include="System\ComponentModel\ComponentResourceManager.cs" />
     <Compile Include="System\Security\Authentication\ExtendedProtection\ExtendedProtectionPolicyTypeConverter.cs" />
+    <Compile Include="$(CommonPath)System\LocalAppContextSwitches.Common.cs">
+      <Link>Common\System\LocalAppContextSwitches.Common.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />
@@ -252,6 +256,7 @@
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Runtime.Serialization.Formatters" />
     <Reference Include="System.Text.RegularExpressions" />
+    <Reference Include="System.Text.Json" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Xml.XDocument" />

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
@@ -42,7 +42,9 @@ namespace System.ComponentModel.Design
 
     internal class RuntimeLicenseContext : LicenseContext
     {
-        internal Hashtable _savedLicenseKeys;
+#pragma warning disable CS3008 // Identifier is not CLS-compliant
+        public Hashtable _savedLicenseKeys;
+#pragma warning restore CS3008 // Identifier is not CLS-compliant
 
         /// <summary>
         /// This method takes a file URL and converts it to a local path. The trick here is that

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
@@ -25,25 +25,59 @@ namespace System.ComponentModel.Design
         /// </summary>
         public static void Serialize(Stream o, string cryptoKey, DesigntimeLicenseContext context)
         {
-            IFormatter formatter = new BinaryFormatter();
+            if (LocalAppContextSwitches.BinaryFormatterEnabled)
+            {
+                IFormatter formatter = new BinaryFormatter();
 #pragma warning disable SYSLIB0011 // Issue https://github.com/dotnet/runtime/issues/39293 tracks finding an alternative to BinaryFormatter
-            formatter.Serialize(o, new object[] { cryptoKey, context._savedLicenseKeys });
+                formatter.Serialize(o, new object[] { cryptoKey, context._savedLicenseKeys });
 #pragma warning restore SYSLIB0011
+            }
+            else
+            {
+                using (BinaryWriter writer = new BinaryWriter(o, encoding: Text.Encoding.UTF8, leaveOpen: true))
+                {
+                    writer.Write(cryptoKey);
+                    writer.Write(context._savedLicenseKeys.Count);
+                    foreach (var key in context._savedLicenseKeys)
+                    {
+                        writer.Write(key.ToString());
+                        writer.Write(context._savedLicenseKeys[key].ToString());
+                    }
+                }
+            }
         }
 
         internal static void Deserialize(Stream o, string cryptoKey, RuntimeLicenseContext context)
         {
+            if (LocalAppContextSwitches.BinaryFormatterEnabled)
+            {
 #pragma warning disable SYSLIB0011 // Issue https://github.com/dotnet/runtime/issues/39293 tracks finding an alternative to BinaryFormatter
-            IFormatter formatter = new BinaryFormatter();
+                IFormatter formatter = new BinaryFormatter();
 
-            object obj = formatter.Deserialize(o);
+                object obj = formatter.Deserialize(o);
 #pragma warning restore SYSLIB0011
 
-            if (obj is object[] value)
-            {
-                if (value[0] is string && (string)value[0] == cryptoKey)
+                if (obj is object[] value)
                 {
-                    context._savedLicenseKeys = (Hashtable)value[1];
+                    if (value[0] is string && (string)value[0] == cryptoKey)
+                    {
+                        context._savedLicenseKeys = (Hashtable)value[1];
+                    }
+                }
+            }
+            else
+            {
+                using (BinaryReader reader = new BinaryReader(o, encoding: Text.Encoding.UTF8, leaveOpen: true))
+                {
+                    string streamCryptoKey = reader.ReadString();
+                    int numEntries = reader.ReadInt32();
+                    if (streamCryptoKey == cryptoKey)
+                    {
+                        for (int i = 0; i < numEntries; i++)
+                        {
+                            context._savedLicenseKeys.Add(reader.ReadString(), reader.ReadString());
+                        }
+                    }
                 }
             }
         }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/LocalAppContextSwitches.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/LocalAppContextSwitches.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    internal static partial class LocalAppContextSwitches
+    {
+        private static int s_binaryFormatterEnabled;
+        public static bool BinaryFormatterEnabled
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", ref s_binaryFormatterEnabled);
+        }
+    }
+}

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignTimeLicenseContextSerializerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignTimeLicenseContextSerializerTests.cs
@@ -11,20 +11,30 @@ namespace System.ComponentModel.Design.Tests
     public class DesigntimeLicenseContextSerializerTests
     {
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SerializeAndDeserialize(bool useBinaryFormatter)
+        [InlineData(false, "key")]
+        [InlineData(true, "key")]
+        [InlineData(false, "")]
+        [InlineData(true, "")]
+        public void SerializeAndDeserialize(bool useBinaryFormatter, string key)
         {
-            if (useBinaryFormatter)
+            AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
+            if (!useBinaryFormatter)
+            {
+                AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", false);
+            }
+            else
             {
                 AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
             }
             var context = new DesigntimeLicenseContext();
-            context.SetSavedLicenseKey(typeof(int), "key");
+            context.SetSavedLicenseKey(typeof(int), key);
             var assembly = typeof(DesigntimeLicenseContextSerializer).Assembly;
             Type runtimeLicenseContextType = assembly.GetType("System.ComponentModel.Design.RuntimeLicenseContext");
             Assert.NotNull(runtimeLicenseContextType);
             object runtimeLicenseContext = Activator.CreateInstance(runtimeLicenseContextType);
+            FieldInfo _savedLicenseKeys = runtimeLicenseContextType.GetField("_savedLicenseKeys");
+            Assert.NotNull(_savedLicenseKeys);
+            _savedLicenseKeys.SetValue(runtimeLicenseContext, new Hashtable());
             Assert.NotNull(runtimeLicenseContext);
 
             Type designtimeLicenseContextSerializer = assembly.GetType("System.ComponentModel.Design.DesigntimeLicenseContextSerializer");
@@ -34,24 +44,26 @@ namespace System.ComponentModel.Design.Tests
             using (MemoryStream stream = new MemoryStream())
             {
                 long position = stream.Position;
-                System.ComponentModel.Design.DesigntimeLicenseContextSerializer.Serialize(stream, "crypto", context);
+                System.ComponentModel.Design.DesigntimeLicenseContextSerializer.Serialize(stream, key, context);
                 stream.Seek(position, SeekOrigin.Begin);
-                deserializeMethod.Invoke(null, new object[] { stream, "crypto", runtimeLicenseContext });
+                deserializeMethod.Invoke(null, new object[] { stream, key, runtimeLicenseContext });
                 Hashtable savedLicenseKeys = runtimeLicenseContext.GetType().GetField("_savedLicenseKeys").GetValue(runtimeLicenseContext) as Hashtable;
                 Assert.NotNull(savedLicenseKeys);
                 var value = savedLicenseKeys[typeof(int).AssemblyQualifiedName];
                 Assert.True(value is string);
-                Assert.Equal("key", value);
+                Assert.Equal(key, value);
             }
         }
 
-        [Fact]
-        public void SerializeWithBinaryFormatter_DeserializeWithBinaryWriter()
+        [Theory]
+        [InlineData("key")]
+        [InlineData("")]
+        public void SerializeWithBinaryFormatter_DeserializeWithBinaryWriter(string key)
         {
             AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
             AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
             var context = new DesigntimeLicenseContext();
-            context.SetSavedLicenseKey(typeof(int), "key");
+            context.SetSavedLicenseKey(typeof(int), key);
             var assembly = typeof(DesigntimeLicenseContextSerializer).Assembly;
             Type runtimeLicenseContextType = assembly.GetType("System.ComponentModel.Design.RuntimeLicenseContext");
             Assert.NotNull(runtimeLicenseContextType);
@@ -65,13 +77,23 @@ namespace System.ComponentModel.Design.Tests
             using (MemoryStream stream = new MemoryStream())
             {
                 long position = stream.Position;
-                System.ComponentModel.Design.DesigntimeLicenseContextSerializer.Serialize(stream, "crypto", context);
+                System.ComponentModel.Design.DesigntimeLicenseContextSerializer.Serialize(stream, key, context);
                 AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", false);
                 // Cannot deserialize anymore
                 stream.Seek(position, SeekOrigin.Begin);
-                deserializeMethod.Invoke(null, new object[] { stream, "crypto", runtimeLicenseContext });
-                Hashtable savedLicenseKeys = runtimeLicenseContext.GetType().GetField("_savedLicenseKeys").GetValue(runtimeLicenseContext) as Hashtable;
-                Assert.Null(savedLicenseKeys);
+                try
+                {
+                    deserializeMethod.Invoke(null, new object[] {stream, key, runtimeLicenseContext});
+                }
+                catch (System.Reflection.TargetInvocationException exception)
+                {
+                    var baseException = exception.GetBaseException();
+                    Assert.True(baseException is System.NotSupportedException);
+                }
+                catch (System.Exception catchAll)
+                {
+                    throw catchAll;
+                }
             }
         }
     }

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignTimeLicenseContextSerializerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignTimeLicenseContextSerializerTests.cs
@@ -10,9 +10,15 @@ namespace System.ComponentModel.Design.Tests
 {
     public class DesigntimeLicenseContextSerializerTests
     {
-        [Fact]
-        public void SerializeAndDeserialize()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SerializeAndDeserialize(bool useBinaryFormatter)
         {
+            if (useBinaryFormatter)
+            {
+                AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+            }
             var context = new DesigntimeLicenseContext();
             context.SetSavedLicenseKey(typeof(int), "key");
             var assembly = typeof(DesigntimeLicenseContextSerializer).Assembly;
@@ -36,6 +42,36 @@ namespace System.ComponentModel.Design.Tests
                 var value = savedLicenseKeys[typeof(int).AssemblyQualifiedName];
                 Assert.True(value is string);
                 Assert.Equal("key", value);
+            }
+        }
+
+        [Fact]
+        public void SerializeWithBinaryFormatter_DeserializeWithBinaryWriter()
+        {
+            AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
+            AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+            var context = new DesigntimeLicenseContext();
+            context.SetSavedLicenseKey(typeof(int), "key");
+            var assembly = typeof(DesigntimeLicenseContextSerializer).Assembly;
+            Type runtimeLicenseContextType = assembly.GetType("System.ComponentModel.Design.RuntimeLicenseContext");
+            Assert.NotNull(runtimeLicenseContextType);
+            object runtimeLicenseContext = Activator.CreateInstance(runtimeLicenseContextType);
+            Assert.NotNull(runtimeLicenseContext);
+
+            Type designtimeLicenseContextSerializer = assembly.GetType("System.ComponentModel.Design.DesigntimeLicenseContextSerializer");
+            Assert.NotNull(designtimeLicenseContextSerializer);
+            Reflection.MethodInfo deserializeMethod = designtimeLicenseContextSerializer.GetMethod("Deserialize", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Static);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                long position = stream.Position;
+                System.ComponentModel.Design.DesigntimeLicenseContextSerializer.Serialize(stream, "crypto", context);
+                AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", false);
+                // Cannot deserialize anymore
+                stream.Seek(position, SeekOrigin.Begin);
+                deserializeMethod.Invoke(null, new object[] { stream, "crypto", runtimeLicenseContext });
+                Hashtable savedLicenseKeys = runtimeLicenseContext.GetType().GetField("_savedLicenseKeys").GetValue(runtimeLicenseContext) as Hashtable;
+                Assert.Null(savedLicenseKeys);
             }
         }
     }

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignTimeLicenseContextSerializerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignTimeLicenseContextSerializerTests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace System.ComponentModel.Design.Tests
+{
+    public class DesigntimeLicenseContextSerializerTests
+    {
+        [Fact]
+        public void SerializeAndDeserialize()
+        {
+            var context = new DesigntimeLicenseContext();
+            context.SetSavedLicenseKey(typeof(int), "key");
+            var assembly = typeof(DesigntimeLicenseContextSerializer).Assembly;
+            Type runtimeLicenseContextType = assembly.GetType("System.ComponentModel.Design.RuntimeLicenseContext");
+            Assert.NotNull(runtimeLicenseContextType);
+            object runtimeLicenseContext = Activator.CreateInstance(runtimeLicenseContextType);
+            Assert.NotNull(runtimeLicenseContext);
+
+            Type designtimeLicenseContextSerializer = assembly.GetType("System.ComponentModel.Design.DesigntimeLicenseContextSerializer");
+            Assert.NotNull(designtimeLicenseContextSerializer);
+            Reflection.MethodInfo deserializeMethod = designtimeLicenseContextSerializer.GetMethod("Deserialize", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Static);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                long position = stream.Position;
+                System.ComponentModel.Design.DesigntimeLicenseContextSerializer.Serialize(stream, "crypto", context);
+                stream.Seek(position, SeekOrigin.Begin);
+                deserializeMethod.Invoke(null, new object[] { stream, "crypto", runtimeLicenseContext });
+                Hashtable savedLicenseKeys = runtimeLicenseContext.GetType().GetField("_savedLicenseKeys").GetValue(runtimeLicenseContext) as Hashtable;
+                Assert.NotNull(savedLicenseKeys);
+                var value = savedLicenseKeys[typeof(int).AssemblyQualifiedName];
+                Assert.True(value is string);
+                Assert.Equal("key", value);
+            }
+        }
+    }
+}

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);FUNCTIONAL_TESTS</DefineConstants>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
@@ -74,6 +74,7 @@
     <Compile Include="Design\DesignerVerbTests.cs" />
     <Compile Include="Design\DesignerVerbCollectionTests.cs" />
     <Compile Include="Design\DesigntimeLicenseContextTests.cs" />
+    <Compile Include="Design\DesigntimeLicenseContextSerializerTests.cs" />
     <Compile Include="Design\HelpKeywordAttributeTests.cs" />
     <Compile Include="Design\Serialization\MemberRelationshipServiceTests.cs" />
     <Compile Include="Design\ServiceContainerTests.cs" />


### PR DESCRIPTION
Switch to Binary Reader/Writer instead and allow for the `System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization` switch to fall back to the current Binary Formatter based (de)serialization.

