### PR TITLE
Test turning on analyzer VSTHRD103 in runtime

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -1,6 +1,13 @@
 ﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
   <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
-    <Rule Id="VSTHRD103" Action="None" />
+    <Rule Id="VSTHRD200" Action="None" />
+    <Rule Id="VSTHRD003" Action="None" />
+    <Rule Id="VSTHRD001" Action="None" />
+    <Rule Id="VSTHRD002" Action="None" />
+    <Rule Id="VSTHRD110" Action="None" />
+    <Rule Id="VSTHRD114" Action="None" />
+    <Rule Id="VSTHRD100" Action="None" />
+    <Rule Id="VSTHRD103" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.DotNet.CodeAnalysis" RuleNamespace="Microsoft.DotNet.CodeAnalysis.Analyzers">
     <Rule Id="BCL0001" Action="Warning" />      <!-- Ensure minimum API surface is respected -->

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -1,4 +1,7 @@
 ﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
+  <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
+    <Rule Id="VSTHRD103" Action="None" />
+  </Rules>
   <Rules AnalyzerId="Microsoft.DotNet.CodeAnalysis" RuleNamespace="Microsoft.DotNet.CodeAnalysis.Analyzers">
     <Rule Id="BCL0001" Action="Warning" />      <!-- Ensure minimum API surface is respected -->
     <Rule Id="BCL0010" Action="Warning" />      <!-- AppContext default value expected to be true -->

--- a/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
@@ -755,7 +755,7 @@ namespace System.IO
 
             if (string.IsNullOrEmpty(contents))
             {
-                new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read).Dispose();
+                new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read).Dispose(); // await DisposeAsync
                 return Task.CompletedTask;
             }
 
@@ -795,7 +795,7 @@ namespace System.IO
             {
                 if (!returningInternalTask)
                 {
-                    fs.Dispose();
+                    fs.Dispose(); // await DisposeAsync
                 }
             }
         }
@@ -862,7 +862,7 @@ namespace System.IO
             }
             finally
             {
-                fs.Dispose();
+                fs.Dispose(); // await DisposeAsync
                 ArrayPool<byte>.Shared.Return(rentedArray);
             }
         }
