### PR TITLE
Fix handling of array constructors in Crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -358,7 +358,11 @@ namespace ILCompiler.DependencyAnalysis
             MethodWithToken method = key.Method;
             bool isInstantiatingStub = key.IsInstantiatingStub;
             bool isPrecodeImportRequired = key.IsPrecodeImportRequired;
-            MethodDesc compilableMethod = method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            MethodDesc compilableMethod = method.Method;
+            if (!compilableMethod.OwningType.IsArray)
+            {
+                compilableMethod = compilableMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            }
             MethodWithGCInfo methodWithGCInfo = null;
 
             if (CompilationModuleGroup.ContainsMethodBody(compilableMethod, false))

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -358,11 +358,7 @@ namespace ILCompiler.DependencyAnalysis
             MethodWithToken method = key.Method;
             bool isInstantiatingStub = key.IsInstantiatingStub;
             bool isPrecodeImportRequired = key.IsPrecodeImportRequired;
-            MethodDesc compilableMethod = method.Method;
-            if (!compilableMethod.OwningType.IsArray)
-            {
-                compilableMethod = compilableMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-            }
+            MethodDesc compilableMethod = method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             MethodWithGCInfo methodWithGCInfo = null;
 
             if (CompilationModuleGroup.ContainsMethodBody(compilableMethod, false))

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1548,7 +1548,7 @@ namespace Internal.JitInterface
 
                 bool allowInstParam = (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_ALLOWINSTPARAM) != 0;
 
-                if (!allowInstParam && canonMethod.RequiresInstArg())
+                if (!allowInstParam && canonMethod != null && canonMethod.RequiresInstArg())
                 {
                     useInstantiatingStub = true;
                 }
@@ -1608,7 +1608,7 @@ namespace Internal.JitInterface
                     if (allowInstParam)
                     {
                         useInstantiatingStub = false;
-                        methodToCall = canonMethod;
+                        methodToCall = canonMethod ?? methodToCall;
                     }
 
                     pResult->kind = CORINFO_CALL_KIND.CORINFO_CALL;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/48204

I have attempted to adapt Michal's fix https://github.com/dotnet/runtimelab/pull/586 to Crossgen2.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 