### PR TITLE
Misc PriorityQueue fixes

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -22,12 +22,6 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            if (source is ICollection ic)
-            {
-                count = ic.Count;
-                return true;
-            }
-
             count = 0;
             return false;
         }

--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -8,6 +8,30 @@ namespace System.Collections.Generic
     /// </summary>
     internal static partial class EnumerableHelpers
     {
+        /// <summary>Attempt to determine the count of the source enumerable without forcing an enumeration.</summary>
+        /// <param name="source">The source enumerable.</param>
+        /// <param name="count">The count determined by the type test.</param>
+        /// <returns>
+        /// True if the source enumerable could be determined without enumerating, false otherwise.
+        /// </returns>
+        internal static bool TryGetCount<T>(IEnumerable<T> source, out int count)
+        {
+            if (source is ICollection<T> ict)
+            {
+                count = ict.Count;
+                return true;
+            }
+
+            if (source is ICollection ic)
+            {
+                count = ic.Count;
+                return true;
+            }
+
+            count = 0;
+            return false;
+        }
+
         /// <summary>Converts an enumerable to an array using the same logic as List{T}.</summary>
         /// <param name="source">The enumerable to convert.</param>
         /// <param name="length">The number of items stored in the resulting array, 0-indexed.</param>

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -619,8 +619,7 @@ namespace System.Collections.Generic
                     break;
                 }
 
-                // Move the minimal child up by one node and
-                // continue recursively from its location.
+                // Move the minimal child up by one node and continue recursively from its location.
                 nodes[nodeIndex] = minChild;
                 nodeIndex = minChildIndex;
             }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -288,6 +288,11 @@ namespace System.Collections.Generic
             }
             else
             {
+                if (EnumerableHelpers.TryGetCount(items, out int count) && count > 0)
+                {
+                    EnsureCapacityCore(_size + count);
+                }
+
                 foreach ((TElement element, TPriority priority) in items)
                 {
                     Enqueue(element, priority);
@@ -303,6 +308,11 @@ namespace System.Collections.Generic
             if (elements is null)
             {
                 throw new ArgumentNullException(nameof(elements));
+            }
+
+            if (EnumerableHelpers.TryGetCount(elements, out int count) && count > 0)
+            {
+                EnsureCapacityCore(_size + count);
             }
 
             if (_size == 0)

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -272,6 +272,7 @@ namespace System.Collections.Generic
             if (_size == 0)
             {
                 _nodes = EnumerableHelpers.ToArray(items, out _size);
+                _version++;
 
                 if (_size > 1)
                 {
@@ -307,6 +308,8 @@ namespace System.Collections.Generic
                 }
 
                 _size = i;
+                _version++;
+
                 if (i > 1)
                 {
                     Heapify();

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -293,12 +293,9 @@ namespace System.Collections.Generic
             }
             else
             {
-                if (EnumerableHelpers.TryGetCount(items, out int count) && count > 0)
+                if (EnumerableHelpers.TryGetCount(items, out int count) && _nodes.Length - _size < count)
                 {
-                    if (_nodes.Length < _size + count)
-                    {
-                        Grow(_size + count);
-                    }
+                    Grow(_size + count);
                 }
 
                 foreach ((TElement element, TPriority priority) in items)
@@ -318,12 +315,9 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException(nameof(elements));
             }
 
-            if (EnumerableHelpers.TryGetCount(elements, out int count) && count > 0)
+            if (EnumerableHelpers.TryGetCount(elements, out int count) && _nodes.Length - _size < count)
             {
-                if (_nodes.Length < _size + count)
-                {
-                    Grow(_size + count);
-                }
+                Grow(_size + count);
             }
 
             if (_size == 0)

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -51,6 +51,13 @@ namespace System.Collections.Generic
         /// </summary>
         private const int Log2Arity = 2;
 
+#if DEBUG
+        static PriorityQueue()
+        {
+            Debug.Assert(Log2Arity > 0 && Math.Pow(2, Log2Arity) == Arity);
+        }
+#endif
+
         /// <summary>
         /// Creates an empty priority queue.
         /// </summary>


### PR DESCRIPTION
Cherry-picked from #48520.

* Ensure array growth method handles overflow appropriately.
* Remove redundant allocations in `EnqueueRange`.
* Add missing enumerator invalidations.
* Misc style fixes.