### PR TITLE
Use SHA256 one-shot for CrlCache

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -28,9 +28,6 @@ namespace Internal.Cryptography.Pal
 
         private const ulong X509_R_CERT_ALREADY_IN_HASH_TABLE = 0x0B07D065;
 
-        [ThreadStatic]
-        private static HashAlgorithm? ts_urlHash;
-
         public static void AddCrlForCertificate(
             SafeX509Handle cert,
             SafeX509StoreHandle store,
@@ -216,18 +213,13 @@ namespace Internal.Cryptography.Pal
 
             uint persistentHash = unchecked((uint)persistentHashLong);
 
-            if (ts_urlHash == null)
-            {
-                ts_urlHash = SHA256.Create();
-            }
-
             Span<byte> hash = stackalloc byte[256 >> 3];
 
             // Endianness isn't important, it just needs to be consistent.
             // (Even if the same storage was used for two different endianness systems it'd stabilize at two files).
             ReadOnlySpan<byte> utf16Url = MemoryMarshal.AsBytes(crlUrl.AsSpan());
 
-            if (!ts_urlHash.TryComputeHash(utf16Url, hash, out int written) || written != hash.Length)
+            if (!SHA256.TryHashData(utf16Url, hash, out int written) || written != hash.Length)
             {
                 Debug.Fail("TryComputeHash failed or produced an incorrect length output");
                 throw new CryptographicException();

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -218,9 +218,9 @@ namespace Internal.Cryptography.Pal
             // (Even if the same storage was used for two different endianness systems it'd stabilize at two files).
             ReadOnlySpan<byte> utf16Url = MemoryMarshal.AsBytes(crlUrl.AsSpan());
 
-            if (!SHA256.TryHashData(utf16Url, hash, out int written) || written != hash.Length)
+            if (SHA256.HashData(utf16Url, hash) != hash.Length)
             {
-                Debug.Fail("TryHashData failed or produced an incorrect length output");
+                Debug.Fail("HashData failed or produced an incorrect length output");
                 throw new CryptographicException();
             }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -212,7 +212,6 @@ namespace Internal.Cryptography.Pal
             }
 
             uint persistentHash = unchecked((uint)persistentHashLong);
-
             Span<byte> hash = stackalloc byte[256 >> 3];
 
             // Endianness isn't important, it just needs to be consistent.
@@ -221,7 +220,7 @@ namespace Internal.Cryptography.Pal
 
             if (!SHA256.TryHashData(utf16Url, hash, out int written) || written != hash.Length)
             {
-                Debug.Fail("TryComputeHash failed or produced an incorrect length output");
+                Debug.Fail("TryHashData failed or produced an incorrect length output");
                 throw new CryptographicException();
             }
 


### PR DESCRIPTION
One more place we can use a hash one-shot instead of a thread-static instance.