### PR TITLE
PriorityQueue Performance Improvements

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -387,7 +387,7 @@ namespace System.Collections.Generic
                 const int GrowthFactor = 2;
                 const int MinimumElementsToGrowBy = 4;
 
-                int newcapacity = Math.Max(GrowthFactor * _nodes.Length * GrowthFactor, _nodes.Length + MinimumElementsToGrowBy);
+                int newcapacity = Math.Max(_nodes.Length * GrowthFactor, _nodes.Length + MinimumElementsToGrowBy);
 
                 // Use the argument value if newcapacity is not large enough or has overflown.
                 // If it exceeds the maximum array length, let Array.Resize throw OutOfMemoryException.

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -44,12 +44,12 @@ namespace System.Collections.Generic
         /// Specifies the arity of the d-ary heap, which here is quaternary.
         /// It is assumed that this value is a power of 2.
         /// </summary>
-        private const int Arity = 4;
+        private const int Arity = 2;
 
         /// <summary>
         /// The binary logarithm of <see cref="Arity" />.
         /// </summary>
-        private const int Log2Arity = 2;
+        private const int Log2Arity = 1;
 
         /// <summary>
         /// Creates an empty priority queue.

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -44,12 +44,12 @@ namespace System.Collections.Generic
         /// Specifies the arity of the d-ary heap, which here is quaternary.
         /// It is assumed that this value is a power of 2.
         /// </summary>
-        private const int Arity = 2;
+        private const int Arity = 4;
 
         /// <summary>
         /// The binary logarithm of <see cref="Arity" />.
         /// </summary>
-        private const int Log2Arity = 1;
+        private const int Log2Arity = 2;
 
         /// <summary>
         /// Creates an empty priority queue.


### PR DESCRIPTION
- Use ref locals to minimize copying.
- Use binary heap instead of quad heap.

## Performance

### PriorityQueue<string, string> master

|              Method | Size |            Mean |        Error |       StdDev |          Median |             Min |             Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |----- |----------------:|-------------:|-------------:|----------------:|----------------:|----------------:|-------:|------:|------:|----------:|
|            HeapSort |   10 |     2,611.00 ns |     8.444 ns |     7.052 ns |     2,611.19 ns |     2,600.34 ns |     2,627.39 ns | 0.0102 |     - |     - |     184 B |
|           Enumerate |   10 |        72.67 ns |     0.229 ns |     0.192 ns |        72.70 ns |        72.44 ns |        73.11 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |   10 |     6,096.25 ns |    31.858 ns |    26.603 ns |     6,100.84 ns |     6,058.37 ns |     6,150.80 ns |      - |     - |     - |         - |
|      K_Max_Elements |   10 |     1,044.18 ns |     3.508 ns |     2.929 ns |     1,044.35 ns |     1,040.08 ns |     1,048.28 ns |      - |     - |     - |         - |
|            HeapSort |  100 |    53,774.03 ns |   354.994 ns |   332.061 ns |    53,640.10 ns |    53,357.79 ns |    54,367.37 ns |      - |     - |     - |   1,624 B |
|           Enumerate |  100 |       546.87 ns |     3.405 ns |     3.185 ns |       548.12 ns |       542.14 ns |       551.77 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |  100 |   136,928.79 ns |   953.871 ns |   796.526 ns |   137,022.70 ns |   135,407.61 ns |   137,808.38 ns |      - |     - |     - |         - |
|      K_Max_Elements |  100 |     7,905.11 ns |   176.800 ns |   181.560 ns |     7,855.12 ns |     7,750.50 ns |     8,401.73 ns |      - |     - |     - |         - |
|            HeapSort | 1000 |   937,339.23 ns | 5,962.281 ns | 4,978.774 ns |   937,926.47 ns |   930,112.87 ns |   945,493.01 ns |      - |     - |     - |  16,024 B |
|           Enumerate | 1000 |     5,279.45 ns |    62.309 ns |    48.647 ns |     5,267.58 ns |     5,220.51 ns |     5,390.56 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue | 1000 | 2,094,658.28 ns | 8,643.392 ns | 7,217.624 ns | 2,092,575.45 ns | 2,082,779.91 ns | 2,108,681.70 ns |      - |     - |     - |         - |
|      K_Max_Elements | 1000 |    52,082.79 ns |   191.983 ns |   149.888 ns |    52,112.34 ns |    51,799.58 ns |    52,358.94 ns |      - |     - |     - |         - |

