### PR TITLE
Enhance coreclr processing of event pipe configuration to be able to write the pid of the current process into the nettrace file

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2511,7 +2511,7 @@ ep_rt_utf8_string_replace (
 			*str = NULL;
 			return false;
 		}
-		ep_rt_utf8_string_snprintf(newStr, newStrSize, "%.*s%s%s", strFound - (*str), *str, strReplacement, strFound + strSearchLen);
+		ep_rt_utf8_string_snprintf(newStr, newStrSize, "%.*s%s%s", (int)(strFound - (*str)), *str, strReplacement, strFound + strSearchLen);
 		ep_rt_utf8_string_free(*str);
 		*str = newStr;
 		return true;

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1867,6 +1867,13 @@ ep_rt_utf16_string_dup (const ep_char16_t *str)
 }
 
 static
+ep_char8_t *
+ep_rt_utf8_string_alloc(size_t len)
+{
+	return g_new(ep_char8_t, len);
+}
+
+static
 inline
 void
 ep_rt_utf8_string_free (ep_char8_t *str)

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1883,7 +1883,7 @@ ep_rt_utf8_string_replace (
 			*str = NULL;
 			return false;
 		}
-		ep_rt_utf8_string_snprintf(newStr, newStrSize, "%.*s%s%s", strFound - (*str), *str, strReplacement, strFound + strSearchLen);
+		ep_rt_utf8_string_snprintf(newStr, newStrSize, "%.*s%s%s", (int)(strFound - (*str)), *str, strReplacement, strFound + strSearchLen);
 		ep_rt_utf8_string_free(*str);
 		*str = newStr;
 		return true;

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1829,6 +1829,22 @@ ep_rt_utf8_string_dup (const ep_char8_t *str)
 static
 inline
 ep_char8_t *
+ep_rt_utf8_string_dup_range (const ep_char8_t *str, const ep_char8_t *strEnd)
+{
+	ptrdiff_t byte_len = strEnd - str;
+	ep_char8_t *buffer = g_new(ep_char8_t, byte_len + 1);
+	if (buffer != NULL)
+	{
+		memcpy (buffer, str, byte_len);
+		buffer [byte_len] = '\0';
+	}
+	return buffer;
+}
+
+
+static
+inline
+ep_char8_t *
 ep_rt_utf8_string_strtok (
 	ep_char8_t *str,
 	const ep_char8_t *delimiter,
@@ -1864,13 +1880,6 @@ ep_rt_utf16_string_dup (const ep_char16_t *str)
 	if (str_dup)
 		memcpy (str_dup, str, str_size);
 	return str_dup;
-}
-
-static
-ep_char8_t *
-ep_rt_utf8_string_alloc(size_t len)
-{
-	return g_new(ep_char8_t, len);
 }
 
 static

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1862,6 +1862,37 @@ g_snprintf ((gchar *)str, (gulong)str_len, (const gchar *)format, __VA_ARGS__)
 
 static
 inline
