### PR TITLE
Check that rsp is within stack limits when redirecting a thread.

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2954,6 +2954,7 @@ BOOL Thread::RedirectThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt)
     bRes = EESetThreadContext(this, pCtx);
     if (!bRes)
     {
+#ifdef _DEBUG
         // In some rare cases the stack pointer may be outside the stack limits.
         // SetThreadContext would fail assuming that we are trying to bypass CFG.
         // 
@@ -2967,6 +2968,9 @@ BOOL Thread::RedirectThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt)
         }
 
         _ASSERTE(!"Failed to SetThreadContext in RedirectThreadAtHandledJITCase - aborting redirect.");
+#endif
+
+        return FALSE;
     }
 
     // Restore original IP


### PR DESCRIPTION
In some rare cases (ex: when doing large `stackaloc`), the stack pointer may be outside of the stack limits.
`SetThreadContext` would fail assuming that we are trying to bypass CFG.

Such failure is benign in nature. The caller will resume the thread and then try suspending again. 
The second attempt is likely to be successful. Either more stack will be committed or the thread will return from the current method and deflate its SP. 
However, currently this failure would cause an assert, which could be a nuisance for stress testing.

Resolves:https://github.com/dotnet/runtime/issues/48378