### PR TITLE
JIT: workaround for unreliable change detection in fgReorderBlocks

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4514,6 +4514,14 @@ PhaseStatus Compiler::optOptimizeLayout()
     madeChanges |= fgReorderBlocks();
     madeChanges |= fgUpdateFlowGraph();
 
+    // fgReorderBlocks can cause unreported IR changes; it calls gtPrepareCost
+    // which can lead to operand swapping. Work around this for now.
+    //
+    // Note phase status only impacts dumping and checking done post-phase,
+    // it has no impact on a release build.
+    //
+    madeChanges = true;
+
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4484,7 +4484,7 @@ PhaseStatus Compiler::optInvertLoops()
         }
     }
 
-    const bool madeChanges = fgModified;
+    bool madeChanges = fgModified;
 
     if (madeChanges)
     {
@@ -4492,6 +4492,15 @@ PhaseStatus Compiler::optInvertLoops()
         //
         fgModified = false;
     }
+
+    // optInvertWhileLoop can cause IR changes even if it does not modify
+    // the flow graph. It calls gtPrepareCost which can cause operand swapping.
+    // Work around this for now.
+    //
+    // Note phase status only impacts dumping and checking done post-phase,
+    // it has no impact on a release build.
+    //
+    madeChanges = true;
 
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
@@ -4514,8 +4523,9 @@ PhaseStatus Compiler::optOptimizeLayout()
     madeChanges |= fgReorderBlocks();
     madeChanges |= fgUpdateFlowGraph();
 
-    // fgReorderBlocks can cause unreported IR changes; it calls gtPrepareCost
-    // which can lead to operand swapping. Work around this for now.
+    // fgReorderBlocks can cause IR changes even if it does not modify
+    // the flow graph. It calls gtPrepareCost which can cause operand swapping.
+    // Work around this for now.
     //
     // Note phase status only impacts dumping and checking done post-phase,
     // it has no impact on a release build.


### PR DESCRIPTION
This method costs trees, which can in turn modify the IR by swapping operands.
As a result the bool value returned doesn't properly reflect whether any
changes happened.

This impacts proper reporting phase status by `optOptimizeLayout'. Since phase
status just gates post-phase dumps and checks, we'll just claim this phase
always modifies IR.

Fixes #48495.