### PR TITLE
Add a test to verify current behavior of floating point

### DIFF
--- a/src/tests/JIT/Directed/Convert/CMakeLists.txt
+++ b/src/tests/JIT/Directed/Convert/CMakeLists.txt
@@ -1,0 +1,8 @@
+project (out_of_range_fp_to_int_conversionsnative)
+include_directories(${INC_PLATFORM_DIR})
+
+# add the executable
+add_library (out_of_range_fp_to_int_conversionsnative SHARED out_of_range_fp_to_int_conversions.cpp)
+
+# add the install targets
+install (TARGETS out_of_range_fp_to_int_conversionsnative DESTINATION bin)

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
@@ -35,7 +35,8 @@ extern "C" DLLEXPORT int32_t ConvertDoubleToLong(double x, FPtoIntegerConversion
 
     case CONVERT_SATURATING:
         return (x != x) ? 0 : (x < INT32_MIN) ? INT32_MIN : (x > INT32_MAX) ? INT32_MAX : (int32_t)x;
-
+    case CONVERT_NATIVECOMPILERBEHAVIOR: // handled above, but add case to silence warning
+        return 0;
     }
 
     return 0;
@@ -47,17 +48,20 @@ extern "C" DLLEXPORT uint32_t ConvertDoubleToUnsignedLong(double x, FPtoIntegerC
         return (uint32_t)x;
 
     x = trunc(x); // truncate (round toward zero)
+    const double int64_max_plus_1 = 0x1.p63; // 0x43e0000000000000 // (uint64_t)INT64_MAX + 1;
 
     switch (t) {
     case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
     case CONVERT_BACKWARD_COMPATIBLE:
-        return ((x != x) || (x < INT64_MIN) || (x > INT64_MAX)) ? 0 : (uint32_t)(int64_t)x;
+        return ((x != x) || (x < INT64_MIN) || (x >= int64_max_plus_1)) ? 0 : (uint32_t)(int64_t)x;
 
     case CONVERT_SENTINEL:
         return ((x != x) || (x < 0) || (x > UINT32_MAX)) ? UINT32_MAX  : (uint32_t)x;
 
     case CONVERT_SATURATING:
         return ((x != x) || (x < 0)) ? 0 : (x > UINT32_MAX) ? UINT32_MAX : (uint32_t)x;
+    case CONVERT_NATIVECOMPILERBEHAVIOR: // handled above, but add case to silence warning
+        return 0;
     }
 
     return 0;
@@ -87,6 +91,8 @@ extern "C" DLLEXPORT int64_t ConvertDoubleToLongLong(double x, FPtoIntegerConver
 
     case CONVERT_SATURATING:
         return (x != x) ? 0 : (x < INT64_MIN) ? INT64_MIN : (x >= int64_max_plus_1) ? INT64_MAX : (int64_t)x;
+    case CONVERT_NATIVECOMPILERBEHAVIOR: // handled above, but add case to silence warning
+        return 0;
     }
 
     return 0;
@@ -145,6 +151,8 @@ extern "C" DLLEXPORT  uint64_t ConvertDoubleToUnsignedLongLong(double x, FPtoInt
             x = trunc(x);
             return (uint64_t)(((x != x) || (x >= int64_max_plus_1)) ? INT64_MIN : (int64_t)x) + (0x8000000000000000);
         }
+    case CONVERT_NATIVECOMPILERBEHAVIOR: // handled above, but add case to silence warning
+        return 0;
     }
 
     return 0;

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
@@ -17,7 +17,7 @@ typedef enum {
     CONVERT_SENTINEL,
     CONVERT_SATURATING,
     CONVERT_NATIVECOMPILERBEHAVIOR,
-    CONVERT_MANAGED_BACKWARD_COMPATIBLE,
+    CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64,
     CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32,
 } FPtoIntegerConversionType;
 