+bool
+ep_rt_utf8_string_replace (
+	ep_char8_t **str,
+	const ep_char8_t *strSearch,
+	const ep_char8_t *strReplacement
+)
+{
+	if ((*str) == NULL)
+		return false;
+
+	ep_char8_t* strFound = strstr(*str, strSearch);
+	if (strFound != NULL)
+	{
+		size_t strSearchLen = strlen(strSearch);
+		size_t newStrSize = strlen(*str) + strlen(strReplacement) - strSearchLen + 1; 
+		ep_char8_t *newStr =  g_new(ep_char8_t, newStrSize);
+		if (newStr == NULL)
+		{
+			*str = NULL;
+			return false;
+		}
+		ep_rt_utf8_string_snprintf(newStr, newStrSize, "%.*s%s%s", strFound - (*str), *str, strReplacement, strFound + strSearchLen);
+		ep_rt_utf8_string_free(*str);
+		*str = newStr;
+		return true;
+	}
+	return false;
+}
+
+static
+inline
 ep_char16_t *
 ep_rt_utf8_to_utf16_string (
 	const ep_char8_t *str,

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -672,6 +672,10 @@ ep_rt_utf8_string_dup (const ep_char8_t *str);
 
 static
 ep_char8_t *
+ep_rt_utf8_string_dup_range (const ep_char8_t *str, const ep_char8_t *strEnd);
+
+static
+ep_char8_t *
 ep_rt_utf8_string_strtok (
 	ep_char8_t *str,
 	const ep_char8_t *delimiter,
@@ -691,10 +695,6 @@ ep_rt_utf8_to_utf16_string (
 static
 ep_char16_t *
 ep_rt_utf16_string_dup (const ep_char16_t *str);
-
-static
-ep_char8_t *
-ep_rt_utf8_string_alloc(size_t len);
 
 static
 void

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -687,6 +687,14 @@ ep_rt_utf8_string_strtok (
 	format, ...) ep_redefine
 
 static
+inline bool
+ep_rt_utf8_string_replace (
+	ep_char8_t **str,
+	const ep_char8_t *strSearch,
+	const ep_char8_t *strReplacement
+);
+
+static
 ep_char16_t *
 ep_rt_utf8_to_utf16_string (
 	const ep_char8_t *str,

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -693,6 +693,10 @@ ep_char16_t *
 ep_rt_utf16_string_dup (const ep_char16_t *str);
 
 static
+ep_char8_t *
+ep_rt_utf8_string_alloc(size_t len);
+
+static
 void
 ep_rt_utf8_string_free (ep_char8_t *str);
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -736,11 +736,8 @@ get_next_config_value_as_utf8_string (const ep_char8_t **data)
 	*data = get_next_config_value (*data, &start, &end);
 
 	ptrdiff_t byte_len = end - start;
-	if (byte_len != 0) {
-		buffer = ep_rt_utf8_string_alloc (byte_len + 1);
-		memcpy (buffer, start, byte_len);
-		buffer [byte_len] = '\0';
-	}
+	if (byte_len != 0)
+		buffer = ep_rt_utf8_string_dup_range(start, end);
 
 	return buffer;
 }

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -729,7 +729,7 @@ get_next_config_value_as_utf8_string (const ep_char8_t **data)
 {
 	EP_ASSERT (data != NULL);
 
-	uint8_t *buffer = NULL;
+	ep_char8_t *buffer = NULL;
 
 	const ep_char8_t *start = NULL;
 	const ep_char8_t *end = NULL;
@@ -737,12 +737,12 @@ get_next_config_value_as_utf8_string (const ep_char8_t **data)
 
 	ptrdiff_t byte_len = end - start;
 	if (byte_len != 0) {
-		buffer = ep_rt_byte_array_alloc (byte_len + 1);
+		buffer = ep_rt_utf8_string_alloc (byte_len + 1);
 		memcpy (buffer, start, byte_len);
 		buffer [byte_len] = '\0';
 	}
 
-	return (ep_char8_t *)buffer;
+	return buffer;
 }
 
 static

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -789,6 +789,22 @@ enable_default_session_via_env_variables (void)
 	if (ep_rt_config_value_get_enable ()) {
 		ep_config = ep_rt_config_value_get_config ();
 		ep_config_output_path = ep_rt_config_value_get_output_path ();
+
+		ep_char8_t pidStr[24];
+		ep_rt_utf8_string_snprintf(pidStr, EP_ARRAY_SIZE (pidStr), "%u", (unsigned)ep_rt_current_process_get_id());
+
+		while (true)
+		{
+			if (ep_rt_utf8_string_replace(&ep_config_output_path, "{pid}", pidStr))
+			{
+				// In case there is a second use of {pid} in the output path
+				continue;
+			}
+
+			// No more instances of {pid} in the OutputPath
+			break;
+		}
+
 		ep_circular_mb = ep_rt_config_value_get_circular_mb ();
 		output_path = NULL;
 

--- a/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.cs
+++ b/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+class NameConfigWithPid
+{
+    static int Main(string[] args)
+    {
+        if (args.Length > 0 && args[0] == "waitforinput")
+        {
+            Console.Error.WriteLine("WaitingForInput in ErrorStream");
+            Console.WriteLine("WaitingForInput");
+            Console.ReadLine();
+            return 100;
+        }
+        else
+        {
+            Process process = new Process();
+            string corerun = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                corerun = corerun + ".exe";
+
+            // Use dll directory as temp directory
+            string tempDir = Path.GetDirectoryName(typeof(NameConfigWithPid).Assembly.Location);
+            string outputPathPattern = Path.Combine(tempDir, "eventPipeStream{pid}_{pid}.nettrace");
+
+            foreach (string oldFile in Directory.EnumerateFiles(tempDir, "eventPipeStream*"))
+            {
+                File.Delete(oldFile);
+            }
+
+            process.StartInfo.FileName = corerun;
+            process.StartInfo.Arguments = typeof(NameConfigWithPid).Assembly.Location + " waitforinput";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardInput = true;
+            process.StartInfo.RedirectStandardError = true;
+
+            process.StartInfo.Environment.Add("COMPlus_EnableEventPipe", "1");
+            process.StartInfo.Environment.Add("COMPlus_EventPipeConfig", "Microsoft-Windows-DotNETRuntime:4c14fccbd:4");
+            process.StartInfo.Environment.Add("COMPlus_EventPipeOutputPath", outputPathPattern);
+
+            process.Start();
+
+            process.StandardError.ReadLine();
+            uint pid = (uint)process.Id;
+            string expectedPath = outputPathPattern.Replace("{pid}", pid.ToString());
+
+            process.StandardInput.WriteLine("input");
+            process.WaitForExit();
+            if (!File.Exists(expectedPath))
+            {
+                Console.WriteLine($"{expectedPath} not found");
+                return 1;
+            }
+            else
+            {
+                Console.WriteLine($"{expectedPath} found");
+                return 100; 
+            }
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.csproj
+++ b/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <GCStressIncompatible>true</GCStressIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Also fix the behavior of get_next_config_value_as_utf8_string to work correctly on coreclr, it was type-punning between a buffer returned by ep_rt_byte_array_alloc and ep_rt_utf8_string_free, which isn't safe in the coreclr implementation