### PR TITLE
Create LclVarAddr with the correct type.

### DIFF
--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -533,7 +533,7 @@ void Rationalizer::RewriteAddress(LIR::Use& use)
 #endif // DEBUG
 
         location->SetOper(addrForm(locationOp));
-        location->gtType = TYP_BYREF;
+        location->gtType = address->TypeGet();
         copyFlags(location, address, GTF_ALL_EFFECT);
 
         use.ReplaceWith(comp, location);


### PR DESCRIPTION
We have such optimization for lclVar addresses that we pass to calls (in `fgMorphArgs`):
```
        if (argx->IsLocalAddrExpr() != nullptr)
        {
            argx->gtType = TYP_I_IMPL;
        }
```
so `ADDR->gtType` could be a better type than `TYP_BYREF`.