### PR TITLE
Fix constant folding for PopCount on 32 bit targets

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4513,7 +4513,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 if (impStackTop().val->IsIntegralConst())
                 {
                     typeInfo argType = verParseArgSigToTypeInfo(sig, sig->args).NormaliseForStack();
-                    ssize_t  cns     = impPopStack().val->AsIntConCommon()->IconValue();
+                    INT64    cns     = impPopStack().val->AsIntConCommon()->IntegralValue();
                     if (argType.IsType(TI_LONG))
                     {
                         retNode = gtNewIconNode(genCountBits(cns), callType);

--- a/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
@@ -337,30 +337,6 @@ namespace System.Numerics.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public static void BitOps_PopCount_Constant()
-        {
-            // PopCount returns constant for constant input
-
-            Assert.Equal(0,  BitOperations.PopCount(0U));
-            Assert.Equal(1,  BitOperations.PopCount(1U));
-            Assert.Equal(1,  BitOperations.PopCount(2U));
-            Assert.Equal(6,  BitOperations.PopCount(1111U));
-            Assert.Equal(29, BitOperations.PopCount(unchecked((uint)-101)));
-            Assert.Equal(31, BitOperations.PopCount(4294967294U));
-            Assert.Equal(32, BitOperations.PopCount(4294967295U));
-
-            Assert.Equal(0,  BitOperations.PopCount(0UL));
-            Assert.Equal(1,  BitOperations.PopCount(1UL));
-            Assert.Equal(1,  BitOperations.PopCount(2UL));
-            Assert.Equal(6,  BitOperations.PopCount(1111UL));
-            Assert.Equal(31, BitOperations.PopCount(4294967294UL));
-            Assert.Equal(32, BitOperations.PopCount(4294967295UL));
-            Assert.Equal(61, BitOperations.PopCount(unchecked((ulong)-101)));
-            Assert.Equal(63, BitOperations.PopCount(18446744073709551614UL));
-            Assert.Equal(64, BitOperations.PopCount(18446744073709551615UL));
-        }
-
         [Theory]
         [InlineData(0b00000000_00000000_00000000_00000001u, int.MaxValue, 0b10000000_00000000_00000000_00000000u)] // % 32 = 31
         [InlineData(0b01000000_00000001_00000000_00000001u, 3, 0b00000000_00001000_00000000_00001010u)]

--- a/src/tests/JIT/Intrinsics/BitOperationsIntrinsics_r.csproj
+++ b/src/tests/JIT/Intrinsics/BitOperationsIntrinsics_r.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BitOperationsPopCount.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Intrinsics/BitOperationsIntrinsics_ro.csproj
+++ b/src/tests/JIT/Intrinsics/BitOperationsIntrinsics_ro.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BitOperationsPopCount.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Intrinsics/BitOperationsPopCount.cs
+++ b/src/tests/JIT/Intrinsics/BitOperationsPopCount.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace BitOperationsPopCountTest
+{
+    class Program
+    {
+        private static int _errorCode = 100;
+
+        static int Main(string[] args)
+        {
+            // PopCount calls with a constant argument are folded
+
+            Test(0U, BitOperations.PopCount(0U), 0);
+            Test(1U, BitOperations.PopCount(1U), 1);
+            Test(2U, BitOperations.PopCount(2U), 1);
+            Test(1111U, BitOperations.PopCount(1111U), 6);
+            Test(unchecked((uint)-101), BitOperations.PopCount(unchecked((uint)-101)), 29);
+            Test(4294967294U, BitOperations.PopCount(4294967294U), 31);
+            Test(4294967295U, BitOperations.PopCount(4294967295U), 32);
+
+            Test(0UL, BitOperations.PopCount(0UL), 0);
+            Test(1UL, BitOperations.PopCount(1UL), 1);
+            Test(2UL, BitOperations.PopCount(2UL), 1);
+            Test(1111UL, BitOperations.PopCount(1111UL), 6);
+            Test(4294967294UL, BitOperations.PopCount(4294967294UL), 31);
+            Test(4294967295UL, BitOperations.PopCount(4294967295UL), 32);
+            Test(unchecked((ulong)-101), BitOperations.PopCount(unchecked((ulong)-101)), 61);
+            Test(18446744073709551614UL, BitOperations.PopCount(18446744073709551614UL), 63);
+            Test(18446744073709551615UL, BitOperations.PopCount(18446744073709551615UL), 64);
+
+            return _errorCode;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Test(ulong input, int output, int expected)
+        {
+            if (output != expected)
+            {
+                Console.WriteLine($"BitOperations.PopCount with a constant argument failed.");
+                Console.WriteLine($"Input:    {input}");
+                Console.WriteLine($"Output:   {output}");
+                Console.WriteLine($"Expected: {expected}");
+
+                _errorCode++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
`IconValue` can only represent `CNS_INT` constants. Use `IntegralValue`, which can represent any integer constant, including `CNS_LNG`. This is technically less efficient on 32 bit, but the presumption is this path is hit rarely enough for that to not matter.

I have verified locally (via the altjit) that the [original reproduction](https://gist.github.com/SingleAccretion/414b32b23ca0f76c2d1410f29cc9a09a) now compiles to the following for `x86`:
```asm
G_M28557_IG01:
       push     ebp
       mov      ebp, esp
G_M28557_IG02:
       pop      ebp
       ret
```

Fixes #48504.

cc @AndyAyersMS