### PR TITLE
Disable TestOnExecuteCustomCommand() for WSC

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.XUnitExtensions;
 using System.Diagnostics;
 using Xunit;
 
@@ -141,6 +142,11 @@ namespace System.ServiceProcess.Tests
         [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnExecuteCustomCommand()
         {
+            if (PlatformDetection.IsWindowsServerCore)
+            {
+                throw new SkipTestException("Skip on Windows Server Core"); // https://github.com/dotnet/runtime/issues/43207
+            }
+
             ServiceController controller = ConnectToServer();
 
             controller.ExecuteCommand(128);


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/43207

(By disabling on Windows Server Core: not a fix, but I don't believe we'll be investigating why it doesn't work there. It does work on Nano.)