### PR TITLE
[mono] Remove MonoRuntimeUnhandledExceptionPolicy

### DIFF
--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1576,14 +1576,6 @@ mono_method_add_generic_virtual_invocation (MonoDomain *domain, MonoVTable *vtab
 											gpointer *vtable_slot,
 											MonoMethod *method, gpointer code);
 
-typedef enum {
-	MONO_UNHANDLED_POLICY_LEGACY,
-	MONO_UNHANDLED_POLICY_CURRENT
-} MonoRuntimeUnhandledExceptionPolicy;
-
-MonoRuntimeUnhandledExceptionPolicy
-mono_runtime_unhandled_exception_policy_get (void);
-
 void
 mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error);
 

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -4178,20 +4178,6 @@ call_unhandled_exception_delegate (MonoDomain *domain, MonoObjectHandle delegate
 	}
 }
 
-static MonoRuntimeUnhandledExceptionPolicy runtime_unhandled_exception_policy = MONO_UNHANDLED_POLICY_CURRENT;
-
-/**
- * mono_runtime_unhandled_exception_policy_get:
- *
- * This is a VM internal routine.
- *
- * Gets the runtime policy for handling unhandled exceptions.
- */
-MonoRuntimeUnhandledExceptionPolicy
-mono_runtime_unhandled_exception_policy_get (void)
-{
-	return runtime_unhandled_exception_policy;
-}
 
 void
 mono_unhandled_exception_internal (MonoObject *exc_raw)
@@ -4379,12 +4365,8 @@ mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error)
 
 leave:
 
-	/* set exitcode only if we will abort the process */
-	if ((main_thread && mono_thread_internal_current () == main_thread->internal_thread)
-		 || mono_runtime_unhandled_exception_policy_get () == MONO_UNHANDLED_POLICY_CURRENT)
-	{
-		mono_environment_exitcode_set (1);
-	}
+	/* set exitcode if we will abort the process */
+        mono_environment_exitcode_set (1);
 }
 
 /**

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -1157,8 +1157,7 @@ start_wrapper_internal (StartInfo *start_info, gsize *stack_ptr)
 
 			g_assert (ex != NULL);
 			MonoClass *klass = mono_object_class (ex);
-			if ((mono_runtime_unhandled_exception_policy_get () != MONO_UNHANDLED_POLICY_LEGACY) &&
-			    !is_threadabort_exception (klass)) {
+			if (!is_threadabort_exception (klass)) {
 				mono_unhandled_exception_internal (&ex->object);
 				mono_invoke_unhandled_exception_hook (&ex->object);
 				g_assert_not_reached ();
@@ -5174,7 +5173,7 @@ mono_thread_internal_unhandled_exception (MonoObject* exc)
 	MonoClass *klass = exc->vtable->klass;
 	if (is_threadabort_exception (klass)) {
 		mono_thread_internal_reset_abort (mono_thread_internal_current ());
-	} else if (mono_runtime_unhandled_exception_policy_get () == MONO_UNHANDLED_POLICY_CURRENT) {
+	} else {
 		mono_unhandled_exception_internal (exc);
 		if (mono_environment_exitcode_get () == 1) {
 			mono_environment_exitcode_set (255);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -898,8 +898,7 @@ mono_thread_abort (MonoObject *obj)
 	/* handle_remove should be eventually called for this thread, too
 	g_free (jit_tls);*/
 
-	if ((mono_runtime_unhandled_exception_policy_get () == MONO_UNHANDLED_POLICY_LEGACY) ||
-			(obj->vtable->klass == mono_defaults.threadabortexception_class) ||
+	if ((obj->vtable->klass == mono_defaults.threadabortexception_class) ||
 			((obj->vtable->klass) == mono_class_try_get_appdomain_unloaded_exception_class () &&
 			mono_thread_info_current ()->runtime_thread)) {
 		mono_thread_exit ();


### PR DESCRIPTION
policy was always set to MONO_UNHANDLED_POLICY_CURRENT.  The legacy (pre-.NET 2.0) policy was not used.