### PR TITLE
Temporarily work around publishing issues with disk space

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -55,12 +55,15 @@ try {
       $optionalParams.Add($SigningValidationAdditionalParameters) | Out-Null
     }
   }
-
+  # note the custom branch to work around https://github.com/dotnet/arcade/issues/6987 .  Try to keep this rebased off master if publishing changes
+  
+  Write-Host "Using Arcade branch master-workaround-publishing-issue to work around disk space issues with alternate build pool.  Will be lost on Arcade updates as this is in eng common.  Contact dnceng for questions."
+  
   & $darc add-build-to-channel `
   --id $buildId `
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `
-  --source-branch master `
+  --source-branch master-workaround-publishing-issue `
   --azdev-pat $AzdoToken `
   --bar-uri $MaestroApiEndPoint `
   --password $MaestroToken `


### PR DESCRIPTION
See https://github.com/dotnet/arcade/commit/d5aa2cf002ac7c96deff375281a134027aa6821e for the branch being used for v3 publishing. 