### PriorityQueue<string, string> PR branch

|              Method | Size |            Mean |         Error |        StdDev |          Median |             Min |             Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |----- |----------------:|--------------:|--------------:|----------------:|----------------:|----------------:|-------:|------:|------:|----------:|
|            HeapSort |   10 |     2,211.85 ns |     15.005 ns |     12.530 ns |     2,218.12 ns |     2,192.54 ns |     2,226.37 ns | 0.0168 |     - |     - |     184 B |
|           Enumerate |   10 |        65.52 ns |      0.587 ns |      0.521 ns |        65.57 ns |        64.77 ns |        66.34 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |   10 |     4,765.44 ns |     41.396 ns |     36.696 ns |     4,761.79 ns |     4,701.92 ns |     4,829.89 ns |      - |     - |     - |         - |
|      K_Max_Elements |   10 |       963.72 ns |      7.120 ns |      5.945 ns |       962.09 ns |       955.55 ns |       974.95 ns |      - |     - |     - |         - |
|            HeapSort |  100 |    51,196.04 ns |    349.304 ns |    309.649 ns |    51,191.60 ns |    50,808.62 ns |    51,738.70 ns |      - |     - |     - |   1,624 B |
|           Enumerate |  100 |       516.26 ns |      3.538 ns |      2.954 ns |       517.23 ns |       510.62 ns |       519.38 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |  100 |   131,836.99 ns |    852.135 ns |    755.396 ns |   131,449.37 ns |   131,133.69 ns |   133,232.38 ns |      - |     - |     - |         - |
|      K_Max_Elements |  100 |     7,478.26 ns |     78.705 ns |     65.722 ns |     7,480.90 ns |     7,317.46 ns |     7,574.62 ns |      - |     - |     - |         - |
|            HeapSort | 1000 | 1,001,641.24 ns | 17,086.617 ns | 15,982.832 ns |   995,504.88 ns |   981,357.62 ns | 1,035,606.84 ns |      - |     - |     - |  16,024 B |
|           Enumerate | 1000 |     5,041.03 ns |     56.957 ns |     50.490 ns |     5,032.40 ns |     4,952.18 ns |     5,146.67 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue | 1000 | 2,275,478.60 ns | 32,725.267 ns | 30,611.235 ns | 2,275,954.91 ns | 2,232,071.88 ns | 2,333,933.48 ns |      - |     - |     - |         - |
|      K_Max_Elements | 1000 |    55,057.58 ns |  1,054.213 ns |  1,035.378 ns |    55,031.64 ns |    53,621.49 ns |    57,047.04 ns |      - |     - |     - |         - |

### PriorityQueue<int, int> master

