### PR TITLE
Remove ProjectGuids from libs projects and update slngen

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "4.4.2",
+      "version": "5.0.5",
       "commands": [
         "slngen"
       ]

--- a/eng/slngen.targets
+++ b/eng/slngen.targets
@@ -11,6 +11,6 @@
     <IncludeInSolutionFile Condition="'$(IsNETCoreAppRef)' == 'true' and '$(MSBuildProjectName)' == 'System.Runtime.CompilerServices.Unsafe'">true</IncludeInSolutionFile>
   </PropertyGroup>
   <ItemGroup>
-    <SlnGenCustomProjectTypeGuid Include=".ilproj" ProjectTypeGuid="{F571AB99-FB84-49F4-A0DF-F27AA55F3F3F}" />
+    <SlnGenCustomProjectTypeGuid Include=".ilproj" ProjectTypeGuid="{9A19103F-16F7-4668-BE54-9A1E7A4F7556}" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
@@ -16,7 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultLanguageSourceExtension>.il</DefaultLanguageSourceExtension>
     <Language>IL</Language>
     <TargetRuntime>Managed</TargetRuntime>
-    <DefaultProjectTypeGuid Condition="'$(DefaultProjectTypeGuid)' == ''">{F571AB99-FB84-49F4-A0DF-F27AA55F3F3F}</DefaultProjectTypeGuid>
+    <DefaultProjectTypeGuid Condition="'$(DefaultProjectTypeGuid)' == ''">{9A19103F-16F7-4668-BE54-9A1E7A4F7556}</DefaultProjectTypeGuid>
     <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     <AlwaysUseNumericalSuffixInItemNames>true</AlwaysUseNumericalSuffixInItemNames>
   </PropertyGroup>

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/NuGet.config
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/NuGet.config
@@ -1,0 +1,12 @@
+<configuration>
+  <!-- This disables restore in VS for projects that target platform specific target frameworks older than net5.0. -->
+  <packageRestore>
+    <!-- The 'automatic' key is set to True when the "Automatically check for missing packages during
+         build in Visual Studio" checkbox is set. Clearing the box sets this to False and disables
+         automatic restore. -->
+    <add key="automatic" value="False" />
+    <!-- The 'enabled' key is True when the "Allow NuGet to download missing packages" checkbox is set.
+         Clearing the box sets this to False, disabling command-line, automatic, and MSBuild-integrated restore. -->
+    <add key="enabled" value="False" />
+  </packageRestore>
+</configuration>

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ProjectGuid>{a32671b6-5470-4f9c-9cd8-4094b9ab0799}</ProjectGuid>
     <NoVbRuntimeReference>true</NoVbRuntimeReference>
     <VBRuntime>None</VBRuntime>
     <OptionStrict>On</OptionStrict>

--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -1,17 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.IL">
-  <!-- Make sure that the DebuggableAttribute is set properly. -->
   <PropertyGroup>
-    <DebugOptimization>IMPL</DebugOptimization>
-    <DebugOptimization Condition="'$(Configuration)' == 'Release'">OPT</DebugOptimization>
-  </PropertyGroup>
-  <PropertyGroup>
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateVersionFile</CoreCompileDependsOn>
-    <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
-    <ProjectGuid>{04BA3E3C-6979-4792-B19E-C797AD607F42}</ProjectGuid>
-    <ExtraMacros Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)' or '$(TargetFramework)' == 'netcoreapp2.0'">#define netcoreapp</ExtraMacros>
-    <IlasmFlags>$(IlasmFlags) -DEBUG=$(DebugOptimization)</IlasmFlags>
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;netcoreapp2.0;netstandard1.0;net45</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
+    <!-- Make sure that the DebuggableAttribute is set properly. -->
+    <DebugOptimization>IMPL</DebugOptimization>
+    <DebugOptimization Condition="'$(Configuration)' == 'Release'">OPT</DebugOptimization>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateVersionFile</CoreCompileDependsOn>
+    <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
+    <ExtraMacros Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)' or '$(TargetFramework)' == 'netcoreapp2.0'">#define netcoreapp</ExtraMacros>
+    <IlasmFlags>$(IlasmFlags) -DEBUG=$(DebugOptimization)</IlasmFlags>
     <CoreAssembly>System.Runtime</CoreAssembly>
     <CoreAssembly Condition="'$(TargetFramework)' == 'netstandard2.0'">netstandard</CoreAssembly>
   </PropertyGroup>

--- a/src/libraries/System.Runtime/tests/TestModule/System.Reflection.TestModule.ilproj
+++ b/src/libraries/System.Runtime/tests/TestModule/System.Reflection.TestModule.ilproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <ProjectGuid>{3B7489C4-65DB-4E69-BE01-F6234133400C}</ProjectGuid>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TestStrongNameKeyId>Microsoft</TestStrongNameKeyId>
   </PropertyGroup>

--- a/src/libraries/System.Runtime/tests/TestStructs/System.TestStructs.ilproj
+++ b/src/libraries/System.Runtime/tests/TestStructs/System.TestStructs.ilproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <ProjectGuid>{6B002B34-089C-4BC4-91DD-57D350DEA91C}</ProjectGuid>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TestStrongNameKeyId>Microsoft</TestStrongNameKeyId>
   </PropertyGroup>

--- a/src/libraries/slngen.proj
+++ b/src/libraries/slngen.proj
@@ -1,12 +1,11 @@
 <!--
-  Important: This project requires to be invoked from within the VS Developer Command Prompt. 
   Targets that can be executed individually even though they are sequenced into build already:
     - UpdateSolutionFile: Adds/updates solution files with slngen which includes dependencies.
     - AddNuGetConfigToSolution: Checks if the solution needs a NuGet.config file to disable restore.
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <ProjTemplatePath>$(RepositoryEngineeringDir)slngen.template.proj</ProjTemplatePath>
     <NuGetConfigTemplatePath>$(RepositoryEngineeringDir)slngen.nuget.config</NuGetConfigTemplatePath>
   </PropertyGroup>


### PR DESCRIPTION
Based on this comment: https://github.com/dotnet/project-system/issues/6830#issuecomment-782591566

1. First commit removes the ProjectGuids from some libs projecsts
2. Second commit updates slngen as it now produces "more VS compatible" sln files.
3. Third commit invokes src/libraries/slngen.proj which adds NuGet.config files where needed.