### PR TITLE
[coop] Enter GC Unsafe mode in mono_gc_init_finalizer_thread

### DIFF
--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -914,7 +914,9 @@ mono_gc_init_finalizer_thread (void)
 #ifndef LAZY_GC_THREAD_CREATION
 	/* do nothing */
 #else
+	MONO_ENTER_GC_UNSAFE;
 	init_finalizer_thread ();
+	MONO_EXIT_GC_UNSAFE;
 #endif
 }
 


### PR DESCRIPTION
When lazy thread creation is used, this external API function is called from a thread in GC Safe mode, so enter GC Unsafe before calling runtime functions.

Fixes a double transition to GC Safe in `mono_gc_pthread_create`.

Fixes https://github.com/dotnet/runtime/issues/47121