|              Method | Size |          Mean |      Error |     StdDev |        Median |           Min |           Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |----- |--------------:|-----------:|-----------:|--------------:|--------------:|--------------:|-------:|------:|------:|----------:|
|            HeapSort |   10 |     169.47 ns |   0.900 ns |   0.751 ns |     169.33 ns |     168.41 ns |     170.90 ns | 0.0097 |     - |     - |     104 B |
|           Enumerate |   10 |      26.55 ns |   0.157 ns |   0.139 ns |      26.50 ns |      26.38 ns |      26.82 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |   10 |     457.64 ns |   1.449 ns |   1.284 ns |     457.89 ns |     454.77 ns |     459.06 ns |      - |     - |     - |         - |
|      K_Max_Elements |   10 |     131.32 ns |   0.985 ns |   0.873 ns |     130.89 ns |     130.36 ns |     132.93 ns |      - |     - |     - |         - |
|            HeapSort |  100 |   2,615.30 ns |  13.750 ns |  11.481 ns |   2,610.16 ns |   2,600.54 ns |   2,642.96 ns | 0.0741 |     - |     - |     824 B |
|           Enumerate |  100 |     222.15 ns |   0.900 ns |   0.798 ns |     222.29 ns |     220.83 ns |     223.72 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |  100 |   8,660.31 ns |  43.103 ns |  40.319 ns |   8,664.44 ns |   8,589.11 ns |   8,719.59 ns |      - |     - |     - |         - |
|      K_Max_Elements |  100 |     484.06 ns |   1.310 ns |   1.162 ns |     484.07 ns |     481.37 ns |     485.96 ns |      - |     - |     - |         - |
|            HeapSort | 1000 |  70,389.28 ns | 351.348 ns | 311.460 ns |  70,368.25 ns |  69,935.17 ns |  70,822.62 ns | 0.5605 |     - |     - |   8,024 B |
|           Enumerate | 1000 |   2,106.86 ns |   9.027 ns |   7.047 ns |   2,104.82 ns |   2,099.36 ns |   2,123.09 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue | 1000 | 167,413.64 ns | 741.954 ns | 657.723 ns | 167,205.49 ns | 166,672.34 ns | 169,095.15 ns |      - |     - |     - |         - |
|      K_Max_Elements | 1000 |   3,237.06 ns |  12.555 ns |   9.802 ns |   3,236.94 ns |   3,219.13 ns |   3,251.88 ns |      - |     - |     - |         - |

### PriorityQueue<int, int> PR branch

|              Method | Size |          Mean |        Error |       StdDev |        Median |           Min |           Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |----- |--------------:|-------------:|-------------:|--------------:|--------------:|--------------:|-------:|------:|------:|----------:|
|            HeapSort |   10 |     162.60 ns |     1.048 ns |     0.929 ns |     162.51 ns |     160.61 ns |     163.72 ns | 0.0100 |     - |     - |     104 B |
|           Enumerate |   10 |      25.82 ns |     0.157 ns |     0.147 ns |      25.79 ns |      25.62 ns |      26.12 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |   10 |     356.76 ns |     1.211 ns |     0.945 ns |     356.85 ns |     354.63 ns |     357.91 ns |      - |     - |     - |         - |
|      K_Max_Elements |   10 |     111.33 ns |     2.927 ns |     3.254 ns |     112.46 ns |     107.46 ns |     116.50 ns |      - |     - |     - |         - |
|            HeapSort |  100 |   2,976.04 ns |    46.222 ns |    43.236 ns |   2,967.98 ns |   2,897.63 ns |   3,052.82 ns | 0.0719 |     - |     - |     824 B |
|           Enumerate |  100 |     214.92 ns |     1.697 ns |     1.588 ns |     214.44 ns |     212.79 ns |     217.43 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue |  100 |   8,814.66 ns |    47.681 ns |    42.268 ns |   8,813.03 ns |   8,742.95 ns |   8,890.31 ns |      - |     - |     - |         - |
|      K_Max_Elements |  100 |     431.95 ns |     4.789 ns |     4.245 ns |     430.47 ns |     426.30 ns |     440.54 ns |      - |     - |     - |         - |
|            HeapSort | 1000 |  78,828.54 ns | 2,119.835 ns | 2,356.191 ns |  78,350.61 ns |  75,256.64 ns |  84,025.36 ns | 0.6068 |     - |     - |   8,024 B |
|           Enumerate | 1000 |   2,053.21 ns |    30.037 ns |    25.083 ns |   2,045.93 ns |   2,019.22 ns |   2,096.44 ns |      - |     - |     - |         - |
| Dequeue_And_Enqueue | 1000 | 159,890.95 ns | 1,384.848 ns | 1,227.631 ns | 159,836.84 ns | 157,858.65 ns | 162,027.53 ns |      - |     - |     - |         - |
|      K_Max_Elements | 1000 |   3,142.46 ns |    24.237 ns |    22.671 ns |   3,138.93 ns |   3,104.62 ns |   3,183.90 ns |      - |     - |     - |         - |