### PR TITLE
Add a Mono ARM64 runtime pack & test build

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -112,6 +112,7 @@ stages:
       - iOS_arm
       - iOS_arm64
       - OSX_x64
+      - OSX_arm64
       - Linux_x64
       - Linux_arm
       - Linux_arm64

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -439,6 +439,7 @@ jobs:
     buildConfig: debug
     platforms:
     - OSX_x64
+    - OSX_arm64
     - Linux_x64
     - Linux_arm64
     # - Linux_musl_arm64


### PR DESCRIPTION
Ref. https://github.com/dotnet/runtime/issues/48531

Seems happy locally

`  Successfully created package '/Users/directhex/Projects/runtime/artifacts/packages/Debug/Shipping/Microsoft.NETCore.App.Runtime.Mono.osx-arm64.6.0.0-dev.nupkg'.`