### PR TITLE
Disable slicebuffers_success and RunContinueWithStressTestsNoState test

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -202,6 +202,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/47734")]
         public async Task SliceBuffers_Success()
         {
             if (!SupportsSendFileSlicing) return; // The overloads under test only support sending byte[] without offset and length

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
@@ -41,6 +41,7 @@ namespace System.Threading.Tasks.Tests
 
         // Stresses on multiple continuations from a single antecedent
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [SkipOnCoreClr("Test timing out: https://github.com/dotnet/runtime/issues/2271", RuntimeConfiguration.Checked)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2271")]
         public static void RunContinueWithStressTestsNoState()
         {

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks.Tests
 
         // Stresses on multiple continuations from a single antecedent
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [SkipOnCoreClr("Test timing out: https://github.com/dotnet/runtime/issues/2271", RuntimeConfiguration.Checked)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/2271")]
         public static void RunContinueWithStressTestsNoState()
         {
             int numIterations = 3;


### PR DESCRIPTION
These tests have been failing for a while now, we have issues to track these failures

related issues https://github.com/dotnet/runtime/issues/47734, https://github.com/dotnet/runtime/issues/2271
