### PR TITLE
Transition JIT memory management from domains to memory managers

### DIFF
--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -353,9 +353,6 @@ struct _MonoDomain {
 
 	GHashTable	   *generic_virtual_cases;
 
-	/* Information maintained by the JIT engine */
-	gpointer runtime_info;
-
 	/* Contains the compiled runtime invoke wrapper used by finalizers */
 	gpointer            finalize_runtime_invoke;
 
@@ -412,16 +409,6 @@ mono_install_runtime_load  (MonoLoadFunc func);
 
 MonoDomain*
 mono_runtime_load (const char *filename, const char *runtime_version);
-
-typedef void (*MonoCreateDomainFunc) (MonoDomain *domain);
-
-void
-mono_install_create_domain_hook (MonoCreateDomainFunc func);
-
-typedef void (*MonoFreeDomainFunc) (MonoDomain *domain);
-
-void
-mono_install_free_domain_hook (MonoFreeDomainFunc func);
 
 void
 mono_runtime_quit_internal (void);

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -112,10 +112,6 @@ static const MonoRuntimeInfo supported_runtimes[] = {
 /* The stable runtime version */
 #define DEFAULT_RUNTIME_VERSION "v4.0.30319"
 
-/* Callbacks installed by the JIT */
-static MonoCreateDomainFunc create_domain_hook;
-static MonoFreeDomainFunc free_domain_hook;
-
 static GSList*
 get_runtimes_from_exe (const char *exe_file, MonoImage **exe_image);
 
@@ -206,18 +202,6 @@ lock_free_mempool_alloc0 (LockFreeMempool *mp, guint size)
 	}
 
 	return res;
-}
-
-void
-mono_install_create_domain_hook (MonoCreateDomainFunc func)
-{
-	create_domain_hook = func;
-}
-
-void
-mono_install_free_domain_hook (MonoFreeDomainFunc func)
-{
-	free_domain_hook = func;
 }
 
 gboolean
@@ -450,9 +434,6 @@ mono_domain_create (void)
 #endif
 
 	mono_alc_create_default (domain);
