### PR TITLE
Support side-by-side Apple Silicon (part 1)

### DIFF
--- a/src/native/corehost/error_codes.h
+++ b/src/native/corehost/error_codes.h
@@ -51,6 +51,8 @@ enum StatusCode
     HostPropertyNotFound                = 0x800080a4,
     CoreHostIncompatibleConfig          = 0x800080a5,
     HostApiUnsupportedScenario          = 0x800080a6,
+    CorehostMustRunAsArchX64            = 0x800080a7,
+    CorehostMustRunAsArchArm64          = 0x800080a8,
 };
 
 #define STATUS_CODE_SUCCEEDED(status_code) ((static_cast<int>(static_cast<StatusCode>(status_code))) >= 0)

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -1101,7 +1101,8 @@ int fx_muxer_t::handle_cli(
             nullptr/*required_buffer_size*/);
     }
 
-    if (pal::strcasecmp(_X("--info"), argv[1]) == 0)
+    if ((pal::strcasecmp(_X("--info"), argv[1]) == 0) &&
+        !((result == StatusCode::CorehostMustRunAsArchArm64) || (result == StatusCode::CorehostMustRunAsArchX64)))
     {
         command_line::print_muxer_info(host_info.dotnet_root);
     }


### PR DESCRIPTION
This prepares for a universal dotnet binary

Add a policy to make .NET 6 and greater run natively on arm64
Add a policy to make older x64 runtimes run on x64
Add mechanism to restart dotnet in the same process with the correct arch

TBD - Add mechanisms to build the universal binaries
TBD - Optimize the runtime search (share the selected framework from first pass with second pass)
TBD - Design documentation - draft in #48628
TBD - installer work