### PR TITLE
Add test for EventListener consuming ThreadPool events 

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipePayloadDecoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipePayloadDecoder.cs
@@ -28,6 +28,7 @@ namespace System.Diagnostics.Tracing
                 }
 
                 Type parameterType = parameters[i].ParameterType;
+                Debug.WriteLine($"[EPPayloadDecoder] parameterType: {parameterType.ToString()}");
                 if (parameterType == typeof(IntPtr))
                 {
                     if (IntPtr.Size == 8)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipePayloadDecoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipePayloadDecoder.cs
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tracing
                 }
                 else
                 {
-                    Debug.Fail("Unsupported type encountered.");
+                    Debug.Fail($"Unsupported type \"{parameterType}\" encountered.");
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipePayloadDecoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipePayloadDecoder.cs
@@ -28,7 +28,7 @@ namespace System.Diagnostics.Tracing
                 }
 
                 Type parameterType = parameters[i].ParameterType;
-                Debug.WriteLine($"[EPPayloadDecoder] parameterType: {parameterType.ToString()}");
+                Type? enumType = parameterType.IsEnum ? Enum.GetUnderlyingType(parameterType) : null;
                 if (parameterType == typeof(IntPtr))
                 {
                     if (IntPtr.Size == 8)
@@ -41,42 +41,42 @@ namespace System.Diagnostics.Tracing
                     }
                     payload = payload.Slice(IntPtr.Size);
                 }
-                else if (parameterType == typeof(int))
+                else if (parameterType == typeof(int) || enumType == typeof(int))
                 {
                     decodedFields[i] = BinaryPrimitives.ReadInt32LittleEndian(payload);
                     payload = payload.Slice(sizeof(int));
                 }
-                else if (parameterType == typeof(uint))
+                else if (parameterType == typeof(uint) || enumType == typeof(uint))
                 {
                     decodedFields[i] = BinaryPrimitives.ReadUInt32LittleEndian(payload);
                     payload = payload.Slice(sizeof(uint));
                 }
-                else if (parameterType == typeof(long))
+                else if (parameterType == typeof(long) || enumType == typeof(long))
                 {
                     decodedFields[i] = BinaryPrimitives.ReadInt64LittleEndian(payload);
                     payload = payload.Slice(sizeof(long));
                 }
-                else if (parameterType == typeof(ulong))
+                else if (parameterType == typeof(ulong) || enumType == typeof(ulong))
                 {
                     decodedFields[i] = BinaryPrimitives.ReadUInt64LittleEndian(payload);
                     payload = payload.Slice(sizeof(ulong));
                 }
-                else if (parameterType == typeof(byte))
+                else if (parameterType == typeof(byte) || enumType == typeof(byte))
                 {
                     decodedFields[i] = MemoryMarshal.Read<byte>(payload);
                     payload = payload.Slice(sizeof(byte));
                 }
-                else if (parameterType == typeof(sbyte))
+                else if (parameterType == typeof(sbyte) || enumType == typeof(sbyte))
                 {
                     decodedFields[i] = MemoryMarshal.Read<sbyte>(payload);
                     payload = payload.Slice(sizeof(sbyte));
                 }
-                else if (parameterType == typeof(short))
+                else if (parameterType == typeof(short) || enumType == typeof(short))
                 {
                     decodedFields[i] = BinaryPrimitives.ReadInt16LittleEndian(payload);
                     payload = payload.Slice(sizeof(short));
                 }
-                else if (parameterType == typeof(ushort))
+                else if (parameterType == typeof(ushort) || enumType == typeof(ushort))
                 {
                     decodedFields[i] = BinaryPrimitives.ReadUInt16LittleEndian(payload);
                     payload = payload.Slice(sizeof(ushort));
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tracing
                 }
                 else
                 {
-                    Debug.Fail($"Unsupported type \"{parameterType}\" encountered.");
+                    Debug.Fail("Unsupported type encountered.");
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
@@ -52,6 +52,7 @@ namespace System.Diagnostics.Tracing
             }
 
             // Decode the payload.
