### PR TITLE
Add Vector conversion to PointF/SizeF/RectangleF

### DIFF
--- a/src/libraries/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
+++ b/src/libraries/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
@@ -404,6 +404,7 @@ namespace System.Drawing
         private int _dummyPrimitive;
         public static readonly System.Drawing.PointF Empty;
         public PointF(float x, float y) { throw null; }
+        public PointF(System.Numerics.Vector2 vector) { throw null; }
         [System.ComponentModel.BrowsableAttribute(false)]
         public readonly bool IsEmpty { get { throw null; } }
         public float X { readonly get { throw null; } set { } }
@@ -413,6 +414,8 @@ namespace System.Drawing
         public readonly bool Equals(System.Drawing.PointF other) { throw null; }
         public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override readonly int GetHashCode() { throw null; }
+        public static explicit operator System.Numerics.Vector2(System.Drawing.PointF point) { throw null; }
+        public static explicit operator System.Drawing.PointF(System.Numerics.Vector2 vector) { throw null; }
         public static System.Drawing.PointF operator +(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
         public static System.Drawing.PointF operator +(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
         public static bool operator ==(System.Drawing.PointF left, System.Drawing.PointF right) { throw null; }
@@ -422,6 +425,7 @@ namespace System.Drawing
         public static System.Drawing.PointF Subtract(System.Drawing.PointF pt, System.Drawing.Size sz) { throw null; }
         public static System.Drawing.PointF Subtract(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
         public override readonly string ToString() { throw null; }
+        public System.Numerics.Vector2 ToVector2() { throw null; }
     }
     [System.ComponentModel.TypeConverterAttribute("System.Drawing.RectangleConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public partial struct Rectangle : System.IEquatable<System.Drawing.Rectangle>
@@ -477,6 +481,7 @@ namespace System.Drawing
         public static readonly System.Drawing.RectangleF Empty;
         public RectangleF(System.Drawing.PointF location, System.Drawing.SizeF size) { throw null; }
         public RectangleF(float x, float y, float width, float height) { throw null; }
+        public RectangleF(System.Numerics.Vector4 vector) { throw null; }
         [System.ComponentModel.BrowsableAttribute(false)]
         public readonly float Bottom { get { throw null; } }
         public float Height { readonly get { throw null; } set { } }
@@ -510,10 +515,13 @@ namespace System.Drawing
         public readonly bool IntersectsWith(System.Drawing.RectangleF rect) { throw null; }
         public void Offset(System.Drawing.PointF pos) { }
         public void Offset(float x, float y) { }
+        public static explicit operator System.Numerics.Vector4(System.Drawing.RectangleF rectangle) { throw null; }
+        public static explicit operator System.Drawing.RectangleF(System.Numerics.Vector4 vector) { throw null; }
         public static bool operator ==(System.Drawing.RectangleF left, System.Drawing.RectangleF right) { throw null; }
         public static implicit operator System.Drawing.RectangleF (System.Drawing.Rectangle r) { throw null; }
         public static bool operator !=(System.Drawing.RectangleF left, System.Drawing.RectangleF right) { throw null; }
         public override readonly string ToString() { throw null; }
+        public System.Numerics.Vector4 ToVector4() { throw null; }
         public static System.Drawing.RectangleF Union(System.Drawing.RectangleF a, System.Drawing.RectangleF b) { throw null; }
     }
     [System.ComponentModel.TypeConverterAttribute("System.Drawing.SizeConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
@@ -557,6 +565,7 @@ namespace System.Drawing
         public SizeF(System.Drawing.PointF pt) { throw null; }
         public SizeF(System.Drawing.SizeF size) { throw null; }
         public SizeF(float width, float height) { throw null; }
+        public SizeF(System.Numerics.Vector2 vector) { throw null; }
         public float Height { readonly get { throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         public readonly bool IsEmpty { get { throw null; } }
@@ -565,6 +574,8 @@ namespace System.Drawing
         public readonly bool Equals(System.Drawing.SizeF other) { throw null; }
         public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override readonly int GetHashCode() { throw null; }
+        public static explicit operator System.Numerics.Vector2(System.Drawing.SizeF size) { throw null; }
+        public static explicit operator System.Drawing.SizeF(System.Numerics.Vector2 vector) { throw null; }
         public static System.Drawing.SizeF operator +(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
         public static System.Drawing.SizeF operator /(System.Drawing.SizeF left, float right) { throw null; }
         public static bool operator ==(System.Drawing.SizeF sz1, System.Drawing.SizeF sz2) { throw null; }
@@ -577,6 +588,7 @@ namespace System.Drawing
         public readonly System.Drawing.PointF ToPointF() { throw null; }
         public readonly System.Drawing.Size ToSize() { throw null; }
         public override readonly string ToString() { throw null; }
+        public System.Numerics.Vector2 ToVector2() { throw null; }
     }
     public static partial class SystemColors
     {

--- a/src/libraries/System.Drawing.Primitives/ref/System.Drawing.Primitives.csproj
+++ b/src/libraries/System.Drawing.Primitives/ref/System.Drawing.Primitives.csproj
@@ -10,5 +10,6 @@
     <ProjectReference Include="..\..\System.ObjectModel\ref\System.ObjectModel.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.ComponentModel.Primitives\ref\System.ComponentModel.Primitives.csproj" />
+    <ProjectReference Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
+++ b/src/libraries/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>System.Drawing</RootNamespace>
     <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);FEATURE_WINDOWS_SYSTEM_COLORS</DefineConstants>
@@ -39,8 +39,10 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Win32.SystemEvents\src\Microsoft.Win32.SystemEvents.csproj" />
     <Reference Include="System.Collections" />
     <Reference Include="System.ComponentModel.Primitives" />
+    <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.ObjectModel" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>

--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/PointF.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/PointF.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace System.Drawing
 {
@@ -30,6 +32,21 @@ namespace System.Drawing
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.PointF'/> struct from the specified
+        /// <see cref="System.Numerics.Vector2"/>.
+        /// </summary>
+        public PointF(Vector2 vector)
+        {
+            x = vector.X;
+            y = vector.Y;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="System.Numerics.Vector2"/> from this <see cref="System.Drawing.PointF"/>.
+        /// </summary>
+        public Vector2 ToVector2() => new Vector2(x, y);
+
+        /// <summary>
         /// Gets a value indicating whether this <see cref='System.Drawing.PointF'/> is empty.
         /// </summary>
         [Browsable(false)]
@@ -52,6 +69,16 @@ namespace System.Drawing
             readonly get => y;
             set => y = value;
         }
+
+        /// <summary>
+        /// Converts the specified <see cref="System.Drawing.PointF"/> to a <see cref="System.Numerics.Vector2"/>.
+        /// </summary>
+        public static explicit operator Vector2(PointF point) => point.ToVector2();
+
+        /// <summary>
+        /// Converts the specified <see cref="System.Numerics.Vector2"/> to a <see cref="System.Drawing.PointF"/>.
+        /// </summary>
+        public static explicit operator PointF(Vector2 vector) => new PointF(vector);
 
         /// <summary>
         /// Translates a <see cref='System.Drawing.PointF'/> by a given <see cref='System.Drawing.Size'/> .

--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/RectangleF.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 
 namespace System.Drawing
 {
@@ -46,6 +47,33 @@ namespace System.Drawing
             width = size.Width;
             height = size.Height;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.RectangleF'/> struct from the specified
+        /// <see cref="System.Numerics.Vector4"/>.
+        /// </summary>
+        public RectangleF(Vector4 vector)
+        {
+            x = vector.X;
+            y = vector.Y;
+            width = vector.Z;
+            height = vector.W;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="System.Numerics.Vector4"/> from this <see cref="System.Drawing.RectangleF"/>.
+        /// </summary>
+        public Vector4 ToVector4() => new Vector4(x, y, width, height);
+
+        /// <summary>
+        /// Converts the specified <see cref="System.Drawing.RectangleF"/> to a <see cref="System.Numerics.Vector4"/>.
+        /// </summary>
+        public static explicit operator Vector4(RectangleF rectangle) => rectangle.ToVector4();
+
+        /// <summary>
+        /// Converts the specified <see cref="System.Numerics.Vector2"/> to a <see cref="System.Drawing.RectangleF"/>.
+        /// </summary>
+        public static explicit operator RectangleF(Vector4 vector) => new RectangleF(vector);
 
         /// <summary>
         /// Creates a new <see cref='System.Drawing.RectangleF'/> with the specified location and size.

--- a/src/libraries/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
+++ b/src/libraries/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 
 namespace System.Drawing
 {
@@ -42,6 +43,21 @@ namespace System.Drawing
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref='System.Drawing.SizeF'/> struct from the specified
+        /// <see cref="System.Numerics.Vector2"/>.
+        /// </summary>
+        public SizeF(Vector2 vector)
+        {
+            width = vector.X;
+            height = vector.Y;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="System.Numerics.Vector2"/> from this <see cref="System.Drawing.SizeF"/>.
+        /// </summary>
+        public Vector2 ToVector2() => new Vector2(width, height);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref='System.Drawing.SizeF'/> class from the specified dimensions.
         /// </summary>
         public SizeF(float width, float height)
@@ -49,6 +65,16 @@ namespace System.Drawing
             this.width = width;
             this.height = height;
         }
+
+        /// <summary>
+        /// Converts the specified <see cref="System.Drawing.SizeF"/> to a <see cref="System.Numerics.Vector2"/>.
+        /// </summary>
+        public static explicit operator Vector2(SizeF size) => size.ToVector2();
+
+        /// <summary>
+        /// Converts the specified <see cref="System.Numerics.Vector2"/> to a <see cref="System.Drawing.SizeF"/>.
+        /// </summary>
+        public static explicit operator SizeF(Vector2 vector) => new SizeF(vector);
 
         /// <summary>
         /// Performs vector addition of two <see cref='System.Drawing.SizeF'/> objects.

--- a/src/libraries/System.Drawing.Primitives/tests/PointFTests.cs
+++ b/src/libraries/System.Drawing.Primitives/tests/PointFTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Numerics;
 using System.Reflection;
 using Xunit;
 
@@ -27,6 +28,25 @@ namespace System.Drawing.PrimitivesTests
 
             Assert.Equal(x, p1.X);
             Assert.Equal(y, p1.Y);
+
+            PointF p2 = new PointF(new Vector2(x, y));
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory]
+        [InlineData(float.MaxValue, float.MinValue)]
+        [InlineData(float.MinValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MaxValue)]
+        [InlineData(float.MinValue, float.MaxValue)]
+        [InlineData(0.0, 0.0)]
+        public void ToFromVector(float x, float y)
+        {
+            PointF point1 = new PointF(x, y);
+            Vector2 vector1 = new Vector2(x, y);
+
+            Assert.Equal(vector1, point1.ToVector2());
+            Assert.Equal(vector1, (Vector2)point1);
+            Assert.Equal(point1, (PointF)vector1);
         }
 
         [Fact]

--- a/src/libraries/System.Drawing.Primitives/tests/RectangleFTests.cs
+++ b/src/libraries/System.Drawing.Primitives/tests/RectangleFTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-
+using System.Numerics;
 using Xunit;
 
 namespace System.Drawing.PrimitivesTest
@@ -28,6 +28,9 @@ namespace System.Drawing.PrimitivesTest
             RectangleF rect2 = new RectangleF(p, s);
 
             Assert.Equal(rect1, rect2);
+
+            RectangleF rect3 = new RectangleF(new Vector4(x, y, width, height));
+            Assert.Equal(rect1, rect3);
         }
 
         [Theory]
@@ -41,6 +44,21 @@ namespace System.Drawing.PrimitivesTest
             RectangleF actual = RectangleF.FromLTRB(left, top, right, bottom);
 
             Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(float.MaxValue, float.MinValue, float.MinValue, float.MaxValue)]
+        [InlineData(float.MaxValue, 0, 0, float.MaxValue)]
+        [InlineData(0, float.MinValue, float.MaxValue, 0)]
+        public void ToFromVector(float x, float y, float width, float height)
+        {
+            RectangleF rect1 = new RectangleF(x, y, width, height);
+            Vector4 vector1 = new Vector4(x, y, width, height);
+
+            Assert.Equal(vector1, rect1.ToVector4());
+            Assert.Equal(vector1, (Vector4)rect1);
+            Assert.Equal(rect1, (RectangleF)vector1);
         }
 
         [Theory]

--- a/src/libraries/System.Drawing.Primitives/tests/SizeFTests.cs
+++ b/src/libraries/System.Drawing.Primitives/tests/SizeFTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Numerics;
 using Xunit;
 
 namespace System.Drawing.PrimitivesTest
@@ -28,6 +29,7 @@ namespace System.Drawing.PrimitivesTest
             Assert.Equal(s1, s2);
             Assert.Equal(s1, new SizeF(p1));
             Assert.Equal(s2, new SizeF(p1));
+            Assert.Equal(s1, new SizeF(new Vector2(width, height)));
 
             Assert.Equal(width, s1.Width);
             Assert.Equal(height, s1.Height);
@@ -37,6 +39,22 @@ namespace System.Drawing.PrimitivesTest
 
             s1.Height = -10.123f;
             Assert.Equal(-10.123, s1.Height, 3);
+        }
+
+        [Theory]
+        [InlineData(float.MaxValue, float.MinValue)]
+        [InlineData(float.MinValue, float.MinValue)]
+        [InlineData(float.MaxValue, float.MaxValue)]
+        [InlineData(float.MinValue, float.MaxValue)]
+        [InlineData(0.0, 0.0)]
+        public void ToFromVector(float x, float y)
+        {
+            SizeF size1 = new SizeF(x, y);
+            Vector2 vector1 = new Vector2(x, y);
+
+            Assert.Equal(vector1, size1.ToVector2());
+            Assert.Equal(vector1, (Vector2)size1);
+            Assert.Equal(size1, (SizeF)vector1);
         }
 
         [Fact]


### PR DESCRIPTION
Implements part of #47940 to allow conversion between `Vector2` and `PointF` / `SizeF` and between `Vector4` and `RectangleF`.

Note that simple field assignment generated the most performant code.