@@ -996,7 +996,7 @@ namespace System.IO
             }
             finally
             {
-                sw.Dispose();
+                sw.Dispose(); // await DisposeAsync
                 if (buffer != null)
                 {
                     ArrayPool<char>.Shared.Return(buffer);
@@ -1024,7 +1024,7 @@ namespace System.IO
             if (string.IsNullOrEmpty(contents))
             {
                 // Just to throw exception if there is a problem opening the file.
-                new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read).Dispose();
+                new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read).Dispose(); // await DisposeAsync
                 return Task.CompletedTask;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -584,7 +584,7 @@ namespace System.IO
             Task<int>? t = _lastSyncCompletedReadTask;
             Debug.Assert(t == null || t.IsCompletedSuccessfully);
 
-            if (t != null && t.Result == val)
+            if (t != null && t.Result == val) // await t
                 return t;
 
             t = Task.FromResult<int>(val);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Windows.cs
@@ -793,7 +793,7 @@ namespace System.IO
                 if (destination.Length < _bufferLength)
                 {
                     Task<int> readTask = ReadNativeAsync(new Memory<byte>(GetBuffer()), 0, cancellationToken);
-                    _readLength = readTask.GetAwaiter().GetResult();
+                    _readLength = readTask.GetAwaiter().GetResult(); // await readTask
                     int n = Math.Min(_readLength, destination.Length);
                     new Span<byte>(GetBuffer(), 0, n).CopyTo(destination.Span);
                     _readPos = n;
@@ -1452,7 +1452,7 @@ namespace System.IO
             finally
             {
                 // Cleanup from the whole copy operation
-                cancellationReg.Dispose();
+                cancellationReg.Dispose(); // await DisposeAsync
                 awaitableOverlapped.Dispose();
 
                 ArrayPool<byte>.Shared.Return(copyBuffer);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -441,7 +441,7 @@ namespace System.IO
                 t = _lastSynchronouslyCompletedTask;
                 Debug.Assert(t == null || t.IsCompletedSuccessfully, "Cached task should have completed successfully");
 
-                if (t == null || t.Result != synchronousResult)
+                if (t == null || t.Result != synchronousResult) // await t
                 {
                     _lastSynchronouslyCompletedTask = t = Task.FromResult(synchronousResult);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -392,7 +392,7 @@ namespace System.IO
                 Task<int>? t = _lastReadTask;
                 Debug.Assert(t == null || t.Status == TaskStatus.RanToCompletion,
                     "Expected that a stored last task completed successfully");
-                return (t != null && t.Result == n) ? t : (_lastReadTask = Task.FromResult<int>(n));
+                return (t != null && t.Result == n) ? t : (_lastReadTask = Task.FromResult<int>(n)); // await t
             }
             catch (OperationCanceledException oce)
             {
@@ -516,7 +516,7 @@ namespace System.IO
             try
             {
                 // If destination is a MemoryStream, CopyTo synchronously:
-                memStrDest.Write(_buffer, pos, n);
+                memStrDest.Write(_buffer, pos, n); // await WriteAsync
                 return Task.CompletedTask;
             }
             catch (Exception ex)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStream.cs
@@ -438,7 +438,7 @@ namespace System.IO
             {
                 int n = Read(buffer, offset, count);
                 Task<int>? t = _lastReadTask;
-                return (t != null && t.Result == n) ? t : (_lastReadTask = Task.FromResult<int>(n));
+                return (t != null && t.Result == n) ? t : (_lastReadTask = Task.FromResult<int>(n)); // await t
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -74,7 +74,7 @@ namespace System.Threading.Tasks
             //     public static Task<Task<TResult>> WhenAny<TResult>(IEnumerable<Task<TResult>> tasks);
             //     public static Task<Task<TResult>> WhenAny<TResult>(params Task<TResult>[] tasks);
             // Used to "cast" from Task<Task> to Task<Task<TResult>>.
-            internal static readonly Func<Task<Task>, Task<TResult>> Value = completed => (Task<TResult>)completed.Result;
+            internal static readonly Func<Task<Task>, Task<TResult>> Value = completed => (Task<TResult>)completed.Result; // await completed
         }
 
         // Construct a promise-style task without any options.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskExtensions.cs
@@ -21,7 +21,7 @@ namespace System.Threading.Tasks
             // task is null, return a canceled task to match the same semantics as CreateUnwrapPromise.
             return
                 !task.IsCompletedSuccessfully ? Task.CreateUnwrapPromise<VoidTaskResult>(task, lookForOce: false) :
-                task.Result ??
+                task.Result ?? // await task
                 Task.FromCanceled(new CancellationToken(true));
         }
 
@@ -40,7 +40,7 @@ namespace System.Threading.Tasks
             // task is null, return a canceled task to match the same semantics as CreateUnwrapPromise.
             return
                 !task.IsCompletedSuccessfully ? Task.CreateUnwrapPromise<TResult>(task, lookForOce: false) :
-                task.Result ??
+                task.Result ?? // await task
                 Task.FromCanceled<TResult>(new CancellationToken(true));
         }
     }


### PR DESCRIPTION
Do not merge.

The objective of this draft PR is to show the output of turning on the existing [VSTHRD103 analyzer](https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md) in the dotnet/runtime repo, as requested in [this comment](https://github.com/dotnet/runtime/issues/45661#issuecomment-767756782).

The analyzer was reviewed in the API Proposal meeting, and we determined that we want to see how noisy it would be in our repo, so we can decide what severity to assign to it once we move the code to the dotnet/roslyn-analyzers repo.

In my local machine, it proved to be very noisy:

<details>
  <summary>Result: 259 Errors</summary>

  ```
D:\runtime> .\build.cmd clr+libs -rc release

...

Build FAILED.

D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\Stream.cs(289,46): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\Stream.cs(440,29): error VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\Stream.cs(488,40): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\Stream.cs(625,23): error VSTHRD003: Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.cs(307,22): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.cs(342,91): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\StreamWriter.cs(228,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\StreamWriter.cs(634,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\StreamWriter.cs(747,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\StreamReader.cs(837,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\TextReader.cs(256,41): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\TextReader.cs(290,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\YieldAwaitable.cs(110,38): error VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\YieldAwaitable.cs(88,29): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\YieldAwaitable.cs(143,38): error VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\YieldAwaitable.cs(132,29): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\ValueTaskAwaiter.cs(126,46): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\YieldAwaitable.cs(162,85): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\YieldAwaitable.cs(168,131): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\YieldAwaitable.cs(177,86): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\StreamReader.cs(918,36): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.cs(435,27): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.cs(458,131): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\BufferedStream.cs(320,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(269,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(350,44): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(490,100): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\StreamWriter.cs(931,22): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\ConfiguredValueTaskAwaitable.cs(156,50): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\BufferedStream.cs(582,27): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\BufferedStream.cs(704,19): error VSTHRD003: Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(738,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(766,28): error VSTHRD114: Avoid returning null from a Task-returning method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(802,28): error VSTHRD114: Avoid returning null from a Task-returning method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(824,28): error VSTHRD114: Avoid returning null from a Task-returning method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(951,27): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(1057,29): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\BufferedStream.cs(1086,19): error VSTHRD003: Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Win32.cs(48,29): error VSTHRD200: Avoid "Async" suffix in names of methods that do not return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\FileStream.Windows.cs(1545,26): error VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\IO\BufferedStream.cs(1288,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\AsyncMethodBuilderCore.cs(127,31): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\AsyncTaskMethodBuilderT.cs(387,31): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\AsyncTaskMethodBuilderT.cs(393,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\AsyncTaskMethodBuilder.cs(84,38): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Diagnostics\Tracing\EventPipeEventDispatcher.cs(161,32): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\CancellationTokenSource.cs(658,57): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Progress.cs(73,41): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\SemaphoreSlim.cs(422,73): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\Common\src\System\Threading\Tasks\TaskToApm.cs(41,32): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\Common\src\System\Threading\Tasks\TaskToApm.cs(62,29): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\Common\src\System\Threading\Tasks\TaskToApm.cs(54,42): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1366,88): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(283,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(312,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(352,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(256,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(377,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(406,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(437,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(479,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskCache.cs(27,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Sources\ManualResetValueTaskSourceCore.cs(184,38): error VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Sources\ManualResetValueTaskSourceCore.cs(176,28): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Sources\ManualResetValueTaskSourceCore.cs(329,34): error VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Sources\ManualResetValueTaskSourceCore.cs(321,24): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(321,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(1133,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(1223,31): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(341,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(628,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(751,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskContinuation.cs(424,33): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskContinuation.cs(428,33): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(557,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(583,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskContinuation.cs(547,24): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(611,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskExtensions.cs(12,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(644,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(687,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskExtensions.cs(31,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(694,23): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(744,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(771,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(800,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(834,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(878,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(885,23): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(938,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(276,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(301,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(329,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(967,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(368,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(997,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(393,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1039,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(422,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1092,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(452,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(493,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1099,35): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1152,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1182,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskScheduler.cs(565,38): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1214,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1258,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(868,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1313,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Future.cs(1320,35): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(552,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(993,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(571,35): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(578,31): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1126,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1190,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1322,38): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1348,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1376,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1410,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1454,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1479,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1508,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1544,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(120,42): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(126,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ConcurrentExclusiveSchedulerPair.cs(197,22): error VSTHRD200: Avoid "Async" suffix in names of methods that do not return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(132,42): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1590,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(138,33): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(144,42): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(173,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(184,26): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6677,22): error VSTHRD200: Avoid "Async" suffix in names of methods that do not return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6714,45): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6714,73): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(520,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(551,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6759,91): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(583,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(626,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(654,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(687,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(721,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(766,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1596,38): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1666,41): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1697,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1726,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1760,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1804,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1829,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ConcurrentExclusiveSchedulerPair.cs(642,30): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\ValueTask.cs(191,22): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1859,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1895,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1601,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1941,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(1969,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2002,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2040,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2088,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2118,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2151,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1645,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2191,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1716,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2241,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1744,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1778,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2336,36): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1822,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1847,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(1884,30): error VSTHRD200: Avoid "Async" suffix in names of methods that do not return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(1896,35): error VSTHRD001: Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1876,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1912,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1958,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2417,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2445,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(1968,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2479,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2523,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2552,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2584,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\FutureFactory.cs(2020,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2622,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2670,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2699,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2731,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2771,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2821,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2847,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2876,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2912,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\TaskFactory.cs(2958,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3397,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3422,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3449,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3482,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3525,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3532,22): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3581,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3607,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3635,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3669,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3713,21): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3720,22): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3772,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3801,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3831,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3867,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3913,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3972,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(3920,31): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(4002,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(4033,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(4070,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(4117,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(4124,31): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5052,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5110,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5124,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5063,24): error VSTHRD003: Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5137,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5099,28): error VSTHRD003: Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5023,53): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5027,77): error VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5148,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5158,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5172,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5194,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5212,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5226,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5244,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5259,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5277,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5306,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5322,37): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5356,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5375,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5397,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5416,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5427,29): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5543,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5604,28): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5626,29): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5781,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5845,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(5866,40): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6007,34): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6050,34): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6151,34): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6207,43): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6237,43): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6258,43): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6273,39): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
D:\runtime\src\libraries\System.Private.CoreLib\src\System\Threading\Tasks\Task.cs(6342,30): error VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type. [D:\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj]
    0 Warning(s)
    259 Error(s)

  ```
</details>