### PR TITLE
Enable CG2 determinism tests on all architectures

### DIFF
--- a/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -3,6 +3,7 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
     <!-- Known not to work with GCStress for now: https://github.com/dotnet/runtime/issues/13394 -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- It is currently failing with JitStress https://github.com/dotnet/runtime/issues/45326-->

--- a/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -3,8 +3,6 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
-    <!-- Crossgen2 currently targets only x64 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <!-- Known not to work with GCStress for now: https://github.com/dotnet/runtime/issues/13394 -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- It is currently failing with JitStress https://github.com/dotnet/runtime/issues/45326-->

--- a/src/tests/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/tests/readytorun/determinism/crossgen2determinism.csproj
@@ -3,8 +3,6 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
-    <!-- Crossgen2 currently targets only x64 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <!-- Known not to work with GCStress for now: https://github.com/dotnet/runtime/issues/13394 -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This is an explicit crossgen test -->

--- a/src/tests/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/tests/readytorun/determinism/crossgen2determinism.csproj
@@ -3,6 +3,7 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
     <!-- Known not to work with GCStress for now: https://github.com/dotnet/runtime/issues/13394 -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This is an explicit crossgen test -->


### PR DESCRIPTION
I have noticed that these two tests are still conditionally
executed on x64 only. I don't see why they shouldn't work on
other architectures.

Thanks

Tomas