### PR TITLE
[release/5.0] Fix lazy machine state unwinding for MSVC epilogues on x86

### DIFF
--- a/src/coreclr/src/vm/i386/gmsx86.cpp
+++ b/src/coreclr/src/vm/i386/gmsx86.cpp
@@ -827,6 +827,8 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
             case 0x89:                          // MOV r/m, reg
                 if (ip[1] == 0xEC)              // MOV ESP, EBP
                     goto mov_esp_ebp;
+                if (ip[1] == 0xDC)              // MOV ESP, EBX
+                    goto mov_esp_ebx;
                 // FALL THROUGH
 
             case 0x18:                          // SBB r/m8, r8
@@ -928,6 +930,13 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 if (ip[1] == 0xE5) {            // MOV ESP, EBP
                 mov_esp_ebp:
                     ESP = PTR_TADDR(lazyState->_ebp);
+                    ip += 2;
+                    break;
+                }
+
+                if (ip[1] == 0xE3) {           // MOV ESP, EBX
+                mov_esp_ebx:
+                    ESP = PTR_TADDR(lazyState->_ebx);
                     ip += 2;
                     break;
                 }


### PR DESCRIPTION
# Description

MSVC introduced changes into their prologue/epilogue helpers. Particularly `_EH_prolog3_catch_GS_align`/`_EH_epilog3_GS_align` had a `mov esp, ebx` instruction the lazy unwinding didn't handle. This helper ended up getting called by 3 FCalls in all coreclr: 

- `DebugDebugger::Log`
- `StubHelpers::ValidateObjec`
- `COMDelegate::BindToMethodName`

# Customer Impact

Customers will see seeing seemingly random behavior once one of these stubs is hit. This manifests as GC holes where the stack walking caused the GC to not find stack roots, effectively unrooting object with references in the stack. A customer reported this from their use of `Debug.WriteLine` .

# Regression?

Yes, with respect to previous releases. The regression was caused by a native toolset update in the build agents.

# Testing

A repro app that used to crash in under a second using GC stress ran successfully for 12+hrs with no issues. 

# Risk

Very targeted fix, both @jkotas and I have stepped through the unwinder logic and it's as minimally invasive as possible while preserving correctness. 