### PR TITLE
[release/5.0] Fix using .NET COM server with `dynamic` keyword (port of #48037)

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
@@ -103,24 +103,28 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
         }
 
         /// <summary>
-        /// Look for typeinfo using IDispatch.GetTypeInfo
+        /// Look for type info using IDispatch.GetTypeInfo
         /// </summary>
         /// <param name="dispatch">IDispatch object</param>
         /// <remarks>
-        /// Some COM objects just dont expose typeinfo. In these cases, this method will return null.
-        /// Some COM objects do intend to expose typeinfo, but may not be able to do so if the type-library is not properly
-        /// registered. This will be considered as acceptable or as an error condition depending on throwIfMissingExpectedTypeInfo
+        /// Some COM objects just don't expose type info. In these cases, this method will return null.
+        /// Some COM objects do intend to expose type info, but may not be able to do so if the type library
+        /// is not properly registered. This will be considered an error.
         /// </remarks>
         /// <returns>Type info</returns>
         internal static ComTypes.ITypeInfo GetITypeInfoFromIDispatch(IDispatch dispatch)
         {
             int hresult = dispatch.TryGetTypeInfoCount(out uint typeCount);
-            Marshal.ThrowExceptionForHR(hresult);
-            Debug.Assert(typeCount <= 1);
             if (typeCount == 0)
             {
+                // COM objects should return a type count of 0 to indicate that type info is not exposed.
+                // Some COM objects may return a non-success HRESULT when type info is not supported, so
+                // we only check the count and not the HRESULT in this case.
                 return null;
             }
+
+            Marshal.ThrowExceptionForHR(hresult);
+            Debug.Assert(typeCount == 1);
 
             IntPtr typeInfoPtr;
             hresult = dispatch.TryGetTypeInfo(0, 0, out typeInfoPtr);

--- a/src/tests/Interop/COM/Dynamic/App.manifest
+++ b/src/tests/Interop/COM/Dynamic/App.manifest
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity
-    type="win32" 
+    type="win32"
     name="COMDynamicTest"
     version="1.0.0.0" />
 
   <dependency>
     <dependentAssembly>
-      <!-- RegFree COM -->
+      <!-- RegFree COM to activate managed server -->
+      <assemblyIdentity
+          type="win32"
+          name="CoreShim.X"
+          version="1.0.0.0"/>
+    </dependentAssembly>
+  </dependency>
+  <dependency>
+    <dependentAssembly>
+      <!-- RegFree COM to activate native server-->
       <assemblyIdentity
           type="win32"
           name="DynamicTestServer.X"

--- a/src/tests/Interop/COM/Dynamic/CoreShim.X.manifest
+++ b/src/tests/Interop/COM/Dynamic/CoreShim.X.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+
+<assemblyIdentity
+  type="win32"
+  name="CoreShim.X"
+  version="1.0.0.0" />
+
+<file name="CoreShim.dll">
+  <!-- ConsumeNETServerTesting -->
+  <comClass
+    clsid="{DE4ACF53-5957-4D31-8BE2-EA6C80683246}"
+    threadingModel="Both" />
+</file>
+
+</assembly>

--- a/src/tests/Interop/COM/Dynamic/Dynamic.csproj
+++ b/src/tests/Interop/COM/Dynamic/Dynamic.csproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
+    <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
     <!-- This test is very slow under some GCStress variations, especially with COMPlus_HeapVerify=1, so disable it under GCStress to avoid test timeouts in the CI.
          Issue: https://github.com/dotnet/runtime/issues/39584
     -->
@@ -18,11 +20,23 @@
     <Compile Include="CollectionTest.cs" />
     <Compile Include="EventTest.cs" />
     <Compile Include="ParametersTest.cs" />
+    <Compile Include="NETServerTest.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ServerGuids.cs" />
+    <Compile Include="../ServerContracts/ServerGuids.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="CoreShim.X.manifest">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Server/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../NETServer/NETServer.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/Dynamic/NETServerTest.cs
+++ b/src/tests/Interop/COM/Dynamic/NETServerTest.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Dynamic
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using TestLibrary;
+
+    internal class NETServerTest
+    {
+        public void Run()
+        {
+            Console.WriteLine($"Running {nameof(NETServerTest)}");
+
+            // Initialize CoreShim and hostpolicymock
+            HostPolicyMock.Initialize(Environment.CurrentDirectory, null);
+            Environment.SetEnvironmentVariable("CORESHIM_COMACT_ASSEMBLYNAME", "NETServer");
+            Environment.SetEnvironmentVariable("CORESHIM_COMACT_TYPENAME", "ConsumeNETServerTesting");
+
+            using (HostPolicyMock.Mock_corehost_resolve_component_dependencies(
+                    0,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty))
+            {
+                Type t = Type.GetTypeFromCLSID(Guid.Parse(Server.Contract.Guids.ConsumeNETServerTesting));
+                dynamic obj = Activator.CreateInstance(t);
+
+                try
+                {
+                    Assert.IsTrue(obj.EqualByCCW(obj));
+                    Assert.IsTrue(obj.NotEqualByRCW(obj));
+                }
+                finally
+                {
+                    obj.ReleaseResources();
+                }
+            }
+        }
+    }
+}

--- a/src/tests/Interop/COM/Dynamic/Program.cs
+++ b/src/tests/Interop/COM/Dynamic/Program.cs
@@ -22,6 +22,7 @@ namespace Dynamic
                 new CollectionTest().Run();
                 new EventTest().Run();
                 new ParametersTest().Run();
+                new NETServerTest().Run();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Issue: #47329
Fix in master: #48037

Minimal version of the fix from master. Only:
- Always treat `IDispatch::GetTypeInfoCount` returning a count of 0 as not supporting type info (even when the returned HRESULT is failure)

## Customer Impact
Customers are unable to use .NET COM servers from a .NET client application with `dynamic`. The only workaround (aside from not using `dynamic`) is to have the .NET COM server explicitly implement `ITypeInfo` - build a type library, manually register it, load the type library when the COM object is created, make the class explicitly implement `ITypeInfo`, forward calls to the type info from the loaded type library, and mark the assembly as imported from a type library. If the client doesn't also own the server being activated, there is no workaround.

## Testing
This PR adds automated tests (most of the changes in this PR).

## Risk
Low. The change is targeted to only usage of `dynamic` with COM objects and the fix is simply to relax an unnecessarily strict return code.

## Regression
No. Support for `dynamic` with COM objects was new in 5.0 (but this is a regression from Framework support)