+            Debug.WriteLine($"Decoding payload: {eventID}");
             object[] decodedPayloadFields = EventPipePayloadDecoder.DecodePayload(ref m_eventData[eventID], payload);
 
             var eventCallbackArgs = new EventWrittenEventArgs(this, (int)eventID, &activityId, &childActivityId)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.cs
@@ -52,7 +52,6 @@ namespace System.Diagnostics.Tracing
             }
 
             // Decode the payload.
-            Debug.WriteLine($"Decoding payload: {eventID}");
             object[] decodedPayloadFields = EventPipePayloadDecoder.DecodePayload(ref m_eventData[eventID], payload);
 
             var eventCallbackArgs = new EventWrittenEventArgs(this, (int)eventID, &activityId, &childActivityId)

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1714,6 +1714,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/22021/consumer/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventlistener/**">
+            <Issue>needs triage</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracevalidation/jittingstarted/JittingStarted/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using System.Threading.Tasks;
+using Tracing.Tests.Common;
+
+namespace Tracing.Tests
+{
+    internal sealed class RuntimeEventListener : EventListener
+    {
+        private readonly string _targetSourceName;
+        private readonly EventLevel _level;
+        
+        public int TPWorkerThreadStartCount = 0;
+        public int TPWorkerThreadStopCount = 0;
+        public int TPWorkerThreadWaitCount = 0;
+        
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name.Equals("Microsoft-Windows-DotNETRuntime"))
+            {
+                EnableEvents(source, EventLevel.Informational, (EventKeywords)0x10000);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName.Equals("ThreadPoolWorkerThreadStart"))
+            {
+                TPWorkerThreadStartCount += 1;
+            }
+            else if (eventData.EventName.Equals("ThreadPoolWorkerThreadStop"))
+            {
+                TPWorkerThreadStopCount += 1;
+            }
+            else if (eventData.EventName.Equals("ThreadPoolWorkerThreadWait"))
+            {
+                TPWorkerThreadWaitCount += 1;
+            }
+        }
+    }
+
+    class EventPipeSmoke
+    {
+        private static int messageIterations = 100;
+
+        static int Main(string[] args)
+        {
+            bool pass = false;
+            using (RuntimeEventListener listener = new RuntimeEventListener())
+            {
+                int someNumber = 0;
+                Task[] tasks = new Task[100];
+                for (int i = 0; i < tasks.Length; i++) 
+                {
+                    tasks[i] = Task.Run(() => { someNumber += 1; });
+                }
+                Task.WaitAll(tasks);
+                Thread.Sleep(1000);
+
+                if (listener.TPWorkerThreadStartCount > 10 ||
+                    listener.TPWorkerThreadStopCount > 10 ||
+                    listener.TPWorkerThreadWaitCount > 10)
+                {
+                    Console.WriteLine("Test Passed.");
+                    return 100;
+                }
+                else
+                {
+                    Console.WriteLine("Test Failed: Did not see any of the expected events.");
+                    Console.WriteLine($"ThreadPoolWorkerThreadStartCount: {listener.TPWorkerThreadStartCount}");
+                    Console.WriteLine($"ThreadPoolWorkerThreadStopCount: {listener.TPWorkerThreadStopCount}");
+                    Console.WriteLine($"ThreadPoolWorkerThreadWaitCount: {listener.TPWorkerThreadWaitCount}");
+                    return -1;
+                }
+            }
+        }
+    }
+}

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -11,8 +11,6 @@ namespace Tracing.Tests
 {
     internal sealed class RuntimeEventListener : EventListener
     {
-        private readonly EventLevel _level;
-        
         public int TPWorkerThreadStartCount = 0;
         public int TPWorkerThreadStopCount = 0;
         public int TPWorkerThreadWaitCount = 0;

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -11,7 +11,6 @@ namespace Tracing.Tests
 {
     internal sealed class RuntimeEventListener : EventListener
     {
-        private readonly string _targetSourceName;
         private readonly EventLevel _level;
         
         public int TPWorkerThreadStartCount = 0;
@@ -45,11 +44,8 @@ namespace Tracing.Tests
 
     class EventPipeSmoke
     {
-        private static int messageIterations = 100;
-
         static int Main(string[] args)
         {
-            bool pass = false;
             using (RuntimeEventListener listener = new RuntimeEventListener())
             {
                 int someNumber = 0;
@@ -59,7 +55,7 @@ namespace Tracing.Tests
                     tasks[i] = Task.Run(() => { someNumber += 1; });
                 }
                 Task.WaitAll(tasks);
-                Thread.Sleep(1000);
+                Thread.Sleep(3000);
 
                 if (listener.TPWorkerThreadStartCount > 10 ||
                     listener.TPWorkerThreadStopCount > 10 ||

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -27,18 +27,16 @@ namespace Tracing.Tests
         {
             if (eventData.EventName.Equals("ThreadPoolWorkerThreadStart"))
             {
-                TPWorkerThreadStartCount += 1;
+                Interlocked.Increment(ref TPWorkerThreadStartCount);
             }
             else if (eventData.EventName.Equals("ThreadPoolWorkerThreadStop"))
             {
-                TPWorkerThreadStopCount += 1;
+                Interlocked.Increment(ref TPWorkerThreadStopCount);
             }
             else if (eventData.EventName.Equals("ThreadPoolWorkerThreadWait"))
             {
-                TPWorkerThreadWaitCount += 1;
+                Interlocked.Increment(ref TPWorkerThreadWaitCount);
             }
-
-            Thread.MemoryBarrier();
         }
     }
 
@@ -57,7 +55,7 @@ namespace Tracing.Tests
 
                 Task.WaitAll(tasks);
 
-                Thread.MemoryBarrier();
+                Interlocked.MemoryBarrierProcessWide();
                 if (listener.TPWorkerThreadStartCount > 0 ||
                     listener.TPWorkerThreadStopCount > 0 ||
                     listener.TPWorkerThreadWaitCount > 0)

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -52,8 +52,8 @@ namespace Tracing.Tests
                 {
                     tasks[i] = Task.Run(() => { someNumber += 1; });
                 }
+
                 Task.WaitAll(tasks);
-                Thread.Sleep(3000);
 
                 if (listener.TPWorkerThreadStartCount > 0 ||
                     listener.TPWorkerThreadStopCount > 0 ||

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -55,9 +55,9 @@ namespace Tracing.Tests
                 Task.WaitAll(tasks);
                 Thread.Sleep(3000);
 
-                if (listener.TPWorkerThreadStartCount > 10 ||
-                    listener.TPWorkerThreadStopCount > 10 ||
-                    listener.TPWorkerThreadWaitCount > 10)
+                if (listener.TPWorkerThreadStartCount > 0 ||
+                    listener.TPWorkerThreadStopCount > 0 ||
+                    listener.TPWorkerThreadWaitCount > 0)
                 {
                     Console.WriteLine("Test Passed.");
                     return 100;

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -40,7 +40,7 @@ namespace Tracing.Tests
         }
     }
 
-    class EventPipeSmoke
+    class EventListenerThreadPool
     {
         static int Main(string[] args)
         {

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -11,9 +11,9 @@ namespace Tracing.Tests
 {
     internal sealed class RuntimeEventListener : EventListener
     {
-        public int TPWorkerThreadStartCount = 0;
-        public int TPWorkerThreadStopCount = 0;
-        public int TPWorkerThreadWaitCount = 0;
+        public volatile int TPWorkerThreadStartCount = 0;
+        public volatile int TPWorkerThreadStopCount = 0;
+        public volatile int TPWorkerThreadWaitCount = 0;
         
         protected override void OnEventSourceCreated(EventSource source)
         {
@@ -37,6 +37,8 @@ namespace Tracing.Tests
             {
                 TPWorkerThreadWaitCount += 1;
             }
+
+            Thread.MemoryBarrier();
         }
     }
 
@@ -55,6 +57,7 @@ namespace Tracing.Tests
 
                 Task.WaitAll(tasks);
 
+                Thread.MemoryBarrier();
                 if (listener.TPWorkerThreadStartCount > 0 ||
                     listener.TPWorkerThreadStopCount > 0 ||
                     listener.TPWorkerThreadWaitCount > 0)

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
 using System.Diagnostics.Tracing;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
@@ -4,6 +4,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EventListenerThreadPool.cs" />

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="EventListenerThreadPool.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We don't have any test covering the case where an EventListener is used to consume ThreadPool events. This PR adds one.  