### PR TITLE
Backport removing dead pwd code

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;
 using System.ComponentModel;
@@ -354,8 +355,8 @@ namespace System.Diagnostics.Tests
                 [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported)), PlatformSpecific(TestPlatforms.Windows), OuterLoop] // Uses P/Invokes, Requires admin privileges
         public void TestUserCredentialsPropertiesOnWindows()
         {
-            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Unit test dummy credentials.")]
-            string username = "test", password = "PassWord123!!";
+            const string username = "testForDotnetRuntime";
+            string password = Convert.ToBase64String(RandomNumberGenerator.GetBytes(33)) + "_-As@!%*(1)4#2";
             try
             {
                 Interop.NetUserAdd(username, password);

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -352,11 +352,13 @@ namespace System.Diagnostics.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/18978")]
-                [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported)), PlatformSpecific(TestPlatforms.Windows), OuterLoop] // Uses P/Invokes, Requires admin privileges
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported)), PlatformSpecific(TestPlatforms.Windows), OuterLoop] // Uses P/Invokes, Requires admin privileges
         public void TestUserCredentialsPropertiesOnWindows()
         {
             const string username = "testForDotnetRuntime";
-            string password = Convert.ToBase64String(RandomNumberGenerator.GetBytes(33)) + "_-As@!%*(1)4#2";
+            var bytes = new byte[33];
+            RandomNumberGenerator.Fill(bytes);
+            string password = Convert.ToBase64String(bytes) + "_-As@!%*(1)4#2";
             try
             {
                 Interop.NetUserAdd(username, password);

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalTest.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Security.Principal;
 using Xunit;
@@ -15,8 +16,7 @@ namespace System.DirectoryServices.AccountManagement.Tests
 
         private void RefreshContext()
         {
-            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Unit test dummy credentials.")]
-            string username = "Administrator", password = "Adrumble@6";
+            string username = "Administrator", password = Environment.GetEnvironmentVariable("TESTPASSWORD");
 
             string OU = "Tests";
             string baseDomain = WindowsIdentity.GetCurrent().Name.Split(new char[] { '\\' })[1] + "-TEST";

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/UserPrincipalTest.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/UserPrincipalTest.cs
@@ -28,33 +28,5 @@ namespace System.DirectoryServices.AccountManagement.Tests
             UserPrincipal user = new UserPrincipal(DomainContext);
             user.Dispose();
         }
-
-        public void ComputedUACCheck()
-        {
-            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Unit test dummy credentials.")]
-            string username = "Administrator", password = "Adrumble@6";
-            //TODO: don't assume it exists, create it if its not
-            string OU = "TestNull";
-            string baseDomain =WindowsIdentity.GetCurrent().Name.Split(new char[] { '\\' })[1] + "-TEST";
-            string domain = $"{baseDomain}.nttest.microsoft.com";
-            string container = $"ou={OU},dc={baseDomain},dc=nttest,dc=microsoft,dc=com";
-
-            PrincipalContext context = new PrincipalContext(ContextType.Domain, domain, container, username, password);
-            UserPrincipal user = UserPrincipal.FindByIdentity(context, IdentityType.SamAccountName, "good");
-
-            // set the wrong password to force account lockout
-            // Is there a way of doing it programmatically except for NetUserSetInfo? (managed code)
-            context.ValidateCredentials("good", "wrong password");
-
-            //verify that the account is locked out
-            Assert.True(user.IsAccountLockedOut(), "trying wrong credentials did not lock the account");
-
-            // if uac is not set correctly, this call might clear the lockout
-            user.SmartcardLogonRequired = false;
-            user.Save();
-
-            //verify that the account is still locked out
-            Assert.True(user.IsAccountLockedOut(), "the account is no longer locked out after writing setting SmartCardLogonRequired");
-        }
     }
 }


### PR DESCRIPTION
Backport https://github.com/dotnet/runtime/pull/48241 as required to remove Credscan noise from all ship branches.

Test only change.