### PR TITLE
Make ApkBuilder optionally generate debuggable apk

### DIFF
--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -207,8 +207,9 @@ public class ApkBuilder
 
         // 3. Generate APK
 
+        string debugModeArg = StripDebugSymbols ? string.Empty : "--debug-mode";
         string apkFile = Path.Combine(OutputDir, "bin", $"{ProjectName}.unaligned.apk");
-        Utils.RunProcess(aapt, $"package -f -m -F {apkFile} -A assets -M AndroidManifest.xml -I {androidJar}", workingDir: OutputDir);
+        Utils.RunProcess(aapt, $"package -f -m -F {apkFile} -A assets -M AndroidManifest.xml -I {androidJar} {debugModeArg}", workingDir: OutputDir);
 
         var dynamicLibs = new List<string>();
         dynamicLibs.Add(Path.Combine(OutputDir, "monodroid", "libmonodroid.so"));


### PR DESCRIPTION
Generate debuggable APK if `StripDebugSymbols=false`.

The tests always set `StripDebugSymbols=false`. The sample app sets it to true when building Release, false otherwise.