-
-	if (create_domain_hook)
-		create_domain_hook (domain);
 
 	MONO_PROFILER_RAISE (domain_loaded, (domain));
 	

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -96,6 +96,9 @@ struct _MonoMemoryManager {
 	/* Information maintained by mono-debug.c */
 	gpointer debug_info;
 
+	/* Information maintained by the execution engine */
+	gpointer runtime_info;
+
 	// !!! REGISTERED AS GC ROOTS !!!
 	// Hashtables for Reflection handles
 	MonoGHashTable *type_hash;

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -21,6 +21,9 @@ memory_manager_init (MonoMemoryManager *memory_manager, MonoDomain *domain, gboo
 	memory_manager->type_hash = mono_g_hash_table_new_type_internal ((GHashFunc)mono_metadata_type_hash, (GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Type Table");
 	memory_manager->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
 	memory_manager->type_init_exception_hash = mono_g_hash_table_new_type_internal (mono_aligned_addr_hash, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Type Initialization Exception Table");
+
+	if (mono_get_runtime_callbacks ()->init_mem_manager)
+		mono_get_runtime_callbacks ()->init_mem_manager (memory_manager);
 }
 
 MonoSingletonMemoryManager *
@@ -76,6 +79,9 @@ static void
 memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
 {
 	// Scan here to assert no lingering references in vtables?
+
+	if (mono_get_runtime_callbacks ()->free_mem_manager)
+		mono_get_runtime_callbacks ()->free_mem_manager (memory_manager);
 
 	if (memory_manager->debug_info) {
 		mono_mem_manager_free_debug_info (memory_manager);

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -637,6 +637,8 @@ typedef struct {
 	GHashTable *(*get_weak_field_indexes) (MonoImage *image);
 	void     (*install_state_summarizer) (void);
 	gboolean (*is_interpreter_enabled) (void);
+	void (*init_mem_manager)(MonoMemoryManager*);
+	void (*free_mem_manager)(MonoMemoryManager*);
 #ifdef ENABLE_METADATA_UPDATE
 	void     (*metadata_update_init) (MonoError *error);
 	void     (*metadata_update_published) (MonoDomain *domain, MonoAssemblyLoadContext *alc, uint32_t generation);

--- a/src/mono/mono/mini/debugger-agent-stubs.c
+++ b/src/mono/mono/mini/debugger-agent-stubs.c
@@ -36,7 +36,7 @@ stub_debugger_agent_single_step_event (void *sigctx)
 }
 
 static void
-stub_debugger_agent_free_domain_info (MonoDomain *domain)
+stub_debugger_agent_free_mem_manager (gpointer mem_manager)
 {
 }
 
@@ -109,7 +109,6 @@ mono_debugger_agent_stub_init (void)
 	cbs.single_step_event = stub_debugger_agent_single_step_event;
 	cbs.single_step_from_context = stub_debugger_agent_single_step_from_context;
 	cbs.breakpoint_from_context = stub_debugger_agent_breakpoint_from_context;
-	cbs.free_domain_info = stub_debugger_agent_free_domain_info;
 	cbs.unhandled_exception = stub_debugger_agent_unhandled_exception;
 	cbs.handle_exception = stub_debugger_agent_handle_exception;
 	cbs.begin_exception_filter = stub_debugger_agent_begin_exception_filter;

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -1761,14 +1761,19 @@ ids_cleanup (void)
 }
 
 static void
-debugger_agent_free_domain_info (MonoDomain *domain)
+debugger_agent_free_mem_manager (gpointer mem_manager)
 {
-	AgentDomainInfo *info = (AgentDomainInfo *)domain_jit_info (domain)->agent_info;
-	int i, j;
+	MonoJitMemoryManager *jit_mm = (MonoJitMemoryManager*)mem_manager;
+	AgentDomainInfo *info = (AgentDomainInfo *)jit_mm->agent_info;
+	int i;
 	GHashTableIter iter;
 	GPtrArray *file_names;
 	char *basename;
 	GSList *l;
+
+	// FIXME:
+	if (mem_manager != get_default_jit_mm ())
+		return;
 
 	if (info) {
 		for (i = 0; i < ID_NUM; ++i)
@@ -1797,8 +1802,9 @@ debugger_agent_free_domain_info (MonoDomain *domain)
 		g_free (info);
 	}
 
-	domain_jit_info (domain)->agent_info = NULL;
+	jit_mm->agent_info = NULL;
 
+#if 0
 	/* Clear ids referencing structures in the domain */
 	dbg_lock ();
 	for (i = 0; i < ID_NUM; ++i) {
@@ -1811,17 +1817,15 @@ debugger_agent_free_domain_info (MonoDomain *domain)
 		}
 	}
 	dbg_unlock ();
-
-	mono_de_domain_remove (domain);
+#endif
 }
 
 static AgentDomainInfo*
-get_agent_domain_info (MonoDomain *domain)
+get_agent_info (void)
 {
 	AgentDomainInfo *info = NULL;
-	MonoJitDomainInfo *jit_info = domain_jit_info (domain);
-
-	info = (AgentDomainInfo *)jit_info->agent_info;
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+	info = (AgentDomainInfo *)jit_mm->agent_info;
 
 	if (info) {
 		mono_memory_read_barrier ();
@@ -1836,7 +1840,7 @@ get_agent_domain_info (MonoDomain *domain)
 
 	mono_memory_write_barrier ();
 
-	gpointer other_info = mono_atomic_cas_ptr (&jit_info->agent_info, info, NULL);
+	gpointer other_info = mono_atomic_cas_ptr (&jit_mm->agent_info, info, NULL);
 
 	if (other_info != NULL) {
 		g_hash_table_destroy (info->loaded_classes);
@@ -1846,7 +1850,7 @@ get_agent_domain_info (MonoDomain *domain)
 		g_free (info);
 	}
 
-	return (AgentDomainInfo *)jit_info->agent_info;
+	return (AgentDomainInfo *)jit_mm->agent_info;
 }
 
 static int
@@ -1858,7 +1862,7 @@ get_id (MonoDomain *domain, IdType type, gpointer val)
 	if (val == NULL)
 		return 0;
 
-	info = get_agent_domain_info (domain);
+	info = get_agent_info ();
 
 	dbg_lock ();
 
@@ -3012,7 +3016,7 @@ static void
 emit_appdomain_load (gpointer key, gpointer value, gpointer user_data)
 {
 	process_profiler_event (EVENT_KIND_APPDOMAIN_CREATE, value);
-	g_hash_table_foreach (get_agent_domain_info ((MonoDomain *)value)->loaded_classes, emit_type_load, NULL);
+	g_hash_table_foreach (get_agent_info ()->loaded_classes, emit_type_load, NULL);
 }
 
 /*
@@ -3846,10 +3850,9 @@ static void
 send_type_load (MonoClass *klass)
 {
 	gboolean type_load = FALSE;
-	MonoDomain *domain = mono_domain_get ();
 	AgentDomainInfo *info = NULL;
 
-	info = get_agent_domain_info (domain);
+	info = get_agent_info ();
 
 	mono_loader_lock ();
 
@@ -3875,7 +3878,7 @@ send_types_for_domain (MonoDomain *domain, void *user_data)
 	MonoDomain* old_domain;
 	AgentDomainInfo *info = NULL;
 
-	info = get_agent_domain_info (domain);
+	info = get_agent_info ();
 	g_assert (info);
 
 	old_domain = mono_domain_get ();
@@ -5794,14 +5797,9 @@ type_comes_from_assembly (gpointer klass, gpointer also_klass, gpointer assembly
 static void
 clear_types_for_assembly (MonoAssembly *assembly)
 {
-	MonoDomain *domain = mono_domain_get ();
 	AgentDomainInfo *info = NULL;
 
-	if (!domain || !domain_jit_info (domain))
-		/* Can happen during shutdown */
-		return;
-
-	info = get_agent_domain_info (domain);
+	info = get_agent_info ();
 
 	mono_loader_lock ();
 	g_hash_table_foreach_remove (info->loaded_classes, type_comes_from_assembly, assembly);
@@ -6336,7 +6334,7 @@ get_types_for_source_file (gpointer key, gpointer value, gpointer user_data)
 	GetTypesForSourceFileArgs *ud = (GetTypesForSourceFileArgs*)user_data;
 	MonoDomain *domain = (MonoDomain*)key;
 
-	AgentDomainInfo *info = (AgentDomainInfo *)domain_jit_info (domain)->agent_info;
+	AgentDomainInfo *info = get_agent_info ();
 
 	/* Update 'source_file_to_class' cache */
 	g_hash_table_iter_init (&iter, info->loaded_classes);
@@ -9859,7 +9857,7 @@ mono_debugger_agent_init (void)
 	cbs.single_step_event = debugger_agent_single_step_event;
 	cbs.single_step_from_context = debugger_agent_single_step_from_context;
 	cbs.breakpoint_from_context = debugger_agent_breakpoint_from_context;
-	cbs.free_domain_info = debugger_agent_free_domain_info;
+	cbs.free_mem_manager = debugger_agent_free_mem_manager;
 	cbs.unhandled_exception = debugger_agent_unhandled_exception;
 	cbs.handle_exception = debugger_agent_handle_exception;
 	cbs.begin_exception_filter = debugger_agent_begin_exception_filter;

--- a/src/mono/mono/mini/debugger-agent.h
+++ b/src/mono/mono/mini/debugger-agent.h
@@ -8,7 +8,7 @@
 #include "mini.h"
 #include <mono/utils/mono-stack-unwinding.h>
 
-#define MONO_DBG_CALLBACKS_VERSION (3)
+#define MONO_DBG_CALLBACKS_VERSION (4)
 // 2. debug_log parameters changed from MonoString* to MonoStringHandle
 // 3. debug_log parameters changed from MonoStringHandle back to MonoString*
 
@@ -20,7 +20,7 @@ struct _MonoDebuggerCallbacks {
 	void (*single_step_event) (void *sigctx);
 	void (*single_step_from_context) (MonoContext *ctx);
 	void (*breakpoint_from_context) (MonoContext *ctx);
-	void (*free_domain_info) (MonoDomain *domain);
+	void (*free_mem_manager) (gpointer mem_manager);
 	void (*unhandled_exception) (MonoException *exc);
 	void (*handle_exception) (MonoException *exc, MonoContext *throw_ctx,
 							  MonoContext *catch_ctx, StackFrameInfo *catch_frame);

--- a/src/mono/mono/mini/debugger-engine.c
+++ b/src/mono/mono/mini/debugger-engine.c
@@ -373,8 +373,10 @@ collect_domain_bp (gpointer key, gpointer value, gpointer user_data)
 	CollectDomainData *ud = (CollectDomainData*)user_data;
 	MonoMethod *m;
 
-	mono_domain_lock (domain);
-	g_hash_table_iter_init (&iter, domain_jit_info (domain)->seq_points);
+	// FIXME:
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+	jit_mm_lock (jit_mm);
+	g_hash_table_iter_init (&iter, jit_mm->seq_points);
 	while (g_hash_table_iter_next (&iter, (void**)&m, (void**)&seq_points)) {
 		if (bp_matches_method (ud->bp, m)) {
 			/* Save the info locally to simplify the code inside the domain lock */
@@ -383,7 +385,7 @@ collect_domain_bp (gpointer key, gpointer value, gpointer user_data)
 			g_ptr_array_add (ud->method_seq_points, seq_points);
 		}
 	}
-	mono_domain_unlock (domain);
+	jit_mm_unlock (jit_mm);
 }
 
 void

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -494,13 +494,11 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 	comp_time = elapsed = 0.0;
 	int local_skip_index = 0;
 
-	/* fixme: ugly hack - delete all previously compiled methods */
-	if (domain_jit_info (domain)) {
-		g_hash_table_destroy (domain_jit_info (domain)->jit_trampoline_hash);
-		domain_jit_info (domain)->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
-		mono_internal_hash_table_destroy (&(domain->jit_code_hash));
-		mono_jit_code_hash_init (&(domain->jit_code_hash));
-	}
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+	g_hash_table_destroy (jit_mm->jit_trampoline_hash);
+	jit_mm->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
+	mono_internal_hash_table_destroy (&(domain->jit_code_hash));
+	mono_jit_code_hash_init (&(domain->jit_code_hash));
 
 	g_timer_start (timer);
 	if (mini_stats_fd)

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -453,12 +453,12 @@ static InterpMethod*
 lookup_imethod (MonoDomain *domain, MonoMethod *method)
 {
 	InterpMethod *imethod;
-	MonoJitDomainInfo *info;
+	MonoJitMemoryManager *jit_mm = jit_mm_for_method (method);
 
-	info = domain_jit_info (domain);
-	mono_domain_jit_code_hash_lock (domain);
-	imethod = (InterpMethod*)mono_internal_hash_table_lookup (&info->interp_code_hash, method);
-	mono_domain_jit_code_hash_unlock (domain);
+	jit_mm_lock (jit_mm);
+	imethod = (InterpMethod*)mono_internal_hash_table_lookup (&jit_mm->interp_code_hash, method);
+	jit_mm_unlock (jit_mm);
+
 	return imethod;
 }
 
@@ -466,16 +466,15 @@ InterpMethod*
 mono_interp_get_imethod (MonoDomain *domain, MonoMethod *method, MonoError *error)
 {
 	InterpMethod *imethod;
-	MonoJitDomainInfo *info;
 	MonoMethodSignature *sig;
+	MonoJitMemoryManager *jit_mm = jit_mm_for_method (method);
 	int i;
 
 	error_init (error);
 
-	info = domain_jit_info (domain);
-	mono_domain_jit_code_hash_lock (domain);
-	imethod = (InterpMethod*)mono_internal_hash_table_lookup (&info->interp_code_hash, method);
-	mono_domain_jit_code_hash_unlock (domain);
+	jit_mm_lock (jit_mm);
+	imethod = (InterpMethod*)mono_internal_hash_table_lookup (&jit_mm->interp_code_hash, method);
+	jit_mm_unlock (jit_mm);
 	if (imethod)
 		return imethod;
 
@@ -496,10 +495,10 @@ mono_interp_get_imethod (MonoDomain *domain, MonoMethod *method, MonoError *erro
 	for (i = 0; i < sig->param_count; ++i)
 		imethod->param_types [i] = mini_get_underlying_type (sig->params [i]);
 
-	mono_domain_jit_code_hash_lock (domain);
-	if (!mono_internal_hash_table_lookup (&info->interp_code_hash, method))
-		mono_internal_hash_table_insert (&info->interp_code_hash, method, imethod);
-	mono_domain_jit_code_hash_unlock (domain);
+	jit_mm_lock (jit_mm);
+	if (!mono_internal_hash_table_lookup (&jit_mm->interp_code_hash, method))
+		mono_internal_hash_table_insert (&jit_mm->interp_code_hash, method, imethod);
+	jit_mm_unlock (jit_mm);
 
 	imethod->prof_flags = mono_profiler_get_call_instrumentation_flags (imethod->method);
 
@@ -2651,14 +2650,13 @@ interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untype
 static InterpMethod*
 lookup_method_pointer (gpointer addr)
 {
-	MonoDomain *domain = mono_domain_get ();
-	MonoJitDomainInfo *info = domain_jit_info (domain);
 	InterpMethod *res = NULL;
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
 
-	mono_domain_lock (domain);
-	if (info->interp_method_pointer_hash)
-		res = (InterpMethod*)g_hash_table_lookup (info->interp_method_pointer_hash, addr);
-	mono_domain_unlock (domain);
+	jit_mm_lock (jit_mm);
+	if (jit_mm->interp_method_pointer_hash)
+		res = (InterpMethod*)g_hash_table_lookup (jit_mm->interp_method_pointer_hash, addr);
+	jit_mm_unlock (jit_mm);
 
 	return res;
 }
@@ -2689,7 +2687,6 @@ interp_create_method_pointer_llvmonly (MonoMethod *method, gboolean unbox, MonoE
 	gpointer addr, entry_func, entry_wrapper;
 	MonoMethodSignature *sig;
 	MonoMethod *wrapper;
-	MonoJitDomainInfo *info;
 	InterpMethod *imethod;
 
 	imethod = mono_interp_get_imethod (domain, method, error);
@@ -2747,12 +2744,13 @@ interp_create_method_pointer_llvmonly (MonoMethod *method, gboolean unbox, MonoE
 
 	addr = mini_llvmonly_create_ftndesc (mono_domain_get (), entry_wrapper, entry_ftndesc);
 
-	info = domain_jit_info (domain);
-	mono_domain_lock (domain);
-	if (!info->interp_method_pointer_hash)
-		info->interp_method_pointer_hash = g_hash_table_new (NULL, NULL);
-	g_hash_table_insert (info->interp_method_pointer_hash, addr, imethod);
-	mono_domain_unlock (domain);
+	// FIXME:
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+	jit_mm_lock (jit_mm);
+	if (!jit_mm->interp_method_pointer_hash)
+		jit_mm->interp_method_pointer_hash = g_hash_table_new (NULL, NULL);
+	g_hash_table_insert (jit_mm->interp_method_pointer_hash, addr, imethod);
+	jit_mm_unlock (jit_mm);
 
 	mono_memory_barrier ();
 	if (unbox)
@@ -2774,7 +2772,6 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 {
 	gpointer addr, entry_func, entry_wrapper = NULL;
 	MonoDomain *domain = mono_domain_get ();
-	MonoJitDomainInfo *info;
 	InterpMethod *imethod = mono_interp_get_imethod (domain, method, error);
 
 	if (imethod->jit_entry)
@@ -2906,12 +2903,12 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 
 	addr = mono_create_ftnptr_arg_trampoline (ftndesc, entry_wrapper);
 
-	info = domain_jit_info (domain);
-	mono_domain_lock (domain);
-	if (!info->interp_method_pointer_hash)
-		info->interp_method_pointer_hash = g_hash_table_new (NULL, NULL);
-	g_hash_table_insert (info->interp_method_pointer_hash, addr, imethod);
-	mono_domain_unlock (domain);
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+	jit_mm_lock (jit_mm);
+	if (!jit_mm->interp_method_pointer_hash)
+		jit_mm->interp_method_pointer_hash = g_hash_table_new (NULL, NULL);
+	g_hash_table_insert (jit_mm->interp_method_pointer_hash, addr, imethod);
+	jit_mm_unlock (jit_mm);
 
 	mono_memory_barrier ();
 	imethod->jit_entry = addr;
@@ -2922,13 +2919,13 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 static void
 interp_free_method (MonoDomain *domain, MonoMethod *method)
 {
-	MonoJitDomainInfo *info = domain_jit_info (domain);
+	MonoJitMemoryManager *jit_mm = jit_mm_for_method (method);
 
-	mono_domain_jit_code_hash_lock (domain);
+	jit_mm_lock (jit_mm);
 	/* InterpMethod is allocated in the domain mempool. We might haven't
 	 * allocated an InterpMethod for this instance yet */
-	mono_internal_hash_table_remove (&info->interp_code_hash, method);
-	mono_domain_jit_code_hash_unlock (domain);
+	mono_internal_hash_table_remove (&jit_mm->interp_code_hash, method);
+	jit_mm_unlock (jit_mm);
 }
 
 #if COUNT_OPS
@@ -7176,12 +7173,12 @@ static void
 interp_print_method_counts (void)
 {
 	MonoDomain *domain = mono_get_root_domain ();
-	MonoJitDomainInfo *info = domain_jit_info (domain);
+	MonoJitMemoryManager *jit_mm = jit_mm_for_method (method);
 
-	mono_domain_jit_code_hash_lock (domain);
-	imethods = (InterpMethod**) malloc (info->interp_code_hash.num_entries * sizeof (InterpMethod*));
-	mono_internal_hash_table_apply (&info->interp_code_hash, interp_add_imethod);
-	mono_domain_jit_code_hash_unlock (domain);
+	jit_mm_lock (jit_mm);
+	imethods = (InterpMethod**) malloc (jit_mm->interp_code_hash.num_entries * sizeof (InterpMethod*));
+	mono_internal_hash_table_apply (&jit_mm->interp_code_hash, interp_add_imethod);
+	jit_mm_unlock (jit_mm);
 
 	qsort (imethods, num_methods, sizeof (InterpMethod*), imethod_opcount_comparer);
 
@@ -7284,10 +7281,13 @@ interp_invalidate_transformed (MonoDomain *domain)
 	mono_stop_world (MONO_THREAD_INFO_FLAGS_NO_GC);
 	metadata_update_prepare_to_invalidate (domain);
 #endif
-	MonoJitDomainInfo *info = domain_jit_info (domain);
-	mono_domain_jit_code_hash_lock (domain);
-	mono_internal_hash_table_apply (&info->interp_code_hash, invalidate_transform);
-	mono_domain_jit_code_hash_unlock (domain);
+
+	// FIXME: Enumerate all memory managers
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+
+	jit_mm_lock (jit_mm);
+	mono_internal_hash_table_apply (&jit_mm->interp_code_hash, invalidate_transform);
+	jit_mm_unlock (jit_mm);
 
 	if (need_stw_restart)
 		mono_restart_world (MONO_THREAD_INFO_FLAGS_NO_GC);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -8563,9 +8563,13 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 		g_printf ("Printing runtime stats at method: %s\n", mono_method_get_full_name (imethod->method));
 		mono_runtime_print_stats ();
 	}
-	if (!g_hash_table_lookup (domain_jit_info (domain)->seq_points, imethod->method))
-		g_hash_table_insert (domain_jit_info (domain)->seq_points, imethod->method, imethod->jinfo->seq_points);
 	mono_domain_unlock (domain);
+
+	MonoJitMemoryManager *jit_mm = jit_mm_for_method (imethod->method);
+	jit_mm_lock (jit_mm);
+	if (!g_hash_table_lookup (jit_mm->seq_points, imethod->method))
+		g_hash_table_insert (jit_mm->seq_points, imethod->method, imethod->jinfo->seq_points);
+	jit_mm_unlock (jit_mm);
 
 	// FIXME: Add a different callback ?
 	MONO_PROFILER_RAISE (jit_done, (method, imethod->jinfo));

--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -92,10 +92,10 @@ alloc_code (LLVMValueRef function, int size)
 	return (unsigned char *)mono_mem_manager_code_reserve (cfg->mem_manager, size);
 }
 
-class MonoJitMemoryManager : public RTDyldMemoryManager
+class MonoLLVMMemoryManager : public RTDyldMemoryManager
 {
 public:
-	~MonoJitMemoryManager() override;
+	~MonoLLVMMemoryManager() override;
 
 	uint8_t *allocateDataSection(uintptr_t Size,
 								 unsigned Alignment,
@@ -113,12 +113,12 @@ private:
 	SmallVector<sys::MemoryBlock, 16> PendingCodeMem;
 };
 
-MonoJitMemoryManager::~MonoJitMemoryManager()
+MonoLLVMMemoryManager::~MonoLLVMMemoryManager()
 {
 }
 
 uint8_t *
-MonoJitMemoryManager::allocateDataSection(uintptr_t Size,
+MonoLLVMMemoryManager::allocateDataSection(uintptr_t Size,
 										  unsigned Alignment,
 										  unsigned SectionID,
 										  StringRef SectionName,
@@ -138,7 +138,7 @@ MonoJitMemoryManager::allocateDataSection(uintptr_t Size,
 }
 
 uint8_t *
-MonoJitMemoryManager::allocateCodeSection(uintptr_t Size,
+MonoLLVMMemoryManager::allocateCodeSection(uintptr_t Size,
 										  unsigned Alignment,
 										  unsigned SectionID,
 										  StringRef SectionName)
@@ -149,7 +149,7 @@ MonoJitMemoryManager::allocateCodeSection(uintptr_t Size,
 }
 
 bool
-MonoJitMemoryManager::finalizeMemory(std::string *ErrMsg)
+MonoLLVMMemoryManager::finalizeMemory(std::string *ErrMsg)
 {
 	for (sys::MemoryBlock &Block : PendingCodeMem) {
 #if LLVM_API_VERSION >= 900
@@ -197,7 +197,7 @@ init_function_pass_manager (legacy::FunctionPassManager &fpm)
 #if LLVM_API_VERSION >= 900
 
 struct MonoLLVMJIT {
-	std::shared_ptr<MonoJitMemoryManager> mmgr;
+	std::shared_ptr<MonoLLVMMemoryManager> mmgr;
 	ExecutionSession execution_session;
 	std::map<VModuleKey, std::shared_ptr<SymbolResolver>> resolvers;
 	TargetMachine *target_machine;
@@ -207,7 +207,7 @@ struct MonoLLVMJIT {
 	legacy::FunctionPassManager fpm;
 
 	MonoLLVMJIT (TargetMachine *tm, Module *pgo_module)
-		: mmgr (std::make_shared<MonoJitMemoryManager>())
+		: mmgr (std::make_shared<MonoLLVMMemoryManager>())
 		, target_machine (tm)
 		, object_layer (
 			AcknowledgeORCv1Deprecation, execution_session,
@@ -331,7 +331,7 @@ public:
 	typedef IRCompileLayer<ObjLayerT, SimpleCompiler> CompileLayerT;
 	typedef CompileLayerT::ModuleHandleT ModuleHandleT;
 
-	MonoLLVMJIT (TargetMachine *TM, MonoJitMemoryManager *mm)
+	MonoLLVMJIT (TargetMachine *TM, MonoLLVMMemoryManager *mm)
 		: TM(TM), ObjectLayer([=] { return std::shared_ptr<RuntimeDyld::MemoryManager> (mm); }),
 		  CompileLayer (ObjectLayer, SimpleCompiler (*TM)),
 		  modules(),
@@ -432,12 +432,12 @@ private:
 	legacy::FunctionPassManager fpm;
 };
 
-static MonoJitMemoryManager *mono_mm;
+static MonoLLVMMemoryManager *mono_mm;
 
 static MonoLLVMJIT *
 make_mono_llvm_jit (TargetMachine *target_machine, llvm::Module *)
 {
-	mono_mm = new MonoJitMemoryManager ();
+	mono_mm = new MonoLLVMMemoryManager ();
 	return new MonoLLVMJIT(target_machine, mono_mm);
 }
 

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -3544,7 +3544,6 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	int dreg;
 	gpointer trampoline;
 	MonoInst *obj, *tramp_ins;
-	MonoDomain *domain;
 	guint8 **code_slot;
 
 	if (virtual_ && !cfg->llvm_only) {
@@ -3597,16 +3596,17 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 		if (target_method_context_used) {
 			code_slot_ins = emit_get_rgctx_method (cfg, target_method_context_used, method, MONO_RGCTX_INFO_METHOD_DELEGATE_CODE);
 		} else {
-			domain = mono_domain_get ();
-			mono_domain_lock (domain);
-			if (!domain_jit_info (domain)->method_code_hash)
-				domain_jit_info (domain)->method_code_hash = g_hash_table_new (NULL, NULL);
-			code_slot = (guint8 **)g_hash_table_lookup (domain_jit_info (domain)->method_code_hash, method);
+			MonoJitMemoryManager *jit_mm = (MonoJitMemoryManager*)cfg->jit_mm;
+
+			jit_mm_lock (jit_mm);
+			if (!jit_mm->method_code_hash)
+				jit_mm->method_code_hash = g_hash_table_new (NULL, NULL);
+			code_slot = (guint8 **)g_hash_table_lookup (jit_mm->method_code_hash, method);
 			if (!code_slot) {
 				code_slot = (guint8 **)m_method_alloc0 (method, sizeof (gpointer));
-				g_hash_table_insert (domain_jit_info (domain)->method_code_hash, method, code_slot);
+				g_hash_table_insert (jit_mm->method_code_hash, method, code_slot);
 			}
-			mono_domain_unlock (domain);
+			jit_mm_unlock (jit_mm);
 
 			code_slot_ins = mini_emit_runtime_constant (cfg, MONO_PATCH_INFO_METHOD_CODE_SLOT, method);
 		}

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -9045,16 +9045,22 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 {
 	SeqPointInfo *info;
 	MonoJitInfo *ji;
+	MonoJitMemoryManager *jit_mm;
+
+	/*
+	 * We don't have access to the method etc. so use the global
+	 * memory manager for now.
+	 */
+	jit_mm = get_default_jit_mm ();
 
 	// FIXME: Add a free function
 
-	mono_domain_lock (domain);
-	info = (SeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->arch_seq_points,
-								code);
-	mono_domain_unlock (domain);
+	jit_mm_lock (jit_mm);
+	info = (SeqPointInfo *)g_hash_table_lookup (jit_mm->arch_seq_points, code);
+	jit_mm_unlock (jit_mm);
 
 	if (!info) {
-		ji = mono_jit_info_table_find (domain, code);
+		ji = mini_jit_info_table_find (code);
 		g_assert (ji);
 
 		// FIXME: Optimize the size
@@ -9062,10 +9068,9 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 
 		info->ss_tramp_addr = &ss_trampoline;
 
-		mono_domain_lock (domain);
-		g_hash_table_insert (domain_jit_info (domain)->arch_seq_points,
-							 code, info);
-		mono_domain_unlock (domain);
+		jit_mm_lock (jit_mm);
+		g_hash_table_insert (jit_mm->arch_seq_points, code, info);
+		jit_mm_unlock (jit_mm);
 	}
 
 	return info;

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -5568,26 +5568,27 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 {
 	SeqPointInfo *info;
 	MonoJitInfo *ji;
+	MonoJitMemoryManager *jit_mm;
+
+	jit_mm = get_default_jit_mm ();
 
 	// FIXME: Add a free function
 
-	mono_domain_lock (domain);
-	info = (SeqPointInfo*)g_hash_table_lookup (domain_jit_info (domain)->arch_seq_points,
-								code);
-	mono_domain_unlock (domain);
+	jit_mm_lock (jit_mm);
+	info = (SeqPointInfo *)g_hash_table_lookup (jit_mm->arch_seq_points, code);
+	jit_mm_unlock (jit_mm);
 
 	if (!info) {
-		ji = mono_jit_info_table_find (domain, code);
+		ji = mini_jit_info_table_find (code);
 		g_assert (ji);
 
 		info = g_malloc0 (sizeof (SeqPointInfo) + (ji->code_size / 4) * sizeof(guint8*));
 
 		info->ss_tramp_addr = &ss_trampoline;
 
-		mono_domain_lock (domain);
-		g_hash_table_insert (domain_jit_info (domain)->arch_seq_points,
-							 code, info);
-		mono_domain_unlock (domain);
+		jit_mm_lock (jit_mm);
+		g_hash_table_insert (jit_mm->arch_seq_points, code, info);
+		jit_mm_unlock (jit_mm);
 	}
 
 	return info;

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -973,11 +973,12 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 	case MONO_RGCTX_INFO_BZERO: {
 		static MonoMethod *memcpy_method [17];
 		static MonoMethod *bzero_method [17];
-		MonoJitDomainInfo *domain_info;
+		MonoJitMemoryManager *jit_mm;
 		int size;
 		guint32 align;
 
-		domain_info = domain_jit_info (domain);
+		/* The memcpy methods are in the default memory alc */
+		jit_mm = get_default_jit_mm ();
 
 		if (MONO_TYPE_IS_REFERENCE (m_class_get_byval_arg (klass))) {
 			size = sizeof (gpointer);
@@ -1005,13 +1006,13 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 				mono_memory_barrier ();
 				memcpy_method [size] = m;
 			}
-			if (!domain_info->memcpy_addr [size]) {
+			if (!jit_mm->memcpy_addr [size]) {
 				gpointer addr = mono_compile_method_checked (memcpy_method [size], error);
 				mono_memory_barrier ();
-				domain_info->memcpy_addr [size] = (gpointer *)addr;
+				jit_mm->memcpy_addr [size] = (gpointer *)addr;
 				mono_error_assert_ok (error);
 			}
-			return domain_info->memcpy_addr [size];
+			return jit_mm->memcpy_addr [size];
 		} else {
 			if (!bzero_method [size]) {
 				MonoMethod *m;
@@ -1026,13 +1027,13 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 				mono_memory_barrier ();
 				bzero_method [size] = m;
 			}
-			if (!domain_info->bzero_addr [size]) {
+			if (!jit_mm->bzero_addr [size]) {
 				gpointer addr = mono_compile_method_checked (bzero_method [size], error);
 				mono_memory_barrier ();
-				domain_info->bzero_addr [size] = (gpointer *)addr;
+				jit_mm->bzero_addr [size] = (gpointer *)addr;
 				mono_error_assert_ok (error);
 			}
-			return domain_info->bzero_addr [size];
+			return jit_mm->bzero_addr [size];
 		}
 	}
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_BOX:
@@ -2009,9 +2010,9 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 	ERROR_DECL (error);
 	gpointer res, info;
 	MonoDomain *domain = mono_domain_get ();
-	MonoJitDomainInfo *domain_info;
 	GSharedVtTrampInfo *tramp_info;
 	GSharedVtTrampInfo tinfo;
+	MonoJitMemoryManager *jit_mm;
 
 	if (mono_llvm_only) {
 		MonoMethod *wrapper;
@@ -2033,16 +2034,17 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 	tinfo.sig = normal_sig;
 	tinfo.gsig = gsharedvt_sig;
 
-	domain_info = domain_jit_info (domain);
+	// FIXME:
+	jit_mm = get_default_jit_mm ();
 
 	/*
 	 * The arg trampolines might only have a finite number in full-aot, so use a cache.
 	 */
-	mono_domain_lock (domain);
-	if (!domain_info->gsharedvt_arg_tramp_hash)
-		domain_info->gsharedvt_arg_tramp_hash = g_hash_table_new (tramp_info_hash, tramp_info_equal);
-	res = g_hash_table_lookup (domain_info->gsharedvt_arg_tramp_hash, &tinfo);
-	mono_domain_unlock (domain);
+	jit_mm_lock (jit_mm);
+	if (!jit_mm->gsharedvt_arg_tramp_hash)
+		jit_mm->gsharedvt_arg_tramp_hash = g_hash_table_new (tramp_info_hash, tramp_info_equal);
+	res = g_hash_table_lookup (jit_mm->gsharedvt_arg_tramp_hash, &tinfo);
+	jit_mm_unlock (jit_mm);
 	if (res)
 		return res;
 
@@ -2085,10 +2087,10 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 	tramp_info = (GSharedVtTrampInfo *)mono_domain_alloc0 (domain, sizeof (GSharedVtTrampInfo));
 	*tramp_info = tinfo;
 
-	mono_domain_lock (domain);
+	jit_mm_lock (jit_mm);
 	/* Duplicates are not a problem */
-	g_hash_table_insert (domain_info->gsharedvt_arg_tramp_hash, tramp_info, addr);
-	mono_domain_unlock (domain);
+	g_hash_table_insert (jit_mm->gsharedvt_arg_tramp_hash, tramp_info, addr);
+	jit_mm_unlock (jit_mm);
 
 	return addr;
 }
@@ -3132,45 +3134,52 @@ mini_method_get_mrgctx (MonoVTable *class_vtable, MonoMethod *method)
 	MonoMethodRuntimeGenericContext *mrgctx;
 	MonoMethodRuntimeGenericContext key;
 	MonoGenericInst *method_inst = mini_method_get_context (method)->method_inst;
-	MonoJitDomainInfo *domain_info = domain_jit_info (domain);
+	MonoJitMemoryManager *jit_mm;
 
 	g_assert (!mono_class_is_gtd (class_vtable->klass));
+
+	jit_mm = jit_mm_for_method (method);
 
 	mono_domain_lock (domain);
 
 	if (!method_inst) {
 		g_assert (mini_method_is_default_method (method));
 
-		if (!domain_info->mrgctx_hash)
-			domain_info->mrgctx_hash = g_hash_table_new (NULL, NULL);
-		mrgctx = (MonoMethodRuntimeGenericContext*)g_hash_table_lookup (domain_info->mrgctx_hash, method);
+		jit_mm_lock (jit_mm);
+		if (!jit_mm->mrgctx_hash)
+			jit_mm->mrgctx_hash = g_hash_table_new (NULL, NULL);
+		mrgctx = (MonoMethodRuntimeGenericContext*)g_hash_table_lookup (jit_mm->mrgctx_hash, method);
+		jit_mm_unlock (jit_mm);
 	} else {
 		g_assert (!method_inst->is_open);
 
-		if (!domain_info->method_rgctx_hash)
-			domain_info->method_rgctx_hash = g_hash_table_new (mrgctx_hash_func, mrgctx_equal_func);
+		jit_mm_lock (jit_mm);
+		if (!jit_mm->method_rgctx_hash)
+			jit_mm->method_rgctx_hash = g_hash_table_new (mrgctx_hash_func, mrgctx_equal_func);
 
 		key.class_vtable = class_vtable;
 		key.method_inst = method_inst;
 
-		mrgctx = (MonoMethodRuntimeGenericContext *)g_hash_table_lookup (domain_info->method_rgctx_hash, &key);
+		mrgctx = (MonoMethodRuntimeGenericContext *)g_hash_table_lookup (jit_mm->method_rgctx_hash, &key);
+		jit_mm_unlock (jit_mm);
 	}
 
 	if (!mrgctx) {
-		//int i;
-
 		mrgctx = (MonoMethodRuntimeGenericContext*)alloc_rgctx_array (domain, 0, TRUE);
 		mrgctx->class_vtable = class_vtable;
 		mrgctx->method_inst = method_inst;
 
+		/* FIXME: The domain lock prevents duplicates */
+		jit_mm_lock (jit_mm);
 		if (!method_inst)
-			g_hash_table_insert (domain_info->mrgctx_hash, method, mrgctx);
+			g_hash_table_insert (jit_mm->mrgctx_hash, method, mrgctx);
 		else
-			g_hash_table_insert (domain_info->method_rgctx_hash, mrgctx, mrgctx);
+			g_hash_table_insert (jit_mm->method_rgctx_hash, mrgctx, mrgctx);
+		jit_mm_unlock (jit_mm);
 
 		/*
 		g_print ("mrgctx alloced for %s <", mono_type_get_full_name (class_vtable->klass));
-		for (i = 0; i < method_inst->type_argc; ++i)
+		for (int i = 0; i < method_inst->type_argc; ++i)
 			g_print ("%s, ", mono_type_full_name (method_inst->type_argv [i]));
 		g_print (">\n");
 		*/

--- a/src/mono/mono/mini/mini-llvm.h
+++ b/src/mono/mono/mini/mini-llvm.h
@@ -7,6 +7,7 @@
 
 #include "mini.h"
 #include "aot-runtime.h"
+#include "mini-runtime.h"
 
 /* LLVM backend */
 
@@ -28,7 +29,7 @@ void mono_llvm_emit_aot_file_info       (MonoAotFileInfo *info, gboolean has_jit
 gpointer mono_llvm_emit_aot_data        (const char *symbol, guint8 *data, int data_len);
 gpointer mono_llvm_emit_aot_data_aligned (const char *symbol, guint8 *data, int data_len, int align);
 void mono_llvm_check_method_supported   (MonoCompile *cfg);
-void mono_llvm_free_domain_info         (MonoDomain *domain);
+void mono_llvm_free_mem_manager         (MonoJitMemoryManager *mem_manager);
 MONO_API void mono_personality              (void);
 void     mono_llvm_create_vars (MonoCompile *cfg);
 void     mono_llvm_fixup_aot_module         (void);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4062,8 +4062,6 @@ mini_create_jit_domain_info (MonoDomain *domain)
 {
 	MonoJitDomainInfo *info = g_new0 (MonoJitDomainInfo, 1);
 
-	info->arch_seq_points = g_hash_table_new (mono_aligned_addr_hash, NULL);
-
 	domain->runtime_info = info;
 }
 
@@ -4079,6 +4077,7 @@ init_jit_mem_manager (MonoMemoryManager *mem_manager)
 	info->delegate_trampoline_hash = g_hash_table_new (class_method_pair_hash, class_method_pair_equal);
 	info->seq_points = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_seq_point_info_free);
 	info->runtime_invoke_hash = mono_conc_hashtable_new_full (mono_aligned_addr_hash, NULL, NULL, runtime_invoke_info_free);
+	info->arch_seq_points = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	mono_jit_code_hash_init (&info->interp_code_hash);
 
 	mem_manager->runtime_info = info;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1786,7 +1786,8 @@ mini_patch_llvm_jit_callees (MonoDomain *domain, MonoMethod *method, gpointer ad
 {
 	MonoJitMemoryManager *jit_mm;
 
-	jit_mm = jit_mm_for_method (method);
+	// FIXME:
+	jit_mm = get_default_jit_mm ();
 	if (!jit_mm->llvm_jit_callees)
 		return;
 
@@ -4156,9 +4157,6 @@ mini_free_jit_domain_info (MonoDomain *domain)
 		g_hash_table_destroy (info->llvm_jit_callees);
 	}
 	mono_internal_hash_table_destroy (&info->interp_code_hash);
-#ifdef ENABLE_LLVM
-	mono_llvm_free_domain_info (domain);
-#endif
 
 	g_free (domain->runtime_info);
 	domain->runtime_info = NULL;
@@ -4200,10 +4198,8 @@ free_jit_mem_manager (MonoMemoryManager *mem_manager)
 		g_hash_table_destroy (info->llvm_jit_callees);
 	}
 	mono_internal_hash_table_destroy (&info->interp_code_hash);
-#if 0
 #ifdef ENABLE_LLVM
-	mono_llvm_free_domain_info (domain);
-#endif
+	mono_llvm_free_mem_manager (info);
 #endif
 
 	g_free (info);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4058,7 +4058,6 @@ mini_create_jit_domain_info (MonoDomain *domain)
 {
 	MonoJitDomainInfo *info = g_new0 (MonoJitDomainInfo, 1);
 
-	info->delegate_trampoline_hash = g_hash_table_new (class_method_pair_hash, class_method_pair_equal);
 	info->llvm_vcall_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	info->runtime_invoke_hash = mono_conc_hashtable_new_full (mono_aligned_addr_hash, NULL, NULL, runtime_invoke_info_free);
 	info->seq_points = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_seq_point_info_free);
@@ -4077,6 +4076,7 @@ init_jit_mem_manager (MonoMemoryManager *mem_manager)
 	info->jump_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	info->jump_target_hash = g_hash_table_new (NULL, NULL);
 	info->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
+	info->delegate_trampoline_hash = g_hash_table_new (class_method_pair_hash, class_method_pair_equal);
 
 	mem_manager->runtime_info = info;
 }

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4128,34 +4128,8 @@ mini_free_jit_domain_info (MonoDomain *domain)
 {
 	MonoJitDomainInfo *info = domain_jit_info (domain);
 
-	g_hash_table_foreach (info->jump_target_hash, delete_jump_list, NULL);
-	g_hash_table_destroy (info->jump_target_hash);
-	if (info->jump_target_got_slot_hash) {
-		g_hash_table_foreach (info->jump_target_got_slot_hash, delete_got_slot_list, NULL);
-		g_hash_table_destroy (info->jump_target_got_slot_hash);
-	}
-	if (info->dynamic_code_hash) {
-		g_hash_table_foreach (info->dynamic_code_hash, dynamic_method_info_free, NULL);
-		g_hash_table_destroy (info->dynamic_code_hash);
-	}
-	g_hash_table_destroy (info->method_code_hash);
-	g_hash_table_destroy (info->jit_trampoline_hash);
-	g_hash_table_destroy (info->delegate_trampoline_hash);
-	g_hash_table_destroy (info->static_rgctx_trampoline_hash);
-	g_hash_table_destroy (info->mrgctx_hash);
-	g_hash_table_destroy (info->method_rgctx_hash);
-	g_hash_table_destroy (info->interp_method_pointer_hash);
-	mono_conc_hashtable_destroy (info->runtime_invoke_hash);
-	g_hash_table_destroy (info->seq_points);
-	g_hash_table_destroy (info->arch_seq_points);
 	if (info->agent_info)
 		mini_get_dbg_callbacks ()->free_domain_info (domain);
-	g_hash_table_destroy (info->gsharedvt_arg_tramp_hash);
-	if (info->llvm_jit_callees) {
-		g_hash_table_foreach (info->llvm_jit_callees, free_jit_callee_list, NULL);
-		g_hash_table_destroy (info->llvm_jit_callees);
-	}
-	mono_internal_hash_table_destroy (&info->interp_code_hash);
 
 	g_free (domain->runtime_info);
 	domain->runtime_info = NULL;

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -15,15 +15,6 @@
 #include "mini.h"
 #include "ee.h"
 
-/* Per-domain information maintained by the JIT */
-typedef struct
-{
-	/* Debugger agent data */
-	gpointer agent_info;
-} MonoJitDomainInfo;
-
-#define domain_jit_info(domain) ((MonoJitDomainInfo*)((domain)->runtime_info))
-
 /*
  * Per-memory manager information maintained by the JIT.
  */

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -27,7 +27,6 @@ typedef struct
 	/* Maps ClassMethodPair -> MonoDelegateTrampInfo */
 	GHashTable *delegate_trampoline_hash;
 	GHashTable *static_rgctx_trampoline_hash;
-	GHashTable *llvm_vcall_trampoline_hash;
 	/* maps MonoMethod -> MonoJitDynamicMethodInfo */
 	GHashTable *dynamic_code_hash;
 	GHashTable *method_code_hash;
@@ -75,7 +74,6 @@ typedef struct {
 	GHashTable *delegate_trampoline_hash;
 	/* Maps ClassMethodPair -> MonoDelegateTrampInfo */
 	GHashTable *static_rgctx_trampoline_hash;
-	GHashTable *llvm_vcall_trampoline_hash;
 	/* maps MonoMethod -> MonoJitDynamicMethodInfo */
 	GHashTable *dynamic_code_hash;
 	GHashTable *method_code_hash;

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -18,49 +18,14 @@
 /* Per-domain information maintained by the JIT */
 typedef struct
 {
-	/* Maps MonoMethod's to a GSList of GOT slot addresses pointing to its code */
-	GHashTable *jump_target_got_slot_hash;
-	GHashTable *jump_target_hash;
-	/* Maps methods/klasses to the address of the given type of trampoline */
-	GHashTable *jump_trampoline_hash;
-	GHashTable *jit_trampoline_hash;
-	/* Maps ClassMethodPair -> MonoDelegateTrampInfo */
-	GHashTable *delegate_trampoline_hash;
-	GHashTable *static_rgctx_trampoline_hash;
-	/* maps MonoMethod -> MonoJitDynamicMethodInfo */
-	GHashTable *dynamic_code_hash;
-	GHashTable *method_code_hash;
-	/* Maps methods to a RuntimeInvokeInfo structure, protected by the associated MonoDomain lock */
-	MonoConcurrentHashTable *runtime_invoke_hash;
-	/* Maps MonoMethod to a GPtrArray containing sequence point locations */
-	/* Protected by the domain lock */
-	GHashTable *seq_points;
 	/* Debugger agent data */
 	gpointer agent_info;
-	/* Maps MonoMethod to an arch-specific structure */
-	GHashTable *arch_seq_points;
-	/* Maps a GSharedVtTrampInfo structure to a trampoline address */
-	GHashTable *gsharedvt_arg_tramp_hash;
-	/* memcpy/bzero methods specialized for small constant sizes */
-	gpointer *memcpy_addr [17];
-	gpointer *bzero_addr [17];
-	gpointer llvm_module;
-	/* Maps MonoMethod -> GSlist of addresses */
-	GHashTable *llvm_jit_callees;
-	/* Maps MonoMethod -> RuntimeMethod */
-	MonoInternalHashTable interp_code_hash;
-	/* Maps MonoMethod -> 	MonoMethodRuntimeGenericContext */
-	GHashTable *mrgctx_hash;
-	GHashTable *method_rgctx_hash;
-	/* Maps gpointer -> InterpMethod */
-	GHashTable *interp_method_pointer_hash;
 } MonoJitDomainInfo;
 
 #define domain_jit_info(domain) ((MonoJitDomainInfo*)((domain)->runtime_info))
 
 /*
  * Per-memory manager information maintained by the JIT.
- * FIXME: Move all data from MonoJitDomainInfo here.
  */
 typedef struct {
 	MonoMemoryManager *mem_manager;

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -111,6 +111,12 @@ jit_mm_for_method (MonoMethod *method)
 	return (MonoJitMemoryManager*)m_method_get_mem_manager (method)->runtime_info;
 }
 
+static inline MonoJitMemoryManager*
+get_default_jit_mm (void)
+{
+	return (MonoJitMemoryManager*)(mono_domain_ambient_memory_manager (mono_get_root_domain ()))->runtime_info;
+}
+
 static inline void
 jit_mm_lock (MonoJitMemoryManager *jit_mm)
 {

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -69,15 +69,20 @@ typedef struct {
 } MonoJitMemoryManager;
 
 static inline MonoJitMemoryManager*
-jit_mm_for_method (MonoMethod *method)
-{
-	return (MonoJitMemoryManager*)m_method_get_mem_manager (method)->runtime_info;
-}
-
-static inline MonoJitMemoryManager*
 get_default_jit_mm (void)
 {
 	return (MonoJitMemoryManager*)(mono_domain_ambient_memory_manager (mono_get_root_domain ()))->runtime_info;
+}
+
+static inline MonoJitMemoryManager*
+jit_mm_for_method (MonoMethod *method)
+{
+	/*
+	 * Some places might not look up the correct memory manager because of generic instances/generic sharing etc.
+	 * So use the same memory manager everywhere, this is not a problem since we don't support unloading yet.
+	 */
+	//return (MonoJitMemoryManager*)m_method_get_mem_manager (method)->runtime_info;
+	return get_default_jit_mm ();
 }
 
 static inline void

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -24,8 +24,8 @@ typedef struct
 	/* Maps methods/klasses to the address of the given type of trampoline */
 	GHashTable *jump_trampoline_hash;
 	GHashTable *jit_trampoline_hash;
-	GHashTable *delegate_trampoline_hash;
 	/* Maps ClassMethodPair -> MonoDelegateTrampInfo */
+	GHashTable *delegate_trampoline_hash;
 	GHashTable *static_rgctx_trampoline_hash;
 	GHashTable *llvm_vcall_trampoline_hash;
 	/* maps MonoMethod -> MonoJitDynamicMethodInfo */
@@ -58,6 +58,70 @@ typedef struct
 } MonoJitDomainInfo;
 
 #define domain_jit_info(domain) ((MonoJitDomainInfo*)((domain)->runtime_info))
+
+/*
+ * Per-memory manager information maintained by the JIT.
+ * FIXME: Move all data from MonoJitDomainInfo here.
+ */
+typedef struct {
+	MonoMemoryManager *mem_manager;
+
+	/* Maps MonoMethod's to a GSList of GOT slot addresses pointing to its code */
+	GHashTable *jump_target_got_slot_hash;
+	GHashTable *jump_target_hash;
+	/* Maps methods/klasses to the address of the given type of trampoline */
+	GHashTable *jump_trampoline_hash;
+	GHashTable *jit_trampoline_hash;
+	GHashTable *delegate_trampoline_hash;
+	/* Maps ClassMethodPair -> MonoDelegateTrampInfo */
+	GHashTable *static_rgctx_trampoline_hash;
+	GHashTable *llvm_vcall_trampoline_hash;
+	/* maps MonoMethod -> MonoJitDynamicMethodInfo */
+	GHashTable *dynamic_code_hash;
+	GHashTable *method_code_hash;
+	/* Maps methods to a RuntimeInvokeInfo structure, protected by the associated MonoDomain lock */
+	MonoConcurrentHashTable *runtime_invoke_hash;
+	/* Maps MonoMethod to a GPtrArray containing sequence point locations */
+	/* Protected by the domain lock */
+	GHashTable *seq_points;
+	/* Debugger agent data */
+	gpointer agent_info;
+	/* Maps MonoMethod to an arch-specific structure */
+	GHashTable *arch_seq_points;
+	/* Maps a GSharedVtTrampInfo structure to a trampoline address */
+	GHashTable *gsharedvt_arg_tramp_hash;
+	/* memcpy/bzero methods specialized for small constant sizes */
+	gpointer *memcpy_addr [17];
+	gpointer *bzero_addr [17];
+	gpointer llvm_module;
+	/* Maps MonoMethod -> GSlist of addresses */
+	GHashTable *llvm_jit_callees;
+	/* Maps MonoMethod -> RuntimeMethod */
+	MonoInternalHashTable interp_code_hash;
+	/* Maps MonoMethod -> 	MonoMethodRuntimeGenericContext */
+	GHashTable *mrgctx_hash;
+	GHashTable *method_rgctx_hash;
+	/* Maps gpointer -> InterpMethod */
+	GHashTable *interp_method_pointer_hash;
+} MonoJitMemoryManager;
+
+static inline MonoJitMemoryManager*
+jit_mm_for_method (MonoMethod *method)
+{
+	return (MonoJitMemoryManager*)m_method_get_mem_manager (method)->runtime_info;
+}
+
+static inline void
+jit_mm_lock (MonoJitMemoryManager *jit_mm)
+{
+	mono_mem_manager_lock (jit_mm->mem_manager);
+}
+
+static inline void
+jit_mm_unlock (MonoJitMemoryManager *jit_mm)
+{
+	mono_mem_manager_unlock (jit_mm->mem_manager);
+}
 
 /*
  * Stores state need to resume exception handling when using LLVM

--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -6845,13 +6845,16 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 {
 	SeqPointInfo *info;
 	MonoJitInfo *ji;
+	MonoJitMemoryManager *jit_mm;
 
-	mono_domain_lock (domain);
-	info = (SeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->arch_seq_points, code);
-	mono_domain_unlock (domain);
+	jit_mm = get_default_jit_mm ();
+
+	jit_mm_lock (jit_mm);
+	info = (SeqPointInfo *)g_hash_table_lookup (jit_mm->arch_seq_points, code);
+	jit_mm_unlock (jit_mm);
 
 	if (!info) {
-		ji = mono_jit_info_table_find (domain, code);
+		ji = mini_jit_info_table_find (code);
 		g_assert (ji);
 
 		// FIXME: Optimize the size
@@ -6859,9 +6862,9 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 
 		info->ss_tramp_addr = &ss_trampoline;
 
-		mono_domain_lock (domain);
-		g_hash_table_insert (domain_jit_info(domain)->arch_seq_points, code, info);
-		mono_domain_unlock (domain);
+		jit_mm_lock (jit_mm);
+		g_hash_table_insert (jit_mm->arch_seq_points, code, info);
+		jit_mm_unlock (jit_mm);
 	}
 
 	return info;

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3103,6 +3103,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	cfg->self_init = (flags & JIT_FLAG_SELF_INIT) != 0;
 	cfg->code_exec_only = (flags & JIT_FLAG_CODE_EXEC_ONLY) != 0;
 	cfg->backend = current_backend;
+	cfg->jit_mm = jit_mm_for_method (cfg->method);
 	cfg->mem_manager = m_method_get_mem_manager (cfg->method);
 
 	if (cfg->method->wrapper_type == MONO_WRAPPER_ALLOC) {

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -949,26 +949,6 @@ mini_assembly_can_skip_verification (MonoDomain *domain, MonoMethod *method)
 	return mono_assembly_has_skip_verification (assembly);
 }
 
-static void
-mono_dynamic_code_hash_insert (MonoDomain *domain, MonoMethod *method, MonoJitDynamicMethodInfo *ji)
-{
-	if (!domain_jit_info (domain)->dynamic_code_hash)
-		domain_jit_info (domain)->dynamic_code_hash = g_hash_table_new (NULL, NULL);
-	g_hash_table_insert (domain_jit_info (domain)->dynamic_code_hash, method, ji);
-}
-
-static MonoJitDynamicMethodInfo*
-mono_dynamic_code_hash_lookup (MonoDomain *domain, MonoMethod *method)
-{
-	MonoJitDynamicMethodInfo *res;
-
-	if (domain_jit_info (domain)->dynamic_code_hash)
-		res = (MonoJitDynamicMethodInfo *)g_hash_table_lookup (domain_jit_info (domain)->dynamic_code_hash, method);
-	else
-		res = NULL;
-	return res;
-}
-
 typedef struct {
 	MonoClass *vtype;
 	GList *active, *inactive;
@@ -2147,9 +2127,13 @@ mono_codegen (MonoCompile *cfg)
 		/* Allocate the code into a separate memory pool so it can be freed */
 		cfg->dynamic_info = g_new0 (MonoJitDynamicMethodInfo, 1);
 		cfg->dynamic_info->code_mp = mono_code_manager_new_dynamic ();
-		mono_domain_lock (cfg->domain);
-		mono_dynamic_code_hash_insert (cfg->domain, cfg->method, cfg->dynamic_info);
-		mono_domain_unlock (cfg->domain);
+
+		MonoJitMemoryManager *jit_mm = (MonoJitMemoryManager*)cfg->jit_mm;
+		jit_mm_lock (jit_mm);
+		if (!jit_mm->dynamic_code_hash)
+			jit_mm->dynamic_code_hash = g_hash_table_new (NULL, NULL);
+		g_hash_table_insert (jit_mm->dynamic_code_hash, cfg->method, cfg->dynamic_info);
+		jit_mm_unlock (jit_mm);
 
 		if (mono_using_xdebug)
 			/* See the comment for cfg->code_domain */
@@ -3821,13 +3805,21 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	if (!cfg->compile_aot && !(flags & JIT_FLAG_DISCARD_RESULTS)) {
 		mono_domain_lock (cfg->domain);
 		mono_jit_info_table_add (cfg->domain, cfg->jit_info);
+		mono_domain_unlock (cfg->domain);
 
-		if (cfg->method->dynamic)
-			mono_dynamic_code_hash_lookup (cfg->domain, cfg->method)->ji = cfg->jit_info;
+		if (cfg->method->dynamic) {
+			MonoJitMemoryManager *jit_mm = (MonoJitMemoryManager*)cfg->jit_mm;
+			MonoJitDynamicMethodInfo *res;
+
+			jit_mm_lock (jit_mm);
+			g_assert (jit_mm->dynamic_code_hash);
+			res = (MonoJitDynamicMethodInfo *)g_hash_table_lookup (jit_mm->dynamic_code_hash, method);
+			jit_mm_unlock (jit_mm);
+			g_assert (res);
+			res->ji = cfg->jit_info;
+		}
 
 		mono_postprocess_patches_after_ji_publish (cfg);
-
-		mono_domain_unlock (cfg->domain);
 	}
 
 #if 0

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1352,6 +1352,7 @@ typedef struct {
 
 	MonoGSharedVtMethodInfo *gsharedvt_info;
 
+	gpointer jit_mm;
 	MonoMemoryManager *mem_manager;
 
 	/* Points to the gsharedvt locals area at runtime */


### PR DESCRIPTION
Move all the data from the per-domain MonoJitDomainInfo structure to the per-memory manager MonoJitMemoryManager structure. To prevent regressions, use the memory manager of the default alc for now.
