### PR TITLE
R2RTest cleanup for Serp compile

### DIFF
--- a/src/coreclr/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/tools/r2rtest/BuildOptions.cs
@@ -45,7 +45,6 @@ namespace R2RTest
         public DirectoryInfo[] RewriteOldPath { get; set; }
         public DirectoryInfo[] RewriteNewPath { get; set; }
         public DirectoryInfo AspNetPath { get; set; }
-        public SerpCompositeScenario CompositeScenario { get; set; }
         public bool MeasurePerf { get; set; }
         public string InputFileSearchString { get; set; }
         public string ConfigurationSuffix => (Release ? "-ret.out" : "-chk.out");

--- a/src/coreclr/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/tools/r2rtest/CommandLineOptions.cs
@@ -165,9 +165,11 @@ namespace R2RTest
                         InputDirectory(),
                         DegreeOfParallelism(),
                         AspNetPath(),
-                        CompositeScenario(),
+                        Composite(),
                         Map(),
                         Pdb(),
+                        CompilationTimeoutMinutes(),
+                        Crossgen2Path(),
                     },
                     options =>
                     {
@@ -295,9 +297,6 @@ namespace R2RTest
             //
             Option AspNetPath() =>
                 new Option<DirectoryInfo>(new[] { "--asp-net-path", "-asp" }, "Path to SERP's ASP.NET Core folder").ExistingOnly();
-
-            Option CompositeScenario() =>
-                new Option<SerpCompositeScenario>(new [] { "--composite-scenario", "-cs" }, "Specifies which layers of a shared framework application are compiled as composite" );
         }
     }
 }


### PR DESCRIPTION
* Simplify compilation logic now a single mega composite image is functional
* Remove composite scenario switch and support just composite or individual assemblies
* Use the same list of allowed Dlls in the serp/bin directory that Serp deployment uses