@@ -30,7 +30,7 @@ extern "C" DLLEXPORT int32_t ConvertDoubleToLong(double x, FPtoIntegerConversion
 
     switch (t) {
     case CONVERT_BACKWARD_COMPATIBLE:
-    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
     case CONVERT_SENTINEL:
         return ((x != x) || (x < INT32_MIN) || (x > INT32_MAX)) ? INT32_MIN : (int32_t)x;
 
@@ -53,7 +53,7 @@ extern "C" DLLEXPORT uint32_t ConvertDoubleToUnsignedLong(double x, FPtoIntegerC
     const double int64_max_plus_1 = 0x1.p63; // 0x43e0000000000000 // (uint64_t)INT64_MAX + 1;
 
     switch (t) {
-    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
     case CONVERT_BACKWARD_COMPATIBLE:
         return ((x != x) || (x < INT64_MIN) || (x >= int64_max_plus_1)) ? 0 : (uint32_t)(int64_t)x;
 
@@ -95,7 +95,7 @@ extern "C" DLLEXPORT int64_t ConvertDoubleToLongLong(double x, FPtoIntegerConver
     const double int32_max_plus1 = ((double)INT32_MAX) + 1;
 
     switch (t) {
-    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
     case CONVERT_BACKWARD_COMPATIBLE:
     case CONVERT_SENTINEL:
         return ((x != x) || (x < INT64_MIN) || (x >= int64_max_plus_1)) ? INT64_MIN : (int64_t)x;
@@ -117,25 +117,6 @@ extern "C" DLLEXPORT int64_t ConvertDoubleToLongLong(double x, FPtoIntegerConver
     }
 
     return 0;
-}
-
-uint64_t ConvertDoubleToUnsignedLongLongManagedBackCompat(double x, FPtoIntegerConversionType t)
-{
-    x = trunc(x); // truncate (round toward zero)
-
-    // (double)INT64_MAX cannot be represented exactly as double
-    const double int64_max_plus_1 = 0x1.p63; // 0x43e0000000000000 // (uint64_t)INT64_MAX + 1;
-
-    if (x < int64_max_plus_1)
-    {
-        return (x < INT64_MIN) ? (uint64_t)INT64_MIN : (uint64_t)(int64_t)x;
-    }
-    else
-    {
-        x -= int64_max_plus_1;
-        x = trunc(x);
-        return (uint64_t)(((x != x) || (x >= int64_max_plus_1)) ? INT64_MIN : (int64_t)x) + (0x8000000000000000);
-    }
 }
 
 extern "C" DLLEXPORT  uint64_t ConvertDoubleToUnsignedLongLong(double x, FPtoIntegerConversionType t)
@@ -173,7 +154,7 @@ extern "C" DLLEXPORT  uint64_t ConvertDoubleToUnsignedLongLong(double x, FPtoInt
             }
         }
 
-    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
         if (x < int64_max_plus_1)
         {
             return (x < INT64_MIN) ? (uint64_t)INT64_MIN : (uint64_t)(int64_t)x;

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <limits.h>
+#include <intrin.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+
+#ifdef _MSC_VER
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT __attribute__((visibility("default")))
+#endif
+
+typedef enum {
+    CONVERT_BACKWARD_COMPATIBLE,
+    CONVERT_SENTINEL,
+    CONVERT_SATURATING,
+    CONVERT_NATIVECOMPILERBEHAVIOR,
+    CONVERT_MANAGED_BACKWARD_COMPATIBLE,
+} FPtoIntegerConversionType;
+
+extern "C" DLLEXPORT int32_t ConvertDoubleToLong(double x, FPtoIntegerConversionType t)
+{
+    if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
+        return (int32_t)x;
+
+    x = trunc(x); // truncate (round toward zero)
+
+    switch (t) {
+    case CONVERT_BACKWARD_COMPATIBLE:
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+    case CONVERT_SENTINEL:
+        return ((x != x) || (x < INT32_MIN) || (x > INT32_MAX)) ? INT32_MIN : (int32_t)x;
+
+    case CONVERT_SATURATING:
+        return (x != x) ? 0 : (x < INT32_MIN) ? INT32_MIN : (x > INT32_MAX) ? INT32_MAX : (int32_t)x;
+
+    }
+
+    return 0;
+}
+
+extern "C" DLLEXPORT uint32_t ConvertDoubleToUnsignedLong(double x, FPtoIntegerConversionType t)
+{
+    if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
+        return (uint32_t)x;
+
+    x = trunc(x); // truncate (round toward zero)
+
+    switch (t) {
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+    case CONVERT_BACKWARD_COMPATIBLE:
+        return ((x != x) || (x < INT64_MIN) || (x > INT64_MAX)) ? 0 : (uint32_t)(int64_t)x;
+
+    case CONVERT_SENTINEL:
+        return ((x != x) || (x < 0) || (x > UINT32_MAX)) ? UINT32_MAX  : (uint32_t)x;
+
+    case CONVERT_SATURATING:
+        return ((x != x) || (x < 0)) ? 0 : (x > UINT32_MAX) ? UINT32_MAX : (uint32_t)x;
+    }
+
+    return 0;
+}
+
+extern "C" DLLEXPORT int64_t ConvertDoubleToLongLong(double x, FPtoIntegerConversionType t)
+{
+    if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
+        return (int64_t)x;
+
+    x = trunc(x); // truncate (round toward zero)
+
+    // (double)INT64_MAX cannot be represented exactly as double
+    const double int64_max_plus_1 = 0x1.p63; // 0x43e0000000000000 // (uint64_t)INT64_MAX + 1;
+    const double int64_min = -0x1.p63; //       0xC3E0000000000000 // INT64_MIN
+    const double uint64_max_plus_1 = 0x1.p64; // 43f0000000000000; // -2.0 * (double)INT64_MIN;
+    const double two63 = 0x1.p63; // 0x43e0000000000000 // (uint64_t)INT64_MAX + 1;
+    const double int32_min = -0x1.p31;// c1e0000000000000// INT32_MIN;
+    const double int32_max = 0x1.fffffffcp30;//  41dfffffffc00000 // INT32_MAX;
+    const double int32_max_plus1 = ((double)INT32_MAX) + 1;
+
+    switch (t) {
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+    case CONVERT_BACKWARD_COMPATIBLE:
+    case CONVERT_SENTINEL:
+        return ((x != x) || (x < INT64_MIN) || (x >= int64_max_plus_1)) ? INT64_MIN : (int64_t)x;
+
+    case CONVERT_SATURATING:
+        return (x != x) ? 0 : (x < INT64_MIN) ? INT64_MIN : (x >= int64_max_plus_1) ? INT64_MAX : (int64_t)x;
+    }
+
+    return 0;
+}
+
+uint64_t ConvertDoubleToUnsignedLongLongManagedBackCompat(double x, FPtoIntegerConversionType t)
+{
+    x = trunc(x); // truncate (round toward zero)
+
+    // (double)INT64_MAX cannot be represented exactly as double
+    const double int64_max_plus_1 = 0x1.p63; // 0x43e0000000000000 // (uint64_t)INT64_MAX + 1;
+
+    if (x < int64_max_plus_1)
+    {
+        return (x < INT64_MIN) ? (uint64_t)INT64_MIN : (uint64_t)(int64_t)x;
+    }
+    else
+    {
+        x -= int64_max_plus_1;
+        x = trunc(x);
+        return (uint64_t)(((x != x) || (x >= int64_max_plus_1)) ? INT64_MIN : (int64_t)x) + (0x8000000000000000);
+    }
+}
+
+extern "C" DLLEXPORT  uint64_t ConvertDoubleToUnsignedLongLong(double x, FPtoIntegerConversionType t)
+{
+    if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
+        return (uint64_t)x;
+
+    x = trunc(x); // truncate (round toward zero)
+
+    // (double)UINT64_MAX cannot be represented exactly as double
+    const double uint64_max_plus_1 = -2.0 * (double)INT64_MIN;
+    // (double)INT64_MAX cannot be represented exactly as double
+    const double int64_max_plus_1 = 0x1.p63; // 0x43e0000000000000 // (uint64_t)INT64_MAX + 1;
+
+
+    switch (t) {
+    case CONVERT_BACKWARD_COMPATIBLE:
+        return ((x != x) || (x < INT64_MIN) || (x >= uint64_max_plus_1)) ? (uint64_t)INT64_MIN : (x < 0) ? (uint64_t)(int64_t)x : (uint64_t)x;
+
+    case CONVERT_SENTINEL:
+        return ((x != x) || (x < 0) || (x >= uint64_max_plus_1)) ? UINT64_MAX : (uint64_t)x;
+
+    case CONVERT_SATURATING:
+        return ((x != x) || (x < 0)) ? 0 : (x >= uint64_max_plus_1) ? UINT64_MAX : (uint64_t)x;
+
+    case CONVERT_MANAGED_BACKWARD_COMPATIBLE:
+        if (x < int64_max_plus_1)
+        {
+            return (x < INT64_MIN) ? (uint64_t)INT64_MIN : (uint64_t)(int64_t)x;
+        }
+        else
+        {
+            x -= int64_max_plus_1;
+            x = trunc(x);
+            return (uint64_t)(((x != x) || (x >= int64_max_plus_1)) ? INT64_MIN : (int64_t)x) + (0x8000000000000000);
+        }
+    }
+
+    return 0;
+}
+

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <limits.h>
-#include <intrin.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <math.h>

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cpp
@@ -21,7 +21,7 @@ typedef enum {
     CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32,
 } FPtoIntegerConversionType;
 
-extern "C" DLLEXPORT int32_t ConvertDoubleToLong(double x, FPtoIntegerConversionType t)
+extern "C" DLLEXPORT int32_t ConvertDoubleToInt32(double x, FPtoIntegerConversionType t)
 {
     if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
         return (int32_t)x;
@@ -44,7 +44,7 @@ extern "C" DLLEXPORT int32_t ConvertDoubleToLong(double x, FPtoIntegerConversion
     return 0;
 }
 
-extern "C" DLLEXPORT uint32_t ConvertDoubleToUnsignedLong(double x, FPtoIntegerConversionType t)
+extern "C" DLLEXPORT uint32_t ConvertDoubleToUInt32(double x, FPtoIntegerConversionType t)
 {
     if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
         return (uint32_t)x;
@@ -70,15 +70,15 @@ extern "C" DLLEXPORT uint32_t ConvertDoubleToUnsignedLong(double x, FPtoIntegerC
     return 0;
 }
 
-static uint64_t CppNativeArm32ConvertDoubleToUnsignedLongLong(double y)
+static uint64_t CppNativeArm32ConvertDoubleToUInt64(double y)
 {
     const double uintmax_plus_1 = -2.0 * (double)INT32_MIN;
-    uint32_t hi32Bits = ConvertDoubleToUnsignedLong(y / uintmax_plus_1, CONVERT_SATURATING);
-    uint32_t lo32Bits = ConvertDoubleToUnsignedLong(y - (((double)hi32Bits) * uintmax_plus_1), CONVERT_SATURATING);
+    uint32_t hi32Bits = ConvertDoubleToUInt32(y / uintmax_plus_1, CONVERT_SATURATING);
+    uint32_t lo32Bits = ConvertDoubleToUInt32(y - (((double)hi32Bits) * uintmax_plus_1), CONVERT_SATURATING);
     return (((uint64_t)hi32Bits) << 32) + lo32Bits;
 }
 
-extern "C" DLLEXPORT int64_t ConvertDoubleToLongLong(double x, FPtoIntegerConversionType t)
+extern "C" DLLEXPORT int64_t ConvertDoubleToInt64(double x, FPtoIntegerConversionType t)
 {
     if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
         return (int64_t)x;
@@ -103,11 +103,11 @@ extern "C" DLLEXPORT int64_t ConvertDoubleToLongLong(double x, FPtoIntegerConver
     case CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32:
         if (x > 0)
         {
-            return (int64_t)CppNativeArm32ConvertDoubleToUnsignedLongLong(x);
+            return (int64_t)CppNativeArm32ConvertDoubleToUInt64(x);
         }
         else
         {
-            return -(int64_t)CppNativeArm32ConvertDoubleToUnsignedLongLong(-x);
+            return -(int64_t)CppNativeArm32ConvertDoubleToUInt64(-x);
         }
 
     case CONVERT_SATURATING:
@@ -119,7 +119,7 @@ extern "C" DLLEXPORT int64_t ConvertDoubleToLongLong(double x, FPtoIntegerConver
     return 0;
 }
 
-extern "C" DLLEXPORT  uint64_t ConvertDoubleToUnsignedLongLong(double x, FPtoIntegerConversionType t)
+extern "C" DLLEXPORT  uint64_t ConvertDoubleToUInt64(double x, FPtoIntegerConversionType t)
 {
     if (t == CONVERT_NATIVECOMPILERBEHAVIOR)
         return (uint64_t)x;
@@ -146,11 +146,11 @@ extern "C" DLLEXPORT  uint64_t ConvertDoubleToUnsignedLongLong(double x, FPtoInt
         {
             if (x < int64_max_plus_1)
             {
-                return (uint64_t)ConvertDoubleToLongLong(x, CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32);
+                return (uint64_t)ConvertDoubleToInt64(x, CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32);
             }
             else
             {
-                return (uint64_t)ConvertDoubleToLongLong(x - int64_max_plus_1, CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32) + (0x8000000000000000);
+                return (uint64_t)ConvertDoubleToInt64(x - int64_max_plus_1, CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32) + (0x8000000000000000);
             }
         }
 

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -127,7 +127,7 @@ namespace FPBehaviorApp
             {
                 case FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
                 case FPtoIntegerConversionType.CONVERT_BACKWARD_COMPATIBLE:
-                    return (IsNaN(x) || (x < long.MinValue) || (x > llong_max_plus_1)) ? 0 : (uint)(long)x;
+                    return (IsNaN(x) || (x < long.MinValue) || (x >= llong_max_plus_1)) ? 0 : (uint)(long)x;
 
                 case FPtoIntegerConversionType.CONVERT_SENTINEL:
                     return (IsNaN(x) || (x < 0) || (x > uint.MaxValue)) ? uint.MaxValue : (uint)x;

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -378,7 +378,7 @@ namespace FPBehaviorApp
 
                 case Architecture.Arm:
                 case Architecture.Arm64:
-                    Program.ManagedConversionRule = FPtoIntegerConversionType.CONVERT_SENTINEL;
+                    Program.ManagedConversionRule = FPtoIntegerConversionType.CONVERT_SATURATING;
                     break;
             }
             Console.WriteLine($"Expected managed float behavior is {Program.ManagedConversionRule} Execute with parameter to adjust");

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -121,12 +121,13 @@ namespace FPBehaviorApp
                 return (uint)x;
 
             x = Truncate(x); // truncate (round toward zero)
+            const double llong_max_plus_1 = (double)((ulong)long.MaxValue + 1);
 
             switch (t)
             {
                 case FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
                 case FPtoIntegerConversionType.CONVERT_BACKWARD_COMPATIBLE:
-                    return (IsNaN(x) || (x < long.MinValue) || (x > long.MaxValue)) ? 0 : (uint)(long)x;
+                    return (IsNaN(x) || (x < long.MinValue) || (x > llong_max_plus_1)) ? 0 : (uint)(long)x;
 
                 case FPtoIntegerConversionType.CONVERT_SENTINEL:
                     return (IsNaN(x) || (x < 0) || (x > uint.MaxValue)) ? uint.MaxValue : (uint)x;

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -34,19 +34,19 @@ namespace FPBehaviorApp
     {
         [DllImport("out_of_range_fp_to_int_conversionsnative")]
         [SuppressGCTransition]
-        public static extern int ConvertDoubleToLong(double x, FPtoIntegerConversionType t);
+        public static extern int ConvertDoubleToInt32(double x, FPtoIntegerConversionType t);
 
         [DllImport("out_of_range_fp_to_int_conversionsnative")]
         [SuppressGCTransition]
-        public static extern uint ConvertDoubleToUnsignedLong(double x, FPtoIntegerConversionType t);
+        public static extern uint ConvertDoubleToUInt32(double x, FPtoIntegerConversionType t);
 
         [DllImport("out_of_range_fp_to_int_conversionsnative")]
         [SuppressGCTransition]
-        public static extern long ConvertDoubleToLongLong(double x, FPtoIntegerConversionType t);
+        public static extern long ConvertDoubleToInt64(double x, FPtoIntegerConversionType t);
 
         [DllImport("out_of_range_fp_to_int_conversionsnative")]
         [SuppressGCTransition]
-        public static extern ulong ConvertDoubleToUnsignedLongLong(double x, FPtoIntegerConversionType t);
+        public static extern ulong ConvertDoubleToUInt64(double x, FPtoIntegerConversionType t);
     }
 
     public static class Managed
@@ -77,7 +77,7 @@ namespace FPBehaviorApp
             return BitConverter.Int64BitsToDouble((long)uintVal);
         }
 
-        public static int ConvertDoubleToLong(double x, FPtoIntegerConversionType t)
+        public static int ConvertDoubleToInt32(double x, FPtoIntegerConversionType t)
         {
             if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
                 return (int)x;
@@ -98,7 +98,7 @@ namespace FPBehaviorApp
             return 0;
         }
 
-        public static uint ConvertDoubleToUnsignedLong(double x, FPtoIntegerConversionType t)
+        public static uint ConvertDoubleToUInt32(double x, FPtoIntegerConversionType t)
         {
             if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
                 return (uint)x;
@@ -123,7 +123,7 @@ namespace FPBehaviorApp
             return 0;
         }
 
-        public static long ConvertDoubleToLongLong(double x, FPtoIntegerConversionType t)
+        public static long ConvertDoubleToInt64(double x, FPtoIntegerConversionType t)
         {
             if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
                 return (long)x;
@@ -143,11 +143,11 @@ namespace FPBehaviorApp
                 case FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32:
                     if (x > 0)
                     {
-                        return (long)CppNativeArm32ConvertDoubleToUnsignedLongLong(x);
+                        return (long)CppNativeArm32ConvertDoubleToUInt64(x);
                     }
                     else
                     {
-                        return -(long)CppNativeArm32ConvertDoubleToUnsignedLongLong(-x);
+                        return -(long)CppNativeArm32ConvertDoubleToUInt64(-x);
                     }
 
                 case FPtoIntegerConversionType.CONVERT_SATURATING:
@@ -156,16 +156,16 @@ namespace FPBehaviorApp
 
             return 0;
 
-            static ulong CppNativeArm32ConvertDoubleToUnsignedLongLong(double y)
+            static ulong CppNativeArm32ConvertDoubleToUInt64(double y)
             {
                 const double uintmax_plus_1 = -2.0 * (double)int.MinValue;
-                uint hi32Bits = ConvertDoubleToUnsignedLong(y / uintmax_plus_1, FPtoIntegerConversionType.CONVERT_SATURATING);
-                uint lo32Bits = ConvertDoubleToUnsignedLong(y - (((double)hi32Bits) * uintmax_plus_1), FPtoIntegerConversionType.CONVERT_SATURATING);
+                uint hi32Bits = ConvertDoubleToUInt32(y / uintmax_plus_1, FPtoIntegerConversionType.CONVERT_SATURATING);
+                uint lo32Bits = ConvertDoubleToUInt32(y - (((double)hi32Bits) * uintmax_plus_1), FPtoIntegerConversionType.CONVERT_SATURATING);
                 return (((ulong)hi32Bits) << (int)32) + lo32Bits;
             }
         }
 
-        public static ulong ConvertDoubleToUnsignedLongLong(double x, FPtoIntegerConversionType t)
+        public static ulong ConvertDoubleToUInt64(double x, FPtoIntegerConversionType t)
         {
             if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
                 return (ulong)x;
@@ -191,11 +191,11 @@ namespace FPBehaviorApp
                     {
                         if (x < two63)
                         {
-                            return (ulong)ConvertDoubleToLongLong(x, FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32);
+                            return (ulong)ConvertDoubleToInt64(x, FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32);
                         }
                         else
                         {
-                            return (ulong)ConvertDoubleToLongLong(x - two63, FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32) + (0x8000000000000000);
+                            return (ulong)ConvertDoubleToInt64(x - two63, FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_ARM32) + (0x8000000000000000);
                         }
                     }
 
@@ -218,42 +218,42 @@ namespace FPBehaviorApp
             return 0;
         }
 
-        public static Vector<int> ConvertToVectorInt(Vector<float> vFloat, FPtoIntegerConversionType t)
+        public static Vector<int> ConvertToVectorInt32(Vector<float> vFloat, FPtoIntegerConversionType t)
         {
             int[] values = new int[Vector<float>.Count];
             for (int i = 0; i < values.Length; i++)
             {
-                values[i] = ConvertDoubleToLong(vFloat[i], t);
+                values[i] = ConvertDoubleToInt32(vFloat[i], t);
             }
             return new Vector<int>(values);
         }
 
-        public static Vector<uint> ConvertToVectorUInt(Vector<float> vFloat, FPtoIntegerConversionType t)
+        public static Vector<uint> ConvertToVectorUInt32(Vector<float> vFloat, FPtoIntegerConversionType t)
         {
             uint[] values = new uint[Vector<float>.Count];
             for (int i = 0; i < values.Length; i++)
             {
-                values[i] = ConvertDoubleToUnsignedLong(vFloat[i], t);
+                values[i] = ConvertDoubleToUInt32(vFloat[i], t);
             }
             return new Vector<uint>(values);
         }
 
-        public static Vector<long> ConvertToVectorLong(Vector<double> vFloat, FPtoIntegerConversionType t)
+        public static Vector<long> ConvertToVectorInt64(Vector<double> vFloat, FPtoIntegerConversionType t)
         {
             long[] values = new long[Vector<double>.Count];
             for (int i = 0; i < values.Length; i++)
             {
-                values[i] = ConvertDoubleToLongLong(vFloat[i], t);
+                values[i] = ConvertDoubleToInt64(vFloat[i], t);
             }
             return new Vector<long>(values);
         }
 
-        public static Vector<ulong> ConvertToVectorULong(Vector<double> vFloat, FPtoIntegerConversionType t)
+        public static Vector<ulong> ConvertToVectorUInt64(Vector<double> vFloat, FPtoIntegerConversionType t)
         {
             ulong[] values = new ulong[Vector<double>.Count];
             for (int i = 0; i < values.Length; i++)
             {
-                values[i] = ConvertDoubleToUnsignedLongLong(vFloat[i], t);
+                values[i] = ConvertDoubleToUInt64(vFloat[i], t);
             }
             return new Vector<ulong>(values);
         }
@@ -289,78 +289,78 @@ namespace FPBehaviorApp
 
             FPtoIntegerConversionType t = tValue.Value;
 
-            if (Managed.ConvertDoubleToLong(dblVal, t) != Native.ConvertDoubleToLong(dblVal, t))
+            if (Managed.ConvertDoubleToInt32(dblVal, t) != Native.ConvertDoubleToInt32(dblVal, t))
             {
                 failures++;
-                Console.WriteLine($"Managed.ConvertDoubleToLong(dblVal, t) != Native.ConvertDoubleToLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToLong(dblVal, t)} != {Native.ConvertDoubleToLong(dblVal, t)}");
+                Console.WriteLine($"Managed.ConvertDoubleToInt32(dblVal, t) != Native.ConvertDoubleToInt32(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToInt32(dblVal, t)} != {Native.ConvertDoubleToInt32(dblVal, t)}");
             }
 
-            if (Managed.ConvertDoubleToUnsignedLong(dblVal, t) != Native.ConvertDoubleToUnsignedLong(dblVal, t))
+            if (Managed.ConvertDoubleToUInt32(dblVal, t) != Native.ConvertDoubleToUInt32(dblVal, t))
             {
                 failures++;
-                Console.WriteLine($"Managed.ConvertDoubleToUnsignedLong(dblVal, t) != Native.ConvertDoubleToUnsignedLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLong(dblVal, t)} != {Native.ConvertDoubleToUnsignedLong(dblVal, t)}");
+                Console.WriteLine($"Managed.ConvertDoubleToUInt32(dblVal, t) != Native.ConvertDoubleToUInt32(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToUInt32(dblVal, t)} != {Native.ConvertDoubleToUInt32(dblVal, t)}");
             }
 
-            if (Managed.ConvertDoubleToLongLong(dblVal, t) != Native.ConvertDoubleToLongLong(dblVal, t))
+            if (Managed.ConvertDoubleToInt64(dblVal, t) != Native.ConvertDoubleToInt64(dblVal, t))
             {
                 failures++;
-                Console.WriteLine($"Managed.ConvertDoubleToLongLong(dblVal, t) != Native.ConvertDoubleToLongLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToLongLong(dblVal, t)} != {Native.ConvertDoubleToLongLong(dblVal, t)}");
+                Console.WriteLine($"Managed.ConvertDoubleToInt64(dblVal, t) != Native.ConvertDoubleToInt64(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToInt64(dblVal, t)} != {Native.ConvertDoubleToInt64(dblVal, t)}");
             }
 
-            if (Managed.ConvertDoubleToUnsignedLongLong(dblVal, t) != Native.ConvertDoubleToUnsignedLongLong(dblVal, t))
+            if (Managed.ConvertDoubleToUInt64(dblVal, t) != Native.ConvertDoubleToUInt64(dblVal, t))
             {
                 failures++;
-                Console.WriteLine($"Managed.ConvertDoubleToUnsignedLongLong(dblVal, t) != Native.ConvertDoubleToUnsignedLongLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLongLong(dblVal, t)} != {Native.ConvertDoubleToUnsignedLongLong(dblVal, t)}");
+                Console.WriteLine($"Managed.ConvertDoubleToUInt64(dblVal, t) != Native.ConvertDoubleToUInt64(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToUInt64(dblVal, t)} != {Native.ConvertDoubleToUInt64(dblVal, t)}");
             }
             
             if (t == ManagedConversionRule)
             {
-                if (Managed.ConvertDoubleToLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToLong(dblVal, t))
+                if (Managed.ConvertDoubleToInt32(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToInt32(dblVal, t))
                 {
                     failures++;
-                    Console.WriteLine($"ConvertDoubleToLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToLong(dblVal, t)}");
+                    Console.WriteLine($"ConvertDoubleToInt32 NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToInt32(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToInt32(dblVal, t)}");
                 }
 
-                if (Managed.ConvertDoubleToUnsignedLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToUnsignedLong(dblVal, t))
+                if (Managed.ConvertDoubleToUInt32(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToUInt32(dblVal, t))
                 {
                     failures++;
-                    Console.WriteLine($"ConvertDoubleToUnsignedLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToUnsignedLong(dblVal, t)}");
+                    Console.WriteLine($"ConvertDoubleToUInt32 NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToUInt32(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToUInt32(dblVal, t)}");
                 }
 
-                if (Managed.ConvertDoubleToLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToLongLong(dblVal, t))
+                if (Managed.ConvertDoubleToInt64(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToInt64(dblVal, t))
                 {
                     failures++;
-                    Console.WriteLine($"ConvertDoubleToLongLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToLongLong(dblVal, t)}");
+                    Console.WriteLine($"ConvertDoubleToInt64 NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToInt64(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToInt64(dblVal, t)}");
                 }
                 
-                if (Managed.ConvertDoubleToUnsignedLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToUnsignedLongLong(dblVal, t))
+                if (Managed.ConvertDoubleToUInt64(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToUInt64(dblVal, t))
                 {
                     failures++;
-                    Console.WriteLine($"ConvertDoubleToUnsignedLongLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToUnsignedLongLong(dblVal, t)}");
+                    Console.WriteLine($"ConvertDoubleToUInt64 NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToUInt64(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToUInt64(dblVal, t)}");
                 }
 
                 Vector<float> vFloat = new Vector<float>((float)dblVal);
                 Vector<double> vDouble = new Vector<double>(dblVal);
 
-                if (Managed.ConvertToVectorInt(vFloat, t) != Vector.ConvertToInt32(vFloat))
+                if (Managed.ConvertToVectorInt32(vFloat, t) != Vector.ConvertToInt32(vFloat))
                 {
                     failures++;
-                    Console.WriteLine($"Managed.ConvertToVectorInt(vFloat, t) != Vector.ConvertToInt32(vFloat) {t} {value} {dblVal} {Managed.ConvertToVectorInt(vFloat, t)} != {Vector.ConvertToInt32(vFloat)}");
+                    Console.WriteLine($"Managed.ConvertToVectorInt32(vFloat, t) != Vector.ConvertToInt32(vFloat) {t} {value} {dblVal} {Managed.ConvertToVectorInt32(vFloat, t)} != {Vector.ConvertToInt32(vFloat)}");
                 }
-                if (Managed.ConvertToVectorUInt(vFloat, t) != Vector.ConvertToUInt32(vFloat))
+                if (Managed.ConvertToVectorUInt32(vFloat, t) != Vector.ConvertToUInt32(vFloat))
                 {
                     failures++;
-                    Console.WriteLine($"Managed.ConvertToVectorUInt(vFloat, t) != Vector.ConvertToUInt32(vFloat) {t} {value} {dblVal} {Managed.ConvertToVectorUInt(vFloat, t)} != {Vector.ConvertToUInt32(vFloat)}");
+                    Console.WriteLine($"Managed.ConvertToVectorUInt32(vFloat, t) != Vector.ConvertToUInt32(vFloat) {t} {value} {dblVal} {Managed.ConvertToVectorUInt32(vFloat, t)} != {Vector.ConvertToUInt32(vFloat)}");
                 }
-                if (Managed.ConvertToVectorLong(vDouble, t) != Vector.ConvertToInt64(vDouble))
+                if (Managed.ConvertToVectorInt64(vDouble, t) != Vector.ConvertToInt64(vDouble))
                 {
                     failures++;
-                    Console.WriteLine($"Managed.ConvertToVectorLong(vDouble, t) != Vector.ConvertToInt64(vDouble) {t} {value} {dblVal} {Managed.ConvertToVectorLong(vDouble, t)} != {Vector.ConvertToInt64(vDouble)}");
+                    Console.WriteLine($"Managed.ConvertToVectorInt64(vDouble, t) != Vector.ConvertToInt64(vDouble) {t} {value} {dblVal} {Managed.ConvertToVectorInt64(vDouble, t)} != {Vector.ConvertToInt64(vDouble)}");
                 }
-                if (Managed.ConvertToVectorULong(vDouble, t) != Vector.ConvertToUInt64(vDouble))
+                if (Managed.ConvertToVectorUInt64(vDouble, t) != Vector.ConvertToUInt64(vDouble))
                 {
                     failures++;
-                    Console.WriteLine($"Managed.ConvertToVectorULong(vDouble, t) != Vector.ConvertToUInt64(vDouble) {t} {value} {dblVal} {Managed.ConvertToVectorULong(vDouble, t)} != {Vector.ConvertToUInt64(vDouble)}");
+                    Console.WriteLine($"Managed.ConvertToVectorUInt64(vDouble, t) != Vector.ConvertToUInt64(vDouble) {t} {value} {dblVal} {Managed.ConvertToVectorUInt64(vDouble, t)} != {Vector.ConvertToUInt64(vDouble)}");
                 }
             }
 

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -1,0 +1,440 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Numerics;
+
+namespace FPBehaviorApp
+{
+    public enum FPtoIntegerConversionType
+    {
+        CONVERT_BACKWARD_COMPATIBLE,
+        CONVERT_SENTINEL,
+        CONVERT_SATURATING,
+        CONVERT_NATIVECOMPILERBEHAVIOR,
+        CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64,
+    }
+
+    public enum ConversionType
+    {
+        ToInt,
+        ToLong,
+        ToUInt,
+        ToULong
+    }
+
+    public static class Native
+    {
+        [DllImport("out_of_range_fp_to_int_conversionsnative")]
+        [SuppressGCTransition]
+        public static extern int ConvertDoubleToLong(double x, FPtoIntegerConversionType t);
+
+        [DllImport("out_of_range_fp_to_int_conversionsnative")]
+        [SuppressGCTransition]
+        public static extern uint ConvertDoubleToUnsignedLong(double x, FPtoIntegerConversionType t);
+
+        [DllImport("out_of_range_fp_to_int_conversionsnative")]
+        [SuppressGCTransition]
+        public static extern long ConvertDoubleToLongLong(double x, FPtoIntegerConversionType t);
+
+        [DllImport("out_of_range_fp_to_int_conversionsnative")]
+        [SuppressGCTransition]
+        public static extern ulong ConvertDoubleToUnsignedLongLong(double x, FPtoIntegerConversionType t);
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    struct DoubleULongBitcaster
+    {
+        [FieldOffset(0)]
+        public ulong UintVal;
+        [FieldOffset(0)]
+        public double DoubleVal;
+    }
+
+    public static class Managed
+    {
+        public static bool IsNaN(double d)
+        {
+            return !(d == d);
+        }
+
+        public static void DumpBits(double d)
+        {
+            DoubleULongBitcaster bitCaster = default(DoubleULongBitcaster);
+            bitCaster.DoubleVal = d;
+            ulong uintVal = bitCaster.UintVal;
+            bool signBit = (int)((uintVal >> 63) & 0x1) != 0;
+            ulong mantissa = uintVal & 0x000F_FFFF_FFFF_FFFF;
+            int exponent = (int)((uintVal >> 52) & 0x7FF);
+            Console.WriteLine($"{signBit} {exponent:x} {mantissa:x}");
+        }
+
+        // Equivalent to Math.Truncate, but written in C# to avoid Debug/Check penalties running on CoreCLR test builds
+        public static double Truncate(double d)
+        {
+            DoubleULongBitcaster bitCaster = default(DoubleULongBitcaster);
+            bitCaster.DoubleVal = d;
+            ulong uintVal = bitCaster.UintVal;
+            int exponent = (int)((uintVal >> 52) & 0x7FF);
+            if (exponent < 1023)
+            {
+                uintVal &= 0x8000_0000_0000_0000ul;
+            }
+            else if (exponent < 1075)
+            {
+                uintVal &= (ulong)(~(0xF_FFFF_FFFF_FFFF >> (exponent - 1023)));
+            }
+            bitCaster.UintVal = uintVal;
+
+            return bitCaster.DoubleVal;
+        }
+
+        public static int ConvertDoubleToLong(double x, FPtoIntegerConversionType t)
+        {
+            if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
+                return (int)x;
+
+            x = Truncate(x); // truncate (round toward zero)
+
+            switch (t)
+            {
+                case FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
+                case FPtoIntegerConversionType.CONVERT_BACKWARD_COMPATIBLE:
+                case FPtoIntegerConversionType.CONVERT_SENTINEL:
+                    return (IsNaN(x) || (x<int.MinValue) || (x > int.MaxValue)) ? int.MinValue: (int) x;
+
+                case FPtoIntegerConversionType.CONVERT_SATURATING:
+                    return IsNaN(x) ? 0 : (x< int.MinValue) ? int.MinValue : (x > int.MaxValue) ? int.MaxValue : (int) x;
+            }
+            return 0;
+        }
+
+        public static uint ConvertDoubleToUnsignedLong(double x, FPtoIntegerConversionType t)
+        {
+            if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
+                return (uint)x;
+
+            x = Truncate(x); // truncate (round toward zero)
+
+            switch (t)
+            {
+                case FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
+                case FPtoIntegerConversionType.CONVERT_BACKWARD_COMPATIBLE:
+                    return (IsNaN(x) || (x < long.MinValue) || (x > long.MaxValue)) ? 0 : (uint)(long)x;
+
+                case FPtoIntegerConversionType.CONVERT_SENTINEL:
+                    return (IsNaN(x) || (x < 0) || (x > uint.MaxValue)) ? uint.MaxValue : (uint)x;
+
+                case FPtoIntegerConversionType.CONVERT_SATURATING:
+                    return (IsNaN(x) || (x < 0)) ? 0 : (x > uint.MaxValue) ? uint.MaxValue : (uint)x;
+            }
+
+            return 0;
+        }
+
+        public static long ConvertDoubleToLongLong(double x, FPtoIntegerConversionType t)
+        {
+            if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
+                return (long)x;
+
+            x = Truncate(x); // truncate (round toward zero)
+
+            // (double)LLONG_MAX cannot be represented exactly as double
+            const double llong_max_plus_1 = (double)((ulong)long.MaxValue + 1);
+
+            switch (t)
+            {
+                case FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
+                case FPtoIntegerConversionType.CONVERT_BACKWARD_COMPATIBLE:
+                case FPtoIntegerConversionType.CONVERT_SENTINEL:
+                    return (IsNaN(x) || (x < long.MinValue) || (x >= llong_max_plus_1)) ? long.MinValue : (long)x;
+
+                case FPtoIntegerConversionType.CONVERT_SATURATING:
+                    return IsNaN(x) ? 0 : (x < long.MinValue) ? long.MinValue : (x >= llong_max_plus_1) ? long.MaxValue : (long)x;
+            }
+
+            return 0;
+        }
+
+        public static ulong ConvertDoubleToUnsignedLongLong(double x, FPtoIntegerConversionType t)
+        {
+            if (t == FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)
+                return (ulong)x;
+
+            x = Truncate(x); // truncate (round toward zero)
+
+            // (double)ULLONG_MAX cannot be represented exactly as double
+            const double ullong_max_plus_1 = -2.0 * (double)long.MinValue;
+
+            switch (t)
+            {
+                case FPtoIntegerConversionType.CONVERT_BACKWARD_COMPATIBLE:
+                    return (IsNaN(x) || (x < long.MinValue) || (x >= ullong_max_plus_1)) ? unchecked((ulong)long.MinValue): (x < 0) ? (ulong)(long)x: (ulong)x;
+
+                case FPtoIntegerConversionType.CONVERT_SENTINEL:
+                    return (IsNaN(x) || (x < 0) || (x >= ullong_max_plus_1)) ? ulong.MaxValue : (ulong)x;
+
+                case FPtoIntegerConversionType.CONVERT_SATURATING:
+                    return (IsNaN(x) || (x < 0)) ? 0 : (x >= ullong_max_plus_1) ? ulong.MaxValue : (ulong)x;
+
+                case FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64:
+                    const double two63 = 2147483648.0 * 4294967296.0;
+
+                    if (x < two63)
+                    {
+                        return (x < long.MinValue) ? unchecked((ulong)long.MinValue) : (ulong)(long)x;
+                    }
+                    else
+                    {
+                        // (double)LLONG_MAX cannot be represented exactly as double
+                        const double llong_max_plus_1 = (double)((ulong)long.MaxValue + 1);
+                        x -= two63;
+                        x = Math.Truncate(x);
+                        return (ulong)((IsNaN(x) || (x >= llong_max_plus_1)) ? long.MinValue : (long)x) + (0x8000000000000000);
+                    }
+            }
+
+            return 0;
+        }
+
+        public static Vector<int> ConvertToVectorInt(Vector<float> vFloat, FPtoIntegerConversionType t)
+        {
+            int[] values = new int[Vector<float>.Count];
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = ConvertDoubleToLong(vFloat[i], t);
+            }
+            return new Vector<int>(values);
+        }
+
+        public static Vector<uint> ConvertToVectorUInt(Vector<float> vFloat, FPtoIntegerConversionType t)
+        {
+            uint[] values = new uint[Vector<float>.Count];
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = ConvertDoubleToUnsignedLong(vFloat[i], t);
+            }
+            return new Vector<uint>(values);
+        }
+
+        public static Vector<long> ConvertToVectorLong(Vector<double> vFloat, FPtoIntegerConversionType t)
+        {
+            long[] values = new long[Vector<double>.Count];
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = ConvertDoubleToLongLong(vFloat[i], t);
+            }
+            return new Vector<long>(values);
+        }
+
+        public static Vector<ulong> ConvertToVectorULong(Vector<double> vFloat, FPtoIntegerConversionType t)
+        {
+            ulong[] values = new ulong[Vector<double>.Count];
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = ConvertDoubleToUnsignedLongLong(vFloat[i], t);
+            }
+            return new Vector<ulong>(values);
+        }
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    struct FloatUIntBitcaster
+    {
+        [FieldOffset(0)]
+        public uint UintVal;
+        [FieldOffset(0)]
+        public float FloatVal;
+    }
+
+    class Program
+    {
+        static int failures = 0;
+        static FPtoIntegerConversionType ManagedConversionRule = FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64;
+
+        static void TestBitValue(uint value, double? dblValNullable = null, FPtoIntegerConversionType? tValue = null)
+        {
+            double dblVal;
+
+            if (dblValNullable.HasValue)
+            {
+                dblVal = dblValNullable.Value;
+            }
+            else
+            {
+                FloatUIntBitcaster bitCaster = new FloatUIntBitcaster();
+                bitCaster.UintVal = value;
+                dblVal = bitCaster.FloatVal;
+            }
+
+            if (!tValue.HasValue)
+            {
+                TestBitValue(value, dblVal, FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64);
+                TestBitValue(value, dblVal, FPtoIntegerConversionType.CONVERT_BACKWARD_COMPATIBLE);
+                TestBitValue(value, dblVal, FPtoIntegerConversionType.CONVERT_SATURATING);
+                TestBitValue(value, dblVal, FPtoIntegerConversionType.CONVERT_SENTINEL);
+                return;
+            }
+
+            FPtoIntegerConversionType t = tValue.Value;
+
+            if (Managed.ConvertDoubleToLong(dblVal, t) != Native.ConvertDoubleToLong(dblVal, t))
+            {
+                failures++;
+                Console.WriteLine($"Managed.ConvertDoubleToLong(dblVal, t) != Native.ConvertDoubleToLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToLong(dblVal, t)} != {Native.ConvertDoubleToLong(dblVal, t)}");
+            }
+
+            if (Managed.ConvertDoubleToUnsignedLong(dblVal, t) != Native.ConvertDoubleToUnsignedLong(dblVal, t))
+            {
+                failures++;
+                Console.WriteLine($"Managed.ConvertDoubleToUnsignedLong(dblVal, t) != Native.ConvertDoubleToUnsignedLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLong(dblVal, t)} != {Native.ConvertDoubleToUnsignedLong(dblVal, t)}");
+            }
+
+            if (Managed.ConvertDoubleToLongLong(dblVal, t) != Native.ConvertDoubleToLongLong(dblVal, t))
+            {
+                failures++;
+                Console.WriteLine($"Managed.ConvertDoubleToLongLong(dblVal, t) != Native.ConvertDoubleToLongLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToLongLong(dblVal, t)} != {Native.ConvertDoubleToLongLong(dblVal, t)}");
+            }
+
+            if (Managed.ConvertDoubleToUnsignedLongLong(dblVal, t) != Native.ConvertDoubleToUnsignedLongLong(dblVal, t))
+            {
+                failures++;
+                Console.WriteLine($"Managed.ConvertDoubleToUnsignedLongLong(dblVal, t) != Native.ConvertDoubleToUnsignedLongLong(dblVal, t) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLongLong(dblVal, t)} != {Native.ConvertDoubleToUnsignedLongLong(dblVal, t)}");
+            }
+            
+            if (t == ManagedConversionRule)
+            {
+                if (Managed.ConvertDoubleToLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToLong(dblVal, t))
+                {
+                    failures++;
+                    Console.WriteLine($"ConvertDoubleToLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToLong(dblVal, t)}");
+                }
+
+                if (Managed.ConvertDoubleToUnsignedLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToUnsignedLong(dblVal, t))
+                {
+                    failures++;
+                    Console.WriteLine($"ConvertDoubleToUnsignedLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToUnsignedLong(dblVal, t)}");
+                }
+
+                if (Managed.ConvertDoubleToLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToLongLong(dblVal, t))
+                {
+                    failures++;
+                    Console.WriteLine($"ConvertDoubleToLongLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToLongLong(dblVal, t)}");
+                }
+                
+                if (Managed.ConvertDoubleToUnsignedLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR) != Managed.ConvertDoubleToUnsignedLongLong(dblVal, t))
+                {
+                    failures++;
+                    Console.WriteLine($"ConvertDoubleToUnsignedLongLong NativeCompilerBehavior(managed) {t} {value} {dblVal} {Managed.ConvertDoubleToUnsignedLongLong(dblVal, FPtoIntegerConversionType.CONVERT_NATIVECOMPILERBEHAVIOR)} != {Managed.ConvertDoubleToUnsignedLongLong(dblVal, t)}");
+                }
+
+                Vector<float> vFloat = new Vector<float>((float)dblVal);
+                Vector<double> vDouble = new Vector<double>(dblVal);
+
+                if (Managed.ConvertToVectorInt(vFloat, t) != Vector.ConvertToInt32(vFloat))
+                {
+                    failures++;
+                    Console.WriteLine($"Managed.ConvertToVectorInt(vFloat, t) != Vector.ConvertToInt32(vFloat) {t} {value} {dblVal} {Managed.ConvertToVectorInt(vFloat, t)} != {Vector.ConvertToInt32(vFloat)}");
+                }
+                if (Managed.ConvertToVectorUInt(vFloat, t) != Vector.ConvertToUInt32(vFloat))
+                {
+                    failures++;
+                    Console.WriteLine($"Managed.ConvertToVectorUInt(vFloat, t) != Vector.ConvertToUInt32(vFloat) {t} {value} {dblVal} {Managed.ConvertToVectorUInt(vFloat, t)} != {Vector.ConvertToUInt32(vFloat)}");
+                }
+                if (Managed.ConvertToVectorLong(vDouble, t) != Vector.ConvertToInt64(vDouble))
+                {
+                    failures++;
+                    Console.WriteLine($"Managed.ConvertToVectorLong(vDouble, t) != Vector.ConvertToInt64(vDouble) {t} {value} {dblVal} {Managed.ConvertToVectorLong(vDouble, t)} != {Vector.ConvertToInt64(vDouble)}");
+                }
+                if (Managed.ConvertToVectorULong(vDouble, t) != Vector.ConvertToUInt64(vDouble))
+                {
+                    failures++;
+                    Console.WriteLine($"Managed.ConvertToVectorULong(vDouble, t) != Vector.ConvertToUInt64(vDouble) {t} {value} {dblVal} {Managed.ConvertToVectorULong(vDouble, t)} != {Vector.ConvertToUInt64(vDouble)}");
+                }
+            }
+
+            if (failures > 100)
+            {
+                Console.WriteLine("Encountered 100 failures");
+                throw new Exception();
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            switch (RuntimeInformation.ProcessArchitecture)
+            {
+                case Architecture.X86:
+                case Architecture.X64:
+                    Program.ManagedConversionRule = FPtoIntegerConversionType.CONVERT_MANAGED_BACKWARD_COMPATIBLE_X86_X64;
+                    break;
+
+                case Architecture.Arm:
+                case Architecture.Arm64:
+                    Program.ManagedConversionRule = FPtoIntegerConversionType.CONVERT_SENTINEL;
+                    break;
+            }
+            Console.WriteLine($"Expected managed float behavior is {Program.ManagedConversionRule} Execute with parameter to adjust");
+            if (args.Length > 0)
+            {
+                if (!Enum.TryParse(args[0], out ManagedConversionRule))
+                {
+                    Console.WriteLine($"Unable to parse {args[0]}");
+                    return 1;
+                }
+            }
+            Console.WriteLine("Specific test cases");
+
+            TestBitValue(0, 9223372036854777856.0);
+            TestBitValue(0, -9223372036854775808.0);
+            TestBitValue(0, -2147483649.0);
+            TestBitValue(0, -2147483648.999999523162841796875);
+            TestBitValue(0, -2147483648.0);
+            TestBitValue(0, -1.0);
+            TestBitValue(0, -0.99999999999999988897769753748434595763683319091796875);
+            TestBitValue(0, 0.0);
+            TestBitValue(0, -0.0);
+            TestBitValue(0, 0.99999999999999988897769753748434595763683319091796875);
+            TestBitValue(0, 1.0);
+            TestBitValue(0, 2147483647.9999997615814208984375);
+            TestBitValue(0, 2147483648.0);
+            TestBitValue(0, 4294967295.999999523162841796875);
+            TestBitValue(0, 4294967296.0);
+            TestBitValue(0, 9223372036854774784.0);
+            TestBitValue(0, 9223372036854775808.0);
+            TestBitValue(0, 18446744073709549568.0);
+            TestBitValue(0, 18446744073709551616.0);
+
+            const int increment = 997; // Largest prime under 1000, use 1 for exhaustive search
+            Console.WriteLine($"Exhaustive scan of first {increment + 1} floats");
+            uint bitValue = 0;
+            for (bitValue = 0; bitValue <= increment; bitValue++)
+            {
+                TestBitValue(bitValue);
+            }
+
+            Console.WriteLine($"Walk through rest of 32bit float space skipping {increment} floats at a time (swap to 1 float at a time for a more exhaustive scan");
+            int i = 0;
+            for (bitValue = increment + 1; bitValue > increment; bitValue+=increment)
+            {
+                if (((++i) % 1_000_000) == 0)
+                    Console.Write(".");
+                TestBitValue(bitValue);
+            }
+
+            if (failures > 0)
+            {
+                Console.WriteLine($"{failures} failures");
+                return 10;
+            }
+
+            return 100;
+        }
+    }
+}

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.csproj
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="out_of_range_fp_to_int_conversions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -963,6 +963,9 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/out_of_range_fp_to_int_conversions/*">
+            <Issue>Mono does not define out of range fp to int conversions</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Devirtualization/Comparer_get_Default/*">
             <Issue>https://github.com/dotnet/runtime/issues/48190</Issue>
         </ExcludeList>


### PR DESCRIPTION
The behavior of floating point to integer conversions outside of the valid range is not consistent today from platform to platform.

This test codifies the existing behavior, so that at the very least, any changes are understood.

As a summary, arm64 follows what is described as the saturating model, x86/x64 follow a model where 32/64 bit signed conversions have sentinel behavior (where NaN and out of range values are set to minint), and the unsigned conversion is performed via the signed 64bit conversion. And finally arm32 follows a model where 32bit operations are saturating, but 64bit conversions are defined in terms of the CRT 64 bit int signed conversion, which is defined based on the CRT 64 unsigned int conversion.

Implementations are provided in both C++ and C# using only standardized defined behavior. Both C++ and C# are used in order to detect cases where one or the other does not correctly implement conversions over the defined range.